### PR TITLE
Show Notifications bell in more places in Reader

### DIFF
--- a/WordPress/Classes/System/Root View/ReaderPresenter.swift
+++ b/WordPress/Classes/System/Root View/ReaderPresenter.swift
@@ -122,17 +122,13 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
                 if screen == .discover {
                     return ReaderDiscoverViewController(topic: topic)
                 } else {
-                    let streamVC = ReaderStreamViewController.controllerWithTopic(topic)
-                    streamVC.isNotificationsBarButtonEnabled = true
-                    return streamVC
+                    return ReaderStreamViewController.controllerWithTopic(topic)
                 }
             } else {
                 return makeErrorViewController() // This should never happen
             }
         case .saved:
-            let streamVC = ReaderStreamViewController.controllerForContentType(.saved)
-            streamVC.isNotificationsBarButtonEnabled = true
-            return streamVC
+            return ReaderStreamViewController.controllerForContentType(.saved)
         case .search:
             return ReaderSearchViewController()
         }
@@ -186,6 +182,8 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
     /// column (split view) or pushing to the navigation stack.
     private func show(_ viewController: UIViewController, isLargeTitle: Bool = false) {
         if let splitViewController {
+            (viewController as? ReaderStreamViewController)?.isNotificationsBarButtonEnabled = true
+
             let navigationVC = UINavigationController(rootViewController: viewController)
             if isLargeTitle {
                 navigationVC.navigationBar.prefersLargeTitles = true

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController+Sharing.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController+Sharing.swift
@@ -1,7 +1,6 @@
-
+import UIKit
 import MobileCoreServices
 import UniformTypeIdentifiers
-import Gridicons
 
 // MARK: - Functionality related to sharing a blog via the reader.
 
@@ -16,15 +15,21 @@ extension ReaderStreamViewController {
             removeShareButton()
             return
         }
+        let button = UIBarButtonItem(title: nil, image: UIImage(systemName: "square.and.arrow.up"), target: self, action: #selector(shareButtonTapped))
+        button.tag = NavigationItemTag.share.rawValue
+        button.accessibilityLabel = NSLocalizedString("Share", comment: "Spoken accessibility label")
+        addRightBarButtonItem(button)
+    }
 
-        let image = UIImage.gridicon(.shareiOS).withRenderingMode(UIImage.RenderingMode.alwaysTemplate)
-        let button = UIButton(frame: CGRect(x: 0, y: 0, width: image.size.width, height: image.size.height))
-        button.setImage(image, for: .normal)
-        button.addTarget(self, action: #selector(shareButtonTapped(_:)), for: .touchUpInside)
-
-        let shareButton = UIBarButtonItem(customView: button)
-        shareButton.accessibilityLabel = NSLocalizedString("Share", comment: "Spoken accessibility label")
-        navigationItem.rightBarButtonItem = shareButton
+    func addRightBarButtonItem(_ item: UIBarButtonItem, after afterTag: NavigationItemTag? = nil) {
+        var items = self.navigationItem.rightBarButtonItems ?? []
+        guard !items.contains(where: { $0.tag == item.tag }) else { return }
+        if let afterTag, let index = items.firstIndex(where: { $0.tag == afterTag.rawValue }) {
+            items.insert(item, at: index)
+        } else {
+            items.append(item)
+        }
+        self.navigationItem.rightBarButtonItems = items
     }
 
     // MARK: Private behavior
@@ -33,7 +38,7 @@ extension ReaderStreamViewController {
         navigationItem.rightBarButtonItem = nil
     }
 
-    @objc private func shareButtonTapped(_ sender: UIButton) {
+    @objc private func shareButtonTapped(_ sender: UIBarButtonItem) {
         guard let sitePendingPost = readerTopic as? ReaderSiteTopic else {
             return
         }
@@ -54,8 +59,7 @@ extension ReaderStreamViewController {
 
         if let presentationController = activityViewController.popoverPresentationController {
             presentationController.permittedArrowDirections = .any
-            presentationController.sourceView = sender
-            presentationController.sourceRect = sender.bounds
+            presentationController.sourceItem = sender
         }
 
         present(activityViewController, animated: true)

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
@@ -88,6 +88,11 @@ import AutomatticTracks
     /// Configuration of cells
     private let cellConfiguration = ReaderCellConfiguration()
 
+    enum NavigationItemTag: Int {
+        case notifications
+        case share
+    }
+
     private var siteID: NSNumber? {
         didSet {
             if siteID != nil {
@@ -366,7 +371,9 @@ import AutomatticTracks
         if isNotificationsBarButtonEnabled && traitCollection.horizontalSizeClass == .regular {
             notificationsButtonCancellable = notificationsButtonViewModel.$image.sink { [weak self] in
                 guard let self else { return }
-                self.navigationItem.rightBarButtonItems = [UIBarButtonItem(image: $0, style: .plain, target: self, action: #selector(buttonShowNotificationsTapped))]
+                let button = UIBarButtonItem(image: $0, style: .plain, target: self, action: #selector(buttonShowNotificationsTapped))
+                button.tag = NavigationItemTag.notifications.rawValue
+                addRightBarButtonItem(button, after: .share)
             }
         }
     }


### PR DESCRIPTION
- Show Notifications bell in Site and Tags screens – basically every screen in the main menu except for search now
- Replace the "Share" Gridicons – we are no longer using these, and it didn't look good next to the bell

<img width="1320" alt="Screenshot 2024-12-17 at 8 44 33 PM" src="https://github.com/user-attachments/assets/1ee3b8b2-4e3b-4be5-a981-d3d85aa22f1c" />
<img width="1320" alt="Screenshot 2024-12-17 at 8 44 31 PM" src="https://github.com/user-attachments/assets/cc725d6a-dd9a-49d5-b407-bd08ab991a89" />


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
