### PR TITLE
Remove `.hound.yml`

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,7 +1,0 @@
-fail_on_violations: true
-
-rubocop:
-  enabled: false
-  
-swiftlint:
-  config_file: .swiftlint.yml


### PR DESCRIPTION
I run `git grep swiftlint` in the context of [replacing the CocoaPods installation with a SwiftPM one](https://github.com/wordpress-mobile/WordPress-iOS/pull/23958#discussion_r1920101295) and got a hit on `.hound.yml`.

We have not been using Hound since at least a year, see paaHJt-68e-p2, so there is no reason to keep carrying the config file in the repo.

I deleted the rest of the PR template which includes UI checks and other testing because this is just an unused file removal, and a file that was not even part of the app source.