### PR TITLE
Fix an issue with non-stable order in Posts and Pages in stats

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -21,6 +21,7 @@
 * [*] Add scroll-to-top button to Reader streams [#23957]
 * [*] Add a quick way to replace a featured image for a post [#23962]
 * [*] Fix an issue with posts in Reader sometimes showing incorrect covers [#23914]
+* [*] Fix non-stable order in Posts and Pages section in Stats [#23915]
 
 25.6
 -----
@@ -35,7 +36,6 @@
 * [*] Reader: Enable quick access to notifications on iPad [#23882]
 * [*] Add support for restricted posts in Reader [#23853]
 * [*] Fix minor appearance issues in the Blaze campaign list [#23891]
-* [*] Fix non-stable order in Posts and Pages section in Stats [#23915]
 * [*] Improve the sidebar animations and layout on some iPad models [#23886]
 * [*] Reader: Fix a couple of rare crashes in Reader [#23907]
 * [*] Reader: Fix an issue with posts shown embedded in the notifications popover on iPad [#23889]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -35,6 +35,7 @@
 * [*] Reader: Enable quick access to notifications on iPad [#23882]
 * [*] Add support for restricted posts in Reader [#23853]
 * [*] Fix minor appearance issues in the Blaze campaign list [#23891]
+* [*] Fix non-stable order in Posts and Pages section in Stats [#23915]
 * [*] Improve the sidebar animations and layout on some iPad models [#23886]
 * [*] Reader: Fix a couple of rare crashes in Reader [#23907]
 * [*] Reader: Fix an issue with posts shown embedded in the notifications popover on iPad [#23889]

--- a/WordPress/Classes/Stores/StatsPeriodStore.swift
+++ b/WordPress/Classes/Stores/StatsPeriodStore.swift
@@ -895,12 +895,24 @@ private extension StatsPeriodStore {
         }
     }
 
-    private func receivedPostsAndPages(_ postsAndPages: StatsTopPostsTimeIntervalData?, _ error: Error?) {
+    private func receivedPostsAndPages(_ data: StatsTopPostsTimeIntervalData?, _ error: Error?) {
         transaction { state in
             state.topPostsAndPagesStatus = error != nil ? .error : .success
 
-            if postsAndPages != nil {
-                state.topPostsAndPages = postsAndPages
+            if let data {
+                let sortedTopPosts = data.topPosts.sorted { lhs, rhs in
+                    if lhs.viewsCount == rhs.viewsCount {
+                        return lhs.title.localizedCaseInsensitiveCompare(rhs.title) == .orderedAscending
+                    }
+                    return lhs.viewsCount > rhs.viewsCount
+                }
+                state.topPostsAndPages = StatsTopPostsTimeIntervalData(
+                    period: data.period,
+                    periodEndDate: data.periodEndDate,
+                    topPosts: sortedTopPosts,
+                    totalViewsCount: data.totalViewsCount,
+                    otherViewsCount: data.otherViewsCount
+                )
             }
         }
     }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23609.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
