### PR TITLE
Fix an issue with Publisize options appearing in the prepublishing sheet for sites that don't support it

### DIFF
--- a/WordPress/Classes/Models/Blog/Blog+Capabilities.swift
+++ b/WordPress/Classes/Models/Blog/Blog+Capabilities.swift
@@ -6,21 +6,21 @@ extension Blog {
     /// Enumeration that contains all of the Blog's available capabilities.
     ///
     public enum Capability: String {
-        case DeleteOthersPosts  = "delete_others_posts"
-        case DeletePosts        = "delete_posts"
-        case EditOthersPages    = "edit_others_pages"
-        case EditOthersPosts    = "edit_others_posts"
-        case EditPages          = "edit_pages"
-        case EditPosts          = "edit_posts"
-        case EditThemeOptions   = "edit_theme_options"
-        case EditUsers          = "edit_users"
-        case ListUsers          = "list_users"
-        case ManageCategories   = "manage_categories"
-        case ManageOptions      = "manage_options"
-        case PromoteUsers       = "promote_users"
-        case PublishPosts       = "publish_posts"
-        case UploadFiles        = "upload_files"
-        case ViewStats          = "view_stats"
+        case DeleteOthersPosts = "delete_others_posts"
+        case DeletePosts = "delete_posts"
+        case EditOthersPages = "edit_others_pages"
+        case EditOthersPosts = "edit_others_posts"
+        case EditPages = "edit_pages"
+        case EditPosts = "edit_posts"
+        case EditThemeOptions = "edit_theme_options"
+        case EditUsers = "edit_users"
+        case ListUsers = "list_users"
+        case ManageCategories = "manage_categories"
+        case ManageOptions = "manage_options"
+        case PromoteUsers = "promote_users"
+        case PublishPosts = "publish_posts"
+        case UploadFiles = "upload_files"
+        case ViewStats = "view_stats"
     }
 
     /// Returns true if a given capability is enabled. False otherwise

--- a/WordPress/Classes/Models/Blog/Blog.h
+++ b/WordPress/Classes/Models/Blog/Blog.h
@@ -194,20 +194,20 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
  *
  *  @warn       For WordPress.com or Jetpack Managed sites this will be nil. Use usernameForSite instead
  */
-@property (nonatomic, strong, readwrite, nullable) NSString       *username;
-@property (nonatomic, strong, readwrite, nullable) NSString       *password;
+@property (nonatomic, strong, readwrite, nullable) NSString *username;
+@property (nonatomic, strong, readwrite, nullable) NSString *password;
 
 
 // Readonly Properties
-@property (nonatomic,   weak,  readonly, nullable) NSArray *sortedPostFormatNames;
-@property (nonatomic,   weak,  readonly, nullable) NSArray *sortedPostFormats;
-@property (nonatomic,   weak,  readonly, nullable) NSArray *sortedConnections;
+@property (nonatomic, weak, readonly, nullable) NSArray *sortedPostFormatNames;
+@property (nonatomic, weak, readonly, nullable) NSArray *sortedPostFormats;
+@property (nonatomic, weak, readonly, nullable) NSArray *sortedConnections;
 @property (nonatomic, readonly, nullable) NSArray<Role *> *sortedRoles;
-@property (nonatomic, strong,  readonly, nullable) WordPressOrgXMLRPCApi *xmlrpcApi;
-@property (nonatomic, strong,  readonly, nullable) WordPressOrgRestApi *selfHostedSiteRestApi;
-@property (nonatomic,   weak,  readonly, nullable) NSString       *version;
-@property (nonatomic, strong,  readonly, nullable) NSString       *authToken;
-@property (nonatomic, strong,  readonly, nullable) NSSet *allowedFileTypes;
+@property (nonatomic, strong, readonly, nullable) WordPressOrgXMLRPCApi *xmlrpcApi;
+@property (nonatomic, strong, readonly, nullable) WordPressOrgRestApi *selfHostedSiteRestApi;
+@property (nonatomic, weak, readonly, nullable) NSString *version;
+@property (nonatomic, strong, readonly, nullable) NSString *authToken;
+@property (nonatomic, strong, readonly, nullable) NSSet *allowedFileTypes;
 @property (nonatomic, copy, readonly, nullable) NSString *usernameForSite;
 @property (nonatomic, assign, readonly) BOOL canBlaze;
 

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
@@ -8,7 +8,12 @@ extension PrepublishingViewController {
     /// Determines whether the account and the post's blog is eligible to see the Jetpack Social row.
     func canDisplaySocialRow(isJetpack: Bool = AppConfiguration.isJetpack,
                              isFeatureEnabled: Bool = RemoteFeatureFlag.jetpackSocialImprovements.enabled()) -> Bool {
-        guard isJetpack && isFeatureEnabled && !isPostPrivate && hasPublicizeServices else {
+        guard isJetpack &&
+                isFeatureEnabled &&
+                !isPostPrivate &&
+                hasPublicizeServices &&
+                post.blog.supportsPublicize()
+        else {
             return false
         }
 
@@ -17,12 +22,7 @@ extension PrepublishingViewController {
             return !isNoConnectionDismissed
         }
 
-        let blogSupportsPublicize = coreDataStack.performQuery { [postObjectID = post.objectID] context in
-            let post = (try? context.existingObject(with: postObjectID)) as? Post
-            return post?.blog.supportsPublicize() ?? false
-        }
-
-        return blogSupportsPublicize
+        return true
     }
 
     func configureSocialCell(_ cell: UITableViewCell) {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/22142

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
