### PR TITLE
Enable fast deceleration for filters on the Discover tab

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,6 +16,8 @@
 * [*] Update site menu style on iPhone [#23944]
 * [*] Integrate zoom transitions in Themes, Reader [#23945, #23947]
 * [*] Fix an issue with site icons cropped in share extensions [#23950]
+* [*] Enable fast deceleration for filters on the Discover tab [#23954]
+
 
 25.6
 -----

--- a/WordPress/Classes/ViewRelated/Reader/Headers/ReaderDiscoverHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Headers/ReaderDiscoverHeaderView.swift
@@ -22,6 +22,8 @@ final class ReaderDiscoverHeaderView: ReaderBaseHeaderView, UITextViewDelegate {
         scrollView.addSubview(channelsStackView)
         scrollView.showsHorizontalScrollIndicator = false
         scrollView.clipsToBounds = false
+        scrollView.decelerationRate = .fast
+
         channelsStackView.pinEdges()
         scrollView.heightAnchor.constraint(equalTo: channelsStackView.heightAnchor).isActive = true
 
@@ -65,7 +67,7 @@ final class ReaderDiscoverHeaderView: ReaderBaseHeaderView, UITextViewDelegate {
 
     private func updateScrollViewInsets() {
         scrollView.contentInset.left = contentView.frame.minX - (isCompact ? 0 : 10)
-        scrollView.contentInset.right = frame.maxX - contentView.frame.maxX
+        scrollView.contentInset.right = frame.maxX - contentView.frame.maxX + 10
         scrollView.contentOffset = CGPoint(x: -scrollView.contentInset.left, y: 0)
     }
 


### PR DESCRIPTION
Fixes #

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
