### PR TITLE
feat: Improve editor session events

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20241116"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "v0.0.3"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "9afee5826d08b64e9349b6753a13c1f387a0d413"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20241116"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "9afee5826d08b64e9349b6753a13c1f387a0d413"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "4476d597b271778d001a26c50d74e527b54ebfef"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e67326cf4e0b967f85976c160b6e3742a401276eabf3e18b25fce8bb219e1350",
+  "originHash" : "7d106f654851308d6802679ad265147edb5c165ff1ef38825f9ff679d6270896",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,8 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "branch" : "v0.0.3",
-        "revision" : "84edec43cc8639d5d8a66a07758902e33f0d2d94"
+        "revision" : "9afee5826d08b64e9349b6753a13c1f387a0d413"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7d106f654851308d6802679ad265147edb5c165ff1ef38825f9ff679d6270896",
+  "originHash" : "8a87409582dec4bc7c7f6ee5d6a6761cead545bd116f82237fc9e6a881e7c3fb",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,7 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "9afee5826d08b64e9349b6753a13c1f387a0d413"
+        "revision" : "4476d597b271778d001a26c50d74e527b54ebfef"
       }
     },
     {

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -127,7 +127,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         self.post = post
 
         self.replaceEditor = replaceEditor
-        self.editorSession = PostEditorAnalyticsSession(editor: .gutenberg, post: post)
+        self.editorSession = PostEditorAnalyticsSession(editor: .gutenbergKit, post: post)
         self.navigationBarManager = navigationBarManager ?? PostEditorNavigationBarManager()
 
         let networkClient = NewGutenbergNetworkClient(blog: post.blog)

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -315,6 +315,16 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 }
 
 extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate {
+    func editorDidLoad(_ viewContoller: GutenbergKit.EditorViewController) {
+        if !editorSession.started {
+            // Note that this method is also used to track startup performance
+            // It assumes this is being called when the editor has finished loading
+            // If you need to refactor this, please ensure that the startup_time_ms property
+            // is still reflecting the actual startup time of the editor
+            editorSession.start()
+        }
+    }
+
     func editor(_ viewContoller: GutenbergKit.EditorViewController, didDisplayInitialContent content: String) {
         // Do nothing
     }

--- a/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorAnalyticsSession.swift
@@ -97,6 +97,7 @@ private extension PostEditorAnalyticsSession {
 extension PostEditorAnalyticsSession {
     enum Editor: String {
         case gutenberg
+        case gutenbergKit = "gutenberg_kit"
         case classic
         case html
     }


### PR DESCRIPTION
- Introduce `gutenberg_kit` editor session event property value.
- Track editor session start event for GutenbergKit sessions.

Related: 

* https://github.com/Automattic/dotcom-forge/issues/8268.
* https://github.com/wordpress-mobile/WordPress-Android/pull/21564
* https://github.com/wordpress-mobile/GutenbergKit/pull/54

To test:

1. Open the experimental editor.
1. Close the editor.
1. Verify `editor_session_start|end` events trigger with a
   `editor: gutenberg_kit` property.

## Regression Notes
1. Potential unintended areas of impact
    Disrupt events for the other editors.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Verify the editor session events work as expected.
3. What automated tests I added (or what prevented me from doing so)
    Deemed unnecessary for this experimental editor analytic event.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
