### PR TITLE
Fix crash in Reader stream empty state views

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -18,6 +18,10 @@
 * [*] Reader: The post cover now uses the standard aspect ratio for covers, so there is no jumping. There are also a few minor improvements to the layout and animations of the cover and the header [#23897, #23909]
 * [*] Reader: Move the "Reading Preferences" button to the "More" menu [#23897]
 * [*] Reader: Hide post toolbar when reading an article and fix like button animations [#23909]
+* [*] Fix an issue with posts shown embedded in the notifications popover on iPad [#23889]
+* [*] The post cover now uses the standard aspect ratio for covers, so there is no jumping. There are also a few minor improvements to the layout and animations of the cover [#23897]
+* [*] Fix an issue with empty state views being non-scrollable in Reader streams [#23908]
+* [*] Move the "Reading Preferences" button to the "More" menu [#23897]
 
 25.5
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -17,11 +17,8 @@
 * [*] Reader: Fix an issue with posts shown embedded in the notifications popover on iPad [#23889]
 * [*] Reader: The post cover now uses the standard aspect ratio for covers, so there is no jumping. There are also a few minor improvements to the layout and animations of the cover and the header [#23897, #23909]
 * [*] Reader: Move the "Reading Preferences" button to the "More" menu [#23897]
+* [*] Reader: Fix an issue with empty state views being non-scrollable in streams [#23908]
 * [*] Reader: Hide post toolbar when reading an article and fix like button animations [#23909]
-* [*] Fix an issue with posts shown embedded in the notifications popover on iPad [#23889]
-* [*] The post cover now uses the standard aspect ratio for covers, so there is no jumping. There are also a few minor improvements to the layout and animations of the cover [#23897]
-* [*] Fix an issue with empty state views being non-scrollable in Reader streams [#23908]
-* [*] Move the "Reading Preferences" button to the "More" menu [#23897]
 
 25.5
 -----

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
@@ -364,7 +364,7 @@ import AutomatticTracks
         // Calculate visible part of the table view in `self.view` coordinates
         let y: CGFloat = {
             if let headerView = tableView.tableHeaderView {
-                return headerView.convert(headerView.frame, to: view).maxY
+                return tableView.convert(headerView.frame, to: view).maxY
             } else {
                 return view.safeAreaInsets.top
             }

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
@@ -197,13 +197,8 @@ import AutomatticTracks
         didSet {
             oldValue?.removeFromSuperview()
             if let emptyStateView {
-                view.addSubview(emptyStateView)
-                emptyStateView.pinEdges(.horizontal, to: view.safeAreaLayoutGuide)
-                NSLayoutConstraint.activate([
-                    emptyStateView.topAnchor.constraint(equalTo: tableView.tableHeaderView?.bottomAnchor ?? view.safeAreaLayoutGuide.topAnchor),
-                    emptyStateView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor),
-                ])
-
+                tableView.addSubview(emptyStateView)
+                layoutEmptyStateView()
                 footerView.isHidden = true
                 hideGhost()
             }
@@ -352,6 +347,8 @@ import AutomatticTracks
         if didSetupView {
             tableView.sizeToFitHeaderView()
         }
+
+        layoutEmptyStateView()
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
@@ -359,6 +356,28 @@ import AutomatticTracks
 
         isCompact = traitCollection.horizontalSizeClass == .compact
         setupNotificationsBarButtonItem()
+    }
+
+    private func layoutEmptyStateView() {
+        guard let emptyStateView else { return }
+
+        // Calculate visible part of the table view in `self.view` coordinates
+        let y: CGFloat = {
+            if let headerView = tableView.tableHeaderView {
+                return headerView.convert(headerView.frame, to: view).maxY
+            } else {
+                return view.safeAreaInsets.top
+            }
+        }()
+
+        // And convert it to the `tableView` coordinate space since that's where
+        // `emptyStateView` belongs.
+        emptyStateView.frame = tableView.convert(CGRect(
+            x: 0,
+            y: y,
+            width: view.bounds.width,
+            height: view.bounds.height - y - view.safeAreaInsets.bottom
+        ), from: view)
     }
 
     private func didChangeIsCompact(_ isCompact: Bool) {
@@ -1599,6 +1618,7 @@ extension ReaderStreamViewController: UIViewControllerTransitioningDelegate {
 
 extension ReaderStreamViewController: UITableViewDelegate, JPScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        layoutEmptyStateView()
         processJetpackBannerVisibility(scrollView)
         $titleView.value?.updateAlpha(in: scrollView)
     }


### PR DESCRIPTION
Fixes https://a8c.sentry.io/issues/6153580880:

```swift
Unable to activate constraint with anchors <NSLayoutYAxisAnchor:0x3038cdd00 "_TtGC11WordPressUI13UIHostingViewGVS_14EmptyStateViewGV7SwiftUI5LabelVS2_4TextVS2_5Image_GSqS4__VS2_9EmptyView__:0x109441680.top"> and <NSLayoutYAxisAnchor:0x30390d500 "WordPress.ReaderDiscoverHeaderView:0x1096cec00.bottom"> because they have no common ancestor.  Does the constraint or its anchors reference items in different view hierarchies?  That's illegal
```

I'm not sure when this happens, but I decided to keep it simple and lay it out with frames. It also fixes an issue with the bottom part of the view being not scrollable (only the header was).

<img width="320" alt="Screenshot 2024-12-18 at 12 39 20 PM" src="https://github.com/user-attachments/assets/2aa0f4da-e4ec-44af-953e-5081bcb28954" />

I kept the nice parallax effect but, of course, you can drag from anywhere.

https://github.com/user-attachments/assets/3de1a46f-6a72-44c7-b6bb-2e69821d39b8


## To test:

You can easily test It by replacing this:

```swift
    override func predicateForFetchRequest() -> NSPredicate {
         return NSPredicate(format: "post != NULL OR topics.@count != 0 OR sites.@count != 0")
     }
```

with this:

```swift
    override func predicateForFetchRequest() -> NSPredicate {
         return NSPredicate(format: "post != NULL AND topics.@count == 999 AND sites.@count != 0")
     }
```

or just disabling internet connection

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
