### PR TITLE
 Fix crash in a GIFAnimatedImage extension

### DIFF
--- a/Modules/Sources/AsyncImageKit/Views/AsyncImageView.swift
+++ b/Modules/Sources/AsyncImageKit/Views/AsyncImageView.swift
@@ -47,7 +47,7 @@ public final class AsyncImageView: UIView {
             if let image {
                 imageView.configure(image: image)
             } else {
-                imageView.prepareForReuse()
+                imageView.reset()
             }
         }
     }
@@ -185,7 +185,7 @@ extension GIFImageView {
         }
     }
 
-    public func prepareForReuse() {
+    public func reset() {
         if isAnimatingGIF {
             prepareForReuse()
         } else {

--- a/Modules/Sources/AsyncImageKit/Views/UIImageView+ImageDownloader.swift
+++ b/Modules/Sources/AsyncImageKit/Views/UIImageView+ImageDownloader.swift
@@ -14,7 +14,7 @@ public struct ImageViewExtensions {
         controller.prepareForReuse()
 
         if let gifView = imageView as? GIFImageView, gifView.isAnimatingGIF {
-            gifView.prepareForReuse()
+            gifView.reset()
         } else {
             imageView.image = nil
         }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
@@ -68,7 +68,7 @@ final class SiteMediaCollectionCell: UICollectionViewCell, Reusable {
         viewModel?.onDisappear()
         viewModel = nil
 
-        imageView.prepareForReuse()
+        imageView.reset()
         imageView.image = nil
         imageView.alpha = 0
 

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaImageView.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaImageView.swift
@@ -53,7 +53,7 @@ final class SiteMediaImageView: UIView {
             if let image {
                 imageView.configure(image: image)
             } else {
-                imageView.prepareForReuse()
+                imageView.reset()
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Views/RichTextView/AnimatedGifAttachmentViewProvider.swift
+++ b/WordPress/Classes/ViewRelated/Views/RichTextView/AnimatedGifAttachmentViewProvider.swift
@@ -11,8 +11,7 @@ class AnimatedGifAttachmentViewProvider: NSTextAttachmentViewProvider {
         guard let animatedImageView = view as? GIFImageView else {
             return
         }
-
-        animatedImageView.prepareForReuse()
+        animatedImageView.reset()
     }
 
     override init(textAttachment: NSTextAttachment, parentView: UIView?, textLayoutManager: NSTextLayoutManager?, location: NSTextLocation) {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/24030

To test:

- Test Reader feed that have some GIFs

**Note:** there are some existing issues with restart of animations on reload. I believe they've been there before. 

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
