### PR TITLE
Change `InMemoryDataStore` from a protocol to a concrete type

### DIFF
--- a/Modules/Sources/WordPressCore/Plugins/PluginDirectoryDataStore.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginDirectoryDataStore.swift
@@ -1,45 +1,24 @@
 import Foundation
-@preconcurrency import Combine
-import WordPressShared
 import WordPressAPI
 import WordPressAPIInternal
 
-public protocol PluginDirectoryDataStore: DataStore where T == PluginInformation, Query == PluginDirectoryDataStoreQuery {
-}
+public typealias PluginDirectoryDataStoreQuery = InMemoryDataStore<PluginInformation>.Query
+public typealias InMemoryPluginDirectoryDataStore = InMemoryDataStore<PluginInformation>
 
-public enum PluginDirectoryDataStoreQuery: Hashable, Sendable {
-    case slug(PluginWpOrgDirectorySlug)
-}
-
-extension PluginDirectoryDataStore {
-    public func get(_ slug: PluginWpOrgDirectorySlug) async throws -> PluginInformation? {
-        try await list(query: .slug(slug)).first
-    }
-}
-
-public actor InMemoryPluginDirectoryDataStore: PluginDirectoryDataStore, InMemoryDataStore {
-    public var storage: [T.ID: T] = [:]
-    public let updates: PassthroughSubject<Set<T.ID>, Never> = .init()
-
-    deinit {
-        updates.send(completion: .finished)
-    }
-
-    public init() {}
-
-    public func list(query: Query) throws -> [T] {
-        let plugins: any Sequence<T>
-        switch query {
-        case let .slug(slug):
-            plugins = storage[slug].flatMap { [$0] } ?? []
-        }
-
-        return plugins.sorted(using: KeyPathComparator(\.name))
+extension PluginDirectoryDataStoreQuery {
+    public static func slug(_ slug: PluginWpOrgDirectorySlug) -> PluginDirectoryDataStoreQuery {
+        .init(sortBy: KeyPathComparator(\.name)) { $0.slug == slug.slug }
     }
 }
 
 extension PluginInformation: @retroactive Identifiable {
     public var id: PluginWpOrgDirectorySlug {
         PluginWpOrgDirectorySlug(slug: slug)
+    }
+}
+
+extension InMemoryPluginDirectoryDataStore {
+    func get(_ slug: PluginWpOrgDirectorySlug) async throws -> PluginInformation? {
+        try await list(query: .slug(slug)).first
     }
 }

--- a/Modules/Sources/WordPressCore/Users/UserService.swift
+++ b/Modules/Sources/WordPressCore/Users/UserService.swift
@@ -48,7 +48,7 @@ public actor UserService: UserServiceProtocol {
 
         // Remove the deleted user from the cached users list.
         if result.deleted {
-            try await userDataStore.delete(query: .id([id]))
+            try await userDataStore.delete(query: .id(id))
         }
     }
 

--- a/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
+++ b/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
@@ -50,9 +50,9 @@ struct InstalledPluginsListView: View {
             ToolbarItem(placement: .topBarTrailing) {
                 Menu {
                     Picker(Strings.filterTitle, selection: $viewModel.filter) {
-                        Text(Strings.filterOptionAll).tag(PluginDataStoreQuery.all)
-                        Text(Strings.filterOptionActive).tag(PluginDataStoreQuery.active)
-                        Text(Strings.filterOptionInactive).tag(PluginDataStoreQuery.inactive)
+                        Text(Strings.filterOptionAll).tag(InstalledPluginsListViewModel.PluginFilter.all)
+                        Text(Strings.filterOptionActive).tag(InstalledPluginsListViewModel.PluginFilter.active)
+                        Text(Strings.filterOptionInactive).tag(InstalledPluginsListViewModel.PluginFilter.inactive)
                     }
                 } label: {
                     Image(systemName: "ellipsis.circle")
@@ -84,8 +84,25 @@ final class InstalledPluginsListViewModel: ObservableObject {
     let service: PluginServiceProtocol
     private var initialLoad = false
 
+    enum PluginFilter: Hashable {
+        case all
+        case active
+        case inactive
+
+        var query: PluginDataStoreQuery {
+            switch self {
+            case .all:
+                return .all
+            case .active:
+                return .active
+            case .inactive:
+                return .inactive
+            }
+        }
+    }
+
     @Published var isRefreshing: Bool = false
-    @Published var filter: PluginDataStoreQuery = .all
+    @Published var filter: PluginFilter = .all
     @Published var displayingPlugins: [InstalledPlugin] = []
     @Published var error: String? = nil
 
@@ -115,7 +132,7 @@ final class InstalledPluginsListViewModel: ObservableObject {
     }
 
     func performQuery() async {
-        for await update in await self.service.installedPluginsUpdates(query: filter) {
+        for await update in await self.service.installedPluginsUpdates(query: filter.query) {
             switch update {
             case let .success(plugins):
                 self.displayingPlugins = plugins


### PR DESCRIPTION
Fewer protocol extensions and boilerplate classes that conform to the old `InMemoryDataStore` protocol.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
