### PR TITLE
Show selected filter in the Discover navigation bar

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,6 +16,7 @@
 * [*] Update site menu style on iPhone [#23944]
 * [*] Integrate zoom transitions in Themes, Reader [#23945, #23947]
 * [*] Fix an issue with site icons cropped in share extensions [#23950]
+* [*] Show selected filter in the Discover navigation bar [#23956]
 * [*] Enable fast deceleration for filters on the Discover tab [#23954]
 
 

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderDiscoverViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderDiscoverViewController.swift
@@ -127,7 +127,10 @@ class ReaderDiscoverViewController: UIViewController, ReaderDiscoverHeaderViewDe
         streamVC.view.pinEdges()
         streamVC.didMove(toParent: self)
 
-        navigationItem.titleView = streamVC.navigationItem.titleView // important
+        streamVC.titleView.detailsLabel.text = selectedChannel.localizedTitle
+        streamVC.titleView.detailsLabel.isHidden = false
+
+        navigationItem.titleView = streamVC.titleView // important
     }
 
     /// TODO: (tech-debt) the app currently stores the responses from the `/discover`

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
@@ -65,8 +65,9 @@ import AutomatticTracks
         return refreshControl
     }()
 
-    private let loadMoreThreashold = 4
+    let titleView = ReaderNavigationCustomTitleView()
 
+    private let loadMoreThreashold = 5
     private let refreshInterval = 300
     private var cleanupAndRefreshAfterScrolling = false
     private let recentlyBlockedSitePostObjectIDs = NSMutableArray()
@@ -77,7 +78,6 @@ import AutomatticTracks
     private var indexPathForGapMarker: IndexPath?
     private var didSetupView = false
     private var didBumpStats = false
-    @Lazy private var titleView = ReaderNavigationCustomTitleView()
     internal let scrollViewTranslationPublisher = PassthroughSubject<Bool, Never>()
     private let notificationsButtonViewModel = NotificationsButtonViewModel()
     private var notificationsButtonCancellable: AnyCancellable?
@@ -1660,7 +1660,7 @@ extension ReaderStreamViewController: UITableViewDelegate, JPScrollViewDelegate 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         layoutEmptyStateView()
         processJetpackBannerVisibility(scrollView)
-        $titleView.value?.updateAlpha(in: scrollView)
+        titleView.updateAlpha(in: scrollView)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderNavigationCustomTitleView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderNavigationCustomTitleView.swift
@@ -4,31 +4,36 @@ import WordPressUI
 /// A custom replacement for a navigation bar title view.
 final class ReaderNavigationCustomTitleView: UIView {
     let textLabel = UILabel()
+    let detailsLabel = UILabel()
+    private lazy var stackView = UIStackView(axis: .vertical, alignment: .center, [textLabel, detailsLabel])
 
     override init(frame: CGRect) {
         super.init(frame: frame)
 
         textLabel.font = WPStyleGuide.navigationBarStandardFont
-        textLabel.alpha = 0
 
-        // The label has to be a subview of the title view because
-        // navigation bar doesn't seem to allow you to change the alpha
-        // of `navigationItem.titleView` itself.
-        addSubview(textLabel)
-        textLabel.pinEdges()
+        detailsLabel.font = .preferredFont(forTextStyle: .footnote)
+        detailsLabel.textColor = .secondaryLabel
+        detailsLabel.isHidden = true
+
+        addSubview(stackView)
+        stackView.pinEdges()
     }
 
     required init?(coder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
 
+    // The label has to be a subview of the title view because
+    // navigation bar doesn't seem to allow you to change the alpha
+    // of `navigationItem.titleView` itself.
     func updateAlpha(in scrollView: UIScrollView) {
         let offsetY = scrollView.contentOffset.y
         if offsetY < 16 {
-            textLabel.alpha = 0
+            stackView.alpha = 0
         } else {
             let alpha = (offsetY - 16) / 24
-            textLabel.alpha = max(0, min(1, alpha))
+            stackView.alpha = max(0, min(1, alpha))
         }
     }
 }


### PR DESCRIPTION
This PR takes advantages of the custom title view we introduced previously to show the selected filter/channel.

<img width="320" alt="Screenshot 2025-01-07 at 1 06 01 PM" src="https://github.com/user-attachments/assets/7cf10652-0daa-4724-a9b8-d2f3e666aa1e" />

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
