### PR TITLE
Add email verification check before showing the Gravatar Quick Editor

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/GravatarQuickEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/GravatarQuickEditorPresenter.swift
@@ -8,6 +8,7 @@ import WordPressMedia
 struct GravatarQuickEditorPresenter {
     let email: String
     let authToken: String
+    let emailVerificationStatus: WPAccount.VerificationStatus
 
     init?(email: String) {
         let context = ContextManager.sharedInstance().mainContext
@@ -16,9 +17,24 @@ struct GravatarQuickEditorPresenter {
         }
         self.email = email
         self.authToken = account.authToken
+        self.emailVerificationStatus = account.verificationStatus
     }
 
     func presentQuickEditor(on presentingViewController: UIViewController) {
+        guard emailVerificationStatus == .verified else {
+            let alert = UIAlertController(
+                title: nil,
+                message: NSLocalizedString(
+                    "avatar.update.email.verification.required",
+                    value: "To update your avatar, you need to verify your email address first.",
+                    comment: "An error message displayed when attempting to update an avatar while the user's email address is not verified."
+                ),
+                preferredStyle: .alert
+            )
+            alert.addAction(UIAlertAction(title: SharedStrings.Button.ok, style: .default))
+            presentingViewController.present(alert, animated: true)
+            return
+        }
         let presenter = QuickEditorPresenter(
             email: Email(email),
             scope: .avatarPicker(AvatarPickerConfiguration(contentLayout: .horizontal())),


### PR DESCRIPTION
Fixes #

Adds an email verification check before showing the Gravatar Quick Editor because a user with an unverified email can't change their avatars due to a recent backend fix. Gravatar needs to have a strict policy that accounts who haven’t verified there email cannot use Gravatar.

The Gravatar Quick Editor handles the unauthorized errors with a session expired message so it's good to have a more accurate and descriptive alert here. In the meantime we'll work on the message on the SDK side.

To test:

You can use a temp inbox like www.emailondeck.com to create an email
Logout and create a new user
Go to Me > My Profile > Add profile photo
Observe: An alert pops saying `To update your avatar, you need to verify your email address first.`
Go to your inbox, verify the email
Go back to Me and repeat the steps
Observe: Gravatar Quick Editor shows

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
