### PR TITLE
Plugin UI minor updates

### DIFF
--- a/WordPress/Classes/Plugins/Views/AddNewPluginView.swift
+++ b/WordPress/Classes/Plugins/Views/AddNewPluginView.swift
@@ -42,6 +42,17 @@ struct AddNewPluginView: View {
         .task(id: 0) {
             await viewModel.onAppear()
         }
+        .task(id: 1) {
+            for await result in await viewModel.service.installedPluginsUpdates(query: .all) {
+                guard case let .success(plugins) = result else { continue }
+
+                viewModel.installedPlugins = plugins.reduce(into: Set()) {
+                    if let slug = $1.possibleWpOrgDirectorySlug {
+                        $0.insert(slug)
+                    }
+                }
+            }
+        }
         .task(id: viewModel.mode) {
             await viewModel.performQuery()
         }
@@ -82,9 +93,9 @@ struct AddNewPluginView: View {
             .frame(maxWidth: .infinity, alignment: .center)
         } else if case .error = row {
             Text("Failed to load plugins. Tap here to retry")
-        } else if case let .plugin(plugin) = row {
+        } else if case let .plugin(plugin, isInstalled) = row {
             NavigationLink(destination: PluginDetailsView(plugin: plugin, service: viewModel.service)) {
-                HStack(alignment: .top) {
+                HStack(alignment: .center) {
                     PluginIconView(plugin: plugin, service: viewModel.service)
 
                     VStack(alignment: .leading, spacing: 4) {
@@ -101,6 +112,22 @@ struct AddNewPluginView: View {
                     }
 
                     Spacer()
+
+                    if isInstalled {
+                        Label {
+                            Text(Strings.installed)
+                        } icon: {
+                            Image(systemName: "checkmark")
+                                .imageScale(.small)
+                        }
+                        .font(.caption.bold())
+                        .foregroundStyle(.green)
+                        .labelStyle(.titleAndIcon)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Color.green.opacity(0.15))
+                        .clipShape(Capsule())
+                    }
                 }
             }
         } else if case .empty = row {
@@ -152,7 +179,7 @@ private enum ListSection: Identifiable, Hashable {
 
 private enum ListRow: Identifiable, Hashable {
     case loading
-    case plugin(PluginInformation)
+    case plugin(PluginInformation, isInstalled: Bool)
     case empty
     case error(String)
 
@@ -160,7 +187,7 @@ private enum ListRow: Identifiable, Hashable {
         switch self {
         case .loading:
             return "loading"
-        case .plugin(let plugin):
+        case .plugin(let plugin, _):
             return plugin.slug
         case .empty:
             return "empty"
@@ -200,6 +227,7 @@ private class AddNewPluginViewModel: ObservableObject {
     private(set) var mode: Mode = .browser
 
     @Published var loadingStates: [Category: Result<Void, Error>] = [:]
+    @Published var installedPlugins: Set<PluginWpOrgDirectorySlug> = []
 
     @Published var searchInput: String = "" {
         didSet {
@@ -279,7 +307,7 @@ private class AddNewPluginViewModel: ObservableObject {
             if plugins.isEmpty {
                 sections = [.searchResult(rows: [.empty])]
             } else {
-                sections = [.searchResult(rows: plugins.map { .plugin($0) })]
+                sections = [.searchResult(rows: plugins.map { .plugin($0, isInstalled: installedPlugins.contains(PluginWpOrgDirectorySlug(slug: $0.slug))) })]
             }
             update(to: sections, ifStillIn: expectedMode)
         } catch {
@@ -305,7 +333,15 @@ private class AddNewPluginViewModel: ObservableObject {
         if plugins.plugins.isEmpty {
             return .plugins(category: category, rows: [.empty])
         } else {
-            return .plugins(category: category, rows: plugins.plugins.map { .plugin($0) })
+            return .plugins(category: category, rows: plugins.plugins.map { .plugin($0, isInstalled: installedPlugins.contains(PluginWpOrgDirectorySlug(slug: $0.slug))) })
         }
     }
+}
+
+private enum Strings {
+    static let installed = NSLocalizedString(
+        "site.plugins.add.installed.tag",
+        value: "Installed",
+        comment: "Tag shown next to plugins that are already installed"
+    )
 }

--- a/WordPress/Classes/Plugins/Views/AddNewPluginView.swift
+++ b/WordPress/Classes/Plugins/Views/AddNewPluginView.swift
@@ -39,10 +39,10 @@ struct AddNewPluginView: View {
                 }
             }
         }
-        .task(id: 0) {
+        .task {
             await viewModel.onAppear()
         }
-        .task(id: 1) {
+        .task {
             for await result in await viewModel.service.installedPluginsUpdates(query: .all) {
                 guard case let .success(plugins) = result else { continue }
 

--- a/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
+++ b/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
@@ -73,7 +73,7 @@ struct InstalledPluginsListView: View {
                 AddNewPluginView(service: viewModel.service)
             }
         }
-        .task(id: 0) {
+        .task {
             await viewModel.onAppear()
         }
         .task(id: viewModel.filter) {

--- a/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
@@ -125,7 +125,7 @@ struct PluginDetailsView: View {
             }
         }
         .listStyle(.plain)
-        .task(id: 0) {
+        .task {
             await viewModel.onAppear()
         }
         .task(id: slug) {

--- a/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
@@ -300,6 +300,7 @@ struct PluginDetailsView: View {
                     }
                     .padding(.horizontal)
                 }
+                .pagingIfAvailable()
             }
             .padding(.vertical)
             .listRowInsets(.zero)
@@ -773,4 +774,15 @@ private enum Strings {
         value: "Please wait while the plugin is being deactivated...",
         comment: "Message shown while a plugin is being deactivated"
     )
+}
+
+private extension View {
+
+    @ViewBuilder
+    func pagingIfAvailable() -> some View {
+        if #available(iOS 17.0, *) {
+            scrollTargetBehavior(.paging)
+        }
+    }
+
 }

--- a/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
@@ -87,18 +87,21 @@ struct PluginDetailsView: View {
 
                     actionButton
                         .view
-                        .disabled(viewModel.isLoading || viewModel.isActivating || viewModel.isDeactivating || viewModel.isUninstalling || viewModel.isInstalling)
+                        .disabled(viewModel.isLoading || (viewModel.operation?.isCompleted == false))
                 }
                 .listRowSeparator(.hidden)
 
-                if viewModel.isUninstalling {
-                    inlineProgressView(title: Strings.uninstallingTitle, message: Strings.uninstallingMessage)
-                } else if viewModel.isInstalling {
-                    inlineProgressView(title: Strings.installingTitle, message: Strings.installingMessage)
-                } else if viewModel.isActivating {
-                    inlineProgressView(title: Strings.activatingTitle, message: Strings.activatingMessage)
-                } else if viewModel.isDeactivating {
-                    inlineProgressView(title: Strings.deactivatingTitle, message: Strings.deactivatingMessage)
+                if let operation = viewModel.operation, !operation.isCompleted {
+                    switch operation.operation {
+                    case .install:
+                        inlineProgressView(title: Strings.installingTitle, message: Strings.installingMessage)
+                    case .uninstall:
+                        inlineProgressView(title: Strings.uninstallingTitle, message: Strings.uninstallingMessage)
+                    case .activate:
+                        inlineProgressView(title: Strings.activatingTitle, message: Strings.activatingMessage)
+                    case .deactivate:
+                        inlineProgressView(title: Strings.deactivatingTitle, message: Strings.deactivatingMessage)
+                    }
                 } else if let error = viewModel.operation?.errorMessage {
                     errorView(title: SharedStrings.Error.generic, message: error)
                 } else if let newVersion {
@@ -448,18 +451,6 @@ final class WordPressPluginDetailViewModel: ObservableObject {
     @Published private(set) var error: String?
 
     @Published private(set) fileprivate var operation: PluginOperationStatus?
-    var isUninstalling: Bool {
-        operation?.operation == .uninstall && operation?.isCompleted == false
-    }
-    var isInstalling: Bool {
-        operation?.operation == .install && operation?.isCompleted == false
-    }
-    var isActivating: Bool {
-        operation?.operation == .activate && operation?.isCompleted == false
-    }
-    var isDeactivating: Bool {
-        operation?.operation == .deactivate && operation?.isCompleted == false
-    }
 
     private var initialLoad = false
 

--- a/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
@@ -91,25 +91,25 @@ struct PluginDetailsView: View {
                 }
                 .listRowSeparator(.hidden)
 
+                if viewModel.isUninstalling {
+                    inlineProgressView(title: Strings.uninstallingTitle, message: Strings.uninstallingMessage)
+                } else if viewModel.isInstalling {
+                    inlineProgressView(title: Strings.installingTitle, message: Strings.installingMessage)
+                } else if viewModel.isActivating {
+                    inlineProgressView(title: Strings.activatingTitle, message: Strings.activatingMessage)
+                } else if viewModel.isDeactivating {
+                    inlineProgressView(title: Strings.deactivatingTitle, message: Strings.deactivatingMessage)
+                } else if let error = viewModel.operation?.errorMessage {
+                    errorView(title: SharedStrings.Error.generic, message: error)
+                } else if let newVersion {
+                    updateAvailableView(newVersion)
+                }
+
                 Text(pluginInfo.shortDescription)
                     .font(.body)
                     .listRowSeparator(.hidden)
             }
             .listSectionSeparator(.hidden)
-
-            if viewModel.isUninstalling {
-                inlineProgressView(title: Strings.uninstallingTitle, message: Strings.uninstallingMessage)
-            } else if viewModel.isInstalling {
-                inlineProgressView(title: Strings.installingTitle, message: Strings.installingMessage)
-            } else if viewModel.isActivating {
-                inlineProgressView(title: Strings.activatingTitle, message: Strings.activatingMessage)
-            } else if viewModel.isDeactivating {
-                inlineProgressView(title: Strings.deactivatingTitle, message: Strings.deactivatingMessage)
-            } else if let error = viewModel.operation?.errorMessage {
-                errorView(title: SharedStrings.Error.generic, message: error)
-            } else if let newVersion {
-                updateAvailableView(newVersion)
-            }
 
             if viewModel.isLoading {
                 ProgressView(Strings.loadingPluginInformation)

--- a/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
@@ -105,6 +105,8 @@ struct PluginDetailsView: View {
                 inlineProgressView(title: Strings.activatingTitle, message: Strings.activatingMessage)
             } else if viewModel.isDeactivating {
                 inlineProgressView(title: Strings.deactivatingTitle, message: Strings.deactivatingMessage)
+            } else if let error = viewModel.operation?.errorMessage {
+                errorView(title: SharedStrings.Error.generic, message: error)
             } else if let newVersion {
                 updateAvailableView(newVersion)
             }
@@ -167,8 +169,7 @@ struct PluginDetailsView: View {
             Button(SharedStrings.Button.cancel, role: .cancel) { }
             Button(SharedStrings.Button.delete, role: .destructive) {
                 Task { @MainActor in
-                    if let plugin = viewModel.installed {
-                        await viewModel.uninstall(plugin)
+                    if let plugin = viewModel.installed, await viewModel.uninstall(plugin) {
                         dismiss()
                     }
                 }
@@ -244,6 +245,28 @@ struct PluginDetailsView: View {
         }
         .padding()
         .background(Color.red.opacity(0.2))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .listRowSeparator(.hidden)
+        .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+    }
+
+    @ViewBuilder
+    private func errorView(title: String, message: String) -> some View {
+        HStack {
+            Image(systemName: "person.crop.circle.badge.exclamationmark")
+
+            VStack(alignment: .leading) {
+                Text(title)
+                    .font(.headline)
+                Text(message)
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+        }
+        .padding()
+        .background(Color.red.opacity(0.5))
         .clipShape(RoundedRectangle(cornerRadius: 8))
         .listRowSeparator(.hidden)
         .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
@@ -390,19 +413,52 @@ enum ActionButton {
     }
 }
 
+private enum PluginOperation: Hashable {
+    case install
+    case uninstall
+    case activate
+    case deactivate
+}
+
+private struct PluginOperationStatus {
+    var operation: PluginOperation
+    var result: Result<Void, Error>?
+
+    var isCompleted: Bool {
+        result != nil
+    }
+
+    var errorMessage: String? {
+        if case let .failure(error)? = result {
+            return (error as? WpApiError)?.errorMessage ?? error.localizedDescription
+        }
+        return nil
+    }
+}
+
 @MainActor
 final class WordPressPluginDetailViewModel: ObservableObject {
     let slug: PluginWpOrgDirectorySlug
     let service: PluginServiceProtocol
 
     @Published private(set) var isLoading = false
-    @Published private(set) var isUninstalling = false
-    @Published private(set) var isInstalling = false
     @Published private(set) var plugin: PluginInformation?
     @Published private(set) var installed: InstalledPlugin?
     @Published private(set) var error: String?
-    @Published private(set) var isActivating = false
-    @Published private(set) var isDeactivating = false
+
+    @Published private(set) fileprivate var operation: PluginOperationStatus?
+    var isUninstalling: Bool {
+        operation?.operation == .uninstall && operation?.isCompleted == false
+    }
+    var isInstalling: Bool {
+        operation?.operation == .install && operation?.isCompleted == false
+    }
+    var isActivating: Bool {
+        operation?.operation == .activate && operation?.isCompleted == false
+    }
+    var isDeactivating: Bool {
+        operation?.operation == .deactivate && operation?.isCompleted == false
+    }
 
     private var initialLoad = false
 
@@ -445,42 +501,51 @@ final class WordPressPluginDetailViewModel: ObservableObject {
     }
 
     func updatePluginStatus(_ plugin: InstalledPlugin, activated: Bool) async {
-        let keyPath: ReferenceWritableKeyPath<WordPressPluginDetailViewModel, Bool> = activated ? \.isActivating : \.isDeactivating
-        self[keyPath: keyPath] = true
-        defer {
-            self[keyPath: keyPath] = false
+        if let operation, !operation.isCompleted {
+            DDLogWarn("Can't update plugin status at the moment, because there is another operation in progress: \(operation)")
+            return
         }
 
+        let operation = activated ? PluginOperation.activate : PluginOperation.deactivate
+
         do {
+            self.operation = .init(operation: operation)
             self.installed = try await service.updatePluginStatus(plugin: plugin, activated: false)
+            self.operation = .init(operation: operation, result: .success(()))
         } catch {
-            // TODO: Show an error notice
+            self.operation = .init(operation: operation, result: .failure(error))
         }
     }
 
-    func uninstall(_ plugin: InstalledPlugin) async {
-        isUninstalling = true
-        defer {
-            isUninstalling = false
+    func uninstall(_ plugin: InstalledPlugin) async -> Bool {
+        if let operation, !operation.isCompleted {
+            DDLogWarn("Can't uninsatll plugin at the moment, because there is another operation in progress: \(operation)")
+            return false
         }
 
         do {
+            self.operation = .init(operation: .uninstall)
             try await service.uninstalledPlugin(slug: plugin.slug)
+            self.operation = .init(operation: .uninstall, result: .success(()))
+            return true
         } catch {
-            // TODO: Show an error notice
+            self.operation = .init(operation: .uninstall, result: .failure(error))
+            return false
         }
     }
 
     func install() async {
-        isInstalling = true
-        defer {
-            isInstalling = false
+        if let operation, !operation.isCompleted {
+            DDLogWarn("Can't install plugin at the moment, because there is another operation in progress: \(operation)")
+            return
         }
 
         do {
+            self.operation = .init(operation: .install)
             self.installed = try await service.installPlugin(slug: slug)
+            self.operation = .init(operation: .install, result: .success(()))
         } catch {
-            // TODO: Show an error notice
+            self.operation = .init(operation: .install, result: .failure(error))
         }
     }
 }

--- a/WordPress/Classes/Plugins/Views/PluginIconView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginIconView.swift
@@ -30,8 +30,7 @@ struct PluginIconView: View {
         CachedAsyncImage(url: iconURL) { image in
             image.resizable()
         } placeholder: {
-            Image("site-menu-plugins")
-                .resizable()
+            Image(systemName: "puzzlepiece.extension")
         }
         .frame(width: Self.iconSize, height: Self.iconSize)
         .clipShape(RoundedRectangle(cornerRadius: 4))


### PR DESCRIPTION
A few UI updates:
1. Show a [installed] label/tag in the "Add New Plugin" screen.
2. The screenshots scroll view is now set to page mode (on iOS 17 and above).
3. Display errors when failing to install/delete/activate/deactivate plugins.

To test:

## Regression Notes
1. Potential unintended areas of impact


4. What I did to test those areas of impact (or what existing automated tests I relied on)


5. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
