### PR TITLE
Integrate zoom transitions in Reader

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,7 +14,7 @@
 * [*] Fix an issue with comments being lost on request failure [#23942]
 * [*] Fix an issue with Referrers in Stats showing invalid icons [#23943]
 * [*] Update site menu style on iPhone [#23944]
-* [*] Integrate zoom transitions in Themes [#23945]
+* [*] Integrate zoom transitions in Themes, Reader [#23945, #23947]
 
 
 25.6

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -59,6 +59,10 @@ final class ReaderPostCell: ReaderStreamBaseCell {
         }
         return ImageSize(scaling: CGSize(width: coverWidth, height: coverWidth), in: window)
     }
+
+    func getViewForZoomTransition() -> UIView {
+        view
+    }
 }
 
 private final class ReaderPostCellView: UIView {

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
@@ -1379,6 +1379,10 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
         // Check to see if we need to load more.
         syncMoreContentIfNeeded(for: tableView, indexPathForVisibleRow: indexPath)
 
+        if traitCollection.horizontalSizeClass == .regular, #available(iOS 18, *) {
+            cell.selectionStyle = .none
+        }
+
         guard cell.isKind(of: ReaderCrossPostCell.self) else {
             return
         }
@@ -1469,6 +1473,18 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
             trackSavedPostNavigation()
         } else {
             WPAnalytics.trackReader(.readerPostCardTapped, properties: topicPropertyForStats() ?? [:])
+        }
+
+        if traitCollection.horizontalSizeClass == .regular, #available(iOS 18, *) {
+            controller.preferredTransition = .zoom { [weak self] context in
+                guard let self, let cell = self.tableView.cellForRow(at: indexPath) else {
+                    return nil
+                }
+                if let cell = (cell as? ReaderPostCell) {
+                    return cell.getViewForZoomTransition()
+                }
+                return cell.contentView
+            }
         }
 
         navigationController?.pushViewController(controller, animated: true)


### PR DESCRIPTION
https://github.com/user-attachments/assets/8cb16850-e470-4dfa-b40d-e18848cfedda


The previous transitions used an awkward gray selected style, which is now gone.

https://github.com/user-attachments/assets/5b1aa219-15f3-4fcc-bfce-27b6c0e259b0





## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
