### PR TITLE
build: Download GutenbergKit artifacts via the Swift plugin

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20241116"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "v0.0.2"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "3c5373483f8cce0807d90c6e8143d61ab6294ea1"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -162,6 +162,8 @@ enum XcodeSupport {
                 .product(name: "ZIPFoundation", package: "ZIPFoundation"),
                 .product(name: "WordPressAPI", package: "wordpress-rs"),
                 .product(name: "ColorStudio", package: "color-studio"),
+            ], plugins: [
+                .plugin(name: "GutenbergKitPlugin", package: "GutenbergKit"),
             ]),
             .xcodeTarget("XcodeTarget_WordPressTests", dependencies: testDependencies + [
                 "WordPressShared",
@@ -197,7 +199,7 @@ enum XcodeSupport {
 }
 
 extension Target {
-    static func xcodeTarget(_ name: String, dependencies: [Dependency]) -> Target {
-        .target(name: name, dependencies: dependencies, path: "Sources/XcodeSupport/\(name)")
+    static func xcodeTarget(_ name: String, dependencies: [Dependency], plugins: [Target.PluginUsage] = []) -> Target {
+        .target(name: name, dependencies: dependencies, path: "Sources/XcodeSupport/\(name)", plugins: plugins)
     }
 }

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20241116"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "3c5373483f8cce0807d90c6e8143d61ab6294ea1"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "9f833599b9173c24253af9e2126ae2b9b4c6b413"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "3c5373483f8cce0807d90c6e8143d61ab6294ea1"
+        "revision" : "9f833599b9173c24253af9e2126ae2b9b4c6b413"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -149,8 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "branch" : "v0.0.2",
-        "revision" : "44b187993e6473cf0e4ef49516ca9de7fb5a4414"
+        "revision" : "3c5373483f8cce0807d90c6e8143d61ab6294ea1"
       }
     },
     {


### PR DESCRIPTION
## Related

- https://github.com/wordpress-mobile/GutenbergKit/pull/45

## Description 

Update GutenbergKit integration to download artifacts via the Swift plugin.

To test: TBD

## Regression Notes
1. Potential unintended areas of impact
    TBD
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    TBD
3. What automated tests I added (or what prevented me from doing so)
    TBD

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
