### PR TITLE
Use latest ci-toolkit, 3.9.1, to print better logs when caching

### DIFF
--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,7 +5,7 @@
 
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed -E 's/^~> ?//' .xcode-version)
-CI_TOOLKIT_PLUGIN_VERSION="3.7.1"
+CI_TOOLKIT_PLUGIN_VERSION="3.9.1"
 
 export IMAGE_ID="xcode-$XCODE_VERSION-macos-14.7.1-v1"
 export CI_TOOLKIT_PLUGIN="automattic/a8c-ci-toolkit#$CI_TOOLKIT_PLUGIN_VERSION"


### PR DESCRIPTION
See changes from https://github.com/Automattic/a8c-ci-toolkit-buildkite-plugin/pull/135

In chatting with @ParaskP7  and @wzieba , we thought it be useful to surface cache performance in CI using the new ci-toolkit version.

Example, the Ruby Gems cache:

![image](https://github.com/user-attachments/assets/327fc102-e336-4384-9652-bb5de5312358)