### PR TITLE
Remove reachability checks from Social Connections

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingConnectionsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingConnectionsViewController.m
@@ -232,11 +232,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
 - (void)handleConnectTapped:(NSIndexPath *)indexPath
 {
-    if (![ReachabilityUtils isInternetReachable]) {
-        [ReachabilityUtils showAlertNoInternetConnection];
-        return;
-    }
-
     if ([UIDevice isPad]) {
         UITableViewCell *cell = [self.tableView cellForRowAtIndexPath:indexPath];
         self.helper.popoverSourceView = cell.textLabel;

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingDetailViewController.m
@@ -238,11 +238,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
 - (void)reconnectPublicizeConnection
 {
-    if (![ReachabilityUtils isInternetReachable]) {
-        [ReachabilityUtils showAlertNoInternetConnection];
-        return;
-    }
-
     SharingService *sharingService = [[SharingService alloc] initWithContextManager:[ContextManager sharedInstance]];
 
     __weak __typeof(self) weakSelf = self;
@@ -273,11 +268,6 @@ static NSString *const CellIdentifier = @"CellIdentifier";
 
 - (void)promptToConfirmDisconnect
 {
-    if (![ReachabilityUtils isInternetReachable]) {
-        [ReachabilityUtils showAlertNoInternetConnection];
-        return;
-    }
-
     NSString *message = NSLocalizedString(@"Disconnecting this account means published posts will no longer be automatically shared to %@", @"Explanatory text for the user. The `%@` is a placeholder for the name of a third-party sharing service.");
     message = [NSString stringWithFormat:message, self.publicizeConnection.label];
     UIAlertController *alert = [UIAlertController alertControllerWithTitle:nil


### PR DESCRIPTION
As in other cases: checking reachability before sending a request is wrong because it's not accurate. I checked that these actions have error handling.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
