### PR TITLE
Integrate GBK in Comment Composer

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -16,6 +16,7 @@ enum FeatureFlag: Int, CaseIterable {
     case newGutenbergPlugins
     case selfHostedSiteUserManagement
     case readerCommentsWebKit
+    case readerGutenbergCommentComposer
     case pluginManagementOverhaul
 
     /// Returns a boolean indicating if the feature is enabled
@@ -53,6 +54,8 @@ enum FeatureFlag: Int, CaseIterable {
             return false
         case .readerCommentsWebKit:
             return BuildConfiguration.current != .appStore
+        case .readerGutenbergCommentComposer:
+            return false
         case .pluginManagementOverhaul:
             return false
         }
@@ -92,6 +95,7 @@ extension FeatureFlag {
         case .selfHostedSiteUserManagement: "Self-hosted Site User Management"
         case .readerCommentsWebKit: "Render Comments using WebKit"
         case .pluginManagementOverhaul: "Plugin Management Overhaul"
+        case .readerGutenbergCommentComposer: "Gutenberg Comment Composer"
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/Composer/CommentComposerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/Composer/CommentComposerViewController.swift
@@ -1,0 +1,170 @@
+import UIKit
+import WordPressUI
+
+final class CommentComposerViewController: UIViewController {
+    private let buttonSend = UIButton(configuration: {
+        var configuration = UIButton.Configuration.borderedProminent()
+        configuration.title = Strings.send
+        configuration.cornerStyle = .capsule
+        configuration.baseBackgroundColor = UIColor.label
+        configuration.baseForegroundColor = UIColor.systemBackground
+        return configuration
+    }())
+
+    private var editor: CommentEditor?
+    private let viewModel: CommentComposerViewModel
+
+    init(viewModel: CommentComposerViewModel) {
+        self.viewModel = viewModel
+
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        view.backgroundColor = .systemBackground
+
+        setupEditor()
+        setupNavigationBar()
+        setupAccessibility()
+
+        updateInterface()
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+
+        WPAnalytics.track(.commentFullScreenEntered)
+    }
+
+    private func setupEditor() {
+        if viewModel.isGutenbergEnabled {
+            setupGutenbergEditor()
+        } else {
+            setupPlainTextEditor()
+        }
+    }
+
+    private func setupPlainTextEditor() {
+        let editorVC = CommentPlainTextEditorViewController()
+        editorVC.suggestionsViewModel = viewModel.suggestionsViewModel
+        editorVC.placeholder = viewModel.placeholder
+        editorVC.delegate = self
+
+        addChild(editorVC)
+        view.addSubview(editorVC.view)
+        editorVC.view.pinEdges([.top, .horizontal], to: view.safeAreaLayoutGuide)
+        editorVC.view.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor).isActive = true
+
+        editorVC.didMove(toParent: self)
+
+        self.editor = editorVC
+    }
+
+    private func setupGutenbergEditor() {
+        let editorVC = CommentGutenbergEditorViewController()
+        editorVC.delegate = self
+
+        addChild(editorVC)
+        view.addSubview(editorVC.view)
+        editorVC.view.pinEdges()
+        editorVC.didMove(toParent: self)
+
+        self.editor = editorVC
+    }
+
+    private func setupAccessibility() {
+        navigationItem.rightBarButtonItem?.accessibilityIdentifier = "button_send_comment"
+    }
+
+    // MARK: - Actions
+
+    @objc private func buttonSendTapped() {
+        Task {
+            await sendComment()
+        }
+    }
+
+    @MainActor
+    private func sendComment() async {
+        do {
+            setLoading(true)
+            try await viewModel.save(text)
+            UINotificationFeedbackGenerator().notificationOccurred(.success)
+            presentingViewController?.dismiss(animated: true)
+        } catch {
+            setLoading(false)
+            UINotificationFeedbackGenerator().notificationOccurred(.error)
+            Notice(title: Strings.failedToSend, message: error.localizedDescription.stringByDecodingXMLCharacters()).post()
+        }
+    }
+
+    private func setLoading(_ isLoading: Bool) {
+        navigationItem.rightBarButtonItem = isLoading ? .activityIndicator : UIBarButtonItem(customView: buttonSend)
+        navigationItem.leftBarButtonItem?.isEnabled = !isLoading
+        editor?.isEnabled = !isLoading
+    }
+
+    @objc private func buttonCancelTapped() {
+        if text.isEmpty {
+            presentingViewController?.dismiss(animated: true)
+        } else {
+            showCloseDraftConfirmationAlert()
+        }
+    }
+
+    private func showCloseDraftConfirmationAlert() {
+        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
+        alert.addCancelActionWithTitle(Strings.closeConfirmationAlertCancel)
+        alert.addDestructiveActionWithTitle(Strings.closeConfirmationAlertDelete) { [weak self] _ in
+            self?.presentingViewController?.dismiss(animated: true)
+        }
+        // TODO: (kean) implement draft saving
+//        alert.addActionWithTitle(Strings.closeConfirmationAlertSaveDraft, style: .default) { _ in
+//
+//        }
+        alert.popoverPresentationController?.barButtonItem = navigationItem.leftBarButtonItem
+        present(alert, animated: true, completion: nil)
+    }
+
+    // MARK: - Private
+
+    private func setupNavigationBar() {
+        title = viewModel.navigationTitle
+
+        navigationItem.leftBarButtonItem = UIBarButtonItem(title: SharedStrings.Button.cancel, style: .plain, target: self, action: #selector(buttonCancelTapped))
+
+        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: buttonSend)
+        buttonSend.addTarget(self, action: #selector(buttonSendTapped), for: .primaryActionTriggered)
+    }
+
+    /// Changes the `refreshButton` enabled state
+    private func updateInterface() {
+        let isEmpty = text.isEmpty
+        buttonSend.isEnabled = !isEmpty
+        isModalInPresentation = !isEmpty
+    }
+
+    private var text: String {
+        editor?.text.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+    }
+}
+
+extension CommentComposerViewController: CommentEditorDelegate {
+    func commentEditor(_ viewController: UIViewController, didUpateText text: String) {
+        updateInterface()
+    }
+}
+
+private enum Strings {
+    static let send = NSLocalizedString("commentComposer.send", value: "Send", comment: "Navigation bar button title")
+    static let failedToSend = NSLocalizedString("commentComposer.failedToSentComment", value: "Failed to send comment", comment: "Error title")
+    static let closeConfirmationAlertCancel = NSLocalizedString("commentComposer.closeConfirmationAlert.keepEditing", value: "Keep Editing", comment: "Button to keep the changes in an alert confirming discaring changes")
+    static let closeConfirmationAlertDelete = NSLocalizedString("commentComposer.closeConfirmationAlert.deleteDraft", value: "Delete Draft", comment: "Button in an alert confirming discaring a new draft")
+    static let closeConfirmationAlertSaveDraft = NSLocalizedString("commentComposer.closeConfirmationAlert.saveDraft", value: "Save Draft", comment: "Button in an alert confirming saving a new draft")
+}

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/Composer/CommentComposerViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/Composer/CommentComposerViewModel.swift
@@ -11,6 +11,10 @@ final class CommentComposerViewModel {
     private let parameters: CommentComposerParameters
     private var context: NSManagedObjectContext
 
+    var isGutenbergEnabled: Bool {
+        FeatureFlag.readerGutenbergCommentComposer.enabled
+    }
+
     /// Send a top-level comment to the given post.
     convenience init(post: ReaderPost) {
         let parameters = CommentComposerParameters(siteID: post.siteID, context: .post)

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/Composer/CommentGutenbergEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/Composer/CommentGutenbergEditorViewController.swift
@@ -77,27 +77,27 @@ extension CommentGutenbergEditorViewController: GutenbergKit.EditorViewControlle
     func editorDidLoad(_ viewContoller: GutenbergKit.EditorViewController) {
         // Do nothing
     }
-    
+
     func editor(_ viewContoller: GutenbergKit.EditorViewController, didDisplayInitialContent content: String) {
         // Do nothing
     }
-    
+
     func editor(_ viewContoller: GutenbergKit.EditorViewController, didEncounterCriticalError error: any Error) {
         // Do nothing
     }
-    
+
     func editor(_ viewController: GutenbergKit.EditorViewController, didUpdateContentWithState state: GutenbergKit.EditorState) {
         editorDidUpdate.send(())
     }
-    
+
     func editor(_ viewController: GutenbergKit.EditorViewController, didUpdateHistoryState state: GutenbergKit.EditorState) {
         // Do nothing
     }
-    
+
     func editor(_ viewController: GutenbergKit.EditorViewController, didLogException error: GutenbergKit.GutenbergJSException) {
         // Do nothing
     }
-    
+
     func editor(_ viewController: GutenbergKit.EditorViewController, didRequestMediaFromSiteMediaLibrary config: GutenbergKit.OpenMediaLibraryAction) {
         // Do nothing
     }

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/Composer/CommentGutenbergEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/Composer/CommentGutenbergEditorViewController.swift
@@ -1,0 +1,110 @@
+import UIKit
+import GutenbergKit
+import WordPressUI
+import Combine
+
+final class CommentGutenbergEditorViewController: UIViewController, CommentEditor {
+    private var editorVC: GutenbergKit.EditorViewController?
+
+    weak var delegate: CommentEditorDelegate?
+
+    var text: String {
+        set {
+            wpAssertionFailure("not supported")
+        }
+        get {
+            currentText
+        }
+    }
+
+    private var currentText = ""
+
+    var isEnabled: Bool = true {
+        didSet {
+            // TODO: implement
+//            if !isEnabled {
+//                textView.resignFirstResponder()
+//            }
+            editorVC?.view.alpha = isEnabled ? 1.0 : 0.5
+            editorVC?.view.isUserInteractionEnabled = isEnabled
+        }
+    }
+
+    var placeholder: String? {
+        didSet {
+            // TODO: implement placeholder
+        }
+    }
+
+    private let editorDidUpdate = PassthroughSubject<Void, Never>()
+    private var cancellables: [AnyCancellable] = []
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        let editorVC = GutenbergKit.EditorViewController(
+            service: EditorService(client: EmptyNetworkClient())
+        )
+        editorVC.delegate = self
+
+        view.addSubview(editorVC.view)
+        editorVC.view.pinEdges(to: view.safeAreaLayoutGuide)
+        self.editorVC = editorVC
+
+        editorDidUpdate
+            .throttle(for: 1.0, scheduler: DispatchQueue.main, latest: true)
+            .sink { [weak self] in self?.refreshText() }
+            .store(in: &cancellables)
+    }
+
+    private func refreshText() {
+        guard let editorVC else { return }
+        Task { @MainActor in
+            do {
+                let text = try await editorVC.getContent()
+                if text != self.currentText {
+                    self.currentText = text
+                    self.delegate?.commentEditor(self, didUpateText: text)
+                }
+            } catch {
+                // TODO: handle errors
+            }
+        }
+    }
+}
+
+extension CommentGutenbergEditorViewController: GutenbergKit.EditorViewControllerDelegate {
+    func editorDidLoad(_ viewContoller: GutenbergKit.EditorViewController) {
+        // Do nothing
+    }
+    
+    func editor(_ viewContoller: GutenbergKit.EditorViewController, didDisplayInitialContent content: String) {
+        // Do nothing
+    }
+    
+    func editor(_ viewContoller: GutenbergKit.EditorViewController, didEncounterCriticalError error: any Error) {
+        // Do nothing
+    }
+    
+    func editor(_ viewController: GutenbergKit.EditorViewController, didUpdateContentWithState state: GutenbergKit.EditorState) {
+        editorDidUpdate.send(())
+    }
+    
+    func editor(_ viewController: GutenbergKit.EditorViewController, didUpdateHistoryState state: GutenbergKit.EditorState) {
+        // Do nothing
+    }
+    
+    func editor(_ viewController: GutenbergKit.EditorViewController, didLogException error: GutenbergKit.GutenbergJSException) {
+        // Do nothing
+    }
+    
+    func editor(_ viewController: GutenbergKit.EditorViewController, didRequestMediaFromSiteMediaLibrary config: GutenbergKit.OpenMediaLibraryAction) {
+        // Do nothing
+    }
+}
+
+private final class EmptyNetworkClient: GutenbergKit.EditorNetworkingClient {
+    func send(_ request: EditorNetworkRequest) async throws -> EditorNetworkResponse {
+        throw URLError(.unknown)
+    }
+}

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/Composer/CommentPlainTextEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/Composer/CommentPlainTextEditorViewController.swift
@@ -1,27 +1,44 @@
 import UIKit
 import WordPressUI
 
-fileprivate enum SuggestionsPosition: Int {
-    case hidden
-    case top
-    case bottom
+protocol CommentEditor {
+    var text: String { get set }
+    var isEnabled: Bool { get set }
 }
 
-final class CommentComposerViewController: UIViewController {
-    private let buttonSend = UIButton(configuration: {
-        var configuration = UIButton.Configuration.borderedProminent()
-        configuration.title = Strings.send
-        configuration.cornerStyle = .capsule
-        configuration.baseBackgroundColor = UIColor.label
-        configuration.baseForegroundColor = UIColor.systemBackground
-        return configuration
-    }())
+protocol CommentEditorDelegate: AnyObject {
+    func commentEditor(_ viewController: UIViewController, didUpateText text: String)
+}
+
+final class CommentPlainTextEditorViewController: UIViewController, CommentEditor {
+    var suggestionsViewModel: SuggestionsListViewModel?
+
+    weak var delegate: CommentEditorDelegate?
+
+    var text: String {
+        set { textView.text = newValue }
+        get { textView.text }
+    }
+
+    var isEnabled: Bool = true {
+        didSet {
+            if !isEnabled {
+                textView.resignFirstResponder()
+            }
+            textView.alpha = isEnabled ? 1.0 : 0.5
+            textView.isUserInteractionEnabled = isEnabled
+        }
+    }
+
+    var placeholder: String? {
+        didSet {
+            placeholderLabel.text = placeholder
+        }
+    }
 
     private let textView = UITextView()
     private let placeholderLabel = UILabel()
     private var suggestionsView: SuggestionsTableView?
-
-    private let viewModel: CommentComposerViewModel
 
     // Static margin between the suggestions view and the text cursor position
     private let suggestionViewMargin: CGFloat = 5
@@ -29,26 +46,10 @@ final class CommentComposerViewController: UIViewController {
     private var suggestionsTopAnchorConstraint: NSLayoutConstraint?
     private var didChangeText: Bool = false
 
-    init(viewModel: CommentComposerViewModel) {
-        self.viewModel = viewModel
-
-        super.init(nibName: nil, bundle: nil)
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = .systemBackground
-
-        setupTextView()
-        setupNavigationBar()
-        setupAccessibility()
-
-        updateInterface()
+        setupView()
     }
 
     override func viewDidAppear(_ animated: Bool) {
@@ -57,16 +58,16 @@ final class CommentComposerViewController: UIViewController {
         textView.becomeFirstResponder()
         setupSuggestionsTableViewIfNeeded()
 
-        WPAnalytics.track(.commentFullScreenEntered)
     }
 
-    private func setupTextView() {
+    private func setupView() {
         textView.font = .preferredFont(forTextStyle: .body)
         textView.textContainerInset = UIEdgeInsets(horizontal: 11, vertical: 16)
         textView.delegate = self
+        textView.accessibilityIdentifier = "edit_comment_text_view"
 
         placeholderLabel.font = .preferredFont(forTextStyle: .body)
-        placeholderLabel.text = viewModel.placeholder
+        placeholderLabel.text = placeholder
         placeholderLabel.textColor = .tertiaryLabel
         placeholderLabel.isHidden = !textView.text.isEmpty
 
@@ -74,19 +75,13 @@ final class CommentComposerViewController: UIViewController {
         placeholderLabel.pinEdges([.leading, .top], insets: UIEdgeInsets(.all, 16))
 
         view.addSubview(textView)
-        textView.pinEdges([.top, .horizontal], to: view.safeAreaLayoutGuide)
-        textView.bottomAnchor.constraint(equalTo: view.keyboardLayoutGuide.topAnchor).isActive = true
-    }
-
-    private func setupAccessibility() {
-        textView.accessibilityIdentifier = "edit_comment_text_view"
-        navigationItem.rightBarButtonItem?.accessibilityIdentifier = "button_send_comment"
+        textView.pinEdges()
     }
 
     // MARK: - Suggestions
 
     private func setupSuggestionsTableViewIfNeeded() {
-        guard let viewModel = viewModel.suggestionsViewModel else {
+        guard let viewModel = suggestionsViewModel else {
             return
         }
         let suggestionsView = SuggestionsTableView(viewModel: viewModel, delegate: self)
@@ -96,87 +91,12 @@ final class CommentComposerViewController: UIViewController {
 
         attachSuggestionsViewIfNeeded()
     }
-
-    // MARK: - Actions
-
-    @objc private func buttonSendTapped() {
-        Task {
-            await sendComment()
-        }
-    }
-
-    @MainActor
-    private func sendComment() async {
-        do {
-            setLoading(true)
-            try await viewModel.save(textView.text ?? "")
-            UINotificationFeedbackGenerator().notificationOccurred(.success)
-            presentingViewController?.dismiss(animated: true)
-        } catch {
-            setLoading(false)
-            UINotificationFeedbackGenerator().notificationOccurred(.error)
-            Notice(title: Strings.failedToSend, message: error.localizedDescription.stringByDecodingXMLCharacters()).post()
-        }
-    }
-
-    private func setLoading(_ isLoading: Bool) {
-        navigationItem.rightBarButtonItem = isLoading ? .activityIndicator : UIBarButtonItem(customView: buttonSend)
-        navigationItem.leftBarButtonItem?.isEnabled = !isLoading
-        textView.resignFirstResponder()
-        textView.alpha = isLoading ? 0.5 : 1.0
-        textView.isUserInteractionEnabled = !isLoading
-    }
-
-    @objc private func buttonCancelTapped() {
-        if text.isEmpty {
-            presentingViewController?.dismiss(animated: true)
-        } else {
-            showCloseDraftConfirmationAlert()
-        }
-    }
-
-    private func showCloseDraftConfirmationAlert() {
-        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-        alert.addCancelActionWithTitle(Strings.closeConfirmationAlertCancel)
-        alert.addDestructiveActionWithTitle(Strings.closeConfirmationAlertDelete) { [weak self] _ in
-            self?.presentingViewController?.dismiss(animated: true)
-        }
-        // TODO: (kean) implement draft saving
-//        alert.addActionWithTitle(Strings.closeConfirmationAlertSaveDraft, style: .default) { _ in
-//
-//        }
-        alert.popoverPresentationController?.barButtonItem = navigationItem.leftBarButtonItem
-        present(alert, animated: true, completion: nil)
-    }
-
-    // MARK: - Private
-
-    private func setupNavigationBar() {
-        title = viewModel.navigationTitle
-
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: SharedStrings.Button.cancel, style: .plain, target: self, action: #selector(buttonCancelTapped))
-
-        navigationItem.rightBarButtonItem = UIBarButtonItem(customView: buttonSend)
-        buttonSend.addTarget(self, action: #selector(buttonSendTapped), for: .primaryActionTriggered)
-    }
-
-    /// Changes the `refreshButton` enabled state
-    private func updateInterface() {
-        let isEmpty = text.isEmpty
-        buttonSend.isEnabled = !isEmpty
-        isModalInPresentation = !isEmpty
-    }
-
-    private var text: String {
-        textView.text.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
 }
 
-extension CommentComposerViewController: UITextViewDelegate {
+extension CommentPlainTextEditorViewController: UITextViewDelegate {
     func textViewDidChange(_ textView: UITextView) {
         placeholderLabel.isHidden = !textView.text.isEmpty
-
-        updateInterface()
+        delegate?.commentEditor(self, didUpateText: textView.text)
     }
 
     func textViewDidChangeSelection(_ textView: UITextView) {
@@ -204,7 +124,7 @@ extension CommentComposerViewController: UITextViewDelegate {
     }
 }
 
-extension CommentComposerViewController: SuggestionsTableViewDelegate {
+extension CommentPlainTextEditorViewController: SuggestionsTableViewDelegate {
     func suggestionsTableView(_ suggestionsTableView: SuggestionsTableView, didSelectSuggestion suggestion: String?, forSearchText text: String) {
         replaceTextAtCaret(text as NSString?, withText: suggestion)
         suggestionsTableView.showSuggestions(forWord: String())
@@ -223,9 +143,7 @@ extension CommentComposerViewController: SuggestionsTableViewDelegate {
     }
 }
 
-// MARK: - Suggestions View Helpers
-//
-private extension CommentComposerViewController {
+private extension CommentPlainTextEditorViewController {
 
     /// Calculates a CGRect for the text caret and converts its value to the view's coordindate system
     var absoluteTextCursorRect: CGRect {
@@ -310,10 +228,8 @@ private extension CommentComposerViewController {
     }
 }
 
-private enum Strings {
-    static let send = NSLocalizedString("commentComposer.send", value: "Send", comment: "Navigation bar button title")
-    static let failedToSend = NSLocalizedString("commentComposer.failedToSentComment", value: "Failed to send comment", comment: "Error title")
-    static let closeConfirmationAlertCancel = NSLocalizedString("commentComposer.closeConfirmationAlert.keepEditing", value: "Keep Editing", comment: "Button to keep the changes in an alert confirming discaring changes")
-    static let closeConfirmationAlertDelete = NSLocalizedString("commentComposer.closeConfirmationAlert.deleteDraft", value: "Delete Draft", comment: "Button in an alert confirming discaring a new draft")
-    static let closeConfirmationAlertSaveDraft = NSLocalizedString("commentComposer.closeConfirmationAlert.saveDraft", value: "Save Draft", comment: "Button in an alert confirming saving a new draft")
+private enum SuggestionsPosition: Int {
+    case hidden
+    case top
+    case bottom
 }


### PR DESCRIPTION
This PR adds an initial implementation of the Gutenberg-based Comment Composer. The change is incomplete, which is why it's hidden under the feature flag.

https://github.com/user-attachments/assets/97fcb147-6bb1-4348-8b86-e02702f2e65d

## To test:

- Enable the "Gutenberg Comment Composer" FF
- **Verify** that you can publish basic Gutenberg comments to a site that supports it. **Note**: there is currently no logic that determines which sites are supported, so it's enabled for all sites.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
