### PR TITLE
fix: Prevent editor more menu crash

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [*] Enable dismissing the virtual keyboard in the experimental editor [#23988]
 * [*] Remove Submit Feedback form from the Me menu [#24020]
 * [*] Fix unselectable group blocks in the experimental editor [https://github.com/wordpress-mobile/GutenbergKit/pull/68]
+* [*] Prevent a intermittent crash when opening the experimental editor's "more" menu [#24065]
 
 25.7
 -----

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -614,11 +614,11 @@ extension NewGutenbergViewController: PostEditorNavigationBarManagerDelegate {
     }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, moreWasPressed sender: UIButton) {
-        fatalError("not supported")
+        // Currently unsupported, do nothing.
     }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, displayCancelMediaUploads sender: UIButton) {
-        fatalError("not supported")
+        // Currently unsupported, do nothing.
     }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, publishButtonWasPressed sender: UIButton) {


### PR DESCRIPTION
The previous temporary code was never removed, leading to a fatal crash.
The usage of a no-op avoids crashes until we refactor the surrounding
code.

Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/24052.

To test:

1. Open the experimental editor.
1. Rapidly open and close the "more" menu found in the top-right corner.

## Regression Notes
1. Potential unintended areas of impact
    None likely.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    N/A.
3. What automated tests I added (or what prevented me from doing so)
    N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
