### PR TITLE
fix: Improve autosave and unsaved changes detection

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250127"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "8ccd1fb448d6691fa1f1ba940657dd241c04790c"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "947c5315198eea96e3e8c32fcc6afa59ef242638"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", from: "1.20.0"),
     ],

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250127"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.1.0"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "131c5fd90f75f1217bbdbc1c4c256f5e942265e7"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", from: "1.20.0"),
     ],

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -48,7 +48,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250127"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "131c5fd90f75f1217bbdbc1c4c256f5e942265e7"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "8ccd1fb448d6691fa1f1ba940657dd241c04790c"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", from: "1.20.0"),
     ],

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,6 +15,7 @@
 * [*] Fix Notifications: quote blocks in the Reply screen are not styled correctly [#13971]
 * [*] Fix Notifications pointing to large threads sometimes break the app [#23993]
 * [*] Fix Reader: Opening comments is slow [#21887]
+* [*] Fix unexpected "unsaved changes" notice when closing an un-edited post containing media in the experimental editor [#24102]
 
 25.7
 -----

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2712221979a1856677c8c49bc57acee25847f5e210606ebbc01a5dec2cb9db5c",
+  "originHash" : "522c06d31326948c9ee8e7ad92f697580ac80b3bcf6f487084d1d97d8d6aefd0",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,8 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "45db2591254cc1140b01cda6e8cadcced359bf2a",
-        "version" : "0.1.0"
+        "revision" : "131c5fd90f75f1217bbdbc1c4c256f5e942265e7"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "39cc50cb2463ffc71c26698c06e248078ae361c464d16abb9c7477d9a4940c67",
+  "originHash" : "aeb249d45bcd791840c72bfdc053ebf3548e3e32b7ea494abf9af14b4fd96a3c",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,7 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "8ccd1fb448d6691fa1f1ba940657dd241c04790c"
+        "revision" : "947c5315198eea96e3e8c32fcc6afa59ef242638"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "522c06d31326948c9ee8e7ad92f697580ac80b3bcf6f487084d1d97d8d6aefd0",
+  "originHash" : "39cc50cb2463ffc71c26698c06e248078ae361c464d16abb9c7477d9a4940c67",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,7 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "131c5fd90f75f1217bbdbc1c4c256f5e942265e7"
+        "revision" : "8ccd1fb448d6691fa1f1ba940657dd241c04790c"
       }
     },
     {

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -273,7 +273,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
         if let title = editorData?.title,
            let content = editorData?.content,
-           title != post.postTitle || content != post.content {
+           editorData?.changed == true {
             post.postTitle = title
             post.content = content
             post.managedObjectContext.map(ContextManager.shared.save)

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -266,7 +266,6 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     }
 
     private func getLatestContent() async {
-        // TODO: read title as well
         let startTime = CFAbsoluteTimeGetCurrent()
         let editorData = try? await editorViewController.getTitleAndContent()
         let duration = CFAbsoluteTimeGetCurrent() - startTime

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -68,10 +68,12 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     // MARK: - GutenbergKit
 
     private let editorViewController: GutenbergKit.EditorViewController
-    private weak var autosaveTimer: Timer?
+
+    lazy var autosaver = Autosaver() {
+        self.performAutoSave()
+    }
 
     // TODO: remove (none of these APIs are needed for the new editor)
-    var autosaver = Autosaver(action: {})
     func prepopulateMediaItems(_ media: [Media]) {}
     var debouncer = WordPressShared.Debouncer(delay: 10)
     var replaceEditor: (EditorViewController, EditorViewController) -> ()
@@ -164,10 +166,6 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
     required init?(coder aDecoder: NSCoder) {
         fatalError()
-    }
-
-    deinit {
-        autosaveTimer?.invalidate()
     }
 
     // MARK: - Lifecycle methods
@@ -319,15 +317,7 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
 
     func editor(_ viewController: GutenbergKit.EditorViewController, didUpdateContentWithState state: GutenbergKit.EditorState) {
         editorContentWasUpdated()
-
-        // Save the changes on disk (crash protection). Throttle to ensure
-        // it doesn't happen too often.
-        if autosaveTimer == nil {
-            autosaveTimer = .scheduledTimer(withTimeInterval: 7, repeats: false) { [weak self] _ in
-                self?.autosaveTimer = nil
-                self?.performAutoSave()
-            }
-        }
+        autosaver.contentDidChange()
     }
 
     func editor(_ viewController: GutenbergKit.EditorViewController, didUpdateHistoryState state: GutenbergKit.EditorState) {


### PR DESCRIPTION
Detecting content changes by comparing the content received from
GutenbergKit to the latest server-provided post content is problematic
as the server makes slight modifications to content markup, creating
perpetually changed content. We now rely upon GutenbergKit's `changed`
parameter as the source of truth.

Embrace the existing `Autosaver` utility so the frequency is higher, as
the utility includes both a time interval and a number of changes count
which determine whether an autosave should occur. This also further
aligns GutenbergKit's behavior with Gutenberg Mobile.

Fix https://github.com/wordpress-mobile/GutenbergKit/issues/79.

Related: 
- https://github.com/wordpress-mobile/GutenbergKit/issues/79
- https://github.com/wordpress-mobile/GutenbergKit/pull/104
- https://github.com/wordpress-mobile/WordPress-Android/pull/21698

To test: 

**1: Posts with media do not have unsaved changes after saving**
See https://github.com/wordpress-mobile/GutenbergKit/issues/79. 

**2: Posts with changes warns when closing the editor**
1. Open a post. 
2. Make changes. 
3. Close the editor. 
4. Verify the editor notifies of unsaved changes. 

**3: Editor manages Publish/Update button enabled state**
1. Open a publish/draft post. 
2. Verify the _Publish_ or _Update_ button is disabled. 
3. Make changes. 
4. Verify the _Publish_ or _Update_ button is enabled. 

**4: Local changes are persisted on quit**
1. Open a post. 
2. Make changes. 
3. Quit the app. 
4. Verify changes are persisted locally, indicated by the app opening the editor with the changes when launching the app. 

## Regression Notes
1. Potential unintended areas of impact
    Unlikely with this dependency upgrade.
6. What I did to test those areas of impact (or what existing automated tests I relied on)
    N/A.
7. What automated tests I added (or what prevented me from doing so)
    N/A.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
