### PR TITLE
WebKit Comments Optimizations

### DIFF
--- a/Modules/Sources/WordPressReader/Comments/Views/CommentContentRenderer.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/CommentContentRenderer.swift
@@ -14,6 +14,8 @@ public protocol CommentContentRenderer: AnyObject {
     /// but it should update its delegate with the correct height through the
     ///  `renderer(_:asyncRenderCompletedWithHeight:)` method.
     func render(comment: String)
+
+    func prepareForReuse()
 }
 
 @MainActor

--- a/Modules/Sources/WordPressReader/Comments/Views/CommentContentRenderer.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/CommentContentRenderer.swift
@@ -20,7 +20,7 @@ public protocol CommentContentRenderer: AnyObject {
 public protocol CommentContentRendererDelegate: AnyObject {
     /// Called when the rendering process completes. Note that this method is only called when using complex rendering methods that involves
     /// asynchronous operations, so the container can readjust its size at a later time.
-    func renderer(_ renderer: CommentContentRenderer, asyncRenderCompletedWithHeight height: CGFloat)
+    func renderer(_ renderer: CommentContentRenderer, asyncRenderCompletedWithHeight height: CGFloat, comment: String)
 
     /// Called whenever the user interacts with a URL within the rendered content.
     func renderer(_ renderer: CommentContentRenderer, interactedWithURL url: URL)

--- a/Modules/Sources/WordPressReader/Comments/Views/CommentWebView.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/CommentWebView.swift
@@ -28,7 +28,7 @@ final class CommentWebView: UIView, CommentContentRendererDelegate {
         print("interact:", url)
     }
 
-    func renderer(_ renderer: any CommentContentRenderer, asyncRenderCompletedWithHeight height: CGFloat) {
+    func renderer(_ renderer: any CommentContentRenderer, asyncRenderCompletedWithHeight height: CGFloat, comment: String) {
         heightConstraint.constant = height
     }
 }

--- a/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
@@ -32,6 +32,7 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
     }
 
     private var cachedHead: String?
+    private var comment: String?
 
     /// A shared web view context with resources that can be reused across
     /// mutliple web view instances.
@@ -66,6 +67,8 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
     }
 
     public func render(comment: String) {
+        self.comment = comment
+
         // - important: `wordPressSharedBundle` contains custom fonts
         webView.loadHTMLString(formattedHTMLString(for: comment), baseURL: Bundle.wordPressSharedBundle.bundleURL)
     }
@@ -75,10 +78,13 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
 
 extension WebCommentContentRenderer: WKNavigationDelegate {
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+        guard let comment else {
+            return
+        }
         // Wait until the HTML document finished loading.
         // This also waits for all of resources within the HTML (images, video thumbnail images) to be fully loaded.
         webView.evaluateJavaScript("document.readyState") { complete, _ in
-            guard complete != nil else {
+            guard complete != nil, self.comment == comment else {
                 return
             }
 
@@ -93,7 +99,7 @@ extension WebCommentContentRenderer: WKNavigationDelegate {
                 /// in the meta tag. The `scrollHeight` value seems to return the height as if it's at 1.0 scale,
                 /// so we'll need to add the custom scale into account.
                 let actualHeight = round(height * self.displaySetting.size.scale)
-                self.delegate?.renderer(self, asyncRenderCompletedWithHeight: actualHeight)
+                self.delegate?.renderer(self, asyncRenderCompletedWithHeight: actualHeight, comment: comment)
             }
         }
     }

--- a/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
@@ -72,6 +72,11 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
         // - important: `wordPressSharedBundle` contains custom fonts
         webView.loadHTMLString(formattedHTMLString(for: comment), baseURL: Bundle.wordPressSharedBundle.bundleURL)
     }
+
+    public func prepareForReuse() {
+        comment = nil
+        webView.stopLoading()
+    }
 }
 
 // MARK: - WKNavigationDelegate

--- a/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
@@ -35,10 +35,25 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
 
     private var cachedHead: String?
 
+    /// A shared web view context with resources that can be reused across
+    /// mutliple web view instances.
+    @MainActor
+    public final class Context {
+        let processPool = WKProcessPool()
+
+        public init() {}
+    }
+
     // MARK: Methods
 
-    public required override init() {
+    public required override convenience init() {
+        self.init(context: .init())
+    }
+
+    public init(context: Context) {
         super.init()
+
+        webView.configuration.processPool = context.processPool
 
         if #available(iOS 16.4, *) {
             webView.isInspectable = true

--- a/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
@@ -18,8 +18,6 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
         return configuration
     }())
 
-    private var comment: String?
-
     /// It can't be changed at the moment, but this capability was included from the
     /// start, and this implementation continues supporting it.
     private var displaySetting = ReaderDisplaySettings.standard
@@ -68,11 +66,6 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
     }
 
     public func render(comment: String) {
-        guard self.comment != comment else {
-            return // Already rendering this comment
-        }
-        self.comment = comment
-
         // - important: `wordPressSharedBundle` contains custom fonts
         webView.loadHTMLString(formattedHTMLString(for: comment), baseURL: Bundle.wordPressSharedBundle.bundleURL)
     }

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -495,8 +495,7 @@ private extension CommentContentTableViewCell {
         func makeRenderer() -> CommentContentRenderer {
             switch renderMethod {
             case .web:
-                let renderer = WebCommentContentRenderer()
-                renderer.tintColor = UIAppColor.primary
+                let renderer = helper.makeWebRenderer()
                 renderer.delegate = self
                 return renderer
             case .richContent(let attributedText):

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -266,12 +266,12 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
 // MARK: - CommentContentRendererDelegate
 
 extension CommentContentTableViewCell: CommentContentRendererDelegate {
-    func renderer(_ renderer: CommentContentRenderer, asyncRenderCompletedWithHeight height: CGFloat) {
+    func renderer(_ renderer: CommentContentRenderer, asyncRenderCompletedWithHeight height: CGFloat, comment: String) {
         if renderMethod == .web {
-            if let constraint = contentContainerHeightConstraint, let comment {
+            if let constraint = contentContainerHeightConstraint {
                 if height != constraint.constant {
                     constraint.constant = height
-                    helper?.setCachedContentHeight(height, for: .init(comment))
+                    helper?.setCachedContentHeight(height, for: comment)
                     onContentLoaded?(height) // We had the right size from the get-go
                 }
             } else {
@@ -511,7 +511,7 @@ private extension CommentContentTableViewCell {
         if renderMethod == .web {
             // reset height constraint to handle cases where the new content requires the webview to shrink.
             contentContainerHeightConstraint?.isActive = true
-            contentContainerHeightConstraint?.constant = helper.getCachedContentHeight(for: TaggedManagedObjectID(comment)) ?? 20
+            contentContainerHeightConstraint?.constant = helper.getCachedContentHeight(for: comment.content) ?? 20
         } else {
             contentContainerHeightConstraint?.isActive = false
         }

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -166,6 +166,8 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     override func prepareForReuse() {
         super.prepareForReuse()
 
+        renderer?.prepareForReuse()
+
         // reset all highlight states.
         isEmphasized = false
 

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -114,6 +114,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     private var onContentLoaded: ((CGFloat) -> Void)? = nil
 
     private var comment: Comment?
+    private var renderer: CommentContentRenderer?
     private var renderMethod: RenderMethod?
     private var helper: ReaderCommentsHelper?
 
@@ -480,21 +481,33 @@ private extension CommentContentTableViewCell {
     // MARK: Content Rendering
 
     func configureRendererIfNeeded(for comment: Comment, renderMethod: RenderMethod, helper: ReaderCommentsHelper) {
-        let renderer: CommentContentRenderer = {
+        if self.renderMethod != renderMethod {
+            self.renderer = nil
+        }
+        self.renderMethod = renderMethod
+
+        let renderer = self.renderer ?? {
+            let renderer = makeRenderer()
+            self.renderer = renderer
+            return renderer
+        }()
+
+        func makeRenderer() -> CommentContentRenderer {
             switch renderMethod {
             case .web:
-                return helper.getRenderer(for: comment)
+                let renderer = WebCommentContentRenderer()
+                renderer.tintColor = UIAppColor.primary
+                renderer.delegate = self
+                return renderer
             case .richContent(let attributedText):
                 let renderer = RichCommentContentRenderer()
                 renderer.richContentDelegate = self.richContentDelegate
                 renderer.attributedText = attributedText
                 renderer.comment = comment
+                renderer.delegate = self
                 return renderer
             }
-        }()
-        renderer.delegate = self
-
-        self.renderMethod = renderMethod // we assume the render method can't change
+        }
 
         if renderMethod == .web {
             // reset height constraint to handle cases where the new content requires the webview to shrink.

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/ContentRenderer/RichCommentContentRenderer.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/ContentRenderer/RichCommentContentRenderer.swift
@@ -21,6 +21,10 @@ class RichCommentContentRenderer: NSObject, CommentContentRenderer {
         textView.attributedText = attributedText
         textView.delegate = self
     }
+
+    func prepareForReuse() {
+        // Do nothing
+    }
 }
 
 // MARK: - WPRichContentViewDelegate

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsHelper.swift
@@ -4,7 +4,7 @@ import WordPressReader
 /// A collection of utilities for managing rendering for comments.
 @MainActor
 @objc class ReaderCommentsHelper: NSObject {
-    private var contentHeights: [TaggedManagedObjectID<Comment>: CGFloat] = [:]
+    private var contentHeights: [String: CGFloat] = [:]
     private let webViewContext = WebCommentContentRenderer.Context()
 
     func makeWebRenderer() -> WebCommentContentRenderer {
@@ -13,11 +13,11 @@ import WordPressReader
         return renderer
     }
 
-    func getCachedContentHeight(for commentID: TaggedManagedObjectID<Comment>) -> CGFloat? {
-        contentHeights[commentID]
+    func getCachedContentHeight(for comment: String) -> CGFloat? {
+        contentHeights[comment]
     }
 
-    func setCachedContentHeight(_ height: CGFloat, for commentID: TaggedManagedObjectID<Comment>) {
-        contentHeights[commentID] = height
+    func setCachedContentHeight(_ height: CGFloat, for comment: String) {
+        contentHeights[comment] = height
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsHelper.swift
@@ -5,6 +5,13 @@ import WordPressReader
 @MainActor
 @objc class ReaderCommentsHelper: NSObject {
     private var contentHeights: [TaggedManagedObjectID<Comment>: CGFloat] = [:]
+    private let webViewContext = WebCommentContentRenderer.Context()
+
+    func makeWebRenderer() -> WebCommentContentRenderer {
+        let renderer = WebCommentContentRenderer(context: webViewContext)
+        renderer.tintColor = UIAppColor.primary
+        return renderer
+    }
 
     func getCachedContentHeight(for commentID: TaggedManagedObjectID<Comment>) -> CGFloat? {
         contentHeights[commentID]

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsHelper.swift
@@ -5,21 +5,6 @@ import WordPressReader
 @MainActor
 @objc class ReaderCommentsHelper: NSObject {
     private var contentHeights: [TaggedManagedObjectID<Comment>: CGFloat] = [:]
-    private let renderers = NSCache<Comment, WebCommentContentRenderer>()
-
-    override init() {
-        renderers.countLimit = 30
-    }
-
-    func getRenderer(for comment: Comment) -> WebCommentContentRenderer {
-        if let renderer = renderers.object(forKey: comment) {
-            return renderer
-        }
-        let renderer = WebCommentContentRenderer()
-        renderer.tintColor = UIAppColor.primary
-        renderers.setObject(renderer, forKey: comment)
-        return renderer
-    }
 
     func getCachedContentHeight(for commentID: TaggedManagedObjectID<Comment>) -> CGFloat? {
         contentHeights[commentID]

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -455,7 +455,6 @@
 
 - (void)refreshAfterCommentModeration
 {
-    [self.tableViewController.tableView reloadData];
     [self refreshNoResultsView];
 }
 
@@ -465,8 +464,6 @@
 }
 
 - (void)refreshTableViewAndNoResultsView:(BOOL)scrollToHighlightedComment {
-    // TODO: remove
-    [self.tableViewController.tableView reloadData];
     [self refreshNoResultsView];
 
     if (scrollToHighlightedComment) {


### PR DESCRIPTION
This PR contains a set of new optimizations to make WebKit-based comments fully viable. It used to be visibly slow in a simulator, but it no longer is:

https://github.com/user-attachments/assets/0aaddd89-6659-4bdf-a36c-ca7681bf90c5

## Changes:

- Thanks to https://github.com/wordpress-mobile/WordPress-iOS/pull/24047, I was able to remove shared cache from `ReaderCommentsHelper`. The rendered are now managed and reused by individual cells. The screen now uses only around 9 web views.
- Remove remaining blank table view `reloadData` calls to eliminate unnecessary reloads
- Reuse `WKProcessPool` across multiple web views, which is what Apple [recommends](https://developer.apple.com/documentation/webkit/wkprocesspool). I tried to measure it, but because it runs out of process, so it’s a hard to do.
- Fix cell reuse and height calculations
- Cancel loading when cells are reused


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
