### PR TITLE
Check plugin updates

### DIFF
--- a/Modules/Sources/WordPressCore/Plugins/InstalledPluginDataStore.swift
+++ b/Modules/Sources/WordPressCore/Plugins/InstalledPluginDataStore.swift
@@ -6,7 +6,7 @@ public typealias InMemoryInstalledPluginDataStore = InMemoryDataStore<InstalledP
 
 extension PluginDataStoreQuery {
     public static var all: PluginDataStoreQuery {
-        .init(sortBy: KeyPathComparator(\.name)) { _ in true }
+        .init(sortBy: KeyPathComparator(\.name))
     }
 
     public static var active: PluginDataStoreQuery {

--- a/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
@@ -9,6 +9,7 @@ public protocol PluginServiceProtocol: Actor {
 
     func installedPluginsUpdates(query: PluginDataStoreQuery) async -> AsyncStream<Result<[InstalledPlugin], Error>>
     func pluginInformationUpdates(query: PluginDirectoryDataStoreQuery) async -> AsyncStream<Result<[PluginInformation], Error>>
+    func newVersionUpdates(query: PluginUpdateChecksDataStoreQuery) async -> AsyncStream<Result<[UpdateCheckPluginInfo], Error>>
 
     func findInstalledPlugin(slug: PluginWpOrgDirectorySlug) async throws -> InstalledPlugin?
 

--- a/Modules/Sources/WordPressCore/Plugins/PluginUpdateChecksDataStore.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginUpdateChecksDataStore.swift
@@ -1,0 +1,19 @@
+import Foundation
+import WordPressAPIInternal
+
+extension UpdateCheckPluginInfo: @retroactive Identifiable {
+    public var id: PluginSlug { plugin }
+}
+
+public typealias PluginUpdateChecksDataStoreQuery = InMemoryDataStore<UpdateCheckPluginInfo>.Query
+public typealias PluginUpdateChecksDataStore = InMemoryDataStore<UpdateCheckPluginInfo>
+
+extension PluginUpdateChecksDataStoreQuery {
+    public static var all: Self {
+        .init(sortBy: nil)
+    }
+
+    public static func slug(_ slug: PluginSlug) -> Self {
+        .init(id: slug)
+    }
+}

--- a/Modules/Sources/WordPressCore/Users/UserDataStore.swift
+++ b/Modules/Sources/WordPressCore/Users/UserDataStore.swift
@@ -6,7 +6,7 @@ public typealias InMemoryUserDataStore = InMemoryDataStore<DisplayUser>
 
 extension UserDataStoreQuery {
     public static var all: UserDataStoreQuery {
-        .init(sortBy: KeyPathComparator(\.username)) { _ in true }
+        .init(sortBy: KeyPathComparator(\.username))
     }
 
     public static func id(_ id: T.ID) -> UserDataStoreQuery {

--- a/Modules/Sources/WordPressCore/WordPressClient.swift
+++ b/Modules/Sources/WordPressCore/WordPressClient.swift
@@ -4,7 +4,7 @@ import WordPressAPI
 public actor WordPressClient {
 
     public let api: WordPressAPI
-    private let rootUrl: String
+    public let rootUrl: String
 
     public init(api: WordPressAPI, rootUrl: ParsedUrl) {
         self.api = api

--- a/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
+++ b/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
@@ -73,7 +73,7 @@ struct InstalledPluginsListView: View {
         .task {
             await viewModel.onAppear()
         }
-        .task(id: 1) {
+        .task {
             await viewModel.versionUpdate()
         }
         .task(id: viewModel.filter) {

--- a/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
+++ b/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
@@ -2,16 +2,13 @@ import SwiftUI
 import AsyncImageKit
 import WordPressUI
 import WordPressAPI
+import WordPressAPIInternal
 import WordPressCore
 
 struct InstalledPluginsListView: View {
     @StateObject private var viewModel: InstalledPluginsListViewModel
 
     @State private var presentAddNewPlugin = false
-
-    init(client: WordPressClient) {
-        self.init(service: PluginService(client: client))
-    }
 
     init(service: PluginServiceProtocol) {
         _viewModel = StateObject(wrappedValue: .init(service: service))
@@ -28,7 +25,7 @@ struct InstalledPluginsListView: View {
                     Section {
                         ForEach(viewModel.displayingPlugins, id: \.self) { plugin in
                             ZStack {
-                                PluginListItemView(plugin: plugin, viewModel: viewModel)
+                                PluginListItemView(plugin: plugin, updateAvailable: viewModel.updateAvailable.index(forKey: plugin.slug) != nil, service: viewModel.service)
                                 if let slug = plugin.possibleWpOrgDirectorySlug {
                                     // Using `PluginListItemView` as `NavigationLink`'s content would show an disclosure
                                     // indicator on the list cell, which looks a bit off with the ellipsis button on the
@@ -76,6 +73,9 @@ struct InstalledPluginsListView: View {
         .task {
             await viewModel.onAppear()
         }
+        .task(id: 1) {
+            await viewModel.versionUpdate()
+        }
         .task(id: viewModel.filter) {
             await viewModel.performQuery()
         }
@@ -118,6 +118,7 @@ final class InstalledPluginsListViewModel: ObservableObject {
     @Published var isRefreshing: Bool = false
     @Published var filter: PluginFilter = .all
     @Published var displayingPlugins: [InstalledPlugin] = []
+    @Published var updateAvailable: [PluginSlug: UpdateCheckPluginInfo] = [:]
     @Published var error: String? = nil
 
     @Published var updating: Set<PluginSlug> = []
@@ -152,6 +153,15 @@ final class InstalledPluginsListViewModel: ObservableObject {
                 self.displayingPlugins = plugins
             case let .failure(error):
                 self.error = (error as? WpApiError)?.errorMessage ?? error.localizedDescription
+            }
+        }
+    }
+
+    func versionUpdate() async {
+        for await update in await self.service.newVersionUpdates(query: .all) {
+            guard let updates = try? update.get() else { continue }
+            self.updateAvailable = updates.reduce(into: [:]) {
+                $0[$1.plugin] = $1
             }
         }
     }

--- a/WordPress/Classes/Plugins/Views/PluginListItemView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginListItemView.swift
@@ -11,16 +11,12 @@ struct PluginListItemView: View {
     @State private var isShowingSafariView = false
 
     let plugin: InstalledPlugin
-    let viewModel: InstalledPluginsListViewModel
-
-    // Add this computed property to avoid direct state access in the view body
-    private var isUpdating: Bool {
-        viewModel.updating.contains(plugin.slug)
-    }
+    let updateAvailable: Bool
+    let service: PluginServiceProtocol
 
     var body: some View {
         HStack(alignment: .top) {
-            PluginIconView(slug: plugin.possibleWpOrgDirectorySlug, service: viewModel.service)
+            PluginIconView(slug: plugin.possibleWpOrgDirectorySlug, service: service)
 
             VStack(alignment: .leading, spacing: 4) {
                 Text(plugin.name.makePlainText())
@@ -33,9 +29,27 @@ struct PluginListItemView: View {
                     .font(.body)
                     .foregroundStyle(.primary)
 
-                Text(Strings.version(plugin.version))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                HStack(alignment: .center) {
+                    Text(Strings.version(plugin.version))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+
+                    if updateAvailable {
+                        Label {
+                            Text("Update available")
+                        } icon: {
+                            Image(systemName: "arrow.triangle.2.circlepath")
+                                .imageScale(.small)
+                        }
+                        .font(.caption.bold())
+                        .foregroundStyle(.orange)
+                        .labelStyle(.titleAndIcon)
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(Color.orange.opacity(0.15))
+                        .clipShape(Capsule())
+                    }
+                }
             }
 
             Spacer()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -146,11 +146,13 @@ extension BlogDetailsViewController {
             return
         }
 
+        let wordpressCoreVersion = blog.version as? String
+
         let viewController: UIViewController
         if Feature.enabled(.pluginManagementOverhaul) {
             let feature = NSLocalizedString("applicationPasswordRequired.feature.plugins", value: "Plugin Management", comment: "Feature name for managing plugins in the app")
             let rootView = ApplicationPasswordRequiredView(blog: self.blog, localizedFeatureName: feature) { client in
-                let service = PluginService(client: client)
+                let service = PluginService(client: client, wordpressCoreVersion: wordpressCoreVersion)
                 InstalledPluginsListView(service: service)
             }
             viewController = UIHostingController(rootView: rootView)


### PR DESCRIPTION
Show an "Update available" label on the plugins list.

The feature is not working at the moment due to a bug in wordpress-rs.

<img src="https://github.com/user-attachments/assets/d869142d-c507-42a3-a29b-75b5c398ec68" width=300 />

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
