### PR TITLE
Integrate zoom transitions in Theme browser

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,6 +14,7 @@
 * [*] Fix an issue with comments being lost on request failure [#23942]
 * [*] Fix an issue with Referrers in Stats showing invalid icons [#23943]
 * [*] Update site menu style on iPhone [#23944]
+* [*] Integrate zoom transitions in Themes [#23945]
 
 
 25.6

--- a/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
+++ b/WordPress/Classes/ViewRelated/Themes/ThemeBrowserViewController.swift
@@ -850,7 +850,13 @@ public protocol ThemePresenter: AnyObject {
         presentUrlForTheme(theme, url: theme?.viewUrl(), onClose: onWebkitViewControllerClose)
     }
 
-    @objc open func presentUrlForTheme(_ theme: Theme?, url: String?, activeButton: Bool = true, modalStyle: UIModalPresentationStyle = .pageSheet, onClose: (() -> Void)? = nil) {
+    @objc open func presentUrlForTheme(
+        _ theme: Theme?,
+        url: String?,
+        activeButton: Bool = true,
+        modalStyle: UIModalPresentationStyle = .pageSheet,
+        onClose: (() -> Void)? = nil
+    ) {
         guard let theme, let url = url.flatMap(URL.init(string:)) else {
             return
         }
@@ -870,8 +876,14 @@ public protocol ThemePresenter: AnyObject {
 
         let webViewController = WebViewControllerFactory.controller(configuration: configuration, source: "theme_browser")
         webViewController.navigationItem.rightBarButtonItem = activateButton
+
         let navigation = UINavigationController(rootViewController: webViewController)
         navigation.modalPresentationStyle = modalStyle
+        if #available(iOS 18, *), let indexPath = collectionView.indexPathsForSelectedItems?.first {
+            navigation.preferredTransition = .zoom(sourceViewProvider: { [weak self] _ in
+                self?.collectionView.cellForItem(at: indexPath)?.contentView
+            })
+        }
 
         if searchController != nil && searchController.isActive {
             searchController.dismiss(animated: true, completion: {


### PR DESCRIPTION
## Before

https://github.com/user-attachments/assets/3c0f2948-6de9-4f88-82be-d0b75d4a59fc

## After

https://github.com/user-attachments/assets/77760c07-df7e-405f-826c-edbee45b9128

https://github.com/user-attachments/assets/9d4ee11b-1146-42ab-9bb2-7f653f428865





To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
