### PR TITLE
Update Blog.dotComID value if needed before saving

### DIFF
--- a/WordPress/Classes/Models/Blog/Blog.m
+++ b/WordPress/Classes/Models/Blog/Blog.m
@@ -97,6 +97,17 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 
 #pragma mark - NSManagedObject subclass methods
 
+- (void)willSave {
+    [super willSave];
+
+    // The `dotComID` getter has a speicial code to _update_ `blogID` value.
+    // This is a weird patch to make sure `blogID` is set to a correct value.
+    //
+    // It's important that calling `[self dotComID]` repeatedly only updates
+    // `Blog` instance once, which is the case at the moment.
+    [self dotComID];
+}
+
 - (void)prepareForDeletion
 {
     [super prepareForDeletion];

--- a/WordPress/WordPressTest/BlogBuilder.swift
+++ b/WordPress/WordPressTest/BlogBuilder.swift
@@ -11,15 +11,18 @@ final class BlogBuilder {
 
     private let context: NSManagedObjectContext
 
-    init(_ context: NSManagedObjectContext) {
+    init(_ context: NSManagedObjectContext, dotComID: NSNumber? = NSNumber(value: arc4random_uniform(999_999))) {
         self.context = context
 
         blog = NSEntityDescription.insertNewObject(forEntityName: Blog.entityName(), into: context) as! Blog
 
+        if let dotComID {
+            blog.dotComID = dotComID
+        }
+
         // Non-null properties in Core Data
-        blog.dotComID = NSNumber(value: arc4random_uniform(999_999))
-        blog.url = "https://\(blog.dotComID!).example.com"
-        blog.xmlrpc = "https://\(blog.dotComID!).example.com/xmlrpc.php"
+        blog.url = "https://\(blog.dotComID?.stringValue ?? "wwww").example.com"
+        blog.xmlrpc = "\(blog.url!)/xmlrpc.php"
     }
 
     func with(atomic: Bool) -> Self {

--- a/WordPress/WordPressTest/BlogTests.swift
+++ b/WordPress/WordPressTest/BlogTests.swift
@@ -289,4 +289,20 @@ final class BlogTests: CoreDataTestCase {
 
         XCTAssertEqual(try blog.wordPressClientParsedUrl().url(), "http://example.com/")
     }
+
+    func testDotComIdShouldBeJetpackSiteID() throws {
+        let blog = BlogBuilder(mainContext, dotComID: nil)
+            .set(blogOption: "jetpack_client_id", value: "123")
+            .build()
+        XCTAssertEqual(blog.jetpack?.siteID?.int64Value, 123)
+
+        try XCTAssertNil(Blog.lookup(withID: 123, in: mainContext))
+        try mainContext.save()
+
+        try XCTAssertNotNil(Blog.lookup(withID: 123, in: mainContext))
+
+        contextManager.performAndSave { context in
+            try? XCTAssertNotNil(Blog.lookup(withID: 123, in: context))
+        }
+    }
 }


### PR DESCRIPTION
## Issue

`Blog.blogID` could be 0, even though it's a dot com site and we know its site id from its jetpack info. This is an edge case that happens after a non-jetpack site is connected to jetpack.

https://github.com/wordpress-mobile/WordPress-iOS/blob/629899b89884529724cbf1b257bc3800f820af85/WordPress/Classes/Models/Blog/Blog.m#L765-L777

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
