### PR TITLE
Remove BottomSheetViewController from reader conversation settings

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsFollowPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsFollowPresenter.swift
@@ -154,9 +154,12 @@ private extension ReaderCommentsFollowPresenter {
         guard let presentingViewController else {
             return
         }
-        let sheetViewController = ReaderCommentsNotificationSheetViewController(isNotificationEnabled: post.receivesCommentNotifications, delegate: self)
-        let bottomSheet = BottomSheetViewController(childViewController: sheetViewController)
-        bottomSheet.show(from: presentingViewController, sourceView: sourceView, sourceBarButtonItem: sourceBarButtonItem)
+        let sheetVC = ReaderCommentsNotificationSheetViewController(isNotificationEnabled: post.receivesCommentNotifications, delegate: self)
+        let navigationVC = UINavigationController(rootViewController: sheetVC)
+        navigationVC.modalPresentationStyle = .popover
+        navigationVC.popoverPresentationController?.sourceItem = sourceBarButtonItem ?? sourceView
+        navigationVC.popoverPresentationController?.adaptiveSheetPresentationController.detents = [.medium()]
+        presentingViewController.present(navigationVC, animated: true)
     }
 
     func informDelegateFollowComplete(success: Bool) {


### PR DESCRIPTION
Removing `BottomSheetViewController` from more places to make sure no other crashes related to it happen.

- Open Reader 
- Open a post 
- Open comments
- Tap "Follow" and wait for success
- Tap the bell to open conversation settings
- Verify that its displayed OK

<img width="800" alt="Screenshot 2024-11-20 at 11 17 10 AM" src="https://github.com/user-attachments/assets/4344d490-437e-407c-8a9d-d1e766eaaa50">
<img width="320" alt="Screenshot 2024-11-20 at 11 20 20 AM" src="https://github.com/user-attachments/assets/22772b67-2ace-4664-b27a-37c4de7d5ae1">


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
