### PR TITLE
Move cached users from UserService to DataStore

### DIFF
--- a/WordPress/Classes/Users/InMemoryUserDataStore.swift
+++ b/WordPress/Classes/Users/InMemoryUserDataStore.swift
@@ -1,0 +1,33 @@
+import Foundation
+import Combine
+
+public actor InMemoryUserDataStore: UserDataStore, InMemoryDataStore {
+    public typealias T = DisplayUser
+
+    public var storage: [T.ID: T] = [:]
+    public let updates: PassthroughSubject<Set<T.ID>, Never> = .init()
+
+    deinit {
+        updates.send(completion: .finished)
+    }
+
+    public func list(query: Query) throws -> [T] {
+        switch query {
+        case .all:
+            return Array(storage.values)
+        case let .id(ids):
+            return storage.reduce(into: []) {
+                if ids.contains($1.key) {
+                    $0.append($1.value)
+                }
+            }
+        case let .search(keyword):
+            let theKeyword = keyword.trimmingCharacters(in: .whitespacesAndNewlines)
+            if theKeyword.isEmpty {
+                return Array(storage.values)
+            } else {
+                return storage.values.search(theKeyword, using: \.searchString)
+            }
+        }
+    }
+}

--- a/WordPress/Classes/Users/UserProvider.swift
+++ b/WordPress/Classes/Users/UserProvider.swift
@@ -1,11 +1,19 @@
 import Foundation
 import Combine
 
-public protocol UserServiceProtocol: Actor {
-    var users: [DisplayUser]? { get }
-    nonisolated var usersUpdates: AsyncStream<[DisplayUser]> { get }
+public protocol UserDataStore: DataStore where T == DisplayUser, Query == UserDataStoreQuery {
+}
 
-    func fetchUsers() async throws -> [DisplayUser]
+public enum UserDataStoreQuery: Equatable {
+    case all
+    case id(Set<DisplayUser.ID>)
+    case search(String)
+}
+
+public protocol UserServiceProtocol: Actor {
+    var dataStore: any UserDataStore { get }
+
+    func fetchUsers() async throws
 
     func isCurrentUserCapableOf(_ capability: String) async -> Bool
 
@@ -24,6 +32,11 @@ actor MockUserProvider: UserServiceProtocol {
 
     var scenario: Scenario
 
+    private let _dataStore: InMemoryUserDataStore = .init()
+    var dataStore: any UserDataStore {
+        _dataStore
+    }
+
     nonisolated let usersUpdates: AsyncStream<[DisplayUser]>
     private let usersUpdatesContinuation: AsyncStream<[DisplayUser]>.Continuation
 
@@ -40,18 +53,17 @@ actor MockUserProvider: UserServiceProtocol {
         (usersUpdates, usersUpdatesContinuation) = AsyncStream<[DisplayUser]>.makeStream()
     }
 
-    func fetchUsers() async throws -> [DisplayUser] {
+    func fetchUsers() async throws {
         switch scenario {
         case .infinitLoading:
             // Do nothing
             try await Task.sleep(for: .seconds(24 * 60 * 60))
-            return []
         case .dummyData:
             let dummyDataUrl = URL(string: "https://my.api.mockaroo.com/users.json?key=067c9730")!
             let response = try await URLSession.shared.data(from: dummyDataUrl)
             let users = try JSONDecoder().decode([DisplayUser].self, from: response.0)
-            self.users = users
-            return users
+            try await _dataStore.delete(query: .all)
+            try await _dataStore.store(users)
         case .error:
             throw URLError(.timedOut)
         }

--- a/WordPress/Classes/Users/Views/DeleteUserConfirmationSheet.swift
+++ b/WordPress/Classes/Users/Views/DeleteUserConfirmationSheet.swift
@@ -16,15 +16,9 @@ struct DeleteUserConfirmationSheet: View {
         NavigationView {
             Form {
                 Section {
-                    if deleteUserViewModel.isFetchingOtherUsers {
-                        LabeledContent(Strings.attributeContentToUserLabel) {
-                            ProgressView()
-                        }
-                    } else {
-                        Picker(Strings.attributeContentToUserLabel, selection: $deleteUserViewModel.selectedUser) {
-                            ForEach(deleteUserViewModel.otherUsers) { user in
-                                Text("\(user.displayName) (\(user.username))").tag(user)
-                            }
+                    Picker(Strings.attributeContentToUserLabel, selection: $deleteUserViewModel.selectedUser) {
+                        ForEach(deleteUserViewModel.otherUsers) { user in
+                            Text("\(user.displayName) (\(user.username))").tag(user)
                         }
                     }
                 } header: {
@@ -53,7 +47,6 @@ struct DeleteUserConfirmationSheet: View {
                     } label: {
                         Text(Strings.attributeContentConfirmationDeleteButton)
                     }
-                    .disabled(deleteUserViewModel.deleteButtonIsDisabled)
                 }
             }
             .onAppear {

--- a/WordPress/Classes/Users/Views/UserListView.swift
+++ b/WordPress/Classes/Users/Views/UserListView.swift
@@ -24,8 +24,6 @@ public struct UserListView: View {
             Group {
                 if let error = viewModel.error {
                     EmptyStateView(error.localizedDescription, systemImage: "exclamationmark.triangle.fill")
-                } else if viewModel.isLoadingItems {
-                    ProgressView()
                 } else {
                     List(viewModel.sortedUsers) { section in
                         Section(section.headerText) {
@@ -49,6 +47,20 @@ public struct UserListView: View {
             }
         }
         .navigationTitle(Strings.usersListTitle)
+        .toolbar {
+            ToolbarItem(placement: .principal) {
+                HStack {
+                    if viewModel.isRefreshing {
+                        ProgressView()
+                    }
+                    Text(Strings.usersListTitle)
+                        .font(.headline)
+                }
+            }
+        }
+        .task(id: viewModel.query) {
+            await viewModel.performQuery()
+        }
         .task { await viewModel.onAppear() }
     }
 

--- a/WordPress/Classes/Utility/DataStore/DataStore.swift
+++ b/WordPress/Classes/Utility/DataStore/DataStore.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// An abstraction of local data storage, with CRUD operations.
+public protocol DataStore: Actor {
+    associatedtype T: Identifiable & Sendable
+    associatedtype Query
+
+    func list(query: Query) async throws -> [T]
+    func delete(query: Query) async throws
+    func store(_ data: [T]) async throws
+
+    /// An AsyncStream that produces up-to-date results for the given query.
+    ///
+    /// The `AsyncStream` should not finish as long as the `DataStore` remains alive and valid.
+    func listStream(query: Query) -> AsyncStream<Result<[T], Error>>
+}

--- a/WordPress/Classes/Utility/DataStore/InMemoryDataStore.swift
+++ b/WordPress/Classes/Utility/DataStore/InMemoryDataStore.swift
@@ -1,0 +1,70 @@
+import Foundation
+import Combine
+
+/// A `DataStore` type that stores data in memory.
+public protocol InMemoryDataStore: DataStore {
+    /// A `Dictionary` to store the data in memory.
+    var storage: [T.ID: T] { get set }
+
+    /// A publisher for sending and subscribing data changes.
+    ///
+    /// The publisher emits events when data changes, with identifiers of changed models.
+    ///
+    /// The publisher does not complete as long as the `InMemoryDataStore` remains alive and valid.
+    var updates: PassthroughSubject<Set<T.ID>, Never> { get }
+}
+
+public extension InMemoryDataStore {
+    func delete(query: Query) async throws {
+        var updated = Set<T.ID>()
+        let result = try await list(query: query)
+        result.forEach {
+            if storage.removeValue(forKey: $0.id) != nil {
+                updated.insert($0.id)
+            }
+        }
+
+        if !updated.isEmpty {
+            updates.send(updated)
+        }
+    }
+
+    func store(_ data: [T]) async throws {
+        var updated = Set<T.ID>()
+        data.forEach {
+            updated.insert($0.id)
+            self.storage[$0.id] = $0
+        }
+
+        if !updated.isEmpty {
+            updates.send(updated)
+        }
+    }
+
+    func listStream(query: Query) -> AsyncStream<Result<[T], Error>> {
+        let stream = AsyncStream<Result<[T], Error>>.makeStream()
+
+        let updatingTask = Task { [weak self] in
+            var iter = await self?.updates.values.makeAsyncIterator()
+            repeat {
+                guard let self else { break }
+                do {
+                    let result = try await self.list(query: query)
+                    stream.continuation.yield(.success(result))
+                } catch {
+                    stream.continuation.yield(.failure(error))
+                }
+            } while await iter?.next() != nil && !Task.isCancelled
+
+            stream.continuation.finish()
+        }
+
+        stream.continuation.onTermination = {
+            if case .cancelled = $0 {
+                updatingTask.cancel()
+            }
+        }
+
+        return stream.stream
+    }
+}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -441,6 +441,7 @@
 		4A266B91282B13A70089CF3D /* CoreDataTestCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A266B90282B13A70089CF3D /* CoreDataTestCase.swift */; };
 		4A2C73E42A943DEA00ACE79E /* TaggedManagedObjectIDTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C73E32A943DEA00ACE79E /* TaggedManagedObjectIDTests.swift */; };
 		4A2C73F72A9585B000ACE79E /* PostRepositoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2C73F62A9585B000ACE79E /* PostRepositoryTests.swift */; };
+		4A2ED63B2CF86A0E009E0821 /* DataStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A2ED63A2CF86A0E009E0821 /* DataStoreTests.swift */; };
 		4A5598852B05AC180083C220 /* PagesListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5598842B05AC180083C220 /* PagesListTests.swift */; };
 		4A5EDD812CE58B9900A605FC /* ZendeskUtilsTests+A8CEmail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A5EDD802CE58B9900A605FC /* ZendeskUtilsTests+A8CEmail.swift */; };
 		4A690C152BA791B100A8E0C5 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 4A690C142BA790BC00A8E0C5 /* PrivacyInfo.xcprivacy */; };
@@ -2332,6 +2333,7 @@
 		4A266B90282B13A70089CF3D /* CoreDataTestCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataTestCase.swift; sourceTree = "<group>"; };
 		4A2C73E32A943DEA00ACE79E /* TaggedManagedObjectIDTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaggedManagedObjectIDTests.swift; sourceTree = "<group>"; };
 		4A2C73F62A9585B000ACE79E /* PostRepositoryTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostRepositoryTests.swift; sourceTree = "<group>"; };
+		4A2ED63A2CF86A0E009E0821 /* DataStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DataStoreTests.swift; sourceTree = "<group>"; };
 		4A2F746A2C2198CB00E72117 /* WordPressAuthenticatorTests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = WordPressAuthenticatorTests.xcconfig; sourceTree = "<group>"; };
 		4A5598842B05AC180083C220 /* PagesListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PagesListTests.swift; sourceTree = "<group>"; };
 		4A5EDD802CE58B9900A605FC /* ZendeskUtilsTests+A8CEmail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "ZendeskUtilsTests+A8CEmail.swift"; sourceTree = "<group>"; };
@@ -6061,6 +6063,7 @@
 				4AD862E42AFAEF1700A07557 /* PostsListAPIStub.swift */,
 				0C1DB60A2B0A9A570028F200 /* ImageDownloaderTests.swift */,
 				4A5598842B05AC180083C220 /* PagesListTests.swift */,
+				4A2ED63A2CF86A0E009E0821 /* DataStoreTests.swift */,
 				93B853211B44165B0064FE72 /* Analytics */,
 				DC06DFF727BD52A100969974 /* BackgroundTasks */,
 				FE32E7EF284496F500744D80 /* Blogging Prompts */,
@@ -10348,6 +10351,7 @@
 				019D699E2A5EA963003B676D /* RootViewCoordinatorTests.swift in Sources */,
 				B09879792B5730BC0048256D /* StatsTrafficDatePickerViewModelTests.swift in Sources */,
 				D821C81B21003AE9002ED995 /* FormattableContentGroupTests.swift in Sources */,
+				4A2ED63B2CF86A0E009E0821 /* DataStoreTests.swift in Sources */,
 				93D86B981C691E71003D8E3E /* LocalCoreDataServiceTests.m in Sources */,
 				0CD6299B2B9AAA9A00325EA4 /* Foundation+Extensions.swift in Sources */,
 				1DF7A0D32BA0B1810003CBA3 /* GutenbergContentParser.swift in Sources */,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -456,7 +456,7 @@
 		4A76A4BB29D4381100AABF4B /* CommentService+LikesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A76A4BA29D4381000AABF4B /* CommentService+LikesTests.swift */; };
 		4A76A4BD29D43BFD00AABF4B /* CommentService+MorderationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A76A4BC29D43BFD00AABF4B /* CommentService+MorderationTests.swift */; };
 		4A76A4BF29D4F0A500AABF4B /* reader-post-comments-success.json in Resources */ = {isa = PBXBuildFile; fileRef = 4A76A4BE29D4F0A500AABF4B /* reader-post-comments-success.json */; };
-		4A76F9112CE207FA0025F7FA /* UserServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A76F9102CE207FA0025F7FA /* UserServiceTests.swift */; };
+		4A76F9112CE207FA0025F7FA /* UserListViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A76F9102CE207FA0025F7FA /* UserListViewModelTests.swift */; };
 		4A9314DC297790C300360232 /* PeopleServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9314DB297790C300360232 /* PeopleServiceTests.swift */; };
 		4A9948E229714EF1006282A9 /* AccountSettingsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9948E129714EF1006282A9 /* AccountSettingsServiceTests.swift */; };
 		4AA7EE0F2ADF7367007D261D /* PostRepositoryPostsListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AA7EE0E2ADF7367007D261D /* PostRepositoryPostsListTests.swift */; };
@@ -2344,7 +2344,7 @@
 		4A76A4BA29D4381000AABF4B /* CommentService+LikesTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CommentService+LikesTests.swift"; sourceTree = "<group>"; };
 		4A76A4BC29D43BFD00AABF4B /* CommentService+MorderationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "CommentService+MorderationTests.swift"; sourceTree = "<group>"; };
 		4A76A4BE29D4F0A500AABF4B /* reader-post-comments-success.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "reader-post-comments-success.json"; sourceTree = "<group>"; };
-		4A76F9102CE207FA0025F7FA /* UserServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserServiceTests.swift; sourceTree = "<group>"; };
+		4A76F9102CE207FA0025F7FA /* UserListViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserListViewModelTests.swift; sourceTree = "<group>"; };
 		4A9314DB297790C300360232 /* PeopleServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PeopleServiceTests.swift; sourceTree = "<group>"; };
 		4A98A9022C2274E100A2CE58 /* WordPressKitTests.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = WordPressKitTests.xcconfig; sourceTree = "<group>"; };
 		4A98A9032C2274E100A2CE58 /* WordPressKit.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = WordPressKit.xcconfig; sourceTree = "<group>"; };
@@ -6412,7 +6412,7 @@
 				4A9314DB297790C300360232 /* PeopleServiceTests.swift */,
 				FEAA6F78298CE4A600ADB44C /* PluginJetpackProxyServiceTests.swift */,
 				1D91080629F847A2003F9A5E /* MediaServiceUpdateTests.m */,
-				4A76F9102CE207FA0025F7FA /* UserServiceTests.swift */,
+				4A76F9102CE207FA0025F7FA /* UserListViewModelTests.swift */,
 			);
 			name = Services;
 			sourceTree = "<group>";
@@ -10197,7 +10197,7 @@
 				4AB6A3602B7C3EB500769115 /* PinghubWebSocketTests.swift in Sources */,
 				F46546352AF550A20017E3D1 /* AllDomainsListItem+Helpers.swift in Sources */,
 				FEA312842987FB0100FFD405 /* BlogJetpackTests.swift in Sources */,
-				4A76F9112CE207FA0025F7FA /* UserServiceTests.swift in Sources */,
+				4A76F9112CE207FA0025F7FA /* UserListViewModelTests.swift in Sources */,
 				0C35FFF429CBA6DA00D224EB /* BlogDashboardPersonalizationViewModelTests.swift in Sources */,
 				7E8980B922E73F4000C567B0 /* EditorSettingsServiceTests.swift in Sources */,
 				1797373720EBAA4100377B4E /* RouteMatcherTests.swift in Sources */,

--- a/WordPress/WordPressTest/DataStoreTests.swift
+++ b/WordPress/WordPressTest/DataStoreTests.swift
@@ -1,0 +1,75 @@
+import Foundation
+import Testing
+
+@testable import WordPress
+
+@Suite(.timeLimit(.minutes(1)))
+struct InMemoryDataStoreTests {
+
+    @Test
+    func testUpdatesAfterCreation() async {
+        let store: InMemoryUserDataStore = InMemoryUserDataStore()
+        let stream = await store.listStream(query: .all)
+
+        await confirmation("The stream produces an update") { confirmation in
+            for await _ in stream.prefix(1) {
+                confirmation()
+            }
+        }
+    }
+
+    @Test
+    func testUpdatesAfterStore() async {
+        let store: InMemoryUserDataStore = InMemoryUserDataStore()
+        let stream = await store.listStream(query: .all)
+
+        Task.detached {
+            try await Task.sleep(for: .milliseconds(50))
+            try await store.store([.MockUser])
+        }
+
+        await confirmation("The stream produces an update", expectedCount: 2) { confirmation in
+            for await _ in stream.prefix(2) {
+                confirmation()
+            }
+        }
+    }
+
+    @Test
+    func testUpdatesAfterDelete() async throws {
+        let store: InMemoryUserDataStore = InMemoryUserDataStore()
+        try await store.store([.MockUser])
+
+        let stream = await store.listStream(query: .all)
+
+        Task.detached {
+            try await Task.sleep(for: .milliseconds(50))
+            try await store.delete(query: .all)
+        }
+
+        await confirmation("The stream produces an update", expectedCount: 2) { confirmation in
+            for await _ in stream.prefix(2) {
+                confirmation()
+            }
+        }
+    }
+
+    @Test
+    func testStreamTerminates() async {
+        var store: InMemoryUserDataStore? = InMemoryUserDataStore()
+        let stream = await store!.listStream(query: .all)
+
+        Task.detached {
+            try await Task.sleep(for: .milliseconds(50))
+            store = nil
+        }
+
+        await confirmation("The stream produces one update and then terminates", expectedCount: 1) { confirmation in
+            for await _ in stream {
+                // Do nothing
+            }
+            confirmation()
+        }
+    }
+
+}


### PR DESCRIPTION
At the moment, we don't use database to store users fetched from REST API, since there should not be too many users in a site and "caching" them in memory is good enough.

The cache exists in the `UserService` as a plain array `users: [DisplayUser]`. This PR extracts that out into a dedicated type, so that we have a bit of structure here to give different types clearer responsibilities.

The new type is called `DataStore`, which has a few simple CRUD functions. Most importantly, similar to `@FetchedResult` and `NSFetchedResultController`, it publishes modal updates via AsyncStream, so that the view can be in-sync with stored data.

At the moment, there is only a `InMemoryDataStore` implementation of `DataStore`, which is used in users, and very likely to be used for plugins in the future. In theory, we can have more implementation, like file based, sqlite based, or Core Data based.

We have a few components in play here. This diagram shows how they interact with each other:

```mermaid
classDiagram
    direction LR
    class SwiftUI.View {
    }
    class ViewModel {
        +@Published properties
        +service
    }
    class Service {
        + dataStore
        + fetchFromRESTAPI()
    }
    class DataStore~Model~ {
        +list() [Model]
        +store(...)
        +delete(...)
        +listStream(...) [AsyncStream]
    }
    <<protocol>> DataStore
    class InMemoryDataStore
    <<protocol>> InMemoryDataStore
    DataStore <|-- InMemoryDataStore
    class InMemoryUserDataStore
    InMemoryDataStore <|-- InMemoryUserDataStore

    SwiftUI.View --o ViewModel: @Published properties
    SwiftUI.View --o ViewModel: .task(...) modifier to subscribe to DataStore updates
    ViewModel --o Service
    Service --o DataStore
    ViewModel "via Service" --o DataStore: subscribes to updates using AsyncStream

```

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
