### PR TITLE
Fix tint color in wpios

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -13,8 +13,8 @@ extension WPStyleGuide {
         // looking the same on newer versions of iOS.
         UIStackView.appearance().backgroundColor = .clear
 
-        UIWindow.appearance().tintColor = UIAppColor.brand
-        UISwitch.appearance().onTintColor = UIAppColor.brand
+        UIWindow.appearance().tintColor = UIAppColor.primary
+        UISwitch.appearance().onTintColor = UIAppColor.primary
 
         UITableView.appearance().sectionHeaderTopPadding = 0
 
@@ -164,7 +164,7 @@ extension WPStyleGuide {
     @objc
     class func configureTableViewActionCell(_ cell: UITableViewCell?) {
         configureTableViewCell(cell)
-        cell?.textLabel?.textColor = UIAppColor.brand
+        cell?.textLabel?.textColor = UIAppColor.primary
     }
 
     @objc

--- a/WordPress/Classes/Utility/App Configuration/AppColor.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppColor.swift
@@ -88,13 +88,7 @@ struct UIAppColor {
 #if IS_JETPACK
     static let tint = UIColor.label
 
-    static let brand = UIColor(light: CSColor.JetpackGreen.shade(.shade40), dark: CSColor.JetpackGreen.shade(.shade30))
-
-    static func brand(_ shade: ColorStudioShade) -> UIColor {
-        CSColor.JetpackGreen.shade(shade)
-    }
-
-    static let primary = CSColor.JetpackGreen.base
+    static let primary = UIColor(light: CSColor.JetpackGreen.shade(.shade40), dark: CSColor.JetpackGreen.shade(.shade30))
 
     static func primary(_ shade: ColorStudioShade) -> UIColor {
         CSColor.JetpackGreen.shade(shade)
@@ -104,13 +98,7 @@ struct UIAppColor {
 #if IS_WORDPRESS
     static let tint = primary
 
-    static let brand = CSColor.WordPressBlue.base
-
-    static func brand(_ shade: ColorStudioShade) -> UIColor {
-        CSColor.WordPressBlue.shade(shade)
-    }
-
-    static let primary = CSColor.Blue.base
+    static let primary = UIColor(light: CSColor.Blue.base, dark: primary(.shade40))
 
     static func primary(_ shade: ColorStudioShade) -> UIColor {
         CSColor.Blue.shade(shade)
@@ -147,5 +135,5 @@ struct UIAppColor {
 
 struct AppColor {
     static let tint = Color(UIAppColor.tint)
-    static let brand = Color(UIAppColor.brand)
+    static let primary = Color(UIAppColor.primary)
 }

--- a/WordPress/Classes/Utility/App Configuration/AppColor.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppColor.swift
@@ -102,7 +102,7 @@ struct UIAppColor {
 #endif
 
 #if IS_WORDPRESS
-    static let tint = brand
+    static let tint = primary
 
     static let brand = CSColor.WordPressBlue.base
 
@@ -142,7 +142,7 @@ struct UIAppColor {
 
     static let prologueBackground = UIColor(light: blue(.shade0), dark: .systemBackground)
 
-    static let switchStyle: SwitchToggleStyle = SwitchToggleStyle(tint: Color(UIAppColor.brand))
+    static let switchStyle: SwitchToggleStyle = SwitchToggleStyle(tint: Color(UIAppColor.primary))
 }
 
 struct AppColor {

--- a/WordPress/Classes/Utility/In-App Feedback/ZendeskAttachmentsSection.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/ZendeskAttachmentsSection.swift
@@ -62,7 +62,7 @@ struct ZendeskAttachmentsSection: View {
                 Image(systemName: "paperclip")
                 Text(Strings.addAttachment)
             }
-            .foregroundStyle(Color(uiColor: UIAppColor.brand))
+            .foregroundStyle(Color(uiColor: UIAppColor.primary))
         }
         .onChange(of: selection, perform: viewModel.process)
     }

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/TwitterDeprecationTableFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/TwitterDeprecationTableFooterView.swift
@@ -27,7 +27,7 @@
             let hyperlinkText = NSAttributedString(string: Constants.hyperlinkText, attributes: [
                 .paragraphStyle: paragraphStyle,
                 .attachment: attachmentURL,
-                .foregroundColor: UIAppColor.brand
+                .foregroundColor: UIAppColor.primary
             ])
             attributedString.append(hyperlinkText)
         }

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -81,7 +81,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
     @objc var isReplyHighlighted: Bool = false {
         didSet {
-            replyButton.tintColor = isReplyHighlighted ? UIAppColor.brand : .label
+            replyButton.tintColor = isReplyHighlighted ? UIAppColor.primary : .label
             replyButton.configuration?.image = UIImage(systemName: isReplyHighlighted ? "arrowshape.turn.up.left.fill" : "arrowshape.turn.up.left")
         }
     }

--- a/WordPress/Classes/ViewRelated/Domains/Views/SiteDomainsView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/SiteDomainsView.swift
@@ -130,7 +130,7 @@ struct SiteDomainsView: View {
             } label: {
                 Text(TextContent.additionalDomainTitle(blog.canRegisterDomainWithPaidPlan))
                     .style(TextStyle.bodyMedium(.regular))
-                    .foregroundColor(AppColor.brand)
+                    .foregroundColor(AppColor.primary)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopover.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopover.swift
@@ -60,7 +60,7 @@ struct CompliancePopover: View {
                     .font(.body)
             }
         }
-        .foregroundColor(AppColor.brand)
+        .foregroundColor(AppColor.primary)
         .frame(height: 44)
     }
 
@@ -70,7 +70,7 @@ struct CompliancePopover: View {
         }) {
             ZStack {
                 RoundedRectangle(cornerRadius: 8)
-                    .fill(AppColor.brand)
+                    .fill(AppColor.primary)
                 Text(Strings.saveButtonTitle)
                     .font(.body)
             }

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallStateView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallStateView.swift
@@ -128,7 +128,7 @@ private extension JetpackRemoteInstallStateView {
         }
 
         struct MainButton {
-            static let normalBackground = UIImage.renderBackgroundImage(fill: UIAppColor.brand)
+            static let normalBackground = UIImage.renderBackgroundImage(fill: UIAppColor.primary)
             static let loadingBackground = UIImage.renderBackgroundImage(fill: UIAppColor.jetpackGreen(.shade70))
             static let titleColor = UIColor.white
             static let font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
@@ -136,7 +136,7 @@ private extension JetpackRemoteInstallStateView {
         }
 
         struct SupportButton {
-            static let color = UIAppColor.brand
+            static let color = UIAppColor.primary
             static let font = WPStyleGuide.fontForTextStyle(.body)
             static let text = NSLocalizedString("Contact Support", comment: "Contact Support button title")
         }

--- a/WordPress/Classes/ViewRelated/Me/All Domains/Views/DomainPurchaseChoicesView.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/Views/DomainPurchaseChoicesView.swift
@@ -85,7 +85,7 @@ struct DomainPurchaseChoicesView: View {
                 Image(imageName)
                     .renderingMode(.template)
                     .resizable()
-                    .foregroundStyle(AppColor.brand)
+                    .foregroundStyle(AppColor.primary)
                     .frame(width: Constants.imageLength, height: Constants.imageLength)
                     .padding(.top, .DS.Padding.double)
                 VStack(alignment: .leading, spacing: .DS.Padding.single) {
@@ -95,7 +95,7 @@ struct DomainPurchaseChoicesView: View {
                         .foregroundStyle(.secondary)
                     if let footer {
                         Text(footer)
-                            .foregroundStyle(AppColor.brand)
+                            .foregroundStyle(AppColor.primary)
                             .font(.body.bold())
                     }
                 }
@@ -122,7 +122,7 @@ struct DomainPurchaseChoicesView: View {
             Text(Strings.chooseSiteSubtitle)
                 .foregroundStyle(Color(.secondaryLabel))
             Text(Strings.chooseSiteFooter)
-                .foregroundStyle(AppColor.brand)
+                .foregroundStyle(AppColor.primary)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/Boolean User Defaults/BooleanUserDefaultsDebugView.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/Boolean User Defaults/BooleanUserDefaultsDebugView.swift
@@ -32,7 +32,7 @@ struct BooleanUserDefaultsDebugView: View {
         .onAppear {
             viewModel.load()
         }
-        .tint(AppColor.brand)
+        .tint(AppColor.primary)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationTableViewCell.swift
@@ -131,7 +131,7 @@ final class NotificationTableViewCell: HostingTableViewCell<NotificationsTableVi
 
     private func likeInlineActionIcon(filled: Bool) -> (image: Image, color: Color?) {
         let image: Image = Image.DS.icon(named: filled ? .starFill : .starOutline)
-        let color: Color? = filled ? AppColor.brand: nil
+        let color: Color? = filled ? AppColor.primary: nil
         return (image: image, color: color)
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/ReplyTextView/ReplyTextView.swift
@@ -272,7 +272,7 @@ import Gridicons
         // Reply button
         replyButton.configuration = {
             var configuration = UIButton.Configuration.plain()
-            configuration.baseForegroundColor = UIAppColor.brand
+            configuration.baseForegroundColor = UIAppColor.primary
             configuration.title = NSLocalizedString("Reply", comment: "Reply to a comment.")
             return configuration
         }()

--- a/WordPress/Classes/ViewRelated/Post/Scheduling/PublishDatePickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Scheduling/PublishDatePickerViewController.swift
@@ -73,7 +73,7 @@ struct PublishDatePickerView: View {
         .environment(\.defaultMinListHeaderHeight, 0)
         .navigationTitle(Strings.title)
         .navigationBarTitleDisplayMode(.inline)
-        .tint(Color(uiColor: UIAppColor.brand))
+        .tint(Color(uiColor: UIAppColor.primary))
     }
 
     private var dateRow: some View {

--- a/WordPress/Classes/ViewRelated/Post/Views/PostMediaUploadsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PostMediaUploadsView.swift
@@ -133,7 +133,7 @@ struct MediaUploadProgressView: View {
                 .stroke(Color.secondary.opacity(0.25), lineWidth: 2)
             Circle()
                 .trim(from: 0, to: progress)
-                .stroke(Color(uiColor: UIAppColor.brand), style: StrokeStyle(lineWidth: 2, lineCap: .round))
+                .stroke(Color(uiColor: UIAppColor.primary), style: StrokeStyle(lineWidth: 2, lineCap: .round))
                 .rotationEffect(.degrees(-90))
                 .animation(.easeOut, value: progress)
         }

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -323,7 +323,7 @@ private final class ReaderPostCellView: UIView {
         buttons.bookmark.configuration = {
             var configuration = buttons.bookmark.configuration ?? .plain()
             configuration.image = UIImage(systemName: viewModel.isBookmarked ? "bookmark.fill" : "bookmark")
-            configuration.baseForegroundColor = viewModel.isBookmarked ? UIAppColor.brand : .secondaryLabel
+            configuration.baseForegroundColor = viewModel.isBookmarked ? UIAppColor.primary : .secondaryLabel
             return configuration
         }()
 

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderRecommendedSitesCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderRecommendedSitesCell.swift
@@ -72,7 +72,7 @@ private final class ReaderRecommendedSitesCellView: UIView {
     let buttonSubscribe = UIButton(configuration: {
         var configuration = UIButton.Configuration.plain()
         configuration.image = UIImage(systemName: "plus.circle")
-        configuration.baseForegroundColor = UIAppColor.brand
+        configuration.baseForegroundColor = UIAppColor.primary
         configuration.contentInsets = .zero
         return configuration
     }())
@@ -160,7 +160,7 @@ private final class ReaderRecommendedSitesCellView: UIView {
         buttonSubscribe.configuration?.baseForegroundColor = .secondaryLabel
         ReaderSubscriptionHelper().toggleFollowingForSite(site) { [weak self] _ in
             self?.buttonSubscribe.configuration?.showsActivityIndicator = false
-            self?.buttonSubscribe.configuration?.baseForegroundColor = UIAppColor.brand
+            self?.buttonSubscribe.configuration?.baseForegroundColor = UIAppColor.primary
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderSearchSuggestionsView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderSearchSuggestionsView.swift
@@ -21,7 +21,7 @@ struct ReaderSearchSuggestionsView: View {
                     viewModel.buttonClearSearchHistoryTapped()
                 } label: {
                     Text(Strings.clearHistory)
-                        .foregroundStyle(AppColor.brand)
+                        .foregroundStyle(AppColor.primary)
                 }
             }
         }

--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarTagsSection.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarTagsSection.swift
@@ -37,14 +37,14 @@ struct ReaderSidebarTagsSection: View {
         } label: {
             Label(Strings.addTag, systemImage: "plus.circle")
         }
-        .listItemTint(AppColor.brand)
+        .listItemTint(AppColor.primary)
 
         Button {
             viewModel.navigate(.discoverTags)
         } label: {
             Label(Strings.discoverTags, systemImage: "sparkle.magnifyingglass")
         }
-        .listItemTint(AppColor.brand)
+        .listItemTint(AppColor.primary)
     }
 
     func delete(at offsets: IndexSet) {

--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarViewController.swift
@@ -142,7 +142,7 @@ private struct ReaderSidebarView: View {
         makeSection(Strings.subscriptions, isExpanded: $isSectionSubscriptionsExpanded) {
             Label(Strings.subscriptions, systemImage: "checkmark.rectangle.stack")
                 .tag(ReaderSidebarItem.allSubscriptions)
-                .listItemTint(AppColor.brand)
+                .listItemTint(AppColor.primary)
                 .withDisabledSelection(isEditing)
 
             ReaderSidebarSubscriptionsSection(viewModel: viewModel)
@@ -206,7 +206,7 @@ private struct ReaderSidebarSection<Content: View>: View {
                     Spacer()
                     Image(systemName: isExpanded ? "chevron.down" : "chevron.forward")
                         .font(.system(size: 14).weight(.semibold))
-                        .foregroundStyle(AppColor.brand)
+                        .foregroundStyle(AppColor.primary)
                         .frame(width: 14)
                 }
                 .contentShape(Rectangle())

--- a/WordPress/Classes/ViewRelated/Reader/Style/WPStyleGuide+ReaderComments.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Style/WPStyleGuide+ReaderComments.swift
@@ -29,6 +29,6 @@ extension WPStyleGuide {
         static let buttonTitleLabelFont = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
         static let buttonBorderColor = UIColor.systemGray3
         static let switchOnTintColor = UIColor.systemGreen
-        static let switchInProgressTintColor = UIAppColor.brand
+        static let switchInProgressTintColor = UIAppColor.primary
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
@@ -52,10 +52,10 @@ struct ReaderSubscriptionCell: View {
                 switch status {
                 case .all:
                     Image(systemName: "bell.and.waves.left.and.right")
-                        .foregroundStyle(AppColor.brand)
+                        .foregroundStyle(AppColor.primary)
                 case .personalized:
                     Image(systemName: "bell")
-                        .foregroundStyle(AppColor.brand)
+                        .foregroundStyle(AppColor.primary)
                 case .none:
                     Image(systemName: "bell.slash")
                         .foregroundStyle(.secondary)

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapView.swift
@@ -69,9 +69,9 @@ private extension CountriesMapView {
 
     func mapColors() -> [UIColor] {
         if traitCollection.userInterfaceStyle == .dark {
-            return [WPStyleGuide.Stats.mapBackground, UIAppColor.brand]
+            return [WPStyleGuide.Stats.mapBackground, UIAppColor.primary]
         } else {
-            return [WPStyleGuide.Stats.mapBackground, UIAppColor.brand]
+            return [WPStyleGuide.Stats.mapBackground, UIAppColor.primary]
         }
     }
 

--- a/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewController.swift
@@ -203,7 +203,7 @@ private struct SidebarProfileContainerView: View {
                             }
                         }
                     }
-                    .tint(Color(UIAppColor.brand))
+                    .tint(Color(UIAppColor.primary))
                 }
 
                 Spacer()
@@ -247,7 +247,7 @@ struct SidebarAddButtonLabel: View {
             Text(title)
         } icon: {
             Image(systemName: "plus.square.fill")
-                .foregroundStyle(AppColor.brand, Color(.secondarySystemFill))
+                .foregroundStyle(AppColor.primary, Color(.secondarySystemFill))
                 .font(.title2)
         }
     }

--- a/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/NotificationsList/NotificationsTableViewCellContent.swift
@@ -111,7 +111,7 @@ fileprivate extension NotificationsTableViewCellContent {
 
         private var indicator: some View {
             Circle()
-                .fill(AppColor.brand)
+                .fill(AppColor.primary)
                 .frame(width: .DS.Padding.single)
         }
 

--- a/WordPress/Classes/ViewRelated/Voice/AudioRecorderVisualizerView.swift
+++ b/WordPress/Classes/ViewRelated/Voice/AudioRecorderVisualizerView.swift
@@ -22,7 +22,7 @@ private struct AudiowaveView: View {
             ForEach(indices, id: \.self) { index in
                 let height = max(10, 80 * normalizePowerLevel(samples[index]))
                 Capsule(style: .continuous)
-                    .fill(Color(uiColor: UIAppColor.brand))
+                    .fill(Color(uiColor: UIAppColor.primary))
                     .frame(width: 10, height: CGFloat(height))
                     .animation(.spring(duration: 0.1), value: height)
             }

--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentView.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentView.swift
@@ -8,7 +8,7 @@ struct VoiceToContentView: View {
     var body: some View {
         contents
             .onAppear(perform: viewModel.onViewAppeared)
-            .tint(Color(uiColor: UIAppColor.brand))
+            .tint(Color(uiColor: UIAppColor.primary))
             .alert(viewModel.errorAlertMessage ?? "", isPresented: $viewModel.isShowingErrorAlert, actions: {
                 Button(SharedStrings.Button.ok, action: buttonCancelTapped)
             })
@@ -150,7 +150,7 @@ private struct RecordButton: View {
 
     private var backgroundColor: Color {
         if !isRecording {
-            return viewModel.isButtonRecordEnabled ? Color(uiColor: UIAppColor.brand) : Color.secondary.opacity(0.5)
+            return viewModel.isButtonRecordEnabled ? Color(uiColor: UIAppColor.primary) : Color.secondary.opacity(0.5)
         }
         return .black
     }


### PR DESCRIPTION
At some point when introducing new colors, wpios was updated to use `.brand` instead of `.primary`, which is incorrect.

<img width="1159" alt="Screenshot 2025-01-06 at 12 55 47 PM" src="https://github.com/user-attachments/assets/747497a6-c283-4af2-9f8e-1197801c4230" />

This PR fixes the primary tint color and also removes `.brand` entirely to avoid any confusion in the future. The new blue color also uses a slightly lighter shade in dark mode – just like we do in jpios. The previous town was too dark.

## Before
<img width="320" alt="Screenshot 2025-01-06 at 12 55 11 PM" src="https://github.com/user-attachments/assets/57058220-c90e-45a4-8c52-5b3ca7c749cb" /> <img width="320" alt="Screenshot 2025-01-06 at 12 55 06 PM" src="https://github.com/user-attachments/assets/53cf8987-e663-4dae-a358-9128ddee49db" />

## After
<img width="320" alt="Screenshot 2025-01-06 at 1 00 19 PM" src="https://github.com/user-attachments/assets/aa1a11c1-e28f-4421-8550-ec08f00ec2de" /> <img width="320" alt="Screenshot 2025-01-06 at 1 28 30 PM" src="https://github.com/user-attachments/assets/0cf960a3-f04b-45c0-a681-0fe745d47d76" />



To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
