### PR TITLE
feat: GutenbergKit history navigation

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20241116"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "beaefbca437ca28f11fdda5805d2709cb6f97e07"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "5a43a1b8ab5034e5be4b4eb93c30885cc41227b2"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20241116"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "4476d597b271778d001a26c50d74e527b54ebfef"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "ae41b33cc5d29da3296a693b28972c1d4d99a2d8"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20241116"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "ae41b33cc5d29da3296a693b28972c1d4d99a2d8"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "beaefbca437ca28f11fdda5805d2709cb6f97e07"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 25.7
 -----
+* [**] Enable history navigation (undo and redo) for the experimental editor. [#23961]
 
 25.6
 -----

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "93ccd17b7aa49e87dbdbd1bd7b1f9c12839051fb218621a4cefac0023ab52947",
+  "originHash" : "e32b9f05246b46d630eb7aa6dcdb452c3e5359a28e21abb3209d98227d55fca7",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,7 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "ae41b33cc5d29da3296a693b28972c1d4d99a2d8"
+        "revision" : "beaefbca437ca28f11fdda5805d2709cb6f97e07"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e32b9f05246b46d630eb7aa6dcdb452c3e5359a28e21abb3209d98227d55fca7",
+  "originHash" : "4cacb81eb20e7d20d1b25f261d9303a24f725104ed3b36743fc2707b7473a93d",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,7 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "beaefbca437ca28f11fdda5805d2709cb6f97e07"
+        "revision" : "5a43a1b8ab5034e5be4b4eb93c30885cc41227b2"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8a87409582dec4bc7c7f6ee5d6a6761cead545bd116f82237fc9e6a881e7c3fb",
+  "originHash" : "93ccd17b7aa49e87dbdbd1bd7b1f9c12839051fb218621a4cefac0023ab52947",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,7 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "4476d597b271778d001a26c50d74e527b54ebfef"
+        "revision" : "ae41b33cc5d29da3296a693b28972c1d4d99a2d8"
       }
     },
     {

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -610,13 +610,11 @@ extension NewGutenbergViewController: PostEditorNavigationBarManagerDelegate {
     }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, undoWasPressed sender: UIButton) {
-        // TODO: reimplement
-        // self.gutenberg.onUndoPressed()
+        editorViewController.undo()
     }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, redoWasPressed sender: UIButton) {
-        // TODO: reimplement
-        // self.gutenberg.onRedoPressed()
+        editorViewController.redo()
     }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, moreWasPressed sender: UIButton) {

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -332,6 +332,11 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
         }
     }
 
+    func editor(_ viewController: GutenbergKit.EditorViewController, didUpdateHistoryState state: GutenbergKit.EditorState) {
+        gutenbergDidRequestToggleRedoButton(!state.hasRedo)
+        gutenbergDidRequestToggleUndoButton(!state.hasUndo)
+    }
+
     func editor(_ viewController: GutenbergKit.EditorViewController, performRequest: GutenbergKit.EditorNetworkRequest) async throws -> GutenbergKit.EditorNetworkResponse {
         throw URLError(.unknown)
     }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -242,22 +242,8 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     }
 
     private func reloadBlogIconView() {
-        let blog = post.blog
-
-//        if blog.hasIcon == true {
-//            let size = CGSize(width: 24, height: 24)
-//            navigationBarManager.siteIconView.imageView.downloadSiteIcon(for: blog, imageSize: size)
-//        } else if blog.isWPForTeams() {
-//            navigationBarManager.siteIconView.imageView.tintColor = UIColor.secondaryLabel
-//            navigationBarManager.siteIconView.imageView.image = UIImage.gridicon(.p2)
-//        } else {
-//            navigationBarManager.siteIconView.imageView.image = UIImage.siteIconPlaceholder
-//        }
-
-        // TODO: implement
-        // Docs: https://wordpress.org/gutenberg-framework/docs/basic-concepts/undo-redo
-        navigationBarManager.undoButton.isHidden = true
-        navigationBarManager.redoButton.isHidden = true
+        let viewModel = SiteIconViewModel(blog: post.blog, size: .small)
+        navigationBarManager.siteIconView.imageView.setIcon(with: viewModel)
     }
 
     // TODO: this should not be called on viewDidLoad


### PR DESCRIPTION
Enable navigating forwards and backwards in the editor history.

Related:

* https://github.com/Automattic/dotcom-forge/issues/9968
* https://github.com/wordpress-mobile/GutenbergKit/pull/55
* https://github.com/wordpress-mobile/WordPress-Android/pull/21570

To test: See https://github.com/wordpress-mobile/GutenbergKit/pull/55.

## Regression Notes
1. Potential unintended areas of impact
    None likely, given the changes are scoped to a single editor.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    N/A.
3. What automated tests I added (or what prevented me from doing so)
    N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
