### PR TITLE
WKWebView content process termination protection

### DIFF
--- a/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
@@ -143,7 +143,6 @@ extension WebCommentContentRenderer: WKNavigationDelegate {
     }
 
     public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
-        NSLog("webViewWebContentProcessDidTerminate")
         isReloadNeeded = true
         if UIApplication.shared.applicationState == .active {
             reloadIfNeeded()

--- a/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
@@ -33,6 +33,8 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
 
     private var cachedHead: String?
     private var comment: String?
+    private var lastReloadDate: Date?
+    private var isReloadNeeded = false
 
     /// A shared web view context with resources that can be reused across
     /// mutliple web view instances.
@@ -64,17 +66,35 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
         webView.scrollView.bounces = false
         webView.scrollView.showsVerticalScrollIndicator = false
         webView.scrollView.backgroundColor = .clear
+
+        NotificationCenter.default.addObserver(self, selector: #selector(applicationWillEnterForeground), name: UIApplication.willEnterForegroundNotification, object: nil)
     }
 
     public func render(comment: String) {
         self.comment = comment
+        actuallyRender(comment: comment)
+    }
 
+    private func actuallyRender(comment: String) {
         webView.loadHTMLString(formattedHTMLString(for: comment), baseURL: nil)
     }
 
     public func prepareForReuse() {
         comment = nil
         webView.stopLoading()
+    }
+
+    @objc private func applicationWillEnterForeground() {
+        reloadIfNeeded()
+    }
+
+    private func reloadIfNeeded() {
+        guard isReloadNeeded, Date.now.timeIntervalSince((lastReloadDate ?? .distantPast)) > 8, let comment else {
+            return
+        }
+        isReloadNeeded = false
+        lastReloadDate = Date()
+        actuallyRender(comment: comment)
     }
 }
 
@@ -119,6 +139,14 @@ extension WebCommentContentRenderer: WKNavigationDelegate {
             }
             self.delegate?.renderer(self, interactedWithURL: destinationURL)
             return .cancel
+        }
+    }
+
+    public func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        NSLog("webViewWebContentProcessDidTerminate")
+        isReloadNeeded = true
+        if UIApplication.shared.applicationState == .active {
+            reloadIfNeeded()
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -130,7 +130,7 @@ extension NSNotification.Name {
             guard let tableView else { return }
 
             if tableView.alpha == 0 {
-                UIView.animate(withDuration: 0.2) {
+                UIView.animate(withDuration: 0.2, delay: 0.1) { // Add 100 ms to let other cells a chance to render
                     tableView.alpha = 1
                 }
             }


### PR DESCRIPTION
Fixes an issue where comments `WKWebView` will go blank after some time in the background.

## To test:

- Open WebKit-based comments
- Close the app
- Open a resource intensive app like camera and take a few pictures
- Wait until the system terminates the web view content processes without actually terminating the app itself (note: this doesn't happen every time, so it may no be super easy to reproduce)
- Re-opened the app
- **Verify** that the comments are reloaded (you'll see the blink)

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
