### PR TITLE
Fix an issue with clear navigation bar background in revision browser

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/Revisions/Browser/RevisionsNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Browser/RevisionsNavigationController.swift
@@ -7,13 +7,6 @@ class RevisionsNavigationController: UINavigationController {
         }
     }
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
-
-        navigationBar.setBackgroundImage(UIImage(color: UIAppColor.neutral(.shade70)), for: .default)
-        navigationBar.shadowImage = UIImage(color: UIAppColor.neutral(.shade60))
-    }
-
     private func setupForBrowserState() {
         guard let revisionView = viewControllers.first as? RevisionDiffsBrowserViewController else {
             return


### PR DESCRIPTION
**Changes:**

- Fix an issue with clear navigation bar background in revision browser
- Show "Close" button instead of "Done" (odd location for done on the left)
- Modernize the "More" menu by using `UIMenu`
- Fix the safe are insets for the toolbar

**Before / After**

<img width="320" alt="Screenshot 2025-01-03 at 9 03 23 AM" src="https://github.com/user-attachments/assets/846b2949-1957-4de0-9827-9586c265214e" /> 
<img width="320" alt="Screenshot 2025-01-03 at 9 55 29 AM" src="https://github.com/user-attachments/assets/93bdc171-3f87-4159-b55a-f1de7c74a6ef" />



To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
