### PR TITLE
Fix an issue where the “Threads” icon was repeated

### DIFF
--- a/WordPress/Classes/Models/PublicizeService.swift
+++ b/WordPress/Classes/Models/PublicizeService.swift
@@ -37,6 +37,7 @@ extension PublicizeService {
         case linkedin
         case instagram = "instagram-business"
         case mastodon
+        case threads
         case unknown
 
         /// Returns the local image for the icon representing the social network.


### PR DESCRIPTION
See Zendesk 9258078

Fixes an issue where threads account would show up 3 times instead of 1 while publishing.

To test:
- Connect a threads account on a Jetpack site
- Write a post, press publish, check social settings

Before:
- There would be 3 threads icons, and if you tapped into the social settings it would show the amount 3 times

After:
- There is an appropriate number of icons and items in the list


Because the code didn't know about Threads, it was mis-mapping the data to what the UI expects. This is a bit of a hack because if we get a new social network we'll probably have the same problem? But that doesn't happen often enough for a big refactor, I'd rather just get this fixed for the user.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
