### PR TITLE
feat: Send editor feedback

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -46,6 +46,7 @@
 * [*] Fix an issue with small tap area of the ellipsis in the post list [#23973]
 * [*] Avoid unexpectedly marking post content as unsaved. [#23969]
 * [*] Fix an issue with Mastodon connection not working [#23981]
+* [**] Send feedback from within the experimental editor "more" options menu. [#23980]
 
 25.6
 -----

--- a/WordPress/Classes/Utility/In-App Feedback/SubmitFeedbackViewController.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/SubmitFeedbackViewController.swift
@@ -4,9 +4,11 @@ import WordPressShared
 
 final class SubmitFeedbackViewController: UIViewController {
     private var source: String
+    private var feedbackPrefix: String?
 
-    init(source: String) {
+    init(source: String, feedbackPrefix: String? = nil) {
         self.source = source
+        self.feedbackPrefix = feedbackPrefix
         super.init(nibName: nil, bundle: nil)
         self.modalPresentationStyle = .formSheet
     }
@@ -18,7 +20,7 @@ final class SubmitFeedbackViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let viewController = UIHostingController(rootView: SubmitFeedbackView(presentingViewController: self, source: source))
+        let viewController = UIHostingController(rootView: SubmitFeedbackView(presentingViewController: self, source: source, feedbackPrefix: feedbackPrefix))
 
         let navigationController = UINavigationController(rootViewController: viewController)
 
@@ -33,6 +35,7 @@ final class SubmitFeedbackViewController: UIViewController {
 private struct SubmitFeedbackView: View {
     weak var presentingViewController: UIViewController?
     let source: String
+    let feedbackPrefix: String?
 
     @State private var text = ""
     @State private var isSubmitting = false
@@ -141,9 +144,10 @@ private struct SubmitFeedbackView: View {
 
         isSubmitting = true
 
+        let descriptionPrefix = feedbackPrefix.map { "[\($0)] " } ?? ""
         ZendeskUtils.sharedInstance.createNewRequest(
             in: presentingViewController,
-            description: text.trim(),
+            description: descriptionPrefix + text.trim(),
             tags: ["appreview_jetpack", "in_app_feedback"],
             attachments: attachmentsViewModel.attachments.compactMap(\.response),
             alertOptions: nil
@@ -195,6 +199,6 @@ private enum Strings {
 
 #Preview {
     NavigationView {
-        SubmitFeedbackView(source: "preview")
+        SubmitFeedbackView(source: "preview", feedbackPrefix: nil)
     }
 }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -290,7 +290,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     }
 
     func showFeedbackView() {
-        self.present(SubmitFeedbackViewController(source: "gutenberg_kit"), animated: true)
+        self.present(SubmitFeedbackViewController(source: "gutenberg_kit", feedbackPrefix: "Editor"), animated: true)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -288,6 +288,10 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         guard let url = URL(string: "https://wordpress.com/support/wordpress-editor/") else { return }
         present(SFSafariViewController(url: url), animated: true)
     }
+
+    func showFeedbackView() {
+        self.present(SubmitFeedbackViewController(source: "gutenberg_kit"), animated: true)
+    }
 }
 
 extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate {
@@ -706,6 +710,9 @@ extension NewGutenbergViewController {
         actions.append(UIAction(title: helpTitle, image: UIImage(systemName: "questionmark.circle")) { [weak self] _ in
             self?.showEditorHelp()
         })
+        actions.append(UIAction(title: Strings.sendFeedback, image: UIImage(systemName: "envelope")) { [weak self] _ in
+            self?.showFeedbackView()
+        })
         return actions
     }
 
@@ -745,6 +752,7 @@ private enum Strings {
     static let postSettings = NSLocalizedString("postEditor.moreMenu.postSettings", value: "Post Settings", comment: "Post Editor / Button in the 'More' menu")
     static let helpAndSupport = NSLocalizedString("postEditor.moreMenu.helpAndSupport", value: "Help & Support", comment: "Post Editor / Button in the 'More' menu")
     static let help = NSLocalizedString("postEditor.moreMenu.help", value: "Help", comment: "Post Editor / Button in the 'More' menu")
+    static let sendFeedback = NSLocalizedString("postEditor.moreMenu.sendFeedback", value: "Send Feedback", comment: "Post Editor / Button in the 'More' menu")
     static let saveDraft = NSLocalizedString("postEditor.moreMenu.saveDraft", value: "Save Draft", comment: "Post Editor / Button in the 'More' menu")
     static let contentStructure = NSLocalizedString("postEditor.moreMenu.contentStructure", value: "Blocks: %li, Words: %li, Characters: %li", comment: "Post Editor / 'More' menu details labels with 'Blocks', 'Words' and 'Characters' counts as parameters (in that order)")
 }


### PR DESCRIPTION
Collecting feedback from users while in editor may uncover valuable
insights.

Related:

- https://github.com/Automattic/dotcom-forge/issues/10125
- https://github.com/wordpress-mobile/WordPress-Android/pull/21586

To test:

1. Open the experimentla editor.
1. Tap the more button (three vertical dots) in the top-right corner.
1. Tap _Send Feedback_.
1. Submit feedback.
1. Verify its delivery within the customer support system.

## Regression Notes
1. Potential unintended areas of impact
    None likely with this limited addition.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    N/A.
3. What automated tests I added (or what prevented me from doing so)
    N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
