### PR TITLE
Add context menus and previews for sites in Reader

### DIFF
--- a/WordPress/Classes/Utility/SharedStrings.swift
+++ b/WordPress/Classes/Utility/SharedStrings.swift
@@ -29,8 +29,10 @@ enum SharedStrings {
         /// - warning: This is the legacy value. It's not compliant with the new format but has the correct translation for different languages.
         static let title = NSLocalizedString("Reader", comment: "The accessibility value of the Reader tab.")
         static let unfollow = NSLocalizedString("reader.button.unfollow", value: "Unfollow", comment: "Reader sidebar button title")
-        static let subscribe = NSLocalizedString("reader.button.subscribe", value: "Subscribe", comment: "Context menu action")
-        static let unsubscribe = NSLocalizedString("reader.button.unsubscribe", value: "Unsubscribe", comment: "Context menu action")
+        static let subscribe = NSLocalizedString("reader.button.subscribe", value: "Subscribe", comment: "A shared button title for Reader")
+        static let unsubscribe = NSLocalizedString("reader.button.unsubscribe", value: "Unsubscribe", comment: "A shared button title for Reader")
+        static let addToFavorites = NSLocalizedString("reader.button.addToFavorites", value: "Add to Favorites", comment: "A shared button title for Reader")
+        static let removeFromFavorites = NSLocalizedString("reader.button.removeFromFavorites", value: "Remove from Favorites", comment: "A shared button title for Reader")
         static let recent = NSLocalizedString("reader.recent.title", value: "Recent", comment: "Used in multiple contexts, usually as a screen title")
         static let discover = NSLocalizedString("reader.discover.title", value: "Discover", comment: "Used in multiple contexts, usually as a screen title")
         static let saved = NSLocalizedString("reader.saved.title", value: "Saved", comment: "Used in multiple contexts, usually as a screen title")

--- a/WordPress/Classes/Utility/SharedStrings.swift
+++ b/WordPress/Classes/Utility/SharedStrings.swift
@@ -29,6 +29,8 @@ enum SharedStrings {
         /// - warning: This is the legacy value. It's not compliant with the new format but has the correct translation for different languages.
         static let title = NSLocalizedString("Reader", comment: "The accessibility value of the Reader tab.")
         static let unfollow = NSLocalizedString("reader.button.unfollow", value: "Unfollow", comment: "Reader sidebar button title")
+        static let subscribe = NSLocalizedString("reader.button.subscribe", value: "Subscribe", comment: "Context menu action")
+        static let unsubscribe = NSLocalizedString("reader.button.unsubscribe", value: "Unsubscribe", comment: "Context menu action")
         static let recent = NSLocalizedString("reader.recent.title", value: "Recent", comment: "Used in multiple contexts, usually as a screen title")
         static let discover = NSLocalizedString("reader.discover.title", value: "Discover", comment: "Used in multiple contexts, usually as a screen title")
         static let saved = NSLocalizedString("reader.saved.title", value: "Saved", comment: "Used in multiple contexts, usually as a screen title")

--- a/WordPress/Classes/Utility/SharedStrings.swift
+++ b/WordPress/Classes/Utility/SharedStrings.swift
@@ -32,6 +32,7 @@ enum SharedStrings {
         static let subscribe = NSLocalizedString("reader.button.subscribe", value: "Subscribe", comment: "A shared button title for Reader")
         static let unsubscribe = NSLocalizedString("reader.button.unsubscribe", value: "Unsubscribe", comment: "A shared button title for Reader")
         static let addToFavorites = NSLocalizedString("reader.button.addToFavorites", value: "Add to Favorites", comment: "A shared button title for Reader")
+        static let notificationSettings = NSLocalizedString("reader.button.notificationSettings", value: "Notification Settings", comment: "A shared button title for Reader")
         static let removeFromFavorites = NSLocalizedString("reader.button.removeFromFavorites", value: "Remove from Favorites", comment: "A shared button title for Reader")
         static let recent = NSLocalizedString("reader.recent.title", value: "Recent", comment: "Used in multiple contexts, usually as a screen title")
         static let discover = NSLocalizedString("reader.discover.title", value: "Discover", comment: "Used in multiple contexts, usually as a screen title")

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderPostMenu.swift
@@ -87,7 +87,7 @@ struct ReaderPostMenu {
     }
 
     private var subscribe: UIAction {
-        UIAction(Strings.subscribe, systemImage: "plus.circle") {
+        UIAction(SharedStrings.Reader.subscribe, systemImage: "plus.circle") {
             ReaderSubscriptionHelper().toggleSiteSubscription(forPost: post)
             track(.subscribe)
         }
@@ -102,7 +102,7 @@ struct ReaderPostMenu {
     }
 
     private var ubsubscribe: UIAction {
-        UIAction(Strings.unsubscribe, systemImage: "minus.circle", attributes: [.destructive]) {
+        UIAction(SharedStrings.Reader.unsubscribe, systemImage: "minus.circle", attributes: [.destructive]) {
             ReaderSubscriptionHelper().toggleSiteSubscription(forPost: post)
             track(.unsubscribe)
         }
@@ -214,8 +214,6 @@ private enum Strings {
     static let viewInBrowser = NSLocalizedString("reader.postContextMenu.viewInBrowser", value: "View in Browser", comment: "Context menu action")
     static let blockOrReport = NSLocalizedString("reader.postContextMenu.blockOrReportMenu", value: "Block or Report", comment: "Context menu action")
     static let goToBlog = NSLocalizedString("reader.postContextMenu.showBlog", value: "Go to Blog", comment: "Context menu action")
-    static let subscribe = NSLocalizedString("reader.postContextMenu.subscribe", value: "Subscribe", comment: "Context menu action")
-    static let unsubscribe = NSLocalizedString("reader.postContextMenu.unsubscribe", value: "Unsubscribe", comment: "Context menu action")
     static let manageNotifications = NSLocalizedString("reader.postContextMenu.manageNotifications", value: "Manage Notifications", comment: "Context menu action")
     static let blogDetails = NSLocalizedString("reader.postContextMenu.blogDetails", value: "Blog Details", comment: "Context menu action (placeholder value when blog name not available – should never happen)")
     static let blockSite = NSLocalizedString("reader.postContextMenu.blockSite", value: "Block Site", comment: "Context menu action")

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderPostMenu.swift
@@ -214,7 +214,7 @@ private enum Strings {
     static let viewInBrowser = NSLocalizedString("reader.postContextMenu.viewInBrowser", value: "View in Browser", comment: "Context menu action")
     static let blockOrReport = NSLocalizedString("reader.postContextMenu.blockOrReportMenu", value: "Block or Report", comment: "Context menu action")
     static let goToBlog = NSLocalizedString("reader.postContextMenu.showBlog", value: "Go to Blog", comment: "Context menu action")
-    static let subscribe = NSLocalizedString("reader.postContextMenu.subscribeT", value: "Subscribe", comment: "Context menu action")
+    static let subscribe = NSLocalizedString("reader.postContextMenu.subscribe", value: "Subscribe", comment: "Context menu action")
     static let unsubscribe = NSLocalizedString("reader.postContextMenu.unsubscribe", value: "Unsubscribe", comment: "Context menu action")
     static let manageNotifications = NSLocalizedString("reader.postContextMenu.manageNotifications", value: "Manage Notifications", comment: "Context menu action")
     static let blogDetails = NSLocalizedString("reader.postContextMenu.blogDetails", value: "Blog Details", comment: "Context menu action (placeholder value when blog name not available – should never happen)")

--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
@@ -65,6 +65,7 @@ struct ReaderSidebarSubscriptionCell: View {
         .sheet(isPresented: $isShowingSettings) {
             ReaderSubscriptionNotificationSettingsView(siteID: site.siteID.intValue)
                 .presentationDetents([.medium, .large])
+                .edgesIgnoringSafeArea(.bottom)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
@@ -64,6 +64,7 @@ struct ReaderSidebarSubscriptionCell: View {
         })
         .sheet(isPresented: $isShowingSettings) {
             ReaderSubscriptionNotificationSettingsView(siteID: site.siteID.intValue)
+                .presentationDetents([.medium, .large])
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
@@ -13,8 +13,14 @@ struct ReaderSidebarSubscriptionsSection: View {
     private var subscriptions: FetchedResults<ReaderSiteTopic>
 
     var body: some View {
-        ForEach(subscriptions, id: \.self) {
-            ReaderSidebarSubscriptionCell(site: $0)
+        ForEach(subscriptions, id: \.self) { site in
+            ReaderSidebarSubscriptionCell(site: site)
+                .contextMenu {
+                    Button(SharedStrings.Reader.unsubscribe, systemImage: "minus.circle", role: .destructive) {
+                        ReaderSubscriptionHelper().unfollow(site)
+                    }
+                }
+
         }
         .onDelete(perform: delete)
     }

--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
@@ -13,14 +13,8 @@ struct ReaderSidebarSubscriptionsSection: View {
     private var subscriptions: FetchedResults<ReaderSiteTopic>
 
     var body: some View {
-        ForEach(subscriptions, id: \.self) { site in
-            ReaderSidebarSubscriptionCell(site: site)
-                .contextMenu {
-                    Button(SharedStrings.Reader.unsubscribe, systemImage: "minus.circle", role: .destructive) {
-                        ReaderSubscriptionHelper().unfollow(site)
-                    }
-                }
-
+        ForEach(subscriptions, id: \.self) {
+            ReaderSidebarSubscriptionCell(site: $0)
         }
         .onDelete(perform: delete)
     }
@@ -56,6 +50,12 @@ struct ReaderSidebarSubscriptionCell: View {
             Button(SharedStrings.Reader.unfollow, role: .destructive) {
                 ReaderSubscriptionHelper().unfollow(site)
             }.tint(.red)
+        }
+        .contextMenu {
+            ReaderSiteFavoriteButton(site: site, source: "context_menu")
+            Button(SharedStrings.Reader.unsubscribe, systemImage: "minus.circle", role: .destructive) {
+                ReaderSubscriptionHelper().unfollow(site)
+            }
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
@@ -46,20 +46,8 @@ struct ReaderSidebarSubscriptionCell: View {
             }
             if editMode?.wrappedValue.isEditing == true {
                 Spacer()
-                Button {
-                    if !site.showInMenu {
-                        WPAnalytics.track(.readerAddSiteToFavoritesTapped)
-                    }
-
-                    let siteObjectID = TaggedManagedObjectID(site)
-                    ContextManager.shared.performAndSave({ managedObjectContext in
-                        let site = try managedObjectContext.existingObject(with: siteObjectID)
-                        site.showInMenu.toggle()
-                    }, completion: nil, on: DispatchQueue.main)
-                } label: {
-                    Image(systemName: site.showInMenu ? "star.fill" : "star")
-                        .foregroundStyle(site.showInMenu ? .pink : .secondary)
-                }.buttonStyle(.plain)
+                ReaderSiteFavoriteButton(site: site, source: "edit_mode")
+                    .labelStyle(.iconOnly)
             }
         }
         .lineLimit(1)
@@ -69,5 +57,26 @@ struct ReaderSidebarSubscriptionCell: View {
                 ReaderSubscriptionHelper().unfollow(site)
             }.tint(.red)
         }
+    }
+}
+
+struct ReaderSiteFavoriteButton: View {
+    let site: ReaderSiteTopic
+    let source: String
+
+    var body: some View {
+        Button {
+            if !site.showInMenu {
+                WPAnalytics.track(.readerAddSiteToFavoritesTapped, properties: ["via": source])
+            }
+            let siteObjectID = TaggedManagedObjectID(site)
+            ContextManager.shared.performAndSave({ managedObjectContext in
+                let site = try managedObjectContext.existingObject(with: siteObjectID)
+                site.showInMenu.toggle()
+            }, completion: nil, on: DispatchQueue.main)
+        } label: {
+            Label(site.showInMenu ? SharedStrings.Reader.removeFromFavorites : SharedStrings.Reader.addToFavorites, systemImage: site.showInMenu ? "star.fill" : "star")
+                .foregroundStyle(site.showInMenu ? .pink : .secondary)
+        }.buttonStyle(.plain)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
@@ -57,9 +57,11 @@ struct ReaderSidebarSubscriptionCell: View {
                 ReaderSubscriptionHelper().unfollow(site)
             }.tint(.red)
         }
-        .contextMenu {
+        .contextMenu(menuItems: {
             ReaderSubscriptionContextMenu(site: site, isShowingSettings: $isShowingSettings)
-        }
+        }, preview: {
+            ReaderTopicPreviewView(topic: site)
+        })
         .sheet(isPresented: $isShowingSettings) {
             ReaderSubscriptionNotificationSettingsView(siteID: site.siteID.intValue)
         }
@@ -91,6 +93,18 @@ struct ReaderSubscriptionContextMenu: View {
                 ReaderSubscriptionHelper().toggleFollowingForSite(site)
             }
         }
+    }
+}
+
+struct ReaderTopicPreviewView: UIViewControllerRepresentable {
+    let topic: ReaderAbstractTopic
+
+    func makeUIViewController(context: Context) -> ReaderStreamViewController {
+        ReaderStreamViewController.controllerWithTopic(topic)
+    }
+
+    func updateUIViewController(_ vc: ReaderStreamViewController, context: Context) {
+        // Do nothing
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
@@ -30,6 +30,7 @@ struct ReaderSidebarSubscriptionsSection: View {
 struct ReaderSidebarSubscriptionCell: View {
     @ObservedObject var site: ReaderSiteTopic
     @Environment(\.editMode) var editMode
+    @State private var isShowingSettings = false
 
     var body: some View {
         HStack {
@@ -57,7 +58,10 @@ struct ReaderSidebarSubscriptionCell: View {
             }.tint(.red)
         }
         .contextMenu {
-            ReaderSubscriptionContextMenu(site: site)
+            ReaderSubscriptionContextMenu(site: site, isShowingSettings: $isShowingSettings)
+        }
+        .sheet(isPresented: $isShowingSettings) {
+            ReaderSubscriptionNotificationSettingsView(siteID: site.siteID.intValue)
         }
     }
 }
@@ -65,12 +69,20 @@ struct ReaderSidebarSubscriptionCell: View {
 struct ReaderSubscriptionContextMenu: View {
     let site: ReaderSiteTopic
 
+    @Binding var isShowingSettings: Bool
+
     var body: some View {
         if let siteURL = URL(string: site.siteURL) {
             ShareLink(item: siteURL)
+            Button(SharedStrings.Button.copyLink, systemImage: "doc.on.doc") {
+                UIPasteboard.general.string = siteURL.absoluteString
+            }
         }
         if site.following {
             ReaderSiteToggleFavoriteButton(site: site, source: "context_menu")
+            Button(SharedStrings.Reader.notificationSettings, systemImage: "bell") {
+                isShowingSettings = true
+            }
             Button(SharedStrings.Reader.unsubscribe, systemImage: "minus.circle", role: .destructive) {
                 ReaderSubscriptionHelper().unfollow(site)
             }

--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
@@ -40,27 +40,49 @@ struct ReaderSidebarSubscriptionCell: View {
             }
             if editMode?.wrappedValue.isEditing == true {
                 Spacer()
-                ReaderSiteFavoriteButton(site: site, source: "edit_mode")
+                ReaderSiteToggleFavoriteButton(site: site, source: "edit_mode")
                     .labelStyle(.iconOnly)
             }
         }
         .lineLimit(1)
         .tag(ReaderSidebarItem.subscription(TaggedManagedObjectID(site)))
+        .swipeActions(edge: .leading) {
+            if let siteURL = URL(string: site.siteURL) {
+                ShareLink(item: siteURL).tint(.blue)
+            }
+        }
         .swipeActions(edge: .trailing) {
             Button(SharedStrings.Reader.unfollow, role: .destructive) {
                 ReaderSubscriptionHelper().unfollow(site)
             }.tint(.red)
         }
         .contextMenu {
-            ReaderSiteFavoriteButton(site: site, source: "context_menu")
+            ReaderSubscriptionContextMenu(site: site)
+        }
+    }
+}
+
+struct ReaderSubscriptionContextMenu: View {
+    let site: ReaderSiteTopic
+
+    var body: some View {
+        if let siteURL = URL(string: site.siteURL) {
+            ShareLink(item: siteURL)
+        }
+        if site.following {
+            ReaderSiteToggleFavoriteButton(site: site, source: "context_menu")
             Button(SharedStrings.Reader.unsubscribe, systemImage: "minus.circle", role: .destructive) {
                 ReaderSubscriptionHelper().unfollow(site)
+            }
+        } else {
+            Button(SharedStrings.Reader.subscribe, systemImage: "plus.circle") {
+                ReaderSubscriptionHelper().toggleFollowingForSite(site)
             }
         }
     }
 }
 
-struct ReaderSiteFavoriteButton: View {
+struct ReaderSiteToggleFavoriteButton: View {
     let site: ReaderSiteTopic
     let source: String
 

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
@@ -84,14 +84,7 @@ struct ReaderSubscriptionCell: View {
 
     private var buttonMore: some View {
         Menu {
-            if let siteURL = URL(string: site.siteURL) {
-                ShareLink(item: siteURL)
-            }
-            Button(role: .destructive) {
-                onDelete(site)
-            } label: {
-                Label(SharedStrings.Reader.unfollow, systemImage: "trash")
-            }
+            ReaderSubscriptionContextMenu(site: site)
         } label: {
             Image(systemName: "ellipsis")
                 .foregroundStyle(.secondary)

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
@@ -43,6 +43,9 @@ struct ReaderSubscriptionCell: View {
             }
             buttonMore
         }
+        .contextMenu {
+            ReaderSubscriptionContextMenu(site: site, isShowingSettings: $isShowingSettings)
+        }
     }
 
     private func makeButtonNotificationSettings(with status: ReaderSubscriptionNotificationsStatus) -> some View {

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
@@ -38,10 +38,13 @@ struct ReaderSubscriptionCell: View {
 
             Spacer()
 
-            if let status = ReaderSubscriptionNotificationsStatus(site: site) {
-                makeButtonNotificationSettings(with: status)
+            HStack(spacing: 0) {
+                if let status = ReaderSubscriptionNotificationsStatus(site: site) {
+                    makeButtonNotificationSettings(with: status)
+                }
+                buttonMore
             }
-            buttonMore
+            .padding(.trailing, -16)
         }
         .contextMenu(menuItems: {
             ReaderSubscriptionContextMenu(site: site, isShowingSettings: $isShowingSettings)
@@ -70,12 +73,13 @@ struct ReaderSubscriptionCell: View {
             }
             .font(.subheadline)
             .frame(width: 34, alignment: .center)
-            .padding(.trailing, 6)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
         .sheet(isPresented: $isShowingSettings) {
             ReaderSubscriptionNotificationSettingsView(siteID: site.siteID.intValue)
                 .presentationDetents([.medium, .large])
+                .edgesIgnoringSafeArea(.bottom)
         }
     }
 
@@ -85,7 +89,8 @@ struct ReaderSubscriptionCell: View {
         } label: {
             Image(systemName: "ellipsis")
                 .foregroundStyle(.secondary)
-                .frame(width: 44, height: 44)
+                .frame(width: 40, height: 40)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
@@ -73,17 +73,9 @@ struct ReaderSubscriptionCell: View {
             .padding(.trailing, 6)
         }
         .buttonStyle(.plain)
-        .popover(isPresented: $isShowingSettings) { settings }
-    }
-
-    @ViewBuilder
-    private var settings: some View {
-        if horizontalSizeClass == .compact {
-            ReaderSubscriptionNotificationSettingsView(siteID: site.siteID.intValue, isCompact: true)
-                .presentationDetents([.medium, .large])
-                .edgesIgnoringSafeArea(.all)
-        } else {
+        .sheet(isPresented: $isShowingSettings) {
             ReaderSubscriptionNotificationSettingsView(siteID: site.siteID.intValue)
+                .presentationDetents([.medium, .large])
         }
     }
 
@@ -93,6 +85,7 @@ struct ReaderSubscriptionCell: View {
         } label: {
             Image(systemName: "ellipsis")
                 .foregroundStyle(.secondary)
+                .frame(width: 44, height: 44)
         }
         .buttonStyle(.plain)
     }

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
@@ -84,7 +84,7 @@ struct ReaderSubscriptionCell: View {
 
     private var buttonMore: some View {
         Menu {
-            ReaderSubscriptionContextMenu(site: site)
+            ReaderSubscriptionContextMenu(site: site, isShowingSettings: $isShowingSettings)
         } label: {
             Image(systemName: "ellipsis")
                 .foregroundStyle(.secondary)

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
@@ -43,9 +43,11 @@ struct ReaderSubscriptionCell: View {
             }
             buttonMore
         }
-        .contextMenu {
+        .contextMenu(menuItems: {
             ReaderSubscriptionContextMenu(site: site, isShowingSettings: $isShowingSettings)
-        }
+        }, preview: {
+            ReaderTopicPreviewView(topic: site)
+        })
     }
 
     private func makeButtonNotificationSettings(with status: ReaderSubscriptionNotificationsStatus) -> some View {

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionNotificationSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionNotificationSettingsView.swift
@@ -3,29 +3,21 @@ import UIKit
 
 struct ReaderSubscriptionNotificationSettingsView: UIViewControllerRepresentable {
     let siteID: Int
-    var isCompact = false
 
     @Environment(\.dismiss) var dismiss
 
     func makeUIViewController(context: Context) -> UIViewController {
         let vc = NotificationSiteSubscriptionViewController(siteId: siteID)
-        if isCompact {
-            vc.navigationItem.rightBarButtonItem = UIBarButtonItem(title: SharedStrings.Button.done, primaryAction: .init { _ in
-                dismiss()
-            })
-            // - warning: UIKit is used to prevent the modifiers from the
-            // containing list to affect this screen/
-            return UINavigationController(rootViewController: vc)
-        }
-        return vc
+        vc.navigationItem.rightBarButtonItem = UIBarButtonItem(title: SharedStrings.Button.done, primaryAction: .init { _ in
+            dismiss()
+        })
+        // - warning: UIKit is used to prevent the modifiers from the
+        // containing list to affect this screen/
+        return UINavigationController(rootViewController: vc)
     }
 
     func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
         // Do nothing
-    }
-
-    func sizeThatFits(_ proposal: ProposedViewSize, uiViewController: UIViewController, context: Context) -> CGSize? {
-        isCompact ? nil : CGSize(width: 320, height: 434)
     }
 }
 


### PR DESCRIPTION
- Fix small tap area for “More” button in the Subscriptions screen in Reader
- Fix “Notification Settings” for individual posts sometimes being clipped
- Add context menu (long-press) and previews for subscriptions with quick access to “Share”, “Copy Link”, “Add to Favorites”, “Notification Settings”, and “Unsubscribe” buttons in both the Subscriptions view and the Sidebar in Reader

<img width="1001" alt="Screenshot 2025-01-09 at 3 26 24 PM" src="https://github.com/user-attachments/assets/4f1d8042-640b-4943-b41a-a0a914ec6688" />

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
