### PR TITLE
Reader: Fix insets for recommended sites/tags on iPad

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderRecommendedSitesCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderRecommendedSitesCell.swift
@@ -36,7 +36,7 @@ final class ReaderRecommendedSitesCell: UITableViewCell {
         backgroundView.layer.cornerRadius = 8
 
         contentView.addSubview(backgroundView)
-        backgroundView.pinEdges(insets: UIEdgeInsets(.all, 16))
+        backgroundView.pinEdges(to: contentView.readableContentGuide)
 
         let titleLabel = UILabel()
         titleLabel.font = .preferredFont(forTextStyle: .subheadline)

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderRecommendedTagsCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderRecommendedTagsCell.swift
@@ -36,7 +36,7 @@ final class ReaderRecommendedTagsCell: UITableViewCell {
         backgroundView.clipsToBounds = true
 
         contentView.addSubview(backgroundView)
-        backgroundView.pinEdges(insets: UIEdgeInsets(.all, 16))
+        backgroundView.pinEdges(to: contentView.readableContentGuide)
 
         let titleLabel = UILabel()
         titleLabel.font = .preferredFont(forTextStyle: .subheadline)


### PR DESCRIPTION
Totally forgot about it when adding the updated cells.


<img width="700" alt="Screenshot 2024-11-20 at 4 19 06 PM" src="https://github.com/user-attachments/assets/8afc62e0-8a5e-488d-b247-bf1ecf30a5e7">

<img width="700" alt="Screenshot 2024-11-20 at 4 23 04 PM" src="https://github.com/user-attachments/assets/710460a7-ec0b-430e-9854-b25c2ef572aa">

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
