### PR TITLE
Fix an issue with compliance popover not dismissing for self-hosted site

### DIFF
--- a/Modules/Sources/DesignSystem/Foundation/CGFloat+DesignSystem.swift
+++ b/Modules/Sources/DesignSystem/Foundation/CGFloat+DesignSystem.swift
@@ -12,10 +12,6 @@ public extension CGFloat {
             public static let max: CGFloat = 48
         }
 
-        public enum Hitbox {
-            public static let minTappableLength: CGFloat = 44
-        }
-
         public enum Radius {
             public static let small: CGFloat = 5
             public static let medium: CGFloat = 10

--- a/Modules/Sources/DesignSystem/Gallery/LengthGallery.swift
+++ b/Modules/Sources/DesignSystem/Gallery/LengthGallery.swift
@@ -30,7 +30,7 @@ struct LengthGallery: View {
         ZStack {
             RoundedRectangle(cornerRadius: .DS.Radius.small)
                 .fill(.background)
-                .frame(height: .DS.Hitbox.minTappableLength)
+                .frame(height: 44)
             HStack {
                 Text(name)
                     .offset(x: .DS.Padding.double)

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopover.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopover.swift
@@ -1,21 +1,28 @@
 import SwiftUI
 import JetpackStatsWidgetsCore
-import DesignSystem
 
 struct CompliancePopover: View {
     @StateObject
     var viewModel: CompliancePopoverViewModel
 
     var body: some View {
-        VStack(alignment: .leading, spacing: .DS.Padding.double) {
-            titleText
-            subtitleText
-            analyticsToggle
-            footnote
-            buttonsHStack
+        ScrollView(.vertical) {
+            VStack(alignment: .leading, spacing: 8) {
+                titleText.padding(.top, 16)
+                subtitleText
+                analyticsToggle.padding(.top, 8)
+                footnote
+            }
+            .padding(20)
         }
-        .padding(.DS.Padding.medium)
-        .fixedSize(horizontal: false, vertical: true)
+        .safeAreaInset(edge: .bottom) {
+            HStack(spacing: 8) {
+                settingsButton
+                saveButton
+            }
+            .padding(20)
+            .background(Color(.systemBackground))
+        }
     }
 
     private var titleText: some View {
@@ -33,7 +40,7 @@ struct CompliancePopover: View {
         Toggle(Strings.toggleTitle, isOn: $viewModel.isAnalyticsEnabled)
             .foregroundStyle(Color(.label))
             .toggleStyle(UIAppColor.switchStyle)
-            .padding(.vertical, .DS.Padding.single)
+            .padding(.vertical, 8)
     }
 
     private var footnote: some View {
@@ -42,26 +49,19 @@ struct CompliancePopover: View {
             .foregroundColor(.secondary)
     }
 
-    private var buttonsHStack: some View {
-        HStack(spacing: .DS.Padding.single) {
-            settingsButton
-            saveButton
-        }.padding(.top, .DS.Padding.medium)
-    }
-
     private var settingsButton: some View {
         Button(action: {
             self.viewModel.didTapSettings()
         }) {
             ZStack {
-                RoundedRectangle(cornerRadius: .DS.Padding.single)
-                    .stroke(.gray, lineWidth: .DS.Border.thin)
+                RoundedRectangle(cornerRadius: 8)
+                    .stroke(.gray, lineWidth: 0.5)
                 Text(Strings.settingsButtonTitle)
                     .font(.body)
             }
         }
         .foregroundColor(AppColor.brand)
-        .frame(height: .DS.Hitbox.minTappableLength)
+        .frame(height: 44)
     }
 
     private var saveButton: some View {
@@ -76,7 +76,7 @@ struct CompliancePopover: View {
             }
         }
         .foregroundColor(.white)
-        .frame(height: .DS.Hitbox.minTappableLength)
+        .frame(height: 44)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverCoordinator.swift
@@ -101,10 +101,10 @@ final class CompliancePopoverCoordinator: CompliancePopoverCoordinatorProtocol {
             contextManager: ContextManager.shared
         )
         complianceViewModel.coordinator = self
-        let complianceViewController = CompliancePopoverViewController(viewModel: complianceViewModel)
-        let bottomSheetViewController = BottomSheetViewController(childViewController: complianceViewController, customHeaderSpacing: 0)
-
-        bottomSheetViewController.show(from: presentingViewController)
+        let complianceVC = CompliancePopoverViewController(viewModel: complianceViewModel)
+        complianceVC.sheetPresentationController?.detents = [.medium(), .large()]
+        complianceVC.isModalInPresentation = true
+        presentingViewController.present(complianceVC, animated: true)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewController.swift
@@ -2,34 +2,12 @@ import UIKit
 import SwiftUI
 import WordPressUI
 
-final class CompliancePopoverViewController: UIViewController {
-
-    // MARK: - Dependencies
-
+final class CompliancePopoverViewController: UIHostingController<CompliancePopover> {
     private let viewModel: CompliancePopoverViewModel
-
-    // MARK: - Views
-
-    private let scrollView: UIScrollView = {
-        let view = UIScrollView()
-        view.showsVerticalScrollIndicator = false
-        view.translatesAutoresizingMaskIntoConstraints = false
-        return view
-    }()
-
-    private let hostingController: UIHostingController<CompliancePopover>
-
-    private var contentView: UIView {
-        return hostingController.view
-    }
-
-    // MARK: - Init
 
     init(viewModel: CompliancePopoverViewModel) {
         self.viewModel = viewModel
-        let content = CompliancePopover(viewModel: viewModel)
-        self.hostingController = UIHostingController(rootView: content)
-        super.init(nibName: nil, bundle: nil)
+        super.init(rootView: CompliancePopover(viewModel: viewModel))
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -40,60 +18,7 @@ final class CompliancePopoverViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.addContentView()
+
         self.viewModel.didDisplayPopover()
-    }
-
-    override func viewDidLayoutSubviews() {
-        super.viewDidLayoutSubviews()
-        // Calculate the size needed for the view to fit its content
-        let targetSize = CGSize(width: view.bounds.width, height: 0)
-        self.contentView.frame = CGRect(origin: .zero, size: targetSize)
-        let contentViewSize = contentView.systemLayoutSizeFitting(targetSize)
-        self.contentView.frame.size = contentViewSize
-
-        // Set the scrollView's content size to match the contentView's size
-        //
-        // Scroll is enabled / disabled automatically depending on whether the `contentSize` is bigger than the its size.
-        self.scrollView.contentSize = contentViewSize
-
-        // Set the preferred content size for the view controller to match the contentView's size
-        //
-        // This property should be updated when `DrawerPresentable.collapsedHeight` is `intrinsicHeight`.
-        // Because under the hood the `BottomSheetViewController` reads this property to layout its subviews.
-        self.preferredContentSize = contentViewSize
-    }
-
-    private func addContentView() {
-        self.view.addSubview(scrollView)
-        self.view.pinSubviewToAllEdges(scrollView)
-        self.hostingController.willMove(toParent: self)
-        self.addChild(hostingController)
-        self.contentView.translatesAutoresizingMaskIntoConstraints = true
-        self.scrollView.addSubview(contentView)
-        self.hostingController.didMove(toParent: self)
-    }
-}
-
-// MARK: - DrawerPresentable
-
-extension CompliancePopoverViewController: DrawerPresentable {
-    var collapsedHeight: DrawerHeight {
-        if traitCollection.verticalSizeClass == .compact {
-            return .maxHeight
-        }
-        return .intrinsicHeight
-    }
-
-    var allowsUserTransition: Bool {
-        return false
-    }
-
-    var allowsDragToDismiss: Bool {
-        false
-    }
-
-    var allowsTapToDismiss: Bool {
-        return false
     }
 }

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewModel.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewModel.swift
@@ -45,13 +45,10 @@ final class CompliancePopoverViewModel: ObservableObject {
             let account = try? WPAccount.lookupDefaultWordPressComAccount(in: context)
             return (account?.userID, account?.wordPressComRestApi)
         }
-
-        guard let accountID, let restAPI else {
-            return
+        if let accountID, let restAPI {
+            let change = AccountSettingsChange.tracksOptOut(!isAnalyticsEnabled)
+            AccountSettingsService(userID: accountID.intValue, api: restAPI).saveChange(change)
         }
-
-        let change = AccountSettingsChange.tracksOptOut(!isAnalyticsEnabled)
-        AccountSettingsService(userID: accountID.intValue, api: restAPI).saveChange(change)
         coordinator?.dismiss()
         defaults.didShowCompliancePopup = true
         analyticsTracker.trackPrivacyChoicesBannerSaveButtonTapped(analyticsEnabled: isAnalyticsEnabled)

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewModel.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewModel.swift
@@ -2,7 +2,7 @@ import Foundation
 import UIKit
 import WordPressUI
 
-class CompliancePopoverViewModel: ObservableObject {
+final class CompliancePopoverViewModel: ObservableObject {
 
     @Published
     var isAnalyticsEnabled: Bool = !WPAppAnalytics.userHasOptedOut()


### PR DESCRIPTION
- Fix https://github.com/wordpress-mobile/WordPress-iOS/issues/23416.
- Remove `BottomSheetViewController` usage
- Fix accessibility issues with dynamic type (not ideal in terms of buttons, but you can at least read everything now)
- Fix https://github.com/wordpress-mobile/WordPress-iOS/issues/21100 (or at least I could not reproduce it)

**Before**

<img width="320" alt="Screenshot 2024-12-31 at 4 16 36 PM" src="https://github.com/user-attachments/assets/906dd1d2-f5cd-4e9c-ab26-234869f3d63e" />

**After**

<img width="320" alt="Screenshot 2024-12-31 at 4 33 47 PM" src="https://github.com/user-attachments/assets/b5fdda78-e0de-42c2-b0ec-b61f2f634b04" /> <img width="320" alt="Screenshot 2024-12-31 at 4 33 45 PM" src="https://github.com/user-attachments/assets/7f766a29-2e9b-4a6f-8011-0606c3aa2c81" />


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
