### PR TITLE
Add Share action to site link context menu on dashboard

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * [*] Fix an issue with compliance popover not dismissing for self-hosted site [#23932]
 * [*] Fix dynamic type support in the compliance popover [#23932]
 * [*] Improve transisions and interactive dismiss gestures for sheets [#23933]
+* [*] Add "Share" action to site link context menu on dashboard [#23935]
 
 25.6
 -----

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -18,7 +18,7 @@ class PostCoordinator: NSObject {
         case maximumRetryTimeIntervalReached
 
         var errorDescription: String? {
-            Strings.genericErrorTitle
+            SharedStrings.Error.generic
         }
 
         var errorUserInfo: [String: Any] {
@@ -177,20 +177,20 @@ class PostCoordinator: NSObject {
             wpAssertionFailure("Failed to show an error alert")
             return
         }
-        let alert = UIAlertController(title: Strings.genericErrorTitle, message: error.localizedDescription, preferredStyle: .alert)
+        let alert = UIAlertController(title: SharedStrings.Error.generic, message: error.localizedDescription, preferredStyle: .alert)
         if let error = error as? PostRepository.PostSaveError {
             switch error {
             case .conflict(let latest):
-                alert.addDefaultActionWithTitle(Strings.buttonOK) { [weak self] _ in
+                alert.addDefaultActionWithTitle(SharedStrings.Button.ok) { [weak self] _ in
                     self?.showResolveConflictView(post: post, remoteRevision: latest, source: .editor)
                 }
             case .deleted:
-                alert.addDefaultActionWithTitle(Strings.buttonOK) { [weak self] _ in
+                alert.addDefaultActionWithTitle(SharedStrings.Button.ok) { [weak self] _ in
                     self?.handlePermanentlyDeleted(post)
                 }
             }
         } else {
-            alert.addDefaultActionWithTitle(Strings.buttonOK, handler: nil)
+            alert.addDefaultActionWithTitle(SharedStrings.Button.ok, handler: nil)
         }
         topViewController.present(alert, animated: true)
     }
@@ -944,9 +944,4 @@ private extension NSManagedObjectID {
         return String(description.suffix(from: index))
             .trimmingCharacters(in: CharacterSet(charactersIn: "/>"))
     }
-}
-
-private enum Strings {
-    static let genericErrorTitle = NSLocalizedString("postNotice.errorTitle", value: "An error occured", comment: "A generic error message title")
-    static let buttonOK = NSLocalizedString("postNotice.ok", value: "OK", comment: "Button OK")
 }

--- a/WordPress/Classes/Users/Views/UserDetailsView.swift
+++ b/WordPress/Classes/Users/Views/UserDetailsView.swift
@@ -240,13 +240,6 @@ struct UserDetailsView: View {
             value: "There was an error deleting the user.",
             comment: "The message in the alert that appears when deleting a user"
         )
-
-        static let deleteUserErrorAlertOkButton = NSLocalizedString(
-            "userDetails.alert.deleteUserErrorAlertOkButton",
-            value: "OK",
-            comment: "The title of the OK button in the alert that appears when deleting a user"
-        )
-
     }
 }
 
@@ -293,7 +286,7 @@ private extension View {
             isPresented: view.$presentDeleteUserError,
             presenting: view.deleteUserViewModel.error,
             actions: { _ in
-                Button(Strings.deleteUserErrorAlertOkButton) {
+                Button(SharedStrings.Button.ok) {
                     view.presentDeleteUserError = false
                 }
             },

--- a/WordPress/Classes/Utility/In-App Feedback/SubmitFeedbackViewController.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/SubmitFeedbackViewController.swift
@@ -56,7 +56,7 @@ private struct SubmitFeedbackView: View {
         .listStyle(.plain)
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
-                Button(Strings.cancel) {
+                Button(SharedStrings.Button.cancel) {
                     if isInputEmpty {
                         dismiss()
                     } else {
@@ -87,7 +87,7 @@ private struct SubmitFeedbackView: View {
             }
         }
         .alert(Strings.attachmentsStillUploadingAlertTitle, isPresented: $isShowingAttachmentsUploadingAlert) {
-            Button(Strings.ok) {}
+            Button(SharedStrings.Button.ok) {}
         }
         .onChange(of: isInputEmpty) {
             presentingViewController?.isModalInPresentation = !$0
@@ -179,8 +179,6 @@ private struct SubmitFeedbackView: View {
 }
 
 private enum Strings {
-    static let ok = NSLocalizedString("submit.feedback.buttonOK", value: "OK", comment: "The button title for the Cancel button in the In-App Feedback screen")
-    static let cancel = NSLocalizedString("submit.feedback.buttonCancel", value: "Cancel", comment: "The button title for the Cancel button in the In-App Feedback screen")
     static let submit = NSLocalizedString("submit.feedback.submit.button", value: "Submit", comment: "The button title for the Submit button in the In-App Feedback screen")
     static let title = NSLocalizedString("submit.feedback.title", value: "Feedback", comment: "The title for the the In-App Feedback screen")
     static let details = NSLocalizedString("submit.feedback.detailsPlaceholder", value: "Details", comment: "The section title and or placeholder")

--- a/WordPress/Classes/Utility/Notifications/PushAuthenticationManager.swift
+++ b/WordPress/Classes/Utility/Notifications/PushAuthenticationManager.swift
@@ -128,10 +128,9 @@ private extension PushAuthenticationManager {
     /// Displays an AlertView indicating that a Login Request has expired.
     ///
     func showLoginExpiredAlert() {
-        let title               = NSLocalizedString("Login Request Expired", comment: "Login Request Expired")
-        let message             = NSLocalizedString("The login request has expired. Log in to WordPress.com to try again.",
-                                                    comment: "WordPress.com Push Authentication Expired message")
-        let acceptButtonTitle   = NSLocalizedString("OK", comment: "OK")
+        let title = NSLocalizedString("Login Request Expired", comment: "Login Request Expired")
+        let message = NSLocalizedString("The login request has expired. Log in to WordPress.com to try again.", comment: "WordPress.com Push Authentication Expired message")
+        let acceptButtonTitle = SharedStrings.Button.ok
 
         alertControllerProxy.show(withTitle: title,
             message: message,
@@ -147,9 +146,9 @@ private extension PushAuthenticationManager {
     ///     - completion: A closure that receives a parameter, indicating whether the login attempt was confirmed or not.
     ///
     func showLoginVerificationAlert(_ message: String, completion: @escaping ((_ approved: Bool) -> ())) {
-        let title               = NSLocalizedString("Verify Log In", comment: "Push Authentication Alert Title")
-        let cancelButtonTitle   = NSLocalizedString("Ignore", comment: "Ignore action. Verb")
-        let acceptButtonTitle   = NSLocalizedString("Approve", comment: "Approve action. Verb")
+        let title = NSLocalizedString("Verify Log In", comment: "Push Authentication Alert Title")
+        let cancelButtonTitle = NSLocalizedString("Ignore", comment: "Ignore action. Verb")
+        let acceptButtonTitle = NSLocalizedString("Approve", comment: "Approve action. Verb")
 
         alertControllerProxy.show(withTitle: title,
                                   message: message,

--- a/WordPress/Classes/Utility/WebViewController/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebViewController/WebKitViewController.swift
@@ -59,7 +59,7 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
                                style: .plain,
                                target: self,
                                action: #selector(share))
-        button.title = NSLocalizedString("Share", comment: "Button label to share a web page")
+        button.title = NSLocalizedString(SharedStrings.Button.share, comment: "Button label to share a web page")
         return button
     }()
     @objc lazy var safariButton: UIBarButtonItem = {

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -1141,8 +1141,6 @@ private extension ZendeskUtils {
     struct LocalizedText {
         static let alertMessageWithName = NSLocalizedString("To continue please enter your email address and name.", comment: "Instructions for alert asking for email and name.")
         static let alertMessage = NSLocalizedString("Please enter your email address.", comment: "Instructions for alert asking for email.")
-        static let alertSubmit = NSLocalizedString("OK", comment: "Submit button on prompt for user information.")
-        static let alertCancel = NSLocalizedString("Cancel", comment: "Cancel prompt for user information.")
         static let emailPlaceholder = NSLocalizedString("Email", comment: "Email address text field placeholder")
         static let emailAccessibilityLabel = NSLocalizedString("Email", comment: "Accessibility label for the Email text field.")
         static let namePlaceholder = NSLocalizedString("Name", comment: "Name text field placeholder")
@@ -1192,8 +1190,8 @@ extension ZendeskUtils {
                 optionalIdentity: false,
                 includesName: true,
                 message: LocalizedText.alertMessageWithName,
-                submit: LocalizedText.alertSubmit,
-                cancel: LocalizedText.alertCancel
+                submit: SharedStrings.Button.ok,
+                cancel: SharedStrings.Button.cancel
             )
         }
 
@@ -1202,8 +1200,8 @@ extension ZendeskUtils {
                 optionalIdentity: false,
                 includesName: false,
                 message: LocalizedText.alertMessage,
-                submit: LocalizedText.alertSubmit,
-                cancel: LocalizedText.alertCancel
+                submit: SharedStrings.Button.ok,
+                cancel: SharedStrings.Button.cancel
             )
         }
     }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -2775,7 +2775,7 @@ extension AztecPostViewController {
 
     func displayUnableToPlayVideoAlert() {
         let alertController = UIAlertController(title: MediaUnableToPlayVideoAlert.title, message: MediaUnableToPlayVideoAlert.message, preferredStyle: .alert)
-        alertController.addAction(UIAlertAction(title: NSLocalizedString("OK", comment: "Default action"), style: .`default`, handler: nil))
+        alertController.addAction(UIAlertAction(title: SharedStrings.Button.ok, style: .default, handler: nil))
         present(alertController, animated: true)
         return
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardPromptsCardCell.swift
@@ -271,7 +271,7 @@ class DashboardPromptsCardCell: UICollectionViewCell, Reusable {
     private lazy var shareButton: UIButton = {
         let button = UIButton()
         button.translatesAutoresizingMaskIntoConstraints = false
-        button.setTitle(Strings.shareButtonTitle, for: .normal)
+        button.setTitle(SharedStrings.Button.share, for: .normal)
         button.setTitleColor(WPStyleGuide.BloggingPrompts.buttonTitleColor, for: .normal)
         button.titleLabel?.font = WPStyleGuide.BloggingPrompts.buttonTitleFont
         button.titleLabel?.adjustsFontForContentSizeCategory = true
@@ -552,7 +552,6 @@ private extension DashboardPromptsCardCell {
         static let cardFrameTitle = NSLocalizedString("Prompts", comment: "Title label for the Prompts card in My Sites tab.")
         static let answerButtonTitle = NSLocalizedString("Answer Prompt", comment: "Title for a call-to-action button on the prompts card.")
         static let answeredLabelTitle = NSLocalizedString("✓ Answered", comment: "Title label that indicates the prompt has been answered.")
-        static let shareButtonTitle = NSLocalizedString("Share", comment: "Title for a button that allows the user to share their answer to the prompt.")
         static let answerInfoSingularFormat = NSLocalizedString("%1$d answer", comment: "Singular format string for displaying the number of users "
                                                                 + "that answered the blogging prompt.")
         static let answerInfoPluralFormat = NSLocalizedString("%1$d answers", comment: "Plural format string for displaying the number of users "

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -10,6 +10,7 @@ import SwiftUI
     func siteIconShouldAllowDroppedImages() -> Bool
     func siteTitleTapped()
     func siteSwitcherTapped(sourceView: UIView)
+    func buttonShareSiteTapped()
     func visitSiteTapped()
 }
 
@@ -116,6 +117,7 @@ class BlogDetailHeaderView: UIView {
             self?.delegate?.siteIconReceivedDroppedImage(images.first)
         }
 
+        titleView.subtitleButton.menu = makeSiteLinkMenu()
         titleView.subtitleButton.addTarget(self, action: #selector(subtitleButtonTapped), for: .touchUpInside)
         titleView.titleButton.addTarget(self, action: #selector(titleButtonTapped), for: .touchUpInside)
 
@@ -124,6 +126,20 @@ class BlogDetailHeaderView: UIView {
         addSubview(titleView)
 
         setupConstraintsForChildViews()
+    }
+
+    private func makeSiteLinkMenu() -> UIMenu {
+        UIMenu(children: [
+            UIAction(title: Strings.visitSite, image: UIImage(systemName: "safari"), handler: { [weak self] _ in
+                self?.delegate?.visitSiteTapped()
+            }),
+            UIAction(title: SharedStrings.Button.copyLink, image: UIImage(systemName: "doc.on.doc"), handler: { [weak self] _ in
+                UIPasteboard.general.url = URL(string: (self?.blog?.displayURL ?? "") as String)
+            }),
+            UIAction(title: SharedStrings.Button.share + "…", image: UIImage(systemName: "square.and.arrow.up"), handler: { [weak self] _ in
+                self?.delegate?.buttonShareSiteTapped()
+            })
+        ])
     }
 
     // MARK: - Constraints
@@ -203,16 +219,6 @@ extension BlogDetailHeaderView {
             configuration.contentInsets = isSidebarModeEnabled ? NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 2, trailing: 0) : NSDirectionalEdgeInsets(top: 2, leading: 0, bottom: 1, trailing: 0)
             configuration.titleLineBreakMode = .byTruncatingTail
             button.configuration = configuration
-
-            button.menu = UIMenu(children: [
-                UIAction(title: Strings.visitSite, image: UIImage(systemName: "safari"), handler: { [weak button] _ in
-                    button?.sendActions(for: .touchUpInside)
-                }),
-                UIAction(title: Strings.actionCopyURL, image: UIImage(systemName: "doc.on.doc"), handler: { [weak button] _ in
-                    UIPasteboard.general.url = URL(string: button?.titleLabel?.text ?? "")
-                })
-            ])
-
             button.accessibilityHint = NSLocalizedString("Tap to view your site", comment: "Accessibility hint for button used to view the user's site")
             button.translatesAutoresizingMaskIntoConstraints = false
             return button
@@ -354,7 +360,5 @@ private extension String {
 }
 
 private enum Strings {
-    static let visitSite = NSLocalizedString("blogHeader.actionVisitSite", value: "Visit site", comment: "Context menu button title")
-    static let actionCopyURL = NSLocalizedString("blogHeader.actionCopyURL", value: "Copy URL", comment: "Context menu button title")
-
+    static let visitSite = NSLocalizedString("blogHeader.actionVisitSite", value: "Visit Site", comment: "Context menu button title")
 }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/Header/HomeSiteHeaderViewController+SiteActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/Header/HomeSiteHeaderViewController+SiteActions.swift
@@ -22,7 +22,7 @@ extension HomeSiteHeaderViewController {
 
     private func makePrimarySection() -> UIMenu {
         let menuItems = [
-            MenuItem.visitSite({ [weak self] in self?.visitSiteTapped() }),
+            MenuItem.visitSite { [weak self] in self?.visitSiteTapped() },
             MenuItem.shareSite { [weak self] in self?.buttonShareSiteTapped() },
         ]
         return UIMenu(options: .displayInline, children: menuItems.map { $0.toAction })
@@ -54,7 +54,7 @@ extension HomeSiteHeaderViewController {
 
     // MARK: - Actions
 
-    private func buttonShareSiteTapped() {
+    func buttonShareSiteTapped() {
         guard let urlString = blog.homeURL as String?,
               let url = URL(string: urlString) else {
             assertionFailure("Site has no URL")
@@ -108,7 +108,7 @@ private enum MenuItem {
     var title: String {
         switch self {
         case .visitSite: return Strings.visitSite
-        case .shareSite: return Strings.shareSite
+        case .shareSite: return SharedStrings.Button.share + "…"
         case .siteTitle: return Strings.siteTitle
         case .personalizeHome: return Strings.personalizeHome
         }
@@ -136,7 +136,6 @@ private enum MenuItem {
 
 private enum Strings {
     static let visitSite = NSLocalizedString("mySite.siteActions.visitSite", value: "Visit site", comment: "Menu title for the visit site option")
-    static let shareSite = NSLocalizedString("mySite.siteActions.shareSite", value: "Share site", comment: "Menu title for the share site option")
     static let siteTitle = NSLocalizedString("mySite.siteActions.siteTitle", value: "Change site title", comment: "Menu title for the change site title option")
     static let siteIcon = NSLocalizedString("mySite.siteActions.siteIcon", value: "Change site icon", comment: "Menu title for the change site icon option")
     static let personalizeHome = NSLocalizedString("mySite.siteActions.personalizeHome", value: "Personalize home", comment: "Menu title for the personalize home option")

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/KeyringAccountHelper.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/KeyringAccountHelper.swift
@@ -86,7 +86,7 @@ private extension KeyringAccountHelper {
         let alertBodyMessage = NSLocalizedString("The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages.",
                                                  comment: "Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages.")
         let continueActionTitle = NSLocalizedString("Learn more", comment: "A button title.")
-        let cancelActionTitle = NSLocalizedString("OK", comment: "A button title for closing the dialog.")
+        let cancelActionTitle = SharedStrings.Button.ok
 
         return ValidationError(header: alertHeaderMessage,
                                body: alertBodyMessage,

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingButtonsViewController.swift
@@ -675,7 +675,7 @@ import WordPressShared
             message.append(error.localizedDescription)
         }
         let controller = UIAlertController(title: title, message: message, preferredStyle: .alert)
-        controller.addCancelActionWithTitle(NSLocalizedString("OK", comment: "A button title."), handler: nil)
+        controller.addCancelActionWithTitle(SharedStrings.Button.ok, handler: nil)
 
         controller.presentFromRootViewController()
     }

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/DeleteSiteViewController.swift
@@ -215,34 +215,31 @@ open class DeleteSiteViewController: UITableViewController {
         let trackedBlog = blog
         WPAppAnalytics.track(.siteSettingsDeleteSiteRequested, with: trackedBlog)
         let service = SiteManagementService(coreDataStack: ContextManager.sharedInstance())
-        service.deleteSiteForBlog(blog,
-                                  success: { [weak self] in
-                                    WPAppAnalytics.track(.siteSettingsDeleteSiteResponseOK, with: trackedBlog)
-                                    let status = NSLocalizedString("Site deleted", comment: "Overlay message displayed when site successfully deleted")
-                                    SVProgressHUD.showDismissibleSuccess(withStatus: status)
+        service.deleteSiteForBlog(blog, success: { [weak self] in
+            WPAppAnalytics.track(.siteSettingsDeleteSiteResponseOK, with: trackedBlog)
+            let status = NSLocalizedString("Site deleted", comment: "Overlay message displayed when site successfully deleted")
+            SVProgressHUD.showDismissibleSuccess(withStatus: status)
 
-                                    self?.updateNavigationStackAfterSiteDeletion()
+            self?.updateNavigationStackAfterSiteDeletion()
 
-                                    let context = ContextManager.shared.mainContext
-                                    let account = try? WPAccount.lookupDefaultWordPressComAccount(in: context)
-                                    if let account {
-                                        AccountService(coreDataStack: ContextManager.sharedInstance()).updateUserDetails(for: account,
-                                                                                                        success: {},
-                                                                                                        failure: { _ in })
-                                    }
-            },
-                                  failure: { error in
-                                    DDLogError("Error deleting site: \(error.localizedDescription)")
-                                    WPAppAnalytics.track(.siteSettingsDeleteSiteResponseError, with: trackedBlog)
-                                    SVProgressHUD.dismiss()
+            let context = ContextManager.shared.mainContext
+            let account = try? WPAccount.lookupDefaultWordPressComAccount(in: context)
+            if let account {
+                AccountService(coreDataStack: ContextManager.sharedInstance()).updateUserDetails(for: account,
+                                                                                                 success: {},
+                                                                                                 failure: { _ in })
+            }
+        }, failure: { error in
+            DDLogError("Error deleting site: \(error.localizedDescription)")
+            WPAppAnalytics.track(.siteSettingsDeleteSiteResponseError, with: trackedBlog)
+            SVProgressHUD.dismiss()
 
-                                    let errorTitle = NSLocalizedString("Delete Site Error", comment: "Title of alert when site deletion fails")
-                                    let alertController = UIAlertController(title: errorTitle, message: error.localizedDescription, preferredStyle: .alert)
+            let errorTitle = NSLocalizedString("Delete Site Error", comment: "Title of alert when site deletion fails")
+            let alertController = UIAlertController(title: errorTitle, message: error.localizedDescription, preferredStyle: .alert)
 
-                                    let okTitle = NSLocalizedString("OK", comment: "Alert dismissal title")
-                                    alertController.addDefaultActionWithTitle(okTitle, handler: nil)
+            alertController.addDefaultActionWithTitle(SharedStrings.Button.ok, handler: nil)
 
-                                    alertController.presentFromRootViewController()
+            alertController.presentFromRootViewController()
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/SiteSettingsViewController+SiteManagement.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/SiteSettingsViewController+SiteManagement.swift
@@ -62,7 +62,7 @@ public extension SiteSettingsViewController {
                 let errorTitle = NSLocalizedString("Export Content Error", comment: "Title of alert when export content fails")
                 let alertController = UIAlertController(title: errorTitle, message: error.localizedDescription, preferredStyle: .alert)
 
-                let okTitle = NSLocalizedString("OK", comment: "Alert dismissal title")
+                let okTitle = SharedStrings.Button.ok
                 _ = alertController.addDefaultActionWithTitle(okTitle, handler: nil)
 
                 alertController.presentFromRootViewController()
@@ -101,7 +101,7 @@ public extension SiteSettingsViewController {
                 let errorTitle = NSLocalizedString("Check Purchases Error", comment: "Title of alert when getting purchases fails")
                 let alertController = UIAlertController(title: errorTitle, message: error.localizedDescription, preferredStyle: .alert)
 
-                let okTitle = NSLocalizedString("OK", comment: "Alert dismissal title")
+                let okTitle = SharedStrings.Button.ok
                 alertController.addDefaultActionWithTitle(okTitle, handler: nil)
 
                 alertController.presentFromRootViewController()

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/SiteTagsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/SiteTagsViewController.swift
@@ -314,7 +314,7 @@ extension SiteTagsViewController {
                                                        comment: "Message of the alert indicating that a tag with that name already exists. The placeholder is the name of the tag"),
                              tagName)
 
-        let acceptTitle = NSLocalizedString("OK", comment: "Alert dismissal title")
+        let acceptTitle = SharedStrings.Button.ok
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
         alertController.addDefaultActionWithTitle(acceptTitle)
         present(alertController, animated: true)

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/StartOverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/StartOverViewController.swift
@@ -145,11 +145,8 @@ open class StartOverViewController: UITableViewController, MFMailComposeViewCont
         let title = String(format: NSLocalizedString("Contact us at %@", comment: "Alert title for contact us alert, placeholder for help email address, inserted at run time."), mailRecipient)
         let message = NSLocalizedString("\nPlease send us an email to have your content cleared out.", comment: "Message to ask the user to send us an email to clear their content.")
 
-        let alertController =  UIAlertController(title: title,
-                                                 message: message,
-                                                 preferredStyle: .alert)
-        alertController.addCancelActionWithTitle(NSLocalizedString("OK",
-                                                 comment: "Button title. An acknowledgement of the message displayed in a prompt."))
+        let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
+        alertController.addCancelActionWithTitle(SharedStrings.Button.ok)
         alertController.presentFromRootViewController()
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Monitoring/PHPLogsView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Monitoring/PHPLogsView.swift
@@ -110,13 +110,13 @@ struct PHPLogsView: View {
             PHPLogsEntryRowView(entry: entry)
                 .swipeActions(edge: .trailing) {
                     ShareLink(item: attributedDescription.string) {
-                        Label("Share", systemImage: "square.and.arrow.up")
+                        Label(SharedStrings.Button.share, systemImage: "square.and.arrow.up")
                     }
                     .tint(Color.blue)
                 }
                 .contextMenu {
                     ShareLink(item: attributedDescription.string) {
-                        Label("Share", systemImage: "square.and.arrow.up")
+                        Label(SharedStrings.Button.share, systemImage: "square.and.arrow.up")
                     }
                 } preview: {
                     Text(AttributedString(attributedDescription))

--- a/WordPress/Classes/ViewRelated/Blog/Site Monitoring/SiteMonitoringEntryDetailsView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Monitoring/SiteMonitoringEntryDetailsView.swift
@@ -9,7 +9,7 @@ struct SiteMonitoringEntryDetailsView: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ShareLink(item: text.string) {
-                    Label("Share", systemImage: "square.and.arrow.up")
+                    Label(SharedStrings.Button.share, systemImage: "square.and.arrow.up")
                 }
             }
     }

--- a/WordPress/Classes/ViewRelated/Blog/Site Monitoring/WebServerLogsView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Monitoring/WebServerLogsView.swift
@@ -123,13 +123,13 @@ struct WebServerLogsView: View {
             WebServerLogsRowView(entry: entry, width: width)
                 .swipeActions(edge: .trailing) {
                     ShareLink(item: attributedDescription.string) {
-                        Label("Share", systemImage: "square.and.arrow.up")
+                        Label(SharedStrings.Button.share, systemImage: "square.and.arrow.up")
                     }
                     .tint(Color.blue)
                 }
                 .contextMenu {
                     ShareLink(item: attributedDescription.string) {
-                        Label("Share", systemImage: "square.and.arrow.up")
+                        Label(SharedStrings.Button.share, systemImage: "square.and.arrow.up")
                     }
                 } preview: {
                     Text(AttributedString(attributedDescription))

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -117,16 +117,12 @@ class RegisterDomainDetailsViewController: UITableViewController {
     }
 
     private func showAlert(title: String? = nil, message: String) {
-        let alertCancel = NSLocalizedString(
-            "OK",
-            comment: "Title of an OK button. Pressing the button acknowledges and dismisses a prompt."
-        )
         let alertController = UIAlertController(
             title: title,
             message: message,
             preferredStyle: .alert
         )
-        alertController.addCancelActionWithTitle(alertCancel, handler: nil)
+        alertController.addCancelActionWithTitle(SharedStrings.Button.ok, handler: nil)
         present(alertController, animated: true, completion: nil)
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatDetailsViewController.swift
@@ -82,8 +82,8 @@ class JetpackScanThreatDetailsViewController: UIViewController {
                                       message: viewModel.fixDescription,
                                       preferredStyle: .alert)
 
-        alert.addAction(UIAlertAction(title: Strings.cancel, style: .cancel))
-        alert.addAction(UIAlertAction(title: Strings.ok, style: .default, handler: { [weak self] _ in
+        alert.addAction(UIAlertAction(title: SharedStrings.Button.cancel, style: .cancel))
+        alert.addAction(UIAlertAction(title: SharedStrings.Button.ok, style: .default, handler: { [weak self] _ in
             guard let self else {
                 return
             }
@@ -105,8 +105,8 @@ class JetpackScanThreatDetailsViewController: UIViewController {
                                       message: String(format: viewModel.ignoreActionMessage, blogName),
                                       preferredStyle: .alert)
 
-        alert.addAction(UIAlertAction(title: Strings.cancel, style: .cancel))
-        alert.addAction(UIAlertAction(title: Strings.ok, style: .default, handler: { [weak self] _ in
+        alert.addAction(UIAlertAction(title: SharedStrings.Button.cancel, style: .cancel))
+        alert.addAction(UIAlertAction(title: SharedStrings.Button.ok, style: .default, handler: { [weak self] _ in
             guard let self else {
                 return
             }
@@ -274,8 +274,6 @@ extension JetpackScanThreatDetailsViewController {
 
     private enum Strings {
         static let title = NSLocalizedString("Threat details", comment: "Title for the Jetpack Scan Threat Details screen")
-        static let ok = NSLocalizedString("OK", comment: "OK button for alert")
-        static let cancel = NSLocalizedString("Cancel", comment: "Cancel button for alert")
         static let jetpackSettingsNotice = NSLocalizedString("Unable to visit Jetpack settings for site", comment: "Message displayed when visiting the Jetpack settings page fails.")
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -150,7 +150,7 @@ final class MediaItemViewController: UITableViewController {
                                         style: .plain,
                                         target: self,
                                         action: #selector(shareTapped))
-        shareItem.accessibilityLabel = NSLocalizedString("Share", comment: "Accessibility label for share buttons in nav bars")
+        shareItem.accessibilityLabel = SharedStrings.Button.share
 
         let trashItem = UIBarButtonItem(image: UIImage(systemName: "trash"),
                                         style: .plain,

--- a/WordPress/Classes/ViewRelated/Media/MediaPicker/MediaPickerMenu.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPicker/MediaPickerMenu.swift
@@ -142,7 +142,7 @@ extension MediaPickerMenu {
 
     private func showAccessRestrictedAlert() {
         let alert = UIAlertController(title: Strings.noCameraAccessTitle, message: Strings.noCameraAccessMessage, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: Strings.buttonOK, style: .cancel))
+        alert.addAction(UIAlertAction(title: SharedStrings.Button.ok, style: .cancel))
         alert.addAction(UIAlertAction(title: Strings.noCameraOpenSettings, style: .default) { _ in
             guard let url = URL(string: UIApplication.openSettingsURLString) else {
                 return assertionFailure("Failed to create Open Settigns URL")
@@ -300,5 +300,4 @@ private enum Strings {
     static let noCameraAccessTitle = NSLocalizedString("mediaPicker.noCameraAccessTitle", value: "Media Capture", comment: "Title for alert when access to camera is not granted")
     static let noCameraAccessMessage = NSLocalizedString("mediaPicker.noCameraAccessMessage", value: "This app needs permission to access the Camera to capture new media, please change the privacy settings if you wish to allow this.", comment: "Message for alert when access to camera is not granted")
     static let noCameraOpenSettings = NSLocalizedString("mediaPicker.openSettings", value: "Open Settings", comment: "Button that opens the Settings app")
-    static let buttonOK = NSLocalizedString("OK", value: "OK", comment: "OK")
 }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
@@ -285,7 +285,7 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
     func siteMediaViewController(_ viewController: SiteMediaCollectionViewController, contextMenuFor media: Media, sourceView: UIView) -> UIMenu? {
         var actions: [UIAction] = []
 
-        actions.append(UIAction(title: Strings.buttonShare, image: UIImage(systemName: "square.and.arrow.up")) { [weak self] _ in
+        actions.append(UIAction(title: SharedStrings.Button.share, image: UIImage(systemName: "square.and.arrow.up")) { [weak self] _ in
             self?.shareSelectedMedia([media], sourceView: sourceView)
         })
         if blog.supports(.mediaDeletion) {
@@ -314,7 +314,6 @@ private enum Strings {
     static let deletionSuccessMessage = NSLocalizedString("mediaLibrary.deletionSuccessMessage", value: "Deleted!", comment: "Text displayed in HUD after successfully deleting a media item")
     static let deletionFailureMessage = NSLocalizedString("mediaLibrary.deletionFailureMessage", value: "Unable to delete all media items.", comment: "Text displayed in HUD if there was an error attempting to delete a group of media items.")
     static let sharingFailureMessage = NSLocalizedString("mediaLibrary.sharingFailureMessage", value: "Unable to share the selected items.", comment: "Text displayed in HUD if there was an error attempting to share a group of media items.")
-    static let buttonShare = NSLocalizedString("mediaLibrary.buttonShare", value: "Share", comment: "Context menu button")
     static let buttonDelete = NSLocalizedString("mediaLibrary.buttonDelete", value: "Delete", comment: "Context menu button")
     static let aspectRatioGrid = NSLocalizedString("mediaLibrary.aspectRatioGrid", value: "Aspect Ratio Grid", comment: "Button name in the more menu")
     static let squareGrid = NSLocalizedString("mediaLibrary.squareGrid", value: "Square Grid", comment: "Button name in the more menu")

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationTableViewCell.swift
@@ -66,7 +66,7 @@ final class NotificationTableViewCell: HostingTableViewCell<NotificationsTableVi
         }
         return NotificationsTableViewCellContent.InlineAction.Configuration(
             icon: Image.DS.icon(named: .blockShare),
-            accessibilityLabel: Strings.shareButtonAccessibilityLabel,
+            accessibilityLabel: SharedStrings.Button.share,
             accessibilityHint: Strings.tapToShareThisPost,
             action: action
         )
@@ -152,12 +152,6 @@ final class NotificationTableViewCell: HostingTableViewCell<NotificationsTableVi
             "notifications.accessibility-like-button-off",
             value: "Not liked",
             comment: "The user has not previously tapped 'Like' on this post or comment"
-        )
-
-        static let shareButtonAccessibilityLabel = NSLocalizedString(
-            "notifications.accessibility-share-button",
-            value: "Share",
-            comment: "A label for screenreader users"
         )
 
         static let tapToLikeThisPost = NSLocalizedString(

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -1107,15 +1107,6 @@ private extension NotificationsViewController {
             )
         }
 
-        let cancelTitle = NSLocalizedString(
-            "Cancel",
-            comment: "Cancels the mark all as read action."
-        )
-        let markAllTitle = NSLocalizedString(
-            "OK",
-            comment: "Marks all notifications as read."
-        )
-
         let alertController = UIAlertController(
             title: String.localizedStringWithFormat(title, filter.confirmationMessageTitle),
             message: nil,
@@ -1123,9 +1114,9 @@ private extension NotificationsViewController {
         )
         alertController.view.accessibilityIdentifier = "mark-all-as-read-alert"
 
-        alertController.addCancelActionWithTitle(cancelTitle)
+        alertController.addCancelActionWithTitle(SharedStrings.Button.cancel)
 
-        alertController.addActionWithTitle(markAllTitle, style: .default) { [weak self] _ in
+        alertController.addActionWithTitle(SharedStrings.Button.ok, style: .default) { [weak self] _ in
             self?.markAllAsRead()
         }
 

--- a/WordPress/Classes/ViewRelated/People/Controllers/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/Controllers/InvitePersonViewController.swift
@@ -545,10 +545,9 @@ private extension InvitePersonViewController {
 
         let message = messageMap[error] ?? messageMap[.unknownError]!
         let title = NSLocalizedString("Sorry!", comment: "Invite Validation Alert")
-        let okTitle = NSLocalizedString("OK", comment: "Alert dismissal title")
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
 
-        alert.addDefaultActionWithTitle(okTitle)
+        alert.addDefaultActionWithTitle(SharedStrings.Button.ok)
         present(alert, animated: true)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -147,7 +147,7 @@ extension PublishingEditor {
 
     func displayMediaIsUploadingAlert() {
         let alertController = UIAlertController(title: MediaUploadingAlert.title, message: MediaUploadingAlert.message, preferredStyle: .alert)
-        alertController.addDefaultActionWithTitle(MediaUploadingAlert.acceptTitle)
+        alertController.addDefaultActionWithTitle(SharedStrings.Button.ok)
         present(alertController, animated: true, completion: nil)
     }
 
@@ -359,5 +359,4 @@ private enum Strings {
 private struct MediaUploadingAlert {
     static let title = NSLocalizedString("Uploading media", comment: "Title for alert when trying to save/exit a post before media upload process is complete.")
     static let message = NSLocalizedString("You are currently uploading media. Please wait until this completes.", comment: "This is a notification the user receives if they are trying to save a post (or exit) before the media upload process is complete.")
-    static let acceptTitle  = NSLocalizedString("OK", comment: "Accept Action")
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -177,7 +177,7 @@ extension PostSettingsViewController {
 
     private func showWarningPostWillBePublishedAlert() {
         let alert = UIAlertController(title: nil, message: Strings.warningPostWillBePublishedAlertMessage, preferredStyle: .alert)
-        alert.addAction(UIAlertAction(title: NSLocalizedString("postSettings.ok", value: "OK", comment: "Button OK"), style: .default))
+        alert.addAction(UIAlertAction(title: SharedStrings.Button.ok, style: .default))
         present(alert, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Views/AbstractPostHelper+Actions.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/AbstractPostHelper+Actions.swift
@@ -42,7 +42,7 @@ extension AbstractPostHelper {
         actions.append(trashAction)
 
         if post is Post, post.status == .publish && post.hasRemote() {
-            let shareAction = UIContextualAction(style: .normal, title: Strings.swipeActionShare) { [weak delegate] _, view, completion in
+            let shareAction = UIContextualAction(style: .normal, title: SharedStrings.Button.share) { [weak delegate] _, view, completion in
                 delegate?.share(post, fromView: view)
                 completion(true)
             }
@@ -56,7 +56,6 @@ extension AbstractPostHelper {
 
 private enum Strings {
     static let swipeActionView = NSLocalizedString("postList.swipeActionView", value: "View", comment: "Title for the 'View' post list row swipe action")
-    static let swipeActionShare = NSLocalizedString("postList.swipeActionShare", value: "Share", comment: "Title for the 'Share' post list row swipe action")
     static let swipeActionTrash = NSLocalizedString("postList.swipeActionDelete", value: "Trash", comment: "Title for the 'Trash' post list row swipe action")
     static let swipeActionDeletePermanently = NSLocalizedString("postList.swipeActionDeletePermanently", value: "Delete", comment: "Title for the 'Delete' post list row swipe action")
 }

--- a/WordPress/Classes/ViewRelated/Post/Views/AbstractPostMenuHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/AbstractPostMenuHelper.swift
@@ -130,7 +130,7 @@ extension AbstractPostButton: AbstractPostMenuAction {
         case .trash: return Strings.trash
         case .delete: return Strings.delete
         case .retry: return Strings.retry
-        case .share: return Strings.share
+        case .share: return SharedStrings.Button.share
         case .blaze: return Strings.blaze
         case .comments: return Strings.comments
         case .settings: return Strings.settings
@@ -191,7 +191,6 @@ extension AbstractPostButton: AbstractPostMenuAction {
         static let view = NSLocalizedString("posts.view.actionTitle", value: "View", comment: "Label for the view post button. Tapping displays the post as it appears on the web.")
         static let preview = NSLocalizedString("posts.preview.actionTitle", value: "Preview", comment: "Label for the preview post button. Tapping displays the post as it appears on the web.")
         static let publish = NSLocalizedString("posts.publish.actionTitle", value: "Publish", comment: "Label for the publish post button.")
-        static let share = NSLocalizedString("posts.share.actionTitle", value: "Share", comment: "Share the post.")
         static let blaze = NSLocalizedString("posts.blaze.actionTitle", value: "Promote with Blaze", comment: "Promote the post with Blaze.")
         static let setHomepage = NSLocalizedString("posts.setHomepage.actionTitle", value: "Set as homepage", comment: "Set the selected page as the homepage.")
         static let setPostsPage = NSLocalizedString("posts.setPostsPage.actionTitle", value: "Set as posts page", comment: "Set the selected page as a posts page.")

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -377,7 +377,7 @@ enum ReaderCommentMenu {
         case .edit:
             return NSLocalizedString("Edit", comment: "Edits the comment")
         case .share:
-            return NSLocalizedString("Share", comment: "Shares the comment URL")
+            return SharedStrings.Button.share
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderPostMenu.swift
@@ -51,7 +51,7 @@ struct ReaderPostMenu {
     // MARK: Actions
 
     private var share: UIAction {
-        UIAction(Strings.share, systemImage: "square.and.arrow.up") {
+        UIAction(SharedStrings.Button.share, systemImage: "square.and.arrow.up") {
             guard let viewController else { return }
             ReaderShareAction().execute(with: post, anchor: anchor ?? viewController.view, vc: viewController)
             track(.share)
@@ -71,7 +71,7 @@ struct ReaderPostMenu {
 
     private var copyPostLink: UIAction? {
         guard let postURL = post.permaLink.flatMap(URL.init) else { return nil }
-        return UIAction(Strings.copyLink, systemImage: "link") {
+        return UIAction(SharedStrings.Button.copyLink, systemImage: "link") {
             UIPasteboard.general.string = postURL.absoluteString
             UINotificationFeedbackGenerator().notificationOccurred(.success)
             track(.copyPostLink)
@@ -198,9 +198,7 @@ private enum ReaderPostMenuAnalyticsButton: String {
 }
 
 private enum Strings {
-    static let share = NSLocalizedString("reader.postContextMenu.share", value: "Share", comment: "Context menu action")
     static let viewInBrowser = NSLocalizedString("reader.postContextMenu.viewInBrowser", value: "View in Browser", comment: "Context menu action")
-    static let copyLink = NSLocalizedString("reader.postContextMenu.copyLink", value: "Copy Link", comment: "Context menu action")
     static let blockOrReport = NSLocalizedString("reader.postContextMenu.blockOrReportMenu", value: "Block or Report", comment: "Context menu action")
     static let goToBlog = NSLocalizedString("reader.postContextMenu.showBlog", value: "Go to Blog", comment: "Context menu action")
     static let subscribe = NSLocalizedString("reader.postContextMenu.subscribeT", value: "Subscribe", comment: "Context menu action")

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController+Sharing.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController+Sharing.swift
@@ -17,7 +17,7 @@ extension ReaderStreamViewController {
         }
         let button = UIBarButtonItem(title: nil, image: UIImage(systemName: "square.and.arrow.up"), target: self, action: #selector(shareButtonTapped))
         button.tag = NavigationItemTag.share.rawValue
-        button.accessibilityLabel = NSLocalizedString("Share", comment: "Spoken accessibility label")
+        button.accessibilityLabel = SharedStrings.Button.share
         addRightBarButtonItem(button)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
@@ -886,11 +886,10 @@ import AutomatticTracks
         if !canSync() {
             let alertTitle = NSLocalizedString("Unable to Load Posts", comment: "Title of a prompt saying the app needs an internet connection before it can load posts")
             let alertMessage = NSLocalizedString("Please check your internet connection and try again.", comment: "Politely asks the user to check their internet connection before trying again. ")
-            let cancelTitle = NSLocalizedString("OK", comment: "Title of a button that dismisses a prompt")
             let alertController = UIAlertController(title: alertTitle,
                 message: alertMessage,
                 preferredStyle: .alert)
-            alertController.addCancelActionWithTitle(cancelTitle, handler: nil)
+            alertController.addCancelActionWithTitle(SharedStrings.Button.ok, handler: nil)
             alertController.presentFromRootViewController()
 
             return
@@ -898,11 +897,10 @@ import AutomatticTracks
         if let syncHelper, syncHelper.isSyncing {
             let alertTitle = NSLocalizedString("Busy", comment: "Title of a prompt letting the user know that they must wait until the current aciton completes.")
             let alertMessage = NSLocalizedString("Please wait until the current fetch completes.", comment: "Asks the user to wait until the currently running fetch request completes.")
-            let cancelTitle = NSLocalizedString("OK", comment: "Title of a button that dismisses a prompt")
             let alertController = UIAlertController(title: alertTitle,
                 message: alertMessage,
                 preferredStyle: .alert)
-            alertController.addCancelActionWithTitle(cancelTitle, handler: nil)
+            alertController.addCancelActionWithTitle(SharedStrings.Button.ok, handler: nil)
             alertController.presentFromRootViewController()
 
             return

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -1133,7 +1133,7 @@ private extension ReaderDetailViewController {
 
     func shareButtonItem(enabled: Bool = true) -> UIBarButtonItem? {
         let button = barButtonItem(with: .gridicon(.shareiOS), action: #selector(didTapShareButton(_:)))
-        button.accessibilityLabel = Strings.shareButtonAccessibilityLabel
+        button.accessibilityLabel = SharedStrings.Button.share
         button.isEnabled = enabled
 
         return button
@@ -1186,11 +1186,7 @@ extension ReaderDetailViewController {
             value: "Open in Safari",
             comment: "Spoken accessibility label"
         )
-        static let shareButtonAccessibilityLabel = NSLocalizedString(
-            "readerDetail.shareButton.accessibilityLabel",
-            value: "Share",
-            comment: "Spoken accessibility label"
-        )
+
         static let moreButtonAccessibilityLabel = NSLocalizedString(
             "readerDetail.moreButton.accessibilityLabel",
             value: "More",

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
@@ -198,7 +198,7 @@ extension ReaderTagsTableViewModel {
             let title = NSLocalizedString("Could Not Follow Topic", comment: "Title of a prompt informing the user there was a probem unsubscribing from a topic in the reader.")
             let message = error?.localizedDescription
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-            alert.addCancelActionWithTitle(NSLocalizedString("OK", comment: "Button title. An acknowledgement of the message displayed in a prompt."))
+            alert.addCancelActionWithTitle(SharedStrings.Button.ok)
             alert.presentFromRootViewController()
         }, source: "manage")
     }
@@ -215,7 +215,7 @@ extension ReaderTagsTableViewModel {
             let title = NSLocalizedString("Could Not Remove Topic", comment: "Title of a prompt informing the user there was a probem unsubscribing from a topic in the reader.")
             let message = error?.localizedDescription
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
-            alert.addCancelActionWithTitle(NSLocalizedString("OK", comment: "Button title. An acknowledgement of the message displayed in a prompt."))
+            alert.addCancelActionWithTitle(SharedStrings.Button.ok)
             alert.presentFromRootViewController()
         }
     }

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
@@ -61,7 +61,7 @@ private extension BloggingPromptsHeaderView {
         infoButton.accessibilityLabel = Strings.infoButtonAccessibilityLabel
         answerPromptButton.setTitle(Strings.answerButtonTitle, for: .normal)
         answeredLabel.text = Strings.answeredLabelTitle
-        shareButton.titleLabel?.text = Strings.shareButtonTitle
+        shareButton.titleLabel?.text = SharedStrings.Button.share
     }
 
     func configureStyles() {
@@ -145,7 +145,6 @@ private extension BloggingPromptsHeaderView {
         static let title = NSLocalizedString("Prompts", comment: "Title label for blogging prompts in the create new bottom action sheet.")
         static let answerButtonTitle = NSLocalizedString("Answer Prompt", comment: "Title for a call-to-action button in the create new bottom action sheet.")
         static let answeredLabelTitle = NSLocalizedString("✓ Answered", comment: "Title label that indicates the prompt has been answered.")
-        static let shareButtonTitle = NSLocalizedString("Share", comment: "Title for a button that allows the user to share their answer to the prompt.")
         static let infoButtonAccessibilityLabel = NSLocalizedString("Learn more about prompts", comment: "Accessibility label for the blogging prompts info button on the prompts header view.")
     }
 

--- a/WordPress/Classes/ViewRelated/System/Fancy Alerts/FancyAlerts+VerificationPrompt.swift
+++ b/WordPress/Classes/ViewRelated/System/Fancy Alerts/FancyAlerts+VerificationPrompt.swift
@@ -36,7 +36,7 @@ extension FancyAlertViewController {
             })
         }
 
-        let defaultButton = FancyAlertViewController.Config.ButtonConfig(Strings.ok) { controller, _ in
+        let defaultButton = FancyAlertViewController.Config.ButtonConfig(SharedStrings.Button.ok) { controller, _ in
             completion?()
             controller.dismiss(animated: true)
         }
@@ -55,7 +55,7 @@ extension FancyAlertViewController {
     }
 
     private static func successfullySentVerificationEmailConfig() -> FancyAlertViewController.Config {
-        let okButton = FancyAlertViewController.Config.ButtonConfig(Strings.ok) { controller, _ in
+        let okButton = FancyAlertViewController.Config.ButtonConfig(SharedStrings.Button.ok) { controller, _ in
             controller.dismiss(animated: true)
         }
 
@@ -71,7 +71,7 @@ extension FancyAlertViewController {
     }
 
     private static func failureSendingVerificationEmailConfig(with error: VerificationFailureError) -> FancyAlertViewController.Config {
-        let okButton = FancyAlertViewController.Config.ButtonConfig(Strings.ok) { controller, _ in
+        let okButton = FancyAlertViewController.Config.ButtonConfig(SharedStrings.Button.ok) { controller, _ in
             controller.dismiss(animated: true)
         }
 
@@ -102,9 +102,6 @@ extension FancyAlertViewController {
 
         static let resendEmail = NSLocalizedString("Resend",
                                                    comment: "Title of secondary button on alert prompting verify their accounts while attempting to publish")
-
-        static let ok = NSLocalizedString("OK",
-                                          comment: "Title of primary button on alert prompting verify their accounts while attempting to publish")
 
         static let emailSentSuccesfully = NSLocalizedString("Verification email sent, check your inbox.",
                                                  comment: "Message shown when a verification email was re-sent succesfully")

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -782,7 +782,6 @@ public protocol ThemePresenter: AnyObject {
                 let successFormat = NSLocalizedString("Thanks for choosing %@ by %@", comment: "Message of alert when theme activation succeeds")
                 let successMessage = String(format: successFormat, theme?.name ?? "", theme?.author ?? "")
                 let manageTitle = NSLocalizedString("Manage site", comment: "Return to blog screen action when theme activation succeeds")
-                let okTitle = NSLocalizedString("OK", comment: "Alert dismissal title")
 
                 self?.updateActivateButton(isLoading: false)
 
@@ -794,14 +793,13 @@ public protocol ThemePresenter: AnyObject {
                     handler: { [weak self] (action: UIAlertAction) in
                         _ = self?.navigationController?.popViewController(animated: true)
                     })
-                alertController.addDefaultActionWithTitle(okTitle, handler: nil)
+            alertController.addDefaultActionWithTitle(SharedStrings.Button.ok, handler: nil)
                 alertController.presentFromRootViewController()
             },
             failure: { [weak self] (error) in
                 DDLogError("Error activating theme \(String(describing: theme.themeId)): \(String(describing: error?.localizedDescription))")
 
                 let errorTitle = NSLocalizedString("Activation Error", comment: "Title of alert when theme activation fails")
-                let okTitle = NSLocalizedString("OK", comment: "Alert dismissal title")
 
                 self?.activityIndicator.stopAnimating()
                 self?.activateButton?.customView = nil
@@ -809,7 +807,7 @@ public protocol ThemePresenter: AnyObject {
                 let alertController = UIAlertController(title: errorTitle,
                     message: error?.localizedDescription,
                     preferredStyle: .alert)
-                alertController.addDefaultActionWithTitle(okTitle, handler: nil)
+            alertController.addDefaultActionWithTitle(SharedStrings.Button.ok, handler: nil)
                 alertController.presentFromRootViewController()
         })
     }

--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentView.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentView.swift
@@ -10,7 +10,7 @@ struct VoiceToContentView: View {
             .onAppear(perform: viewModel.onViewAppeared)
             .tint(Color(uiColor: UIAppColor.brand))
             .alert(viewModel.errorAlertMessage ?? "", isPresented: $viewModel.isShowingErrorAlert, actions: {
-                Button(Strings.ok, action: buttonCancelTapped)
+                Button(SharedStrings.Button.ok, action: buttonCancelTapped)
             })
     }
 
@@ -189,6 +189,5 @@ private enum Strings {
     static let retry = NSLocalizedString("postFromAudio.retry", value: "Retry", comment: "Button title")
     static let notEnoughRequests = NSLocalizedString("postFromAudio.notEnoughRequestsMessage", value: "You don't have enough requests available to create a post from audio.", comment: "Message for 'not eligible' state view")
     static let upgrade = NSLocalizedString("postFromAudio.buttonUpgrade", value: "Upgrade for more requests", comment: "Button title")
-    static let ok = NSLocalizedString("postFromAudio.ok", value: "OK", comment: "Button title")
     static let close = NSLocalizedString("postFromAudio.close", value: "Close", comment: "Button close title (only used as an accessibility identifier)")
 }


### PR DESCRIPTION

**Changes:**

- Add Share action to site link context menu on dashboard
- Replace some of the common button titles with `SharedStrings.Button.*`


<img width="320" alt="Screenshot 2025-01-02 at 1 24 47 PM" src="https://github.com/user-attachments/assets/1233f32c-4530-43a2-a44b-e4a34ba003e4" />


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
