### PR TITLE
Address localization and test build failures

### DIFF
--- a/WordPress/Classes/Utility/WebViewController/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebViewController/WebKitViewController.swift
@@ -57,7 +57,7 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
                                style: .plain,
                                target: self,
                                action: #selector(share))
-        button.title = NSLocalizedString(SharedStrings.Button.share, comment: "Button label to share a web page")
+        button.title = NSLocalizedString("webKit.button.share", value: "Share", comment: "Button label to share a web page")
         return button
     }()
     @objc lazy var safariButton: UIBarButtonItem = {

--- a/WordPress/WordPressTest/SiteIconViewModelTests.swift
+++ b/WordPress/WordPressTest/SiteIconViewModelTests.swift
@@ -1,6 +1,6 @@
 import UIKit
 import XCTest
-
+import WordPressUI
 @testable import WordPress
 
 final class SiteIconViewModelTests: XCTestCase {


### PR DESCRIPTION
In https://github.com/wordpress-mobile/WordPress-iOS/pull/23951#issuecomment-2577169233 I commented regarding a few build failures unrelated to the CocoaPods removal I found when creating https://github.com/wordpress-mobile/WordPress-iOS/pull/23958

This PR addresses them, see commits list.

---

I also noticed that the UI tests seem to fail consistently, see for example:

- https://buildkite.com/automattic/wordpress-ios/builds/25319
- https://buildkite.com/automattic/wordpress-ios/builds/25312
- https://buildkite.com/automattic/wordpress-ios/builds/25307

The failing tests are:

```
testBasicPostPublishWithCategoryAndTag() in EditorGutenbergTests
testAddRemoveFeaturedImage() in EditorGutenbergTests
testTextPostPublish() in EditorGutenbergTests
```

I downloaded the test results from Buildkite and had a look. Here's what I found that might help further fixing.

I think `testBasicPostPublishWithCategoryAndTag` and `testTextPostPublish` might be failing because the blogging reminders prompt is not dismissed after creating the post:

![image](https://github.com/user-attachments/assets/4ea50297-ffad-44f7-bfea-ccf132fd1ddf)

As for `testAddRemoveFeaturedImage()`, it might be failing because of a change in labels. See in the screenshot of the test result how the test is looking for `"CurrentFeaturedImage"` but that only matches for that string are in the test code itself.

![image](https://github.com/user-attachments/assets/1a54a6a1-c80b-45ca-bc4b-59099d5a3ab5)