### PR TITLE
Fix incorrect background color for draft post cells on dashboard

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * [*] Remove Submit Feedback form from the Me menu [#24020]
 * [*] Fix unselectable group blocks in the experimental editor [https://github.com/wordpress-mobile/GutenbergKit/pull/68]
 * [*] Prevent a intermittent crash when opening the experimental editor's "more" menu [#24065]
+* [*] Fix incorrect background color for draft post cells on dashboard [#24080]
 
 25.7
 -----

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/Views/BlogDashboardPostCardGhostCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/Views/BlogDashboardPostCardGhostCell.swift
@@ -8,6 +8,7 @@ class BlogDashboardPostCardGhostCell: UITableViewCell, NibReusable {
         super.awakeFromNib()
 
         WPStyleGuide.configureTableViewCell(self)
-        WPStyleGuide.applyPostCardStyle(self)
+
+        backgroundColor = .clear
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Views/PostCompactCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PostCompactCell.swift
@@ -39,7 +39,8 @@ final class PostCompactCell: UITableViewCell, Reusable {
 
     private func setupStyles() {
         WPStyleGuide.configureTableViewCell(self)
-        WPStyleGuide.applyPostCardStyle(self)
+
+        backgroundColor = .clear
 
         titleLabel.font = .preferredFont(forTextStyle: .headline)
         titleLabel.adjustsFontForContentSizeCategory = true
@@ -52,8 +53,6 @@ final class PostCompactCell: UITableViewCell, Reusable {
 
         featuredImageView.layer.cornerRadius = Constants.imageRadius
         featuredImageView.layer.masksToBounds = true
-
-        contentView.backgroundColor = .systemBackground
     }
 
     private func setupLayout() {

--- a/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.swift
+++ b/WordPress/Classes/ViewRelated/Post/WPStyleGuide+Posts.swift
@@ -4,12 +4,6 @@ import WordPressShared
 /// A WPStyleGuide extension with styles and methods specific to the Posts feature.
 ///
 extension WPStyleGuide {
-
-    class func applyPostCardStyle(_ cell: UITableViewCell) {
-        cell.backgroundColor = .systemGroupedBackground
-        cell.contentView.backgroundColor = .systemGroupedBackground
-    }
-
     class func applyBorderStyle(_ view: UIView) {
         view.updateConstraint(for: .height, withRelation: .equal, setConstant: .hairlineBorderWidth, setActive: true)
         view.backgroundColor = .separator


### PR DESCRIPTION
Before / After

<img width="320" alt="Screenshot 2025-02-14 at 10 18 27 AM" src="https://github.com/user-attachments/assets/51df3734-a743-4824-8d3b-9a9cc41393ca" /> <img width="320" alt="Screenshot 2025-02-14 at 10 24 29 AM" src="https://github.com/user-attachments/assets/8d3355ef-91f1-4469-9700-e6ad753c1018" />



To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
