### PR TITLE
Fix WKWebView retain cycle in Reader

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -52,6 +52,7 @@
 * [*] Fix an issue with Mastodon connection not working [#23981]
 * [**] Send feedback from within the experimental editor "more" options menu. [#23980]
 * [**] Support accessing the code editor within the experimental editor. [#23979]
+* [*] Fix WKWebView retain cycle in Reader [#24028]
 
 25.6
 -----

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/ContentRenderer/WebCommentContentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/ContentRenderer/WebCommentContentRenderer.swift
@@ -44,7 +44,9 @@ class WebCommentContentRenderer: NSObject, CommentContentRenderer {
         webView.scrollView.showsVerticalScrollIndicator = false
         webView.scrollView.backgroundColor = .clear
         webView.configuration.allowsInlineMediaPlayback = true
-        webView.configuration.userContentController.add(self, name: "eventHandler")
+
+        // - warning: It retains the handler. It can't be `self`.
+        webView.configuration.userContentController.add(ReaderWebViewMessageHandler(), name: "eventHandler")
     }
 
     func render() -> UIView {
@@ -110,20 +112,6 @@ extension WebCommentContentRenderer: WKNavigationDelegate {
             self.delegate?.renderer(self, interactedWithURL: destinationURL)
         }
     }
-}
-
-// MARK: - WKScriptMessageHandler
-
-extension WebCommentContentRenderer: WKScriptMessageHandler {
-
-    func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
-        guard let body = message.body as? String,
-              let event = ReaderWebView.EventMessage(rawValue: body)?.analyticEvent else {
-            return
-        }
-        WPAnalytics.track(event)
-    }
-
 }
 
 // MARK: - Private Methods

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -28,7 +28,8 @@ class ReaderWebView: WKWebView {
             isInspectable = true
         }
 
-        configuration.userContentController.add(self, name: "eventHandler")
+        // - warning: It retains the handler. It can't be `self`.
+        configuration.userContentController.add(ReaderWebViewMessageHandler(), name: "eventHandler")
     }
 
     /// Loads a HTML content into the webview and apply styles
@@ -311,8 +312,7 @@ class ReaderWebView: WKWebView {
     }
 }
 
-extension ReaderWebView: WKScriptMessageHandler {
-
+final class ReaderWebViewMessageHandler: NSObject, WKScriptMessageHandler {
     enum EventMessage: String {
         case articleTextHighlighted
         case articleTextCopied
@@ -342,5 +342,4 @@ extension ReaderWebView: WKScriptMessageHandler {
         }
         WPAnalytics.track(event)
     }
-
 }


### PR DESCRIPTION
Fixes #

To test:

- I checked that `ReaderWebViewMessageHandler` gets called and `ReaderWebView` deinit also does

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
