### PR TITLE
Reader: Fix an issue where tapping on post avatar opens post

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -226,6 +226,8 @@ private final class ReaderPostCellView: UIView {
         buttons.reblog.addTarget(self, action: #selector(buttonReblogTapped), for: .primaryActionTriggered)
         buttons.comment.addTarget(self, action: #selector(buttonCommentTapped), for: .primaryActionTriggered)
         buttons.like.addTarget(self, action: #selector(buttonLikeTapped), for: .primaryActionTriggered)
+
+        avatarView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: buttonAuthorTapped))
     }
 
     @objc private func buttonAuthorTapped() {

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -227,7 +227,7 @@ private final class ReaderPostCellView: UIView {
         buttons.comment.addTarget(self, action: #selector(buttonCommentTapped), for: .primaryActionTriggered)
         buttons.like.addTarget(self, action: #selector(buttonLikeTapped), for: .primaryActionTriggered)
 
-        avatarView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: buttonAuthorTapped))
+        avatarView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(buttonAuthorTapped)))
     }
 
     @objc private func buttonAuthorTapped() {


### PR DESCRIPTION
Reader: Fix an issue where tapping on post avatar opens post (should open site)

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
