### PR TITLE
Fix crash when pushing the same VC twice in Reader

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,7 @@
 * [*] Fix minor appearance issues in the Blaze campaign list [#23891]
 * [*] Improve the sidebar animations and layout on some iPad models [#23886]
 * [*] Fix an issue with posts shown embedded in the notifications popover on iPad [#23889]
+* [*] Fix a couple of rare crashes in Reader [#23907]
 * [*] The post cover now uses the standard aspect ratio for covers, so there is no jumping. There are also a few minor improvements to the layout and animations of the cover [#23897]
 * [*] Move the "Reading Preferences" button to the "More" menu [#23897]
 

--- a/WordPress/Classes/System/Root View/ReaderPresenter.swift
+++ b/WordPress/Classes/System/Root View/ReaderPresenter.swift
@@ -92,7 +92,7 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
         } else {
             if let latestContentVC {
                 // Return to the previous view controller preserving its state
-                mainNavigationController.pushViewController(latestContentVC, animated: true)
+                mainNavigationController.safePushViewController(latestContentVC, animated: true)
             }
         }
     }
@@ -191,7 +191,7 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
             splitViewController.setViewController(navigationVC, for: .secondary)
         } else {
             latestContentVC = viewController
-            mainNavigationController.pushViewController(viewController, animated: true)
+            mainNavigationController.safePushViewController(viewController, animated: true)
         }
     }
 
@@ -201,9 +201,9 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
         if let splitViewController {
             let navigationVC = splitViewController.viewController(for: .secondary) as? UINavigationController
             wpAssert(navigationVC != nil)
-            navigationVC?.pushViewController(viewController, animated: true)
+            navigationVC?.safePushViewController(viewController, animated: true)
         } else {
-            mainNavigationController.pushViewController(viewController, animated: true)
+            mainNavigationController.safePushViewController(viewController, animated: true)
         }
     }
 
@@ -246,5 +246,16 @@ final class ReaderPresenter: NSObject, SplitViewDisplayable {
         if secondary.viewControllers.isEmpty {
             showInitialSelection()
         }
+    }
+}
+
+private extension UINavigationController {
+    // TODO: fix when stack trace becomes available
+    // A workaround for https://a8c.sentry.io/issues/3140539221.
+    func safePushViewController(_ viewController: UIViewController, animated: Bool) {
+        guard !children.contains(viewController) else {
+            return wpAssertionFailure("pushing the same view controller more than once", userInfo: ["viewController": "\(viewController)"])
+        }
+        pushViewController(viewController, animated: animated)
     }
 }


### PR DESCRIPTION
Fixes https://a8c.sentry.io/issues/3140539221.

It is as a workaround as I don't know how to reproduce it. Hopefully, it will become clearer once we get a full stack trace from `wpAssertionFailure`. 

To test:

I verified that the fix works by calling `safePushViewController` twice.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
