### PR TITLE
feat: GutenbergKit code editor

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20241116"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "5a43a1b8ab5034e5be4b4eb93c30885cc41227b2"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "5a0a5054ac8b0a71299e3c8ab4601c6d45e701ec"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20241116"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "5a0a5054ac8b0a71299e3c8ab4601c6d45e701ec"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "2128c9167eeb779ac05d64675a632b0e42b79cfb"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20241116"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "2128c9167eeb779ac05d64675a632b0e42b79cfb"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "cc52214a50893b41898607ac0bff7f2787b085bb"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -47,6 +47,7 @@
 * [*] Avoid unexpectedly marking post content as unsaved. [#23969]
 * [*] Fix an issue with Mastodon connection not working [#23981]
 * [**] Send feedback from within the experimental editor "more" options menu. [#23980]
+* [**] Support accessing the code editor within the experimental editor. [#23979]
 
 25.6
 -----

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "cc23994fa7cdcf18782712f28e823bb56a70994e186e61bb5ba912f1386d66a7",
+  "originHash" : "06b660824580cbb78f97d290a26dfae626f29436ef196ddf3afed2cb4fb10d4f",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -141,7 +141,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "5a43a1b8ab5034e5be4b4eb93c30885cc41227b2"
+        "revision" : "5a0a5054ac8b0a71299e3c8ab4601c6d45e701ec"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9916e2ddc788c372f4ed8ab3588f8178fe8ddcc59d67e2ce943b17db35c6c149",
+  "originHash" : "d8a7faa1972ab73744be3161f236c4bae7faf7c44f840b7bd0a52b3ee1ee6d6c",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -141,7 +141,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "2128c9167eeb779ac05d64675a632b0e42b79cfb"
+        "revision" : "cc52214a50893b41898607ac0bff7f2787b085bb"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "06b660824580cbb78f97d290a26dfae626f29436ef196ddf3afed2cb4fb10d4f",
+  "originHash" : "9916e2ddc788c372f4ed8ab3588f8178fe8ddcc59d67e2ce943b17db35c6c149",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -141,7 +141,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "5a0a5054ac8b0a71299e3c8ab4601c6d45e701ec"
+        "revision" : "2128c9167eeb779ac05d64675a632b0e42b79cfb"
       }
     },
     {


### PR DESCRIPTION
Related:

* https://github.com/Automattic/dotcom-forge/issues/10117
* https://github.com/wordpress-mobile/GutenbergKit/pull/60
* https://github.com/wordpress-mobile/WordPress-Android/pull/21582

To test: See https://github.com/wordpress-mobile/GutenbergKit/pull/60.

## Regression Notes
1. Potential unintended areas of impact
    Regressions within Aztec and Gutenberg Mobile.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    Manually tested the editors.
3. What automated tests I added (or what prevented me from doing so)
    Deemed unnecessary for the experimental editor.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
