### PR TITLE
feat: Log GutenbergKit errors

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20241116"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "7c72b11fd9c4dba754706b4e79325f59b37ea3b6"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "fb31301ea6a94376237947afb4242f75c074f43c"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20241116"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "ff7e97410c56dd54c145b4511752996d38f49a96"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "7c72b11fd9c4dba754706b4e79325f59b37ea3b6"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20241116"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "f8c5c417c789c8d052093838e622828ae4ec076f"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "ff7e97410c56dd54c145b4511752996d38f49a96"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
     ],
     targets: XcodeSupport.targets + [

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1f2cbbc585c412b25ab65bc4628c74121f18c47c82152bd8377b23856d8b3bc8",
+  "originHash" : "5ebdf4185e258d4ee09d79ca86bc6b3cf3875e4b1f4017498da1dc8c489e66cb",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -141,7 +141,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "7c72b11fd9c4dba754706b4e79325f59b37ea3b6"
+        "revision" : "fb31301ea6a94376237947afb4242f75c074f43c"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "bdd4522467cae8240bb329316f3ab2112ec42c71b43de6901c4c585d28604cc1",
+  "originHash" : "1f2cbbc585c412b25ab65bc4628c74121f18c47c82152bd8377b23856d8b3bc8",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -141,7 +141,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "ff7e97410c56dd54c145b4511752996d38f49a96"
+        "revision" : "7c72b11fd9c4dba754706b4e79325f59b37ea3b6"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "114eb974f44334d6023e80c52968915782f38292095257acdcd8026cfbe347a3",
+  "originHash" : "bdd4522467cae8240bb329316f3ab2112ec42c71b43de6901c4c585d28604cc1",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -141,7 +141,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "f8c5c417c789c8d052093838e622828ae4ec076f"
+        "revision" : "ff7e97410c56dd54c145b4511752996d38f49a96"
       }
     },
     {

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -292,6 +292,12 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     func showFeedbackView() {
         self.present(SubmitFeedbackViewController(source: "gutenberg_kit", feedbackPrefix: "Editor"), animated: true)
     }
+
+    func logException(_ exception: GutenbergJSException, with callback: @escaping () -> Void) {
+        DispatchQueue.main.async {
+            WordPressAppDelegate.crashLogging?.logJavaScriptException(exception, callback: callback)
+        }
+    }
 }
 
 extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate {
@@ -331,9 +337,10 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
         gutenbergDidRequestToggleUndoButton(!state.hasUndo)
     }
 
-    func editor(_ viewController: GutenbergKit.EditorViewController, didLogError error: GutenbergKit.EditorError) {
-        // TODO: Log error to application montioring service
-        NSLog(">>>> Gutenberg Error: \(error)")
+    func editor(_ viewController: GutenbergKit.EditorViewController, didLogException error: GutenbergKit.GutenbergJSException) {
+        logException(error) {
+            // Do nothing
+        }
     }
 
     func editor(_ viewController: GutenbergKit.EditorViewController, performRequest: GutenbergKit.EditorNetworkRequest) async throws -> GutenbergKit.EditorNetworkResponse {
@@ -812,3 +819,7 @@ extension NewGutenbergViewController {
         })
     }
 }
+
+// Extend Gutenberg JavaScript exception struct to conform the protocol defined in the Crash Logging service
+extension GutenbergJSException.StacktraceLine: @retroactive AutomatticTracks.JSStacktraceLine {}
+extension GutenbergJSException: @retroactive AutomatticTracks.JSException {}

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -331,6 +331,11 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
         gutenbergDidRequestToggleUndoButton(!state.hasUndo)
     }
 
+    func editor(_ viewController: GutenbergKit.EditorViewController, didLogError error: GutenbergKit.EditorError) {
+        // TODO: Log error to application montioring service
+        NSLog(">>>> Gutenberg Error: \(error)")
+    }
+
     func editor(_ viewController: GutenbergKit.EditorViewController, performRequest: GutenbergKit.EditorNetworkRequest) async throws -> GutenbergKit.EditorNetworkResponse {
         throw URLError(.unknown)
     }


### PR DESCRIPTION
Log GutenbergKit (GBK) errors to the observability platform. 

Related: 

* https://github.com/Automattic/dotcom-forge/issues/10210
* https://github.com/wordpress-mobile/GutenbergKit/pull/64
* https://github.com/wordpress-mobile/WordPress-Android/pull/21621

To test: 

1. Checkout this WP-iOS branch. 
2. Clone the sibling [GBK branch](https://github.com/wordpress-mobile/GutenbergKit/pull/64). 
4. Modify `Package.swift` to point `GutenbergKit` to your local clone of the GBK repository. 
5. Referencing [GBK documentation](https://github.com/wordpress-mobile/GutenbergKit/blob/f8c5c417c789c8d052093838e622828ae4ec076f/README.md#ios), start the GBK project server and configuring environment variables. However, **configure the environment variables within WordPress-iOS, not GBK's Demo app.** 
6. Run the WP-iOS app. 
7. Introduce an intentional error in GBK (example diff below).
8. Verify the error arrives in relevant Sentry project.

<details><summary>Example error diff</summary>
<p>

```diff
diff --git a/src/components/editor/index.jsx b/src/components/editor/index.jsx
index 582d33c..6aa5d48 100644
--- a/src/components/editor/index.jsx
+++ b/src/components/editor/index.jsx
@@ -67,6 +67,7 @@ export default function Editor({ post, children }) {

	return (
		<div className="gutenberg-kit-editor-interface">
+			{intentionalReferenceError}
			<EditorLoadNotice className="gutenberg-kit-editor-interface__load-notice" />
			<BlockEditorProvider
				value={postBlocks}

```

</p>
</details> 


## Regression Notes
1. Potential unintended areas of impact
    Regressions in Gutenberg Mobile or Aztec editors.
1. What I did to test those areas of impact (or what existing automated tests I relied on)
    Manually tested. 
1. What automated tests I added (or what prevented me from doing so)
    Deemed unnecessary for the experimental editor. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
