### PR TITLE
Enable toolbar hiding on iPad too

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -1143,17 +1143,6 @@ private extension ReaderDetailViewController {
         let image = image.withRenderingMode(.alwaysTemplate)
         return UIBarButtonItem(image: image, style: .plain, target: self, action: action)
     }
-
-    /// Checks if the view is visible in the viewport.
-    func isVisibleInScrollView(_ view: UIView) -> Bool {
-        guard view.superview != nil, !view.isHidden else {
-            return false
-        }
-
-        let scrollViewFrame = CGRect(origin: scrollView.contentOffset, size: scrollView.frame.size)
-        let convertedViewFrame = scrollView.convert(view.bounds, from: view)
-        return scrollViewFrame.intersects(convertedViewFrame)
-    }
 }
 
 // MARK: - NoResultsViewControllerDelegate

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -812,8 +812,6 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
 extension ReaderDetailViewController: UIScrollViewDelegate {
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        guard traitCollection.horizontalSizeClass == .compact else { return }
-
         let currentOffset = scrollView.contentOffset.y
         // Using `safeAreaLayoutGuide.layoutFrame.height` because it doesn't
         // change when we extend the scroll view size by hiding the toolbar

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -67,7 +67,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     private let activityIndicator = UIActivityIndicatorView(style: .medium)
 
     /// The actual header
-    private let featuredImage = ReaderDetailFeaturedImageView()
+    private let featuredImageView = ReaderDetailFeaturedImageView()
 
     /// The actual header
     private lazy var header: ReaderDetailHeaderHostingView = {
@@ -202,7 +202,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             return
         }
 
-        featuredImage.viewWillDisappear()
+        featuredImageView.viewWillDisappear()
         toolbar.viewWillDisappear()
     }
 
@@ -210,7 +210,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         super.viewWillTransition(to: size, with: coordinator)
 
         coordinator.animate(alongsideTransition: { _ in
-            self.featuredImage.deviceDidRotate()
+            self.featuredImageView.deviceDidRotate()
         })
     }
 
@@ -222,7 +222,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     func render(_ post: ReaderPost) {
         configureDiscoverAttribution(post)
 
-        featuredImage.configure(for: post, with: self)
+        featuredImageView.configure(for: post, with: self)
         toolbar.configure(for: post, in: self)
         header.configure(for: post)
         fetchLikes()
@@ -245,12 +245,12 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             self?.webView.loadHTMLString(post.contentForDisplay())
         }
 
-        guard !featuredImage.isLoaded else {
+        guard !featuredImageView.isLoaded else {
             return
         }
 
         // Load the image
-        featuredImage.load { [weak self] in
+        featuredImageView.load { [weak self] in
             self?.hideLoading()
         }
 
@@ -301,7 +301,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     func hideLoading() {
-        guard !featuredImage.isLoading, !isLoadingWebView else {
+        guard !featuredImageView.isLoading, !isLoadingWebView else {
             return
         }
 
@@ -448,7 +448,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         }
 
         // Featured image view
-        featuredImage.displaySetting = displaySetting
+        featuredImageView.displaySetting = displaySetting
 
         // Update Reader Post web view
         if let contentForDisplay = post?.contentForDisplay() {
@@ -507,18 +507,18 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     private func setupFeaturedImage() {
         configureFeaturedImage()
 
-        featuredImage.configure(
+        featuredImageView.configure(
             scrollView: scrollView,
             navigationBar: navigationController?.navigationBar,
             navigationItem: navigationItem
         )
 
-        guard !featuredImage.isLoaded else {
+        guard !featuredImageView.isLoaded else {
             return
         }
 
         // Load the image
-        featuredImage.load { [weak self] in
+        featuredImageView.load { [weak self] in
             guard let self else {
                 return
             }
@@ -527,24 +527,24 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     private func configureFeaturedImage() {
-        guard featuredImage.superview == nil else {
+        guard featuredImageView.superview == nil else {
             return
         }
 
         if ReaderDisplaySetting.customizationEnabled {
-            featuredImage.displaySetting = displaySetting
+            featuredImageView.displaySetting = displaySetting
         }
 
-        featuredImage.useCompatibilityMode = useCompatibilityMode
+        featuredImageView.useCompatibilityMode = useCompatibilityMode
 
-        featuredImage.delegate = coordinator
+        featuredImageView.delegate = coordinator
 
-        view.insertSubview(featuredImage, belowSubview: webView)
+        view.insertSubview(featuredImageView, belowSubview: webView)
 
         NSLayoutConstraint.activate([
-            featuredImage.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 0),
-            featuredImage.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 0),
-            featuredImage.topAnchor.constraint(equalTo: view.topAnchor, constant: 0)
+            featuredImageView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 0),
+            featuredImageView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 0),
+            featuredImageView.topAnchor.constraint(equalTo: view.topAnchor, constant: 0)
         ])
 
         headerContainerView.translatesAutoresizingMaskIntoConstraints = false

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailFeaturedImageView.swift
@@ -141,8 +141,11 @@ final class ReaderDetailFeaturedImageView: UIView {
         imageView.pinEdges()
 
         addSubview(gradientView)
-        gradientView.heightAnchor.constraint(equalToConstant: 120).isActive = true
         gradientView.pinEdges([.top, .horizontal])
+        NSLayoutConstraint.activate([
+            gradientView.heightAnchor.constraint(equalToConstant: 120).withPriority(999),
+            gradientView.bottomAnchor.constraint(lessThanOrEqualTo: bottomAnchor) // Make sure it collapses
+        ])
 
         isUserInteractionEnabled = false
 


### PR DESCRIPTION
This PR also fixes a regression where the gradient view was visible when no featured image was present.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
