### PR TITLE
Remove WordPressUI from service extension target dependencies

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -195,7 +195,6 @@ enum XcodeSupport {
             .xcodeTarget("XcodeTarget_ShareExtension", dependencies: shareAndDraftExtensionsDependencies),
             .xcodeTarget("XcodeTarget_DraftActionExtension", dependencies: shareAndDraftExtensionsDependencies),
             .xcodeTarget("XcodeTarget_NotificationServiceExtension", dependencies: [
-                "WordPressUI",
                 "WordPressShared",
             ]),
             .xcodeTarget("XcodeTarget_StatsWidget", dependencies: [

--- a/WordPress/WordPressNotificationServiceExtension/Sources/FormattableContent/RemoteNotificationStyles.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/FormattableContent/RemoteNotificationStyles.swift
@@ -1,7 +1,6 @@
 import Foundation
 
 import WordPressShared
-import WordPressUI
 
 // MARK: - RemoteNotificationStyles
 
@@ -18,14 +17,14 @@ class RemoteNotificationStyles: FormattableContentStyles {
         style.alignment          = .natural
         style.lineBreakMode      = .byWordWrapping
 
-        let prevailingLineHeight = UIDevice.isPad() ? CGFloat(16) : CGFloat(12)
+        let prevailingLineHeight = UIDevice.current.userInterfaceIdiom == .pad ? CGFloat(16) : CGFloat(12)
         style.minimumLineHeight  = prevailingLineHeight
 
         return style
     }()
 
     private lazy var noticonFont: UIFont = {
-        let prevailingFontSize = UIDevice.isPad() ? CGFloat(15) : CGFloat(14)
+        let prevailingFontSize = UIDevice.current.userInterfaceIdiom == .pad ? CGFloat(15) : CGFloat(14)
         return UIFont(name: "Noticons", size: prevailingFontSize)!
     }()
 


### PR DESCRIPTION
NotificationServiceExtension targets use one function in WordPressUI: `UIDevice.isPad`. This PR removes this dependency because I don't think using a one-line function is worth bringing in the whole library.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
