### PR TITLE
Refactor: Remove ImageLoader usages from Blaze

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,8 @@
 * [*] (Hidden under a feature flag) User Management for self-hosted sites. [#23768]
 * [*] Enable quick access to notifications from Reader on iPad [#23882]
 * [*] Add support for restricted posts in Reader [#23853]
+* [*] Fix minor appearance issues in the Blaze campaign list [#23891]
+* [*] Improve the sidebar animations and layout on some iPad models [#23886]
 
 25.5
 -----

--- a/WordPress/Classes/Utility/Media/AsyncImageView.swift
+++ b/WordPress/Classes/Utility/Media/AsyncImageView.swift
@@ -49,6 +49,7 @@ final class AsyncImageView: UIView {
         }
     }
 
+    /// - parameter size: Target image size in pixels.
     func setImage(
         with imageURL: URL,
         host: MediaHost? = nil,

--- a/WordPress/Classes/Utility/Media/ImageRequest.swift
+++ b/WordPress/Classes/Utility/Media/ImageRequest.swift
@@ -28,7 +28,7 @@ final class ImageRequest {
 }
 
 struct ImageRequestOptions {
-    /// Resize the thumbnail to the given size. By default, `nil`.
+    /// Resize the thumbnail to the given size (in pixels). By default, `nil`.
     var size: CGSize?
 
     /// If enabled, uses ``MemoryCache`` for caching decompressed images.

--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignTableViewCell.swift
@@ -67,10 +67,9 @@ final class BlazeCampaignTableViewCell: UITableViewCell, Reusable {
         return stackView
     }()
 
-    private lazy var featuredImageView: CachedAnimatedImageView = {
-        let imageView = CachedAnimatedImageView()
+    private lazy var featuredImageView: AsyncImageView = {
+        let imageView = AsyncImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
-        imageView.contentMode = .scaleAspectFill
         imageView.clipsToBounds = true
         imageView.layer.cornerRadius = Metrics.featuredImageCornerRadius
         return imageView
@@ -83,12 +82,6 @@ final class BlazeCampaignTableViewCell: UITableViewCell, Reusable {
         imageView.tintColor = .separator
         imageView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
         return imageView
-    }()
-
-    // MARK: - Properties
-
-    private lazy var imageLoader: ImageLoader = {
-        return ImageLoader(imageView: featuredImageView, gifStrategy: .mediumGIFs)
     }()
 
     // MARK: - Initializers
@@ -110,15 +103,15 @@ final class BlazeCampaignTableViewCell: UITableViewCell, Reusable {
 
         titleLabel.text = viewModel.title
 
-        imageLoader.prepareForReuse()
+        featuredImageView.prepareForReuse()
         featuredImageView.isHidden = viewModel.imageURL == nil
         if let imageURL = viewModel.imageURL {
             let host = MediaHost(with: blog, failure: { error in
                 WordPressAppDelegate.crashLogging?.logError(error)
             })
-
             let preferredSize = CGSize(width: Metrics.featuredImageSize, height: Metrics.featuredImageSize)
-            imageLoader.loadImage(with: imageURL, from: host, preferredSize: preferredSize)
+                .scaled(by: UITraitCollection.current.displayScale)
+            featuredImageView.setImage(with: imageURL, host: host, size: preferredSize)
         }
 
         statsStackView.arrangedSubviews.forEach { $0.removeFromSuperview() }
@@ -131,11 +124,6 @@ final class BlazeCampaignTableViewCell: UITableViewCell, Reusable {
 
     private func commonInit() {
         setupViews()
-        applyStyle()
-    }
-
-    private func applyStyle() {
-        backgroundColor = .systemGroupedBackground
     }
 
     private func setupViews() {

--- a/WordPress/Classes/ViewRelated/Blaze/Overlay/BlazePostPreviewView.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Overlay/BlazePostPreviewView.swift
@@ -47,8 +47,8 @@ final class BlazePostPreviewView: UIView {
         return label
     }()
 
-    private lazy var featuredImageView: CachedAnimatedImageView = {
-        let imageView = CachedAnimatedImageView()
+    private lazy var featuredImageView: AsyncImageView = {
+        let imageView = AsyncImageView()
         imageView.translatesAutoresizingMaskIntoConstraints = false
 
         NSLayoutConstraint.activate([
@@ -65,10 +65,6 @@ final class BlazePostPreviewView: UIView {
     // MARK: - Properties
 
     private let post: AbstractPost
-
-    private lazy var imageLoader: ImageLoader = {
-        return ImageLoader(imageView: featuredImageView, gifStrategy: .mediumGIFs)
-    }()
 
     // MARK: - Initializers
 
@@ -95,16 +91,17 @@ final class BlazePostPreviewView: UIView {
     }
 
     private func setupFeaturedImage() {
+        featuredImageView.prepareForReuse()
+
         if let url = post.featuredImageURL {
             featuredImageView.isHidden = false
-
             let host = MediaHost(with: post, failure: { error in
                 // We'll log the error, so we know it's there, but we won't halt execution.
                 WordPressAppDelegate.crashLogging?.logError(error)
             })
-
             let preferredSize = CGSize(width: featuredImageView.frame.width, height: featuredImageView.frame.height)
-            imageLoader.loadImage(with: url, from: host, preferredSize: preferredSize)
+                .scaled(by: UITraitCollection.current.displayScale)
+            featuredImageView.setImage(with: url, host: host, size: preferredSize)
 
         } else {
             featuredImageView.isHidden = true

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignView.swift
@@ -5,15 +5,13 @@ import WordPressKit
 final class DashboardBlazeCampaignView: UIView {
     private let statusView = BlazeCampaignStatusView()
     private let titleLabel = UILabel()
-    private let imageView = CachedAnimatedImageView()
+    private let imageView = AsyncImageView()
 
     private lazy var statsView: UIStackView = {
         let stackView = UIStackView()
         stackView.distribution = .fillEqually
         return stackView
     }()
-
-    private lazy var imageLoader = ImageLoader(imageView: imageView)
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -59,13 +57,15 @@ final class DashboardBlazeCampaignView: UIView {
 
         titleLabel.text = viewModel.title
 
-        imageLoader.prepareForReuse()
+        imageView.prepareForReuse()
         imageView.isHidden = viewModel.imageURL == nil
         if let imageURL = viewModel.imageURL {
             let host = MediaHost(with: blog, failure: { error in
                 WordPressAppDelegate.crashLogging?.logError(error)
             })
-            imageLoader.loadImage(with: imageURL, from: host, preferredSize: Constants.imageSize)
+            let targetSize = Constants.imageSize
+                .scaled(by: UITraitCollection.current.displayScale)
+            imageView.setImage(with: imageURL, host: host, size: targetSize)
         }
 
         statsView.isHidden = !viewModel.isShowingStats


### PR DESCRIPTION
This brings us one step closer to removing `AlamofireImage` and consolidating all the image management code in `ImageDownloader` and `AsyncImageView`.

My initial idea was to update the existing (deprecated) `ImageLoader` to use `ImageDownloader`, but after a quick search, I realized that there were only seven remaining places where it was used. So, I decided to remove `ImageLoader` usages instead.

### Changes:

- Update Blaze cells to use `AsyncImageView`
- Fix an issue with Blaze campaigns in the Blaze screen being displayed with a gray background (not sure why it was there in the first place, clearly an issue)

### Before / After

<img width="320" alt="Screenshot 2024-12-12 at 4 13 04 PM" src="https://github.com/user-attachments/assets/b269d9a3-b9ee-49a5-91b9-f95420bc3702" /> <img width="320" alt="Screenshot 2024-12-12 at 4 25 04 PM" src="https://github.com/user-attachments/assets/2c979078-8073-48ba-a128-1fffbf75d05d" />

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
