### PR TITLE
Update site menu style on iPhone

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -13,6 +13,8 @@
 * [*] Fix an issue with clear navigation bar background in revision browser [#23941]
 * [*] Fix an issue with comments being lost on request failure [#23942]
 * [*] Fix an issue with Referrers in Stats showing invalid icons [#23943]
+* [*] Update site menu style on iPhone [#23944]
+
 
 25.6
 -----

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
@@ -22,7 +22,6 @@ final class DashboardQuickActionsCardCell: UICollectionViewCell, Reusable, UITab
     private var items: [DashboardQuickActionItemViewModel] = []
     private var viewModel: DashboardQuickActionsViewModel?
     private weak var parentViewController: BlogDashboardViewController?
-    private weak var blogDetailsViewController: BlogDetailsViewController?
     private var cancellables: [AnyCancellable] = []
 
     override init(frame: CGRect) {
@@ -109,13 +108,9 @@ final class DashboardQuickActionsCardCell: UICollectionViewCell, Reusable, UITab
             trackQuickActionsEvent(.statsAccessed, blog: blog)
             StatsViewController.show(for: blog, from: parentViewController)
         case .more:
-            let viewController = BlogDetailsViewController()
-            viewController.isScrollEnabled = true
-            viewController.tableView.isScrollEnabled = true
-            viewController.blog = blog
-            viewController.presentationDelegate = self
-            self.blogDetailsViewController = viewController
-            self.parentViewController?.show(viewController, sender: nil)
+            let viewController = SiteMenuViewController(blog: blog)
+            viewController.delegate = self
+            parentViewController.show(viewController, sender: nil)
         }
     }
 
@@ -124,15 +119,11 @@ final class DashboardQuickActionsCardCell: UICollectionViewCell, Reusable, UITab
     }
 }
 
-// MARK: - DashboardQuickActionsCardCell (BlogDetailsPresentationDelegate)
+// MARK: - DashboardQuickActionsCardCell (SiteMenuViewControllerDelegate)
 
-extension DashboardQuickActionsCardCell: BlogDetailsPresentationDelegate {
-    func showBlogDetailsSubsection(_ subsection: BlogDetailsSubsection) {
-        self.blogDetailsViewController?.showDetailView(for: subsection)
-    }
-
-    func presentBlogDetailsViewController(_ viewController: UIViewController) {
-        self.blogDetailsViewController?.show(viewController, sender: nil)
+extension DashboardQuickActionsCardCell: SiteMenuViewControllerDelegate {
+    func siteMenuViewController(_ siteMenuViewController: SiteMenuViewController, showDetailsViewController viewController: UIViewController) {
+        siteMenuViewController.show(viewController, sender: nil)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -323,6 +323,10 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
     if (@available(iOS 17.0, *)) {
         [self registerForTraitChanges:@[[UITraitHorizontalSizeClass self]] withAction:@selector(handleTraitChanges)];
     }
+
+    if (self.isSidebarModeEnabled && ![self isSplitViewDisplayed]) {
+        self.tableView.backgroundColor = [UIColor systemBackgroundColor];
+    }
 }
 
 - (void)viewWillAppear:(BOOL)animated
@@ -1038,7 +1042,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 }
 
 - (Boolean)isSplitViewDisplayed {
-    return self.isSidebarModeEnabled;
+    return self.splitViewController != nil;
 }
 
 /// This section is available on Jetpack only.
@@ -1053,7 +1057,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
     [rows addObject:[self mediaRow]];
     [rows addObject:[self commentsRow]];
 
-    NSString *title = self.isSidebarModeEnabled ? nil : [BlogDetailsViewControllerStrings contentSectionTitle];
+    NSString *title = [self isSplitViewDisplayed] ? nil : [BlogDetailsViewControllerStrings contentSectionTitle];
     return [[BlogDetailsSection alloc] initWithTitle:title andRows:rows category:BlogDetailsSectionCategoryContent];
 }
 
@@ -1582,7 +1586,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
         [WPStyleGuide configureTableViewDestructiveActionCell:cell];
     } else {
         if (row.showsDisclosureIndicator) {
-            cell.accessoryType = [self isSplitViewDisplayed] ? UITableViewCellAccessoryNone : UITableViewCellAccessoryDisclosureIndicator;
+            cell.accessoryType = [self isSidebarModeEnabled] ? UITableViewCellAccessoryNone : UITableViewCellAccessoryDisclosureIndicator;
         } else {
             cell.accessoryType = UITableViewCellAccessoryNone;
         }
@@ -1713,7 +1717,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
     CommentsViewController *commentsVC = [CommentsViewController controllerWithBlog:self.blog];
     commentsVC.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
 
-    if (self.isSidebarModeEnabled) {
+    if ([self isSplitViewDisplayed]) {
         commentsVC.isSidebarModeEnabled = YES;
 
         UISplitViewController *splitVC = [[UISplitViewController alloc] initWithStyle:UISplitViewControllerStyleDoubleColumn];
@@ -1795,7 +1799,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
     [self trackEvent:WPAnalyticsStatOpenedSiteSettings fromSource:source];
     SiteSettingsViewController *controller = [[SiteSettingsViewController alloc] initWithBlog:self.blog];
     controller.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
-    if (self.isSidebarModeEnabled) {
+    if ([self isSplitViewDisplayed]) {
         UINavigationController *navigationController = [[UINavigationController alloc] initWithRootViewController:controller];
         __weak BlogDetailsViewController *weakSelf = self;
 #pragma clang diagnostic push
@@ -1863,7 +1867,7 @@ NSString * const WPCalypsoDashboardPath = @"https://wordpress.com/home/";
 
 - (void)showDashboard
 {
-    if (self.isSidebarModeEnabled) {
+    if ([self isSplitViewDisplayed]) {
         MySiteViewController *controller = [MySiteViewController makeForBlog:self.blog isSidebarModeEnabled:true];
         [self.presentationDelegate presentBlogDetailsViewController:controller];
     } else {

--- a/WordPress/Classes/ViewRelated/System/Sidebar/SiteMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SiteMenuViewController.swift
@@ -37,7 +37,9 @@ final class SiteMenuViewController: UIViewController {
         blogDetailsVC.view.translatesAutoresizingMaskIntoConstraints = false
         view.pinSubviewToAllEdges(blogDetailsVC.view)
 
-        blogDetailsVC.showInitialDetailsForBlog()
+        if splitViewController != nil {
+            blogDetailsVC.showInitialDetailsForBlog()
+        }
 
         navigationItem.title = blog.settings?.name ?? (blog.displayURL as String?) ?? ""
 
@@ -65,7 +67,7 @@ final class SiteMenuViewController: UIViewController {
         super.viewDidAppear(animated)
 
         if #available(iOS 17, *) {
-            if tipObserver == nil {
+            if tipObserver == nil && splitViewController != nil {
                 tipObserver = registerTipPopover(AppTips.SidebarTip(), sourceItem: getTipAnchor(), arrowDirection: [.up])
             }
         }


### PR DESCRIPTION
The previous version appeared undesigned with a style that's typically reserved for settings screen. The new version uses the styles previously introduced on iPad. It's also easier on the eyes.

before / after 

<img width="320" alt="Screenshot 2025-01-06 at 10 24 29 AM" src="https://github.com/user-attachments/assets/cad092c3-19d6-4187-be07-f438fd444f0c" /> <img width="320" alt="Screenshot 2025-01-06 at 10 10 08 AM" src="https://github.com/user-attachments/assets/07fbc87d-2f0b-4475-a7d2-8c8fe56ef99f" />



To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
