### PR TITLE
Make Xcode report concurrency warnings on the Modules package

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -1,6 +1,8 @@
-// swift-tools-version: 5.9
+// swift-tools-version: 6.0
 
 import PackageDescription
+
+let concurrencyWarning: [SwiftSetting] = [.swiftLanguageMode(.v5), .enableUpcomingFeature("StrictConcurrency")]
 
 let package = Package(
     name: "Modules",
@@ -51,22 +53,22 @@ let package = Package(
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [
-        .target(name: "JetpackStatsWidgetsCore"),
-        .target(name: "DesignSystem"),
+        .target(name: "JetpackStatsWidgetsCore", swiftSettings: concurrencyWarning),
+        .target(name: "DesignSystem", swiftSettings: concurrencyWarning),
         .target(name: "UITestsFoundation", dependencies: [
             .product(name: "ScreenObject", package: "ScreenObject"),
             .product(name: "XCUITestHelpers", package: "XCUITestHelpers"),
-        ]),
-        .target(name: "WordPressFlux"),
-        .target(name: "WordPressSharedObjC", resources: [.process("Resources")]),
-        .target(name: "WordPressShared", dependencies: [.target(name: "WordPressSharedObjC")], resources: [.process("Resources")]),
-        .target(name: "WordPressUI", dependencies: [.target(name: "WordPressShared")], resources: [.process("Resources")]),
-        .testTarget(name: "JetpackStatsWidgetsCoreTests", dependencies: [.target(name: "JetpackStatsWidgetsCore")]),
-        .testTarget(name: "DesignSystemTests", dependencies: [.target(name: "DesignSystem")]),
-        .testTarget(name: "WordPressFluxTests", dependencies: ["WordPressFlux"]),
-        .testTarget(name: "WordPressSharedTests", dependencies: [.target(name: "WordPressShared")]),
-        .testTarget(name: "WordPressSharedObjCTests", dependencies: [.target(name: "WordPressShared")], resources: [.process("Resources")]),
-        .testTarget(name: "WordPressUITests", dependencies: [.target(name: "WordPressUI")]),
+        ], swiftSettings: concurrencyWarning),
+        .target(name: "WordPressFlux", swiftSettings: concurrencyWarning),
+        .target(name: "WordPressSharedObjC", resources: [.process("Resources")], swiftSettings: concurrencyWarning),
+        .target(name: "WordPressShared", dependencies: [.target(name: "WordPressSharedObjC")], resources: [.process("Resources")], swiftSettings: concurrencyWarning),
+        .target(name: "WordPressUI", dependencies: [.target(name: "WordPressShared")], resources: [.process("Resources")], swiftSettings: concurrencyWarning),
+        .testTarget(name: "JetpackStatsWidgetsCoreTests", dependencies: [.target(name: "JetpackStatsWidgetsCore")], swiftSettings: concurrencyWarning),
+        .testTarget(name: "DesignSystemTests", dependencies: [.target(name: "DesignSystem")], swiftSettings: concurrencyWarning),
+        .testTarget(name: "WordPressFluxTests", dependencies: ["WordPressFlux"], swiftSettings: concurrencyWarning),
+        .testTarget(name: "WordPressSharedTests", dependencies: [.target(name: "WordPressShared")], swiftSettings: concurrencyWarning),
+        .testTarget(name: "WordPressSharedObjCTests", dependencies: [.target(name: "WordPressShared")], resources: [.process("Resources")], swiftSettings: concurrencyWarning),
+        .testTarget(name: "WordPressUITests", dependencies: [.target(name: "WordPressUI")], swiftSettings: concurrencyWarning),
     ]
 )
 
@@ -85,20 +87,22 @@ let package = Package(
 /// into every target that depends on it. Make sure to avoid including frameworks
 /// with large resources bundled into multiple targets.
 enum XcodeSupport {
-    static let products: [Product] = [
-        .library(name: "XcodeTarget_App", targets: ["XcodeTarget_App"]),
-        .library(name: "XcodeTarget_WordPressTests", targets: ["XcodeTarget_WordPressTests"]),
-        .library(name: "XcodeTarget_WordPressAuthentificator", targets: ["XcodeTarget_WordPressAuthentificator"]),
-        .library(name: "XcodeTarget_WordPressAuthentificatorTests", targets: ["XcodeTarget_WordPressAuthentificatorTests"]),
-        .library(name: "XcodeTarget_ShareExtension", targets: ["XcodeTarget_ShareExtension"]),
-        .library(name: "XcodeTarget_DraftActionExtension", targets: ["XcodeTarget_DraftActionExtension"]),
-        .library(name: "XcodeTarget_NotificationServiceExtension", targets: ["XcodeTarget_NotificationServiceExtension"]),
-        .library(name: "XcodeTarget_Intents", targets: ["XcodeTarget_Intents"]),
-        .library(name: "XcodeTarget_StatsWidget", targets: ["XcodeTarget_StatsWidget"]),
-        .library(name: "XcodeTarget_UITests", targets: ["XcodeTarget_UITests"]),
-    ]
+    static var products: [Product] {
+        [
+            .library(name: "XcodeTarget_App", targets: ["XcodeTarget_App"]),
+            .library(name: "XcodeTarget_WordPressTests", targets: ["XcodeTarget_WordPressTests"]),
+            .library(name: "XcodeTarget_WordPressAuthentificator", targets: ["XcodeTarget_WordPressAuthentificator"]),
+            .library(name: "XcodeTarget_WordPressAuthentificatorTests", targets: ["XcodeTarget_WordPressAuthentificatorTests"]),
+            .library(name: "XcodeTarget_ShareExtension", targets: ["XcodeTarget_ShareExtension"]),
+            .library(name: "XcodeTarget_DraftActionExtension", targets: ["XcodeTarget_DraftActionExtension"]),
+            .library(name: "XcodeTarget_NotificationServiceExtension", targets: ["XcodeTarget_NotificationServiceExtension"]),
+            .library(name: "XcodeTarget_Intents", targets: ["XcodeTarget_Intents"]),
+            .library(name: "XcodeTarget_StatsWidget", targets: ["XcodeTarget_StatsWidget"]),
+            .library(name: "XcodeTarget_UITests", targets: ["XcodeTarget_UITests"]),
+        ]
+    }
 
-    static let targets: [Target] = {
+    static var targets: [Target] {
         let wordPresAuthentificatorDependencies: [Target.Dependency] = [
             "WordPressShared",
             "WordPressUI",
@@ -193,7 +197,7 @@ enum XcodeSupport {
                 .product(name: "BuildkiteTestCollector", package: "test-collector-swift"),
             ]),
         ]
-    }()
+    }
 }
 
 extension Target {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -2,8 +2,6 @@
 
 import PackageDescription
 
-let concurrencyWarning: [SwiftSetting] = [.swiftLanguageMode(.v5), .enableUpcomingFeature("StrictConcurrency")]
-
 let package = Package(
     name: "Modules",
     platforms: [
@@ -53,22 +51,22 @@ let package = Package(
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [
-        .target(name: "JetpackStatsWidgetsCore", swiftSettings: concurrencyWarning),
-        .target(name: "DesignSystem", swiftSettings: concurrencyWarning),
+        .target(name: "JetpackStatsWidgetsCore", swiftSettings: [.swiftLanguageMode(.v5)]),
+        .target(name: "DesignSystem", swiftSettings: [.swiftLanguageMode(.v5)]),
         .target(name: "UITestsFoundation", dependencies: [
             .product(name: "ScreenObject", package: "ScreenObject"),
             .product(name: "XCUITestHelpers", package: "XCUITestHelpers"),
-        ], swiftSettings: concurrencyWarning),
-        .target(name: "WordPressFlux", swiftSettings: concurrencyWarning),
-        .target(name: "WordPressSharedObjC", resources: [.process("Resources")], swiftSettings: concurrencyWarning),
-        .target(name: "WordPressShared", dependencies: [.target(name: "WordPressSharedObjC")], resources: [.process("Resources")], swiftSettings: concurrencyWarning),
-        .target(name: "WordPressUI", dependencies: [.target(name: "WordPressShared")], resources: [.process("Resources")], swiftSettings: concurrencyWarning),
-        .testTarget(name: "JetpackStatsWidgetsCoreTests", dependencies: [.target(name: "JetpackStatsWidgetsCore")], swiftSettings: concurrencyWarning),
-        .testTarget(name: "DesignSystemTests", dependencies: [.target(name: "DesignSystem")], swiftSettings: concurrencyWarning),
-        .testTarget(name: "WordPressFluxTests", dependencies: ["WordPressFlux"], swiftSettings: concurrencyWarning),
-        .testTarget(name: "WordPressSharedTests", dependencies: [.target(name: "WordPressShared")], swiftSettings: concurrencyWarning),
-        .testTarget(name: "WordPressSharedObjCTests", dependencies: [.target(name: "WordPressShared")], resources: [.process("Resources")], swiftSettings: concurrencyWarning),
-        .testTarget(name: "WordPressUITests", dependencies: [.target(name: "WordPressUI")], swiftSettings: concurrencyWarning),
+        ], swiftSettings: [.swiftLanguageMode(.v5)]),
+        .target(name: "WordPressFlux", swiftSettings: [.swiftLanguageMode(.v5)]),
+        .target(name: "WordPressSharedObjC", resources: [.process("Resources")], swiftSettings: [.swiftLanguageMode(.v5)]),
+        .target(name: "WordPressShared", dependencies: [.target(name: "WordPressSharedObjC")], resources: [.process("Resources")], swiftSettings: [.swiftLanguageMode(.v5)]),
+        .target(name: "WordPressUI", dependencies: [.target(name: "WordPressShared")], resources: [.process("Resources")], swiftSettings: [.swiftLanguageMode(.v5)]),
+        .testTarget(name: "JetpackStatsWidgetsCoreTests", dependencies: [.target(name: "JetpackStatsWidgetsCore")], swiftSettings: [.swiftLanguageMode(.v5)]),
+        .testTarget(name: "DesignSystemTests", dependencies: [.target(name: "DesignSystem")], swiftSettings: [.swiftLanguageMode(.v5)]),
+        .testTarget(name: "WordPressFluxTests", dependencies: ["WordPressFlux"], swiftSettings: [.swiftLanguageMode(.v5)]),
+        .testTarget(name: "WordPressSharedTests", dependencies: [.target(name: "WordPressShared")], swiftSettings: [.swiftLanguageMode(.v5)]),
+        .testTarget(name: "WordPressSharedObjCTests", dependencies: [.target(name: "WordPressShared")], resources: [.process("Resources")], swiftSettings: [.swiftLanguageMode(.v5)]),
+        .testTarget(name: "WordPressUITests", dependencies: [.target(name: "WordPressUI")], swiftSettings: [.swiftLanguageMode(.v5)]),
     ]
 )
 


### PR DESCRIPTION
This PR will introduce about 100+ more warnings. I'll "address" (probably just `@unchecked Sendable`) them in follow up PRs.

As the warnings gone, I'll remove the compiler flags, which means compiler will report errors if new code violates concurrency rules. 

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
