### PR TITLE
SwiftLint Build Tool Plugin example

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "822b466f7c9d218a370cba191ffe95a167618303fb894fc6a315e201f055c91b",
+  "originHash" : "7c1eb3d87f681cb2007fbf6cccd11b30ffe744d2c5b08efd5500ada5d9733c3f",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -339,6 +339,15 @@
       "state" : {
         "revision" : "4f9164a0a2c9a6a7ff53a2833d54a5c79c957342",
         "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "swiftlintplugins",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/SimplyDanny/SwiftLintPlugins",
+      "state" : {
+        "revision" : "7a3d77f3dd9f91d5cea138e52c20cfceabf352de",
+        "version" : "0.58.2"
       }
     },
     {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -7739,6 +7739,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				3FE686092D3C2F2F00862F57 /* PBXTargetDependency */,
 				3FCFFAFE2994A949002840C9 /* PBXTargetDependency */,
 				096A92FD26E2A0AE00448C68 /* PBXTargetDependency */,
 				932225B01C7CE50300443B02 /* PBXTargetDependency */,
@@ -8251,6 +8252,9 @@
 				sk,
 			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
+			packageReferences = (
+				3FE686072D3C2EFC00862F57 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */,
+			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
 			projectDirPath = "";
@@ -10262,6 +10266,10 @@
 			isa = PBXTargetDependency;
 			target = FFA8E22A1F94E3DE0002170F /* SwiftLint */;
 			targetProxy = 3FCFFAFF2994AB25002840C9 /* PBXContainerItemProxy */;
+		};
+		3FE686092D3C2F2F00862F57 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			productRef = 3FE686082D3C2F2F00862F57 /* SwiftLintBuildToolPlugin */;
 		};
 		4AD953BE2C21451700D0EEFA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -13770,6 +13778,17 @@
 		};
 /* End XCConfigurationList section */
 
+/* Begin XCRemoteSwiftPackageReference section */
+		3FE686072D3C2EFC00862F57 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/SimplyDanny/SwiftLintPlugins";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 0.58.2;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
 /* Begin XCSwiftPackageProductDependency section */
 		0C2155A52C39A24D00EFE2C0 /* XcodeTarget_UITests */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -13830,6 +13849,11 @@
 		0CFFFECA2C36F5760044709B /* XcodeTarget_WordPressAuthentificatorTests */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = XcodeTarget_WordPressAuthentificatorTests;
+		};
+		3FE686082D3C2F2F00862F57 /* SwiftLintBuildToolPlugin */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3FE686072D3C2EFC00862F57 /* XCRemoteSwiftPackageReference "SwiftLintPlugins" */;
+			productName = "plugin:SwiftLintBuildToolPlugin";
 		};
 /* End XCSwiftPackageProductDependency section */
 


### PR DESCRIPTION
After 

I applied this diff

```diff
diff --git a/WordPress/Classes/Utility/AppIcon.swift b/WordPress/Classes/Utility/AppIcon.swift
index 60ab3d4897..eee88e68d6 100644
--- a/WordPress/Classes/Utility/AppIcon.swift
+++ b/WordPress/Classes/Utility/AppIcon.swift
@@ -1,5 +1,14 @@
 import UIKit
 
+
+
+
+
+
+
+
+
+
 /// Encapsulates a custom icon used by the app and provides some convenience
 /// methods around using custom icons.
 ///
```

The built the app. Xcode crashed 👍 

```
-------------------------------------
Translated Report (Full Report Below)
-------------------------------------

Process:               Xcode [52987]
Path:                  /Applications/Xcode.app/Contents/MacOS/Xcode
Identifier:            com.apple.dt.Xcode
Version:               16.2 (23507)
Build Info:            IDEApplication-23507000000000000~2 (16C5032a)
App Item ID:           497799835
App External ID:       870964517
Code Type:             ARM-64 (Native)
Parent Process:        launchd [1]
User ID:               501

Date/Time:             2025-01-21 16:41:29.7745 +1100
OS Version:            macOS 14.7 (23H124)
Report Version:        12
Anonymous UUID:        90B97DF3-A221-5205-B9B6-7DDFCB9DD5E3

Sleep/Wake UUID:       2871315C-A06F-4086-A8D2-D9464C5FE32A

Time Awake Since Boot: 110000 seconds
Time Since Wake:       9456 seconds

System Integrity Protection: enabled

Crashed Thread:        0  Dispatch queue: com.apple.main-thread

Exception Type:        EXC_CRASH (SIGABRT)
Exception Codes:       0x0000000000000000, 0x0000000000000000

Termination Reason:    Namespace SIGNAL, Code 6 Abort trap: 6
Terminating Process:   Xcode [52987]

Application Specific Information:
com.apple.main-thread
abort() called


Application Specific Signatures:
(_section) != nil

Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   libsystem_kernel.dylib        	       0x1878315d0 __pthread_kill + 8
1   libsystem_pthread.dylib       	       0x187869c20 pthread_kill + 288
2   libsystem_c.dylib             	       0x187776a30 abort + 180
3   IDEKit                        	       0x10a899554 +[IDEAssertionHandler _handleAssertionWithLogString:assertionSignature:assertionReason:extraBacktrace:] + 964
4   IDEKit                        	       0x10a8999e4 -[IDEAssertionHandler handleFailureInMethod:object:fileName:lineNumber:assertionSignature:messageFormat:arguments:] + 876
5   DVTFoundation                 	       0x106a25358 _DVTAssertionHandler + 424
6   DVTFoundation                 	       0x106a254d8 _DVTAssertionFailureHandler + 196
7   IDEFoundation                 	       0x10efd4460 __63-[IDEActivityLogSectionRecorder addMessage:ignoreMessageLimit:]_block_invoke_3 + 592
8   IDEFoundation                 	       0x10efcfd34 __58-[IDEActivityLogSectionRecorder enqueueOrderedAsyncBlock:]_block_invoke + 152
9   DVTFoundation                 	       0x106b37c9c __DVT_CALLING_CLIENT_BLOCK__ + 16
10  DVTFoundation                 	       0x106b396c0 ___DVTAsyncPerformBlockOnMainRunLoop_block_invoke + 176
11  CoreFoundation                	       0x187949070 __CFRUNLOOP_IS_CALLING_OUT_TO_A_BLOCK__ + 28
12  CoreFoundation                	       0x187948f84 __CFRunLoopDoBlocks + 356
13  CoreFoundation                	       0x187947db8 __CFRunLoopRun + 812
14  CoreFoundation                	       0x187947434 CFRunLoopRunSpecific + 608
15  HIToolbox                     	       0x1920f219c RunCurrentEventLoopInMode + 292
16  HIToolbox                     	       0x1920f1e2c ReceiveNextEventCommon + 220
17  HIToolbox                     	       0x1920f1d30 _BlockUntilNextEventMatchingListInModeWithFilter + 76
18  AppKit                        	       0x18b1a6cc8 _DPSNextEvent + 660
19  AppKit                        	       0x18b99d4d0 -[NSApplication(NSEventRouting) _nextEventMatchingEventMask:untilDate:inMode:dequeue:] + 700
20  AppKit                        	       0x18b199ffc -[NSApplication run] + 476
21  IDEKit                        	       0x10a868f14 -[IDEApplication run] + 192
22  AppKit                        	       0x18b171240 NSApplicationMain + 880
23  dyld                          	       0x1874df154 start + 2476
```

---

The plugin seems to ignore the `.swiftlint.yml` configuration:

<img width="1215" alt="image" src="https://github.com/user-attachments/assets/fd47fe01-7833-4edf-898f-6c8d4b03b61a" />


Fixes #

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
