### PR TITLE
Disable universal links support for QR code login

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,6 +16,7 @@
 * [*] Update site menu style on iPhone [#23944]
 * [*] Integrate zoom transitions in Themes, Reader [#23945, #23947]
 * [*] Fix an issue with site icons cropped in share extensions [#23950]
+* [*] Disable universal links support for QR code login. You can only scan the codes using the app now. [#23953]
 
 25.6
 -----

--- a/WordPress/Classes/ViewRelated/QR Login/Coordinators/QRLoginCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/QR Login/Coordinators/QRLoginCoordinator.swift
@@ -18,13 +18,13 @@ struct QRLoginCoordinator: QRLoginParentCoordinator {
 
     static func didHandle(url: URL) -> Bool {
         guard
-            let token = QRLoginURLParser(urlString: url.absoluteString).parse(),
+            let _ = QRLoginURLParser(urlString: url.absoluteString).parse(),
             let source = UIApplication.shared.leafViewController
         else {
             return false
         }
-
-        self.init(origin: .deepLink).showVerifyAuthorization(token: token, from: source)
+        self.init(origin: .deepLink).showCameraScanningView(from: source)
+        Notice(title: Strings.scanFromApp).post()
         return true
     }
 
@@ -34,10 +34,7 @@ struct QRLoginCoordinator: QRLoginParentCoordinator {
 
     func showVerifyAuthorization(token: QRLoginToken, from source: UIViewController? = nil) {
         let controller = QRLoginVerifyAuthorizationViewController()
-        controller.coordinator = QRLoginVerifyCoordinator(token: token,
-                                                          view: controller,
-                                                          parentCoordinator: self)
-
+        controller.coordinator = QRLoginVerifyCoordinator(token: token, view: controller, parentCoordinator: self)
         pushOrPresent(controller, from: source)
     }
 }
@@ -114,4 +111,8 @@ extension QRLoginCoordinator {
     static func present(token: QRLoginToken, from source: UIViewController, origin: QRLoginOrigin) {
         QRLoginCoordinator(origin: origin).showVerifyAuthorization(token: token, from: source)
     }
+}
+
+private enum Strings {
+    static let scanFromApp = NSLocalizedString("qrLogin.codeHasToBeScannedFromTheAppNotice.title", value: "Please scan the code using the app", comment: "Informational notice title. Showed when you scan a code using a camera app outside of the app, which is not allowed.")
 }

--- a/WordPress/Classes/ViewRelated/QR Login/Coordinators/QRLoginScanningCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/QR Login/Coordinators/QRLoginScanningCoordinator.swift
@@ -4,6 +4,7 @@ class QRLoginScanningCoordinator: NSObject {
     let parentCoordinator: QRLoginParentCoordinator
     let view: QRLoginScanningView
     var cameraSession: QRCodeScanningSession
+    private var didHandleToken = false
 
     init(view: QRLoginScanningView, parentCoordinator: QRLoginParentCoordinator, cameraSession: QRCodeScanningSession = QRLoginCameraSession()) {
         self.view = view
@@ -48,6 +49,9 @@ extension QRLoginScanningCoordinator {
     }
 
     func didScanToken(_ token: QRLoginToken) {
+        guard !didHandleToken else { return }
+        didHandleToken = true // Prevents the subsequent captures.
+
         parentCoordinator.track(.qrLoginScannerScannedCode)
 
         // Give the user a tap to let them know they've successfully scanned the code


### PR DESCRIPTION
**Changes:**

- Disable universal links support for QR code login. You'll now have to scan the code using the app.
- Fix an issue with the confirmation screen being shown multiple times


https://github.com/user-attachments/assets/6cd07fd3-07ea-4eba-8c0f-bfb49d306bc0



To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
