### PR TITLE
Bump up Gravatar to 3.1.1

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -22,7 +22,7 @@ let package = Package(
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs", from: "9.1.0"),
         .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS", from: "3.4.2"),
         .package(url: "https://github.com/Automattic/AutomatticAbout-swift", from: "1.1.4"),
-        .package(url: "https://github.com/Automattic/Gravatar-SDK-iOS", from: "3.1.0"),
+        .package(url: "https://github.com/Automattic/Gravatar-SDK-iOS", from: "3.1.1"),
         .package(url: "https://github.com/Automattic/Gridicons-iOS", branch: "develop"),
         .package(url: "https://github.com/Automattic/ScreenObject", from: "0.2.3"),
         .package(url: "https://github.com/Automattic/XCUITestHelpers", from: "0.4.0"),

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e67326cf4e0b967f85976c160b6e3742a401276eabf3e18b25fce8bb219e1350",
+  "originHash" : "050f4516b852a8d02524960543d183cfa2327095133e9b4c17745fa7a494cc9a",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -132,8 +132,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/Gravatar-SDK-iOS",
       "state" : {
-        "revision" : "b4f63edd2f81c37025817b23fee83721d034c320",
-        "version" : "3.1.0"
+        "revision" : "e7c6606015bab7258c4de9dde9d87736677ddc73",
+        "version" : "3.1.1"
       }
     },
     {


### PR DESCRIPTION
Fixes #

Bumps up Gravatar to 3.1.1 to bring in a bug fix.

To test:

The fix can be tested https://github.com/Automattic/Gravatar-SDK-iOS/pull/623

## Regression Notes
1. Potential unintended areas of impact
No change in the Jetpack code.

2. What I did to test those areas of impact (or what existing automated tests I relied on)
-

3. What automated tests I added (or what prevented me from doing so)
-
PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
