### PR TITLE
WebKit Comments Enhancements 

### DIFF
--- a/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
@@ -69,8 +69,7 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
     public func render(comment: String) {
         self.comment = comment
 
-        // - important: `wordPressSharedBundle` contains custom fonts
-        webView.loadHTMLString(formattedHTMLString(for: comment), baseURL: Bundle.wordPressSharedBundle.bundleURL)
+        webView.loadHTMLString(formattedHTMLString(for: comment), baseURL: nil)
     }
 
     public func prepareForReuse() {

--- a/Modules/Sources/WordPressReader/Resources/gutenbergContentStyles.css
+++ b/Modules/Sources/WordPressReader/Resources/gutenbergContentStyles.css
@@ -1,27 +1,3 @@
-@font-face {
-    font-family: 'Noto Serif';
-    src: local('NotoSerif-Regular'), url('NotoSerif-Regular.ttf') format('truetype');
-}
-
-@font-face {
-    font-family: 'Noto Serif';
-    src: local('NotoSerif-Bold'), url('NotoSerif-Bold.ttf') format('truetype');
-    font-weight: bold;
-}
-
-@font-face {
-    font-family: 'Noto Serif';
-    src: local('NotoSerif-Italic'), url('NotoSerif-Italic.ttf') format('truetype');
-    font-style: italic;
-}
-
-@font-face {
-    font-family: 'Noto Serif';
-    src: local('NotoSerif-BoldItalic'), url('NotoSerif-BoldItalic.ttf') format('truetype');
-    font-weight: bold;
-    font-style: italic;
-}
-
 :root {
     /* informs WebKit that this template supports both appearance modes. */
     color-scheme: light dark;

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -52,7 +52,7 @@ enum FeatureFlag: Int, CaseIterable {
         case .selfHostedSiteUserManagement:
             return false
         case .readerCommentsWebKit:
-            return false
+            return BuildConfiguration.current != .appStore
         case .pluginManagementOverhaul:
             return false
         }

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentComposerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentComposerViewController.swift
@@ -118,10 +118,7 @@ final class CommentComposerViewController: UIViewController {
     }
 
     private func setLoading(_ isLoading: Bool) {
-        buttonSend.configuration?.showsActivityIndicator = isLoading
-        buttonSend.configuration?.title = isLoading ? nil : Strings.send
-        buttonSend.isEnabled = isLoading
-        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: buttonSend) // Update layout
+        navigationItem.rightBarButtonItem = isLoading ? .activityIndicator : UIBarButtonItem(customView: buttonSend)
         navigationItem.leftBarButtonItem?.isEnabled = !isLoading
         textView.resignFirstResponder()
         textView.alpha = isLoading ? 0.5 : 1.0
@@ -157,7 +154,6 @@ final class CommentComposerViewController: UIViewController {
 
         navigationItem.leftBarButtonItem = UIBarButtonItem(title: SharedStrings.Button.cancel, style: .plain, target: self, action: #selector(buttonCancelTapped))
 
-        buttonSend.heightAnchor.constraint(equalToConstant: 36).isActive = true
         navigationItem.rightBarButtonItem = UIBarButtonItem(customView: buttonSend)
         buttonSend.addTarget(self, action: #selector(buttonSendTapped), for: .primaryActionTriggered)
     }

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentComposerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentComposerViewController.swift
@@ -12,6 +12,8 @@ final class CommentComposerViewController: UIViewController {
         var configuration = UIButton.Configuration.borderedProminent()
         configuration.title = Strings.send
         configuration.cornerStyle = .capsule
+        configuration.baseBackgroundColor = UIColor.label
+        configuration.baseForegroundColor = UIColor.systemBackground
         return configuration
     }())
 

--- a/WordPress/Classes/ViewRelated/Comments/Style/WPStyleGuide+CommentDetail.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Style/WPStyleGuide+CommentDetail.swift
@@ -23,8 +23,6 @@ extension WPStyleGuide {
         }
 
         public struct Content {
-            static let buttonTintColor: UIColor = .secondaryLabel
-
             static let nameFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
             static let nameTextColor = CommentDetail.textColor
 

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentCellViewModel.swift
@@ -51,12 +51,13 @@ final class CommentCellViewModel: NSObject {
         init?(comment: Comment) {
             if let imageURL = comment.avatarURLForDisplay() {
                 self = .url(imageURL)
+            } else {
+                let email = comment.gravatarEmailForDisplay()
+                guard !email.isEmpty else {
+                    return nil
+                }
+                self = .email(email)
             }
-            let email = comment.gravatarEmailForDisplay()
-            guard !email.isEmpty else {
-                return nil
-            }
-            self = .email(email)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -477,6 +477,9 @@ private extension CommentContentTableViewCell {
         if renderMethod == .web {
             // reset height constraint to handle cases where the new content requires the webview to shrink.
             contentContainerHeightConstraint?.isActive = true
+            // - warning: It's important to set height to the minimum supported
+            // value because `WKWebView` can only increase the content height and
+            // never decreases it when the content changes.
             contentContainerHeightConstraint?.constant = helper.getCachedContentHeight(for: content) ?? 20
         } else {
             contentContainerHeightConstraint?.isActive = false

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -358,19 +358,19 @@ private extension CommentContentTableViewCell {
         dateLabel?.font = style.dateFont
         dateLabel?.textColor = style.dateTextColor
 
-        accessoryButton?.tintColor = Style.buttonTintColor
+        accessoryButton?.tintColor = .secondaryLabel
         accessoryButton?.setImage(accessoryButtonImage, for: .normal)
         accessoryButton?.addTarget(self, action: #selector(accessoryButtonTapped), for: .touchUpInside)
 
         replyButton.configuration = makeReactionButtonConfiguration(systemImage: "arrowshape.turn.up.left")
-        replyButton.tintColor = .label
+        replyButton.tintColor = .secondaryLabel
         replyButton.setTitle(.reply, for: .normal)
         replyButton.addTarget(self, action: #selector(replyButtonTapped), for: .touchUpInside)
         replyButton.maximumContentSizeCategory = .accessibilityMedium
         replyButton.accessibilityIdentifier = .replyButtonAccessibilityId
 
         likeButton.configuration = makeReactionButtonConfiguration(systemImage: "star")
-        likeButton.tintColor = .label
+        likeButton.tintColor = .secondaryLabel
 
         likeButton.addTarget(self, action: #selector(likeButtonTapped), for: .touchUpInside)
         likeButton.maximumContentSizeCategory = .accessibilityMedium
@@ -383,15 +383,16 @@ private extension CommentContentTableViewCell {
 
     private func makeReactionButtonConfiguration(systemImage: String) -> UIButton.Configuration {
         var configuration = UIButton.Configuration.plain()
+        let font = UIFont.preferredFont(forTextStyle: .footnote)
         configuration.image = UIImage(systemName: systemImage)
-        configuration.imagePlacement = .top
-        configuration.imagePadding = 5
+        configuration.imagePlacement = .leading
+        configuration.imagePadding = 6
         configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer {
             var attributes = $0
-            attributes.font = UIFont.preferredFont(forTextStyle: .footnote)
+            attributes.font = font
             return attributes
         }
-        configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(font: UIFont.preferredFont(forTextStyle: .caption1))
+        configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(font: font)
         return configuration
     }
 
@@ -427,10 +428,11 @@ private extension CommentContentTableViewCell {
     }
 
     func updateLikeButton(isLiked: Bool, likeCount: Int) {
-        likeButton.tintColor = isLiked ? UIAppColor.primary : .label
+        likeButton.tintColor = isLiked ? UIAppColor.primary : .secondaryLabel
         if var configuration = likeButton.configuration {
             configuration.image = UIImage(systemName: isLiked ? "star.fill" : "star")
-            configuration.title = {
+            configuration.title = likeCount > 0 ? "\(likeCount)" : nil
+            likeButton.accessibilityLabel = {
                 switch likeCount {
                 case .zero: .noLikes
                 case 1: String(format: .singularLikeFormat, likeCount)

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -79,10 +79,6 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         }
     }
 
-    // MARK: Constants
-
-    private let contentButtonsTopSpacing: CGFloat = 15
-
     // MARK: Outlets
 
     @IBOutlet private weak var containerStackView: UIStackView!
@@ -197,9 +193,6 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
         // Configure feature availability.
         isAccessoryButtonEnabled = comment.isApproved()
-
-        // When reaction bar is hidden, add some space between the webview and the moderation bar.
-        containerStackView.setCustomSpacing(contentButtonsTopSpacing, after: contentContainerView)
     }
 
     /// Configures the cell with a `Comment` object, to be displayed in the post details view.
@@ -214,8 +207,6 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
         likeButton.isHidden = true
 
         isAccessoryButtonEnabled = false
-
-        shouldHideSeparator = true
 
         containerStackLeadingConstraint.constant = 0
         containerStackTrailingConstraint.constant = 0
@@ -354,6 +345,7 @@ private extension CommentContentTableViewCell {
         accessoryButton?.addTarget(self, action: #selector(accessoryButtonTapped), for: .touchUpInside)
 
         replyButton.configuration = makeReactionButtonConfiguration(systemImage: "arrowshape.turn.up.left")
+        replyButton.configuration?.contentInsets.leading = 0
         replyButton.tintColor = .secondaryLabel
         replyButton.setTitle(.reply, for: .normal)
         replyButton.addTarget(self, action: #selector(replyButtonTapped), for: .touchUpInside)
@@ -366,8 +358,6 @@ private extension CommentContentTableViewCell {
         likeButton.addTarget(self, action: #selector(likeButtonTapped), for: .touchUpInside)
         likeButton.maximumContentSizeCategory = .accessibilityMedium
         likeButton.accessibilityIdentifier = .likeButtonAccessibilityId
-
-        separatorView.layoutMargins = .init(top: 0, left: 20, bottom: 0, right: 0).flippedForRightToLeft
 
         applyStyles()
     }
@@ -383,6 +373,7 @@ private extension CommentContentTableViewCell {
             attributes.font = font
             return attributes
         }
+        configuration.contentInsets = .init(top: 12, leading: 8, bottom: 12, trailing: 8)
         configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(font: font)
         return configuration
     }

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -86,8 +86,6 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     // MARK: Outlets
 
     @IBOutlet private weak var containerStackView: UIStackView!
-    @IBOutlet private weak var containerStackBottomConstraint: NSLayoutConstraint!
-
     @IBOutlet private weak var containerStackLeadingConstraint: NSLayoutConstraint!
     @IBOutlet private weak var containerStackTrailingConstraint: NSLayoutConstraint!
     private var defaultLeadingMargin: CGFloat = 0
@@ -105,7 +103,6 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     @IBOutlet private weak var likeButton: UIButton!
 
     @IBOutlet private weak var highlightBarView: UIView!
-    @IBOutlet private weak var separatorView: UIView!
 
     // MARK: Private Properties
 
@@ -137,12 +134,6 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
     private var isAccessoryButtonEnabled: Bool = false {
         didSet {
             accessoryButton.isHidden = !isAccessoryButtonEnabled
-        }
-    }
-
-    var shouldHideSeparator = false {
-        didSet {
-            separatorView.isHidden = shouldHideSeparator
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.xib
@@ -28,31 +28,31 @@
                         </constraints>
                     </view>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="hcN-S7-sLG" userLabel="Container Stack View">
-                        <rect key="frame" x="16" y="0.0" width="288" height="330"/>
+                        <rect key="frame" x="16" y="0.0" width="288" height="336"/>
                         <subviews>
                             <view contentMode="scaleToFill" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="f2E-yC-BJS" userLabel="Header View">
-                                <rect key="frame" x="0.0" y="0.0" width="288" height="119"/>
+                                <rect key="frame" x="0.0" y="0.0" width="288" height="53"/>
                                 <subviews>
                                     <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="9QY-3I-cxv" userLabel="Avatar Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="18" width="38" height="38"/>
+                                        <rect key="frame" x="0.0" y="11.5" width="28" height="28"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="9QY-3I-cxv" secondAttribute="height" multiplier="1:1" id="3HU-89-TeJ"/>
-                                            <constraint firstAttribute="width" constant="38" id="Apb-Vu-nw6"/>
+                                            <constraint firstAttribute="width" constant="28" id="Apb-Vu-nw6"/>
                                         </constraints>
                                     </imageView>
-                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="2" translatesAutoresizingMaskIntoConstraints="NO" id="CzL-pe-Tnr" userLabel="Name Stack View">
-                                        <rect key="frame" x="48" y="18" width="208" height="36"/>
+                                    <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="CzL-pe-Tnr" userLabel="Name Stack View">
+                                        <rect key="frame" x="38" y="8" width="218" height="35"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="po6-3F-ppN" userLabel="Name Container View">
-                                                <rect key="frame" x="0.0" y="0.0" width="208" height="18"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="218" height="18"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="761" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HpE-B7-6wr" userLabel="Name Label">
-                                                        <rect key="frame" x="0.0" y="0.0" width="169.5" height="18"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="179.5" height="18"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Badge" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hDo-cU-sWp" userLabel="Badge Label" customClass="BadgeLabel" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="174.5" y="1" width="33.5" height="13.5"/>
+                                                        <rect key="frame" x="184.5" y="2" width="33.5" height="13.5"/>
                                                         <color key="backgroundColor" name="Blue50"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
                                                         <color key="textColor" name="White"/>
@@ -62,7 +62,7 @@
                                                                 <real key="value" value="5"/>
                                                             </userDefinedRuntimeAttribute>
                                                             <userDefinedRuntimeAttribute type="number" keyPath="cornerRadius">
-                                                                <real key="value" value="3"/>
+                                                                <real key="value" value="5"/>
                                                             </userDefinedRuntimeAttribute>
                                                             <userDefinedRuntimeAttribute type="number" keyPath="verticalPadding">
                                                                 <real key="value" value="1"/>
@@ -77,12 +77,12 @@
                                                     <constraint firstItem="HpE-B7-6wr" firstAttribute="leading" secondItem="po6-3F-ppN" secondAttribute="leading" id="a9I-ZO-CNF"/>
                                                     <constraint firstAttribute="bottom" secondItem="HpE-B7-6wr" secondAttribute="bottom" id="d2g-ej-XWq"/>
                                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="HpE-B7-6wr" secondAttribute="trailing" id="p0y-Cp-XXb"/>
-                                                    <constraint firstItem="hDo-cU-sWp" firstAttribute="firstBaseline" secondItem="HpE-B7-6wr" secondAttribute="firstBaseline" constant="-3" id="pzL-bf-kIJ"/>
+                                                    <constraint firstItem="hDo-cU-sWp" firstAttribute="firstBaseline" secondItem="HpE-B7-6wr" secondAttribute="firstBaseline" constant="-2" id="pzL-bf-kIJ"/>
                                                     <constraint firstItem="hDo-cU-sWp" firstAttribute="leading" secondItem="HpE-B7-6wr" secondAttribute="trailing" constant="5" id="zBO-4n-va3"/>
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ghT-Xy-q8c" userLabel="Date Label">
-                                                <rect key="frame" x="0.0" y="20" width="208" height="16"/>
+                                                <rect key="frame" x="0.0" y="19" width="218" height="16"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <color key="textColor" systemColor="secondaryLabelColor"/>
                                                 <nil key="highlightedColor"/>
@@ -90,7 +90,7 @@
                                         </subviews>
                                     </stackView>
                                     <button hidden="YES" opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="1G8-cc-t5d" userLabel="Accessory Button">
-                                        <rect key="frame" x="256" y="15" width="44" height="44"/>
+                                        <rect key="frame" x="256" y="3.5" width="44" height="44"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="1G8-cc-t5d" secondAttribute="height" multiplier="1:1" id="1CB-OD-6k3"/>
                                             <constraint firstAttribute="height" constant="44" id="L5a-rf-l5V"/>
@@ -106,42 +106,43 @@
                                     </button>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="CzL-pe-Tnr" secondAttribute="bottom" constant="15" id="FLO-bi-cgb"/>
-                                    <constraint firstItem="CzL-pe-Tnr" firstAttribute="top" secondItem="9QY-3I-cxv" secondAttribute="top" id="Fs5-LK-eAC"/>
+                                    <constraint firstAttribute="height" priority="149" id="Ap1-2V-eIl"/>
+                                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="CzL-pe-Tnr" secondAttribute="bottom" constant="8" id="FLO-bi-cgb"/>
+                                    <constraint firstItem="CzL-pe-Tnr" firstAttribute="centerY" secondItem="9QY-3I-cxv" secondAttribute="centerY" id="KkE-Do-0L9"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="CzL-pe-Tnr" secondAttribute="trailing" id="R3L-jf-zLP"/>
-                                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="9QY-3I-cxv" secondAttribute="bottom" priority="750" constant="15" id="S4y-cM-fX9"/>
-                                    <constraint firstItem="9QY-3I-cxv" firstAttribute="top" secondItem="f2E-yC-BJS" secondAttribute="top" constant="18" id="VRu-Tu-EzK"/>
+                                    <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="9QY-3I-cxv" secondAttribute="bottom" priority="750" constant="8" id="S4y-cM-fX9"/>
+                                    <constraint firstItem="9QY-3I-cxv" firstAttribute="top" relation="greaterThanOrEqual" secondItem="f2E-yC-BJS" secondAttribute="top" constant="8" id="VRu-Tu-EzK"/>
                                     <constraint firstItem="1G8-cc-t5d" firstAttribute="centerY" secondItem="9QY-3I-cxv" secondAttribute="centerY" id="iiu-dq-fba"/>
                                     <constraint firstItem="1G8-cc-t5d" firstAttribute="leading" secondItem="CzL-pe-Tnr" secondAttribute="trailing" id="kMf-Ux-GI7"/>
                                     <constraint firstItem="9QY-3I-cxv" firstAttribute="leading" secondItem="f2E-yC-BJS" secondAttribute="leading" id="mzW-Rh-t4b"/>
-                                    <constraint firstItem="CzL-pe-Tnr" firstAttribute="top" relation="greaterThanOrEqual" secondItem="f2E-yC-BJS" secondAttribute="top" constant="18" id="pAn-nJ-PTk"/>
+                                    <constraint firstItem="CzL-pe-Tnr" firstAttribute="top" relation="greaterThanOrEqual" secondItem="f2E-yC-BJS" secondAttribute="top" constant="8" id="pAn-nJ-PTk"/>
                                     <constraint firstItem="CzL-pe-Tnr" firstAttribute="leading" secondItem="9QY-3I-cxv" secondAttribute="trailing" constant="10" id="shs-JU-Qg8"/>
                                     <constraint firstAttribute="trailing" secondItem="1G8-cc-t5d" secondAttribute="trailing" constant="-12" id="xTt-ug-Tgu"/>
                                 </constraints>
                             </view>
                             <view contentMode="scaleToFill" verticalHuggingPriority="252" translatesAutoresizingMaskIntoConstraints="NO" id="M0y-BK-TEh" userLabel="Content Container View">
-                                <rect key="frame" x="0.0" y="119" width="288" height="0.0"/>
+                                <rect key="frame" x="0.0" y="53" width="288" height="0.0"/>
                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <constraints>
                                     <constraint firstAttribute="height" id="t5W-a4-bo7"/>
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="QT8-DO-J30" userLabel="Reaction Stack View">
-                                <rect key="frame" x="0.0" y="119" width="288" height="211"/>
+                                <rect key="frame" x="0.0" y="53" width="288" height="283"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="761" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VoI-YI-Qgc" userLabel="Reply Button">
-                                        <rect key="frame" x="0.0" y="90.5" width="208" height="30"/>
+                                        <rect key="frame" x="0.0" y="126.5" width="208" height="30"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <color key="tintColor" systemColor="secondaryLabelColor"/>
                                         <inset key="titleEdgeInsets" minX="2" minY="0.0" maxX="0.0" maxY="0.0"/>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="762" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X2J-8b-R5F" userLabel="Like Button">
-                                        <rect key="frame" x="208" y="90.5" width="30" height="30"/>
+                                        <rect key="frame" x="208" y="126.5" width="30" height="30"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <color key="tintColor" systemColor="secondaryLabelColor"/>
                                     </button>
                                     <view contentMode="scaleToFill" horizontalHuggingPriority="1" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="8GH-U7-J7H" userLabel="Spacer View">
-                                        <rect key="frame" x="238" y="80.5" width="50" height="50"/>
+                                        <rect key="frame" x="238" y="116.5" width="50" height="50"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="50" placeholder="YES" id="4wt-Z8-Xp5"/>
@@ -154,7 +155,7 @@
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="trailing" secondItem="hcN-S7-sLG" secondAttribute="trailing" constant="16" id="2zy-oR-X5O"/>
-                    <constraint firstAttribute="bottom" secondItem="hcN-S7-sLG" secondAttribute="bottom" constant="10" id="FxL-ee-fbZ"/>
+                    <constraint firstAttribute="bottom" secondItem="hcN-S7-sLG" secondAttribute="bottom" priority="999" constant="4" id="FxL-ee-fbZ"/>
                     <constraint firstItem="mNJ-fg-sKO" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="II8-F0-CBs"/>
                     <constraint firstItem="mNJ-fg-sKO" firstAttribute="leading" secondItem="H2p-sc-9uM" secondAttribute="leading" id="eId-Od-5wj"/>
                     <constraint firstItem="hcN-S7-sLG" firstAttribute="top" secondItem="H2p-sc-9uM" secondAttribute="top" id="esQ-oB-yxJ"/>

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.xib
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23094" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="23504" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23084"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="23506"/>
         <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
@@ -127,21 +127,21 @@
                                 </constraints>
                             </view>
                             <stackView opaque="NO" contentMode="scaleToFill" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="QT8-DO-J30" userLabel="Reaction Stack View">
-                                <rect key="frame" x="0.0" y="119" width="288" height="210"/>
+                                <rect key="frame" x="0.0" y="119" width="288" height="211"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="761" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="VoI-YI-Qgc" userLabel="Reply Button">
-                                        <rect key="frame" x="0.0" y="90" width="208" height="30"/>
+                                        <rect key="frame" x="0.0" y="90.5" width="208" height="30"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <color key="tintColor" systemColor="secondaryLabelColor"/>
                                         <inset key="titleEdgeInsets" minX="2" minY="0.0" maxX="0.0" maxY="0.0"/>
                                     </button>
                                     <button opaque="NO" contentMode="scaleToFill" horizontalHuggingPriority="762" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="X2J-8b-R5F" userLabel="Like Button">
-                                        <rect key="frame" x="208" y="90" width="30" height="30"/>
+                                        <rect key="frame" x="208" y="90.5" width="30" height="30"/>
                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                         <color key="tintColor" systemColor="secondaryLabelColor"/>
                                     </button>
                                     <view contentMode="scaleToFill" horizontalHuggingPriority="1" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="8GH-U7-J7H" userLabel="Spacer View">
-                                        <rect key="frame" x="238" y="80" width="50" height="50"/>
+                                        <rect key="frame" x="238" y="80.5" width="50" height="50"/>
                                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="50" placeholder="YES" id="4wt-Z8-Xp5"/>
@@ -149,13 +149,6 @@
                                     </view>
                                 </subviews>
                             </stackView>
-                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="qId-Th-B9r">
-                                <rect key="frame" x="0.0" y="329" width="288" height="1"/>
-                                <color key="backgroundColor" systemColor="systemGray5Color"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" constant="1" id="HnG-UL-I2f"/>
-                                </constraints>
-                            </view>
                         </subviews>
                     </stackView>
                 </subviews>
@@ -184,13 +177,12 @@
                 <outlet property="likeButton" destination="X2J-8b-R5F" id="6w2-io-GXb"/>
                 <outlet property="nameLabel" destination="HpE-B7-6wr" id="MLa-k9-IlC"/>
                 <outlet property="replyButton" destination="VoI-YI-Qgc" id="Z9J-Tp-bur"/>
-                <outlet property="separatorView" destination="qId-Th-B9r" id="VEc-Bb-Zi6"/>
             </connections>
             <point key="canvasLocation" x="153.62318840579712" y="329.46428571428572"/>
         </tableViewCell>
     </objects>
     <resources>
-        <image name="gravatar" width="32" height="32"/>
+        <image name="gravatar" width="85" height="85"/>
         <image name="square.and.arrow.up" catalog="system" width="110" height="128"/>
         <namedColor name="Blue50">
             <color red="0.023529411764705882" green="0.45882352941176469" blue="0.7686274509803922" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -199,13 +191,10 @@
             <color red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </namedColor>
         <systemColor name="secondaryLabelColor">
-            <color red="0.23529411759999999" green="0.23529411759999999" blue="0.26274509800000001" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
+            <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
         <systemColor name="systemBackgroundColor">
             <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
-        </systemColor>
-        <systemColor name="systemGray5Color">
-            <color red="0.8980392157" green="0.8980392157" blue="0.91764705879999997" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>
     </resources>
 </document>

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsHelper.swift
@@ -20,4 +20,8 @@ import WordPressReader
     func setCachedContentHeight(_ height: CGFloat, for comment: String) {
         contentHeights[comment] = height
     }
+
+    func resetCachedContentHeights() {
+        contentHeights.removeAll()
+    }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
@@ -74,6 +74,23 @@ final class ReaderCommentsTableViewController: UIViewController, UITableViewData
         tableView.delegate = self
     }
 
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        guard let previous = previousTraitCollection else {
+            return
+        }
+        let current = traitCollection
+
+        guard previous.horizontalSizeClass != current.horizontalSizeClass ||
+                previous.preferredContentSizeCategory != current.preferredContentSizeCategory else {
+            return
+        }
+
+        containerViewController?.helper.resetCachedContentHeights() // important
+        tableView.reloadData()
+    }
+
     // MARK: - Actions
 
     @objc func comment(at indexPath: IndexPath) -> Comment? {

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
@@ -139,10 +139,10 @@ final class ReaderCommentsTableViewController: UIViewController, UITableViewData
         switch type {
         case .insert:
             guard let newIndexPath else { return }
-            tableView.insertRows(at: [newIndexPath], with: .automatic)
+            tableView.insertRows(at: [newIndexPath], with: .none)
         case .delete:
             guard let indexPath else { return }
-            tableView.deleteRows(at: [indexPath], with: .automatic)
+            tableView.deleteRows(at: [indexPath], with: .none)
         case .update:
             // The cells are responsible for updating themselves
             break
@@ -155,7 +155,9 @@ final class ReaderCommentsTableViewController: UIViewController, UITableViewData
     }
 
     func controllerDidChangeContent(_ controller: NSFetchedResultsController<any NSFetchRequestResult>) {
-        tableView.endUpdates()
+        UIView.performWithoutAnimation {
+            tableView.endUpdates()
+        }
     }
 
     // MARK: - UITableViewDataSource

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -19,7 +19,6 @@
 @property (nonatomic, strong) NSNumber *postSiteID;
 @property (nonatomic, strong) WPContentSyncHelper *syncHelper;
 @property (nonatomic, strong) UITableView *tableView;
-@property (nonatomic, strong) NoResultsViewController *noResultsViewController;
 @property (nonatomic, strong) UIView *buttonAddComment;
 @property (nonatomic, strong) NSLayoutConstraint *replyTextViewHeightConstraint;
 @property (nonatomic) BOOL isLoggedIn;
@@ -36,6 +35,8 @@
 
 /// A cached instance for the new comment header view.
 @property (nonatomic, strong) UIView *cachedHeaderView;
+@property (nonatomic, strong) UIActivityIndicatorView *activityIndicator;
+@property (nonatomic, strong) UIView *emptyStateView;
 
 @property (nonatomic, strong) NSIndexPath *highlightedIndexPath;
 
@@ -79,9 +80,9 @@
     [self checkIfLoggedIn];
 
     [self configureNavbar];
-    [self configureNoResultsView];
     [self configureCommentButton];
     [self configureViewConstraints];
+    self.activityIndicator = [self makeActivityIndicator];
 
     [self listenForClipboardChanges];
 }
@@ -175,11 +176,6 @@
     [self refreshFollowButton];
 }
 
-- (void)configureNoResultsView
-{
-    self.noResultsViewController = [NoResultsViewController controller];
-}
-
 - (void)configureCommentButton
 {
     self.buttonAddComment = [self makeCommentButton];
@@ -204,22 +200,9 @@
     // If we couldn't fetch the comments lets let the user know
     if (self.fetchCommentsError != nil) {
         return NSLocalizedString(@"There has been an unexpected error while loading the comments.", @"Message shown when comments for a post can not be loaded.");
-    }
-    // Let's just display the same message, for consistency's sake
-    else if (self.isLoadingPost || self.syncHelper.isSyncing) {
-        return NSLocalizedString(@"Fetching comments...", @"A brief prompt shown when the comment list is empty, letting the user know the app is currently fetching new comments.");
     } else {
         return NSLocalizedString(@"Be the first to leave a comment.", @"Message shown encouraging the user to leave a comment on a post in the reader.");
     }
-}
-
-- (UIView *)noResultsAccessoryView
-{
-    UIView *loadingAccessoryView = nil;
-    if ((self.isLoadingPost || self.syncHelper.isSyncing) && self.fetchCommentsError == nil) {
-        loadingAccessoryView = [NoResultsViewController loadingAccessoryView];
-    }
-    return loadingAccessoryView;
 }
 
 - (void)checkIfLoggedIn
@@ -392,55 +375,39 @@
     [self.tableViewController setLoadingFooterHidden:YES];
 }
 
-- (void)refreshNoResultsView
+- (void)refreshEmptyStateView
 {
-    [self.noResultsViewController removeFromView];
+    [self.activityIndicator stopAnimating];
+    [self.emptyStateView removeFromSuperview];
+    self.emptyStateView = nil;
 
     BOOL isTableViewEmpty = self.tableViewController.isEmpty;
     if (!isTableViewEmpty) {
         return;
     }
 
-    NSString *image = nil;
-    NSString *subtitle = nil;
-    if (self.fetchCommentsError != nil) {
-        image = @"wp-illustration-reader-empty";
-        NSError *error = self.fetchCommentsError;
-        if (error && [error.domain isEqualToString:WordPressComRestApiErrorDomain] && error.code == WordPressComRestApiErrorCodeAuthorizationRequired) {
-            subtitle = NSLocalizedString(@"You don't have permission to view this private blog.",
-                                          @"Error message that informs reader comments from a private blog cannot be fetched.");
-
-        }
-    }
-    [self.noResultsViewController configureWithTitle:self.noResultsTitleText
-                                     attributedTitle:nil
-                                   noConnectionTitle:nil
-                                         buttonTitle:nil
-                                            subtitle:subtitle
-                                noConnectionSubtitle:nil
-                                  attributedSubtitle:nil
-                     attributedSubtitleConfiguration:nil
-                                               image:image
-                                       subtitleImage:nil
-                                       accessoryView:[self noResultsAccessoryView]];
-
-    [self.noResultsViewController hideImageView:NO];
-    [self addChildViewController:self.noResultsViewController];
-
-    // when the table view is not yet properly initialized, use the view's frame instead to prevent wrong frame values.
-    if (self.tableView.window == nil) {
-        self.noResultsViewController.view.frame = self.view.frame;
+    if (self.isLoadingPost || self.syncHelper.isSyncing) {
+        [self.activityIndicator startAnimating];
     } else {
-        self.noResultsViewController.view.frame = self.tableView.frame;
-    }
+        NSString *subtitle = nil;
+        if (self.fetchCommentsError != nil) {
+            NSError *error = self.fetchCommentsError;
+            if (error && [error.domain isEqualToString:WordPressComRestApiErrorDomain] && error.code == WordPressComRestApiErrorCodeAuthorizationRequired) {
+                subtitle = NSLocalizedString(@"You don't have permission to view this private blog.",
+                                             @"Error message that informs reader comments from a private blog cannot be fetched.");
 
-    [self.view insertSubview:self.noResultsViewController.view belowSubview:self.buttonAddComment];
-    [self.noResultsViewController didMoveToParentViewController:self];
+            }
+        }
+        self.emptyStateView = [self makeEmptyStateViewWithTitle:self.noResultsTitleText imageName:@"wp-illustration-reader-empty" description:subtitle];
+        [self.view addSubview:self.emptyStateView];
+        self.emptyStateView.translatesAutoresizingMaskIntoConstraints = NO;
+        [self.view pinSubviewToAllEdges:self.emptyStateView];
+    }
 }
 
 - (void)refreshAfterCommentModeration
 {
-    [self refreshNoResultsView];
+    [self refreshEmptyStateView];
 }
 
 - (void)updateTableViewForAttachments
@@ -449,7 +416,7 @@
 }
 
 - (void)refreshTableViewAndNoResultsView:(BOOL)scrollToHighlightedComment {
-    [self refreshNoResultsView];
+    [self refreshEmptyStateView];
 
     if (scrollToHighlightedComment) {
         [self navigateToCommentIDIfNeeded];
@@ -514,7 +481,7 @@
         }
     } failure:failure];
 
-    [self refreshNoResultsView];
+    [self refreshEmptyStateView];
 }
 
 - (void)syncHelper:(WPContentSyncHelper *)syncHelper syncMoreWithSuccess:(void (^)(BOOL))success failure:(void (^)(NSError *))failure

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -552,7 +552,7 @@
     // reason: 'unexpected start state'
     // This seems like a framework bug, so to avoid it skip configuring cells
     // while the app is backgrounded.
-    if ([[UIApplication sharedApplication] applicationState] == UIApplicationStateBackground) {
+    if (![Feature enabled:FeatureFlagReaderCommentsWebKit] && [[UIApplication sharedApplication] applicationState] == UIApplicationStateBackground) {
         return;
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -399,7 +399,7 @@
             }
         }
         self.emptyStateView = [self makeEmptyStateViewWithTitle:self.noResultsTitleText imageName:@"wp-illustration-reader-empty" description:subtitle];
-        [self.view addSubview:self.emptyStateView];
+        [self.view insertSubview:self.emptyStateView belowSubview:self.buttonAddComment];
         self.emptyStateView.translatesAutoresizingMaskIntoConstraints = NO;
         [self.view pinSubviewToAllEdges:self.emptyStateView];
     }

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -131,7 +131,6 @@ extension NSNotification.Name {
         cell.indentationWidth = Constants.indentationWidth
         cell.indentationLevel = min(Constants.maxIndentationLevel, Int(comment.depth))
         cell.accessoryButtonType = isModerationMenuEnabled(for: comment) ? .ellipsis : .share
-        cell.shouldHideSeparator = true
 
         // if the comment can be moderated, show the context menu when tapping the accessory button.
         // Note that accessoryButtonAction will be ignored when the menu is assigned.

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import SwiftUI
 import WordPressShared
 import WordPressUI
 
@@ -25,6 +26,29 @@ extension NSNotification.Name {
         view.addSubview(button)
         button.pinEdges([.horizontal, .bottom])
         return button
+    }
+
+    func makeActivityIndicator() -> UIActivityIndicatorView {
+        let spinner = UIActivityIndicatorView()
+        view.addSubview(spinner)
+        spinner.pinCenter()
+        return spinner
+    }
+
+    func makeEmptyStateView(title: String, imageName: String?, description: String?) -> UIView {
+        UIHostingView(view: EmptyStateView(label: {
+            if let imageName {
+                Label(title, image: imageName)
+            } else {
+                Text(title)
+            }
+        }, description: {
+            if let description {
+                Text(description)
+            }
+        }, actions: {
+            EmptyView()
+        }))
     }
 
     func buttonAddCommentTapped() {


### PR DESCRIPTION
This PR contains the final set of fixes and improvements for the Comments screen to make it mergable in `trunk`. The remaining changes can and will be made on top of this work in `trunk`.

## Changes

- Fix a layout issue ([screenshot](https://github.com/user-attachments/assets/86997db7-301b-4b0a-b074-26bf1a94ef41)) with the empty state views. Use an understated `UIActivityIndicator` for the initial loading ([recording](https://github.com/user-attachments/assets/1717cc3c-6d38-4138-9a01-672804ac04a6)). Integrate new `EmptyStateView` for other scenarios.
- Remove no longer used custom fonts from the comments web view.
- Remove animations when updating the list
- Fix an issue with cells not updating when the app is in the background
- Add support for trait collection changes. **Note**: is looks a bit janky because of the async nature of WebKit-based rendering, but I think it's acceptable because you don't really notice it on screen rotation and other traits don't randomly change.
- Update Comments cells layout. Update design of buttons. Buttons now use horizontal layout to take less vertical space, have larger vertical insets for an increased tap area, and maintain visual hierarchy thanks to the new `.secondary` style.
- Enable FF for non-App Store builds

<img width="340" alt="Screenshot 2025-02-11 at 3 13 49 PM" src="https://github.com/user-attachments/assets/fbca8dc2-54cc-4c04-b6fa-5caaaf5ce8f3" />





## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
