### PR TITLE
Implement plugin actions in the details screen

### DIFF
--- a/Modules/Sources/WordPressCore/Plugins/InstalledPlugin.swift
+++ b/Modules/Sources/WordPressCore/Plugins/InstalledPlugin.swift
@@ -1,47 +1,42 @@
 import Foundation
 import WordPressAPI
+import WordPressAPIInternal
 
 public struct InstalledPlugin: Equatable, Hashable, Identifiable, Sendable {
     public var slug: PluginSlug
-    public var iconURL: URL?
     public var name: String
     public var version: String
     public var author: String
     public var shortDescription: String
-    public var isActive: Bool
+    public var status: PluginStatus
+    public var networkOnly: Bool
 
-    public init(slug: PluginSlug, iconURL: URL?, name: String, version: String, author: String, shortDescription: String, isActive: Bool) {
-        self.slug = slug
-        self.iconURL = iconURL
-        self.name = name
-        self.version = version
-        self.author = author
-        self.shortDescription = shortDescription
-        self.isActive = isActive
-    }
-
-    public init(plugin: PluginWithViewContext) {
-        self.slug = plugin.plugin
-        iconURL = nil
-        name = plugin.name
-        version = plugin.version
-        author = plugin.author
-        shortDescription = plugin.description.raw
-        isActive = plugin.status == .active || plugin.status == .networkActive
-    }
-
-    public init(plugin: PluginWithEditContext) {
-        self.slug = plugin.plugin
-        iconURL = nil
-        name = plugin.name
-        version = plugin.version
-        author = plugin.author
-        shortDescription = plugin.description.raw
-        isActive = plugin.status == .active || plugin.status == .networkActive
+    public var isActive: Bool {
+        status == .active || status == .networkActive
     }
 
     public var id: String {
         slug.slug
+    }
+
+    init(plugin: PluginWithEditContext) {
+        self.slug = plugin.plugin
+        self.name = plugin.name
+        self.version = plugin.version
+        self.author = plugin.author
+        self.shortDescription = plugin.description.raw
+        self.status = plugin.status
+        self.networkOnly = plugin.networkOnly
+    }
+
+    init(plugin: PluginWithViewContext) {
+        self.slug = plugin.plugin
+        self.name = plugin.name
+        self.version = plugin.version
+        self.author = plugin.author
+        self.shortDescription = plugin.description.raw
+        self.status = plugin.status
+        self.networkOnly = plugin.networkOnly
     }
 
     public var possibleWpOrgDirectorySlug: PluginWpOrgDirectorySlug? {

--- a/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
@@ -14,9 +14,10 @@ public protocol PluginServiceProtocol: Actor {
 
     func resolveIconURL(of slug: PluginWpOrgDirectorySlug, plugin: PluginInformation?) async -> URL?
 
-    func togglePluginActivation(slug: PluginSlug) async throws
+    func updatePluginStatus(plugin: InstalledPlugin, activated: Bool) async throws -> InstalledPlugin
 
     func uninstalledPlugin(slug: PluginSlug) async throws
+    func installPlugin(slug: PluginWpOrgDirectorySlug) async throws -> InstalledPlugin
 
     func fetchPluginsDirectory(category: WordPressOrgApiPluginDirectoryCategory) async throws
     func pluginDirectoryUpdates(query: CategorizedPluginInformationDataStoreQuery) async -> AsyncStream<Result<[CategorizedPluginInformation], Error>>

--- a/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
+++ b/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
@@ -156,17 +156,6 @@ final class InstalledPluginsListViewModel: ObservableObject {
         }
     }
 
-    func toggle(slug: PluginSlug) async {
-        self.updating.insert(slug)
-        defer { self.updating.remove(slug) }
-
-        do {
-            try await self.service.togglePluginActivation(slug: slug)
-        } catch {
-            DDLogError("Failed to update plugin: \(error)")
-        }
-    }
-
     func uninstall(slug: PluginSlug) async {
         self.updating.insert(slug)
         defer { self.updating.remove(slug) }

--- a/WordPress/Classes/Plugins/Views/PluginListItemView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginListItemView.swift
@@ -40,58 +40,9 @@ struct PluginListItemView: View {
 
             Spacer()
         }
-        .contextMenu(menuItems: {
-            menuItems
-        })
-        .overlay(alignment: .topTrailing) {
-            Menu {
-                menuItems
-            } label: {
-                Image(systemName: "ellipsis")
-                    .padding(4)
-                    .frame(width: 44, height: 44, alignment: .topTrailing)
-                    .contentShape(Rectangle())
-            }
-            .foregroundStyle(.secondary)
-        }
         .sheet(isPresented: $isShowingSafariView) {
             if let url = plugin.possibleWpOrgDirectoryURL {
                 SafariView(url: url)
-            }
-        }
-    }
-
-    @ViewBuilder
-    private var menuItems: some View {
-        Section {
-            if plugin.isActive {
-                Button(Strings.deactivate, systemImage: "bolt.slash") {
-                    Task {
-                        await viewModel.toggle(slug: plugin.slug)
-                    }
-                }
-            } else {
-                Button(Strings.activate, systemImage: "bolt") {
-                    Task {
-                        await viewModel.toggle(slug: plugin.slug)
-                    }
-                }
-                Button(Strings.delete, systemImage: "trash", role: .destructive) {
-                    Task {
-                        await viewModel.uninstall(slug: plugin.slug)
-                    }
-                }
-            }
-        }
-        .disabled(isUpdating)
-
-        if plugin.possibleWpOrgDirectoryURL != nil {
-            Section {
-                Button {
-                    isShowingSafariView = true
-                } label: {
-                    Label(Strings.viewOnWordPressOrg, systemImage: "safari")
-                }
             }
         }
     }


### PR DESCRIPTION
These actions all reuse a progress section of the details to show the ongoing action. Maybe we should show a full screen HUD to block all user interaction while plugin is activating/deleting/...?

This PR also deletes the context menu in the plugins list, because the details screen is a better place for them, considering we need to show the ongoing action status and potential error messages.

https://github.com/user-attachments/assets/099a177b-7646-4a74-b0fa-2516fe13bf9c.mp4



## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
