### PR TITLE
Fix an issue with Referrers in Stats showing invalid icons

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 * [*] Fix incorrect chevron icons direction in RTL languages [#23940]
 * [*] Fix an issue with clear navigation bar background in revision browser [#23941]
 * [*] Fix an issue with comments being lost on request failure [#23942]
+* [*] Fix an issue with Referrers in Stats showing invalid icons [#23943]
 
 25.6
 -----

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -502,27 +502,19 @@ private extension SiteStatsPeriodViewModel {
         let referrers = store.getTopReferrers()?.referrers.prefix(10) ?? []
 
         func rowDataFromReferrer(referrer: StatsReferrer) -> StatsTotalRowData {
-            var icon: UIImage? = nil
-            var iconURL: URL? = nil
-
-            switch referrer.iconURL?.lastPathComponent {
-            case "search-engine.png":
-                icon = Style.imageForGridiconType(.search)
-            case nil:
-                icon = Style.imageForGridiconType(.globe)
-            default:
-                iconURL = referrer.iconURL
-            }
-
-            return StatsTotalRowData(name: referrer.title,
-                                     data: referrer.viewsCount.abbreviatedString(),
-                                     icon: icon,
-                                     socialIconURL: iconURL,
-                                     showDisclosure: true,
-                                     disclosureURL: referrer.url,
-                                     childRows: referrer.children.map { rowDataFromReferrer(referrer: $0) },
-                                     statSection: .periodReferrers,
-                                     isReferrerSpam: referrer.isSpam)
+            return StatsTotalRowData(
+                name: referrer.title,
+                data: referrer.viewsCount.abbreviatedString(),
+                icon: nil,
+                socialIconURL: nil,
+                showDisclosure: true,
+                disclosureURL: referrer.url,
+                childRows: referrer.children.map {
+                    rowDataFromReferrer(referrer: $0)
+                },
+                statSection: .periodReferrers,
+                isReferrerSpam: referrer.isSpam
+            )
         }
 
         return referrers.map { rowDataFromReferrer(referrer: $0) }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -274,12 +274,16 @@ class SiteStatsInsightsDetailsViewModel: Observable {
 
                     // Views Visitors
                     let weekEnd = futureEndOfWeekDate(for: periodSummary)
-                    rows.append(contentsOf: SiteStatsImmuTableRows.viewVisitorsImmuTableRows(periodSummary,
-                                                                                             selectedSegment: selectedViewsVisitorsSegment,
-                                                                                             periodDate: selectedDate!,
-                                                                                             periodEndDate: weekEnd,
-                                                                                             siteStatsInsightsDelegate: nil,
-                                                                                             viewsAndVisitorsDelegate: viewsAndVisitorsDelegate))
+                    rows.append(
+                        contentsOf: SiteStatsImmuTableRows.viewVisitorsImmuTableRows(
+                            periodSummary,
+                            selectedSegment: selectedViewsVisitorsSegment,
+                            periodDate: selectedDate!,
+                            periodEndDate: weekEnd,
+                            siteStatsInsightsDelegate: nil,
+                            viewsAndVisitorsDelegate: viewsAndVisitorsDelegate
+                        )
+                    )
 
                     // Referrers
                     if let referrers = viewsAndVisitorsData.topReferrers {
@@ -287,13 +291,16 @@ class SiteStatsInsightsDetailsViewModel: Observable {
                         let chartViewModel = StatsReferrersChartViewModel(referrers: referrers)
                         let chartView: UIView? = referrers.totalReferrerViewsCount > 0 ?  chartViewModel.makeReferrersChartView() : nil
 
-                        var referrersRow = TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodReferrers.itemSubtitle,
-                                                                   dataSubtitle: StatSection.periodReferrers.dataSubtitle,
-                                                                   dataRows: referrersData,
-                                                                   statSection: StatSection.periodReferrers,
-                                                                   siteStatsPeriodDelegate: nil, //TODO - look at if I need to be not null
-                                                                   siteStatsReferrerDelegate: nil,
-                                                                   siteStatsInsightsDetailsDelegate: insightsDetailsDelegate)
+                        var referrersRow = TopTotalsPeriodStatsRow(
+                            itemSubtitle: StatSection.periodReferrers.itemSubtitle,
+                            dataSubtitle: StatSection.periodReferrers.dataSubtitle,
+                            dataRows: referrersData,
+                            statSection: StatSection.periodReferrers,
+                            siteStatsPeriodDelegate: nil,
+                            //TODO - look at if I need to be not null
+                            siteStatsReferrerDelegate: nil,
+                            siteStatsInsightsDetailsDelegate: insightsDetailsDelegate
+                        )
                         referrersRow.topAccessoryView = chartView
                         rows.append(referrersRow)
                     }
@@ -304,12 +311,18 @@ class SiteStatsInsightsDetailsViewModel: Observable {
                     if isMapShown {
                         rows.append(CountriesMapRow(countriesMap: map, statSection: .periodCountries))
                     }
-                    rows.append(CountriesStatsRow(itemSubtitle: StatSection.periodCountries.itemSubtitle,
-                                                  dataSubtitle: StatSection.periodCountries.dataSubtitle,
-                                                  statSection: isMapShown ? nil : .periodCountries,
-                                                  dataRows: countriesRowData(topCountries: viewsAndVisitorsData.topCountries),
-                                                  siteStatsPeriodDelegate: nil,
-                                                  siteStatsInsightsDetailsDelegate: insightsDetailsDelegate))
+                    rows.append(
+                        CountriesStatsRow(
+                            itemSubtitle: StatSection.periodCountries.itemSubtitle,
+                            dataSubtitle: StatSection.periodCountries.dataSubtitle,
+                            statSection: isMapShown ? nil : .periodCountries,
+                            dataRows: countriesRowData(
+                                topCountries: viewsAndVisitorsData.topCountries
+                            ),
+                            siteStatsPeriodDelegate: nil,
+                            siteStatsInsightsDetailsDelegate: insightsDetailsDelegate
+                        )
+                    )
                     return rows
                 }
 
@@ -326,29 +339,42 @@ class SiteStatsInsightsDetailsViewModel: Observable {
                 let emailFollowersCount = insightsStore.getEmailFollowers()?.emailFollowersCount ?? 0
 
                 if dotComFollowersCount > 0 || emailFollowersCount > 0 {
-                    let chartViewModel = StatsFollowersChartViewModel(dotComFollowersCount: dotComFollowersCount,
-                                                                      emailFollowersCount: emailFollowersCount)
+                    let chartViewModel = StatsFollowersChartViewModel(
+                        dotComFollowersCount: dotComFollowersCount,
+                        emailFollowersCount: emailFollowersCount
+                    )
 
                     let chartView: UIView = chartViewModel.makeFollowersChartView()
 
-                    var chartRow = TopTotalsPeriodStatsRow(itemSubtitle: "",
-                            dataSubtitle: "",
-                            dataRows: followersRowData(dotComFollowersCount: dotComFollowersCount,
-                                                                             emailFollowersCount: emailFollowersCount,
-                                                                             totalCount: dotComFollowersCount + emailFollowersCount),
-                            statSection: StatSection.insightsFollowersWordPress,
-                            siteStatsPeriodDelegate: nil, //TODO - look at if I need to be not null
-                            siteStatsReferrerDelegate: nil)
+                    var chartRow = TopTotalsPeriodStatsRow(
+                        itemSubtitle: "",
+                        dataSubtitle: "",
+                        dataRows: followersRowData(
+                            dotComFollowersCount: dotComFollowersCount,
+                            emailFollowersCount: emailFollowersCount,
+                            totalCount: dotComFollowersCount + emailFollowersCount
+                        ),
+                        statSection: StatSection.insightsFollowersWordPress,
+                        siteStatsPeriodDelegate: nil,
+                        //TODO - look at if I need to be not null
+                        siteStatsReferrerDelegate: nil
+                    )
                     chartRow.topAccessoryView = chartView
                     rows.append(chartRow)
                 }
 
-                rows.append(TabbedTotalsStatsRow(tabsData: [tabDataForFollowerType(.insightsFollowersWordPress),
-                                                            tabDataForFollowerType(.insightsFollowersEmail)],
+                rows.append(
+                    TabbedTotalsStatsRow(
+                        tabsData: [
+                            tabDataForFollowerType(.insightsFollowersWordPress),
+                            tabDataForFollowerType(.insightsFollowersEmail)
+                        ],
                         statSection: .insightsFollowersWordPress,
                         siteStatsInsightsDelegate: insightsDetailsDelegate,
                         siteStatsDetailsDelegate: detailsDelegate,
-                        showTotalCount: false))
+                        showTotalCount: false
+                    )
+                )
                 return rows
             }
         case .insightsLikesTotals:
@@ -358,21 +384,32 @@ class SiteStatsInsightsDetailsViewModel: Observable {
                 let likesTotalsData = revampStore.getLikesTotalsData()
 
                 if let summary = likesTotalsData.summary {
-                    rows.append(TotalInsightStatsRow(dataRow: createLikesTotalInsightsRow(periodSummary: summary),
-                                                     statSection: statSection,
-                                                     siteStatsInsightsDelegate: nil)
+                    rows.append(
+                        TotalInsightStatsRow(
+                            dataRow: createLikesTotalInsightsRow(
+                                periodSummary: summary
+                            ),
+                            statSection: statSection,
+                            siteStatsInsightsDelegate: nil
+                        )
                     )
                 }
 
                 if let topPostsAndPages = likesTotalsData.topPostsAndPages {
-                    rows.append(TopTotalsPeriodStatsRow(itemSubtitle: StatSection.periodPostsAndPages.itemSubtitle,
-                                                        dataSubtitle: StatSection.periodPostsAndPages.dataSubtitle,
-                                                        dataRows: postsAndPagesRowData(topPostsAndPages: topPostsAndPages),
-                                                        statSection: StatSection.periodPostsAndPages,
-                                                        siteStatsPeriodDelegate: nil,
-                                                        siteStatsReferrerDelegate: nil,
-                                                        siteStatsInsightsDetailsDelegate: insightsDetailsDelegate,
-                                                        siteStatsDetailsDelegate: detailsDelegate))
+                    rows.append(
+                        TopTotalsPeriodStatsRow(
+                            itemSubtitle: StatSection.periodPostsAndPages.itemSubtitle,
+                            dataSubtitle: StatSection.periodPostsAndPages.dataSubtitle,
+                            dataRows: postsAndPagesRowData(
+                                topPostsAndPages: topPostsAndPages
+                            ),
+                            statSection: StatSection.periodPostsAndPages,
+                            siteStatsPeriodDelegate: nil,
+                            siteStatsReferrerDelegate: nil,
+                            siteStatsInsightsDetailsDelegate: insightsDetailsDelegate,
+                            siteStatsDetailsDelegate: detailsDelegate
+                        )
+                    )
                 }
 
                 return rows


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23858.

I made it work the same way as the web (no icons at all):

<img width="420" alt="Screenshot 2025-01-03 at 12 35 34 PM" src="https://github.com/user-attachments/assets/9cf34545-c071-4749-87ab-4d09b74464a2" />


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
