### PR TITLE
build: Integrate GutenbergKit 0.1.0

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250127"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", branch: "trunk"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.1.0"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", from: "1.20.0"),
     ],

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "a18ee90026e750cb84f202a7e7f61ca1a244247842cba1b3ed1cbe7fd5bbefe2",
+  "originHash" : "75fed979514ba51feb1e17be7b1054f54eaf5ca96b5c622015cd9ba62529596a",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,8 +150,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "branch" : "trunk",
-        "revision" : "5a645ef7f57142e928ff7c58b51d8e51f80a0fa4"
+        "revision" : "45db2591254cc1140b01cda6e8cadcced359bf2a",
+        "version" : "0.1.0"
       }
     },
     {


### PR DESCRIPTION
Integrate the GutenbergKit 0.1.0 release.

Related: https://github.com/wordpress-mobile/WordPress-Android/pull/21693 

To test: Smoke test the editor.

## Regression Notes
1. Potential unintended areas of impact
    Unlikely for a version bump.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    N/A
3. What automated tests I added (or what prevented me from doing so)
    N/A

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
