### PR TITLE
Reader: Hide toolbar for AFK posts

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import UIKit
 import Combine
+import WordPressShared
 
 final class ReaderPostCell: ReaderStreamBaseCell {
     private let view = ReaderPostCellView()
@@ -71,6 +72,7 @@ private final class ReaderPostCellView: UIView {
     let imageView = ImageView()
 
     // Footer
+    private lazy var toolbarView = UIStackView(buttons.allButtons)
     let buttons = ReaderPostToolbarButtons()
 
     private lazy var postPreview = UIStackView(axis: .vertical, alignment: .leading, spacing: 12, [
@@ -89,6 +91,7 @@ private final class ReaderPostCellView: UIView {
 
     private var viewModel: ReaderPostCellViewModel? // important: has to retain
 
+    private var toolbarViewHeightConstraint: NSLayoutConstraint?
     private var imageViewConstraints: [NSLayoutConstraint] = []
     private var cancellables: [AnyCancellable] = []
 
@@ -106,6 +109,11 @@ private final class ReaderPostCellView: UIView {
     }
 
     func prepareForReuse() {
+        if let constraint = toolbarViewHeightConstraint {
+            constraint.isActive = false
+            toolbarView.isHidden = false
+            toolbarViewHeightConstraint = nil
+        }
         cancellables = []
         avatarView.prepareForReuse()
         imageView.prepareForReuse()
@@ -141,7 +149,6 @@ private final class ReaderPostCellView: UIView {
         // These seems to be an issue with `lineBreakMode` in `UIButton.Configuration`
         // and `.firstLineBaseline`, so reserving to `.center`.
         let headerView = UIStackView(alignment: .center, [buttonAuthor, dot, timeLabel])
-        let toolbarView = UIStackView(buttons.allButtons)
 
         for view in [avatarView, headerView, postPreview, buttonMore, toolbarView] {
             addSubview(view)
@@ -292,8 +299,15 @@ private final class ReaderPostCellView: UIView {
             imageView.setImage(with: imageURL, size: preferredCoverSize)
         }
 
-        configureToolbar(with: viewModel.toolbar)
-        configureToolbarAccessibility(with: viewModel.toolbar)
+        if !viewModel.isToolbarHidden {
+            configureToolbar(with: viewModel.toolbar)
+            configureToolbarAccessibility(with: viewModel.toolbar)
+        } else {
+            let constraint = toolbarView.heightAnchor.constraint(equalToConstant: 12)
+            constraint.isActive = true
+            toolbarView.isHidden = true
+            toolbarViewHeightConstraint = constraint
+        }
     }
 
     private var preferredCoverSize: CGSize? {

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCellViewModel.swift
@@ -12,6 +12,7 @@ final class ReaderPostCellViewModel {
     let imageURL: URL?
 
     // Footer (Buttons)
+    private(set) var isToolbarHidden = false
     let toolbar: ReaderPostToolbarViewModel
 
     weak var viewController: ReaderStreamViewController?
@@ -36,7 +37,11 @@ final class ReaderPostCellViewModel {
         self.title = post.titleForDisplay() ?? ""
         self.details = post.contentPreviewForDisplay() ?? ""
         self.imageURL = post.featuredImageURLForDisplay()
+
         self.toolbar = ReaderPostToolbarViewModel.make(post: post)
+        if isP2 && post.primaryTag == "afk" {
+            self.isToolbarHidden = true
+        }
 
         if isP2 {
             self.avatarURL = post.authorAvatarURL.flatMap(URL.init)


### PR DESCRIPTION
A small QoL improvement to avoid showing a wall of buttons you never want to tap anyway. If you _really_ want to, you can still do that from the details screen.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
