### PR TITLE
Browse plugin details from WordPress.org plugin directory

### DIFF
--- a/Modules/Sources/WordPressCore/Plugins/InstalledPluginDataStore.swift
+++ b/Modules/Sources/WordPressCore/Plugins/InstalledPluginDataStore.swift
@@ -20,4 +20,8 @@ extension PluginDataStoreQuery {
     public static func slug(_ slug: PluginSlug) -> PluginDataStoreQuery {
         .init(sortBy: KeyPathComparator(\.name)) { $0.slug == slug }
     }
+
+    public static func slug(_ slug: PluginWpOrgDirectorySlug) -> PluginDataStoreQuery {
+        .init(sortBy: KeyPathComparator(\.name)) { $0.possibleWpOrgDirectorySlug == slug }
+    }
 }

--- a/Modules/Sources/WordPressCore/Plugins/PluginService.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginService.swift
@@ -34,6 +34,10 @@ public actor PluginService: PluginServiceProtocol {
         try await pluginDirectoryDataStore.store([plugin])
     }
 
+    public func findInstalledPluginsUpdates(slug: PluginWpOrgDirectorySlug) async throws -> InstalledPlugin? {
+        try await installedPluginDataStore.list(query: .slug(slug)).first
+    }
+
     public func installedPluginsUpdates(query: PluginDataStoreQuery) async -> AsyncStream<Result<[InstalledPlugin], Error>> {
         await installedPluginDataStore.listStream(query: query)
     }

--- a/Modules/Sources/WordPressCore/Plugins/PluginService.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginService.swift
@@ -34,7 +34,7 @@ public actor PluginService: PluginServiceProtocol {
         try await pluginDirectoryDataStore.store([plugin])
     }
 
-    public func findInstalledPluginsUpdates(slug: PluginWpOrgDirectorySlug) async throws -> InstalledPlugin? {
+    public func findInstalledPlugin(slug: PluginWpOrgDirectorySlug) async throws -> InstalledPlugin? {
         try await installedPluginDataStore.list(query: .slug(slug)).first
     }
 

--- a/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
@@ -10,6 +10,8 @@ public protocol PluginServiceProtocol: Actor {
     func installedPluginsUpdates(query: PluginDataStoreQuery) async -> AsyncStream<Result<[InstalledPlugin], Error>>
     func pluginInformationUpdates(query: PluginDirectoryDataStoreQuery) async -> AsyncStream<Result<[PluginInformation], Error>>
 
+    func findInstalledPluginsUpdates(slug: PluginWpOrgDirectorySlug) async throws -> InstalledPlugin?
+
     func resolveIconURL(of slug: PluginWpOrgDirectorySlug, plugin: PluginInformation?) async -> URL?
 
     func togglePluginActivation(slug: PluginSlug) async throws

--- a/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
@@ -10,7 +10,7 @@ public protocol PluginServiceProtocol: Actor {
     func installedPluginsUpdates(query: PluginDataStoreQuery) async -> AsyncStream<Result<[InstalledPlugin], Error>>
     func pluginInformationUpdates(query: PluginDirectoryDataStoreQuery) async -> AsyncStream<Result<[PluginInformation], Error>>
 
-    func findInstalledPluginsUpdates(slug: PluginWpOrgDirectorySlug) async throws -> InstalledPlugin?
+    func findInstalledPlugin(slug: PluginWpOrgDirectorySlug) async throws -> InstalledPlugin?
 
     func resolveIconURL(of slug: PluginWpOrgDirectorySlug, plugin: PluginInformation?) async -> URL?
 

--- a/WordPress/Classes/Plugins/Views/AddNewPluginView.swift
+++ b/WordPress/Classes/Plugins/Views/AddNewPluginView.swift
@@ -83,23 +83,25 @@ struct AddNewPluginView: View {
         } else if case .error = row {
             Text("Failed to load plugins. Tap here to retry")
         } else if case let .plugin(plugin) = row {
-            HStack(alignment: .top) {
-                PluginIconView(plugin: plugin, service: viewModel.service)
+            NavigationLink(destination: PluginDetailsView(plugin: plugin, service: viewModel.service)) {
+                HStack(alignment: .top) {
+                    PluginIconView(plugin: plugin, service: viewModel.service)
 
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(plugin.name.makePlainText())
-                        .lineLimit(1)
-                        .font(.headline)
-                        .foregroundStyle(.primary)
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(plugin.name.makePlainText())
+                            .lineLimit(1)
+                            .font(.headline)
+                            .foregroundStyle(.primary)
 
-                    // TODO: use `shortDescription` instead.
-                    Text(plugin.author.makePlainText())
-                        .lineLimit(2)
-                        .font(.body)
-                        .foregroundStyle(.primary)
+                        // TODO: use `shortDescription` instead.
+                        Text(plugin.author.makePlainText())
+                            .lineLimit(2)
+                            .font(.body)
+                            .foregroundStyle(.primary)
+                    }
+
+                    Spacer()
                 }
-
-                Spacer()
             }
         } else if case .empty = row {
             Text("No plugins found")

--- a/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
@@ -359,7 +359,7 @@ enum ActionButton {
         let button: AnyView
         switch self {
         case let .install(_, action):
-            button = AnyView(Button("Install", action: action)
+            button = AnyView(Button(Strings.installButton, action: action)
                     .font(.callout.bold()))
         case let .activate(_, action):
             button = AnyView(Button(Strings.activateButton, action: action)
@@ -605,6 +605,12 @@ private enum Strings {
         "pluginDetails.viewOnWordPressOrg.button",
         value: "View on WordPress.org",
         comment: "Button label to view plugin on WordPress.org"
+    )
+
+    static let installButton = NSLocalizedString(
+        "pluginDetails.install.button",
+        value: "Install",
+        comment: "Button label to install a plugin"
     )
 
     static let activateButton = NSLocalizedString(

--- a/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
@@ -54,14 +54,14 @@ struct PluginDetailsView: View {
         // TODO: Use `shortDescription`
         self.pluginInfo = .init(name: plugin.name, author: plugin.author, shortDescription: plugin.author)
         self.service = service
-        _viewModel = StateObject(wrappedValue: .init(slug: slug, plugin: plugin, installed: nil, service: service))
+        _viewModel = StateObject(wrappedValue: .init(slug: slug, service: service))
     }
 
     init(slug: PluginWpOrgDirectorySlug, plugin: InstalledPlugin, service: PluginServiceProtocol) {
         self.slug = slug
         self.pluginInfo = .init(name: plugin.name, author: plugin.author, shortDescription: plugin.shortDescription)
         self.service = service
-        _viewModel = StateObject(wrappedValue: .init(slug: slug, plugin: nil, installed: plugin, service: service))
+        _viewModel = StateObject(wrappedValue: .init(slug: slug, service: service))
     }
 
     var body: some View {
@@ -390,7 +390,7 @@ final class WordPressPluginDetailViewModel: ObservableObject {
 
     private var initialLoad = false
 
-    init(slug: PluginWpOrgDirectorySlug, plugin: PluginInformation?, installed: InstalledPlugin?, service: PluginServiceProtocol) {
+    init(slug: PluginWpOrgDirectorySlug, service: PluginServiceProtocol) {
         self.slug = slug
         self.service = service
     }

--- a/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
@@ -364,7 +364,7 @@ enum ActionButton {
         case let .activate(_, action):
             button = AnyView(Button(Strings.activateButton, action: action)
                     .font(.callout.bold()))
-        case .activated(_):
+        case .activated:
             button = AnyView(Button(Strings.activatedButton, action: { })
                 .font(.callout)
                 .disabled(true))

--- a/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
@@ -5,10 +5,22 @@ import WordPressCore
 import WordPressAPIInternal
 
 struct PluginDetailsView: View {
+    private struct BasicPluginInfo {
+        var name: String
+        var author: String
+        var shortDescription: String
+
+        init(name: String, author: String, shortDescription: String) {
+            self.name = name.makePlainText()
+            self.author = author.makePlainText()
+            self.shortDescription = shortDescription.makePlainText()
+        }
+    }
+
     let slug: PluginWpOrgDirectorySlug
-    // TODO: This should be optional, to support installing a new plugin
-    let plugin: InstalledPlugin
     let service: PluginServiceProtocol
+
+    private let pluginInfo: BasicPluginInfo
 
     @State var newVersion: UpdateCheckPluginInfo? = nil
     @State private var tappedScreenshot: Screenshot? = nil
@@ -18,11 +30,38 @@ struct PluginDetailsView: View {
 
     @Environment(\.dismiss) var dismiss
 
+    var wpOrgURL: URL? {
+        URL(string: "https://wordpress.org/plugins/\(slug.slug)/")
+    }
+
+    var actionButton: ActionButton {
+        if let plugin = viewModel.installed {
+            return plugin.isActive
+                ? .activated(plugin: plugin)
+                : .activate(plugin: plugin) {
+                    // TODO
+                }
+        } else {
+            return .install(slug: slug) {
+                // TODO
+            }
+        }
+    }
+
+    init(plugin: PluginInformation, service: PluginServiceProtocol) {
+        let slug = PluginWpOrgDirectorySlug(slug: plugin.slug)
+        self.slug = slug
+        // TODO: Use `shortDescription`
+        self.pluginInfo = .init(name: plugin.name, author: plugin.author, shortDescription: plugin.author)
+        self.service = service
+        _viewModel = StateObject(wrappedValue: .init(slug: slug, plugin: plugin, installed: nil, service: service))
+    }
+
     init(slug: PluginWpOrgDirectorySlug, plugin: InstalledPlugin, service: PluginServiceProtocol) {
         self.slug = slug
-        self.plugin = plugin
+        self.pluginInfo = .init(name: plugin.name, author: plugin.author, shortDescription: plugin.shortDescription)
         self.service = service
-        _viewModel = StateObject(wrappedValue: .init(slug: slug, service: service))
+        _viewModel = StateObject(wrappedValue: .init(slug: slug, plugin: nil, installed: plugin, service: service))
     }
 
     var body: some View {
@@ -34,11 +73,11 @@ struct PluginDetailsView: View {
                     PluginIconView(slug: slug, service: service)
 
                     VStack(alignment: .leading) {
-                        Text(plugin.name.makePlainText())
+                        Text(pluginInfo.name)
                             .font(.headline)
                             .fontWeight(.bold)
                             .lineLimit(3, reservesSpace: false)
-                        Text(Strings.author(plugin.author))
+                        Text(Strings.author(pluginInfo.author))
                             .lineLimit(1)
                             .foregroundStyle(.secondary)
                             .font(.caption)
@@ -46,19 +85,13 @@ struct PluginDetailsView: View {
 
                     Spacer()
 
-                    Button(plugin.isActive ? Strings.activatedButton : Strings.activateButton) {
-                        Task {
-                            await viewModel.activate(plugin)
-                        }
-                    }
-                    .font(plugin.isActive ? .callout : .callout.bold())
-                    .buttonStyle(.borderedProminent)
-                    .buttonBorderShape(.capsule)
-                    .disabled(plugin.isActive || viewModel.isUninstalling)
+                    actionButton
+                        .view
+                        .disabled(viewModel.isLoading || viewModel.isActivating || viewModel.isUninstalling)
                 }
                 .listRowSeparator(.hidden)
 
-                Text(plugin.shortDescription.makePlainText())
+                Text(pluginInfo.shortDescription)
                     .font(.body)
                     .listRowSeparator(.hidden)
             }
@@ -93,13 +126,15 @@ struct PluginDetailsView: View {
         .toolbar {
             ToolbarItem(placement: .topBarTrailing) {
                 Menu {
-                    Button(role: .destructive) {
-                        showDeleteConfirmation = true
-                    } label: {
-                        Label(Strings.deleteButton, systemImage: "trash")
+                    if viewModel.installed != nil {
+                        Button(role: .destructive) {
+                            showDeleteConfirmation = true
+                        } label: {
+                            Label(Strings.deleteButton, systemImage: "trash")
+                        }
                     }
 
-                    if let url = plugin.possibleWpOrgDirectoryURL {
+                    if let url = wpOrgURL {
                         Section {
                             ShareLink(item: url)
                             Button {
@@ -118,15 +153,17 @@ struct PluginDetailsView: View {
             Button(SharedStrings.Button.cancel, role: .cancel) { }
             Button(SharedStrings.Button.delete, role: .destructive) {
                 Task { @MainActor in
-                    await viewModel.uninstall(plugin)
-                    dismiss()
+                    if let plugin = viewModel.installed {
+                        await viewModel.uninstall(plugin)
+                        dismiss()
+                    }
                 }
             }
         } message: {
-            Text(Strings.deletePluginMessage(plugin.name.makePlainText()))
+            Text(Strings.deletePluginMessage(pluginInfo.name))
         }
         .sheet(isPresented: $isShowingSafariView) {
-            if let url = plugin.possibleWpOrgDirectoryURL {
+            if let url = wpOrgURL {
                 SafariView(url: url)
             }
         }
@@ -313,6 +350,32 @@ private struct RatingView: View {
     }
 }
 
+enum ActionButton {
+    case install(slug: PluginWpOrgDirectorySlug, action: () -> Void)
+    case activate(plugin: InstalledPlugin, action: () -> Void)
+    case activated(plugin: InstalledPlugin)
+
+    var view: some View {
+        let button: AnyView
+        switch self {
+        case let .install(_, action):
+            button = AnyView(Button("Install", action: action)
+                    .font(.callout.bold()))
+        case let .activate(_, action):
+            button = AnyView(Button(Strings.activateButton, action: action)
+                    .font(.callout.bold()))
+        case .activated(_):
+            button = AnyView(Button(Strings.activatedButton, action: { })
+                .font(.callout)
+                .disabled(true))
+        }
+
+        return button
+            .buttonStyle(.borderedProminent)
+            .buttonBorderShape(.capsule)
+    }
+}
+
 @MainActor
 final class WordPressPluginDetailViewModel: ObservableObject {
     let slug: PluginWpOrgDirectorySlug
@@ -321,12 +384,13 @@ final class WordPressPluginDetailViewModel: ObservableObject {
     @Published private(set) var isLoading = false
     @Published private(set) var isUninstalling = false
     @Published private(set) var plugin: PluginInformation?
+    @Published private(set) var installed: InstalledPlugin?
     @Published private(set) var error: String?
     @Published private(set) var isActivating = false
 
     private var initialLoad = false
 
-    init(slug: PluginWpOrgDirectorySlug, service: PluginServiceProtocol) {
+    init(slug: PluginWpOrgDirectorySlug, plugin: PluginInformation?, installed: InstalledPlugin?, service: PluginServiceProtocol) {
         self.slug = slug
         self.service = service
     }
@@ -342,7 +406,12 @@ final class WordPressPluginDetailViewModel: ObservableObject {
         }
 
         do {
+            self.installed = try await service.findInstalledPluginsUpdates(slug: slug)
             try await service.fetchPluginInformation(slug: slug)
+
+            // Re-fetch installed plugins to ensure a more accurate check of whether the plugin is already installed
+            try await service.fetchInstalledPlugins()
+            self.installed = try await service.findInstalledPluginsUpdates(slug: slug)
         } catch {
             self.error = (error as? WpApiError)?.errorMessage ?? error.localizedDescription
         }

--- a/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
@@ -406,12 +406,12 @@ final class WordPressPluginDetailViewModel: ObservableObject {
         }
 
         do {
-            self.installed = try await service.findInstalledPluginsUpdates(slug: slug)
+            self.installed = try await service.findInstalledPlugin(slug: slug)
             try await service.fetchPluginInformation(slug: slug)
 
             // Re-fetch installed plugins to ensure a more accurate check of whether the plugin is already installed
             try await service.fetchInstalledPlugins()
-            self.installed = try await service.findInstalledPluginsUpdates(slug: slug)
+            self.installed = try await service.findInstalledPlugin(slug: slug)
         } catch {
             self.error = (error as? WpApiError)?.errorMessage ?? error.localizedDescription
         }


### PR DESCRIPTION
The plugin details view is now used to display all plugin details, regardless of whether it's installed.

I haven't implemented all actions (like installing new plugins) yet. I'll create follow-up PRs for that.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
