### PR TITLE
Don’t send/store cookies for EU-US DPA geolookup

### DIFF
--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/ComplianceLocationService.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/ComplianceLocationService.swift
@@ -1,7 +1,9 @@
 import WordPressKit
 
 class ComplianceLocationService {
+    private let session = URLSession(configuration: .ephemeral)
+
     func getIPCountryCode(completion: @escaping (Result<String, Error>) -> Void) {
-        IPLocationRemote().fetchIPCountryCode(completion: completion)
+        IPLocationRemote(urlSession: session).fetchIPCountryCode(completion: completion)
     }
 }


### PR DESCRIPTION
By using `URLSession.default` we send any cookies the rest of the app has for `public-api.wordpress.com`. For the geo-lookup, we could potentially send WP.com user IDs even after the user logs out. 

This PR ensures we use an empty cookie jar for each request.

