### PR TITLE
fix: Avoid unexpectedly marking post content as unsaved

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,10 @@
 25.7
 -----
+* [**] Enable history navigation (undo and redo) for the experimental editor. [#23961]
+* [*] Avoid unexpectedly marking post content as unsaved. [#23969]
+
+25.6
+-----
 * [**] Add Image Playground support (part of Apple Intelligence suite) for adding images to your posts, generated featured image, site icons, and more [#23688]
 * [**] Enable history navigation (undo and redo) for the experimental editor. [#23961]
 * [**] Various bug fixes and improvements in the new experimental editor [#23919]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,10 +1,5 @@
 25.7
 -----
-* [**] Enable history navigation (undo and redo) for the experimental editor. [#23961]
-* [*] Avoid unexpectedly marking post content as unsaved. [#23969]
-
-25.6
------
 * [**] Add Image Playground support (part of Apple Intelligence suite) for adding images to your posts, generated featured image, site icons, and more [#23688]
 * [**] Enable history navigation (undo and redo) for the experimental editor. [#23961]
 * [**] Various bug fixes and improvements in the new experimental editor [#23919]
@@ -48,6 +43,8 @@
 * [*] Fix an issue with fullscreen button in reply view clipped by the notch [#23965]
 * [*] Remove "Lazy Images" option that is no longer part of the Jetpack plugin [#23966]
 * [*] Fix an issue with "Speed up your site" section not refreshing (fails silently) [#23966]
+* [**] Enable history navigation (undo and redo) for the experimental editor. [#23961]
+* [*] Avoid unexpectedly marking post content as unsaved. [#23969]
 
 25.6
 -----

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -70,18 +70,6 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     private let editorViewController: GutenbergKit.EditorViewController
     private weak var autosaveTimer: Timer?
 
-    var editorHasChanges: Bool {
-        var changes = post.changes
-        // TODO: cleanup (+ it doesn't handle scenarios like load from a revision)
-        // - warning: it has to compare two version serialized using the same system
-        if editorViewController.initialContent != post.content {
-            changes.content = post.content
-        } else {
-            changes.content = nil // yes, it needs to be set to .none manually
-        }
-        return !changes.isEmpty
-    }
-
     // TODO: remove (none of these APIs are needed for the new editor)
     var autosaver = Autosaver(action: {})
     func prepopulateMediaItems(_ media: [Media]) {}


### PR DESCRIPTION
The custom `editorHasChanges` implementation resulted in an
always-"dirty" state, even after saving changes via the "Update" or
"Save draft" buttons. This removal, results in the editor relying upon
the existing `editorHasChanges` implementation, which appears to be more
accurate.

https://github.com/wordpress-mobile/WordPress-iOS/blob/388dbb167b7ae6fd763ed4c90076dc94679a9dc6/WordPress/Classes/ViewRelated/Post/PostEditor.swift#L81-L83

Fixes https://github.com/Automattic/dotcom-forge/issues/10114.

To test:

**1: Update published posts**
1. Open an existing, published post with the experimental editor.
1. Update the content.
1. Tap the "Update" button in the top right.
1. After the post saves, tap the back button in the top left.
1. Verify the app does not prompt save or discard unsaved changes.

**2: Update draft posts**
1. Open an existing, draft post with the experimental editor.
1. Update the content.
1. Tap the more button (three vertical dots) in the top right.
1. Tap the "Save Draft" button. 
1. After the post saves, tap the back button in the top left.
1. Verify the app does not prompt save or discard unsaved changes.

## Regression Notes
1. Potential unintended areas of impact
    Introduce post state bugs.
3. What I did to test those areas of impact (or what existing automated tests I relied on)
    Manually test creating/saving/updating/publishing posts.
4. What automated tests I added (or what prevented me from doing so)
    Deemed unnecessary for the experimental editor.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
