### PR TITLE
feat: Swipe to dismiss GutenbergKit keyboard

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20241116"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "2ac7859864969d134fc86c8301ed47f33ba1fecc"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "f8c5c417c789c8d052093838e622828ae4ec076f"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20241116"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "cc52214a50893b41898607ac0bff7f2787b085bb"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "2ac7859864969d134fc86c8301ed47f33ba1fecc"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 25.8
 -----
-
+* [*] Enable dismissing the virtual keyboard in the experimental editor [#23988]
 
 25.7
 -----

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "be8cf0e1cdaf1e20cf7ffc013307019e4fa824831ee20fe9897ad6bbcdbe4d9c",
+  "originHash" : "114eb974f44334d6023e80c52968915782f38292095257acdcd8026cfbe347a3",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -141,7 +141,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "2ac7859864969d134fc86c8301ed47f33ba1fecc"
+        "revision" : "f8c5c417c789c8d052093838e622828ae4ec076f"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "384e396170e1bac4b5b82a62fac1cbc68b97107163c6fd0f73b311483427ab36",
+  "originHash" : "be8cf0e1cdaf1e20cf7ffc013307019e4fa824831ee20fe9897ad6bbcdbe4d9c",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -141,7 +141,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "cc52214a50893b41898607ac0bff7f2787b085bb"
+        "revision" : "2ac7859864969d134fc86c8301ed47f33ba1fecc"
       }
     },
     {


### PR DESCRIPTION
Allow dismissing the virtual keyboard within the GutenbergKit editor. Supersedes https://github.com/wordpress-mobile/WordPress-iOS/pull/23988. 

Related:

* https://github.com/Automattic/dotcom-forge/issues/8673
* https://github.com/wordpress-mobile/GutenbergKit/pull/63

To test: See https://github.com/wordpress-mobile/GutenbergKit/pull/63.

## Regression Notes
1. Potential unintended areas of impact
    None likely given single dependency update.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    N/A.
3. What automated tests I added (or what prevented me from doing so)
    N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
