### PR TITLE
feat: GutenbergKit dismiss keyboard

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20241116"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "2d1f383e5d53a1bce045e4a645939a0d2b89cbac"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "d781e7bf7fcf6519ae4c41babaacb22baf5d7741"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20241116"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "d781e7bf7fcf6519ae4c41babaacb22baf5d7741"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "fc14666b5474edce9ec2c101793e1a6f7772c1e2"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20241116"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "cc52214a50893b41898607ac0bff7f2787b085bb"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "2d1f383e5d53a1bce045e4a645939a0d2b89cbac"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -48,6 +48,7 @@
 * [*] Fix an issue with Mastodon connection not working [#23981]
 * [**] Send feedback from within the experimental editor "more" options menu. [#23980]
 * [**] Support accessing the code editor within the experimental editor. [#23979]
+* [**] Add button for dismissing the keyboard within the experimental editor. [#23988]
 
 25.6
 -----

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "89ff051906de0af1ea57666eb6c4fe9a3d33daf5b6010c9ec82559e0df16fc40",
+  "originHash" : "b492cb4a9c92206d9cecbd2232df72d92c04316eed0d37f0f62c20f196401e23",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -141,7 +141,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "2d1f383e5d53a1bce045e4a645939a0d2b89cbac"
+        "revision" : "d781e7bf7fcf6519ae4c41babaacb22baf5d7741"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b492cb4a9c92206d9cecbd2232df72d92c04316eed0d37f0f62c20f196401e23",
+  "originHash" : "f8b4457172c41a23aaf20dcdc7d4842b5c49d5dee8a9aba71beece8e251d5c3f",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -141,7 +141,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "d781e7bf7fcf6519ae4c41babaacb22baf5d7741"
+        "revision" : "fc14666b5474edce9ec2c101793e1a6f7772c1e2"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d8a7faa1972ab73744be3161f236c4bae7faf7c44f840b7bd0a52b3ee1ee6d6c",
+  "originHash" : "89ff051906de0af1ea57666eb6c4fe9a3d33daf5b6010c9ec82559e0df16fc40",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -141,7 +141,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "cc52214a50893b41898607ac0bff7f2787b085bb"
+        "revision" : "2d1f383e5d53a1bce045e4a645939a0d2b89cbac"
       }
     },
     {


### PR DESCRIPTION
Add a button dedicated to dismissing the virtual keyboard.

Related:

- https://github.com/Automattic/dotcom-forge/issues/8673
- https://github.com/wordpress-mobile/GutenbergKit/pull/61
- https://github.com/wordpress-mobile/WordPress-Android/pull/21602

To test: See https://github.com/wordpress-mobile/GutenbergKit/pull/61.

## Regression Notes
1. Potential unintended areas of impact
    Unlikely with this single dependency bump.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    N/A
3. What automated tests I added (or what prevented me from doing so)
    N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
