### PR TITLE
Minor improvements to Gutenberg Comments

### DIFF
--- a/Modules/Sources/WordPressReader/Comments/Views/CommentContentRenderer.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/CommentContentRenderer.swift
@@ -5,13 +5,15 @@ import UIKit
 public protocol CommentContentRenderer: AnyObject {
     var delegate: CommentContentRendererDelegate? { get set }
 
+    /// A view for rendering the comments.
+    var view: UIView { get }
+
     init()
 
-    /// Returns a view component that's configured to display the formatted content of the comment.
-    ///
-    /// Note that the renderer *might* return a view with the wrong sizing at first, but it should update its delegate with the correct height
-    /// through the `renderer(_:asyncRenderCompletedWithHeight:)` method.
-    func render(comment: String) -> UIView
+    /// Note that the renderer *might* return a view with the wrong sizing at first,
+    /// but it should update its delegate with the correct height through the
+    ///  `renderer(_:asyncRenderCompletedWithHeight:)` method.
+    func render(comment: String)
 }
 
 @MainActor

--- a/Modules/Sources/WordPressReader/Comments/Views/CommentWebView.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/CommentWebView.swift
@@ -48,6 +48,13 @@ final class CommentWebView: UIView, CommentContentRendererDelegate {
     """)
 }
 
+@available(iOS 17, *)
+#Preview("Media") {
+    makeView(comment: """
+    <p>Test image in the middle.</p>\n<figure class=\"wp-block-image size-medium\"><img src=\"https://fastly.picsum.photos/id/31/3264/4912.jpg?hmac=lfmmWE3h_aXmRwDDZ7pZb6p0Foq6u86k_PpaFMnq0r8\" alt=\"\" /></figure>\n<p>Text below.</p>\n
+    """)
+}
+
 @MainActor
 private func makeView(comment: String) -> UIView {
     let webView = CommentWebView(comment: comment)

--- a/Modules/Sources/WordPressReader/Comments/Views/CommentWebView.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/CommentWebView.swift
@@ -4,21 +4,18 @@ import UIKit
 @MainActor
 final class CommentWebView: UIView, CommentContentRendererDelegate {
     let renderer = WebCommentContentRenderer()
-    let webView: UIView
-    lazy var heightConstraint = webView.heightAnchor.constraint(equalToConstant: 20)
+    lazy var heightConstraint = renderer.view.heightAnchor.constraint(equalToConstant: 20)
 
     init(comment: String) {
-        let webView = renderer.render(comment: comment)
-        self.webView = webView
-
         super.init(frame: .zero)
 
-        renderer.delegate = self
-
-        addSubview(webView)
-        webView.pinEdges()
+        addSubview(renderer.view)
+        renderer.view.pinEdges()
 
         heightConstraint.isActive = true
+
+        renderer.delegate = self
+        renderer.render(comment: comment)
     }
 
     required init?(coder: NSCoder) {

--- a/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
@@ -9,6 +9,8 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
 
     public weak var delegate: CommentContentRendererDelegate?
 
+    public var view: UIView { webView }
+
     private let webView = WKWebView(frame: .zero, configuration: {
         let configuration = WKWebViewConfiguration()
         configuration.allowsInlineMediaPlayback = true
@@ -50,15 +52,14 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
         webView.scrollView.backgroundColor = .clear
     }
 
-    public func render(comment: String) -> UIView {
+    public func render(comment: String) {
         guard self.comment != comment else {
-            return webView // Already rendering this comment
+            return // Already rendering this comment
         }
         self.comment = comment
 
         // - important: `wordPressSharedBundle` contains custom fonts
         webView.loadHTMLString(formattedHTMLString(for: comment), baseURL: Bundle.wordPressSharedBundle.bundleURL)
-        return webView
     }
 }
 

--- a/Modules/Sources/WordPressReader/Resources/gutenbergCommentHeadTemplate.html
+++ b/Modules/Sources/WordPressReader/Resources/gutenbergCommentHeadTemplate.html
@@ -4,25 +4,4 @@
     <style>
         %2$@
     </style>
-    <script>
-        function debounce(fn, timeout) {
-            let timer;
-            return () => {
-                clearTimeout(timer);
-                timer = setTimeout(fn, timeout);
-            }
-        }
-        const postEvent = (event) => window.webkit.messageHandlers.eventHandler.postMessage(event);
-        const textHighlighted = debounce(
-            () => postEvent("commentTextHighlighted"),
-            1000
-        );
-        document.addEventListener('selectionchange', function(event) {
-            const selection = document.getSelection().toString();
-            if (selection.length > 0) {
-                textHighlighted();
-            }
-        });
-        document.addEventListener('copy', event => postEvent("commentTextCopied"));
-    </script>
 </head>

--- a/Modules/Sources/WordPressReader/Resources/gutenbergContentStyles.css
+++ b/Modules/Sources/WordPressReader/Resources/gutenbergContentStyles.css
@@ -99,10 +99,7 @@ a.mention {
 
 .wp-block-image img,
 p > img:not(.emoji) {
-    display: block;
-    margin: 0 auto; /* align center */
-    width: auto;
-    height: auto;
+    max-height: 360px;
 }
 
 /* apply border radius to all image elements. */

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -513,13 +513,14 @@ private extension CommentContentTableViewCell {
             contentContainerHeightConstraint?.isActive = false
         }
 
-        let contentView = renderer.render(comment: comment.content)
+        let contentView = renderer.view
         if contentContainerView.subviews.first != contentView {
             contentContainerView.subviews.forEach { $0.removeFromSuperview() }
             contentView.removeFromSuperview()
             contentContainerView?.addSubview(contentView)
             contentView.pinEdges()
         }
+        renderer.render(comment: comment.content)
     }
 
     // MARK: Button Actions

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/ContentRenderer/RichCommentContentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/ContentRenderer/RichCommentContentRenderer.swift
@@ -7,17 +7,19 @@ import WordPressReader
 class RichCommentContentRenderer: NSObject, CommentContentRenderer {
     weak var delegate: CommentContentRendererDelegate?
 
+    var view: UIView { textView }
+
     weak var richContentDelegate: WPRichContentViewDelegate? = nil
     var attributedText: NSAttributedString?
     var comment: Comment?
 
+    lazy var textView = newRichContentView()
+
     required override init() {}
 
-    func render(comment: String) -> UIView {
-        let textView = newRichContentView()
+    func render(comment: String) {
         textView.attributedText = attributedText
         textView.delegate = self
-        return textView
     }
 }
 


### PR DESCRIPTION
(see comments)

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
