### PR TITLE
Fix an issue with posts shown embedded in the notifications popover

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 * [*] Add support for restricted posts in Reader [#23853]
 * [*] Fix minor appearance issues in the Blaze campaign list [#23891]
 * [*] Improve the sidebar animations and layout on some iPad models [#23886]
+* [*] Fix an issue with posts shown embedded in the notifications popover on iPad [#23889]
 
 25.5
 -----

--- a/WordPress/Classes/System/Root View/ReaderPresenter.swift
+++ b/WordPress/Classes/System/Root View/ReaderPresenter.swift
@@ -230,11 +230,9 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
         case .subscriptions:
             viewModel.selection = .allSubscriptions
         case let .post(postID, siteID, isFeed):
-            viewModel.selection = nil
-            show(ReaderDetailViewController.controllerWithPostID(NSNumber(value: postID), siteID: NSNumber(value: siteID), isFeed: isFeed))
+            push(ReaderDetailViewController.controllerWithPostID(NSNumber(value: postID), siteID: NSNumber(value: siteID), isFeed: isFeed))
         case let .postURL(url):
-            viewModel.selection = nil
-            show(ReaderDetailViewController.controllerWithPostURL(url))
+            push(ReaderDetailViewController.controllerWithPostURL(url))
         case let .topic(topic):
             viewModel.selection = nil
             show(ReaderStreamViewController.controllerWithTopic(topic))

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -777,11 +777,17 @@ extension NotificationsViewController {
         if let postID = note.metaPostID,
             let siteID = note.metaSiteID,
             note.kind == .matcher || note.kind == .newPost {
-            let readerViewController = ReaderDetailViewController.controllerWithPostID(postID, siteID: siteID)
-            readerViewController.navigationItem.largeTitleDisplayMode = .never
-            readerViewController.hidesBottomBarWhenPushed = true
-            readerViewController.coordinator?.notificationID = note.notificationId
-            displayViewController(readerViewController)
+
+            if isSidebarModeEnabled && splitViewController == nil {
+                presentingViewController?.dismiss(animated: true)
+                RootViewCoordinator.sharedPresenter.showReader(path: .post(postID: postID.intValue, siteID: siteID.intValue))
+            } else {
+                let readerViewController = ReaderDetailViewController.controllerWithPostID(postID, siteID: siteID)
+                readerViewController.navigationItem.largeTitleDisplayMode = .never
+                readerViewController.hidesBottomBarWhenPushed = true
+                readerViewController.coordinator?.notificationID = note.notificationId
+                displayViewController(readerViewController)
+            }
             return
         }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23883. New behavior on iPad:

https://github.com/user-attachments/assets/33da6442-d02d-4c33-ab4a-f58ea28c045b

Reader will now also no longer lose the current navigation state when opening a deep link with a post.


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
