### PR TITLE
Remove "Lazy Images" Jetpack option

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -40,6 +40,7 @@
 * [*] Fix “Notification Settings” for individual posts sometimes being clipped [#23964]
 * [*] Add context menu (long-press) and previews for subscriptions with quick access to “Share”, “Copy Link”, “Add to Favorites”, “Notification Settings”, and “Unsubscribe” buttons in both the Subscriptions view and the Sidebar in Reader [#23964]
 * [*] Fix an issue with fullscreen button in reply view clipped by the notch [#23965]
+* [*] Remove "Lazy Images" option that is no longer part of the Jetpack plugin [#23966]
 
 25.6
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -41,6 +41,7 @@
 * [*] Add context menu (long-press) and previews for subscriptions with quick access to “Share”, “Copy Link”, “Add to Favorites”, “Notification Settings”, and “Unsubscribe” buttons in both the Subscriptions view and the Sidebar in Reader [#23964]
 * [*] Fix an issue with fullscreen button in reply view clipped by the notch [#23965]
 * [*] Remove "Lazy Images" option that is no longer part of the Jetpack plugin [#23966]
+* [*] Fix an issue with "Speed up your site" section not refreshing (fails silently) [#23966]
 
 25.6
 -----

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c6c4224bb9091cbaed87a958001b2435576248fec163dc8ce6be041f8e1da166",
+  "originHash" : "e25628bd63dad3b77f7c0ba1cdf36c20bd1dfaf03b083ccfc06d8806824c77df",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -383,7 +383,7 @@
       "location" : "https://github.com/wordpress-mobile/WordPressKit-iOS",
       "state" : {
         "branch" : "wpios-edition",
-        "revision" : "908d96a6ff4eb38217e57c03996bf1f3e9cdb114"
+        "revision" : "a9a057ea6fba8080c146497336951dc805409771"
       }
     },
     {

--- a/WordPress/Classes/Models/Blog/BlogSettings.swift
+++ b/WordPress/Classes/Models/Blog/BlogSettings.swift
@@ -71,6 +71,7 @@ open class BlogSettings: NSManagedObject {
 
     /// Jetpack Setting: lazy load images.
     ///
+    @available(*, deprecated)
     @NSManaged var jetpackLazyLoadImages: Bool
 
     // MARK: - Discussion

--- a/WordPress/Classes/Services/BlogJetpackSettingsService.swift
+++ b/WordPress/Classes/Services/BlogJetpackSettingsService.swift
@@ -142,29 +142,6 @@ struct BlogJetpackSettingsService {
         )
     }
 
-    func updateJetpackLazyImagesModuleSettingForBlog(_ blog: Blog, success: @escaping () -> Void, failure: @escaping (Error?) -> Void) {
-        guard let blogSettings = blog.settings else {
-            failure(nil)
-            return
-        }
-
-        let isActive = blogSettings.jetpackLazyLoadImages
-        updateJetpackModuleActiveSettingForBlog(
-            blog,
-            module: BlogJetpackSettingsServiceRemote.Keys.lazyLoadImages,
-            active: isActive,
-            success: {
-                self.coreDataStack.performAndSave({ context in
-                    guard let blogSettingsInContext = Blog.lookup(withObjectID: blog.objectID, in: context)?.settings else {
-                        return
-                    }
-                    blogSettingsInContext.jetpackLazyLoadImages = isActive
-                }, completion: success, on: .main)
-            },
-            failure: failure
-        )
-    }
-
     func updateJetpackServeImagesFromOurServersModuleSettingForBlog(_ blog: Blog, success: @escaping () -> Void, failure: @escaping (Error?) -> Void) {
         guard let blogSettings = blog.settings else {
             failure(nil)
@@ -235,7 +212,6 @@ private extension BlogJetpackSettingsService {
     }
 
     func updateJetpackModulesSettings(_ settings: BlogSettings, remoteSettings: RemoteBlogJetpackModulesSettings) {
-        settings.jetpackLazyLoadImages = remoteSettings.lazyLoadImages
         settings.jetpackServeImagesFromOurServers = remoteSettings.serveImagesFromOurServers
     }
 

--- a/WordPress/Classes/Utility/SharedStrings.swift
+++ b/WordPress/Classes/Utility/SharedStrings.swift
@@ -23,6 +23,7 @@ enum SharedStrings {
 
     enum Error {
         static let generic = NSLocalizedString("shared.error.geneirc", value: "Something went wrong", comment: "A generic error message")
+        static let refreshFailed = NSLocalizedString("shared.error.failiedToReloadData", value: "Failed to update data", comment: "A generic error title indicating that a screen failed to fetch the latest data")
     }
 
     enum Reader {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSpeedUpSiteSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSpeedUpSiteSettingsViewController.swift
@@ -32,6 +32,7 @@ open class JetpackSpeedUpSiteSettingsViewController: UITableViewController {
 
     open override func viewDidLoad() {
         super.viewDidLoad()
+
         title = NSLocalizedString("Speed up your site", comment: "Title for the Speed up your site Settings Screen")
         ImmuTable.registerRows([SwitchRow.self], tableView: tableView)
         WPStyleGuide.configureColors(view: view, tableView: tableView)
@@ -51,34 +52,18 @@ open class JetpackSpeedUpSiteSettingsViewController: UITableViewController {
     }
 
     func tableViewModel() -> ImmuTable {
-
-        let serveImagesFromOurServers = SwitchRow(title: NSLocalizedString("Serve images from our servers",
-                                                                           comment: "Title for the Serve images from our servers setting"),
-                                                  value: self.settings.jetpackServeImagesFromOurServers,
-                                                  onChange: self.serveImagesFromOurServersValueChanged())
-
-        let lazyLoadImages = SwitchRow(title: NSLocalizedString("\"Lazy-load\" images",
-                                                          comment: "Title for the lazy load images setting"),
-                                       value: self.settings.jetpackLazyLoadImages,
-                                       onChange: self.lazyLoadImagesValueChanged())
+        let serveImagesFromOurServers = SwitchRow(
+            title: NSLocalizedString("Serve images from our servers",
+                                     comment: "Title for the Serve images from our servers setting"),
+            value: self.settings.jetpackServeImagesFromOurServers,
+            onChange: self.serveImagesFromOurServersValueChanged())
 
         return ImmuTable(sections: [
             ImmuTableSection(
                 headerText: "",
                 rows: [serveImagesFromOurServers],
-                footerText: NSLocalizedString("Jetpack will optimize your images and serve them from the server " +
-                                              "location nearest to your visitors. Using our global content delivery " +
-                                              "network will boost the loading speed of your site.",
-                                              comment: "Footer for the Serve images from our servers setting")),
-
-            ImmuTableSection(
-                headerText: "",
-                rows: [lazyLoadImages],
-                footerText: NSLocalizedString("Improve your site's speed by only loading images visible on the screen. " +
-                                              "New images will load just before they scroll into view. This prevents " +
-                                              "viewers from having to download all the images on a page all at once, " +
-                                              "even ones they can't see.",
-                                              comment: "Footer for the Serve images from our servers setting")),
+                footerText: NSLocalizedString("Jetpack will optimize your images and serve them from the server location nearest to your visitors. Using our global content delivery network will boost the loading speed of your site.", comment: "Footer for the Serve images from our servers setting")
+            )
         ])
     }
 
@@ -95,19 +80,6 @@ open class JetpackSpeedUpSiteSettingsViewController: UITableViewController {
                                                                                     failure: { [weak self] (_) in
                                                                                         self?.refreshSettingsAfterSavingError()
                                                                                     })
-        }
-    }
-
-    fileprivate func lazyLoadImagesValueChanged() -> (_ newValue: Bool) -> Void {
-        return { [unowned self] newValue in
-            self.settings.jetpackLazyLoadImages = newValue
-            self.reloadViewModel()
-            WPAnalytics.trackSettingsChange("jetpack_speed_up_site", fieldName: "lazy_load_images", value: newValue as Any)
-            self.service.updateJetpackLazyImagesModuleSettingForBlog(self.blog,
-                                                                     success: {},
-                                                                     failure: { [weak self] (_) in
-                                                                         self?.refreshSettingsAfterSavingError()
-                                                                     })
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSpeedUpSiteSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSpeedUpSiteSettingsViewController.swift
@@ -24,6 +24,7 @@ open class JetpackSpeedUpSiteSettingsViewController: UITableViewController {
 
     @objc public convenience init(blog: Blog) {
         self.init(style: .insetGrouped)
+
         self.blog = blog
         self.service = BlogJetpackSettingsService(coreDataStack: ContextManager.shared)
     }
@@ -41,6 +42,7 @@ open class JetpackSpeedUpSiteSettingsViewController: UITableViewController {
 
     open override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
         reloadViewModel()
         refreshSettings()
     }
@@ -77,7 +79,7 @@ open class JetpackSpeedUpSiteSettingsViewController: UITableViewController {
 
             self.service.updateJetpackServeImagesFromOurServersModuleSettingForBlog(self.blog,
                                                                                     success: {},
-                                                                                    failure: { [weak self] (_) in
+                                                                                    failure: { [weak self] _ in
                                                                                         self?.refreshSettingsAfterSavingError()
                                                                                     })
         }
@@ -86,14 +88,16 @@ open class JetpackSpeedUpSiteSettingsViewController: UITableViewController {
     // MARK: - Persistance
 
     fileprivate func refreshSettings() {
-        service.syncJetpackModulesForBlog(blog,
-                                          success: { [weak self] in
-                                              self?.reloadViewModel()
-                                              DDLogInfo("Reloaded Speed up site settings")
-                                          },
-                                          failure: { (error: Error?) in
-                                              DDLogError("Error while syncing blog Speed up site settings: \(String(describing: error))")
-                                          })
+        service.syncJetpackModulesForBlog(
+            blog,
+            success: { [weak self] in
+                self?.reloadViewModel()
+                DDLogInfo("Reloaded Speed up site settings")
+            },
+            failure: { (error: Error?) in
+                Notice(title: SharedStrings.Error.refreshFailed, message: error?.localizedDescription).post()
+                DDLogError("Error while syncing blog Speed up site settings: \(String(describing: error))")
+        })
     }
 
     fileprivate func refreshSettingsAfterSavingError() {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/23881.

## Changes

- Remove "Lazy-load" option
- Add error handling for data refresh
- Fix an issue with refresh (see https://github.com/wordpress-mobile/WordPressKit-iOS/pull/827)


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
