### PR TITLE
Prerequisites for removing AlamofireImage

### DIFF
--- a/WordPress/Classes/Extensions/Media/CircularProgressView+ActivityIndicatorType.swift
+++ b/WordPress/Classes/Extensions/Media/CircularProgressView+ActivityIndicatorType.swift
@@ -1,3 +1,4 @@
+import UIKit
 
 extension CircularProgressView: ActivityIndicatorType {
     func startAnimating() {

--- a/WordPress/Classes/Utility/Media/AsyncImageView.swift
+++ b/WordPress/Classes/Utility/Media/AsyncImageView.swift
@@ -4,7 +4,7 @@ import Gifu
 /// A simple image view that supports rendering both static and animated images
 /// (see ``AnimatedImage``).
 @MainActor
-final class ImageView: UIView {
+final class AsyncImageView: UIView {
     let imageView = GIFImageView()
 
     private var errorView: UIImageView?

--- a/WordPress/Classes/Utility/Media/AsyncImageView.swift
+++ b/WordPress/Classes/Utility/Media/AsyncImageView.swift
@@ -49,8 +49,13 @@ final class AsyncImageView: UIView {
         }
     }
 
-    func setImage(with imageURL: URL, host: MediaHost? = nil, size: CGSize? = nil) {
-        controller.setImage(with: imageURL, host: host, size: size)
+    func setImage(
+        with imageURL: URL,
+        host: MediaHost? = nil,
+        size: CGSize? = nil,
+        completion: (@MainActor (Result<UIImage, Error>) -> Void)? = nil
+    ) {
+        controller.setImage(with: imageURL, host: host, size: size, completion: completion)
     }
 
     private func setState(_ state: ImageViewController.State) {

--- a/WordPress/Classes/Utility/Media/ImageDownloader.swift
+++ b/WordPress/Classes/Utility/Media/ImageDownloader.swift
@@ -2,6 +2,8 @@ import UIKit
 
 struct ImageRequestOptions {
     /// Resize the thumbnail to the given size. By default, `nil`.
+    ///
+    /// - warning: The size is in pixels.
     var size: CGSize?
 
     /// If enabled, uses ``MemoryCache`` for caching decompressed images.

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -40,21 +40,13 @@ import WordPressShared
     private var placeholder: UIImage?
     private var selectedPhotonQuality: UInt = Constants.defaultPhotonQuality
 
-    @objc convenience init(imageView: CachedAnimatedImageView, gifStrategy: GIFStrategy = .mediumGIFs) {
-        self.init(imageView: imageView, gifStrategy: gifStrategy, loadingIndicator: nil)
-    }
-
-    init(imageView: CachedAnimatedImageView, gifStrategy: GIFStrategy = .mediumGIFs, loadingIndicator: ActivityIndicatorType?) {
+    @objc init(imageView: CachedAnimatedImageView, gifStrategy: GIFStrategy = .mediumGIFs) {
         self.imageView = imageView
         imageView.gifStrategy = gifStrategy
 
-        if let loadingIndicator {
-            self.loadingIndicator = loadingIndicator
-        } else {
-            let loadingIndicator = CircularProgressView(style: .primary)
-            loadingIndicator.backgroundColor = .clear
-            self.loadingIndicator = loadingIndicator
-        }
+        let loadingIndicator = CircularProgressView(style: .primary)
+        loadingIndicator.backgroundColor = .clear
+        self.loadingIndicator = loadingIndicator
 
         super.init()
 

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -94,17 +94,17 @@ import WordPressShared
     ///   - success: A closure to be called if the image was loaded successfully.
     ///   - error: A closure to be called if there was an error loading the image.
     ///
-    func loadImage(with url: URL, success: ImageLoaderSuccessBlock?, error: ImageLoaderFailureBlock?) {
-        successHandler = success
-        errorHandler = error
-
-        if url.isGif {
-            loadGif(with: url, from: .publicSite)
-        } else {
-            imageView.clean()
-            loadStaticImage(with: url, from: .publicSite)
-        }
-    }
+//    func loadImage(with url: URL, success: ImageLoaderSuccessBlock?, error: ImageLoaderFailureBlock?) {
+//        successHandler = success
+//        errorHandler = error
+//
+//        if url.isGif {
+//            loadGif(with: url, from: .publicSite)
+//        } else {
+//            imageView.clean()
+//            loadStaticImage(with: url, from: .publicSite)
+//        }
+//    }
 
     @objc(loadImageWithURL:fromPost:preferredSize:placeholder:success:error:)
     func loadImage(with url: URL, from post: AbstractPost, preferredSize size: CGSize = .zero, placeholder: UIImage?, success: ImageLoaderSuccessBlock?, error: ImageLoaderFailureBlock?) {

--- a/WordPress/Classes/Utility/Media/ImageLoader.swift
+++ b/WordPress/Classes/Utility/Media/ImageLoader.swift
@@ -78,26 +78,6 @@ import WordPressShared
         }
     }
 
-    /// Load an image from a specific URL. As no source is provided, we can assume
-    /// that this is from a public site. Supports animated images (gifs) as well.
-    ///
-    /// - Parameters:
-    ///   - url: The URL to load the image from.
-    ///   - success: A closure to be called if the image was loaded successfully.
-    ///   - error: A closure to be called if there was an error loading the image.
-    ///
-//    func loadImage(with url: URL, success: ImageLoaderSuccessBlock?, error: ImageLoaderFailureBlock?) {
-//        successHandler = success
-//        errorHandler = error
-//
-//        if url.isGif {
-//            loadGif(with: url, from: .publicSite)
-//        } else {
-//            imageView.clean()
-//            loadStaticImage(with: url, from: .publicSite)
-//        }
-//    }
-
     @objc(loadImageWithURL:fromPost:preferredSize:placeholder:success:error:)
     func loadImage(with url: URL, from post: AbstractPost, preferredSize size: CGSize = .zero, placeholder: UIImage?, success: ImageLoaderSuccessBlock?, error: ImageLoaderFailureBlock?) {
 

--- a/WordPress/Classes/Utility/Media/ImageViewController.swift
+++ b/WordPress/Classes/Utility/Media/ImageViewController.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 
+/// A convenience class for managing image downloads for individual views.
 @MainActor
 final class ImageViewController {
     var downloader: ImageDownloader = .shared
@@ -11,7 +12,7 @@ final class ImageViewController {
     enum State {
         case loading
         case success(UIImage)
-        case failure
+        case failure(Error)
     }
 
     deinit {
@@ -23,7 +24,11 @@ final class ImageViewController {
         task = nil
     }
 
-    func setImage(with imageURL: URL, host: MediaHost? = nil, size: CGSize? = nil) {
+    func setImage(
+        with imageURL: URL,
+        host: MediaHost? = nil,
+        size: CGSize? = nil
+    ) {
         task?.cancel()
 
         if let image = downloader.cachedImage(for: imageURL, size: size) {
@@ -43,7 +48,7 @@ final class ImageViewController {
                     self?.onStateChanged(.success(image))
                 } catch {
                     guard !Task.isCancelled else { return }
-                    self?.onStateChanged(.failure)
+                    self?.onStateChanged(.failure(error))
                 }
             }
         }

--- a/WordPress/Classes/Utility/Media/ImageViewController.swift
+++ b/WordPress/Classes/Utility/Media/ImageViewController.swift
@@ -24,15 +24,18 @@ final class ImageViewController {
         task = nil
     }
 
+    /// - parameter completion: Gets called on completion _after_ `onStateChanged`.
     func setImage(
         with imageURL: URL,
         host: MediaHost? = nil,
-        size: CGSize? = nil
+        size: CGSize? = nil,
+        completion: (@MainActor (Result<UIImage, Error>) -> Void)? = nil
     ) {
         task?.cancel()
 
         if let image = downloader.cachedImage(for: imageURL, size: size) {
             onStateChanged(.success(image))
+            completion?(.success(image))
         } else {
             onStateChanged(.loading)
             task = Task { @MainActor [downloader, weak self] in
@@ -44,11 +47,15 @@ final class ImageViewController {
                     } else {
                         image = try await downloader.image(from: imageURL, options: options)
                     }
+                    // This line guarantees that if you cancel on the main thread,
+                    // none of the `onStateChanged` callbacks get called.
                     guard !Task.isCancelled else { return }
                     self?.onStateChanged(.success(image))
+                    completion?(.success(image))
                 } catch {
                     guard !Task.isCancelled else { return }
                     self?.onStateChanged(.failure(error))
+                    completion?(.failure(error))
                 }
             }
         }

--- a/WordPress/Classes/Utility/Media/UIImageView+ImageDownloader.swift
+++ b/WordPress/Classes/Utility/Media/UIImageView+ImageDownloader.swift
@@ -21,8 +21,13 @@ struct ImageViewExtensions {
         }
     }
 
-    func setImage(with imageURL: URL, host: MediaHost? = nil, size: CGSize? = nil) {
-        controller.setImage(with: imageURL, host: host, size: size)
+    func setImage(
+        with imageURL: URL,
+        host: MediaHost? = nil,
+        size: CGSize? = nil,
+        completion: (@MainActor (Result<UIImage, Error>) -> Void)? = nil
+    ) {
+        controller.setImage(with: imageURL, host: host, size: size, completion: completion)
     }
 
     var controller: ImageViewController {

--- a/WordPress/Classes/ViewRelated/Blog/Blog + Me/GravatarButtonView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog + Me/GravatarButtonView.swift
@@ -1,3 +1,5 @@
+import UIKit
+
 /// a circular image view with an auto-updating gravatar image
 class GravatarButtonView: CircularImageView {
 

--- a/WordPress/Classes/ViewRelated/Media/External/ExternalMediaPickerCollectionCell.swift
+++ b/WordPress/Classes/ViewRelated/Media/External/ExternalMediaPickerCollectionCell.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 final class ExternalMediaPickerCollectionCell: UICollectionViewCell {
-    private let imageView = ImageView()
+    private let imageView = AsyncImageView()
     private var selectionView: SiteMediaCollectionCellSelectionOverlayView?
 
     override init(frame: CGRect) {

--- a/WordPress/Classes/ViewRelated/Pages/Views/PageListCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/Views/PageListCell.swift
@@ -9,7 +9,7 @@ final class PageListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
     private let titleLabel = UILabel()
     private let badgeIconView = UIImageView()
     private let badgesLabel = UILabel()
-    private let featuredImageView = ImageView()
+    private let featuredImageView = AsyncImageView()
     private let icon = UIImageView()
     private let indicator = UIActivityIndicatorView(style: .medium)
     private let ellipsisButton = UIButton(type: .custom)

--- a/WordPress/Classes/ViewRelated/Post/Views/PostListCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PostListCell.swift
@@ -23,7 +23,7 @@ final class PostListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
 
     private let headerView = PostListHeaderView()
     private let contentLabel = UILabel()
-    private let featuredImageView = ImageView()
+    private let featuredImageView = AsyncImageView()
     private let statusLabel = UILabel()
 
     // MARK: - Properties

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -68,7 +68,7 @@ private final class ReaderPostCellView: UIView {
     // Content
     let titleLabel = UILabel()
     let detailsLabel = UILabel()
-    let imageView = ImageView()
+    let imageView = AsyncImageView()
 
     // Footer
     let buttons = ReaderPostToolbarButtons()

--- a/WordPress/Classes/ViewRelated/Reader/Views/ReaderAvatarView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Views/ReaderAvatarView.swift
@@ -1,7 +1,7 @@
 import UIKit
 
 final class ReaderAvatarView: UIView {
-    private let asyncImageView = ImageView()
+    private let asyncImageView = AsyncImageView()
 
     override init(frame: CGRect) {
         super.init(frame: frame)

--- a/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextImage.swift
+++ b/WordPress/Classes/ViewRelated/Views/WPRichText/WPRichTextImage.swift
@@ -1,4 +1,4 @@
-import Foundation
+import UIKit
 
 open class WPRichTextImage: UIControl, WPRichTextMediaAttachment {
 


### PR DESCRIPTION
A couple of small changes getting us closer to removing `AlamofireImage`.

- Add missing UIKit imports
- Remove `LoadingIndicator` parameter from `ImageLoader` (plan is to integrate `AsyncImageView`)
- Remove unused APIs from `ImageLoader`
- Add completion callback to `ImageViewController` (this will be needed to replace af.setImage)
- Add `error` to `ImageViewController.failure` state
- Rename `ImageView` to `AsyncImageView` (purpose more clear and rhymes with `AsyncImage)

I also plan to move `ImageDownloader` to a new SwiftPM package soon. I'm thinking about naming it `WordPressMedia` and adding other media-related stuff there too. Thoughts?

To test: n/a for now

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
