### PR TITLE
Present `WpApiError.errorMessage` instead of `localizedDescription`

### DIFF
--- a/WordPress/Classes/ApplicationToken/ApplicationTokenListView.swift
+++ b/WordPress/Classes/ApplicationToken/ApplicationTokenListView.swift
@@ -92,22 +92,6 @@ class ApplicationTokenListViewModel: ObservableObject {
     }
 }
 
-private extension WpApiError {
-    var errorMessage: String {
-        switch self {
-        case .InvalidHttpStatusCode, .SiteUrlParsingError, .UnknownError:
-            return NSLocalizedString("Something went wrong", comment: "A generic error message")
-        case let .RequestExecutionFailed(_, reason):
-            return reason
-        case .ResponseParsingError:
-            return NSLocalizedString("generic.error.unparsableResponse", value: "Your site sent a response that the app could not parse", comment: "Error message when failing to parse API responses")
-        case let .WpError(_, errorMessage, _, _):
-            let format = NSLocalizedString("generic.error.rest-api-error", value: "Your site sent an error response: %@", comment: "Error message format when REST API returns an error response. The first argument is error message.")
-            return String(format: format, errorMessage)
-        }
-    }
-}
-
 // MARK: - Localization
 
 extension ApplicationTokenListView {

--- a/WordPress/Classes/Extensions/WpApiError+Localized.swift
+++ b/WordPress/Classes/Extensions/WpApiError+Localized.swift
@@ -1,0 +1,20 @@
+import Foundation
+import WordPressAPI
+
+/// `WpApiError` confirms to `LocalizedError`, but with an implementation that's not suitable for displaying on UI.
+/// When presenting `WpApiError`, we should use the `errorMessage` function instead of `localizedDescription`.
+extension WpApiError {
+    var errorMessage: String {
+        switch self {
+        case .InvalidHttpStatusCode, .SiteUrlParsingError, .UnknownError:
+            return NSLocalizedString("Something went wrong", comment: "A generic error message")
+        case let .RequestExecutionFailed(_, reason):
+            return reason
+        case .ResponseParsingError:
+            return NSLocalizedString("generic.error.unparsableResponse", value: "Your site sent a response that the app could not parse", comment: "Error message when failing to parse API responses")
+        case let .WpError(_, errorMessage, _, _):
+            let format = NSLocalizedString("generic.error.rest-api-error", value: "Your site sent an error response: %@", comment: "Error message format when REST API returns an error response. The first argument is error message.")
+            return String(format: format, errorMessage)
+        }
+    }
+}

--- a/WordPress/Classes/Extensions/WpApiError+Localized.swift
+++ b/WordPress/Classes/Extensions/WpApiError+Localized.swift
@@ -1,7 +1,7 @@
 import Foundation
 import WordPressAPI
 
-/// `WpApiError` confirms to `LocalizedError`, but with an implementation that's not suitable for displaying on UI.
+/// `WpApiError` conforms to `LocalizedError`, but with an implementation that's not suitable for displaying on UI.
 /// When presenting `WpApiError`, we should use the `errorMessage` function instead of `localizedDescription`.
 extension WpApiError {
     var errorMessage: String {

--- a/WordPress/Classes/Extensions/WpApiError+Localized.swift
+++ b/WordPress/Classes/Extensions/WpApiError+Localized.swift
@@ -7,7 +7,7 @@ extension WpApiError {
     var errorMessage: String {
         switch self {
         case .InvalidHttpStatusCode, .SiteUrlParsingError, .UnknownError:
-            return NSLocalizedString("Something went wrong", comment: "A generic error message")
+            return SharedStrings.Error.generic
         case let .RequestExecutionFailed(_, reason):
             return reason
         case .ResponseParsingError:

--- a/WordPress/Classes/Users/ViewModel/UserListViewModel.swift
+++ b/WordPress/Classes/Users/ViewModel/UserListViewModel.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import Combine
 import WordPressShared
+import WordPressAPI
 
 @MainActor
 class UserListViewModel: ObservableObject {
@@ -57,7 +58,7 @@ class UserListViewModel: ObservableObject {
     private(set) var sortedUsers: [Section] = []
 
     @Published
-    private(set) var error: Error? = nil
+    private(set) var error: String? = nil
 
     @Published
     var searchTerm: String = "" {
@@ -101,7 +102,7 @@ class UserListViewModel: ObservableObject {
             case let .success(users):
                 self.sortedUsers = self.sortUsers(users)
             case let .failure(error):
-                self.error = error
+                self.error = (error as? WpApiError)?.errorMessage ?? error.localizedDescription
             }
         }
     }
@@ -115,7 +116,7 @@ class UserListViewModel: ObservableObject {
             do {
                 try await userService.fetchUsers()
             } catch {
-                self.error = error
+                self.error = (error as? WpApiError)?.errorMessage ?? error.localizedDescription
             }
         }
 

--- a/WordPress/Classes/Users/Views/UserDetailsView.swift
+++ b/WordPress/Classes/Users/Views/UserDetailsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WordPressAPI
 
 struct UserDetailsView: View {
 
@@ -107,8 +108,7 @@ struct UserDetailsView: View {
                 Button(role: .cancel) {
                     presentPasswordAlert = false
                 } label: {
-                    // TODO: Replace with `SharedStrings.Button.cancel`
-                    Text(NSLocalizedString("shared.button.cancel", value: "Cancel", comment: "A shared button title used in different contexts"))
+                    Text(SharedStrings.Button.cancel)
                 }
             },
             message: {
@@ -299,8 +299,7 @@ private extension View {
             },
             message: { error in
                 Text(Strings.deleteUserErrorAlertMessage)
-                // TODO: Use appropriate localized error message
-                Text(error.localizedDescription)
+                Text((error as? WpApiError)?.errorMessage ?? error.localizedDescription)
             })
     }
 }

--- a/WordPress/Classes/Users/Views/UserListView.swift
+++ b/WordPress/Classes/Users/Views/UserListView.swift
@@ -23,7 +23,7 @@ public struct UserListView: View {
 
             Group {
                 if let error = viewModel.error {
-                    EmptyStateView(error.localizedDescription, systemImage: "exclamationmark.triangle.fill")
+                    EmptyStateView(error, systemImage: "exclamationmark.triangle.fill")
                 } else {
                     List(viewModel.sortedUsers) { section in
                         Section(section.headerText) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -113,7 +113,8 @@ extension BlogDetailsViewController {
     }
 
     @objc func shouldAddUsersRow() -> Bool {
-        FeatureFlag.selfHostedSiteUserManagement.enabled && blog.isSelfHosted
+        // Only admin users can list users.
+        FeatureFlag.selfHostedSiteUserManagement.enabled && blog.isSelfHosted && blog.isAdmin
     }
 
     @objc func shouldAddPluginsRow() -> Bool {


### PR DESCRIPTION
What says in the title.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
