### PR TITLE
Enable quick access to notifications from Reader

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,8 @@
 * [*] [internal] Update Gravatar SDK to 3.0.0 [#23701]
 * [*] Use the Gravatar Quick Editor to update the avatar [#23729]
 * [*] (Hidden under a feature flag) User Management for self-hosted sites. [#23768]
+* [*] Enable quick access to notifications from Reader on iPad [#23882]
+* [*] Add support for restricted posts in Reader [#23853]
 
 25.5
 -----

--- a/WordPress/Classes/System/Root View/ReaderPresenter.swift
+++ b/WordPress/Classes/System/Root View/ReaderPresenter.swift
@@ -122,13 +122,17 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
                 if screen == .discover {
                     return ReaderDiscoverViewController(topic: topic)
                 } else {
-                    return ReaderStreamViewController.controllerWithTopic(topic)
+                    let streamVC = ReaderStreamViewController.controllerWithTopic(topic)
+                    streamVC.isNotificationsBarButtonEnabled = true
+                    return streamVC
                 }
             } else {
                 return makeErrorViewController() // This should never happen
             }
         case .saved:
-            return ReaderStreamViewController.controllerForContentType(.saved)
+            let streamVC = ReaderStreamViewController.controllerForContentType(.saved)
+            streamVC.isNotificationsBarButtonEnabled = true
+            return streamVC
         case .search:
             return ReaderSearchViewController()
         }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -286,33 +286,15 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         navigationController?.navigationBar.accessibilityIdentifier = "my-site-navigation-bar"
 
         if isSidebarModeEnabled {
-            navigationItem.rightBarButtonItems = makeRegularClassSizeNavigationItems()
-
-            notificationsButtonViewModel.$image.dropFirst()
-                .receive(on: DispatchQueue.main) // Skip on hop
-                .sink { [weak self] _ in
-                    guard let self else { return }
-                    self.navigationItem.rightBarButtonItems = self.makeRegularClassSizeNavigationItems()
-                }.store(in: &cancellables)
+            notificationsButtonViewModel.$image.sink { [weak self] in
+                guard let self else { return }
+                self.navigationItem.rightBarButtonItem = UIBarButtonItem(image: $0, style: .plain, target: self, action: #selector(buttonShowNotificationsTapped))
+            }.store(in: &cancellables)
         }
     }
 
-    private func makeRegularClassSizeNavigationItems() -> [UIBarButtonItem] {
-        return [
-            UIBarButtonItem(image: notificationsButtonViewModel.image, style: .plain, target: self, action: #selector(buttonShowNotificationsTapped))
-        ]
-    }
-
     @objc private func buttonShowNotificationsTapped(_ sender: UIBarButtonItem) {
-        let notificationsVC = UIStoryboard(name: "Notifications", bundle: nil).instantiateInitialViewController() as! NotificationsViewController
-        notificationsVC.isSidebarModeEnabled = true
-
-        let navigationVC = UINavigationController(rootViewController: notificationsVC)
-        navigationVC.modalPresentationStyle = .popover
-        navigationVC.preferredContentSize = CGSize(width: 375, height: 800)
-        navigationVC.popoverPresentationController?.sourceItem = sender
-        navigationVC.popoverPresentationController?.permittedArrowDirections = [.up]
-        present(navigationVC, animated: true)
+        NotificationsViewController.showInPopover(from: self, sourceItem: sender)
     }
 
     private func configureNavBarAppearance(animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -117,6 +117,18 @@ class NotificationsViewController: UIViewController, UITableViewDataSource, UITa
 
     // MARK: - View Lifecycle
 
+    static func showInPopover(from presentingVC: UIViewController, sourceItem: UIPopoverPresentationControllerSourceItem) {
+        let notificationsVC = UIStoryboard(name: "Notifications", bundle: nil).instantiateInitialViewController() as! NotificationsViewController
+        notificationsVC.isSidebarModeEnabled = true
+
+        let navigationVC = UINavigationController(rootViewController: notificationsVC)
+        navigationVC.modalPresentationStyle = .popover
+        navigationVC.preferredContentSize = CGSize(width: 375, height: 800)
+        navigationVC.popoverPresentationController?.sourceItem = sourceItem
+        navigationVC.popoverPresentationController?.permittedArrowDirections = [.up]
+        presentingVC.present(navigationVC, animated: true)
+    }
+
     required init?(coder aDecoder: NSCoder) {
         super.init(coder: aDecoder)
 

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderDiscoverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderDiscoverViewController.swift
@@ -14,6 +14,8 @@ class ReaderDiscoverViewController: UIViewController, ReaderDiscoverHeaderViewDe
     private let tags: ManagedObjectsObserver<ReaderTagTopic>
     private let viewContext: NSManagedObjectContext
     private var cancellables: [AnyCancellable] = []
+    private let notificationsButtonViewModel = NotificationsButtonViewModel()
+    private var notificationsButtonCancellable: AnyCancellable?
 
     init(topic: ReaderAbstractTopic) {
         wpAssert(ReaderHelpers.topicIsDiscover(topic))
@@ -42,8 +44,29 @@ class ReaderDiscoverViewController: UIViewController, ReaderDiscoverHeaderViewDe
         showSelectInterestsIfNeeded()
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        setupNotificationsBarButtonItem()
+    }
+
     private func setupNavigation() {
         navigationItem.largeTitleDisplayMode = .never
+        setupNotificationsBarButtonItem()
+    }
+
+    private func setupNotificationsBarButtonItem() {
+        notificationsButtonCancellable = nil
+        if traitCollection.horizontalSizeClass == .regular {
+            notificationsButtonCancellable =         notificationsButtonViewModel.$image.sink { [weak self] in
+                guard let self else { return }
+                self.navigationItem.rightBarButtonItems = [UIBarButtonItem(image: $0, style: .plain, target: self, action: #selector(buttonShowNotificationsTapped))]
+            }
+        }
+    }
+
+    @objc private func buttonShowNotificationsTapped(_ sender: UIBarButtonItem) {
+        NotificationsViewController.showInPopover(from: self, sourceItem: sender)
     }
 
     private func setupHeaderView() {

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderDiscoverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderDiscoverViewController.swift
@@ -58,7 +58,7 @@ class ReaderDiscoverViewController: UIViewController, ReaderDiscoverHeaderViewDe
     private func setupNotificationsBarButtonItem() {
         notificationsButtonCancellable = nil
         if traitCollection.horizontalSizeClass == .regular {
-            notificationsButtonCancellable =         notificationsButtonViewModel.$image.sink { [weak self] in
+            notificationsButtonCancellable = notificationsButtonViewModel.$image.sink { [weak self] in
                 guard let self else { return }
                 self.navigationItem.rightBarButtonItems = [UIBarButtonItem(image: $0, style: .plain, target: self, action: #selector(buttonShowNotificationsTapped))]
             }

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
@@ -78,6 +78,8 @@ import AutomatticTracks
     private var didBumpStats = false
     @Lazy private var titleView = ReaderNavigationCustomTitleView()
     internal let scrollViewTranslationPublisher = PassthroughSubject<Bool, Never>()
+    private let notificationsButtonViewModel = NotificationsButtonViewModel()
+    private var notificationsButtonCancellable: AnyCancellable?
 
     /// Content management
     let content = ReaderTableContent()
@@ -176,6 +178,7 @@ import AutomatticTracks
     private var showConfirmation = true
 
     var isEmbeddedInDiscover = false
+    var isNotificationsBarButtonEnabled = false
     var preferredTableHeaderView: UIView?
 
     var isCompact = true {
@@ -350,11 +353,26 @@ import AutomatticTracks
         super.traitCollectionDidChange(previousTraitCollection)
 
         isCompact = traitCollection.horizontalSizeClass == .compact
+        setupNotificationsBarButtonItem()
     }
 
     private func didChangeIsCompact(_ isCompact: Bool) {
         (tableView.tableHeaderView as? ReaderBaseHeaderView)?.isCompact = isCompact
         tableView.reloadData()
+    }
+
+    private func setupNotificationsBarButtonItem() {
+        notificationsButtonCancellable = nil
+        if isNotificationsBarButtonEnabled && traitCollection.horizontalSizeClass == .regular {
+            notificationsButtonCancellable =         notificationsButtonViewModel.$image.sink { [weak self] in
+                guard let self else { return }
+                self.navigationItem.rightBarButtonItems = [UIBarButtonItem(image: $0, style: .plain, target: self, action: #selector(buttonShowNotificationsTapped))]
+            }
+        }
+    }
+
+    @objc private func buttonShowNotificationsTapped(_ sender: UIBarButtonItem) {
+        NotificationsViewController.showInPopover(from: self, sourceItem: sender)
     }
 
     // MARK: - Topic acquisition

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
@@ -364,7 +364,7 @@ import AutomatticTracks
     private func setupNotificationsBarButtonItem() {
         notificationsButtonCancellable = nil
         if isNotificationsBarButtonEnabled && traitCollection.horizontalSizeClass == .regular {
-            notificationsButtonCancellable =         notificationsButtonViewModel.$image.sink { [weak self] in
+            notificationsButtonCancellable = notificationsButtonViewModel.$image.sink { [weak self] in
                 guard let self else { return }
                 self.navigationItem.rightBarButtonItems = [UIBarButtonItem(image: $0, style: .plain, target: self, action: #selector(buttonShowNotificationsTapped))]
             }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23717 by adding the "Notifications" bell directly to the main Reader screens. If the app re-opens on one of these screens thanks to state restoration, you will see the bell regardless of whether the menu is opened or the orientation. The bell provides instant information: do I have any new notifications? It also allows you to glance over the newest notifications quickly.

<img width="1320" alt="Screenshot 2024-12-10 at 2 28 55 PM" src="https://github.com/user-attachments/assets/85effb04-ec5f-4aeb-b0da-8eaeee51179b">

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
