### PR TITLE
Add media URLs and entity IDs

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * [*] [internal] Update Gravatar SDK to 3.0.0 [#23701]
 * [*] Use the Gravatar Quick Editor to update the avatar [#23729]
 * [*] (Hidden under a feature flag) User Management for self-hosted sites. [#23768]
+* [*] Add URL and ID to the Media details screen, add IDs for posts [#23887]
 * [*] Enable quick access to notifications from Reader on iPad [#23882]
 * [*] Add support for restricted posts in Reader [#23853]
 * [*] Fix minor appearance issues in the Blaze campaign list [#23891]

--- a/WordPress/Classes/Utility/ImmuTable/WPImmuTableRows.swift
+++ b/WordPress/Classes/Utility/ImmuTable/WPImmuTableRows.swift
@@ -468,3 +468,17 @@ class ExpandableRow: ImmuTableRow {
         cell.urlCallback = onLinkTap
     }
 }
+
+struct TextViewRow: ImmuTableRow {
+    static var cell = ImmuTableCell.class(TextViewTableCell.self)
+
+    let title: String
+    let details: String
+    var action: ImmuTableAction?
+
+    func configureCell(_ cell: UITableViewCell) {
+        let cell = cell as! TextViewTableCell
+        cell.titleLabel.text = title
+        cell.detailsView.text = details
+    }
+}

--- a/WordPress/Classes/ViewRelated/Cells/TextViewTableCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/TextViewTableCell.swift
@@ -1,0 +1,27 @@
+import UIKit
+import WordPressUI
+
+final class TextViewTableCell: UITableViewCell {
+    let titleLabel = UILabel()
+    let detailsView = UITextView.makeLabel()
+
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        detailsView.textContainer.maximumNumberOfLines = 1
+        detailsView.textContainer.lineBreakMode = .byTruncatingMiddle
+        detailsView.textColor = .secondaryLabel
+        detailsView.font = .preferredFont(forTextStyle: .body)
+        detailsView.dataDetectorTypes = .link
+
+        titleLabel.setContentCompressionResistancePriority(.init(900), for: .horizontal)
+
+        let stackView = UIStackView(spacing: 3, [titleLabel, UIView(), detailsView])
+        contentView.addSubview(stackView)
+        stackView.pinEdges(to: contentView.layoutMarginsGuide)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Cells/TextViewTableCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/TextViewTableCell.swift
@@ -16,7 +16,7 @@ final class TextViewTableCell: UITableViewCell {
 
         titleLabel.setContentCompressionResistancePriority(.init(900), for: .horizontal)
 
-        let stackView = UIStackView(spacing: 3, [titleLabel, UIView(), detailsView])
+        let stackView = UIStackView(alignment: .firstBaseline, spacing: 3, [titleLabel, UIView(), detailsView])
         contentView.addSubview(stackView)
         stackView.pinEdges(to: contentView.layoutMarginsGuide)
     }

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -40,7 +40,7 @@ final class MediaItemViewController: UITableViewController {
         tableView.showsVerticalScrollIndicator = false
         tableView.cellLayoutMarginsFollowReadableWidth = true
 
-        ImmuTable.registerRows([TextRow.self, EditableTextRow.self], tableView: tableView)
+        ImmuTable.registerRows([TextRow.self, EditableTextRow.self, TextViewRow.self], tableView: tableView)
 
         updateViewModel()
         updateNavigationItem()
@@ -96,6 +96,7 @@ final class MediaItemViewController: UITableViewController {
         let presenter = MediaMetadataPresenter(media: media)
 
         var rows = [ImmuTableRow]()
+        rows.append(TextViewRow(title: Strings.url, details: media.remoteURL ?? ""))
         rows.append(TextRow(title: NSLocalizedString("File name", comment: "Label for the file name for a media asset (image / video)"), value: media.filename ?? ""))
         rows.append(TextRow(title: NSLocalizedString("File type", comment: "Label for the file type (.JPG, .PNG, etc) for a media asset (image / video)"), value: presenter.fileType ?? ""))
 
@@ -460,4 +461,8 @@ private struct MediaMetadata {
         media.desc = desc
         media.alt = alt
     }
+}
+
+private enum Strings {
+    static let url = NSLocalizedString("siteMedia.details.url", value: "URL", comment: "Title for the URL field")
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -45,6 +45,10 @@ final class MediaItemViewController: UITableViewController {
         updateViewModel()
         updateNavigationItem()
         updateTitle()
+
+        if let mediaID = media.mediaID, mediaID.intValue > 0 {
+            tableView.tableFooterView = EntityMetadataTableFooterView.make(id: mediaID)
+        }
     }
 
     private func updateTitle() {
@@ -90,6 +94,7 @@ final class MediaItemViewController: UITableViewController {
         // constraint doesn't seem to go into effect until after `viewDidLayoutSubviews`.
         headerMaxHeightConstraint.constant = view.bounds.height * 0.75
         tableView.sizeToFitHeaderView()
+        tableView.sizeToFitFooterView()
     }
 
     private var metadataRows: [ImmuTableRow] {

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -28,9 +28,16 @@ extension PostSettingsViewController {
         apost.original().isStatus(in: [.draft, .pending])
     }
 
-    @objc func setupStandaloneEditor() {
-        guard isStandalone else { return }
+    @objc func onViewDidLoad() {
+        if isStandalone {
+            setupStandaloneEditor()
+        }
+        if let postID = apost.postID, postID.intValue > 0 {
+            tableView.tableFooterView = EntityMetadataTableFooterView.make(id: postID)
+        }
+    }
 
+    private func setupStandaloneEditor() {
         wpAssert(navigationController?.presentationController != nil)
         navigationController?.presentationController?.delegate = self
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -147,7 +147,7 @@ FeaturedImageViewControllerDelegate>
     // reachability callbacks to trigger before such initial setup completes.
     //
     [self setupReachability];
-    [self setupStandaloneEditor];
+    [self onViewDidLoad];
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -160,6 +160,12 @@ FeaturedImageViewControllerDelegate>
     [self setupPublicizeConnections]; // Refresh in case the user disconnects from unsupported services.
     [self configureMetaSectionRows];
     [self reloadData];
+}
+
+- (void)viewDidLayoutSubviews {
+    [super viewDidLayoutSubviews];
+
+    [self.tableView sizeToFitFooterView];
 }
 
 - (void)didReceiveMemoryWarning

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/UITableView+Header.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/UITableView+Header.swift
@@ -58,7 +58,7 @@ extension UITableView {
     ///
     /// Source: https://gist.github.com/smileyborg/50de5da1c921b73bbccf7f76b3694f6a
     ///
-    func sizeToFitFooterView() {
+    @objc func sizeToFitFooterView() {
         guard let tableFooterView else {
             return
         }

--- a/WordPress/Classes/ViewRelated/Views/EntityMetadataTableFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Views/EntityMetadataTableFooterView.swift
@@ -1,0 +1,30 @@
+import UIKit
+
+final class EntityMetadataTableFooterView: UIView {
+    let textLabel = UILabel()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        textLabel.textColor = .tertiaryLabel
+        textLabel.font = .preferredFont(forTextStyle: .footnote)
+        textLabel.textAlignment = .center
+
+        addSubview(textLabel)
+        textLabel.pinEdges(insets: UIEdgeInsets(.all, 8))
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    static func make(id: NSNumber) -> UIView {
+        let footerView = EntityMetadataTableFooterView()
+        footerView.textLabel.text = "\(Strings.id) \(id)"
+        return footerView
+    }
+}
+
+private enum Strings {
+    static let id = NSLocalizedString("entityMetadataFooterView.id", value: "ID", comment: "A name of the ID field (it's a technical field, has to be short, displayed below everything else)")
+}


### PR DESCRIPTION
## Media URLs

Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23876 by adding media URLs in the "Media Details" screen (the same way the desktop version does).

- Uses `UITextView` link recognition, so it shows a standard system menu and preview for URLs
- URL trimmed in the middle, so you see the domain and the filename

<img width="320" alt="Screenshot 2024-12-11 at 3 29 18 PM" src="https://github.com/user-attachments/assets/bce99ef6-61c3-44c6-8fb5-318b3aa9712d" /> <img width="320" alt="Screenshot 2024-12-11 at 3 29 24 PM" src="https://github.com/user-attachments/assets/df7b1f0d-238f-467b-9428-4e8dedfdc855" />

## IDs

Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/10038 by showing IDs of media, posts, and pages. It's something only very few users are going to need, so the app shows it in a small font at the bottom.

<img width="320" alt="Screenshot 2024-12-11 at 3 07 57 PM" src="https://github.com/user-attachments/assets/383f9b9a-21dd-43f1-8584-463d7448d7d0" /> <img width="320" alt="Screenshot 2024-12-11 at 3 23 04 PM" src="https://github.com/user-attachments/assets/e56d52c5-f2bf-48db-a981-602de0197afc" />




To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
