### PR TITLE
Bypass SwiftLint using `ACTION` instead of `CONFIGURATION`

### DIFF
--- a/Scripts/BuildPhases/SwiftLint.sh
+++ b/Scripts/BuildPhases/SwiftLint.sh
@@ -10,7 +10,7 @@ fi
 
 # Do not run when archiving (ACTION = install).
 #
-# For some reason, running when trying to archive, via CLI, results in a compilation failure.
+# For some reason, running when trying to archive, via CLI, results in a compilation failure at times.
 #
 # fatal error: module 'WordPressSharedObjC' in AST file '/path/to/DerivedData/ModuleCache.noindex/EQUUY9BHSJ5N/WordPressSharedObjC-5G93B85NZ09I.pcm'
 # (imported by AST file '/Users/gio/Developer/a8c/wpios/DerivedData/WordPress/Build/Intermediates.noindex/ArchiveIntermediates/WordPress Alpha/PrecompiledHeaders/WordPress-Bridging-Header-swift_1L0UBHDEION2G-clang_EQUUY9BHSJ5N.pch')

--- a/Scripts/BuildPhases/SwiftLint.sh
+++ b/Scripts/BuildPhases/SwiftLint.sh
@@ -8,15 +8,16 @@ if [ -n "${CI+x}" ]; then
   exit 0
 fi
 
-# Only run on debug builds.
+# Do not run when archiving (ACTION = install).
+#
 # For some reason, running when trying to archive, via CLI, results in a compilation failure.
 #
 # fatal error: module 'WordPressSharedObjC' in AST file '/path/to/DerivedData/ModuleCache.noindex/EQUUY9BHSJ5N/WordPressSharedObjC-5G93B85NZ09I.pcm'
 # (imported by AST file '/Users/gio/Developer/a8c/wpios/DerivedData/WordPress/Build/Intermediates.noindex/ArchiveIntermediates/WordPress Alpha/PrecompiledHeaders/WordPress-Bridging-Header-swift_1L0UBHDEION2G-clang_EQUUY9BHSJ5N.pch')
 # is not defined in any loaded module map file;
 # maybe you need to load '/Users/gio/Developer/a8c/wpios/DerivedData/WordPress/Build/Intermediates.noindex/ArchiveIntermediates/WordPress Alpha/IntermediateBuildFilesPath/GeneratedModuleMaps-iphoneos/WordPressSharedObjC.modulemap'?
-if [ "${CONFIGURATION}" != "Debug" ]; then
-  echo 'Running in a build configuration other than Debug. Skipping SwiftLint in production builds.'
+if [ "${ACTION}" == "install" ]; then
+  echo "info: Running during archival (detected ACTION = $ACTION). Skipping SwiftLint because of a build failure during archival we are yet to investigate."
   exit 0
 fi
 


### PR DESCRIPTION
Follows up on
https://github.com/wordpress-mobile/WordPress-iOS/pull/23996#discussion_r1959477946

Makes the logic more precise, given the error occurs when archiving.

**To test:** One can only test this locally because we bypass the SwiftLint build phase in CI in favor of the dedicated linter.

Here are screenshots from my local machine:

<img width="1212" alt="image" src="https://github.com/user-attachments/assets/e4428725-612c-4e2a-8d5e-e40eba0656b2" />
_A successful build, including SwiftLint_

<img width="1251" alt="image" src="https://github.com/user-attachments/assets/f02b821d-aa7c-4e73-83db-12c53fc45afd" />

<!-- purple -->
> [!IMPORTANT]  
> One of the prototype builds failed, but the error is about is at the AppCenter level
>
> ![image](https://github.com/user-attachments/assets/53148bf1-17e9-461b-8623-58cd76f83707)



## Regression Notes

1. Potential unintended areas of impact – N.A.
2. What I did to test those areas of impact (or what existing automated tests I relied on) – N.A.
3. What automated tests I added (or what prevented me from doing so) – N.A.

---

**PR submission checklist:**

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes. **N.A.**
- [x] I have considered adding accessibility improvements for my changes. **N.A.**
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary. **N.A.**

**UI changes testing checklist:** Not a UI PR.