### PR TITLE
Reader: Fix layout for cross-post cells on iPad

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderCrossPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderCrossPostCell.swift
@@ -1,8 +1,49 @@
 import Foundation
 import AutomatticTracks
 import WordPressShared
+import WordPressUI
 
 final class ReaderCrossPostCell: ReaderStreamBaseCell {
+    private let view = ReaderCrossPostView()
+    private var contentViewConstraints: [NSLayoutConstraint] = []
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        contentView.addSubview(view)
+        view.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            view.topAnchor.constraint(equalTo: contentView.topAnchor),
+            view.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).withPriority(999),
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("Not implemented")
+    }
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+
+        view.prepareForReuse()
+    }
+
+    func configure(with post: ReaderPost) {
+        view.configure(with: post)
+    }
+
+    override func didUpdateCompact(_ isCompact: Bool) {
+        setNeedsUpdateConstraints()
+    }
+
+    override func updateConstraints() {
+        NSLayoutConstraint.deactivate(contentViewConstraints)
+        contentViewConstraints = view.pinEdges(.horizontal, to: isCompact ? contentView : contentView.readableContentGuide)
+        super.updateConstraints()
+    }
+}
+
+private final class ReaderCrossPostView: UIView {
     private let avatarView = ReaderAvatarView()
     private let iconView = ReaderAvatarView()
     private let headerLabel = UILabel()
@@ -27,22 +68,18 @@ final class ReaderCrossPostCell: ReaderStreamBaseCell {
         .foregroundColor: UIColor.secondaryLabel
     ]
 
-    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
-        super.init(style: style, reuseIdentifier: reuseIdentifier)
+    override init(frame: CGRect) {
+        super.init(frame: frame)
 
         setupStyle()
         setupLayout()
-
-        selectedBackgroundView = ReaderPostCell.makeSelectedBackgroundView()
     }
 
     required init?(coder: NSCoder) {
         fatalError("Not implemented")
     }
 
-    override func prepareForReuse() {
-        super.prepareForReuse()
-
+    func prepareForReuse() {
         avatarView.prepareForReuse()
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -5,7 +5,6 @@ import WordPressShared
 
 final class ReaderPostCell: ReaderStreamBaseCell {
     private let view = ReaderPostCellView()
-
     private var contentViewConstraints: [NSLayoutConstraint] = []
 
     static let avatarSize: CGFloat = SiteIconViewModel.Size.small.width
@@ -21,12 +20,6 @@ final class ReaderPostCell: ReaderStreamBaseCell {
             view.topAnchor.constraint(equalTo: contentView.topAnchor),
             view.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).withPriority(999),
         ])
-    }
-
-    static func makeSelectedBackgroundView() -> UIView {
-        let view = UIView()
-        view.backgroundColor = UIColor.opaqueSeparator.withAlphaComponent(0.2)
-        return view
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
There was an issue with the layout of these cells on iPad, presumably a result of an automatic merge of a bunch of the previous PRs. I fixed it by adopting the same implementation as in ReaderPostCell.

Not sharing the screenshots because it's P2-only.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
