### PR TITLE
feat: Request feedback when disabling the experimental editor

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WordPressUI
+import UIKit
 
 class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvider {
 
@@ -24,6 +25,17 @@ class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvid
 
     func didChangeValue(for feature: WordPressUI.Feature, to newValue: Bool) {
         flagStore.override(flag(for: feature), withValue: newValue)
+
+        if feature.key == FeatureFlag.newGutenberg.key && !newValue {
+            let alert = UIAlertController(title: Strings.editorFeedbackTitle, message: Strings.editorFeedbackMessage, preferredStyle: .alert)
+            alert.addAction(UIAlertAction(title: Strings.editorFeedbackDecline, style: .cancel, handler: nil))
+            alert.addAction(UIAlertAction(title: Strings.editorFeedbackAccept, style: .default, handler: { _ in
+                let feedbackViewController = SubmitFeedbackViewController(source: "experimental_features", feedbackPrefix: "Editor")
+                self.presentViewController(feedbackViewController)
+            }))
+
+            self.presentViewController(alert)
+        }
     }
 
     private func flag(for feature: WordPressUI.Feature) -> OverridableFlag {
@@ -32,5 +44,21 @@ class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvid
         }
 
         return flag
+    }
+
+    private func presentViewController(_ viewController: UIViewController) {
+        DispatchQueue.main.async {
+            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+               let topController = windowScene.windows.first?.rootViewController {
+                topController.present(viewController, animated: true, completion: nil)
+            }
+        }
+    }
+
+    enum Strings {
+        static let editorFeedbackTitle = NSLocalizedString("Share Feedback", comment: "Title for the alert asking for feedback")
+        static let editorFeedbackMessage = NSLocalizedString("Are you willing to share feedback on the experimental editor?", comment: "Message for the alert asking for feedback on the experimental editor")
+        static let editorFeedbackDecline = NSLocalizedString("Not now", comment: "Dismiss button title for the alert asking for feedback")
+        static let editorFeedbackAccept = NSLocalizedString("Send feedback", comment: "Accept button title for the alert asking for feedback")
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
@@ -56,9 +56,9 @@ class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvid
     }
 
     enum Strings {
-        static let editorFeedbackTitle = NSLocalizedString("Share Feedback", comment: "Title for the alert asking for feedback")
-        static let editorFeedbackMessage = NSLocalizedString("Are you willing to share feedback on the experimental editor?", comment: "Message for the alert asking for feedback on the experimental editor")
-        static let editorFeedbackDecline = NSLocalizedString("Not now", comment: "Dismiss button title for the alert asking for feedback")
-        static let editorFeedbackAccept = NSLocalizedString("Send feedback", comment: "Accept button title for the alert asking for feedback")
+        static let editorFeedbackTitle = NSLocalizedString("experimentalFeatures.editorFeedbackTitle", value: "Share Feedback", comment: "Title for the alert asking for feedback")
+        static let editorFeedbackMessage = NSLocalizedString("experimentalFeatures.editorFeedbackMessage", value: "Are you willing to share feedback on the experimental editor?", comment: "Message for the alert asking for feedback on the experimental editor")
+        static let editorFeedbackDecline = NSLocalizedString("experimentalFeatures.editorFeedbackDecline", value: "Not now", comment: "Dismiss button title for the alert asking for feedback")
+        static let editorFeedbackAccept = NSLocalizedString("experimentalFeatures.editorFeedbackAccept", value: "Send feedback", comment: "Accept button title for the alert asking for feedback")
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
@@ -48,7 +48,7 @@ class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvid
 
     private func presentViewController(_ viewController: UIViewController) {
         DispatchQueue.main.async {
-            if let windowScene = UIApplication.shared.connectedScenes.first as? UIWindowScene,
+            if let windowScene = UIViewController.topViewController?.view.window?.windowScene,
                let topController = windowScene.windows.first?.rootViewController {
                 topController.present(viewController, animated: true, completion: nil)
             }


### PR DESCRIPTION
Relates to https://github.com/Automattic/dotcom-forge/issues/10126. Users disabling the experimental editor may have valuable feedback regarding why they are no longer using it.

<details><summary>Screen recording</summary>
<p>


https://github.com/user-attachments/assets/aa624e85-3647-45ea-bb43-339b22c20e5e



</p>
</details> 

To test: 

1. Navigate to _Me_ → _App Settings_ → _Experimental Features_. 
2. Disable the _Experimental block editor_. 
3. Verify declining to share feedback succeeds; verify sending feedback succeeds. 

## Regression Notes
1. Potential unintended areas of impact
    Unlikely with this limited change. 
4. What I did to test those areas of impact (or what existing automated tests I relied on)
    N/A
6. What automated tests I added (or what prevented me from doing so)
    N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
