### PR TITLE
Reader: Add search directly to the menu

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarListsSection.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarListsSection.swift
@@ -12,15 +12,21 @@ struct ReaderSidebarListsSection: View {
     private var lists: FetchedResults<ReaderListTopic>
 
     var body: some View {
-        ForEach(lists, id: \.self) { list in
-            Label {
-                Text(list.title)
-                    .lineLimit(1)
-            } icon: {
-                Image(systemName: "list.star")
-                    .foregroundStyle(.secondary)
-            }
-            .tag(ReaderSidebarItem.list(TaggedManagedObjectID(list)))
+        ForEach(lists, id: \.self, content: ReaderSidebarListCell.init)
+    }
+}
+
+struct ReaderSidebarListCell: View {
+    let list: ReaderListTopic
+
+    var body: some View {
+        Label {
+            Text(list.title)
+                .lineLimit(1)
+        } icon: {
+            Image(systemName: "list.star")
+                .foregroundStyle(.secondary)
         }
+        .tag(ReaderSidebarItem.list(TaggedManagedObjectID(list)))
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSearchResultsView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSearchResultsView.swift
@@ -1,0 +1,32 @@
+import SwiftUI
+
+struct ReaderSidebarSearchResultsView: View {
+    let searchText: String
+
+    @FetchRequest(
+        sortDescriptors: [SortDescriptor(\.title, order: .forward)],
+        predicate: NSPredicate(format: "following = YES")
+    )
+    private var topics: FetchedResults<ReaderAbstractTopic>
+
+    var body: some View {
+        ForEach(filteredTopics(), id: \.objectID) {
+            switch $0 {
+            case let site as ReaderSiteTopic:
+                ReaderSidebarSubscriptionCell(site: site)
+            case let list as ReaderListTopic:
+                ReaderSidebarListCell(list: list)
+            default:
+                EmptyView()
+            }
+        }
+    }
+
+    private func filteredTopics() -> [ReaderAbstractTopic] {
+        let searchText = searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !searchText.isEmpty else {
+            return []
+        }
+        return topics.search(searchText, using: \.title)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarViewController.swift
@@ -72,6 +72,8 @@ private struct ReaderSidebarView: View {
     )
     private var favorites: FetchedResults<ReaderSiteTopic>
 
+    @State private var searchText = ""
+
     @Environment(\.layoutDirection) var layoutDirection
     @Environment(\.editMode) var editMode
 
@@ -79,6 +81,7 @@ private struct ReaderSidebarView: View {
 
     var body: some View {
         list
+            .searchable(text: $searchText)
             .toolbar {
                 EditButton()
             }
@@ -106,6 +109,15 @@ private struct ReaderSidebarView: View {
 
     @ViewBuilder
     private var content: some View {
+        if !searchText.isEmpty {
+            ReaderSidebarSearchResultsView(searchText: searchText)
+        } else {
+            regularContent
+        }
+    }
+
+    @ViewBuilder
+    private var regularContent: some View {
         Section {
             let screens = ReaderStaticScreen.allCases
             ForEach(ReaderStaticScreen.allCases) {


### PR DESCRIPTION
Add a way to quickly search your sites directly from the menu.

The only thing I don't particular like is that the search appears by default on iPad (no scrolling needed). It can be a bit confusing next to a "global" search, but I think it's an acceptable trade-off.

<img width="800" alt="Screenshot 2024-11-21 at 12 28 20 PM" src="https://github.com/user-attachments/assets/4d048fb9-f5d2-4484-aefd-037e29a09cbc">
<img width="320" alt="Screenshot 2024-11-21 at 12 28 30 PM" src="https://github.com/user-attachments/assets/4ddcb560-2d3b-474f-a282-462005219b1b">

https://github.com/user-attachments/assets/294ed0c7-b5e4-4014-94ca-98c610c15569



## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
