### PR TITLE
Add initial CommentCellViewModel implementation

### DIFF
--- a/WordPress/Classes/Models/Comment/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment/Comment+CoreDataClass.swift
@@ -20,7 +20,7 @@ public class Comment: NSManagedObject {
         return status.isEqual(to: CommentStatusType.approved.description)
     }
 
-    @objc func isReadOnly() -> Bool {
+    private func isReadOnly() -> Bool {
         guard let blog else {
             return true
         }
@@ -77,8 +77,8 @@ public class Comment: NSManagedObject {
     }
 
     func canReply() -> Bool {
-        if let readerPost = post as? ReaderPost {
-            return readerPost.commentsOpen
+        if let post = post as? ReaderPost {
+            return post.commentsOpen
         }
         return !isReadOnly()
     }

--- a/WordPress/Classes/Models/Comment/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment/Comment+CoreDataClass.swift
@@ -54,10 +54,6 @@ public class Comment: NSManagedObject {
         return status.isEqual(to: Comment.descriptionFor(.spam)) || status.isEqual(to: Comment.descriptionFor(.unapproved))
     }
 
-    func numberOfLikes() -> Int {
-        return Int(likeCount)
-    }
-
     func canEditAuthorData() -> Bool {
         // If the authorID is zero, the user is unregistered. Therefore, the data can be edited.
         return authorID == 0

--- a/WordPress/Classes/Models/Comment/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment/Comment+CoreDataClass.swift
@@ -78,23 +78,20 @@ public class Comment: NSManagedObject {
 
     func canReply() -> Bool {
         if let readerPost = post as? ReaderPost {
-            return readerPost.commentsOpen && ReaderHelpers.isLoggedIn()
+            return readerPost.commentsOpen
         }
-
         return !isReadOnly()
     }
 
     // NOTE: Comment Likes could be disabled, but the API doesn't have that info yet. Let's update this once it's available.
     func canLike() -> Bool {
-        if let _ = post as? ReaderPost {
-            return ReaderHelpers.isLoggedIn()
+        if (post as? ReaderPost) != nil {
+            return true
         }
-
         guard let blog else {
             // Disable likes feature for self-hosted sites.
             return false
         }
-
         return !isReadOnly() && blog.supports(.commentLikes)
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
@@ -429,7 +429,8 @@ private extension CommentDetailViewController {
     }
 
     func configureContentCell(_ cell: CommentContentTableViewCell, comment: Comment) {
-        let viewModel = CommentCellViewModel(comment: comment)
+        let viewModel = CommentCellViewModel(comment: comment, notification: notification)
+
         cell.configure(viewModel: viewModel, helper: helper) { [weak self] _ in
             self?.tableView.performBatchUpdates({})
         }
@@ -443,10 +444,6 @@ private extension CommentDetailViewController {
         cell.accessoryButtonType = .info
         cell.accessoryButtonAction = { [weak self] senderView in
             self?.presentUserInfoSheet(senderView)
-        }
-
-        cell.likeButtonAction = { [weak self] in
-            self?.toggleCommentLike()
         }
 
         cell.replyButtonAction = { [weak self] in
@@ -650,33 +647,6 @@ private extension CommentDetailViewController {
                                                                         comment: "Error displayed if a comment fails to get updated")
                                         self?.displayNotice(title: message)
                                      })
-    }
-
-    func toggleCommentLike() {
-        guard let siteID else {
-            refreshData() // revert the like button state.
-            return
-        }
-
-        if comment.isLiked {
-            isNotificationComment ? WPAppAnalytics.track(.notificationsCommentUnliked, withBlogID: notification?.metaSiteID) :
-                                    CommentAnalytics.trackCommentUnLiked(comment: comment)
-        } else {
-            isNotificationComment ? WPAppAnalytics.track(.notificationsCommentLiked, withBlogID: notification?.metaSiteID) :
-                                    CommentAnalytics.trackCommentLiked(comment: comment)
-        }
-
-        commentService.toggleLikeStatus(for: comment, siteID: siteID, success: { [weak self] in
-            guard let self, let notification = self.notification else {
-                return
-            }
-            let mediator = NotificationSyncMediator()
-            mediator?.invalidateCacheForNotification(notification.notificationId, completion: {
-                mediator?.syncNote(with: notification.notificationId)
-            })
-        }, failure: { _ in
-            self.refreshData() // revert the like button state.
-        })
     }
 
     @objc func shareCommentURL(_ barButtonItem: UIBarButtonItem) {

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
@@ -429,7 +429,8 @@ private extension CommentDetailViewController {
     }
 
     func configureContentCell(_ cell: CommentContentTableViewCell, comment: Comment) {
-        cell.configure(with: comment, helper: helper) { [weak self] _ in
+        let viewModel = CommentCellViewModel(comment: comment)
+        cell.configure(viewModel: viewModel, helper: helper) { [weak self] _ in
             self?.tableView.performBatchUpdates({})
         }
 

--- a/WordPress/Classes/ViewRelated/Comments/Style/WPStyleGuide+CommentDetail.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Style/WPStyleGuide+CommentDetail.swift
@@ -24,7 +24,6 @@ extension WPStyleGuide {
 
         public struct Content {
             static let buttonTintColor: UIColor = .secondaryLabel
-            static let likedTintColor: UIColor = UIAppColor.primary
 
             static let nameFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
             static let nameTextColor = CommentDetail.textColor

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentCellViewModel.swift
@@ -21,10 +21,14 @@ final class CommentCellViewModel: NSObject {
     // MARK: State
 
     struct State: Hashable {
+        let title: String
+        let dateCreated: Date?
         var isLiked: Bool
         var likeCount: Int
 
         init(comment: Comment) {
+            self.title = comment.authorForDisplay()
+            self.dateCreated = comment.dateCreated
             self.isLiked = comment.isLiked
             self.likeCount = Int(comment.likeCount)
         }

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentCellViewModel.swift
@@ -29,12 +29,16 @@ final class CommentCellViewModel: NSObject {
         var dateCreated: Date?
         var isLiked: Bool
         var likeCount: Int
+        var isLikeEnabled: Bool
+        var isReplyEnabled: Bool
 
         init(comment: Comment) {
             self.title = comment.authorForDisplay()
             self.dateCreated = comment.dateCreated
             self.isLiked = comment.isLiked
             self.likeCount = Int(comment.likeCount)
+            self.isLikeEnabled = comment.canLike()
+            self.isReplyEnabled = comment.canReply()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentCellViewModel.swift
@@ -7,12 +7,16 @@ final class CommentCellViewModel: NSObject {
     private let notification: Notification?
     private let coreDataStack = ContextManager.shared
 
+    @Published private(set) var avatar: Avatar?
     @Published private(set) var state: State
 
     init(comment: Comment, notification: Notification? = nil) {
         self.comment = comment
         self.notification = notification
+
         self.state = State(comment: comment)
+        self.avatar = Avatar(comment: comment)
+
         super.init()
 
         NotificationCenter.default.addObserver(self, selector: #selector(objectDidChange), name: .NSManagedObjectContextObjectsDidChange, object: comment.managedObjectContext)
@@ -21,8 +25,8 @@ final class CommentCellViewModel: NSObject {
     // MARK: State
 
     struct State: Hashable {
-        let title: String
-        let dateCreated: Date?
+        var title: String
+        var dateCreated: Date?
         var isLiked: Bool
         var likeCount: Int
 
@@ -34,6 +38,23 @@ final class CommentCellViewModel: NSObject {
         }
     }
 
+    enum Avatar: Hashable {
+        case url(URL)
+        case email(String)
+
+        init?(comment: Comment) {
+            if let imageURL = comment.avatarURLForDisplay() {
+                self = .url(imageURL)
+            }
+            let email = comment.gravatarEmailForDisplay()
+            guard !email.isEmpty else {
+                return nil
+            }
+            self = .email(email)
+        }
+    }
+
+    /// This method emits changes only when something actually changes in the object.
     @objc private func objectDidChange(_ notification: Foundation.Notification) {
         wpAssert(Thread.isMainThread)
 
@@ -47,6 +68,11 @@ final class CommentCellViewModel: NSObject {
         let state = State(comment: comment)
         if state != self.state {
             self.state = state
+        }
+
+        let avatar = Avatar(comment: comment)
+        if avatar != self.avatar {
+            self.avatar = avatar
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentCellViewModel.swift
@@ -7,6 +7,7 @@ final class CommentCellViewModel: NSObject {
     private let notification: Notification?
     private let coreDataStack = ContextManager.shared
 
+    @Published private(set) var content: String?
     @Published private(set) var avatar: Avatar?
     @Published private(set) var state: State
 
@@ -14,6 +15,7 @@ final class CommentCellViewModel: NSObject {
         self.comment = comment
         self.notification = notification
 
+        self.content = comment.content
         self.state = State(comment: comment)
         self.avatar = Avatar(comment: comment)
 
@@ -77,6 +79,10 @@ final class CommentCellViewModel: NSObject {
         let avatar = Avatar(comment: comment)
         if avatar != self.avatar {
             self.avatar = avatar
+        }
+
+        if comment.content != self.content {
+            self.content = comment.content
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentCellViewModel.swift
@@ -1,14 +1,52 @@
 import Foundation
+import Combine
 
 final class CommentCellViewModel: NSObject {
     @objc let comment: Comment
+
     private let notification: Notification?
     private let coreDataStack = ContextManager.shared
 
-    init(comment: Comment, notification: Notification?) {
+    @Published private(set) var state: State
+
+    init(comment: Comment, notification: Notification? = nil) {
         self.comment = comment
         self.notification = notification
+        self.state = State(comment: comment)
+        super.init()
+
+        NotificationCenter.default.addObserver(self, selector: #selector(objectDidChange), name: .NSManagedObjectContextObjectsDidChange, object: comment.managedObjectContext)
     }
+
+    // MARK: State
+
+    struct State: Hashable {
+        var isLiked: Bool
+        var likeCount: Int
+
+        init(comment: Comment) {
+            self.isLiked = comment.isLiked
+            self.likeCount = Int(comment.likeCount)
+        }
+    }
+
+    @objc private func objectDidChange(_ notification: Foundation.Notification) {
+        wpAssert(Thread.isMainThread)
+
+        let updated = notification.userInfo?[NSUpdatedObjectsKey] as? Set<NSManagedObject>
+        let refreshed = notification.userInfo?[NSRefreshedObjectsKey] as? Set<NSManagedObject>
+
+        guard updated?.contains(comment) ?? refreshed?.contains(comment) ?? false else {
+            return
+        }
+
+        let state = State(comment: comment)
+        if state != self.state {
+            self.state = state
+        }
+    }
+
+    // MARK: Actions
 
     func buttonLikeTapped() {
         guard let siteID else {

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentCellViewModel.swift
@@ -2,8 +2,57 @@ import Foundation
 
 final class CommentCellViewModel: NSObject {
     @objc let comment: Comment
+    private let notification: Notification?
+    private let coreDataStack = ContextManager.shared
 
-    init(comment: Comment) {
+    init(comment: Comment, notification: Notification?) {
         self.comment = comment
+        self.notification = notification
     }
+
+    func buttonLikeTapped() {
+        guard let siteID else {
+            return wpAssertionFailure("context missing")
+        }
+        if comment.isLiked {
+            notification != nil ? WPAppAnalytics.track(.notificationsCommentUnliked, withBlogID: siteID) : CommentAnalytics.trackCommentUnLiked(comment: comment)
+        } else {
+            notification != nil ? WPAppAnalytics.track(.notificationsCommentLiked, withBlogID: siteID) : CommentAnalytics.trackCommentLiked(comment: comment)
+        }
+
+        let service = CommentService(coreDataStack: coreDataStack)
+        if !comment.isLiked {
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+        }
+        service.toggleLikeStatus(for: comment, siteID: siteID, success: { [weak self] in
+            self?.didToggleLike()
+        }, failure: { error in
+            Notice(title: Strings.failedToLike, message: error?.localizedDescription).post()
+            UINotificationFeedbackGenerator().notificationOccurred(.error)
+        })
+    }
+
+    private func didToggleLike() {
+        guard let notification, let mediator = NotificationSyncMediator() else { return }
+        mediator.invalidateCacheForNotification(notification.notificationId) {
+            mediator.syncNote(with: notification.notificationId)
+        }
+    }
+
+    private var siteID: NSNumber? {
+        if let siteID = (comment.post as? ReaderPost)?.siteID {
+            return siteID
+        }
+        if let siteID = comment.blog?.dotComID {
+            return siteID
+        }
+        if let siteID = notification?.metaSiteID {
+            return siteID
+        }
+        return nil
+    }
+}
+
+private enum Strings {
+    static let failedToLike = NSLocalizedString("comments.failedToLike", value: "Failed to like comment", comment: "Error title")
 }

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentCellViewModel.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+final class CommentCellViewModel: NSObject {
+    @objc let comment: Comment
+
+    init(comment: Comment) {
+        self.comment = comment
+    }
+}

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -190,6 +190,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         self.comment = comment
         self.viewModel = viewModel
         self.helper = helper
+        self.onContentLoaded = onContentLoaded
 
         viewModel.$state.sink { [weak self] in
             self?.configure(with: $0)
@@ -199,15 +200,15 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
             self?.configureAvatar(with: $0)
         }.store(in: &cancellables)
 
+        viewModel.$content.sink { [weak self] in
+            self?.configureContent($0 ?? "", renderMethod: renderMethod, helper: helper)
+        }.store(in: &cancellables)
+
         // Configure feature availability.
         isAccessoryButtonEnabled = comment.isApproved()
 
         // When reaction bar is hidden, add some space between the webview and the moderation bar.
         containerStackView.setCustomSpacing(contentButtonsTopSpacing, after: contentContainerView)
-
-        // Configure content renderer.
-        self.onContentLoaded = onContentLoaded
-        configureRenderer(for: comment, renderMethod: renderMethod, helper: helper)
     }
 
     /// Configures the cell with a `Comment` object, to be displayed in the post details view.
@@ -445,7 +446,7 @@ private extension CommentContentTableViewCell {
 
     // MARK: Content Rendering
 
-    func configureRenderer(for comment: Comment, renderMethod: RenderMethod, helper: ReaderCommentsHelper) {
+    func configureContent(_ content: String, renderMethod: RenderMethod, helper: ReaderCommentsHelper) {
         if self.renderMethod != renderMethod {
             self.renderer = nil
         }
@@ -467,7 +468,7 @@ private extension CommentContentTableViewCell {
                 let renderer = RichCommentContentRenderer()
                 renderer.richContentDelegate = self.richContentDelegate
                 renderer.attributedText = attributedText
-                renderer.comment = comment
+                renderer.comment = viewModel?.comment
                 renderer.delegate = self
                 return renderer
             }
@@ -476,7 +477,7 @@ private extension CommentContentTableViewCell {
         if renderMethod == .web {
             // reset height constraint to handle cases where the new content requires the webview to shrink.
             contentContainerHeightConstraint?.isActive = true
-            contentContainerHeightConstraint?.constant = helper.getCachedContentHeight(for: comment.content) ?? 20
+            contentContainerHeightConstraint?.constant = helper.getCachedContentHeight(for: content) ?? 20
         } else {
             contentContainerHeightConstraint?.isActive = false
         }
@@ -488,7 +489,7 @@ private extension CommentContentTableViewCell {
             contentContainerView?.addSubview(contentView)
             contentView.pinEdges()
         }
-        renderer.render(comment: comment.content)
+        renderer.render(comment: content)
     }
 
     // MARK: Button Actions

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -28,8 +28,6 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
     @objc var replyButtonAction: (() -> Void)? = nil
 
-    @objc var likeButtonAction: (() -> Void)? = nil
-
     @objc var contentLinkTapAction: ((URL) -> Void)? = nil
 
     @objc weak var richContentDelegate: WPRichContentViewDelegate? = nil
@@ -176,7 +174,6 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         // reset all button actions.
         accessoryButtonAction = nil
         replyButtonAction = nil
-        likeButtonAction = nil
         contentLinkTapAction = nil
 
         onContentLoaded = nil
@@ -544,7 +541,7 @@ private extension CommentContentTableViewCell {
 
     @objc func likeButtonTapped() {
         updateLikeButton(liked: !isLiked, numberOfLikes: isLiked ? likeCount - 1 : likeCount + 1, animated: true)
-        likeButtonAction?()
+        viewModel?.buttonLikeTapped()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -165,6 +165,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
         viewModel = nil
         cancellables = []
+        avatarImageView.wp.prepareForReuse()
         renderer?.prepareForReuse()
 
         // reset all highlight states.
@@ -206,20 +207,9 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
             self?.configure(with: $0)
         }.store(in: &cancellables)
 
-        // Always cancel ongoing image downloads, just in case. This is to prevent comment cells being displayed with the wrong avatar image,
-        // likely resulting from previous download operation before the cell is reused.
-        //
-        // Note that when downloading an image, any ongoing operation will be cancelled in UIImageView+Networking.
-        // This is more of a preventative step where the cancellation is made to happen as early as possible.
-        //
-        // Ref: https://github.com/wordpress-mobile/WordPress-iOS/issues/17972
-        avatarImageView.cancelImageDownload()
-
-        if let avatarURL = URL(string: comment.authorAvatarURL) {
-            configureImage(with: avatarURL)
-        } else {
-            configureImageWithGravatarEmail(comment.gravatarEmailForDisplay())
-        }
+        viewModel.$avatar.sink { [weak self] in
+            self?.configureAvatar(with: $0)
+        }.store(in: &cancellables)
 
         // Configure feature availability.
         isCommentReplyEnabled = comment.canReply()
@@ -266,7 +256,6 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     private func configure(with state: CommentCellViewModel.State) {
         nameLabel.text = state.title
         dateLabel.text = state.dateCreated?.toMediumString()
-
         updateLikeButton(isLiked: state.isLiked, likeCount: state.likeCount)
     }
 }
@@ -423,28 +412,22 @@ private extension CommentContentTableViewCell {
         dateLabel?.textColor = style.dateTextColor
     }
 
-    /// Configures the avatar image view with the provided URL.
-    /// If the URL does not contain any image, the default placeholder image will be displayed.
-    /// - Parameter url: The URL containing the image.
-    func configureImage(with url: URL?) {
-        if let someURL = url, let gravatar = AvatarURL(url: someURL) {
-            avatarImageView.downloadGravatar(gravatar, placeholder: Style.placeholderImage, animate: true)
+    private func configureAvatar(with avatar: CommentCellViewModel.Avatar?) {
+        guard let avatar else {
+            avatarImageView.wp.prepareForReuse()
             return
         }
-
-        // handle non-gravatar images
-        avatarImageView.downloadImage(from: url, placeholderImage: Style.placeholderImage)
-    }
-
-    /// Configures the avatar image view from Gravatar based on provided email.
-    /// If the Gravatar image for the provided email doesn't exist, the default placeholder image will be displayed.
-    /// - Parameter gravatarEmail: The email to be used for querying the Gravatar image.
-    func configureImageWithGravatarEmail(_ email: String?) {
-        guard let someEmail = email else {
-            return
+        switch avatar {
+        case .url(let imageURL):
+            if let gravatar = AvatarURL(url: imageURL) {
+                avatarImageView.downloadGravatar(gravatar, placeholder: Style.placeholderImage, animate: false)
+            } else {
+                avatarImageView.image = Style.placeholderImage
+                avatarImageView.wp.setImage(with: imageURL)
+            }
+        case .email(let email):
+            avatarImageView.downloadGravatar(for: email, placeholderImage: Style.placeholderImage)
         }
-
-        avatarImageView.downloadGravatar(for: someEmail, placeholderImage: Style.placeholderImage)
     }
 
     func updateContainerLeadingConstraint() {

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -2,6 +2,7 @@ import UIKit
 import WordPressUI
 import WordPressReader
 import Gravatar
+import Combine
 
 class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
@@ -116,12 +117,9 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     private var renderMethod: RenderMethod?
     private var helper: ReaderCommentsHelper?
     private var viewModel: CommentCellViewModel?
+    private var cancellables: [AnyCancellable] = []
 
     // MARK: Like Button State
-
-    private var isLiked: Bool = false
-
-    private var likeCount: Int = 0
 
     /// Styling configuration based on `ReaderDisplaySetting`. The parameter is optional so that the styling approach
     /// can be scoped by using the "legacy" style when the passed parameter is nil.
@@ -166,6 +164,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         super.prepareForReuse()
 
         viewModel = nil
+        cancellables = []
         renderer?.prepareForReuse()
 
         // reset all highlight states.
@@ -206,6 +205,10 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         nameLabel?.setText(comment.authorForDisplay())
         dateLabel?.setText(comment.dateForDisplay()?.toMediumString() ?? String())
 
+        viewModel.$state.sink { [weak self] in
+            self?.configure(with: $0)
+        }.store(in: &cancellables)
+
         // Always cancel ongoing image downloads, just in case. This is to prevent comment cells being displayed with the wrong avatar image,
         // likely resulting from previous download operation before the cell is reused.
         //
@@ -220,8 +223,6 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         } else {
             configureImageWithGravatarEmail(comment.gravatarEmailForDisplay())
         }
-
-        updateLikeButton(liked: comment.isLiked, numberOfLikes: comment.numberOfLikes())
 
         // Configure feature availability.
         isCommentReplyEnabled = comment.canReply()
@@ -263,6 +264,10 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         default:
             return
         }
+    }
+
+    private func configure(with state: CommentCellViewModel.State) {
+        updateLikeButton(isLiked: state.isLiked, likeCount: state.likeCount)
     }
 }
 
@@ -353,17 +358,6 @@ private extension CommentContentTableViewCell {
         }
     }
 
-    var likeButtonTitle: String {
-        switch likeCount {
-        case .zero:
-            return .noLikes
-        case 1:
-            return String(format: .singularLikeFormat, likeCount)
-        default:
-            return String(format: .pluralLikesFormat, likeCount)
-        }
-    }
-
     // assign base styles for all the cell components.
     func configureViews() {
         // Store default margin for use in content layout.
@@ -399,7 +393,6 @@ private extension CommentContentTableViewCell {
 
         likeButton.addTarget(self, action: #selector(likeButtonTapped), for: .touchUpInside)
         likeButton.maximumContentSizeCategory = .accessibilityMedium
-        updateLikeButton(liked: false, numberOfLikes: 0)
         likeButton.accessibilityIdentifier = .likeButtonAccessibilityId
 
         separatorView.layoutMargins = .init(top: 0, left: 20, bottom: 0, right: 0).flippedForRightToLeft
@@ -458,27 +451,22 @@ private extension CommentContentTableViewCell {
         containerStackLeadingConstraint?.constant = (indentationWidth * CGFloat(indentationLevel)) + defaultLeadingMargin
     }
 
-    /// Updates the style and text of the Like button.
-    /// - Parameters:
-    ///   - liked: Represents the target state – true if the comment is liked, or should be false otherwise.
-    ///   - numberOfLikes: The number of likes to be displayed.
-    ///   - animated: Whether the Like button state change should be animated or not. Defaults to false.
-    ///   - completion: Completion block called once the animation is completed. Defaults to nil.
-    func updateLikeButton(liked: Bool, numberOfLikes: Int, animated: Bool = false) {
-        isLiked = liked
-        likeCount = numberOfLikes
-        likeButton.tintColor = liked ? Style.likedTintColor : .label
+    func updateLikeButton(isLiked: Bool, likeCount: Int) {
+        likeButton.tintColor = isLiked ? UIAppColor.primary : .label
         if var configuration = likeButton.configuration {
-            configuration.image = UIImage(systemName: liked ? "star.fill" : "star")
-            configuration.title = likeButtonTitle
+            configuration.image = UIImage(systemName: isLiked ? "star.fill" : "star")
+            configuration.title = {
+                switch likeCount {
+                case .zero: .noLikes
+                case 1: String(format: .singularLikeFormat, likeCount)
+                default: String(format: .pluralLikesFormat, likeCount)
+                }
+            }()
             likeButton.configuration = configuration
         } else {
             wpAssertionFailure("missing configuration")
         }
-        likeButton.accessibilityLabel = liked ? String(numberOfLikes) + .commentIsLiked : String(numberOfLikes) + .commentIsNotLiked
-        if liked && animated {
-            likeButton.imageView?.fadeInWithRotationAnimation()
-        }
+        likeButton.accessibilityLabel = isLiked ? String(likeCount) + .commentIsLiked : String(likeCount) + .commentIsNotLiked
     }
 
     // MARK: Content Rendering
@@ -540,8 +528,18 @@ private extension CommentContentTableViewCell {
     }
 
     @objc func likeButtonTapped() {
-        updateLikeButton(liked: !isLiked, numberOfLikes: isLiked ? likeCount - 1 : likeCount + 1, animated: true)
-        viewModel?.buttonLikeTapped()
+        guard let viewModel else {
+            return wpAssertionFailure("ViewModel missing")
+        }
+        if !viewModel.state.isLiked, let imageView = likeButton.imageView {
+            // Animate the changes and then update the model to avoid animation interruptions
+            updateLikeButton(isLiked: true, likeCount: viewModel.state.likeCount + 1)
+            imageView.fadeInWithRotationAnimation { _ in
+                viewModel.buttonLikeTapped()
+            }
+        } else {
+            viewModel.buttonLikeTapped()
+        }
     }
 }
 
@@ -554,8 +552,6 @@ private extension String {
     static let likeButtonAccessibilityId = "like-comment-button"
     static let reply = NSLocalizedString("Reply", comment: "Reply to a comment.")
     static let noLikes = NSLocalizedString("Like", comment: "Button title to Like a comment.")
-    static let singularLikeFormat = NSLocalizedString("%1$d Like", comment: "Singular button title to Like a comment. "
-                                                        + "%1$d is a placeholder for the number of Likes.")
-    static let pluralLikesFormat = NSLocalizedString("%1$d Likes", comment: "Plural button title to Like a comment. "
-                                                + "%1$d is a placeholder for the number of Likes.")
+    static let singularLikeFormat = NSLocalizedString("%1$d Like", comment: "Singular button title to Like a comment. %1$d is a placeholder for the number of Likes.")
+    static let pluralLikesFormat = NSLocalizedString("%1$d Likes", comment: "Plural button title to Like a comment. %1$d is a placeholder for the number of Likes.")
 }

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -117,6 +117,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     private var renderer: CommentContentRenderer?
     private var renderMethod: RenderMethod?
     private var helper: ReaderCommentsHelper?
+    private var viewModel: CommentCellViewModel?
 
     // MARK: Like Button State
 
@@ -166,6 +167,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     override func prepareForReuse() {
         super.prepareForReuse()
 
+        viewModel = nil
         renderer?.prepareForReuse()
 
         // reset all highlight states.
@@ -194,12 +196,14 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     ///   - renderMethod: Specifies how to display the comment body. See `RenderMethod`.
     ///   - onContentLoaded: Callback to be called once the content has been loaded. Provides the new content height as parameter.
     func configure(
-        with comment: Comment,
+        viewModel: CommentCellViewModel,
         renderMethod: RenderMethod = .web,
         helper: ReaderCommentsHelper,
         onContentLoaded: ((CGFloat) -> Void)?
     ) {
+        let comment = viewModel.comment
         self.comment = comment
+        self.viewModel = viewModel
         self.helper = helper
 
         nameLabel?.setText(comment.authorForDisplay())
@@ -241,7 +245,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     ///   - comment: The `Comment` object to display.
     ///   - onContentLoaded: Callback to be called once the content has been loaded. Provides the new content height as parameter.
     func configureForPostDetails(with comment: Comment, helper: ReaderCommentsHelper, onContentLoaded: ((CGFloat) -> Void)?) {
-        configure(with: comment, helper: helper, onContentLoaded: onContentLoaded)
+        configure(viewModel: CommentCellViewModel(comment: comment), helper: helper, onContentLoaded: onContentLoaded)
 
         isCommentLikesEnabled = false
         isCommentReplyEnabled = false

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -207,7 +207,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
         // Configure content renderer.
         self.onContentLoaded = onContentLoaded
-        configureRendererIfNeeded(for: comment, renderMethod: renderMethod, helper: helper)
+        configureRenderer(for: comment, renderMethod: renderMethod, helper: helper)
     }
 
     /// Configures the cell with a `Comment` object, to be displayed in the post details view.
@@ -445,7 +445,7 @@ private extension CommentContentTableViewCell {
 
     // MARK: Content Rendering
 
-    func configureRendererIfNeeded(for comment: Comment, renderMethod: RenderMethod, helper: ReaderCommentsHelper) {
+    func configureRenderer(for comment: Comment, renderMethod: RenderMethod, helper: ReaderCommentsHelper) {
         if self.renderMethod != renderMethod {
             self.renderer = nil
         }

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -134,18 +134,6 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
     // MARK: Visibility Control
 
-    private var isCommentReplyEnabled: Bool = false {
-        didSet {
-            replyButton.isHidden = !isCommentReplyEnabled
-        }
-    }
-
-    private var isCommentLikesEnabled: Bool = false {
-        didSet {
-            likeButton.isHidden = !isCommentLikesEnabled
-        }
-    }
-
     private var isAccessoryButtonEnabled: Bool = false {
         didSet {
             accessoryButton.isHidden = !isAccessoryButtonEnabled
@@ -212,8 +200,6 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         }.store(in: &cancellables)
 
         // Configure feature availability.
-        isCommentReplyEnabled = comment.canReply()
-        isCommentLikesEnabled = comment.canLike()
         isAccessoryButtonEnabled = comment.isApproved()
 
         // When reaction bar is hidden, add some space between the webview and the moderation bar.
@@ -232,8 +218,9 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     func configureForPostDetails(with comment: Comment, helper: ReaderCommentsHelper, onContentLoaded: ((CGFloat) -> Void)?) {
         configure(viewModel: CommentCellViewModel(comment: comment), helper: helper, onContentLoaded: onContentLoaded)
 
-        isCommentLikesEnabled = false
-        isCommentReplyEnabled = false
+        replyButton.isHidden = true
+        likeButton.isHidden = true
+
         isAccessoryButtonEnabled = false
 
         shouldHideSeparator = true
@@ -256,6 +243,10 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     private func configure(with state: CommentCellViewModel.State) {
         nameLabel.text = state.title
         dateLabel.text = state.dateCreated?.toMediumString()
+
+        replyButton.isHidden = !state.isReplyEnabled
+        likeButton.isHidden = !state.isLikeEnabled
+
         updateLikeButton(isLiked: state.isLiked, likeCount: state.likeCount)
     }
 }

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -202,9 +202,6 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         self.viewModel = viewModel
         self.helper = helper
 
-        nameLabel?.setText(comment.authorForDisplay())
-        dateLabel?.setText(comment.dateForDisplay()?.toMediumString() ?? String())
-
         viewModel.$state.sink { [weak self] in
             self?.configure(with: $0)
         }.store(in: &cancellables)
@@ -267,6 +264,9 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     }
 
     private func configure(with state: CommentCellViewModel.State) {
+        nameLabel.text = state.title
+        dateLabel.text = state.dateCreated?.toMediumString()
+
         updateLikeButton(isLiked: state.isLiked, likeCount: state.likeCount)
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
@@ -9,6 +9,7 @@ final class ReaderCommentsTableViewController: UIViewController, UITableViewData
 
     private let post: ReaderPost
     private let commentCellReuseID = "commentCellReuseID"
+    private var viewModels: [NSManagedObjectID: CommentCellViewModel] = [:]
     private let moc = ContextManager.shared.mainContext
 
     /// - note: Temporary code.
@@ -167,8 +168,18 @@ final class ReaderCommentsTableViewController: UIViewController, UITableViewData
         let cell = tableView.dequeueReusableCell(withIdentifier: commentCellReuseID, for: indexPath) as! CommentContentTableViewCell
         cell.selectionStyle = .none
         let comment = fetchResultsController.object(at: indexPath)
-        containerViewController?.configureCell(cell, comment: comment, indexPath: indexPath)
+        let viewModel = makeCellViewModel(comment: comment)
+        containerViewController?.configureCell(cell, viewModel: viewModel, indexPath: indexPath)
         return cell
+    }
+
+    private func makeCellViewModel(comment: Comment) -> CommentCellViewModel {
+        if let viewModel = viewModels[comment.objectID] {
+            return viewModel
+        }
+        let viewModel = CommentCellViewModel(comment: comment)
+        viewModels[comment.objectID] = viewModel
+        return viewModel
     }
 
     // MARK: - UITableViewDataDelegate

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.h
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.h
@@ -14,6 +14,7 @@ typedef NS_ENUM(NSUInteger, ReaderCommentsSource) {
 };
 
 @class Comment;
+@class CommentCellViewModel;
 @class CommentContentTableViewCell;
 @class ReaderPost;
 @class ReaderCommentsHelper;
@@ -40,7 +41,7 @@ typedef NS_ENUM(NSUInteger, ReaderCommentsSource) {
 - (void)refreshAfterCommentModeration;
 - (NSAttributedString *)cacheContentForComment:(Comment *)comment;
 - (void)trackReplyTo:(BOOL)replyTarget;
-- (void)configureCell:(CommentContentTableViewCell *)cell comment:(Comment *)comment indexPath:(NSIndexPath *)indexPath;
+- (void)configureCell:(CommentContentTableViewCell *)cell viewModel:(CommentCellViewModel *)viewModel indexPath:(NSIndexPath *)indexPath;
 - (UIView *)cachedHeaderView;
 - (void)loadMore;
 - (void)highlightCommentAtIndexPath:(NSIndexPath *)indexPath;

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -606,7 +606,7 @@
     return [[ContextManager sharedInstance] mainContext];
 }
 
-- (void)configureCell:(CommentContentTableViewCell *)cell comment:(Comment *)comment indexPath:(NSIndexPath *)indexPath
+- (void)configureCell:(CommentContentTableViewCell *)cell viewModel:(CommentCellViewModel *)viewModel indexPath:(NSIndexPath *)indexPath
 {
     // When backgrounding, the app takes a snapshot, which triggers a layout pass,
     // which refreshes the cells, and for some reason triggers an assertion failure
@@ -622,7 +622,9 @@
         return;
     }
 
-    [self configureContentCell:cell comment:comment indexPath:indexPath tableView:self.tableViewController.tableView];
+    Comment *comment = viewModel.comment;
+
+    [self configureContentCell:cell viewModel:viewModel indexPath:indexPath tableView:self.tableViewController.tableView];
 
     if (self.highlightedIndexPath) {
         cell.isEmphasized = (indexPath == self.highlightedIndexPath);

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -143,21 +143,6 @@
 
 #pragma mark - Tracking methods
 
-- (void)trackCommentLikedOrUnliked:(Comment *) comment {
-    ReaderPost *post = self.post;
-    WPAnalyticsStat stat;
-    if (comment.isLiked) {
-        stat = WPAnalyticsStatReaderArticleCommentLiked;
-    } else {
-        stat = WPAnalyticsStatReaderArticleCommentUnliked;
-    }
-
-    NSMutableDictionary *properties = [NSMutableDictionary dictionary];
-    properties[WPAppAnalyticsKeyPostID] = post.postID;
-    properties[WPAppAnalyticsKeyBlogID] = post.siteID;
-    [WPAnalytics trackReaderStat:stat properties:properties];
-}
-
 - (void)trackReplyTo:(BOOL)replyTarget {
     ReaderPost *post = self.post;
     NSDictionary *railcar = post.railcarDictionary;
@@ -516,24 +501,6 @@
     }
 }
 
-- (void)didTapLikeForComment:(Comment *)comment atIndexPath:(NSIndexPath *)indexPath
-{
-    CommentService *commentService = [[CommentService alloc] initWithCoreDataStack:[ContextManager sharedInstance]];
-
-    if (!comment.isLiked) {
-        [[UINotificationFeedbackGenerator new] notificationOccurred:UINotificationFeedbackTypeSuccess];
-    }
-
-    __typeof(self) __weak weakSelf = self;
-    [commentService toggleLikeStatusForComment:comment siteID:self.post.siteID success:^{
-        [weakSelf trackCommentLikedOrUnliked:comment];
-    } failure:^(NSError * __unused error) {
-        // in case of failure, revert the cell's like state.
-        [weakSelf.tableView reloadRowsAtIndexPaths:@[indexPath] withRowAnimation:UITableViewRowAnimationAutomatic];
-        [[UINotificationFeedbackGenerator new] notificationOccurred:UINotificationFeedbackTypeError];
-    }];
-}
-
 #pragma mark - Sync methods
 
 - (void)syncHelper:(WPContentSyncHelper *)syncHelper syncContentWithUserInteraction:(BOOL)userInteraction success:(void (^)(BOOL))success failure:(void (^)(NSError *))failure
@@ -644,10 +611,6 @@
 
     cell.replyButtonAction = ^{
         [weakSelf didTapReplyAtIndexPath:indexPath];
-    };
-
-    cell.likeButtonAction = ^{
-        [weakSelf didTapLikeForComment:comment atIndexPath:indexPath];
     };
 
     cell.contentLinkTapAction = ^(NSURL * _Nonnull url) {

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -98,10 +98,11 @@ extension NSNotification.Name {
 
     func configureContentCell(
         _ cell: CommentContentTableViewCell,
-        comment: Comment,
+        viewModel: CommentCellViewModel,
         indexPath: IndexPath,
         tableView: UITableView
     ) {
+        let comment = viewModel.comment
         cell.badgeTitle = comment.isFromPostAuthor() ? .authorBadgeText : nil
         cell.indentationWidth = Constants.indentationWidth
         cell.indentationLevel = min(Constants.maxIndentationLevel, Int(comment.depth))
@@ -113,7 +114,7 @@ extension NSNotification.Name {
         cell.accessoryButton.showsMenuAsPrimaryAction = isModerationMenuEnabled(for: comment)
         cell.accessoryButton.menu = isModerationMenuEnabled(for: comment) ? menu(for: comment, indexPath: indexPath, tableView: tableView, sourceView: cell.accessoryButton) : nil
         let renderMethod: CommentContentTableViewCell.RenderMethod = Feature.enabled(.readerCommentsWebKit) ? .web : .richContent(self.cacheContent(for: comment))
-        cell.configure(with: comment, renderMethod: renderMethod, helper: helper) { [weak tableView] _ in
+        cell.configure(viewModel: viewModel, renderMethod: renderMethod, helper: helper) { [weak tableView] _ in
             guard let tableView else { return }
 
             if tableView.alpha == 0 {


### PR DESCRIPTION
In the previous PRs, I removed blank `reloadData` calls. To replace them, I'm adding `CommentCellViewModel` that will perform targeted update for only things that change and when they change.

The ViewModel also makes comment cells self-contained so that they can be easily reused across screens (`ReaderCommentsViewController,` `CommentDetailViewController,` `ReaderDetailViewController`). It also allowed me to removed a bit more of the Objective-C code from `ReaderCommentsViewController`.

The ViewModel also abstracts the Core Data objects away from the UI, so it will be easy to replace them in the future with a new data layer, which is evidently the plan.

##To test:

- Test liking comments from both the Notifications tab and the Comments in Reader

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
