### PR TITLE
Self hosted site plugin management list UI update

### DIFF
--- a/Modules/Sources/WordPressCore/Plugins/InstalledPlugin.swift
+++ b/Modules/Sources/WordPressCore/Plugins/InstalledPlugin.swift
@@ -8,14 +8,16 @@ public struct InstalledPlugin: Equatable, Hashable, Identifiable, Sendable {
     public var version: String
     public var author: String
     public var shortDescription: String
+    public var isActive: Bool
 
-    public init(slug: PluginSlug, iconURL: URL?, name: String, version: String, author: String, shortDescription: String) {
+    public init(slug: PluginSlug, iconURL: URL?, name: String, version: String, author: String, shortDescription: String, isActive: Bool) {
         self.slug = slug
         self.iconURL = iconURL
         self.name = name
         self.version = version
         self.author = author
         self.shortDescription = shortDescription
+        self.isActive = isActive
     }
 
     public init(plugin: PluginWithViewContext) {
@@ -25,6 +27,7 @@ public struct InstalledPlugin: Equatable, Hashable, Identifiable, Sendable {
         version = plugin.version
         author = plugin.author
         shortDescription = plugin.description.raw
+        isActive = plugin.status == .active || plugin.status == .networkActive
     }
 
     public var id: String {

--- a/Modules/Sources/WordPressCore/Plugins/InstalledPlugin.swift
+++ b/Modules/Sources/WordPressCore/Plugins/InstalledPlugin.swift
@@ -30,6 +30,16 @@ public struct InstalledPlugin: Equatable, Hashable, Identifiable, Sendable {
         isActive = plugin.status == .active || plugin.status == .networkActive
     }
 
+    public init(plugin: PluginWithEditContext) {
+        self.slug = plugin.plugin
+        iconURL = nil
+        name = plugin.name
+        version = plugin.version
+        author = plugin.author
+        shortDescription = plugin.description.raw
+        isActive = plugin.status == .active || plugin.status == .networkActive
+    }
+
     public var id: String {
         slug.slug
     }

--- a/Modules/Sources/WordPressCore/Plugins/InstalledPluginDataStore.swift
+++ b/Modules/Sources/WordPressCore/Plugins/InstalledPluginDataStore.swift
@@ -6,8 +6,10 @@ import WordPressAPI
 public protocol InstalledPluginDataStore: DataStore where T == InstalledPlugin, Query == PluginDataStoreQuery {
 }
 
-public enum PluginDataStoreQuery: Equatable, Sendable {
+public enum PluginDataStoreQuery: Hashable, Sendable {
     case all
+    case active
+    case inactive
 }
 
 public actor InMemoryInstalledPluginDataStore: InstalledPluginDataStore, InMemoryDataStore {
@@ -23,9 +25,16 @@ public actor InMemoryInstalledPluginDataStore: InstalledPluginDataStore, InMemor
     public init() {}
 
     public func list(query: Query) throws -> [T] {
+        let plugins: any Sequence<T>
         switch query {
         case .all:
-            return storage.values.sorted(using: KeyPathComparator(\.slug.slug))
+            plugins = storage.values
+        case .active:
+            plugins = storage.values.filter { $0.isActive }
+        case .inactive:
+            plugins = storage.values.filter { !$0.isActive }
         }
+
+        return plugins.sorted(using: KeyPathComparator(\.slug.slug))
     }
 }

--- a/Modules/Sources/WordPressCore/Plugins/InstalledPluginDataStore.swift
+++ b/Modules/Sources/WordPressCore/Plugins/InstalledPluginDataStore.swift
@@ -10,6 +10,7 @@ public enum PluginDataStoreQuery: Hashable, Sendable {
     case all
     case active
     case inactive
+    case slug(PluginSlug)
 }
 
 public actor InMemoryInstalledPluginDataStore: InstalledPluginDataStore, InMemoryDataStore {
@@ -33,6 +34,8 @@ public actor InMemoryInstalledPluginDataStore: InstalledPluginDataStore, InMemor
             plugins = storage.values.filter { $0.isActive }
         case .inactive:
             plugins = storage.values.filter { !$0.isActive }
+        case let .slug(slug):
+            plugins = storage.values.first { $0.slug == slug }.flatMap { [$0] } ?? []
         }
 
         return plugins.sorted(using: KeyPathComparator(\.slug.slug))

--- a/Modules/Sources/WordPressCore/Plugins/PluginService.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginService.swift
@@ -20,8 +20,8 @@ public actor PluginService: PluginServiceProtocol {
         try await installedPluginDataStore.store(plugins)
     }
 
-    public func installedPluginsUpdates() async -> AsyncStream<Result<[InstalledPlugin], Error>> {
-        await installedPluginDataStore.listStream(query: .all)
+    public func installedPluginsUpdates(query: PluginDataStoreQuery) async -> AsyncStream<Result<[InstalledPlugin], Error>> {
+        await installedPluginDataStore.listStream(query: query)
     }
 
     public func resolveIconURL(of slug: PluginWpOrgDirectorySlug) async -> URL? {

--- a/Modules/Sources/WordPressCore/Plugins/PluginService.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 import WordPressAPI
+@preconcurrency import WordPressAPIInternal
 
 public actor PluginService: PluginServiceProtocol {
     private let client: WordPressClient
@@ -36,6 +37,18 @@ public actor PluginService: PluginServiceProtocol {
         }
 
         return nil
+    }
+
+    public func togglePluginActivation(slug: PluginSlug) async throws {
+        let plugin = try await client.api.plugins.retrieveWithViewContext(pluginSlug: slug)
+        let newStatus: PluginStatus = plugin.data.status == .inactive ? (plugin.data.networkOnly ? .networkActive : .active) : .inactive
+        let newPlugin = try await client.api.plugins.update(pluginSlug: slug, params: .init(status: newStatus))
+        try await installedPluginDataStore.store([.init(plugin: newPlugin.data)])
+    }
+
+    public func uninstalledPlugin(slug: PluginSlug) async throws {
+        let _ = try await client.api.plugins.delete(pluginSlug: slug)
+        try await installedPluginDataStore.delete(query: .slug(slug))
     }
 
 }

--- a/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
@@ -5,7 +5,7 @@ public protocol PluginServiceProtocol: Actor {
 
     func fetchInstalledPlugins() async throws
 
-    func installedPluginsUpdates() async -> AsyncStream<Result<[InstalledPlugin], Error>>
+    func installedPluginsUpdates(query: PluginDataStoreQuery) async -> AsyncStream<Result<[InstalledPlugin], Error>>
 
     func resolveIconURL(of slug: PluginWpOrgDirectorySlug) async -> URL?
 

--- a/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
@@ -9,6 +9,10 @@ public protocol PluginServiceProtocol: Actor {
 
     func resolveIconURL(of slug: PluginWpOrgDirectorySlug) async -> URL?
 
+    func togglePluginActivation(slug: PluginSlug) async throws
+
+    func uninstalledPlugin(slug: PluginSlug) async throws
+
 }
 
 extension PluginServiceProtocol {

--- a/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
+++ b/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
@@ -19,12 +19,12 @@ struct InstalledPluginsListView: View {
         ZStack {
             if let error = viewModel.error {
                 EmptyStateView(error, systemImage: "exclamationmark.triangle.fill")
-            } else if viewModel.isRefreshing && viewModel.plugins.isEmpty {
+            } else if viewModel.isRefreshing && viewModel.displayingPlugins.isEmpty {
                 Label { Text(Strings.loading) } icon: { ProgressView() }
             } else {
                 List {
                     Section {
-                        ForEach(viewModel.plugins, id: \.self) { plugin in
+                        ForEach(viewModel.displayingPlugins, id: \.self) { plugin in
                             PluginListItemView(
                                 plugin: plugin,
                                 service: viewModel.service
@@ -38,10 +38,23 @@ struct InstalledPluginsListView: View {
             }
         }
         .navigationTitle(Strings.title)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    Picker(Strings.filterTitle, selection: $viewModel.filter) {
+                        Text(Strings.filterOptionAll).tag(PluginDataStoreQuery.all)
+                        Text(Strings.filterOptionActive).tag(PluginDataStoreQuery.active)
+                        Text(Strings.filterOptionInactive).tag(PluginDataStoreQuery.inactive)
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+            }
+        }
         .task(id: 0) {
             await viewModel.onAppear()
         }
-        .task(id: 1) {
+        .task(id: viewModel.filter) {
             await viewModel.performQuery()
         }
     }
@@ -50,16 +63,22 @@ struct InstalledPluginsListView: View {
         static let title: String = NSLocalizedString("site.plugins.title", value: "Plugins", comment: "Installed plugins list title")
         static let loading: String = NSLocalizedString("site.plugins.loading", value: "Loading installed plugins…", comment: "Message displayed when fetching installed plugins from the site")
         static let noPluginInstalled: String = NSLocalizedString("site.plugins.noInstalledPlugins", value: "You haven't installed any plugins yet", comment: "No installed plugins message")
+        static let filterTitle: String = NSLocalizedString("site.plugins.filter.title", value: "Filter", comment: "Title of the plugin filter picker")
+        static let filterOptionAll: String = NSLocalizedString("site.plugins.filter.option.all", value: "All", comment: "The plugin fillter option for displaying all plugins")
+        static let filterOptionActive: String = NSLocalizedString("site.plugins.filter.option.all", value: "Active", comment: "The plugin fillter option for displaying active plugins")
+        static let filterOptionInactive: String = NSLocalizedString("site.plugins.filter.option.all", value: "Inactive", comment: "The plugin fillter option for displaying inactive plugins")
     }
 }
 
 @MainActor
 final class InstalledPluginsListViewModel: ObservableObject {
+
     let service: PluginServiceProtocol
     private var initialLoad = false
 
     @Published var isRefreshing: Bool = false
-    @Published var plugins: [InstalledPlugin] = []
+    @Published var filter: PluginDataStoreQuery = .all
+    @Published var displayingPlugins: [InstalledPlugin] = []
     @Published var error: String? = nil
 
     init(service: PluginServiceProtocol) {
@@ -86,10 +105,10 @@ final class InstalledPluginsListViewModel: ObservableObject {
     }
 
     func performQuery() async {
-        for await update in await self.service.installedPluginsUpdates() {
+        for await update in await self.service.installedPluginsUpdates(query: filter) {
             switch update {
             case let .success(plugins):
-                self.plugins = plugins
+                self.displayingPlugins = plugins
             case let .failure(error):
                 self.error = (error as? WpApiError)?.errorMessage ?? error.localizedDescription
             }

--- a/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
+++ b/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
@@ -25,10 +25,7 @@ struct InstalledPluginsListView: View {
                 List {
                     Section {
                         ForEach(viewModel.displayingPlugins, id: \.self) { plugin in
-                            PluginListItemView(
-                                plugin: plugin,
-                                service: viewModel.service
-                            )
+                            PluginListItemView(plugin: plugin, viewModel: viewModel)
                         }
                     }
                     .listSectionSeparator(.hidden, edges: .top)
@@ -81,6 +78,8 @@ final class InstalledPluginsListViewModel: ObservableObject {
     @Published var displayingPlugins: [InstalledPlugin] = []
     @Published var error: String? = nil
 
+    @Published var updating: Set<PluginSlug> = []
+
     init(service: PluginServiceProtocol) {
         self.service = service
     }
@@ -113,5 +112,28 @@ final class InstalledPluginsListViewModel: ObservableObject {
                 self.error = (error as? WpApiError)?.errorMessage ?? error.localizedDescription
             }
         }
+    }
+
+    func toggle(slug: PluginSlug) async {
+        self.updating.insert(slug)
+        defer { self.updating.remove(slug) }
+
+        do {
+            try await self.service.togglePluginActivation(slug: slug)
+        } catch {
+            DDLogError("Failed to update plugin: \(error)")
+        }
+    }
+
+    func uninstall(slug: PluginSlug) async {
+        self.updating.insert(slug)
+        defer { self.updating.remove(slug) }
+
+        do {
+            try await self.service.uninstalledPlugin(slug: slug)
+        } catch {
+            DDLogError("Failed to uninstall plugin: \(error)")
+        }
+
     }
 }

--- a/WordPress/Classes/Plugins/Views/PluginListItemView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginListItemView.swift
@@ -3,10 +3,12 @@ import SwiftUI
 import AsyncImageKit
 import WordPressAPI
 import WordPressCore
+import SafariServices
 
 struct PluginListItemView: View {
 
     @ScaledMetric(relativeTo: .body) var descriptionFontSize: CGFloat = 14
+    @State private var showingSafariView = false
 
     let plugin: InstalledPlugin
     let viewModel: InstalledPluginsListViewModel
@@ -71,8 +73,14 @@ struct PluginListItemView: View {
                 }
                 .disabled(isUpdating)
 
-                Section {
-                    Button("View on WordPress.org", systemImage: "safari") {}
+                if let url = wpOrgURL {
+                    Section {
+                        Button {
+                            showingSafariView = true
+                        } label: {
+                            Label("View on WordPress.org", systemImage: "safari")
+                        }
+                    }
                 }
             } label: {
                 Image(systemName: "ellipsis")
@@ -81,6 +89,11 @@ struct PluginListItemView: View {
                     .contentShape(Rectangle())
             }
             .foregroundStyle(.secondary)
+        }
+        .sheet(isPresented: $showingSafariView) {
+            if let url = wpOrgURL {
+                SafariView(url: url)
+            }
         }
     }
 
@@ -114,6 +127,11 @@ struct PluginListItemView: View {
         }
     }
 
+    private var wpOrgURL: URL? {
+        guard let slug = plugin.possibleWpOrgDirectorySlug else { return nil }
+        return URL(string: "https://wordpress.org/plugins/\(slug.slug)/")
+    }
+
     private enum Strings {
         static func author(_ author: String) -> String {
             let format = NSLocalizedString("site.plugins.list.item.author", value: "By %@", comment: "The plugin author displayed in the plugins list. The first argument is plugin author name")
@@ -126,5 +144,16 @@ struct PluginListItemView: View {
         }
 
         static let noDescriptionAvailable: String = NSLocalizedString("site.plugins.list.item.noDescriptionAvailable", value: "The plugin author did not provide a description for this plugin.", comment: "The message displayed when a plugin has no description")
+    }
+}
+
+private struct SafariView: UIViewControllerRepresentable {
+    let url: URL
+
+    func makeUIViewController(context: Context) -> SFSafariViewController {
+        SFSafariViewController(url: url)
+    }
+
+    func updateUIViewController(_ controller: SFSafariViewController, context: Context) {
     }
 }

--- a/WordPress/Classes/Plugins/Views/PluginListItemView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginListItemView.swift
@@ -53,18 +53,18 @@ struct PluginListItemView: View {
             Menu {
                 Section {
                     if plugin.isActive {
-                        Button("Deactivate", systemImage: "bolt.slash") {
+                        Button(Strings.deactivate, systemImage: "bolt.slash") {
                             Task {
                                 await viewModel.toggle(slug: plugin.slug)
                             }
                         }
                     } else {
-                        Button("Activate", systemImage: "bolt") {
+                        Button(Strings.activate, systemImage: "bolt") {
                             Task {
                                 await viewModel.toggle(slug: plugin.slug)
                             }
                         }
-                        Button("Delete", systemImage: "trash") {
+                        Button(Strings.delete, systemImage: "trash") {
                             Task {
                                 await viewModel.uninstall(slug: plugin.slug)
                             }
@@ -73,12 +73,12 @@ struct PluginListItemView: View {
                 }
                 .disabled(isUpdating)
 
-                if let url = wpOrgURL {
+                if wpOrgURL != nil {
                     Section {
                         Button {
                             showingSafariView = true
                         } label: {
-                            Label("View on WordPress.org", systemImage: "safari")
+                            Label(Strings.viewOnWordPressOrg, systemImage: "safari")
                         }
                     }
                 }
@@ -144,6 +144,11 @@ struct PluginListItemView: View {
         }
 
         static let noDescriptionAvailable: String = NSLocalizedString("site.plugins.list.item.noDescriptionAvailable", value: "The plugin author did not provide a description for this plugin.", comment: "The message displayed when a plugin has no description")
+
+        static let activate: String = NSLocalizedString("site.plugins.list.item.action.activate", value: "Activate", comment: "Button to activate a plugin")
+        static let deactivate: String = NSLocalizedString("site.plugins.list.item.action.deactivate", value: "Deactivate", comment: "Button to deactivate a plugin")
+        static let delete: String = NSLocalizedString("site.plugins.list.item.action.delete", value: "Delete", comment: "Button to delete a plugin")
+        static let viewOnWordPressOrg: String = NSLocalizedString("site.plugins.list.item.action.viewOnWordPressOrg", value: "View on WordPress.org", comment: "Button to view the plugin on WordPress.org website")
     }
 }
 

--- a/WordPress/Classes/Plugins/Views/PluginListItemView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginListItemView.swift
@@ -8,63 +8,52 @@ struct PluginListItemView: View {
 
     @ScaledMetric(relativeTo: .body) var descriptionFontSize: CGFloat = 14
 
-    private var slug: PluginWpOrgDirectorySlug?
-    private var iconURL: URL?
-    private var name: String
-    private var version: String
-    private var author: String
-    private var shortDescription: String
-    private var service: PluginServiceProtocol
-
-    init(plugin: InstalledPlugin, service: PluginServiceProtocol) {
-        self.slug = plugin.possibleWpOrgDirectorySlug
-        self.iconURL = plugin.iconURL
-        self.name = plugin.name
-        self.version = plugin.version
-        self.author = plugin.author
-        self.shortDescription = plugin.shortDescription
-        self.service = service
-    }
+    var plugin: InstalledPlugin
+    var service: PluginServiceProtocol
 
     var body: some View {
         HStack(alignment: .top) {
-            PluginIconView(slug: slug, service: service)
+            PluginIconView(slug: plugin.possibleWpOrgDirectorySlug, service: service)
 
             VStack(alignment: .leading, spacing: 0) {
-                Text(name)
+                Text(plugin.name)
                     .lineLimit(1)
                     .font(.headline)
                     .foregroundStyle(.primary)
 
-                if !author.isEmpty {
-                    Text(Strings.author(author))
+                if !plugin.author.isEmpty {
+                    Text(Strings.author(plugin.author))
                         .lineLimit(1)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                 }
 
                 Group {
-                    if shortDescription.isEmpty {
+                    if plugin.shortDescription.isEmpty {
                         Text(Strings.noDescriptionAvailable)
                             .font(.system(size: descriptionFontSize).italic())
                     } else if let html = renderedDescription() {
                         Text(html)
                     } else {
-                        Text(shortDescription)
+                        Text(plugin.shortDescription)
                             .font(.system(size: descriptionFontSize))
                     }
                 }
+                .lineLimit(2)
                 .padding(.vertical, 4)
 
-                Text(Strings.version(version))
+                Text(Strings.version(plugin.version))
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
         }
     }
 
+    // TODO: Use `WebCommentContentRenderer` instead.
+    // There are potential crash and performance issues in NSAttributedString's HTML support.
+    // http://www.openradar.me/20978452
     func renderedDescription() -> AttributedString? {
-        guard var data = shortDescription.data(using: .utf8) else {
+        guard var data = plugin.shortDescription.data(using: .utf8) else {
             return nil
         }
 

--- a/WordPress/Classes/Plugins/Views/PluginListItemView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginListItemView.swift
@@ -3,11 +3,11 @@ import SwiftUI
 import AsyncImageKit
 import WordPressAPI
 import WordPressCore
+import WordPressShared
 import SafariServices
 
 struct PluginListItemView: View {
 
-    @ScaledMetric(relativeTo: .body) var descriptionFontSize: CGFloat = 14
     @State private var showingSafariView = false
 
     let plugin: InstalledPlugin
@@ -23,24 +23,15 @@ struct PluginListItemView: View {
             PluginIconView(slug: plugin.possibleWpOrgDirectorySlug, service: viewModel.service)
 
             VStack(alignment: .leading, spacing: 0) {
-                Text(plugin.name)
+                Text(plugin.name.makePlainText())
                     .lineLimit(1)
                     .font(.headline)
                     .foregroundStyle(.primary)
 
-                Group {
-                    if plugin.shortDescription.isEmpty {
-                        Text(Strings.noDescriptionAvailable)
-                            .font(.system(size: descriptionFontSize).italic())
-                    } else if let html = renderedDescription() {
-                        Text(html)
-                    } else {
-                        Text(plugin.shortDescription)
-                            .font(.system(size: descriptionFontSize))
-                    }
-                }
-                .lineLimit(2)
-                .padding(.vertical, 4)
+                Text(plugin.shortDescription.makePlainText())
+                    .lineLimit(2)
+                    .font(.body)
+                    .foregroundStyle(.primary)
 
                 Text(Strings.version(plugin.version))
                     .font(.caption)
@@ -94,36 +85,6 @@ struct PluginListItemView: View {
             if let url = wpOrgURL {
                 SafariView(url: url)
             }
-        }
-    }
-
-    // TODO: Use `WebCommentContentRenderer` instead.
-    // There are potential crash and performance issues in NSAttributedString's HTML support.
-    // http://www.openradar.me/20978452
-    func renderedDescription() -> AttributedString? {
-        guard var data = plugin.shortDescription.data(using: .utf8) else {
-            return nil
-        }
-
-        // We want to use the system font, instead of the default "Times New Roman" font in the rendered HTML.
-        // Using `.defaultAttributes: [.font: systemFont(...)]` in the `NSAttributedString` initialiser below doesn't
-        // work. Using a CSS style here as a workaround.
-        data.append(contentsOf: "<style> body { font-family: -apple-system; font-size: \(descriptionFontSize)px; } </style>".data(using: .utf8)!)
-
-        do {
-            let string = try NSAttributedString(
-                data: data,
-                options: [
-                    .documentType: NSAttributedString.DocumentType.html,
-                    .characterEncoding: String.Encoding.utf8.rawValue,
-                    .sourceTextScaling: NSTextScalingType.iOS,
-                ],
-                documentAttributes: nil
-            )
-            return try AttributedString(string, including: \.uiKit)
-        } catch {
-            DDLogError("Failed to parse HTML: \(error)")
-            return nil
         }
     }
 

--- a/WordPress/Classes/Plugins/Views/PluginListItemView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginListItemView.swift
@@ -134,21 +134,21 @@ struct PluginListItemView: View {
 
     private enum Strings {
         static func author(_ author: String) -> String {
-            let format = NSLocalizedString("site.plugins.list.item.author", value: "By %@", comment: "The plugin author displayed in the plugins list. The first argument is plugin author name")
+            let format = NSLocalizedString("sitePluginsList.item.author", value: "By %@", comment: "The plugin author displayed in the plugins list. The first argument is plugin author name")
             return String(format: format, author)
         }
 
         static func version(_ version: String) -> String {
-            let format = NSLocalizedString("site.plugins.list.item.author", value: "Version: %@", comment: "The plugin version displayed in the plugins list. The first argument is plugin version")
+            let format = NSLocalizedString("sitePluginsList.item.author", value: "Version: %@", comment: "The plugin version displayed in the plugins list. The first argument is plugin version")
             return String(format: format, version)
         }
 
-        static let noDescriptionAvailable: String = NSLocalizedString("site.plugins.list.item.noDescriptionAvailable", value: "The plugin author did not provide a description for this plugin.", comment: "The message displayed when a plugin has no description")
+        static let noDescriptionAvailable: String = NSLocalizedString("sitePluginsList.item.noDescriptionAvailable", value: "The plugin author did not provide a description for this plugin.", comment: "The message displayed when a plugin has no description")
 
-        static let activate: String = NSLocalizedString("site.plugins.list.item.action.activate", value: "Activate", comment: "Button to activate a plugin")
-        static let deactivate: String = NSLocalizedString("site.plugins.list.item.action.deactivate", value: "Deactivate", comment: "Button to deactivate a plugin")
-        static let delete: String = NSLocalizedString("site.plugins.list.item.action.delete", value: "Delete", comment: "Button to delete a plugin")
-        static let viewOnWordPressOrg: String = NSLocalizedString("site.plugins.list.item.action.viewOnWordPressOrg", value: "View on WordPress.org", comment: "Button to view the plugin on WordPress.org website")
+        static let activate: String = NSLocalizedString("sitePluginsList.itemAction.activate", value: "Activate", comment: "Button to activate a plugin")
+        static let deactivate: String = NSLocalizedString("sitePluginsList.itemAction.deactivate", value: "Deactivate", comment: "Button to deactivate a plugin")
+        static let delete: String = NSLocalizedString("sitePluginsList.itemAction.delete", value: "Delete", comment: "Button to delete a plugin")
+        static let viewOnWordPressOrg: String = NSLocalizedString("sitePluginsList.itemAction.viewOnWordPressOrg", value: "View on WordPress.org", comment: "Button to view the plugin on WordPress.org website")
     }
 }
 

--- a/WordPress/Classes/Plugins/Views/PluginListItemView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginListItemView.swift
@@ -40,39 +40,12 @@ struct PluginListItemView: View {
 
             Spacer()
         }
+        .contextMenu(menuItems: {
+            menuItems
+        })
         .overlay(alignment: .bottomTrailing) {
             Menu {
-                Section {
-                    if plugin.isActive {
-                        Button(Strings.deactivate, systemImage: "bolt.slash") {
-                            Task {
-                                await viewModel.toggle(slug: plugin.slug)
-                            }
-                        }
-                    } else {
-                        Button(Strings.activate, systemImage: "bolt") {
-                            Task {
-                                await viewModel.toggle(slug: plugin.slug)
-                            }
-                        }
-                        Button(Strings.delete, systemImage: "trash") {
-                            Task {
-                                await viewModel.uninstall(slug: plugin.slug)
-                            }
-                        }
-                    }
-                }
-                .disabled(isUpdating)
-
-                if wpOrgURL != nil {
-                    Section {
-                        Button {
-                            showingSafariView = true
-                        } label: {
-                            Label(Strings.viewOnWordPressOrg, systemImage: "safari")
-                        }
-                    }
-                }
+                menuItems
             } label: {
                 Image(systemName: "ellipsis")
                     .padding(4)
@@ -84,6 +57,41 @@ struct PluginListItemView: View {
         .sheet(isPresented: $showingSafariView) {
             if let url = wpOrgURL {
                 SafariView(url: url)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var menuItems: some View {
+        Section {
+            if plugin.isActive {
+                Button(Strings.deactivate, systemImage: "bolt.slash") {
+                    Task {
+                        await viewModel.toggle(slug: plugin.slug)
+                    }
+                }
+            } else {
+                Button(Strings.activate, systemImage: "bolt") {
+                    Task {
+                        await viewModel.toggle(slug: plugin.slug)
+                    }
+                }
+                Button(Strings.delete, systemImage: "trash") {
+                    Task {
+                        await viewModel.uninstall(slug: plugin.slug)
+                    }
+                }
+            }
+        }
+        .disabled(isUpdating)
+
+        if wpOrgURL != nil {
+            Section {
+                Button {
+                    showingSafariView = true
+                } label: {
+                    Label(Strings.viewOnWordPressOrg, systemImage: "safari")
+                }
             }
         }
     }

--- a/WordPress/Classes/Plugins/Views/PluginListItemView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginListItemView.swift
@@ -39,6 +39,30 @@ struct PluginListItemView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+
+            Spacer()
+        }
+        .overlay(alignment: .bottomTrailing) {
+            Menu {
+                Section {
+                    if plugin.isActive {
+                        Button("Deactivate", systemImage: "bolt.slash") {}
+                    } else {
+                        Button("Activate", systemImage: "bolt") {}
+                    }
+
+                    Button("Delete", systemImage: "trash") {}
+                }
+                Section {
+                    Button("View on WordPress.org", systemImage: "safari") {}
+                }
+            } label: {
+                Image(systemName: "ellipsis")
+                    .padding(4)
+                    .frame(width: 44, height: 44, alignment: .bottomTrailing)
+                    .contentShape(Rectangle())
+            }
+            .foregroundStyle(.secondary)
         }
     }
 

--- a/WordPress/Classes/Plugins/Views/PluginListItemView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginListItemView.swift
@@ -8,12 +8,17 @@ struct PluginListItemView: View {
 
     @ScaledMetric(relativeTo: .body) var descriptionFontSize: CGFloat = 14
 
-    var plugin: InstalledPlugin
-    var service: PluginServiceProtocol
+    let plugin: InstalledPlugin
+    let viewModel: InstalledPluginsListViewModel
+
+    // Add this computed property to avoid direct state access in the view body
+    private var isUpdating: Bool {
+        viewModel.updating.contains(plugin.slug)
+    }
 
     var body: some View {
         HStack(alignment: .top) {
-            PluginIconView(slug: plugin.possibleWpOrgDirectorySlug, service: service)
+            PluginIconView(slug: plugin.possibleWpOrgDirectorySlug, service: viewModel.service)
 
             VStack(alignment: .leading, spacing: 0) {
                 Text(plugin.name)
@@ -46,13 +51,26 @@ struct PluginListItemView: View {
             Menu {
                 Section {
                     if plugin.isActive {
-                        Button("Deactivate", systemImage: "bolt.slash") {}
+                        Button("Deactivate", systemImage: "bolt.slash") {
+                            Task {
+                                await viewModel.toggle(slug: plugin.slug)
+                            }
+                        }
                     } else {
-                        Button("Activate", systemImage: "bolt") {}
+                        Button("Activate", systemImage: "bolt") {
+                            Task {
+                                await viewModel.toggle(slug: plugin.slug)
+                            }
+                        }
+                        Button("Delete", systemImage: "trash") {
+                            Task {
+                                await viewModel.uninstall(slug: plugin.slug)
+                            }
+                        }
                     }
-
-                    Button("Delete", systemImage: "trash") {}
                 }
+                .disabled(isUpdating)
+
                 Section {
                     Button("View on WordPress.org", systemImage: "safari") {}
                 }

--- a/WordPress/Classes/Plugins/Views/PluginListItemView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginListItemView.swift
@@ -76,7 +76,7 @@ struct PluginListItemView: View {
                         await viewModel.toggle(slug: plugin.slug)
                     }
                 }
-                Button(Strings.delete, systemImage: "trash") {
+                Button(Strings.delete, systemImage: "trash", role: .destructive) {
                     Task {
                         await viewModel.uninstall(slug: plugin.slug)
                     }

--- a/WordPress/Classes/Plugins/Views/PluginListItemView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginListItemView.swift
@@ -21,13 +21,6 @@ struct PluginListItemView: View {
                     .font(.headline)
                     .foregroundStyle(.primary)
 
-                if !plugin.author.isEmpty {
-                    Text(Strings.author(plugin.author))
-                        .lineLimit(1)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-
                 Group {
                     if plugin.shortDescription.isEmpty {
                         Text(Strings.noDescriptionAvailable)


### PR DESCRIPTION
Updates:
- Removed author info.
- The plugin description is now displayed in up to two lines. They are still rendered as HTML, though.
- Add a more menu button to navigation bar to filter by plugin state.
- Add a more menu button to each plugin row, to activate/deactivate/delete the plugin.
<img width="559" alt="Screenshot 2025-02-03 at 11 20 15 PM" src="https://github.com/user-attachments/assets/dbb73514-5aba-4e9d-ae34-22a564b359be" />


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
