### PR TITLE
build: Update AutomatticAbout

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
         .package(url: "https://github.com/AliSoftware/OHHTTPStubs", from: "9.1.0"),
         .package(url: "https://github.com/apple/swift-collections", from: "1.0.0"),
         .package(url: "https://github.com/Automattic/Automattic-Tracks-iOS", from: "3.4.2"),
-        .package(url: "https://github.com/Automattic/AutomatticAbout-swift", from: "1.1.4"),
+        .package(url: "https://github.com/Automattic/AutomatticAbout-swift", from: "1.1.5"),
         .package(url: "https://github.com/Automattic/Gravatar-SDK-iOS", from: "3.1.1"),
         .package(url: "https://github.com/Automattic/Gridicons-iOS", branch: "develop"),
         .package(url: "https://github.com/Automattic/ScreenObject", from: "0.2.3"),

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d8a7faa1972ab73744be3161f236c4bae7faf7c44f840b7bd0a52b3ee1ee6d6c",
+  "originHash" : "384e396170e1bac4b5b82a62fac1cbc68b97107163c6fd0f73b311483427ab36",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/AutomatticAbout-swift",
       "state" : {
-        "revision" : "31045d654bcc1f2b56c85dd658f160fad5b50a29",
-        "version" : "1.1.4"
+        "revision" : "606384a7492faa1139d489080dd961b0b57f9fd9",
+        "version" : "1.1.5"
       }
     },
     {


### PR DESCRIPTION
> [!Warning]
> The public launch date for the Woo 2.0 Brand Rollout project is Feb 4th. ⚠️ So, **this change should not be released earlier or later**. Since we release apps weekly or bi-weekly, please target the week of Feb 4th, If that’s not feasible, the following week.

Include the latest Woo branding. Relates to pbMoDN-4vZ-p2.

To test:

1. Navigate to _Me_ → _About Jetpack for iOS_.
1. Verify the new logo is displayed for the Woo marble.

| Light | Dark |
| - | - |
| ![Simulator Screenshot - iPhone 16 Pro - 2025-01-09 at 10 38 17](https://github.com/user-attachments/assets/5315173f-ff5c-4459-be07-78b18662f2fa) | ![Simulator Screenshot - iPhone 16 Pro - 2025-01-09 at 10 38 26](https://github.com/user-attachments/assets/3961bb9e-788c-4d99-9e88-34d557193f39) |

## Regression Notes
1. Potential unintended areas of impact
    None, unlikely for this single dependency update.
3. What I did to test those areas of impact (or what existing automated tests I relied on)
    N/A.
4. What automated tests I added (or what prevented me from doing so)
    N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
