### PR TITLE
Fix crash in toolbarSafeAreaView

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -82,9 +82,6 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     /// Likes summary view
     private let likesSummary: ReaderDetailLikesView = .loadFromNib()
 
-    /// A view that fills the bottom portion outside of the safe area
-    @IBOutlet weak var toolbarSafeAreaView: UIView!
-
     /// View used to show errors
     private let noResultsViewController = NoResultsViewController.controller()
 
@@ -444,7 +441,6 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
             // Toolbar
             toolbar.displaySetting = displaySetting
-            toolbarSafeAreaView.backgroundColor = toolbar.backgroundColor
         }
 
         // Featured image view


### PR DESCRIPTION
This view was removed in `trunk`, but evidently I forgot a reference.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
