### PR TITLE
Tweak code signing lanes naming and make them all public

### DIFF
--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -235,7 +235,7 @@ platform :ios do
   lane :build_and_upload_jetpack_for_app_store do
     sentry_check_cli_installed
 
-    jetpack_appstore_code_signing
+    update_certs_and_profiles_jetpack_app_store
 
     build_app(
       scheme: 'Jetpack',

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -169,7 +169,7 @@ platform :ios do
 
     sentry_check_cli_installed
 
-    appstore_code_signing
+    update_certs_and_profiles_wordpress_app_store
 
     build_app(
       scheme: 'WordPress',

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -285,7 +285,7 @@ platform :ios do
   lane :build_and_upload_wordpress_prototype_build do
     sentry_check_cli_installed
 
-    alpha_code_signing
+    update_certs_and_profiles_wordpress_enterprise
 
     build_and_upload_prototype_build(
       scheme: 'WordPress Alpha',

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -305,7 +305,7 @@ platform :ios do
   lane :build_and_upload_jetpack_prototype_build do
     sentry_check_cli_installed
 
-    jetpack_alpha_code_signing
+    update_certs_and_profiles_jetpack_enterprise
 
     build_and_upload_prototype_build(
       scheme: 'Jetpack',

--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -1,5 +1,11 @@
 # frozen_string_literal: true
 
+CODE_SIGNING_STORAGE_OPTIONS = {
+  storage_mode: 's3',
+  s3_bucket: 'a8c-fastlane-match',
+  s3_region: 'us-east-2'
+}.freeze
+
 # Lanes related to Code Signing and Provisioning Profiles
 #
 platform :ios do
@@ -140,14 +146,12 @@ def update_code_signing(type:, team_id:, readonly:, app_identifiers:, api_key_pa
   # NOTE: It might be neccessary to add `force: true` alongside `readonly: true` in order to regenerate some provisioning profiles.
   # If this turns out to be a hard requirement, we should consider updating the method with logic to toggle the two setting based on whether we're fetching or renewing.
   match(
-    storage_mode: 's3',
-    s3_bucket: 'a8c-fastlane-match',
-    s3_region: 'us-east-2',
     type: type,
     team_id: team_id,
     readonly: readonly,
     app_identifier: app_identifiers,
-    api_key_path: api_key_path
+    api_key_path: api_key_path,
+    **CODE_SIGNING_STORAGE_OPTIONS
   )
 end
 

--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -18,9 +18,9 @@ platform :ios do
   #
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
-  lane :update_wordpress_certs_and_profiles do |options|
-    alpha_code_signing(options)
-    appstore_code_signing(options)
+  lane :update_wordpress_certs_and_profiles do |readonly: true|
+    alpha_code_signing(readonly: readonly)
+    appstore_code_signing(readonly: readonly)
   end
 
   # Downloads all the required certificates and profiles (using `match`) for all Jetpack variants.
@@ -28,9 +28,9 @@ platform :ios do
   #
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
-  lane :update_jetpack_certs_and_profiles do |options|
-    jetpack_alpha_code_signing(options)
-    jetpack_appstore_code_signing(options)
+  lane :update_jetpack_certs_and_profiles do |readonly: true|
+    jetpack_alpha_code_signing(readonly: readonly)
+    jetpack_appstore_code_signing(readonly: readonly)
   end
 
   ########################################################################
@@ -42,10 +42,10 @@ platform :ios do
   #
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
-  private_lane :alpha_code_signing do |options|
+  private_lane :alpha_code_signing do |readonly: true|
     update_code_signing_enterprise(
       app_identifiers: ALL_WORDPRESS_BUNDLE_IDENTIFIERS.map { |id| id.sub(WORDPRESS_BUNDLE_IDENTIFIER, 'org.wordpress.alpha') },
-      readonly: options.fetch(:readonly, true)
+      readonly: readonly
     )
   end
 
@@ -54,10 +54,10 @@ platform :ios do
   #
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
-  private_lane :appstore_code_signing do |options|
+  private_lane :appstore_code_signing do |readonly: true|
     update_code_signing_app_store(
-      readonly: options.fetch(:readonly, true),
-      app_identifiers: ALL_WORDPRESS_BUNDLE_IDENTIFIERS
+      app_identifiers: ALL_WORDPRESS_BUNDLE_IDENTIFIERS,
+      readonly: readonly
     )
   end
 
@@ -66,10 +66,10 @@ platform :ios do
   #
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
-  private_lane :jetpack_alpha_code_signing do |options|
+  private_lane :jetpack_alpha_code_signing do |readonly: true|
     update_code_signing_enterprise(
       app_identifiers: ALL_JETPACK_BUNDLE_IDENTIFIERS.map { |id| id.sub(JETPACK_BUNDLE_IDENTIFIER, 'com.jetpack.alpha') },
-      readonly: options.fetch(:readonly, true)
+      readonly: readonly
     )
   end
 
@@ -78,10 +78,10 @@ platform :ios do
   #
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
-  private_lane :jetpack_appstore_code_signing do |options|
+  private_lane :jetpack_appstore_code_signing do |readonly: true|
     update_code_signing_app_store(
-      readonly: options.fetch(:readonly, true),
-      app_identifiers: ALL_JETPACK_BUNDLE_IDENTIFIERS
+      app_identifiers: ALL_JETPACK_BUNDLE_IDENTIFIERS,
+      readonly: readonly
     )
   end
 end

--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -29,7 +29,7 @@ platform :ios do
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
   lane :update_certs_and_profiles_jetpack do |readonly: true|
-    jetpack_alpha_code_signing(readonly: readonly)
+    update_certs_and_profiles_jetpack_enterprise(readonly: readonly)
     jetpack_appstore_code_signing(readonly: readonly)
   end
 
@@ -66,7 +66,7 @@ platform :ios do
   #
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
-  private_lane :jetpack_alpha_code_signing do |readonly: true|
+  private_lane :update_certs_and_profiles_jetpack_enterprise do |readonly: true|
     update_code_signing_enterprise(
       app_identifiers: ALL_JETPACK_BUNDLE_IDENTIFIERS.map { |id| id.sub(JETPACK_BUNDLE_IDENTIFIER, 'com.jetpack.alpha') },
       readonly: readonly

--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -33,16 +33,12 @@ platform :ios do
     update_certs_and_profiles_jetpack_app_store(readonly: readonly)
   end
 
-  ########################################################################
-  # Private lanes
-  ########################################################################
-
   # Downloads all the required certificates and profiles (using `match``) for the WordPress Alpha builds (`org.wordpress.alpha`) in the Enterprise account
   # Optionally, it can create any new necessary certificate or profile.
   #
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
-  private_lane :update_certs_and_profiles_wordpress_enterprise do |readonly: true|
+  lane :update_certs_and_profiles_wordpress_enterprise do |readonly: true|
     update_code_signing_enterprise(
       app_identifiers: ALL_WORDPRESS_BUNDLE_IDENTIFIERS.map { |id| id.sub(WORDPRESS_BUNDLE_IDENTIFIER, 'org.wordpress.alpha') },
       readonly: readonly
@@ -54,7 +50,7 @@ platform :ios do
   #
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
-  private_lane :update_certs_and_profiles_wordpress_app_store do |readonly: true|
+  lane :update_certs_and_profiles_wordpress_app_store do |readonly: true|
     update_code_signing_app_store(
       app_identifiers: ALL_WORDPRESS_BUNDLE_IDENTIFIERS,
       readonly: readonly
@@ -66,7 +62,7 @@ platform :ios do
   #
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
-  private_lane :update_certs_and_profiles_jetpack_enterprise do |readonly: true|
+  lane :update_certs_and_profiles_jetpack_enterprise do |readonly: true|
     update_code_signing_enterprise(
       app_identifiers: ALL_JETPACK_BUNDLE_IDENTIFIERS.map { |id| id.sub(JETPACK_BUNDLE_IDENTIFIER, 'com.jetpack.alpha') },
       readonly: readonly
@@ -78,7 +74,7 @@ platform :ios do
   #
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
-  private_lane :update_certs_and_profiles_jetpack_app_store do |readonly: true|
+  lane :update_certs_and_profiles_jetpack_app_store do |readonly: true|
     update_code_signing_app_store(
       app_identifiers: ALL_JETPACK_BUNDLE_IDENTIFIERS,
       readonly: readonly

--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -30,7 +30,7 @@ platform :ios do
   #
   lane :update_certs_and_profiles_jetpack do |readonly: true|
     update_certs_and_profiles_jetpack_enterprise(readonly: readonly)
-    jetpack_appstore_code_signing(readonly: readonly)
+    update_certs_and_profiles_jetpack_app_store(readonly: readonly)
   end
 
   ########################################################################
@@ -78,7 +78,7 @@ platform :ios do
   #
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
-  private_lane :jetpack_appstore_code_signing do |readonly: true|
+  private_lane :update_certs_and_profiles_jetpack_app_store do |readonly: true|
     update_code_signing_app_store(
       app_identifiers: ALL_JETPACK_BUNDLE_IDENTIFIERS,
       readonly: readonly

--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -142,6 +142,7 @@ def update_code_signing(type:, team_id:, readonly:, app_identifiers:, api_key_pa
   match(
     storage_mode: 's3',
     s3_bucket: 'a8c-fastlane-match',
+    s3_region: 'us-east-2',
     type: type,
     team_id: team_id,
     readonly: readonly,

--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -9,8 +9,8 @@ platform :ios do
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
   lane :update_certs_and_profiles do |options|
-    update_wordpress_certs_and_profiles(options)
-    update_jetpack_certs_and_profiles(options)
+    update_certs_and_profiles_wordpress(options)
+    update_certs_and_profiles_jetpack(options)
   end
 
   # Downloads all the required certificates and profiles (using `match`) for all WordPress variants.
@@ -18,7 +18,7 @@ platform :ios do
   #
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
-  lane :update_wordpress_certs_and_profiles do |readonly: true|
+  lane :update_certs_and_profiles_wordpress do |readonly: true|
     alpha_code_signing(readonly: readonly)
     appstore_code_signing(readonly: readonly)
   end
@@ -28,7 +28,7 @@ platform :ios do
   #
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
-  lane :update_jetpack_certs_and_profiles do |readonly: true|
+  lane :update_certs_and_profiles_jetpack do |readonly: true|
     jetpack_alpha_code_signing(readonly: readonly)
     jetpack_appstore_code_signing(readonly: readonly)
   end

--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -19,7 +19,7 @@ platform :ios do
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
   lane :update_certs_and_profiles_wordpress do |readonly: true|
-    alpha_code_signing(readonly: readonly)
+    update_certs_and_profiles_wordpress_enterprise(readonly: readonly)
     appstore_code_signing(readonly: readonly)
   end
 
@@ -42,7 +42,7 @@ platform :ios do
   #
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
-  private_lane :alpha_code_signing do |readonly: true|
+  private_lane :update_certs_and_profiles_wordpress_enterprise do |readonly: true|
     update_code_signing_enterprise(
       app_identifiers: ALL_WORDPRESS_BUNDLE_IDENTIFIERS.map { |id| id.sub(WORDPRESS_BUNDLE_IDENTIFIER, 'org.wordpress.alpha') },
       readonly: readonly

--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -20,7 +20,7 @@ platform :ios do
   #
   lane :update_certs_and_profiles_wordpress do |readonly: true|
     update_certs_and_profiles_wordpress_enterprise(readonly: readonly)
-    appstore_code_signing(readonly: readonly)
+    update_certs_and_profiles_wordpress_app_store(readonly: readonly)
   end
 
   # Downloads all the required certificates and profiles (using `match`) for all Jetpack variants.
@@ -54,7 +54,7 @@ platform :ios do
   #
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
-  private_lane :appstore_code_signing do |readonly: true|
+  private_lane :update_certs_and_profiles_wordpress_app_store do |readonly: true|
     update_code_signing_app_store(
       app_identifiers: ALL_WORDPRESS_BUNDLE_IDENTIFIERS,
       readonly: readonly

--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -80,6 +80,26 @@ platform :ios do
       readonly: readonly
     )
   end
+
+  # Downloads all the required certificates and profiles (using `match`) for both Jetpack and WordPress App Store variants.
+  # Optionally, it can create any new necessary certificate or profile.
+  #
+  # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
+  #
+  lane :update_certs_and_profiles_app_store do |readonly: true|
+    update_certs_and_profiles_jetpack_app_store(readonly: readonly)
+    update_certs_and_profiles_wordpress_app_store(readonly: readonly)
+  end
+
+  # Downloads all the required certificates and profiles (using `match`) for both Jetpack and WordPress Enterprise variants.
+  # Optionally, it can create any new necessary certificate or profile.
+  #
+  # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
+  #
+  lane :update_certs_and_profiles_enterprise do |readonly: true|
+    update_certs_and_profiles_jetpack_enterprise(readonly: readonly)
+    update_certs_and_profiles_wordpress_enterprise(readonly: readonly)
+  end
 end
 
 def update_code_signing_enterprise(readonly:, app_identifiers:)


### PR DESCRIPTION
This was done in the context of regenerating soon expiring certificates, see pdnsEh-1ZG-p2

I tweaked the name to be hierarchical. That is, the lane that updates everything is `update_certs_and_profiles`, the lane that updates all the WordPress variants is `update_certs_and_profiles_wordpress`, the lane that update only the WordPress App Store variant is `update_certs_and_profiles_wordpress_app_store`.

I also made all lanes public, so they can be called individually, and added new lanes for updating both app's App Store or Enterprise code siging.

## Testing

I run these locally as part of the certificates update work.

## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.