### PR TITLE
Remove title field from comment composer

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250127"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", branch: "task/make-title-optional"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", branch: "trunk"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", from: "1.20.0"),
     ],

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250127"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.0.5"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", branch: "task/make-title-optional"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", from: "1.20.0"),
     ],

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "99df7d25cd0011bd3f0fe8ea52b2a7b16e360c788cf5a595af20cc2de61c1114",
+  "originHash" : "9d09e550a90ffbd92a56ca0bb82d7aba43e0974082504b7093e3fc125d1fbb7a",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "68eaa32df758a0a195bbd0a592f77367902a7f5f",
-        "version" : "0.0.5"
+        "branch" : "task/make-title-optional",
+        "revision" : "fe59eb1630bc3437867e92a50a7bf5f9e6efff84"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9d09e550a90ffbd92a56ca0bb82d7aba43e0974082504b7093e3fc125d1fbb7a",
+  "originHash" : "a18ee90026e750cb84f202a7e7f61ca1a244247842cba1b3ed1cbe7fd5bbefe2",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "branch" : "task/make-title-optional",
-        "revision" : "fe59eb1630bc3437867e92a50a7bf5f9e6efff84"
+        "branch" : "trunk",
+        "revision" : "5a645ef7f57142e928ff7c58b51d8e51f80a0fa4"
       }
     },
     {

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/Composer/CommentGutenbergEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/Composer/CommentGutenbergEditorViewController.swift
@@ -44,10 +44,10 @@ final class CommentGutenbergEditorViewController: UIViewController, CommentEdito
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        let editorVC = GutenbergKit.EditorViewController(
-            content: initialContent ?? "",
-            service: EditorService(client: EmptyNetworkClient())
-        )
+        var configuration = EditorConfiguration(content: initialContent ?? "")
+        configuration.hideTitle = true
+
+        let editorVC = GutenbergKit.EditorViewController(configuration: configuration)
         editorVC.delegate = self
 
         view.addSubview(editorVC.view)
@@ -103,11 +103,5 @@ extension CommentGutenbergEditorViewController: GutenbergKit.EditorViewControlle
 
     func editor(_ viewController: GutenbergKit.EditorViewController, didRequestMediaFromSiteMediaLibrary config: GutenbergKit.OpenMediaLibraryAction) {
         // Do nothing
-    }
-}
-
-private final class EmptyNetworkClient: GutenbergKit.EditorNetworkingClient {
-    func send(_ request: EditorNetworkRequest) async throws -> EditorNetworkResponse {
-        throw URLError(.unknown)
     }
 }


### PR DESCRIPTION
This PR removes the title field from comment composer.

<img width="320" alt="Screenshot 2025-02-18 at 9 32 11 AM" src="https://github.com/user-attachments/assets/fa193695-691f-4368-bfa2-d2abfed90b8a" />

Related GutenbergKit PR: https://github.com/wordpress-mobile/GutenbergKit/pull/94.

## To test:

- Enable "Gutenberg Comment Composer" FF
- In Reader, create a new comment and **verify** that the composer doesn't have the title field
- In Posts, smoke test the GBK editor

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
