### PR TITLE
iPad: Default to the displace mode

### DIFF
--- a/WordPress/Classes/System/Root View/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/Root View/SplitViewRootPresenter.swift
@@ -82,7 +82,7 @@ final class SplitViewRootPresenter: RootViewPresenter {
         case .notifications:
             splitVC.preferredSplitBehavior = .tile
         default:
-            splitVC.preferredSplitBehavior = .automatic
+            splitVC.preferredSplitBehavior = .displace
         }
 
         let content: SplitViewDisplayable


### PR DESCRIPTION
The app was originally designed to work with the `.displace` mode. The `.tile` behavior looks a bit rough and confusing. It turns out, the `.automatic` behavior switches to `.tile` quite often depending on the screen size, which we don't want.

**Before**

https://github.com/user-attachments/assets/08f235b3-a4f1-44f2-a75f-3f67b2efc249

**After**

https://github.com/user-attachments/assets/e218058a-8261-4cf0-8067-b219bba21707


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
