### PR TITLE
Declare WordPressClient as class instead of actor

### DIFF
--- a/WordPress/Classes/Networking/WordPressClient.swift
+++ b/WordPress/Classes/Networking/WordPressClient.swift
@@ -29,7 +29,7 @@ struct WordPressSite {
     }
 }
 
-actor WordPressClient {
+final class WordPressClient {
 
     enum ReachabilityStatus {
         case unknown
@@ -45,7 +45,7 @@ actor WordPressClient {
         self.rootUrl = rootUrl.url()
     }
 
-    init(site: WordPressSite) {
+    convenience init(site: WordPressSite) {
         // `site.barUrl` is a legal HTTP URL, which should be convertable to the `ParsedUrl` type.
         let parsedUrl: ParsedUrl
         do {


### PR DESCRIPTION
WordPressClient has immutable stored properties, and does not have to be an actor.

This change gets rid of a few warnings.

> Non-sendable type 'WordPressAPI' in implicitly asynchronous access to
> actor-isolated property 'api' cannot cross actor boundary; this is an error
> in the Swift 6 language mode

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
