### PR TITLE
Add a new screen to for browsing and adding new plugins

### DIFF
--- a/Modules/Sources/WordPressCore/DataStore/InMemoryDataStore.swift
+++ b/Modules/Sources/WordPressCore/DataStore/InMemoryDataStore.swift
@@ -7,9 +7,9 @@ public actor InMemoryDataStore<T: Sendable & Identifiable>: DataStore {
     public struct Query: Sendable {
         // TODO: Replace this with `Predicate` once iOS 17 becomes the minimal deployment target.
         let filter: @Sendable (T) -> Bool
-        let sortBy: any SortComparator<T>
+        let sortBy: (any SortComparator<T>)?
 
-        public init(sortBy: any SortComparator<T>, filter: @escaping @Sendable (T) -> Bool) {
+        public init(sortBy: (any SortComparator<T>)?, filter: @escaping @Sendable (T) -> Bool) {
             self.sortBy = sortBy
             self.filter = filter
         }
@@ -32,9 +32,13 @@ public actor InMemoryDataStore<T: Sendable & Identifiable>: DataStore {
     }
 
     public func list(query: Query) async throws -> [T] {
-        storage.values
-            .filter(query.filter)
-            .sorted(using: query.sortBy)
+        let result = storage.values.filter(query.filter)
+
+        if let sortBy = query.sortBy {
+            return result.sorted(using: sortBy)
+        }
+
+        return result
     }
 
     public func delete(query: Query) async throws {

--- a/Modules/Sources/WordPressCore/Plugins/PluginDirectoryDataStore.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginDirectoryDataStore.swift
@@ -2,6 +2,8 @@ import Foundation
 import WordPressAPI
 import WordPressAPIInternal
 
+// MARK: - DataStore for full plugin deatils
+
 public typealias PluginDirectoryDataStoreQuery = InMemoryDataStore<PluginInformation>.Query
 public typealias InMemoryPluginDirectoryDataStore = InMemoryDataStore<PluginInformation>
 
@@ -20,5 +22,27 @@ extension PluginInformation: @retroactive Identifiable {
 extension InMemoryPluginDirectoryDataStore {
     func get(_ slug: PluginWpOrgDirectorySlug) async throws -> PluginInformation? {
         try await list(query: .slug(slug)).first
+    }
+}
+
+// MARK: - DataStore for plugin browser (featured, recommended plugins), which contains shortened `PluginInformation`
+
+public typealias CategorizedPluginInfomrationDataStoreQuery = InMemoryDataStore<CategorizedPluginInfomration>.Query
+public typealias CategorizedPluginInfomrationDataStore = InMemoryDataStore<CategorizedPluginInfomration>
+
+public struct CategorizedPluginInfomration: Identifiable, Sendable {
+    public var category: WordPressOrgApiPluginDirectoryCategory
+    public var plugins: [PluginInformation]
+
+    public var id: WordPressOrgApiPluginDirectoryCategory { category }
+}
+
+extension CategorizedPluginInfomrationDataStore.Query {
+    public static func category(_ category: WordPressOrgApiPluginDirectoryCategory) -> CategorizedPluginInfomrationDataStore.Query {
+        .init(sortBy: nil) { $0.category == category }
+    }
+
+    public static func category(_ categories: Set<WordPressOrgApiPluginDirectoryCategory>) -> CategorizedPluginInfomrationDataStore.Query {
+        .init(sortBy: nil) { categories.contains($0.category) }
     }
 }

--- a/Modules/Sources/WordPressCore/Plugins/PluginDirectoryDataStore.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginDirectoryDataStore.swift
@@ -27,22 +27,22 @@ extension InMemoryPluginDirectoryDataStore {
 
 // MARK: - DataStore for plugin browser (featured, recommended plugins), which contains shortened `PluginInformation`
 
-public typealias CategorizedPluginInfomrationDataStoreQuery = InMemoryDataStore<CategorizedPluginInfomration>.Query
-public typealias CategorizedPluginInfomrationDataStore = InMemoryDataStore<CategorizedPluginInfomration>
+public typealias CategorizedPluginInformationDataStoreQuery = InMemoryDataStore<CategorizedPluginInformation>.Query
+public typealias CategorizedPluginInformationDataStore = InMemoryDataStore<CategorizedPluginInformation>
 
-public struct CategorizedPluginInfomration: Identifiable, Sendable {
+public struct CategorizedPluginInformation: Identifiable, Sendable {
     public var category: WordPressOrgApiPluginDirectoryCategory
     public var plugins: [PluginInformation]
 
     public var id: WordPressOrgApiPluginDirectoryCategory { category }
 }
 
-extension CategorizedPluginInfomrationDataStore.Query {
-    public static func category(_ category: WordPressOrgApiPluginDirectoryCategory) -> CategorizedPluginInfomrationDataStore.Query {
+extension CategorizedPluginInformationDataStore.Query {
+    public static func category(_ category: WordPressOrgApiPluginDirectoryCategory) -> CategorizedPluginInformationDataStore.Query {
         .init(sortBy: nil) { $0.category == category }
     }
 
-    public static func category(_ categories: Set<WordPressOrgApiPluginDirectoryCategory>) -> CategorizedPluginInfomrationDataStore.Query {
+    public static func category(_ categories: Set<WordPressOrgApiPluginDirectoryCategory>) -> CategorizedPluginInformationDataStore.Query {
         .init(sortBy: nil) { categories.contains($0.category) }
     }
 }

--- a/Modules/Sources/WordPressCore/Plugins/PluginService.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginService.swift
@@ -8,6 +8,7 @@ public actor PluginService: PluginServiceProtocol {
     private let wpOrgClient: WordPressOrgApiClient
     private let installedPluginDataStore = InMemoryInstalledPluginDataStore()
     private let pluginDirectoryDataStore = InMemoryPluginDirectoryDataStore()
+    private let pluginDirectoryBrowserDataStore = CategorizedPluginInfomrationDataStore()
     private let urlSession: URLSession
 
     public init(client: WordPressClient) {
@@ -41,8 +42,12 @@ public actor PluginService: PluginServiceProtocol {
         await pluginDirectoryDataStore.listStream(query: query)
     }
 
-    public func resolveIconURL(of slug: PluginWpOrgDirectorySlug) async -> URL? {
+    public func resolveIconURL(of slug: PluginWpOrgDirectorySlug, plugin: PluginInformation?) async -> URL? {
         // TODO: Cache the icon URL
+
+        if let plugin, let url = await findIconFromPluginDirectory(pluginInfo: plugin) {
+            return url
+        }
 
         if let url = await findIconFromPluginDirectory(slug: slug) {
             return url
@@ -67,6 +72,21 @@ public actor PluginService: PluginServiceProtocol {
         try await installedPluginDataStore.delete(query: .slug(slug))
     }
 
+    public func fetchPluginsDirectory(category: WordPressOrgApiPluginDirectoryCategory) async throws {
+        // Hard-code the pagination parameters for now. We can suface these parameters when the app needs pagination.
+        let plugins = try await wpOrgClient.browsePlugins(category: category, page: 1, pageSize: 10).plugins
+        try await pluginDirectoryBrowserDataStore.delete(query: .category(category))
+        try await pluginDirectoryBrowserDataStore.store([CategorizedPluginInfomration(category: category, plugins: plugins)])
+    }
+
+    public func pluginDirectoryUpdates(query: CategorizedPluginInfomrationDataStoreQuery) async -> AsyncStream<Result<[CategorizedPluginInfomration], Error>> {
+        await pluginDirectoryBrowserDataStore.listStream(query: query)
+    }
+
+    public func searchPluginsDirectory(input: String) async throws -> [PluginInformation] {
+        // Hard-code the pagination parameters for now. We can suface these parameters when the app needs pagination.
+        try await wpOrgClient.searchPlugins(search: input, page: 1, pageSize: 20).plugins
+    }
 }
 
 private extension PluginService {
@@ -87,6 +107,10 @@ private extension PluginService {
             return nil
         }
 
+        return await findIconFromPluginDirectory(pluginInfo: pluginInfo)
+    }
+
+    func findIconFromPluginDirectory(pluginInfo: PluginInformation) async -> URL? {
         guard let icons = pluginInfo.icons else { return nil }
 
         let supportedFormat: Set<String> = ["png", "jpg", "jpeg", "gif"]

--- a/Modules/Sources/WordPressCore/Plugins/PluginService.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginService.swift
@@ -8,7 +8,7 @@ public actor PluginService: PluginServiceProtocol {
     private let wpOrgClient: WordPressOrgApiClient
     private let installedPluginDataStore = InMemoryInstalledPluginDataStore()
     private let pluginDirectoryDataStore = InMemoryPluginDirectoryDataStore()
-    private let pluginDirectoryBrowserDataStore = CategorizedPluginInfomrationDataStore()
+    private let pluginDirectoryBrowserDataStore = CategorizedPluginInformationDataStore()
     private let urlSession: URLSession
 
     public init(client: WordPressClient) {
@@ -76,10 +76,10 @@ public actor PluginService: PluginServiceProtocol {
         // Hard-code the pagination parameters for now. We can suface these parameters when the app needs pagination.
         let plugins = try await wpOrgClient.browsePlugins(category: category, page: 1, pageSize: 10).plugins
         try await pluginDirectoryBrowserDataStore.delete(query: .category(category))
-        try await pluginDirectoryBrowserDataStore.store([CategorizedPluginInfomration(category: category, plugins: plugins)])
+        try await pluginDirectoryBrowserDataStore.store([CategorizedPluginInformation(category: category, plugins: plugins)])
     }
 
-    public func pluginDirectoryUpdates(query: CategorizedPluginInfomrationDataStoreQuery) async -> AsyncStream<Result<[CategorizedPluginInfomration], Error>> {
+    public func pluginDirectoryUpdates(query: CategorizedPluginInformationDataStoreQuery) async -> AsyncStream<Result<[CategorizedPluginInformation], Error>> {
         await pluginDirectoryBrowserDataStore.listStream(query: query)
     }
 

--- a/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
@@ -10,17 +10,22 @@ public protocol PluginServiceProtocol: Actor {
     func installedPluginsUpdates(query: PluginDataStoreQuery) async -> AsyncStream<Result<[InstalledPlugin], Error>>
     func pluginInformationUpdates(query: PluginDirectoryDataStoreQuery) async -> AsyncStream<Result<[PluginInformation], Error>>
 
-    func resolveIconURL(of slug: PluginWpOrgDirectorySlug) async -> URL?
+    func resolveIconURL(of slug: PluginWpOrgDirectorySlug, plugin: PluginInformation?) async -> URL?
 
     func togglePluginActivation(slug: PluginSlug) async throws
 
     func uninstalledPlugin(slug: PluginSlug) async throws
+
+    func fetchPluginsDirectory(category: WordPressOrgApiPluginDirectoryCategory) async throws
+    func pluginDirectoryUpdates(query: CategorizedPluginInfomrationDataStoreQuery) async -> AsyncStream<Result<[CategorizedPluginInfomration], Error>>
+
+    func searchPluginsDirectory(input: String) async throws -> [PluginInformation]
 
 }
 
 extension PluginServiceProtocol {
     public func resolveIconURL(of plugin: InstalledPlugin) async -> URL? {
         guard let slug = plugin.possibleWpOrgDirectorySlug else { return nil }
-        return await resolveIconURL(of: slug)
+        return await resolveIconURL(of: slug, plugin: nil)
     }
 }

--- a/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
@@ -17,7 +17,7 @@ public protocol PluginServiceProtocol: Actor {
     func uninstalledPlugin(slug: PluginSlug) async throws
 
     func fetchPluginsDirectory(category: WordPressOrgApiPluginDirectoryCategory) async throws
-    func pluginDirectoryUpdates(query: CategorizedPluginInfomrationDataStoreQuery) async -> AsyncStream<Result<[CategorizedPluginInfomration], Error>>
+    func pluginDirectoryUpdates(query: CategorizedPluginInformationDataStoreQuery) async -> AsyncStream<Result<[CategorizedPluginInformation], Error>>
 
     func searchPluginsDirectory(input: String) async throws -> [PluginInformation]
 

--- a/WordPress/Classes/Plugins/Views/AddNewPluginView.swift
+++ b/WordPress/Classes/Plugins/Views/AddNewPluginView.swift
@@ -1,0 +1,309 @@
+import Foundation
+import SwiftUI
+import WordPressCore
+import WordPressAPI
+import WordPressAPIInternal
+
+struct AddNewPluginView: View {
+    @Environment(\.dismiss) var dismiss
+
+    @StateObject private var viewModel: AddNewPluginViewModel
+
+    init(service: PluginServiceProtocol) {
+        _viewModel = .init(wrappedValue: AddNewPluginViewModel(service: service))
+    }
+
+    var body: some View {
+        List {
+            ForEach(viewModel.listSections, id: \.self) { section in
+                Section {
+                    ForEach(section.rows, id: \.self, content: rowContent(_:))
+                } header: {
+                    Text(section.header)
+                        .textCase(nil)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                }
+                .listSectionSeparator(.hidden, edges: .all)
+            }
+        }
+        .listStyle(.grouped)
+        .scrollContentBackground(.hidden)
+        .navigationTitle("Add New Plugin")
+        .navigationBarTitleDisplayMode(.inline)
+        .searchable(text: $viewModel.searchInput)
+        .toolbar {
+            ToolbarItem {
+                Button(SharedStrings.Button.cancel, role: .cancel) {
+                    dismiss()
+                }
+            }
+        }
+        .task(id: 0) {
+            await viewModel.onAppear()
+        }
+        .task(id: viewModel.mode) {
+            await viewModel.performQuery()
+        }
+    }
+
+    @ViewBuilder
+    func pluginSectionContent(plugins: [PluginInformation]) -> some View {
+        ForEach(plugins, id: \.slug) { plugin in
+            HStack(alignment: .top) {
+                PluginIconView(plugin: plugin, service: viewModel.service)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(plugin.name.makePlainText())
+                        .lineLimit(1)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+
+                    // TODO: use `shortDescription` instead.
+                    Text(plugin.author.makePlainText())
+                        .lineLimit(2)
+                        .font(.body)
+                        .foregroundStyle(.primary)
+                }
+
+                Spacer()
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func rowContent(_ row: ListRow) -> some View {
+        if case .loading = row {
+            Label {
+                Text("Loading plugins...")
+            } icon: { ProgressView() }
+            .font(.callout)
+            .foregroundColor(.secondary)
+            .frame(maxWidth: .infinity, alignment: .center)
+        } else if case .error = row {
+            Text("Failed to load plugins. Tap here to retry")
+        } else if case let .plugin(plugin) = row {
+            HStack(alignment: .top) {
+                PluginIconView(plugin: plugin, service: viewModel.service)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(plugin.name.makePlainText())
+                        .lineLimit(1)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+
+                    // TODO: use `shortDescription` instead.
+                    Text(plugin.author.makePlainText())
+                        .lineLimit(2)
+                        .font(.body)
+                        .foregroundStyle(.primary)
+                }
+
+                Spacer()
+            }
+        } else if case .empty = row {
+            Text("No plugins found")
+        } else {
+            Text("Impossible to reach here")
+        }
+    }
+}
+
+private enum ListSection: Identifiable, Hashable {
+    case plugins(category: AddNewPluginViewModel.Category, rows: [ListRow])
+    case searchResult(rows: [ListRow])
+
+    var id: AnyHashable {
+        switch self {
+        case let .plugins(category, _):
+            return category
+        case .searchResult:
+            return "search-result"
+        }
+    }
+
+    var rows: [ListRow] {
+        switch self {
+        case let .plugins(_, rows):
+            return rows
+        case let .searchResult(rows):
+            return rows
+        }
+    }
+
+    var header: String {
+        switch self {
+        case let .plugins(category, _):
+            switch category {
+            case .featured:
+                return "Featured"
+            case .popular:
+                return "Popular"
+            case .recommended:
+                return "Recommended"
+            }
+        case .searchResult:
+            return "Search Results"
+        }
+    }
+}
+
+private enum ListRow: Identifiable, Hashable {
+    case loading
+    case plugin(PluginInformation)
+    case empty
+    case error(String)
+
+    var id: AnyHashable {
+        switch self {
+        case .loading:
+            return "loading"
+        case .plugin(let plugin):
+            return plugin.slug
+        case .empty:
+            return "empty"
+        case .error(let error):
+            return error
+        }
+    }
+}
+
+@MainActor
+private class AddNewPluginViewModel: ObservableObject {
+    enum Mode: Hashable {
+        case browser
+        case searchResult(input: String)
+    }
+
+    enum Category: Hashable, CaseIterable {
+        case featured
+        case popular
+        case recommended
+
+        var wpOrgCategory: WordPressOrgApiPluginDirectoryCategory {
+            // TODO: Update the returned values to be the correct onces after updating the wordpress-rs library
+            switch self {
+            case .featured:
+                return .topRated
+            case .popular:
+                return .popular
+            case .recommended:
+                return .topRated
+            }
+        }
+    }
+
+    let service: PluginServiceProtocol
+    private var initialLoad = false
+    private(set) var mode: Mode = .browser
+
+    @Published var loadingStates: [Category: Result<Void, Error>] = [:]
+
+    @Published var searchInput: String = "" {
+        didSet {
+            let input = searchInput.trim()
+            self.mode = input.isEmpty ? Mode.browser : .searchResult(input: input)
+        }
+    }
+
+    @Published private(set) var listSections: [ListSection] = []
+
+    init(service: PluginServiceProtocol) {
+        self.service = service
+    }
+
+    func onAppear() async {
+        guard !initialLoad else { return }
+        initialLoad = true
+
+        await withTaskGroup(of: Void.self) { [service] group in
+            for category in Category.allCases {
+                self.loadingStates[category] = nil
+                group.addTask {
+                    do {
+                        try await service.fetchPluginsDirectory(category: category.wpOrgCategory)
+                        await MainActor.run {
+                            self.loadingStates[category] = .success(())
+                        }
+                    } catch {
+                        await MainActor.run {
+                            self.loadingStates[category] = .failure(error)
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    func performQuery() async {
+        await performQuery(in: mode)
+    }
+
+    func performQuery(in mode: Mode) async {
+        switch mode {
+        case .browser:
+            await presentBrowserMode()
+        case let .searchResult(input):
+            await presentSearchResult(forInput: input)
+        }
+    }
+
+    func presentBrowserMode() async {
+        let categories = Category.allCases.map { $0.wpOrgCategory }
+        for await result in await service.pluginDirectoryUpdates(query: .category(Set(categories))) {
+            let sections: [ListSection]
+            switch result {
+            case let .success(all):
+                sections = Category.allCases.map { category in
+                    section(for: category, plugins: all.first { $0.category == category.wpOrgCategory })
+                }
+            case .failure:
+                // TODO: Never throw atm, but we should handle it anyways.
+                sections = []
+                break
+            }
+            update(to: sections, ifStillIn: .browser)
+        }
+    }
+
+    func presentSearchResult(forInput input: String) async {
+        let expectedMode = Mode.searchResult(input: input)
+        do {
+            update(to: [.searchResult(rows: [.loading])], ifStillIn: expectedMode)
+
+            let plugins = try await service.searchPluginsDirectory(input: input)
+
+            let sections: [ListSection]
+            if plugins.isEmpty {
+                sections = [.searchResult(rows: [.empty])]
+            } else {
+                sections = [.searchResult(rows: plugins.map { .plugin($0) })]
+            }
+            update(to: sections, ifStillIn: expectedMode)
+        } catch {
+            update(to: [.searchResult(rows: [.error(error.localizedDescription)])], ifStillIn: expectedMode)
+        }
+    }
+
+    func update(to sections: [ListSection], ifStillIn mode: Mode) {
+        if mode == self.mode {
+            self.listSections = sections
+        }
+    }
+
+    func section(for category: Category, plugins: CategorizedPluginInfomration?) -> ListSection {
+        if self.loadingStates[category] == nil {
+            return .plugins(category: category, rows: [.loading])
+        } else if case let .failure(error)? = self.loadingStates[category] {
+            return .plugins(category: category, rows: [.error(error.localizedDescription)])
+        }
+
+        guard let plugins else { return .plugins(category: category, rows: [.loading]) }
+
+        if plugins.plugins.isEmpty {
+            return .plugins(category: category, rows: [.empty])
+        } else {
+            return .plugins(category: category, rows: plugins.plugins.map { .plugin($0) })
+        }
+    }
+}

--- a/WordPress/Classes/Plugins/Views/AddNewPluginView.swift
+++ b/WordPress/Classes/Plugins/Views/AddNewPluginView.swift
@@ -291,7 +291,7 @@ private class AddNewPluginViewModel: ObservableObject {
         }
     }
 
-    func section(for category: Category, plugins: CategorizedPluginInfomration?) -> ListSection {
+    func section(for category: Category, plugins: CategorizedPluginInformation?) -> ListSection {
         if self.loadingStates[category] == nil {
             return .plugins(category: category, rows: [.loading])
         } else if case let .failure(error)? = self.loadingStates[category] {

--- a/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
+++ b/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
@@ -7,6 +7,8 @@ import WordPressCore
 struct InstalledPluginsListView: View {
     @StateObject private var viewModel: InstalledPluginsListViewModel
 
+    @State private var presentAddNewPlugin = false
+
     init(client: WordPressClient) {
         self.init(service: PluginService(client: client))
     }
@@ -48,6 +50,13 @@ struct InstalledPluginsListView: View {
         .navigationTitle(Strings.title)
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    presentAddNewPlugin = true
+                } label: {
+                    Image(systemName: "plus")
+                }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
                 Menu {
                     Picker(Strings.filterTitle, selection: $viewModel.filter) {
                         Text(Strings.filterOptionAll).tag(InstalledPluginsListViewModel.PluginFilter.all)
@@ -57,6 +66,11 @@ struct InstalledPluginsListView: View {
                 } label: {
                     Image(systemName: "ellipsis.circle")
                 }
+            }
+        }
+        .sheet(isPresented: $presentAddNewPlugin) {
+            NavigationStack {
+                AddNewPluginView(service: viewModel.service)
             }
         }
         .task(id: 0) {

--- a/WordPress/Classes/Plugins/Views/PluginIconView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginIconView.swift
@@ -2,15 +2,29 @@ import Foundation
 import SwiftUI
 import AsyncImageKit
 import WordPressAPI
+import WordPressAPIInternal
 import WordPressCore
 
 struct PluginIconView: View {
     private static let iconSize: CGFloat = 44
 
     let slug: PluginWpOrgDirectorySlug?
+    let plugin: PluginInformation?
     @State var iconURL: URL?
 
     var service: PluginServiceProtocol
+
+    init(slug: PluginWpOrgDirectorySlug?, service: PluginServiceProtocol) {
+        self.slug = slug
+        self.plugin = nil
+        self.service = service
+    }
+
+    init(plugin: PluginInformation, service: PluginServiceProtocol) {
+        self.slug = PluginWpOrgDirectorySlug(slug: plugin.slug)
+        self.plugin = plugin
+        self.service = service
+    }
 
     var body: some View {
         CachedAsyncImage(url: iconURL) { image in
@@ -20,9 +34,10 @@ struct PluginIconView: View {
                 .resizable()
         }
         .frame(width: Self.iconSize, height: Self.iconSize)
+        .clipShape(RoundedRectangle(cornerRadius: 4))
         .task(id: slug?.slug) {
             guard let slug else { return }
-            iconURL = await service.resolveIconURL(of: slug)
+            iconURL = await service.resolveIconURL(of: slug, plugin: plugin)
         }
     }
 }


### PR DESCRIPTION
Similar to the "Add New Plugin" page on wp-admin, the "Add New Plugin" screen here shows featured, popular, and recommended plugins from WordPress.org.

Please note that I didn't put too much thought into the UI. I will create follow-up PRs to make it look nicer. Let me know if you have any suggestions, though.

In follow-up PRs, I'll add navigating to the details page and installing plugin from there.

https://github.com/user-attachments/assets/75ce1352-b47e-47fb-baa0-0436cf6196f8.mp4

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
