### PR TITLE
Add "Active" and "Inactive" headers to the plugins list

### DIFF
--- a/Modules/Sources/WordPressCore/Plugins/PluginService.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginService.swift
@@ -49,6 +49,10 @@ public actor PluginService: PluginServiceProtocol {
         try await installedPluginDataStore.list(query: .slug(slug)).first
     }
 
+    public func installedPlugins(query: PluginDataStoreQuery) async throws -> [InstalledPlugin] {
+        try await installedPluginDataStore.list(query: query)
+    }
+
     public func installedPluginsUpdates(query: PluginDataStoreQuery) async -> AsyncStream<Result<[InstalledPlugin], Error>> {
         await installedPluginDataStore.listStream(query: query)
     }

--- a/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
@@ -12,6 +12,7 @@ public protocol PluginServiceProtocol: Actor {
     func newVersionUpdates(query: PluginUpdateChecksDataStoreQuery) async -> AsyncStream<Result<[UpdateCheckPluginInfo], Error>>
 
     func findInstalledPlugin(slug: PluginWpOrgDirectorySlug) async throws -> InstalledPlugin?
+    func installedPlugins(query: PluginDataStoreQuery) async throws -> [InstalledPlugin]
 
     func resolveIconURL(of slug: PluginWpOrgDirectorySlug, plugin: PluginInformation?) async -> URL?
 

--- a/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
+++ b/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
@@ -22,58 +22,9 @@ struct InstalledPluginsListView: View {
                 Label { Text(Strings.loading) } icon: { ProgressView() }
             } else {
                 if viewModel.showNoPluginsView {
-                    EmptyStateView {
-                        Image(systemName: "puzzlepiece.extension")
-                    } description: {
-                        Group {
-                            switch viewModel.filter {
-                            case .all:
-                                Text(Strings.noPluginInstalled)
-                            case .active:
-                                Text(Strings.noPluginsActive)
-                            case .inactive:
-                                Text(Strings.noPluginsInactive)
-                            }
-                        }
-                        .font(.body)
-                        .foregroundStyle(.primary)
-                    } actions: {
-                        if viewModel.filter == .all {
-                            Button(Strings.addPluginButton, systemImage: "plus") {
-                                presentAddNewPlugin = true
-                            }
-                            .buttonStyle(.borderedProminent)
-                        }
-                    }
+                    noPluginsView
                 } else {
-                    List {
-                        ForEach(viewModel.sections, id: \.self) { section in
-                            Section {
-                                ForEach(section.plugins, id: \.self) { plugin in
-                                    NavigationLink {
-                                        if let slug = plugin.possibleWpOrgDirectorySlug {
-                                            PluginDetailsView(slug: slug, plugin: plugin, service: viewModel.service)
-                                        }
-                                    } label: {
-                                        PluginListItemView(
-                                            plugin: plugin,
-                                            updateAvailable: viewModel.updateAvailable.index(forKey: plugin.slug) != nil,
-                                            service: viewModel.service
-                                        )
-                                    }
-                                }
-                            } header: {
-                                Text(section.filter.title)
-                                    .textCase(nil)
-                                    .font(.headline)
-                                    .foregroundStyle(.primary)
-                            }
-                            .listSectionSeparator(.hidden, edges: .all)
-                        }
-                    }
-                    .listStyle(.grouped)
-                    .scrollContentBackground(.hidden)
-                    .refreshable(action: viewModel.refreshItems)
+                    pluginsList
                 }
             }
         }
@@ -112,6 +63,56 @@ struct InstalledPluginsListView: View {
         .task(id: viewModel.filter) {
             await viewModel.performQuery()
         }
+    }
+
+    @ViewBuilder
+    var noPluginsView: some View {
+        EmptyStateView {
+            Image(systemName: "puzzlepiece.extension")
+        } description: {
+            Text(viewModel.localizedFilterTitle)
+                .font(.body)
+                .foregroundStyle(.primary)
+        } actions: {
+            if viewModel.filter == .all {
+                Button(Strings.addPluginButton, systemImage: "plus") {
+                    presentAddNewPlugin = true
+                }
+                .buttonStyle(.borderedProminent)
+            }
+        }
+    }
+
+    @ViewBuilder
+    var pluginsList: some View {
+        List {
+            ForEach(viewModel.sections, id: \.self) { section in
+                Section {
+                    ForEach(section.plugins, id: \.self) { plugin in
+                        NavigationLink {
+                            if let slug = plugin.possibleWpOrgDirectorySlug {
+                                PluginDetailsView(slug: slug, plugin: plugin, service: viewModel.service)
+                            }
+                        } label: {
+                            PluginListItemView(
+                                plugin: plugin,
+                                updateAvailable: viewModel.updateAvailable.index(forKey: plugin.slug) != nil,
+                                service: viewModel.service
+                            )
+                        }
+                    }
+                } header: {
+                    Text(section.filter.title)
+                        .textCase(nil)
+                        .font(.headline)
+                        .foregroundStyle(.primary)
+                }
+                .listSectionSeparator(.hidden, edges: .all)
+            }
+        }
+        .listStyle(.grouped)
+        .scrollContentBackground(.hidden)
+        .refreshable(action: viewModel.refreshItems)
     }
 }
 
@@ -188,6 +189,17 @@ private final class InstalledPluginsListViewModel: ObservableObject {
     @Published var error: String? = nil
 
     @Published var updating: Set<PluginSlug> = []
+
+    var localizedFilterTitle: String {
+        switch filter {
+        case .all:
+            Strings.noPluginInstalled
+        case .active:
+            Strings.noPluginsActive
+        case .inactive:
+            Strings.noPluginsInactive
+        }
+    }
 
     init(service: PluginServiceProtocol) {
         self.service = service

--- a/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
+++ b/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
@@ -25,15 +25,16 @@ struct InstalledPluginsListView: View {
                     Section {
                         ForEach(viewModel.displayingPlugins, id: \.self) { plugin in
                             ZStack {
-                                PluginListItemView(plugin: plugin, updateAvailable: viewModel.updateAvailable.index(forKey: plugin.slug) != nil, service: viewModel.service)
-                                if let slug = plugin.possibleWpOrgDirectorySlug {
-                                    // Using `PluginListItemView` as `NavigationLink`'s content would show an disclosure
-                                    // indicator on the list cell, which looks a bit off with the ellipsis button on the
-                                    // list cell.
-                                    // Here we use an empty transparent `NavigationLink` as a workaround to hide the
-                                    // disclosure indicator.
-                                    NavigationLink { PluginDetailsView(slug: slug, plugin: plugin, service: viewModel.service) } label: { EmptyView() }
-                                        .opacity(0.0)
+                                NavigationLink {
+                                    if let slug = plugin.possibleWpOrgDirectorySlug {
+                                        PluginDetailsView(slug: slug, plugin: plugin, service: viewModel.service)
+                                    }
+                                } label: {
+                                    PluginListItemView(
+                                        plugin: plugin,
+                                        updateAvailable: viewModel.updateAvailable.index(forKey: plugin.slug) != nil,
+                                        service: viewModel.service
+                                    )
                                 }
                             }
                         }

--- a/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
+++ b/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
@@ -21,34 +21,60 @@ struct InstalledPluginsListView: View {
             } else if viewModel.isRefreshing && viewModel.sections.isEmpty {
                 Label { Text(Strings.loading) } icon: { ProgressView() }
             } else {
-                List {
-                    ForEach(viewModel.sections, id: \.self) { section in
-                        Section {
-                            ForEach(section.plugins, id: \.self) { plugin in
-                                NavigationLink {
-                                    if let slug = plugin.possibleWpOrgDirectorySlug {
-                                        PluginDetailsView(slug: slug, plugin: plugin, service: viewModel.service)
-                                    }
-                                } label: {
-                                    PluginListItemView(
-                                        plugin: plugin,
-                                        updateAvailable: viewModel.updateAvailable.index(forKey: plugin.slug) != nil,
-                                        service: viewModel.service
-                                    )
-                                }
+                if viewModel.showNoPluginsView {
+                    EmptyStateView {
+                        Image(systemName: "puzzlepiece.extension")
+                    } description: {
+                        Group {
+                            switch viewModel.filter {
+                            case .all:
+                                Text(Strings.noPluginInstalled)
+                            case .active:
+                                Text(Strings.noPluginsActive)
+                            case .inactive:
+                                Text(Strings.noPluginsInactive)
                             }
-                        } header: {
-                            Text(section.filter.title)
-                                .textCase(nil)
-                                .font(.headline)
-                                .foregroundStyle(.primary)
                         }
-                        .listSectionSeparator(.hidden, edges: .all)
+                        .font(.body)
+                        .foregroundStyle(.primary)
+                    } actions: {
+                        if viewModel.filter == .all {
+                            Button(Strings.addPluginButton, systemImage: "plus") {
+                                presentAddNewPlugin = true
+                            }
+                            .buttonStyle(.borderedProminent)
+                        }
                     }
+                } else {
+                    List {
+                        ForEach(viewModel.sections, id: \.self) { section in
+                            Section {
+                                ForEach(section.plugins, id: \.self) { plugin in
+                                    NavigationLink {
+                                        if let slug = plugin.possibleWpOrgDirectorySlug {
+                                            PluginDetailsView(slug: slug, plugin: plugin, service: viewModel.service)
+                                        }
+                                    } label: {
+                                        PluginListItemView(
+                                            plugin: plugin,
+                                            updateAvailable: viewModel.updateAvailable.index(forKey: plugin.slug) != nil,
+                                            service: viewModel.service
+                                        )
+                                    }
+                                }
+                            } header: {
+                                Text(section.filter.title)
+                                    .textCase(nil)
+                                    .font(.headline)
+                                    .foregroundStyle(.primary)
+                            }
+                            .listSectionSeparator(.hidden, edges: .all)
+                        }
+                    }
+                    .listStyle(.grouped)
+                    .scrollContentBackground(.hidden)
+                    .refreshable(action: viewModel.refreshItems)
                 }
-                .listStyle(.grouped)
-                .scrollContentBackground(.hidden)
-                .refreshable(action: viewModel.refreshItems)
             }
         }
         .navigationTitle(Strings.title)
@@ -93,6 +119,9 @@ private enum Strings {
     static let title: String = NSLocalizedString("site.plugins.title", value: "Plugins", comment: "Installed plugins list title")
     static let loading: String = NSLocalizedString("site.plugins.loading", value: "Loading installed plugins…", comment: "Message displayed when fetching installed plugins from the site")
     static let noPluginInstalled: String = NSLocalizedString("site.plugins.noInstalledPlugins", value: "You haven't installed any plugins yet", comment: "No installed plugins message")
+    static let noPluginsActive = NSLocalizedString("site.plugins.empty.active", value: "No active plugins", comment: "Message shown when there are no active plugins on the site")
+    static let noPluginsInactive = NSLocalizedString("site.plugins.empty.inactive", value: "No inactive plugins", comment: "Message shown when there are no inactive plugins on the site")
+    static let addPluginButton = NSLocalizedString("site.plugins.empty.addButton", value: "Add Plugin", comment: "Button label to add a new plugin when no plugins are installed")
     static let filterTitle: String = NSLocalizedString("site.plugins.filter.title", value: "Filter", comment: "Title of the plugin filter picker")
     static let filterOptionAll: String = NSLocalizedString("site.plugins.filter.option.all", value: "All", comment: "The plugin fillter option for displaying all plugins")
     static let filterOptionActive: String = NSLocalizedString("site.plugins.filter.option.all", value: "Active", comment: "The plugin fillter option for displaying active plugins")
@@ -141,8 +170,19 @@ private final class InstalledPluginsListViewModel: ObservableObject {
     let service: PluginServiceProtocol
     private var initialLoad = false
 
-    @Published var isRefreshing: Bool = false
-    @Published var filter: PluginFilter = .all
+    @Published var isRefreshing: Bool = false {
+        didSet {
+            Task { await self.updateListContent() }
+        }
+    }
+    @Published var showNoPluginsView: Bool = false
+    @Published var filter: PluginFilter = .all {
+        didSet {
+            // Hide "No Plugins" view when switching filters. The property will be updated to the correct value
+            // in the `performQuery` function.
+            self.showNoPluginsView = false
+        }
+    }
     @Published var sections = [ListSection]()
     @Published var updateAvailable: [PluginSlug: UpdateCheckPluginInfo] = [:]
     @Published var error: String? = nil
@@ -165,6 +205,8 @@ private final class InstalledPluginsListViewModel: ObservableObject {
         isRefreshing = true
         defer { isRefreshing = false }
 
+        self.showNoPluginsView = false
+
         do {
             try await self.service.fetchInstalledPlugins()
         } catch {
@@ -172,22 +214,37 @@ private final class InstalledPluginsListViewModel: ObservableObject {
         }
     }
 
+    func updateListContent() async {
+        do {
+            let plugins = try await self.service.installedPlugins(query: filter.query)
+            updateList(with: .success(plugins))
+        } catch {
+            updateList(with: .failure(error))
+        }
+    }
+
     func performQuery() async {
-        for await update in await self.service.installedPluginsUpdates(query: filter.query) {
-            switch update {
-            case let .success(plugins):
-                self.sections = plugins
-                    .reduce(into: [PluginFilter: [InstalledPlugin]]()) { result, plugin in
-                        let filter: PluginFilter = plugin.isActive ? .active : .inactive
-                        result[filter, default: []].append(plugin)
-                    }
-                    .map { filter, plugins in
-                        ListSection(plugins: plugins, filter: filter)
-                    }
-                    .sorted(using: KeyPathComparator(\ListSection.filter.rawValue))
-            case let .failure(error):
-                self.error = (error as? WpApiError)?.errorMessage ?? error.localizedDescription
-            }
+        for await plugins in await self.service.installedPluginsUpdates(query: filter.query) {
+            updateList(with: plugins)
+        }
+    }
+
+    func updateList(with plugins: Result<[InstalledPlugin], Error>) {
+        switch plugins {
+        case let .success(plugins):
+            self.showNoPluginsView = !self.isRefreshing && plugins.isEmpty
+            self.sections = plugins
+                .reduce(into: [PluginFilter: [InstalledPlugin]]()) { result, plugin in
+                    let filter: PluginFilter = plugin.isActive ? .active : .inactive
+                    result[filter, default: []].append(plugin)
+                }
+                .map { filter, plugins in
+                    ListSection(plugins: plugins, filter: filter)
+                }
+                .sorted(using: KeyPathComparator(\ListSection.filter.rawValue))
+        case let .failure(error):
+            self.showNoPluginsView = false
+            self.error = (error as? WpApiError)?.errorMessage ?? error.localizedDescription
         }
     }
 

--- a/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
+++ b/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
@@ -18,13 +18,13 @@ struct InstalledPluginsListView: View {
         ZStack {
             if let error = viewModel.error {
                 EmptyStateView(error, systemImage: "exclamationmark.triangle.fill")
-            } else if viewModel.isRefreshing && viewModel.displayingPlugins.isEmpty {
+            } else if viewModel.isRefreshing && viewModel.sections.isEmpty {
                 Label { Text(Strings.loading) } icon: { ProgressView() }
             } else {
                 List {
-                    Section {
-                        ForEach(viewModel.displayingPlugins, id: \.self) { plugin in
-                            ZStack {
+                    ForEach(viewModel.sections, id: \.self) { section in
+                        Section {
+                            ForEach(section.plugins, id: \.self) { plugin in
                                 NavigationLink {
                                     if let slug = plugin.possibleWpOrgDirectorySlug {
                                         PluginDetailsView(slug: slug, plugin: plugin, service: viewModel.service)
@@ -37,11 +37,17 @@ struct InstalledPluginsListView: View {
                                     )
                                 }
                             }
+                        } header: {
+                            Text(section.filter.title)
+                                .textCase(nil)
+                                .font(.headline)
+                                .foregroundStyle(.primary)
                         }
+                        .listSectionSeparator(.hidden, edges: .all)
                     }
-                    .listSectionSeparator(.hidden, edges: .top)
                 }
-                .listStyle(.plain)
+                .listStyle(.grouped)
+                .scrollContentBackground(.hidden)
                 .refreshable(action: viewModel.refreshItems)
             }
         }
@@ -57,9 +63,9 @@ struct InstalledPluginsListView: View {
             ToolbarItem(placement: .topBarTrailing) {
                 Menu {
                     Picker(Strings.filterTitle, selection: $viewModel.filter) {
-                        Text(Strings.filterOptionAll).tag(InstalledPluginsListViewModel.PluginFilter.all)
-                        Text(Strings.filterOptionActive).tag(InstalledPluginsListViewModel.PluginFilter.active)
-                        Text(Strings.filterOptionInactive).tag(InstalledPluginsListViewModel.PluginFilter.inactive)
+                        Text(Strings.filterOptionAll).tag(PluginFilter.all)
+                        Text(Strings.filterOptionActive).tag(PluginFilter.active)
+                        Text(Strings.filterOptionInactive).tag(PluginFilter.inactive)
                     }
                 } label: {
                     Image(systemName: "ellipsis.circle")
@@ -81,44 +87,63 @@ struct InstalledPluginsListView: View {
             await viewModel.performQuery()
         }
     }
+}
 
-    private enum Strings {
-        static let title: String = NSLocalizedString("site.plugins.title", value: "Plugins", comment: "Installed plugins list title")
-        static let loading: String = NSLocalizedString("site.plugins.loading", value: "Loading installed plugins…", comment: "Message displayed when fetching installed plugins from the site")
-        static let noPluginInstalled: String = NSLocalizedString("site.plugins.noInstalledPlugins", value: "You haven't installed any plugins yet", comment: "No installed plugins message")
-        static let filterTitle: String = NSLocalizedString("site.plugins.filter.title", value: "Filter", comment: "Title of the plugin filter picker")
-        static let filterOptionAll: String = NSLocalizedString("site.plugins.filter.option.all", value: "All", comment: "The plugin fillter option for displaying all plugins")
-        static let filterOptionActive: String = NSLocalizedString("site.plugins.filter.option.all", value: "Active", comment: "The plugin fillter option for displaying active plugins")
-        static let filterOptionInactive: String = NSLocalizedString("site.plugins.filter.option.all", value: "Inactive", comment: "The plugin fillter option for displaying inactive plugins")
+private enum Strings {
+    static let title: String = NSLocalizedString("site.plugins.title", value: "Plugins", comment: "Installed plugins list title")
+    static let loading: String = NSLocalizedString("site.plugins.loading", value: "Loading installed plugins…", comment: "Message displayed when fetching installed plugins from the site")
+    static let noPluginInstalled: String = NSLocalizedString("site.plugins.noInstalledPlugins", value: "You haven't installed any plugins yet", comment: "No installed plugins message")
+    static let filterTitle: String = NSLocalizedString("site.plugins.filter.title", value: "Filter", comment: "Title of the plugin filter picker")
+    static let filterOptionAll: String = NSLocalizedString("site.plugins.filter.option.all", value: "All", comment: "The plugin fillter option for displaying all plugins")
+    static let filterOptionActive: String = NSLocalizedString("site.plugins.filter.option.all", value: "Active", comment: "The plugin fillter option for displaying active plugins")
+    static let filterOptionInactive: String = NSLocalizedString("site.plugins.filter.option.all", value: "Inactive", comment: "The plugin fillter option for displaying inactive plugins")
+}
+
+private struct ListSection: Hashable, Identifiable {
+    var plugins: [InstalledPlugin]
+    var filter: PluginFilter
+
+    var id: PluginFilter { filter }
+}
+
+private enum PluginFilter: Int, Hashable {
+    // The order here matches the order of grouped plugins
+    case all
+    case active
+    case inactive
+
+    var query: PluginDataStoreQuery {
+        switch self {
+        case .all:
+            return .all
+        case .active:
+            return .active
+        case .inactive:
+            return .inactive
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .all:
+            return Strings.filterOptionAll
+        case .active:
+            return Strings.filterOptionActive
+        case .inactive:
+            return Strings.filterOptionInactive
+        }
     }
 }
 
 @MainActor
-final class InstalledPluginsListViewModel: ObservableObject {
+private final class InstalledPluginsListViewModel: ObservableObject {
 
     let service: PluginServiceProtocol
     private var initialLoad = false
 
-    enum PluginFilter: Hashable {
-        case all
-        case active
-        case inactive
-
-        var query: PluginDataStoreQuery {
-            switch self {
-            case .all:
-                return .all
-            case .active:
-                return .active
-            case .inactive:
-                return .inactive
-            }
-        }
-    }
-
     @Published var isRefreshing: Bool = false
     @Published var filter: PluginFilter = .all
-    @Published var displayingPlugins: [InstalledPlugin] = []
+    @Published var sections = [ListSection]()
     @Published var updateAvailable: [PluginSlug: UpdateCheckPluginInfo] = [:]
     @Published var error: String? = nil
 
@@ -151,7 +176,15 @@ final class InstalledPluginsListViewModel: ObservableObject {
         for await update in await self.service.installedPluginsUpdates(query: filter.query) {
             switch update {
             case let .success(plugins):
-                self.displayingPlugins = plugins
+                self.sections = plugins
+                    .reduce(into: [PluginFilter: [InstalledPlugin]]()) { result, plugin in
+                        let filter: PluginFilter = plugin.isActive ? .active : .inactive
+                        result[filter, default: []].append(plugin)
+                    }
+                    .map { filter, plugins in
+                        ListSection(plugins: plugins, filter: filter)
+                    }
+                    .sorted(using: KeyPathComparator(\ListSection.filter.rawValue))
             case let .failure(error):
                 self.error = (error as? WpApiError)?.errorMessage ?? error.localizedDescription
             }


### PR DESCRIPTION
Also added empty states to the list.

https://github.com/user-attachments/assets/b66ebd67-4ad7-4dcb-bf55-575bf1c1fc95.mp4



## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
