### PR TITLE
Fix an issue with comments being lost on request failure

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 * [*] Fix layout issues in Privacy Settings section of App Settings [#23936]
 * [*] Fix incorrect chevron icons direction in RTL languages [#23940]
 * [*] Fix an issue with clear navigation bar background in revision browser [#23941]
+* [*] Fix an issue with comments being lost on request failure [#23942]
 
 25.6
 -----

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
@@ -1068,13 +1068,15 @@ private extension CommentDetailViewController {
             return
         }
 
+        replyTextView?.setShowingLoadingIndicator(true)
+
         commentService.createReply(for: comment, content: content) { reply in
             self.commentService.uploadComment(reply, success: { [weak self] in
-                self?.displayReplyNotice(success: true)
+                self?.didSendReply(success: true)
                 self?.refreshCommentReplyIfNeeded()
             }, failure: { [weak self] error in
                 DDLogError("Failed uploading comment reply: \(String(describing: error))")
-                self?.displayReplyNotice(success: false)
+                self?.didSendReply(success: false, error: error)
             })
         }
     }
@@ -1084,21 +1086,30 @@ private extension CommentDetailViewController {
             return
         }
 
+        replyTextView?.setShowingLoadingIndicator(true)
+
         commentService.replyToHierarchicalComment(withID: NSNumber(value: comment.commentID),
                                                   post: post,
                                                   content: content,
                                                   success: { [weak self] in
-            self?.displayReplyNotice(success: true)
+            self?.didSendReply(success: true)
             self?.refreshCommentReplyIfNeeded()
         }, failure: { [weak self] error in
             DDLogError("Failed creating post comment reply: \(String(describing: error))")
-            self?.displayReplyNotice(success: false)
+            self?.didSendReply(success: false, error: error)
         })
     }
 
-    func displayReplyNotice(success: Bool) {
+    func didSendReply(success: Bool, error: Error? = nil) {
+        replyTextView?.setShowingLoadingIndicator(false)
+        if success {
+            replyTextView?.text = ""
+        } else {
+            replyTextView?.becomeFirstResponder()
+        }
+
         let message = success ? ReplyMessages.successMessage : ReplyMessages.failureMessage
-        displayNotice(title: message)
+        displayNotice(title: message, message: error?.localizedDescription)
     }
 
     func configureSuggestionsView() {

--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
@@ -143,19 +143,14 @@ import Gridicons
 
     // MARK: - IBActions
     @IBAction fileprivate func btnReplyPressed() {
-        guard let handler = onReply else {
-            return
-        }
+        guard let onReply else { return }
 
         // Load the new text
         let newText = textView.text
         textView.resignFirstResponder()
 
-        // Cleanup + Shrink
-        text = String()
-
         // Hit the handler
-        handler(newText!)
+        onReply(newText ?? "")
     }
 
     @IBAction fileprivate func btnEnterFullscreenPressed(_ sender: Any) {
@@ -275,8 +270,12 @@ import Gridicons
                                                                       comment: "Accessibility Label for the enter full screen button on the comment reply text view")
 
         // Reply button
-        replyButton.setTitleColor(UIAppColor.brand, for: .normal)
-        replyButton.titleLabel?.text = NSLocalizedString("Reply", comment: "Reply to a comment.")
+        replyButton.configuration = {
+            var configuration = UIButton.Configuration.plain()
+            configuration.baseForegroundColor = UIAppColor.brand
+            configuration.title = NSLocalizedString("Reply", comment: "Reply to a comment.")
+            return configuration
+        }()
         replyButton.accessibilityIdentifier = "reply-button"
         replyButton.accessibilityLabel = NSLocalizedString("Reply", comment: "Accessibility label for the reply button")
         refreshReplyButton()
@@ -295,6 +294,16 @@ import Gridicons
         /// Initial Sizing: Final step, since this depends on other control(s) initialization
         ///
         frame.size.height = minimumHeight
+    }
+
+    @objc func setShowingLoadingIndicator(_ isLoading: Bool) {
+        isUserInteractionEnabled = !isLoading
+
+        textView.alpha = isLoading ? 0.33 : 1.0
+
+        replyButton.isEnabled = !isLoading
+        replyButton.configuration?.title = isLoading ? nil : NSLocalizedString("Reply", comment: "Reply to a comment.")
+        replyButton.configuration?.showsActivityIndicator = isLoading
     }
 
     // MARK: - Refresh Helpers

--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
@@ -147,17 +147,6 @@ import Gridicons
             return
         }
 
-        // We can't reply without an internet connection
-        let appDelegate = WordPressAppDelegate.shared
-        guard appDelegate!.connectionAvailable else {
-            let title = NSLocalizedString("No Connection", comment: "Title of error prompt when no internet connection is available.")
-            let message = NSLocalizedString("The Internet connection appears to be offline.",
-                                            comment: "Message of error prompt shown when a user tries to perform an action without an internet connection.")
-            WPError.showAlert(withTitle: title, message: message)
-            textView.resignFirstResponder()
-            return
-        }
-
         // Load the new text
         let newText = textView.text
         textView.resignFirstResponder()

--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.xib
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -102,7 +102,6 @@
                                     </constraints>
                                     <fontDescription key="fontDescription" style="UICTFontTextStyleBody"/>
                                     <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                    <state key="normal" title="Reply"/>
                                     <connections>
                                         <action selector="btnReplyPressed" destination="-1" eventType="touchUpInside" id="Jeq-hG-haN"/>
                                     </connections>

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -916,6 +916,9 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
         NSString *successMessage = NSLocalizedString(@"Reply Sent!", @"The app successfully sent a comment");
         [weakSelf displayNoticeWithTitle:successMessage message:nil];
 
+        [weakSelf.replyTextView setShowingLoadingIndicator:NO];
+        weakSelf.replyTextView.text = @"";
+
         [weakSelf trackReplyTo:replyToComment];
         [weakSelf.tableView deselectSelectedRowWithAnimation:YES];
         [weakSelf refreshReplyTextViewPlaceholder];
@@ -931,10 +934,15 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
         DDLogError(@"Error sending reply: %@", error);
         [generator notificationOccurred:UINotificationFeedbackTypeError];
         NSString *message = NSLocalizedString(@"There has been an unexpected error while sending your reply", "Reply Failure Message");
-        [weakSelf displayNoticeWithTitle:message message:nil];
+        [weakSelf.replyTextView setShowingLoadingIndicator:NO];
+        [weakSelf displayNoticeWithTitle:message message:[error localizedDescription]];
+
+        [weakSelf.replyTextView becomeFirstResponder];
 
         [weakSelf refreshTableViewAndNoResultsView:NO];
     };
+
+    [self.replyTextView setShowingLoadingIndicator:YES];
 
     CommentService *service = [[CommentService alloc] initWithCoreDataStack:[ContextManager sharedInstance]];
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/11307 by adopting the same UI/UX that the app uses for sending posts: 

- Show a spinner during request
- Keep the text during the request; clear only on success
- Show more details about an error (localizedDescription)

https://github.com/user-attachments/assets/4c733917-e522-4e7d-8f4f-129a6ee40714


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
