### PR TITLE
Add ReaderCommentsTableViewController

### DIFF
--- a/Modules/Sources/WordPressUI/Extensions/UITableView+Helpers.swift
+++ b/Modules/Sources/WordPressUI/Extensions/UITableView+Helpers.swift
@@ -87,4 +87,29 @@ extension UITableView {
         }
         return true
     }
+
+    /// Updates the layout of the given state view inside the table view to
+    /// achieve a nice parallax effect and ensure the state view covers the
+    /// visible scroll view area.
+    public func layoutEmptyStateView(_ stateView: UIView, in viewController: UIViewController) {
+        let view: UIView = viewController.view
+
+        // Calculate visible part of the table view in `self.view` coordinates
+        let y: CGFloat = {
+            if let headerView = self.tableHeaderView {
+                return self.convert(headerView.frame, to: view).maxY
+            } else {
+                return view.safeAreaInsets.top
+            }
+        }()
+
+        // And convert it to the `tableView` coordinate space since that's where
+        // `emptyStateView` belongs.
+        stateView.frame = self.convert(CGRect(
+            x: 0,
+            y: y,
+            width: view.bounds.width,
+            height: view.bounds.height - y - view.safeAreaInsets.bottom
+        ), from: view)
+    }
 }

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
@@ -1002,7 +1002,9 @@ private extension CommentDetailViewController {
 
         button.placeholder = String(format: .replyPlaceholderFormat, comment.authorForDisplay())
         button.accessibilityHint = NSLocalizedString("Reply Text", comment: "Notifications Reply Accessibility Identifier")
-        button.addTarget(self, action: #selector(buttonAddCommentTapped), for: .primaryActionTriggered)
+        button.onTap = { [weak self] in
+            self?.buttonAddCommentTapped()
+        }
         button.isHidden = true
         containerStackView.addArrangedSubview(button)
         addCommentButton = button

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -402,10 +402,10 @@ extension NotificationDetailsViewController {
         replyTextView.placeholder = NSLocalizedString("Write a reply", comment: "Placeholder text for inline compose view")
         replyTextView.accessibilityLabel = NSLocalizedString("Reply Text", comment: "Notifications Reply Accessibility Identifier")
 
-        replyTextView.addAction(UIAction { _ in
+        replyTextView.onTap = {
             // TODO: (kean) remove the remaining .comment-related code
             wpAssertionFailure("Notifications have been using NotificationCommentDetailViewController since 2023")
-        }, for: .primaryActionTriggered)
+        }
 
         replyTextView.setContentCompressionResistancePriority(.required, for: .vertical)
 

--- a/WordPress/Classes/ViewRelated/Notifications/Views/CommentLargeButton.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/CommentLargeButton.swift
@@ -33,6 +33,8 @@ final class CommentLargeButton: UIButton {
         accessibilityIdentifier = "button_add_comment_large"
         accessibilityLabel = NSLocalizedString("addCommentButton.accessibilityIdentifity", value: "Add Comment", comment: "Accessibility identifier for an 'Add Comment' button")
 
+        backgroundColor = .systemBackground
+
         placeholderLabel.textColor = .tertiaryLabel
 
         placeholderLabel.text = CommentComposerViewModel.leaveCommentLocalizedPlaceholder
@@ -43,7 +45,7 @@ final class CommentLargeButton: UIButton {
 
         let stackView = UIStackView(alignment: .center, spacing: 8, [iconView, containerView])
         addSubview(stackView)
-        stackView.pinEdges(insets: UIEdgeInsets.init(top: 14, left: 20, bottom: 8, right: 20))
+        stackView.pinEdges(to: safeAreaLayoutGuide, insets: UIEdgeInsets.init(top: 14, left: 20, bottom: 8, right: 20))
 
         let divider = SeparatorView.horizontal()
         addSubview(divider)

--- a/WordPress/Classes/ViewRelated/Notifications/Views/CommentLargeButton.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/CommentLargeButton.swift
@@ -2,10 +2,13 @@ import UIKit
 import WordPressUI
 import WordPressShared
 
-final class CommentLargeButton: UIButton {
+final class CommentLargeButton: UIView {
     private let iconView = MyProfileIconView(hidesWhenEmpty: true)
-    private var containerView = CommentFieldContainerView()
+    private var containerView = UIView()
     private let placeholderLabel = UILabel()
+    private let button = UIButton()
+
+    var onTap: (() -> Void)?
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -15,6 +18,13 @@ final class CommentLargeButton: UIButton {
     required init(coder: NSCoder) {
         super.init(coder: coder)!
         setupView()
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        containerView.layer.cornerRadius = containerView.bounds.height / 2
+        containerView.layer.masksToBounds = true
     }
 
     var placeholder: String? {
@@ -43,15 +53,12 @@ final class CommentLargeButton: UIButton {
         let divider = SeparatorView.horizontal()
         addSubview(divider)
         divider.pinEdges([.top, .horizontal])
-    }
-}
 
-private final class CommentFieldContainerView: UIView {
-    // LayoutSubviews in UIButton subclasses seems to get called too early
-    override func layoutSubviews() {
-        super.layoutSubviews()
-
-        layer.cornerRadius = bounds.height / 2
-        layer.masksToBounds = true
+        addSubview(button)
+        button.pinEdges() // Make sure it covers everything
     }
-}
+
+    @objc private func buttonTapped() {
+        onTap?()
+    }
+ }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/CommentLargeButton.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/CommentLargeButton.swift
@@ -4,7 +4,7 @@ import WordPressShared
 
 final class CommentLargeButton: UIButton {
     private let iconView = MyProfileIconView(hidesWhenEmpty: true)
-    private var containerView = UIView()
+    private var containerView = CommentFieldContainerView()
     private let placeholderLabel = UILabel()
 
     override init(frame: CGRect) {
@@ -15,13 +15,6 @@ final class CommentLargeButton: UIButton {
     required init(coder: NSCoder) {
         super.init(coder: coder)!
         setupView()
-    }
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-
-        containerView.layer.cornerRadius = containerView.bounds.height / 2
-        containerView.layer.masksToBounds = true
     }
 
     var placeholder: String? {
@@ -50,5 +43,15 @@ final class CommentLargeButton: UIButton {
         let divider = SeparatorView.horizontal()
         addSubview(divider)
         divider.pinEdges([.top, .horizontal])
+    }
+}
+
+private final class CommentFieldContainerView: UIView {
+    // LayoutSubviews in UIButton subclasses seems to get called too early
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        layer.cornerRadius = bounds.height / 2
+        layer.masksToBounds = true
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/CommentLargeButton.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/CommentLargeButton.swift
@@ -4,7 +4,7 @@ import WordPressShared
 
 final class CommentLargeButton: UIView {
     private let iconView = MyProfileIconView(hidesWhenEmpty: true)
-    private var containerView = UIView()
+    private var containerView = CommentLargeButtonContainerView()
     private let placeholderLabel = UILabel()
     private let button = UIButton()
 
@@ -18,13 +18,6 @@ final class CommentLargeButton: UIView {
     required init(coder: NSCoder) {
         super.init(coder: coder)!
         setupView()
-    }
-
-    override func layoutSubviews() {
-        super.layoutSubviews()
-
-        containerView.layer.cornerRadius = containerView.bounds.height / 2
-        containerView.layer.masksToBounds = true
     }
 
     var placeholder: String? {
@@ -55,10 +48,20 @@ final class CommentLargeButton: UIView {
         divider.pinEdges([.top, .horizontal])
 
         addSubview(button)
+        button.addTarget(self, action: #selector(buttonTapped), for: .primaryActionTriggered)
         button.pinEdges() // Make sure it covers everything
     }
 
     @objc private func buttonTapped() {
         onTap?()
     }
- }
+}
+
+private final class CommentLargeButtonContainerView: UIView {
+    override func layoutSubviews() {
+        super.layoutSubviews()
+
+        layer.cornerRadius = bounds.height / 2
+        layer.masksToBounds = true
+    }
+}

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
@@ -4,7 +4,6 @@ import WordPressUI
 
 final class ReaderCommentsTableViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, NSFetchedResultsControllerDelegate {
     @objc let tableView = UITableView(frame: .zero, style: .plain)
-    private var emptyStateView: UIView?
     private let padingFooterView = PagingFooterView(state: .loading)
     private lazy var fetchResultsController = makeFetchResultsController()
 
@@ -14,6 +13,8 @@ final class ReaderCommentsTableViewController: UIViewController, UITableViewData
 
     /// - note: Temporary code.
     @objc weak var containerViewController: ReaderCommentsViewController?
+
+    @objc var isEmpty: Bool { fetchResultsController.isEmpty() }
 
     @objc init(post: ReaderPost) {
         self.post = post
@@ -115,24 +116,6 @@ final class ReaderCommentsTableViewController: UIViewController, UITableViewData
         }
     }
 
-    @objc func showEmptyStateView(title: String) {
-        emptyStateView?.removeFromSuperview()
-        let stateView = UIHostingView(view: EmptyStateView(tilte, systemImage: "message"))
-        tableView.addSubview(stateView)
-        emptyStateView = stateView
-        layoutEmptyStateView()
-    }
-
-    @objc func hideEmptyStateView() {
-        emptyStateView?.removeFromSuperview()
-        emptyStateView = nil
-    }
-
-    private func layoutEmptyStateView() {
-        guard let emptyStateView else { return }
-        tableView.layoutEmptyStateView(emptyStateView, in: self)
-    }
-
     // MARK: - NSFetchedResultsController
 
     private func makeFetchResultsController() -> NSFetchedResultsController<Comment> {
@@ -197,8 +180,6 @@ final class ReaderCommentsTableViewController: UIViewController, UITableViewData
     // MARK: - UIScrollViewDelegate
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
-        layoutEmptyStateView()
-
         if scrollView.contentOffset.y + scrollView.frame.size.height > scrollView.contentSize.height - 500 {
             containerViewController?.loadMore()
         }

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
@@ -4,6 +4,7 @@ import WordPressUI
 
 final class ReaderCommentsTableViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, NSFetchedResultsControllerDelegate {
     @objc let tableView = UITableView(frame: .zero, style: .plain)
+    private var emptyStateView: UIView?
     private let padingFooterView = PagingFooterView(state: .loading)
     private lazy var fetchResultsController = makeFetchResultsController()
 
@@ -114,6 +115,24 @@ final class ReaderCommentsTableViewController: UIViewController, UITableViewData
         }
     }
 
+    @objc func showEmptyStateView(title: String) {
+        emptyStateView?.removeFromSuperview()
+        let stateView = UIHostingView(view: EmptyStateView(tilte, systemImage: "message"))
+        tableView.addSubview(stateView)
+        emptyStateView = stateView
+        layoutEmptyStateView()
+    }
+
+    @objc func hideEmptyStateView() {
+        emptyStateView?.removeFromSuperview()
+        emptyStateView = nil
+    }
+
+    private func layoutEmptyStateView() {
+        guard let emptyStateView else { return }
+        tableView.layoutEmptyStateView(emptyStateView, in: self)
+    }
+
     // MARK: - NSFetchedResultsController
 
     private func makeFetchResultsController() -> NSFetchedResultsController<Comment> {
@@ -178,6 +197,8 @@ final class ReaderCommentsTableViewController: UIViewController, UITableViewData
     // MARK: - UIScrollViewDelegate
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        layoutEmptyStateView()
+
         if scrollView.contentOffset.y + scrollView.frame.size.height > scrollView.contentSize.height - 500 {
             containerViewController?.loadMore()
         }

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
@@ -1,33 +1,62 @@
 import UIKit
+import CoreData
 import WordPressUI
 
-final class ReaderCommentsTableViewController: UIViewController {
+final class ReaderCommentsTableViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, NSFetchedResultsControllerDelegate {
     private let tableView = UITableView(frame: .zero, style: .plain)
     private let padingFooterView = PagingFooterView(state: .loading)
+    private lazy var fetchResultsController = makeFetchResultsController()
 
+    private let post: ReaderPost
     private let commentCellReuseID = "commentCellReuseID"
+    private let moc = ContextManager.shared.mainContext
+
+    /// - note: Temporary code.
+    @objc weak var containerViewController: ReaderCommentsViewController?
+
+    @objc init(post: ReaderPost) {
+        self.post = post
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         view.backgroundColor = .systemBackground
 
+        // Setup view
         setupTableView()
+
+        // Setup fetch
+        do {
+            try fetchResultsController.performFetch()
+            tableView.reloadData()
+            fetchResultsController.delegate = self
+        } catch {
+            wpAssertionFailure("fetch failed", userInfo: ["error": "\(error)"])
+        }
     }
 
     private func setupTableView() {
         tableView.cellLayoutMarginsFollowReadableWidth = true
         tableView.preservesSuperviewLayoutMargins = true
 
-        if Feature.enabled(.readerCommentsWebKit) {
-            // We use this to mask the initial WebKit warmup that takes a bit of time
-            // the first time you initialize a web view. It renders asynchronously, and
-            // we don't want to show cells with empty messages.
-            tableView.alpha = 0.0
-        }
+        // TODO: re-implement
+//        if Feature.enabled(.readerCommentsWebKit) {
+//            // We use this to mask the initial WebKit warmup that takes a bit of time
+//            // the first time you initialize a web view. It renders asynchronously, and
+//            // we don't want to show cells with empty messages.
+//            tableView.alpha = 0.0
+//        }
 
         let nib = UINib(nibName: CommentContentTableViewCell.classNameWithoutNamespaces(), bundle: nil)
         tableView.register(nib, forCellReuseIdentifier: commentCellReuseID)
+        tableView.rowHeight = UITableView.automaticDimension
+        tableView.estimatedRowHeight = 200
 
         tableView.separatorStyle = .singleLine
         tableView.separatorInsetReference = .fromAutomaticInsets
@@ -39,6 +68,9 @@ final class ReaderCommentsTableViewController: UIViewController {
 
         view.addSubview(tableView)
         tableView.pinEdges()
+
+        tableView.dataSource = self
+        tableView.delegate = self
     }
 
     @objc func setBottomInset(_ inset: CGFloat) {
@@ -54,7 +86,63 @@ final class ReaderCommentsTableViewController: UIViewController {
             tableView.sizeToFitFooterView()
         }
     }
-}
 
-// TODO: (kean)
-// - Remove estimatedRowHeights
+    // MARK: - NSFetchedResultsController
+
+    private func makeFetchResultsController() -> NSFetchedResultsController<Comment> {
+        let request = NSFetchRequest<Comment>(entityName: Comment.entityName())
+        request.predicate = NSPredicate(format: "post = %@ AND status = %@ AND visibleOnReader = YES", post, CommentStatusType.approved.description)
+        request.sortDescriptors = [
+            NSSortDescriptor(keyPath: \Comment.hierarchy, ascending: true)
+        ]
+        request.fetchBatchSize = 40
+        return NSFetchedResultsController(fetchRequest: request, managedObjectContext: moc, sectionNameKeyPath: nil, cacheName: nil)
+    }
+
+    // MARK: - NSFetchedResultsControllerDelegate
+
+    func controllerWillChangeContent(_ controller: NSFetchedResultsController<any NSFetchRequestResult>) {
+        tableView.beginUpdates()
+    }
+
+    func controller(_ controller: NSFetchedResultsController<NSFetchRequestResult>, didChange anObject: Any, at indexPath: IndexPath?, for type: NSFetchedResultsChangeType, newIndexPath: IndexPath?) {
+        switch type {
+        case .insert:
+            guard let newIndexPath else { return }
+            tableView.insertRows(at: [newIndexPath], with: .automatic)
+        case .delete:
+            guard let indexPath else { return }
+            tableView.deleteRows(at: [indexPath], with: .automatic)
+        case .update:
+            // The cells are responsible for updating themselves
+            break
+        case .move:
+            guard let indexPath, let newIndexPath else { return }
+            tableView.moveRow(at: indexPath, to: newIndexPath)
+        @unknown default:
+            break
+        }
+    }
+
+    func controllerDidChangeContent(_ controller: NSFetchedResultsController<any NSFetchRequestResult>) {
+        tableView.endUpdates()
+    }
+
+    // MARK: - UITableViewDataSource
+
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        fetchResultsController.fetchedObjects?.count ?? 0
+    }
+
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = tableView.dequeueReusableCell(withIdentifier: commentCellReuseID, for: indexPath) as! CommentContentTableViewCell
+        // TODO: configure cell
+        let comment = fetchResultsController.object(at: indexPath)
+        containerViewController?.configureCell(cell, comment: comment, indexPath: indexPath)
+        return cell
+    }
+
+    // MARK: - UITableViewDataSource
+
+    // TODO: add delegate
+}

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
@@ -72,6 +72,31 @@ final class ReaderCommentsTableViewController: UIViewController, UITableViewData
         tableView.delegate = self
     }
 
+    // MARK: - Actions
+
+    @objc func scrollToComment(withID commentID: NSNumber) {
+        let comments = fetchResultsController.fetchedObjects ?? []
+        guard let comment = comments.first(where: { $0.commentID == commentID }) else {
+            return
+        }
+
+        // Force the table view to be laid out first before scrolling to indexPath.
+        // This avoids a case where a cell instance could be orphaned and displayed randomly on top of the other cells.
+        guard let indexPath = fetchResultsController.indexPath(forObject: comment) else {
+            return
+        }
+        tableView.layoutIfNeeded()
+
+        // Ensure that the indexPath exists before scrolling to it.
+        if indexPath.section >= 0,
+           indexPath.row >= 0,
+           indexPath.section < tableView.numberOfSections,
+           indexPath.row < tableView.numberOfRows(inSection: indexPath.section) {
+            tableView.scrollToRow(at: indexPath, at: .top, animated: true)
+            containerViewController?.highlightComment(at: indexPath)
+        }
+    }
+
     @objc func setBottomInset(_ inset: CGFloat) {
         tableView.contentInset.bottom = inset
     }

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
@@ -58,8 +58,7 @@ final class ReaderCommentsTableViewController: UIViewController, UITableViewData
         tableView.rowHeight = UITableView.automaticDimension
         tableView.estimatedRowHeight = 200
 
-        tableView.separatorStyle = .singleLine
-        tableView.separatorInsetReference = .fromAutomaticInsets
+        tableView.separatorStyle = .none
 
         // Hide cell separator for the last row
         tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: 0))

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
@@ -3,7 +3,7 @@ import CoreData
 import WordPressUI
 
 final class ReaderCommentsTableViewController: UIViewController, UITableViewDataSource, UITableViewDelegate, NSFetchedResultsControllerDelegate {
-    private let tableView = UITableView(frame: .zero, style: .plain)
+    @objc let tableView = UITableView(frame: .zero, style: .plain)
     private let padingFooterView = PagingFooterView(state: .loading)
     private lazy var fetchResultsController = makeFetchResultsController()
 

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
@@ -3,6 +3,7 @@ import WordPressUI
 
 final class ReaderCommentsTableViewController: UIViewController {
     let tableView = UITableView(frame: .zero, style: .plain)
+    let padingFooterView = PagingFooterView(state: .loading)
 
     private let commentCellReuseID = "commentCellReuseID"
 
@@ -15,7 +16,6 @@ final class ReaderCommentsTableViewController: UIViewController {
     }
 
     private func setupTableView() {
-        tableView = UITableView(frame: view.bounds, style: .plain)
         tableView.cellLayoutMarginsFollowReadableWidth = true
         tableView.preservesSuperviewLayoutMargins = true
 
@@ -41,7 +41,7 @@ final class ReaderCommentsTableViewController: UIViewController {
         tableView.pinEdges()
     }
 
-    func setTableLoadingFooterHidden(_ isHidden: Bool) {
+    @objc func setLoadingFooterHidden(_ isHidden: Bool) {
         if isHidden {
             // Hide cell separator for the last row
             tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: 0))
@@ -51,7 +51,6 @@ final class ReaderCommentsTableViewController: UIViewController {
         }
     }
 }
-
 
 // TODO: (kean)
 // - Remove estimatedRowHeights

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
@@ -1,0 +1,57 @@
+import UIKit
+import WordPressUI
+
+final class ReaderCommentsTableViewController: UIViewController {
+    let tableView = UITableView(frame: .zero, style: .plain)
+
+    private let commentCellReuseID = "commentCellReuseID"
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .systemBackground
+
+        setupTableView()
+    }
+
+    private func setupTableView() {
+        tableView = UITableView(frame: view.bounds, style: .plain)
+        tableView.cellLayoutMarginsFollowReadableWidth = true
+        tableView.preservesSuperviewLayoutMargins = true
+
+        if Feature.enabled(.readerCommentsWebKit) {
+            // We use this to mask the initial WebKit warmup that takes a bit of time
+            // the first time you initialize a web view. It renders asynchronously, and
+            // we don't want to show cells with empty messages.
+            tableView.alpha = 0.0
+        }
+
+        let nib = UINib(nibName: CommentContentTableViewCell.classNameWithoutNamespaces(), bundle: nil)
+        tableView.register(nib, forCellReuseIdentifier: commentCellReuseID)
+
+        tableView.separatorStyle = .singleLine
+        tableView.separatorInsetReference = .fromAutomaticInsets
+
+        // Hide cell separator for the last row
+        tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: 0))
+
+        setTableLoadingFooterHidden(true)
+
+        view.addSubview(tableView)
+        tableView.pinEdges()
+    }
+
+    func setTableLoadingFooterHidden(_ isHidden: Bool) {
+        if isHidden {
+            // Hide cell separator for the last row
+            tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: 0))
+        } else {
+            tableView.tableFooterView = PagingFooterView(state: .loading)
+            tableView.sizeToFitFooterView()
+        }
+    }
+}
+
+
+// TODO: (kean)
+// - Remove estimatedRowHeights

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
@@ -2,8 +2,8 @@ import UIKit
 import WordPressUI
 
 final class ReaderCommentsTableViewController: UIViewController {
-    let tableView = UITableView(frame: .zero, style: .plain)
-    let padingFooterView = PagingFooterView(state: .loading)
+    private let tableView = UITableView(frame: .zero, style: .plain)
+    private let padingFooterView = PagingFooterView(state: .loading)
 
     private let commentCellReuseID = "commentCellReuseID"
 
@@ -35,10 +35,14 @@ final class ReaderCommentsTableViewController: UIViewController {
         // Hide cell separator for the last row
         tableView.tableFooterView = UIView(frame: CGRect(x: 0, y: 0, width: view.bounds.width, height: 0))
 
-        setTableLoadingFooterHidden(true)
+        setLoadingFooterHidden(true)
 
         view.addSubview(tableView)
         tableView.pinEdges()
+    }
+
+    @objc func setBottomInset(_ inset: CGFloat) {
+        tableView.contentInset.bottom = inset
     }
 
     @objc func setLoadingFooterHidden(_ isHidden: Bool) {

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
@@ -115,6 +115,16 @@ final class ReaderCommentsTableViewController: UIViewController, UITableViewData
         }
     }
 
+    // MARK: - EmptyStateView
+
+    func showEmptyStateView(imageName: String, title: String) {
+
+    }
+
+    func hideEmptyStateView() {
+        
+    }
+
     // MARK: - NSFetchedResultsController
 
     private func makeFetchResultsController() -> NSFetchedResultsController<Comment> {

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
@@ -115,16 +115,6 @@ final class ReaderCommentsTableViewController: UIViewController, UITableViewData
         }
     }
 
-    // MARK: - EmptyStateView
-
-    func showEmptyStateView(imageName: String, title: String) {
-
-    }
-
-    func hideEmptyStateView() {
-        
-    }
-
     // MARK: - NSFetchedResultsController
 
     private func makeFetchResultsController() -> NSFetchedResultsController<Comment> {

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
@@ -74,9 +74,13 @@ final class ReaderCommentsTableViewController: UIViewController, UITableViewData
 
     // MARK: - Actions
 
+    @objc func comment(at indexPath: IndexPath) -> Comment? {
+        fetchResultsController.object(at: indexPath)
+    }
+
     @objc func scrollToComment(withID commentID: NSNumber) {
         let comments = fetchResultsController.fetchedObjects ?? []
-        guard let comment = comments.first(where: { $0.commentID == commentID }) else {
+        guard let comment = comments.first(where: { $0.commentID == commentID.int32Value }) else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
@@ -136,13 +136,23 @@ final class ReaderCommentsTableViewController: UIViewController, UITableViewData
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: commentCellReuseID, for: indexPath) as! CommentContentTableViewCell
-        // TODO: configure cell
+        cell.selectionStyle = .none
         let comment = fetchResultsController.object(at: indexPath)
         containerViewController?.configureCell(cell, comment: comment, indexPath: indexPath)
         return cell
     }
 
-    // MARK: - UITableViewDataSource
+    // MARK: - UITableViewDataDelegate
 
-    // TODO: add delegate
+    func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
+        containerViewController?.cachedHeaderView()
+    }
+
+    // MARK: - UIScrollViewDelegate
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        if scrollView.contentOffset.y + scrollView.frame.size.height > scrollView.contentSize.height - 500 {
+            containerViewController?.loadMore()
+        }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
@@ -45,13 +45,12 @@ final class ReaderCommentsTableViewController: UIViewController, UITableViewData
         tableView.cellLayoutMarginsFollowReadableWidth = true
         tableView.preservesSuperviewLayoutMargins = true
 
-        // TODO: re-implement
-//        if Feature.enabled(.readerCommentsWebKit) {
-//            // We use this to mask the initial WebKit warmup that takes a bit of time
-//            // the first time you initialize a web view. It renders asynchronously, and
-//            // we don't want to show cells with empty messages.
-//            tableView.alpha = 0.0
-//        }
+        if Feature.enabled(.readerCommentsWebKit) {
+            // We use this to mask the initial WebKit warmup that takes a bit of time
+            // the first time you initialize a web view. It renders asynchronously, and
+            // we don't want to show cells with empty messages.
+            tableView.alpha = 0.0
+        }
 
         let nib = UINib(nibName: CommentContentTableViewCell.classNameWithoutNamespaces(), bundle: nil)
         tableView.register(nib, forCellReuseIdentifier: commentCellReuseID)

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.h
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.h
@@ -14,6 +14,7 @@ typedef NS_ENUM(NSUInteger, ReaderCommentsSource) {
 };
 
 @class Comment;
+@class CommentContentTableViewCell;
 @class ReaderPost;
 @class ReaderCommentsHelper;
 
@@ -38,5 +39,6 @@ typedef NS_ENUM(NSUInteger, ReaderCommentsSource) {
 - (void)refreshAfterCommentModeration;
 - (NSAttributedString *)cacheContentForComment:(Comment *)comment;
 - (void)trackReplyTo:(BOOL)replyTarget;
+- (void)configureCell:(CommentContentTableViewCell *)cell comment:(Comment *)comment indexPath:(NSIndexPath *)indexPath;
 
 @end

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.h
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.h
@@ -40,5 +40,7 @@ typedef NS_ENUM(NSUInteger, ReaderCommentsSource) {
 - (NSAttributedString *)cacheContentForComment:(Comment *)comment;
 - (void)trackReplyTo:(BOOL)replyTarget;
 - (void)configureCell:(CommentContentTableViewCell *)cell comment:(Comment *)comment indexPath:(NSIndexPath *)indexPath;
+- (UIView *)cachedHeaderView;
+- (void)loadMore;
 
 @end

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.h
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.h
@@ -42,5 +42,6 @@ typedef NS_ENUM(NSUInteger, ReaderCommentsSource) {
 - (void)configureCell:(CommentContentTableViewCell *)cell comment:(Comment *)comment indexPath:(NSIndexPath *)indexPath;
 - (UIView *)cachedHeaderView;
 - (void)loadMore;
+- (void)highlightCommentAtIndexPath:(NSIndexPath *)indexPath;
 
 @end

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.h
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.h
@@ -24,6 +24,7 @@ typedef NS_ENUM(NSUInteger, ReaderCommentsSource) {
 @property (nonatomic, assign, readwrite) BOOL allowsPushingPostDetails;
 @property (nonatomic, assign, readwrite) ReaderCommentsSource source;
 @property (nonatomic, strong, readonly) ReaderCommentsHelper *helper;
+@property (nonatomic, strong, readonly) UIView *buttonAddComment;
 
 - (void)setupWithPostID:(NSNumber *)postID siteID:(NSNumber *)siteID;
 

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -498,35 +498,12 @@
     double delayInSeconds = 0.5;
     dispatch_time_t popTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delayInSeconds * NSEC_PER_SEC));
     dispatch_after(popTime, dispatch_get_main_queue(), ^(void){
-        [self scrollToCommentID];
+        [self.tableViewController scrollToCommentWithID:self.navigateToCommentID];
     });
 }
 
-- (void)scrollToCommentID
-{
-    // Find the comment if it exists
-    NSArray<Comment *> *comments = [self.tableViewHandler.resultsController fetchedObjects];
-    NSArray<Comment *> *filteredComments = [comments filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"commentID == %@", self.navigateToCommentID]];
-    Comment *comment = [filteredComments firstObject];
-
-    if (!comment) {
-        return;
-    }
-
-    // Force the table view to be laid out first before scrolling to indexPath.
-    // This avoids a case where a cell instance could be orphaned and displayed randomly on top of the other cells.
-    NSIndexPath *indexPath = [self.tableViewHandler.resultsController indexPathForObject:comment];
-    [self.tableView layoutIfNeeded];
-
-    // Ensure that the indexPath exists before scrolling to it.
-    if (indexPath.section >=0
-        && indexPath.row >=0
-        && indexPath.section < self.tableView.numberOfSections
-        && indexPath.row < [self.tableView numberOfRowsInSection:indexPath.section])
-    {
-        [self.tableView scrollToRowAtIndexPath:indexPath atScrollPosition:UITableViewScrollPositionTop animated:YES];
-        self.highlightedIndexPath = indexPath;
-    }
+- (void)highlightCommentAtIndexPath:(NSIndexPath *)indexPath {
+    self.highlightedIndexPath = indexPath;
 }
 
 #pragma mark - Actions

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -15,8 +15,6 @@
 // crash in certain circumstances when the tableView lays out its visible cells,
 // and those cells contain WPRichTextEmbeds. -- Aerych, 2016.11.30
 static CGFloat const EstimatedCommentRowHeight = 300.0;
-static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
-
 
 @interface ReaderCommentsViewController () <NSFetchedResultsControllerDelegate,
                                             WPRichContentViewDelegate, // TODO: Remove once we switch to the `.web` rendering method.
@@ -86,7 +84,8 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     self.estimatedRowHeights = [[NSCache alloc] init];
     self.cachedAttributedStrings = [[NSCache alloc] init];
 
-    self.tableViewController = [ReaderCommentsTableViewController new];
+    self.tableViewController = [[ReaderCommentsTableViewController alloc] initWithPost:self.post];
+    self.tableViewController.containerViewController = self;
     [self configureTableViewController:self.tableViewController];
 
     self.view.backgroundColor = [UIColor systemBackgroundColor];
@@ -483,6 +482,9 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
         return;
     }
 
+    // TODO: (kean) reimplement
+    return ;
+
     NSString *image = nil;
     NSString *subtitle = nil;
     if (self.fetchCommentsError != nil) {
@@ -690,7 +692,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 
 - (void)setupWithPostID:(NSNumber *)postID siteID:(NSNumber *)siteID
 {
-    ReaderPostService *service      = [[ReaderPostService alloc] initWithCoreDataStack:[ContextManager sharedInstance]];
+    ReaderPostService *service = [[ReaderPostService alloc] initWithCoreDataStack:[ContextManager sharedInstance]];
     __weak __typeof(self) weakSelf  = self;
     
     self.postSiteID = siteID;
@@ -715,24 +717,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     return [[ContextManager sharedInstance] mainContext];
 }
 
-- (NSFetchRequest *)fetchRequest
-{
-    if (!self.post) {
-        return nil;
-    }
-
-    // Moderated comments could still be cached, so filter out non-approved comments.
-    NSString *approvedStatus = [Comment descriptionFor:CommentStatusTypeApproved];
-
-    NSFetchRequest *fetchRequest = [[NSFetchRequest alloc] initWithEntityName:NSStringFromClass([Comment class])];
-    fetchRequest.predicate = [NSPredicate predicateWithFormat:@"post = %@ AND status = %@ AND visibleOnReader = %@", self.post, approvedStatus, @YES];
-    NSSortDescriptor *sortDescriptor = [[NSSortDescriptor alloc] initWithKey:@"hierarchy" ascending:YES];
-    [fetchRequest setSortDescriptors:@[sortDescriptor]];
-
-    return fetchRequest;
-}
-
-- (void)configureCell:(UITableViewCell *)aCell atIndexPath:(NSIndexPath *)indexPath
+- (void)configureCell:(CommentContentTableViewCell *)cell comment:(Comment *)comment indexPath:(NSIndexPath *)indexPath
 {
     // When backgrounding, the app takes a snapshot, which triggers a layout pass,
     // which refreshes the cells, and for some reason triggers an assertion failure
@@ -748,8 +733,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
         return;
     }
 
-    Comment *comment = [self.tableViewHandler.resultsController objectAtIndexPath:indexPath];
-    CommentContentTableViewCell *cell = (CommentContentTableViewCell *)aCell;
     [self configureContentCell:cell comment:comment indexPath:indexPath handler:self.tableViewHandler];
 
     if (self.highlightedIndexPath) {
@@ -804,14 +787,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 - (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
 {
     return self.cachedHeaderView;
-}
-
-- (UITableViewCell *)tableView:(UITableView *)tableView cellForRowAtIndexPath:(NSIndexPath *)indexPath
-{
-    NSString *cellIdentifier = CommentContentCellIdentifier;
-    UITableViewCell *cell = [self.tableView dequeueReusableCellWithIdentifier:cellIdentifier forIndexPath:indexPath];
-    [self configureCell:cell atIndexPath:indexPath];
-    return cell;
 }
 
 - (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -20,7 +20,7 @@
 @property (nonatomic, strong) WPContentSyncHelper *syncHelper;
 @property (nonatomic, strong) UITableView *tableView;
 @property (nonatomic, strong) NoResultsViewController *noResultsViewController;
-@property (nonatomic, strong) UIView *buttonComment;
+@property (nonatomic, strong) UIView *buttonAddComment;
 @property (nonatomic, strong) NSLayoutConstraint *replyTextViewHeightConstraint;
 @property (nonatomic) BOOL isLoggedIn;
 @property (nonatomic) BOOL needsUpdateAttachmentsAfterScrolling;
@@ -116,7 +116,7 @@
 {
     [super viewDidLayoutSubviews];
 
-    [self.tableViewController setBottomInset:self.buttonComment.frame.size.height];
+    [self.tableViewController setBottomInset:self.buttonAddComment.frame.size.height];
 }
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
@@ -196,19 +196,19 @@
 
 - (void)configureCommentButton
 {
-    self.buttonComment = [self makeCommentButton];
+    self.buttonAddComment = [self makeCommentButton];
 }
 
 #pragma mark - Autolayout Helpers
 
 - (void)configureViewConstraints
 {
-    self.buttonComment.translatesAutoresizingMaskIntoConstraints = false;
+    self.buttonAddComment.translatesAutoresizingMaskIntoConstraints = false;
 
     // TODO:
     // This LayoutConstraint is just a helper, meant to hide / display the ReplyTextView, as needed.
     // Whenever iOS 8 is set as the deployment target, let's always attach this one, and enable / disable it as needed!
-    self.replyTextViewHeightConstraint = [NSLayoutConstraint constraintWithItem:self.buttonComment attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:0 multiplier:1 constant:0];
+    self.replyTextViewHeightConstraint = [NSLayoutConstraint constraintWithItem:self.buttonAddComment attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:0 multiplier:1 constant:0];
 }
 
 #pragma mark - Helpers
@@ -388,7 +388,7 @@
 - (void)refreshReplyTextView
 {
     BOOL showsReplyTextView = self.shouldDisplayReplyTextView;
-    self.buttonComment.hidden = !showsReplyTextView;
+    self.buttonAddComment.hidden = !showsReplyTextView;
     
     if (showsReplyTextView) {
         [self.view removeConstraint:self.replyTextViewHeightConstraint];
@@ -447,7 +447,7 @@
         self.noResultsViewController.view.frame = self.tableView.frame;
     }
 
-    [self.view insertSubview:self.noResultsViewController.view belowSubview:self.buttonComment];
+    [self.view insertSubview:self.noResultsViewController.view belowSubview:self.buttonAddComment];
     [self.noResultsViewController didMoveToParentViewController:self];
 }
 
@@ -511,7 +511,7 @@
     if (!indexPath || !self.canComment) {
         return;
     }
-    Comment *comment = [self.tableViewController commentAtIndexPath:indexPath];
+    Comment *comment = [self.tableViewController commentAt:indexPath];
     if (comment) {
         [self didTapReplyWithComment:comment];
     }

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -11,11 +11,6 @@
 
 @class Comment;
 
-// NOTE: We want the cells to have a rather large estimated height.  This avoids a peculiar
-// crash in certain circumstances when the tableView lays out its visible cells,
-// and those cells contain WPRichTextEmbeds. -- Aerych, 2016.11.30
-static CGFloat const EstimatedCommentRowHeight = 300.0;
-
 @interface ReaderCommentsViewController () <NSFetchedResultsControllerDelegate,
                                             WPRichContentViewDelegate, // TODO: Remove once we switch to the `.web` rendering method.
                                             WPContentSyncHelperDelegate,
@@ -29,7 +24,6 @@ static CGFloat const EstimatedCommentRowHeight = 300.0;
 @property (nonatomic, strong) NoResultsViewController *noResultsViewController;
 @property (nonatomic, strong) UIView *buttonComment;
 @property (nonatomic, strong) NSLayoutConstraint *replyTextViewHeightConstraint;
-@property (nonatomic, strong) NSCache *estimatedRowHeights;
 @property (nonatomic) BOOL isLoggedIn;
 @property (nonatomic) BOOL needsUpdateAttachmentsAfterScrolling;
 @property (nonatomic) BOOL needsRefreshTableViewAfterScrolling;
@@ -81,7 +75,6 @@ static CGFloat const EstimatedCommentRowHeight = 300.0;
 {
     [super viewDidLoad];
 
-    self.estimatedRowHeights = [[NSCache alloc] init];
     self.cachedAttributedStrings = [[NSCache alloc] init];
 
     self.tableViewController = [[ReaderCommentsTableViewController alloc] initWithPost:self.post];
@@ -765,18 +758,6 @@ static CGFloat const EstimatedCommentRowHeight = 300.0;
     cell.contentLinkTapAction = ^(NSURL * _Nonnull url) {
         [weakSelf interactWithURL:url];
     };
-}
-
-- (CGFloat)tableView:(UITableView *)tableView estimatedHeightForRowAtIndexPath:(NSIndexPath *)indexPath
-{
-    // NOTE: When using a `CommentContentTableViewCell` with `.web` rendering method, this method needs to return `UITableViewAutomaticDimension`.
-    // Using cached estimated heights could get some cells to keep reloading their HTMLs indefinitely, causing the app to hang!
-
-    NSNumber *cachedHeight = [self.estimatedRowHeights objectForKey:indexPath];
-    if (cachedHeight.doubleValue) {
-        return cachedHeight.doubleValue;
-    }
-    return EstimatedCommentRowHeight;
 }
 
 - (void)loadMore

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -726,7 +726,7 @@
         return;
     }
 
-    [self configureContentCell:cell comment:comment indexPath:indexPath handler:self.tableViewHandler];
+    [self configureContentCell:cell comment:comment indexPath:indexPath tableView:self.tableViewController.tableView];
 
     if (self.highlightedIndexPath) {
         cell.isEmphasized = (indexPath == self.highlightedIndexPath);

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -128,6 +128,10 @@
     [self refreshTableViewAndNoResultsView];
 }
 
+- (UITableView *)tableView {
+    self.tableViewController.tableView;
+}
+
 #pragma mark - Split View Support
 
 /**

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -72,10 +72,6 @@
 
     self.cachedAttributedStrings = [[NSCache alloc] init];
 
-    self.tableViewController = [[ReaderCommentsTableViewController alloc] initWithPost:self.post];
-    self.tableViewController.containerViewController = self;
-    [self configureTableViewController:self.tableViewController];
-
     self.view.backgroundColor = [UIColor systemBackgroundColor];
     self.commentModified = NO;
     self.helper = [ReaderCommentsHelper new];
@@ -128,8 +124,9 @@
     [self refreshTableViewAndNoResultsView];
 }
 
-- (UITableView *)tableView {
-    self.tableViewController.tableView;
+- (UITableView *)tableView
+{
+    return self.tableViewController.tableView;
 }
 
 #pragma mark - Split View Support
@@ -321,6 +318,10 @@
     _post = post;
 
     if (_post.isWPCom || _post.isJetpack) {
+        self.tableViewController = [[ReaderCommentsTableViewController alloc] initWithPost:self.post];
+        self.tableViewController.containerViewController = self;
+        [self configureTableViewController:self.tableViewController];
+
         self.syncHelper = [[WPContentSyncHelper alloc] init];
         self.syncHelper.delegate = self;
     }
@@ -410,13 +411,10 @@
 {
     [self.noResultsViewController removeFromView];
 
-    // TODO: (kean) reimplement empty state view
-//    BOOL isTableViewEmpty = (self.tableViewHandler.resultsController.fetchedObjects.count == 0);
-//    if (!isTableViewEmpty) {
-//        return;
-//    }
-
-    return ;
+    BOOL isTableViewEmpty = self.tableViewController.isEmpty;
+    if (!isTableViewEmpty) {
+        return;
+    }
 
     NSString *image = nil;
     NSString *subtitle = nil;

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -39,9 +39,6 @@
 /// A cached instance for the new comment header view.
 @property (nonatomic, strong) UIView *cachedHeaderView;
 
-/// Convenience computed variable that returns a separator inset that "hides" the separator by pushing it off the screen.
-@property (nonatomic, assign) UIEdgeInsets hiddenSeparatorInsets;
-
 @property (nonatomic, strong) NSIndexPath *highlightedIndexPath;
 
 @property (nonatomic, strong) ReaderCommentsTableViewController *tableViewController;
@@ -306,53 +303,6 @@
     }
 
     return _subscriptionSettingsBarButtonItem;
-}
-
-/// NOTE: In order for the inset to work across orientations, the tableView should use `UITableViewSeparatorInsetFromAutomaticInsets` to
-/// base the separator insets on the cell layout margins instead of the edges.
-///
-/// With the default inset reference (i.e. `UITableViewSeparatorInsetFromCellEdges`), sometimes the cell configuration is called before the
-/// orientation animation is completed – and this caused the computed separator insets to intermittently return the wrong table view size.
-///
-- (UIEdgeInsets)hiddenSeparatorInsets {
-    CGFloat rightInset = CGRectGetWidth(self.tableView.frame);
-
-    // Add an extra inset for landscape iPad (without a split view) where the separator does reach the trailing edge.
-    // Otherwise, after orientation the inset may not be enough to hide the separator.
-    if (self.view.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassRegular) {
-        rightInset -= self.tableView.separatorInset.left;
-    }
-
-    // Note: no need to flip the insets manually for RTL layout. The system will automatically take care of this.
-    return UIEdgeInsetsMake(0, -self.tableView.separatorInset.left, 0, rightInset);
-}
-
-/// Determines whether a separator should be drawn for the provided index path.
-/// The method returns YES if the index path represent a comment that is placed before a top-level comment.
-///
-/// Example:
-///
-/// - comment 1
-///     - comment 2
-///         - comment 3      --> returns YES.
-/// - comment 4
-///     - comment 5
-///         - comment 6
-///             - comment 7
-///         - comment 8      --> returns YES.
-/// - comment 9
-///
-- (BOOL)shouldShowSeparatorForIndexPath:(NSIndexPath *)indexPath
-{
-    NSIndexPath *nextIndexPath = [NSIndexPath indexPathForRow:indexPath.row + 1 inSection:indexPath.section];
-    NSArray<id<NSFetchedResultsSectionInfo>> *sections = self.tableViewHandler.resultsController.sections;
-
-    if (sections && sections[indexPath.section] && nextIndexPath.row < sections[indexPath.section].numberOfObjects) {
-        Comment *nextComment = [self.tableViewHandler.resultsController objectAtIndexPath:nextIndexPath];
-        return [nextComment isTopLevelComment];
-    }
-
-    return NO;
 }
 
 - (void)listenForClipboardChanges
@@ -734,9 +684,6 @@
 
     // support for legacy content rendering method.
     cell.richContentDelegate = self;
-
-    // show separator when the comment is the "last leaf" of its top-level comment.
-    cell.separatorInset = [self shouldShowSeparatorForIndexPath:indexPath] ? UIEdgeInsetsZero : self.hiddenSeparatorInsets;
 
     // configure button actions.
     __weak __typeof(self) weakSelf = self;

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -20,7 +20,6 @@
 @property (nonatomic, strong) NSNumber *postSiteID;
 @property (nonatomic, strong) WPContentSyncHelper *syncHelper;
 @property (nonatomic, strong) UITableView *tableView;
-@property (nonatomic, strong) WPTableViewHandler *tableViewHandler;
 @property (nonatomic, strong) NoResultsViewController *noResultsViewController;
 @property (nonatomic, strong) UIView *buttonComment;
 @property (nonatomic, strong) NSLayoutConstraint *replyTextViewHeightConstraint;
@@ -190,17 +189,6 @@
     self.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;
 
     [self refreshFollowButton];
-}
-
-- (void)configureTableViewHandler
-{
-    self.tableView = [UITableView new];
-    self.tableViewHandler = [[WPTableViewHandler alloc] initWithTableView:self.tableView];
-    self.tableViewHandler.updateRowAnimation = UITableViewRowAnimationNone;
-    self.tableViewHandler.insertRowAnimation = UITableViewRowAnimationNone;
-    self.tableViewHandler.moveRowAnimation = UITableViewRowAnimationNone;
-    self.tableViewHandler.deleteRowAnimation = UITableViewRowAnimationNone;
-    [self.tableViewHandler setListensForContentChanges:NO];
 }
 
 - (void)configureNoResultsView
@@ -467,7 +455,7 @@
 
 - (void)refreshAfterCommentModeration
 {
-    [self.tableViewHandler refreshTableView];
+    [self.tableViewController.tableView reloadData];
     [self refreshNoResultsView];
 }
 
@@ -477,11 +465,9 @@
 }
 
 - (void)refreshTableViewAndNoResultsView:(BOOL)scrollToHighlightedComment {
-    [self.tableViewHandler refreshTableView];
+    // TODO: remove
+    [self.tableViewController.tableView reloadData];
     [self refreshNoResultsView];
-    [self.managedObjectContext performBlock:^{
-        [self updateCachedContent];
-    }];
 
     if (scrollToHighlightedComment) {
         [self navigateToCommentIDIfNeeded];
@@ -491,17 +477,6 @@
 - (void)refreshTableViewAndNoResultsView {
     [self refreshTableViewAndNoResultsView:YES];
 }
-
-- (void)updateCachedContent
-{
-    if (![Feature enabled:FeatureFlagReaderCommentsWebKit]) {
-        NSArray *comments = self.tableViewHandler.resultsController.fetchedObjects;
-        for(Comment *comment in comments) {
-            [self cacheContentForComment:comment];
-        }
-    }
-}
-
 
 - (NSAttributedString *)cacheContentForComment:(Comment *)comment
 {

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -21,12 +21,10 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 @interface ReaderCommentsViewController () <NSFetchedResultsControllerDelegate,
                                             WPRichContentViewDelegate, // TODO: Remove once we switch to the `.web` rendering method.
                                             WPContentSyncHelperDelegate,
-                                            WPTableViewHandlerDelegate,
                                             ReaderCommentsFollowPresenterDelegate>
 
 @property (nonatomic, strong, readwrite) ReaderPost *post;
 @property (nonatomic, strong) NSNumber *postSiteID;
-@property (nonatomic, strong) UIActivityIndicatorView *activityFooter;
 @property (nonatomic, strong) WPContentSyncHelper *syncHelper;
 @property (nonatomic, strong) UITableView *tableView;
 @property (nonatomic, strong) WPTableViewHandler *tableViewHandler;
@@ -110,18 +108,9 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 {
     [super viewWillAppear:animated];
 
-    [[NSNotificationCenter defaultCenter] addObserver:self
-                                             selector:@selector(handleApplicationDidBecomeActive:)
-                                                 name:UIApplicationDidBecomeActiveNotification
-                                               object:nil];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(handleApplicationDidBecomeActive:) name:UIApplicationDidBecomeActiveNotification object:nil];
 
     [self refreshAndSync];
-}
-
-- (void)viewDidAppear:(BOOL)animated
-{
-    [super viewDidAppear:animated];
-    [self.tableView reloadData];
 }
 
 - (void)viewWillDisappear:(BOOL)animated
@@ -135,6 +124,13 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     }
 
     [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
+}
+
+- (void)viewDidLayoutSubviews
+{
+    [super viewDidLayoutSubviews];
+
+    self.tableViewController.tableView.contentInset.bottom = self.buttonComment.frame.size.height;
 }
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
@@ -234,7 +230,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 
 - (void)configureViewConstraints
 {
-    self.tableView.translatesAutoresizingMaskIntoConstraints = false;
     self.buttonComment.translatesAutoresizingMaskIntoConstraints = false;
 
     NSMutableDictionary *views = [[NSMutableDictionary alloc] initWithDictionary:@{
@@ -260,7 +255,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     // Whenever iOS 8 is set as the deployment target, let's always attach this one, and enable / disable it as needed!
     self.replyTextViewHeightConstraint = [NSLayoutConstraint constraintWithItem:self.buttonComment attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:0 multiplier:1 constant:0];
 }
-
 
 #pragma mark - Helpers
 
@@ -429,21 +423,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     return self.post.siteID ?: self.postSiteID;
 }
 
-- (UIActivityIndicatorView *)activityFooter
-{
-    if (_activityFooter) {
-        return _activityFooter;
-    }
-
-    _activityFooter = [[UIActivityIndicatorView alloc] initWithActivityIndicatorStyle:UIActivityIndicatorViewStyleMedium];
-    _activityFooter.activityIndicatorViewStyle = UIActivityIndicatorViewStyleMedium;
-    _activityFooter.hidesWhenStopped = YES;
-    _activityFooter.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleRightMargin;
-    [_activityFooter stopAnimating];
-
-    return _activityFooter;
-}
-
 - (BOOL)isLoadingPost
 {
     return self.post == nil;
@@ -512,21 +491,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 
 - (void)refreshInfiniteScroll
 {
-    if (self.syncHelper.hasMoreContent) {
-        CGFloat width = CGRectGetWidth(self.tableView.bounds);
-        UIView *footerView = [[UIView alloc] initWithFrame:CGRectMake(0.0f, 0.0f, width, 50.0f)];
-        footerView.autoresizingMask = UIViewAutoresizingFlexibleWidth;
-        CGRect rect = self.activityFooter.frame;
-        rect.origin.x = (width - rect.size.width) / 2.0;
-        self.activityFooter.frame = rect;
-
-        [footerView addSubview:self.activityFooter];
-        self.tableView.tableFooterView = footerView;
-        
-    } else {
-        self.tableView.tableFooterView = [self tableFooterViewForHiddenSeparators];
-        self.activityFooter = nil;
-    }
+    [self.tableViewController setLoadingFooterHidden:YES];
 }
 
 - (void)refreshNoResultsView
@@ -712,7 +677,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 - (void)syncHelper:(WPContentSyncHelper *)syncHelper syncMoreWithSuccess:(void (^)(BOOL))success failure:(void (^)(NSError *))failure
 {
     self.fetchCommentsError = nil;
-    [self.activityFooter startAnimating];
+    [self.tableViewController setLoadingFooterHidden:NO];
 
     CommentService *service = [[CommentService alloc] initWithCoreDataStack:[ContextManager sharedInstance]];
     NSInteger page = [service numberOfHierarchicalPagesSyncedforPost:self.post] + 1;
@@ -725,7 +690,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 
 - (void)syncContentEnded:(WPContentSyncHelper *)syncHelper
 {
-    [self.activityFooter stopAnimating];
+    [self.tableViewController setLoadingFooterHidden:YES];
     if ([self.tableViewHandler isScrolling]) {
         self.needsRefreshTableViewAfterScrolling = YES;
         return;
@@ -737,7 +702,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 - (void)syncContentFailed:(WPContentSyncHelper *)syncHelper
 {
     self.fetchCommentsError = [NSError errorWithDomain:@"" code:0 userInfo:nil];
-    [self.activityFooter stopAnimating];
+    [self.tableViewController setLoadingFooterHidden:YES];
     [self refreshTableViewAndNoResultsView];
 }
 
@@ -758,7 +723,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     } failure:^(NSError *error) {
         DDLogError(@"[RestAPI] %@", error);
         self.fetchCommentsError = error;
-        [self.activityFooter stopAnimating];
+        [self.tableViewController setLoadingFooterHidden:YES];
         [self refreshTableViewAndNoResultsView];
     }];
 }

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -54,6 +54,8 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 
 @property (nonatomic, strong) NSIndexPath *highlightedIndexPath;
 
+@property (nonatomic, strong) ReaderCommentsTableViewController *tableViewController;
+
 @end
 
 
@@ -83,14 +85,19 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 {
     [super viewDidLoad];
 
-    self.view.backgroundColor = [UIColor murielBasicBackground];
+    self.estimatedRowHeights = [[NSCache alloc] init];
+    self.cachedAttributedStrings = [[NSCache alloc] init];
+
+    self.tableViewController = [ReaderCommentsTableViewController new];
+    [self configureTableViewController:self.tableViewController];
+
+    self.view.backgroundColor = [UIColor systemBackgroundColor];
     self.commentModified = NO;
     self.helper = [ReaderCommentsHelper new];
 
     [self checkIfLoggedIn];
 
     [self configureNavbar];
-    [self configureTableView];
     [self configureTableViewHandler];
     [self configureNoResultsView];
     [self configureCommentButton];
@@ -200,38 +207,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
     [self refreshFollowButton];
 }
 
-- (void)configureTableView
-{
-    self.tableView = [[UITableView alloc] initWithFrame:self.view.bounds style:UITableViewStylePlain];
-    self.tableView.translatesAutoresizingMaskIntoConstraints = NO;
-    self.tableView.cellLayoutMarginsFollowReadableWidth = YES;
-    self.tableView.preservesSuperviewLayoutMargins = YES;
-    self.tableView.backgroundColor = [UIColor murielBasicBackground];
-    if ([Feature enabled:FeatureFlagReaderCommentsWebKit]) {
-        // We use this to mask the initial WebKit warmup that takes a bit of time
-        // the first time you initialize a web view. It renders asyncronously, and
-        // we don't want to show cells with empty messages.
-        self.tableView.alpha = 0.0;
-    }
-    [self.view addSubview:self.tableView];
-
-    // register the content cell
-    UINib *nib = [UINib nibWithNibName:[CommentContentTableViewCell classNameWithoutNamespaces] bundle:nil];
-    [self.tableView registerNib:nib forCellReuseIdentifier:CommentContentCellIdentifier];
-
-    // configure table view separator
-    self.tableView.separatorStyle = UITableViewCellSeparatorStyleSingleLine;
-    self.tableView.separatorInsetReference = UITableViewSeparatorInsetFromAutomaticInsets;
-
-    // hide cell separator for the last row
-    self.tableView.tableFooterView = [self tableFooterViewForHiddenSeparators];
-
-    self.tableView.keyboardDismissMode = UIScrollViewKeyboardDismissModeInteractive;
-
-    self.estimatedRowHeights = [[NSCache alloc] init];
-    self.cachedAttributedStrings = [[NSCache alloc] init];
-}
-
 - (void)configureTableViewHandler
 {
     self.tableViewHandler = [[WPTableViewHandler alloc] initWithTableView:self.tableView];
@@ -315,11 +290,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 - (void)checkIfLoggedIn
 {
     self.isLoggedIn = [AccountHelper isDotcomAvailable];
-}
-
-- (UIView *)tableFooterViewForHiddenSeparators
-{
-    return [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.tableView.frame.size.width, 0)];
 }
 
 - (void)setHighlightedIndexPath:(NSIndexPath *)highlightedIndexPath

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -714,33 +714,6 @@
     }
 }
 
-#pragma mark - UIScrollView Delegate Methods
-
-- (void)scrollViewDidEndDecelerating:(UIScrollView *)scrollView
-{
-    [self.tableView deselectSelectedRowWithAnimation:YES];
-
-    if (self.needsRefreshTableViewAfterScrolling) {
-        self.needsRefreshTableViewAfterScrolling = NO;
-        [self refreshTableViewAndNoResultsView];
-
-        // If we reloaded the tableView we also updated cell heights
-        // so there is no need to update for attachments.
-        self.needsUpdateAttachmentsAfterScrolling = NO;
-    }
-
-    if (self.needsUpdateAttachmentsAfterScrolling) {
-        self.needsUpdateAttachmentsAfterScrolling = NO;
-
-        for (UITableViewCell *cell in [self.tableView visibleCells]) {
-            if ([cell isKindOfClass:[CommentContentTableViewCell class]]) {
-                [(CommentContentTableViewCell *)cell ensureRichContentTextViewLayout];
-            }
-        }
-        [self updateTableViewForAttachments];
-    }
-}
-
 #pragma mark - WPRichContentDelegate Methods
 
 - (void)richContentView:(WPRichContentView *)richContentView didReceiveImageAction:(WPRichTextImage *)image

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -410,7 +410,7 @@
 {
     [self.noResultsViewController removeFromView];
 
-    // TODO: (kean) reimplement
+    // TODO: (kean) reimplement empty state view
 //    BOOL isTableViewEmpty = (self.tableViewHandler.resultsController.fetchedObjects.count == 0);
 //    if (!isTableViewEmpty) {
 //        return;

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -130,7 +130,7 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 {
     [super viewDidLayoutSubviews];
 
-    self.tableViewController.tableView.contentInset.bottom = self.buttonComment.frame.size.height;
+    [self.tableViewController setBottomInset:self.buttonComment.frame.size.height];
 }
 
 - (void)traitCollectionDidChange:(UITraitCollection *)previousTraitCollection
@@ -205,12 +205,12 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 
 - (void)configureTableViewHandler
 {
+    self.tableView = [UITableView new];
     self.tableViewHandler = [[WPTableViewHandler alloc] initWithTableView:self.tableView];
     self.tableViewHandler.updateRowAnimation = UITableViewRowAnimationNone;
     self.tableViewHandler.insertRowAnimation = UITableViewRowAnimationNone;
     self.tableViewHandler.moveRowAnimation = UITableViewRowAnimationNone;
     self.tableViewHandler.deleteRowAnimation = UITableViewRowAnimationNone;
-    self.tableViewHandler.delegate = self;
     [self.tableViewHandler setListensForContentChanges:NO];
 }
 
@@ -222,8 +222,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 - (void)configureCommentButton
 {
     self.buttonComment = [self makeCommentButton];
-    [self.view addSubview:self.buttonComment];
-    [self.view bringSubviewToFront:self.buttonComment];
 }
 
 #pragma mark - Autolayout Helpers
@@ -231,24 +229,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
 - (void)configureViewConstraints
 {
     self.buttonComment.translatesAutoresizingMaskIntoConstraints = false;
-
-    NSMutableDictionary *views = [[NSMutableDictionary alloc] initWithDictionary:@{
-        @"tableView": self.tableView,
-        @"replyTextView": self.buttonComment
-    }];
-
-    NSString *verticalVisualFormatString = @"V:|[tableView][replyTextView]";
-
-    // TableView Contraints
-    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:verticalVisualFormatString options:0 metrics:nil views:views]];
-
-    [self.view addConstraints:[NSLayoutConstraint constraintsWithVisualFormat:@"|[tableView]|" options:0 metrics:nil views:views]];
-
-    [NSLayoutConstraint activateConstraints:@[
-        [self.buttonComment.leadingAnchor constraintEqualToAnchor:self.view.leadingAnchor],
-        [self.buttonComment.trailingAnchor constraintEqualToAnchor:self.view.trailingAnchor],
-        [self.view.keyboardLayoutGuide.topAnchor constraintEqualToAnchor:self.buttonComment.bottomAnchor]
-    ]];
 
     // TODO:
     // This LayoutConstraint is just a helper, meant to hide / display the ReplyTextView, as needed.
@@ -727,7 +707,6 @@ static NSString *CommentContentCellIdentifier = @"CommentContentTableViewCell";
         [self refreshTableViewAndNoResultsView];
     }];
 }
-
 
 #pragma mark - UITableView Delegate Methods
 

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -5,7 +5,6 @@
 #import "ReaderPost.h"
 #import "ReaderPostService.h"
 #import "UIView+Subviews.h"
-#import "WPTableViewHandler.h"
 #import "WordPress-Swift.h"
 #import "WPAppAnalytics.h"
 
@@ -84,7 +83,6 @@
     [self checkIfLoggedIn];
 
     [self configureNavbar];
-    [self configureTableViewHandler];
     [self configureNoResultsView];
     [self configureCommentButton];
     [self configureViewConstraints];
@@ -408,12 +406,12 @@
 {
     [self.noResultsViewController removeFromView];
 
-    BOOL isTableViewEmpty = (self.tableViewHandler.resultsController.fetchedObjects.count == 0);
-    if (!isTableViewEmpty) {
-        return;
-    }
-
     // TODO: (kean) reimplement
+//    BOOL isTableViewEmpty = (self.tableViewHandler.resultsController.fetchedObjects.count == 0);
+//    if (!isTableViewEmpty) {
+//        return;
+//    }
+
     return ;
 
     NSString *image = nil;
@@ -513,8 +511,10 @@
     if (!indexPath || !self.canComment) {
         return;
     }
-    Comment *comment = [self.tableViewHandler.resultsController objectAtIndexPath:indexPath];
-    [self didTapReplyWithComment:comment];
+    Comment *comment = [self.tableViewController commentAtIndexPath:indexPath];
+    if (comment) {
+        [self didTapReplyWithComment:comment];
+    }
 }
 
 - (void)didTapLikeForComment:(Comment *)comment atIndexPath:(NSIndexPath *)indexPath
@@ -568,11 +568,6 @@
 - (void)syncContentEnded:(WPContentSyncHelper *)syncHelper
 {
     [self.tableViewController setLoadingFooterHidden:YES];
-    if ([self.tableViewHandler isScrolling]) {
-        self.needsRefreshTableViewAfterScrolling = YES;
-        return;
-    }
-
     [self refreshTableViewAndNoResultsView];
 }
 
@@ -680,11 +675,6 @@
 
 - (BOOL)richContentViewShouldUpdateLayoutForAttachments:(WPRichContentView *)richContentView
 {
-    if (self.tableViewHandler.isScrolling) {
-        self.needsUpdateAttachmentsAfterScrolling = YES;
-        return NO;
-    }
-
     return YES;
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -779,49 +779,11 @@ static CGFloat const EstimatedCommentRowHeight = 300.0;
     return EstimatedCommentRowHeight;
 }
 
-- (CGFloat)tableView:(UITableView *)tableView heightForRowAtIndexPath:(NSIndexPath *)indexPath
+- (void)loadMore
 {
-    return UITableViewAutomaticDimension;
-}
-
-- (UIView *)tableView:(UITableView *)tableView viewForHeaderInSection:(NSInteger)section
-{
-    return self.cachedHeaderView;
-}
-
-- (void)tableView:(UITableView *)tableView didSelectRowAtIndexPath:(NSIndexPath *)indexPath
-{
-    [self.tableView deselectRowAtIndexPath:indexPath animated:NO];
-}
-
-- (BOOL)tableView:(UITableView *)tableView shouldHighlightRowAtIndexPath:(NSIndexPath *)indexPath
-{
-    return NO;
-}
-
-- (void)tableView:(UITableView *)tableView willDisplayCell:(UITableViewCell *)cell forRowAtIndexPath:(NSIndexPath *)indexPath
-{
-    [self.estimatedRowHeights setObject:@(cell.frame.size.height) forKey:indexPath];
-
-    // Are we approaching the end of the table?
-    if ((indexPath.section + 1 == [self.tableViewHandler numberOfSectionsInTableView:tableView]) &&
-        (indexPath.row + 4 >= [self.tableViewHandler tableView:tableView numberOfRowsInSection:indexPath.section])) {
-
-        // Only 3 rows till the end of table
-        if (self.syncHelper.hasMoreContent) {
-            [self.syncHelper syncMoreContent];
-        }
+    if (self.syncHelper.hasMoreContent) {
+        [self.syncHelper syncMoreContent];
     }
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForHeaderInSection:(NSInteger)section
-{
-    return UITableViewAutomaticDimension;
-}
-
-- (CGFloat)tableView:(UITableView *)tableView heightForFooterInSection:(NSInteger)section
-{
-    return 0;
 }
 
 #pragma mark - UIScrollView Delegate Methods

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -21,8 +21,7 @@ extension NSNotification.Name {
         let button = CommentLargeButton()
         button.addTarget(self, action: #selector(buttonAddCommentTapped), for: .primaryActionTriggered)
         view.addSubview(button)
-        button.pinEdges(.horizontal)
-        button.pinEdges(.bottom, to: view.safeAreaLayoutGuide)
+        button.pinEdges([.horizontal, .bottom])
         return button
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -96,15 +96,11 @@ extension NSNotification.Name {
     }
 
     func configureContentCell(
-        _ cell: UITableViewCell,
+        _ cell: CommentContentTableViewCell,
         comment: Comment,
         indexPath: IndexPath,
-        handler: WPTableViewHandler
+        tableView: UITableView
     ) {
-        guard let cell = cell as? CommentContentTableViewCell else {
-            return
-        }
-
         cell.badgeTitle = comment.isFromPostAuthor() ? .authorBadgeText : nil
         cell.indentationWidth = Constants.indentationWidth
         cell.indentationLevel = min(Constants.maxIndentationLevel, Int(comment.depth))
@@ -114,24 +110,22 @@ extension NSNotification.Name {
         // if the comment can be moderated, show the context menu when tapping the accessory button.
         // Note that accessoryButtonAction will be ignored when the menu is assigned.
         cell.accessoryButton.showsMenuAsPrimaryAction = isModerationMenuEnabled(for: comment)
-        cell.accessoryButton.menu = isModerationMenuEnabled(for: comment) ? menu(for: comment, indexPath: indexPath, handler: handler, sourceView: cell.accessoryButton) : nil
+        cell.accessoryButton.menu = isModerationMenuEnabled(for: comment) ? menu(for: comment, indexPath: indexPath, tableView: tableView, sourceView: cell.accessoryButton) : nil
         let renderMethod: CommentContentTableViewCell.RenderMethod = Feature.enabled(.readerCommentsWebKit) ? .web : .richContent(self.cacheContent(for: comment))
-        cell.configure(with: comment, renderMethod: renderMethod, helper: helper) { _ in
-            if handler.tableView.alpha == 0 {
+        cell.configure(with: comment, renderMethod: renderMethod, helper: helper) { [weak tableView] _ in
+            guard let tableView else { return }
+
+            if tableView.alpha == 0 {
                 UIView.animate(withDuration: 0.2) {
-                    handler.tableView.alpha = 1
+                    tableView.alpha = 1
                 }
             }
-
-            // don't adjust cell height when it's already scrolled out of viewport.
-            guard let visibleIndexPaths = handler.tableView.indexPathsForVisibleRows,
-                  visibleIndexPaths.contains(indexPath) else {
-                      return
-                  }
-
-            UIView.setAnimationsEnabled(false)
-            handler.tableView.performBatchUpdates({})
-            UIView.setAnimationsEnabled(true)
+            // don't adjust cell height when it's out of the viewport.
+            if (tableView.indexPathsForVisibleRows ?? []).contains(indexPath) {
+                UIView.setAnimationsEnabled(false)
+                tableView.performBatchUpdates({})
+                UIView.setAnimationsEnabled(true)
+            }
         }
     }
 
@@ -251,8 +245,8 @@ private extension ReaderCommentsViewController {
     ///    | Baz   •|
     ///     --------
     ///
-    func menu(for comment: Comment, indexPath: IndexPath, handler: WPTableViewHandler, sourceView: UIView?) -> UIMenu {
-        let commentMenus = commentMenu(for: comment, indexPath: indexPath, handler: handler, sourceView: sourceView)
+    func menu(for comment: Comment, indexPath: IndexPath, tableView: UITableView, sourceView: UIView?) -> UIMenu {
+        let commentMenus = commentMenu(for: comment, indexPath: indexPath, tableView: tableView, sourceView: sourceView)
         return UIMenu(title: "", options: .displayInline, children: commentMenus.map {
             UIMenu(title: "", options: .displayInline, children: $0.map({ menu in menu.toAction }))
         })
@@ -261,7 +255,7 @@ private extension ReaderCommentsViewController {
     /// Returns a list of array that each contains a menu item. Separators will be shown between each array. Note that
     /// the order of comment menu will determine the order of appearance for the corresponding menu element.
     ///
-    func commentMenu(for comment: Comment, indexPath: IndexPath, handler: WPTableViewHandler, sourceView: UIView?) -> [[ReaderCommentMenu]] {
+    func commentMenu(for comment: Comment, indexPath: IndexPath, tableView: UITableView, sourceView: UIView?) -> [[ReaderCommentMenu]] {
         return [
             [
                 .unapprove { [weak self] in
@@ -275,8 +269,9 @@ private extension ReaderCommentsViewController {
                 }
             ],
             [
-                .edit { [weak self] in
-                    self?.editMenuTapped(for: comment, indexPath: indexPath, tableView: handler.tableView)
+                .edit { [weak self, weak tableView] in
+                    guard let tableView else { return }
+                    self?.editMenuTapped(for: comment, indexPath: indexPath, tableView: tableView)
                 },
                 .share { [weak self] in
                     self?.shareComment(comment, sourceView: sourceView)

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -103,10 +103,7 @@ extension NSNotification.Name {
         // if the comment can be moderated, show the context menu when tapping the accessory button.
         // Note that accessoryButtonAction will be ignored when the menu is assigned.
         cell.accessoryButton.showsMenuAsPrimaryAction = isModerationMenuEnabled(for: comment)
-        cell.accessoryButton.menu = isModerationMenuEnabled(for: comment) ? menu(for: comment,
-                                                                                 indexPath: indexPath,
-                                                                                 handler: handler,
-                                                                                 sourceView: cell.accessoryButton) : nil
+        cell.accessoryButton.menu = isModerationMenuEnabled(for: comment) ? menu(for: comment, indexPath: indexPath, handler: handler, sourceView: cell.accessoryButton) : nil
         let renderMethod: CommentContentTableViewCell.RenderMethod = Feature.enabled(.readerCommentsWebKit) ? .web : .richContent(self.cacheContent(for: comment))
         cell.configure(with: comment, renderMethod: renderMethod, helper: helper) { _ in
             if handler.tableView.alpha == 0 {

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -12,7 +12,7 @@ extension NSNotification.Name {
 @objc extension ReaderCommentsViewController {
     func configureTableViewController(_ vc: ReaderCommentsTableViewController) {
         addChild(vc)
-        view.addSubview(vc.view)
+        view.insertSubview(vc.view, belowSubview: buttonAddComment)
         vc.view.pinEdges()
         vc.didMove(toParent: self)
     }

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 import WordPressShared
+import WordPressUI
 
 // Notification sent when a comment is moderated/edited to allow views that display Comments to update if necessary.
 // Specifically, the Comments snippet on ReaderDetailViewController.
@@ -19,6 +20,8 @@ extension NSNotification.Name {
     func makeCommentButton() -> UIView {
         let button = CommentLargeButton()
         button.addTarget(self, action: #selector(buttonAddCommentTapped), for: .primaryActionTriggered)
+        view.addSubview(button)
+        button.pinEdges([.horizontal, .bottom])
         return button
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -21,7 +21,8 @@ extension NSNotification.Name {
         let button = CommentLargeButton()
         button.addTarget(self, action: #selector(buttonAddCommentTapped), for: .primaryActionTriggered)
         view.addSubview(button)
-        button.pinEdges([.horizontal, .bottom])
+        button.pinEdges(.horizontal)
+        button.pinEdges(.bottom, to: view.safeAreaLayoutGuide)
         return button
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -19,7 +19,9 @@ extension NSNotification.Name {
 
     func makeCommentButton() -> UIView {
         let button = CommentLargeButton()
-        button.addTarget(self, action: #selector(buttonAddCommentTapped), for: .primaryActionTriggered)
+        button.onTap = { [weak self] in
+            self?.buttonAddCommentTapped()
+        }
         view.addSubview(button)
         button.pinEdges([.horizontal, .bottom])
         return button

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -9,6 +9,13 @@ extension NSNotification.Name {
 }
 
 @objc extension ReaderCommentsViewController {
+    func configureTableViewController(_ vc: ReaderCommentsTableViewController) {
+        addChild(vc)
+        view.addSubview(vc.view)
+        vc.view.pinEdges()
+        vc.didMove(toParent: self)
+    }
+
     func makeCommentButton() -> UIView {
         let button = CommentLargeButton()
         button.addTarget(self, action: #selector(buttonAddCommentTapped), for: .primaryActionTriggered)

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
@@ -367,24 +367,7 @@ import AutomatticTracks
 
     private func layoutEmptyStateView() {
         guard let emptyStateView else { return }
-
-        // Calculate visible part of the table view in `self.view` coordinates
-        let y: CGFloat = {
-            if let headerView = tableView.tableHeaderView {
-                return tableView.convert(headerView.frame, to: view).maxY
-            } else {
-                return view.safeAreaInsets.top
-            }
-        }()
-
-        // And convert it to the `tableView` coordinate space since that's where
-        // `emptyStateView` belongs.
-        emptyStateView.frame = tableView.convert(CGRect(
-            x: 0,
-            y: y,
-            width: view.bounds.width,
-            height: view.bounds.height - y - view.safeAreaInsets.bottom
-        ), from: view)
+        tableView.layoutEmptyStateView(emptyStateView, in: self)
     }
 
     private func didChangeIsCompact(_ isCompact: Bool) {


### PR DESCRIPTION
This is the first phase of the `ReaderCommentsViewController` rework. It adds `ReaderCommentsTableViewController` to extract table view management code. The new version is written in Swift and no longer uses `WPTableViewHandler`.

The key difference is that in the new version, the app avoids frequent `tableView.reloadData()` calls that currently negatively affect the comment renderers, and especially the WebKit-based one. It's not fully done, but the goal is to ensure that the cells are only updated based on the specific changes to `Comment`.

## To test:

A smoke test that the comments are displayed will do for now. Not everything has been implement yet. 

## Next Steps

- Integrate `EmptyStateView`
- Finalize WebKit-based rendering and remove `WPRichTextView`

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
