### PR TITLE
Fix an issue with wrong cover images appearing in Reader

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -44,7 +44,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/MediaEditor-iOS", branch: "task/spm-support"),
         .package(url: "https://github.com/wordpress-mobile/NSObject-SafeExpectations", from: "0.0.6"),
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", branch: "trunk"),
-        .package(url: "https://github.com/wordpress-mobile/WordPressKit-iOS", branch: "wpios-edition"),
+        .package(url: "https://github.com/wordpress-mobile/WordPressKit-iOS", branch: "fix/featured-images-reader-posts"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20241116"),

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -20,6 +20,7 @@
 * [*] Disable universal links support for QR code login. You can only scan the codes using the app now. [#23953]
 * [*] Add scroll-to-top button to Reader streams [#23957]
 * [*] Add a quick way to replace a featured image for a post [#23962]
+* [*] Fix an issue with posts in Reader sometimes showing incorrect covers [#23914]
 
 25.6
 -----
@@ -40,7 +41,6 @@
 * [*] Reader: The post cover now uses the standard aspect ratio for covers, so there is no jumping. There are also a few minor improvements to the layout and animations of the cover and the header [#23897, #23909]
 * [*] Reader: Move the "Reading Preferences" button to the "More" menu [#23897]
 * [*] Reader: Fix an issue with empty state views being non-scrollable in streams [#23908]
-* [*] Reader: Fix an issue with posts sometimes showing incorrect covers [#23914]
 * [*] Reader: Hide post toolbar when reading an article and fix like button animations [#23909]
 * [*] Reader: Fix off-by-one error in post details like counter when post is liked by you [#23912]
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -40,6 +40,7 @@
 * [*] Reader: The post cover now uses the standard aspect ratio for covers, so there is no jumping. There are also a few minor improvements to the layout and animations of the cover and the header [#23897, #23909]
 * [*] Reader: Move the "Reading Preferences" button to the "More" menu [#23897]
 * [*] Reader: Fix an issue with empty state views being non-scrollable in streams [#23908]
+* [*] Reader: Fix an issue with posts sometimes showing incorrect covers [#23914]
 * [*] Reader: Hide post toolbar when reading an article and fix like button animations [#23909]
 * [*] Reader: Fix off-by-one error in post details like counter when post is liked by you [#23912]
 

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -383,8 +383,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/WordPressKit-iOS",
       "state" : {
-        "branch" : "wpios-edition",
-        "revision" : "77b3f5e98da1e837e3983615c9fd1b38d66e3084"
+        "branch" : "fix/featured-images-reader-posts",
+        "revision" : "87e2a0902e84e03afdc29bb5b52b3a3d6a1e14d9"
       }
     },
     {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/13317 by removing the questionable logic in https://github.com/wordpress-mobile/WordPressKit-iOS/pull/825. The app will no longer show random images as post covers – only actual featured images. 

**Note**: I opened a discussion about business logic. Web supports other display types for posts via `display_type`, which is something we'll likely need to also support in the future. Once we add support for featured media (different from "cover"), we can think about showing it there.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
