### PR TITLE
Remove Submit Feedback form from the Me menu

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,8 @@
 25.8
 -----
 * [*] Enable dismissing the virtual keyboard in the experimental editor [#23988]
+* [*] Remove Submit Feedback form from the Me menu [#24020]
+
 
 25.7
 -----

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -207,11 +207,6 @@ class MeViewController: UITableViewController {
                     action: displayShareFlow()
                 ),
                 ButtonRow(
-                    title: Strings.submitFeedback,
-                    textAlignment: .left,
-                    action: showFeedbackView()
-                ),
-                ButtonRow(
                     title: RowTitles.about,
                     textAlignment: .left,
                     action: pushAbout(),
@@ -309,15 +304,6 @@ class MeViewController: UITableViewController {
             self.present(controller, animated: true) {
                 self.tableView.deselectSelectedRowWithAnimation(true)
             }
-        }
-    }
-
-    func showFeedbackView() -> ImmuTableAction {
-        return { [weak self] row in
-            defer {
-                self?.tableView.deselectSelectedRowWithAnimation(true)
-            }
-            self?.present(SubmitFeedbackViewController(source: "me_menu"), animated: true)
         }
     }
 


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/24019.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
