### PR TITLE
Reader: Fix an issue with follow button state not updating

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -667,6 +667,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     [self.followCommentsService fetchSubscriptionStatusWithSuccess:^(BOOL isSubscribed) {
         // update the ReaderPost button to keep it in-sync.
         weakSelf.post.isSubscribedComments = isSubscribed;
+        [weakSelf refreshFollowButton];
         [ContextManager.sharedInstance saveContext:weakSelf.post.managedObjectContext];
     } failure:^(NSError *error) {
         DDLogError(@"Error fetching subscription status for post: %@", error);
@@ -919,7 +920,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
         [weakSelf trackReplyTo:replyToComment];
         [weakSelf.tableView deselectSelectedRowWithAnimation:YES];
         [weakSelf refreshReplyTextViewPlaceholder];
-        [weakSelf refreshFollowButton];
 
         // Dispatch is used here to address an issue in iOS 15 where some cells could disappear from the screen after `reloadData`.
         // This seems to be affecting the Simulator environment only since I couldn't reproduce it on the device, but I'm fixing it just in case.

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -919,6 +919,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
         [weakSelf trackReplyTo:replyToComment];
         [weakSelf.tableView deselectSelectedRowWithAnimation:YES];
         [weakSelf refreshReplyTextViewPlaceholder];
+        [weakSelf refreshFollowButton];
 
         // Dispatch is used here to address an issue in iOS 15 where some cells could disappear from the screen after `reloadData`.
         // This seems to be affecting the Simulator environment only since I couldn't reproduce it on the device, but I'm fixing it just in case.


### PR DESCRIPTION
 Fix an issue with follow button state not updating.

To test:

- Follow a conversation in Reader
- Terminate the app
- Re-open the same conversastion
- **Verify** that the "Follow" button state updates (it currently shows a "Bell" image when you are subscribed)

In the previous implementation, it would always incorrectly show "Follow" the first time you open the page.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
