### PR TITLE
Fix an issue with blogging reminders prompt not being shown after publishing a new post

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [**] Add new lightbox screen for images with modern transitions and enhanced performance [#23922]
 * [*] Add prefetching to Reader streams [#23928]
+* [*] Fix an issue with blogging reminders prompt not being shown after publishing a new post [#23930]
 
 25.6
 -----

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -23,7 +23,7 @@ class AztecPostViewController: UIViewController, PostEditor {
 
     /// Closure to be executed when the editor gets closed.
     ///
-    var onClose: ((_ changesSaved: Bool) -> ())?
+    var onClose: (() -> ())?
 
     /// Verification Prompt Helper
     ///

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Reminders/BloggingRemindersFlowIntroViewController.swift
@@ -29,7 +29,7 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
         label.font = WPStyleGuide.serifFontForTextStyle(.title1, fontWeight: .semibold)
         label.numberOfLines = 2
         label.textAlignment = .center
-        label.text = TextContent.introTitle
+        label.text = Strings.introTitle
         return label
     }()
 
@@ -46,7 +46,7 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
     private lazy var getStartedButton: UIButton = {
         let button = FancyButton()
         button.isPrimary = true
-        button.setTitle(TextContent.introButtonTitle, for: .normal)
+        button.setTitle(Strings.introButtonTitle, for: .normal)
         button.addTarget(self, action: #selector(getStartedTapped), for: .touchUpInside)
         return button
     }()
@@ -57,18 +57,6 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
     private let tracker: BloggingRemindersTracker
     private let source: BloggingRemindersTracker.FlowStartSource
     private weak var delegate: BloggingRemindersFlowDelegate?
-
-    private var introDescription: String {
-        switch source {
-        case .publishFlow:
-            return TextContent.postPublishingintroDescription
-        case .blogSettings,
-             .notificationSettings,
-             .statsInsights,
-             .bloggingPromptsFeatureIntroduction:
-            return TextContent.siteSettingsIntroDescription
-        }
-    }
 
     init(for blog: Blog,
          tracker: BloggingRemindersTracker,
@@ -98,7 +86,7 @@ class BloggingRemindersFlowIntroViewController: UIViewController {
 
         configureStackView()
         configureConstraints()
-        promptLabel.text = introDescription
+        promptLabel.text = Strings.introDescription
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -197,18 +185,10 @@ extension BloggingRemindersFlowIntroViewController: ChildDrawerPositionable {
 
 // MARK: - Constants
 
-private enum TextContent {
-    static let introTitle = NSLocalizedString("Set your blogging reminders",
-                                              comment: "Title of the Blogging Reminders Settings screen.")
-
-    static let postPublishingintroDescription = NSLocalizedString("Your post is publishing... in the meantime, set up your blogging reminders on days you want to post.",
-                                                    comment: "Description on the first screen of the Blogging Reminders Settings flow called aftet post publishing.")
-
-    static let siteSettingsIntroDescription = NSLocalizedString("Set up your blogging reminders on days you want to post.",
-                                                            comment: "Description on the first screen of the Blogging Reminders Settings flow called from site settings.")
-
-    static let introButtonTitle = NSLocalizedString("Set reminders",
-                                                    comment: "Title of the set goals button in the Blogging Reminders Settings flow.")
+private enum Strings {
+    static let introTitle = NSLocalizedString("bloggingRemindersPrompt.intro.title", value: "Blogging Reminders", comment: "Title of the Blogging Reminders Settings screen.")
+    static let introDescription = NSLocalizedString("bloggingRemindersPrompt.intro.details", value: "Set up your blogging reminders on days you want to post.", comment: "Description on the first screen of the Blogging Reminders Settings flow called aftet post publishing.")
+    static let introButtonTitle = NSLocalizedString("bloggingRemindersPrompt.intro.continueButton", value: "Set reminders", comment: "Title of the set goals button in the Blogging Reminders Settings flow.")
 }
 
 private enum Images {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -91,7 +91,7 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
 
     var editorSession: PostEditorAnalyticsSession
 
-    var onClose: ((Bool) -> Void)?
+    var onClose: (() -> Void)?
 
     var postIsReblogged: Bool = false
 

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -34,7 +34,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
     var analyticsEditorSource: String { Analytics.editorSource }
     var editorSession: PostEditorAnalyticsSession
-    var onClose: ((Bool) -> Void)?
+    var onClose: (() -> Void)?
 
     // MARK: - Set content
 
@@ -321,7 +321,7 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
     }
 
     func editor(_ viewContoller: GutenbergKit.EditorViewController, didEncounterCriticalError error: any Error) {
-        onClose?(false)
+        onClose?()
     }
 
     func editor(_ viewController: GutenbergKit.EditorViewController, didUpdateContentWithState state: GutenbergKit.EditorState) {

--- a/WordPress/Classes/ViewRelated/Pages/Controllers/EditPageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/Controllers/EditPageViewController.swift
@@ -67,7 +67,7 @@ class EditPageViewController: UIViewController {
 
     private func show(_ editor: EditorViewController) {
         editor.entryPoint = entryPoint
-        editor.onClose = { [weak self] _ in
+        editor.onClose = { [weak self] in
             // Dismiss navigation controller
             self?.dismiss(animated: true) {
                 // Dismiss self

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -26,7 +26,7 @@ protocol PublishingEditor where Self: UIViewController {
     var alertBarButtonItem: UIBarButtonItem? { get }
 
     /// Closure to be executed when the editor gets closed.
-    var onClose: ((_ changesSaved: Bool) -> Void)? { get set }
+    var onClose: (() -> Void)? { get set }
 
     /// Return the current html in the editor
     func getHTML() -> String
@@ -204,19 +204,18 @@ extension PublishingEditor {
     }
 
     func discardUnsavedChangesAndUpdateGUI() {
-        let postDeleted = discardChanges()
-        dismissOrPopView(didSave: !postDeleted)
+        discardChanges()
+        dismissOrPopView()
     }
 
-    @discardableResult
-    func discardChanges() -> Bool {
+    func discardChanges() {
         guard post.status != .trash else {
-            return true // No revision is created for trashed posts
+            return // No revision is created for trashed posts
         }
 
         guard let context = post.managedObjectContext else {
             wpAssertionFailure("Missing managedObjectContext")
-            return true
+            return
         }
 
         WPAppAnalytics.track(.editorDiscardedChanges, withProperties: [WPAppAnalyticsKeyEditorSource: analyticsEditorSource], with: post)
@@ -233,7 +232,6 @@ extension PublishingEditor {
 
         AbstractPost.deleteLatestRevision(post, in: context)
         ContextManager.shared.saveContextAndWait(context)
-        return true
     }
 
     private func showCloseDraftConfirmationAlert() {
@@ -276,7 +274,7 @@ extension PublishingEditor {
 // MARK: - Publishing
 
 extension PublishingEditor {
-    func dismissOrPopView(didSave: Bool = true, presentBloggingReminders: Bool = false) {
+    func dismissOrPopView(presentBloggingReminders: Bool = false) {
         stopEditing()
 
         WPAppAnalytics.track(.editorClosed, withProperties: [WPAppAnalyticsKeyEditorSource: analyticsEditorSource], with: post)
@@ -284,7 +282,7 @@ extension PublishingEditor {
         if let onClose {
             // if this closure exists, the presentation of the Blogging Reminders flow (if needed)
             // needs to happen in the closure.
-            onClose(didSave)
+            onClose()
         } else if isModal(), let controller = presentingViewController {
             controller.dismiss(animated: true) {
                 if presentBloggingReminders {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -267,7 +267,7 @@ extension PostEditor where Self: UIViewController {
 
         let deletedObjects = ((userInfo[NSDeletedObjectsKey] as? Set<NSManagedObject>) ?? [])
         if deletedObjects.contains(where: { $0.objectID == originalPostID }) {
-            onClose?(false)
+            onClose?()
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
@@ -53,7 +53,7 @@ struct PostListEditorPresenter {
         let editor = EditPostViewController(post: post)
         editor.modalPresentationStyle = .fullScreen
         editor.entryPoint = entryPoint
-        editor.onClose = { _ in
+        editor.onClose = {
             NotificationCenter.default.post(name: .postListEditorPresenterDidHideEditor, object: nil)
         }
         postListViewController.present(editor, animated: false)


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/18696. I also updated the localization to no longer say "while the post is publishing..." – it's guaranteed to be published by this point. 



To test:


https://github.com/user-attachments/assets/6df0a9f0-fbf0-45db-ad9b-a523e2b0ac3c



## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
