### PR TITLE
Fix layout issues in Privacy Settings section of App Settings

### DIFF
--- a/Modules/Sources/WordPressUI/Extensions/UIImage+Color.swift
+++ b/Modules/Sources/WordPressUI/Extensions/UIImage+Color.swift
@@ -13,6 +13,7 @@ public extension UIImage {
         if let cgImage = image.cgImage {
             self.init(cgImage: cgImage, scale: image.scale, orientation: .up)
         } else {
+            assertionFailure("faield to render image with color")
             self.init()
         }
     }

--- a/Modules/Sources/WordPressUI/Extensions/UIImage+Color.swift
+++ b/Modules/Sources/WordPressUI/Extensions/UIImage+Color.swift
@@ -4,13 +4,16 @@ public extension UIImage {
 
     /// Create an image of the given `size` that's made of a single `color`.
     ///
-    /// Size is in points.
+    /// - parameter size: Size in points.
     convenience init(color: UIColor, size: CGSize = CGSize(width: 1.0, height: 1.0)) {
-        let image = UIGraphicsImageRenderer(size: size).image { rendererContext in
+        let image = UIGraphicsImageRenderer(size: size).image { context in
             color.setFill()
-            rendererContext.fill(CGRect(origin: .zero, size: size))
+            context.fill(CGRect(origin: .zero, size: size))
         }
-
-        self.init(cgImage: image.cgImage!) // Force because there's no reason that the `cgImage` should be nil
+        if let cgImage = image.cgImage {
+            self.init(cgImage: cgImage, scale: image.scale, orientation: .up)
+        } else {
+            self.init()
+        }
     }
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * [*] Fix dynamic type support in the compliance popover [#23932]
 * [*] Improve transisions and interactive dismiss gestures for sheets [#23933]
 * [*] Add "Share" action to site link context menu on dashboard [#23935]
+* [*] Fix layout issues in Privacy Settings section of App Settings [#23936]
 
 25.6
 -----

--- a/WordPress/Classes/ViewRelated/Me/App Settings/Privacy Settings/PrivacySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/Privacy Settings/PrivacySettingsViewController.swift
@@ -38,7 +38,7 @@ class PrivacySettingsViewController: UITableViewController {
             PaddedInfoRow.self,
             SwitchRow.self,
             PaddedLinkRow.self
-            ], tableView: self.tableView)
+        ], tableView: self.tableView)
 
         handler = ImmuTableViewHandler(takeOver: self)
         reloadViewModel()


### PR DESCRIPTION
Before and after:

<img width="320" alt="Screenshot 2025-01-02 at 2 57 36 PM" src="https://github.com/user-attachments/assets/e3e8b795-6246-439b-822e-4f77f6a31450" /> <img width="320" alt="Screenshot 2025-01-02 at 1 54 07 PM" src="https://github.com/user-attachments/assets/8ccfbc86-fed0-4fc7-8dec-f591cd489371" />


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
