### PR TITLE
Remove some WordPressAuthenticator import statements

### DIFF
--- a/WordPress/Classes/Login/WordPressDotComAuthenticator.swift
+++ b/WordPress/Classes/Login/WordPressDotComAuthenticator.swift
@@ -140,7 +140,7 @@ struct WordPressDotComAuthenticator {
         // This sending notification code exists because that's what the existing login system does. We can consider
         // removing this notification once WordPressAuthenticator is removed.
         if case .default = context {
-            let notification = Foundation.Notification.Name(rawValue: WordPressAuthenticator.WPSigninDidFinishNotification)
+            let notification = Foundation.Notification.Name(rawValue: WordPressAuthenticationManager.WPSigninDidFinishNotification)
             let newAccount = try? coreDataStack.mainContext.existingObject(with: accountID)
             NotificationCenter.default.post(name: notification, object: newAccount)
         }

--- a/WordPress/Classes/Login/WordPressDotComAuthenticator.swift
+++ b/WordPress/Classes/Login/WordPressDotComAuthenticator.swift
@@ -1,7 +1,6 @@
 import AuthenticationServices
 import Foundation
 import UIKit
-import WordPressAuthenticator
 
 import Alamofire
 

--- a/WordPress/Classes/Stores/StatsWidgetsStore.swift
+++ b/WordPress/Classes/Stores/StatsWidgetsStore.swift
@@ -285,7 +285,7 @@ private extension StatsWidgetsStore {
     /// Observes WPSigninDidFinishNotification and wordpressLoginFinishedJetpackLogin notifications and initializes the widget.
     /// The site data is loaded after this notification and widget data can be cached.
     func observeAccountSignInForWidgets() {
-        NotificationCenter.default.addObserver(self, selector: #selector(initializeStatsWidgetsIfNeeded), name: NSNotification.Name(rawValue: WordPressAuthenticator.WPSigninDidFinishNotification), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(initializeStatsWidgetsIfNeeded), name: NSNotification.Name(rawValue: WordPressAuthenticationManager.WPSigninDidFinishNotification), object: nil)
         NotificationCenter.default.addObserver(self, selector: #selector(initializeStatsWidgetsIfNeeded), name: .wordpressLoginFinishedJetpackLogin, object: nil)
     }
 

--- a/WordPress/Classes/Stores/StatsWidgetsStore.swift
+++ b/WordPress/Classes/Stores/StatsWidgetsStore.swift
@@ -1,6 +1,5 @@
 import JetpackStatsWidgetsCore
 import WidgetKit
-import WordPressAuthenticator
 
 class StatsWidgetsStore {
     private let coreDataStack: CoreDataStack

--- a/WordPress/Classes/System/3D Touch/WP3DTouchShortcutCreator.swift
+++ b/WordPress/Classes/System/3D Touch/WP3DTouchShortcutCreator.swift
@@ -1,5 +1,4 @@
 import UIKit
-import WordPressAuthenticator
 
 public protocol ApplicationShortcutsProvider {
     var shortcutItems: [UIApplicationShortcutItem]? { get set }

--- a/WordPress/Classes/System/3D Touch/WP3DTouchShortcutCreator.swift
+++ b/WordPress/Classes/System/3D Touch/WP3DTouchShortcutCreator.swift
@@ -55,7 +55,7 @@ open class WP3DTouchShortcutCreator: NSObject {
 
     fileprivate func registerForNotifications() {
         let notificationCenter = NotificationCenter.default
-        notificationCenter.addObserver(self, selector: #selector(WP3DTouchShortcutCreator.createLoggedInShortcuts), name: NSNotification.Name(rawValue: WordPressAuthenticator.WPSigninDidFinishNotification), object: nil)
+        notificationCenter.addObserver(self, selector: #selector(WP3DTouchShortcutCreator.createLoggedInShortcuts), name: NSNotification.Name(rawValue: WordPressAuthenticationManager.WPSigninDidFinishNotification), object: nil)
         notificationCenter.addObserver(self, selector: #selector(WP3DTouchShortcutCreator.createLoggedInShortcuts), name: .WPRecentSitesChanged, object: nil)
         notificationCenter.addObserver(self, selector: #selector(WP3DTouchShortcutCreator.createLoggedInShortcuts), name: .WPBlogUpdated, object: nil)
         notificationCenter.addObserver(self, selector: #selector(WP3DTouchShortcutCreator.createLoggedInShortcuts), name: .WPAccountDefaultWordPressComAccountChanged, object: nil)

--- a/WordPress/Classes/System/WindowManager.swift
+++ b/WordPress/Classes/System/WindowManager.swift
@@ -1,5 +1,4 @@
 import Foundation
-import WordPressAuthenticator
 
 /// This class takes care of managing the App window and its `rootViewController`.
 /// This is mostly intended to handle the UI transitions between authenticated and unauthenticated user sessions.

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import WordPressAuthenticator
 import WordPressEditor
 
 class RegisterDomainDetailsViewController: UITableViewController {

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/Views/RegisterDomainDetailsErrorSectionFooter.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/Views/RegisterDomainDetailsErrorSectionFooter.swift
@@ -1,5 +1,4 @@
 import UIKit
-import WordPressAuthenticator
 
 class RegisterDomainDetailsErrorSectionFooter: UITableViewHeaderFooterView, NibReusable {
 

--- a/WordPress/Classes/ViewRelated/Domains/DomainSelectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/DomainSelectionViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import WordPressAuthenticator
 import SwiftUI
 
 enum DomainSelectionType: Int, Identifiable {

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/JetpackRemoteInstallViewController.swift
@@ -1,5 +1,3 @@
-import WordPressAuthenticator
-
 protocol JetpackRemoteInstallDelegate: AnyObject {
     func jetpackRemoteInstallCompleted()
     func jetpackRemoteInstallCanceled()

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallStateView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallStateView.swift
@@ -1,5 +1,3 @@
-import WordPressAuthenticator
-
 protocol JetpackRemoteInstallStateViewDelegate: AnyObject {
     func mainButtonDidTouch()
     func customerSupportButtonDidTouch()
@@ -106,7 +104,7 @@ private extension JetpackRemoteInstallStateView {
         }
     }
 
-    @IBAction func mainButtonAction(_ sender: NUXButton) {
+    @IBAction func mainButtonAction(_ sender: UIButton) {
         delegate?.mainButtonDidTouch()
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/Webview/JetpackConnectionWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/Webview/JetpackConnectionWebViewController.swift
@@ -1,7 +1,6 @@
 import UIKit
 @preconcurrency import WebKit
 import Gridicons
-import WordPressAuthenticator
 import Combine
 
 protocol JetpackConnectionWebDelegate: AnyObject {

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -1,6 +1,5 @@
 import UIKit
 import WordPressShared
-import WordPressAuthenticator
 import AutomatticAbout
 
 class MeViewController: UITableViewController {

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/ChangeUsernameViewController.swift
@@ -1,5 +1,4 @@
 import Combine
-import WordPressAuthenticator
 
 class ChangeUsernameViewController: SignupUsernameTableViewController {
     typealias CompletionBlock = (String?) -> Void

--- a/WordPress/Classes/ViewRelated/NUX/Controllers/Social Signup/SignupUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Controllers/Social Signup/SignupUsernameViewController.swift
@@ -1,5 +1,4 @@
 import SVProgressHUD
-import WordPressAuthenticator
 
 protocol SignupUsernameViewControllerDelegate: AnyObject {
     func usernameSelected(_ username: String)

--- a/WordPress/Classes/ViewRelated/NUX/Helpers/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Helpers/WordPressAuthenticationManager.swift
@@ -7,6 +7,8 @@ import UIKit
 //
 @objc
 class WordPressAuthenticationManager: NSObject {
+    static let WPSigninDidFinishNotification = WordPressAuthenticator.WPSigninDidFinishNotification
+
     static var isPresentingSignIn = false
     private let windowManager: WindowManager
 
@@ -565,7 +567,7 @@ private extension WordPressAuthenticationManager {
             /// HACK: An alternative notification to LoginFinished. Observe this instead of `WPSigninDidFinishNotification` for Jetpack logins.
             /// When WPTabViewController no longer destroy's and rebuilds the view hierarchy this alternate notification can be removed.
             ///
-            let notification = isJetpackLogin == true ? .wordpressLoginFinishedJetpackLogin : Foundation.Notification.Name(rawValue: WordPressAuthenticator.WPSigninDidFinishNotification)
+            let notification = isJetpackLogin == true ? .wordpressLoginFinishedJetpackLogin : Foundation.Notification.Name(rawValue: WordPressAuthenticationManager.WPSigninDidFinishNotification)
             NotificationCenter.default.post(name: notification, object: account)
 
             syncGroup.leave()

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -2,7 +2,6 @@ import Foundation
 import Combine
 import CoreData
 import WordPressShared
-import WordPressAuthenticator
 import Gridicons
 import UIKit
 import WordPressUI

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import WordPressAuthenticator
 import Combine
 import WordPressUI
 import SwiftUI

--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
@@ -1,4 +1,3 @@
-
 import UIKit
 
 import WordPressAuthenticator

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/ErrorStates/ErrorStateView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/ErrorStates/ErrorStateView.swift
@@ -1,4 +1,3 @@
-
 import UIKit
 
 import Gridicons

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -93,7 +93,7 @@ class MySitesCoordinator: NSObject {
     // MARK: Notifications Handling
 
     private func addSignInObserver() {
-        let notificationName = NSNotification.Name(WordPressAuthenticator.WPSigninDidFinishNotification)
+        let notificationName = NSNotification.Name(WordPressAuthenticationManager.WPSigninDidFinishNotification)
         NotificationCenter.default.addObserver(self,
                                                selector: #selector(signinDidFinish),
                                                name: notificationName,

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -1,5 +1,4 @@
 import UIKit
-import WordPressAuthenticator
 
 @objc
 class MySitesCoordinator: NSObject {

--- a/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewModel.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewModel.swift
@@ -1,7 +1,6 @@
 import Foundation
 import Combine
 import WordPressKit
-import WordPressAuthenticator
 
 enum SidebarSelection: Hashable {
     case welcome

--- a/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewModel.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewModel.swift
@@ -66,7 +66,7 @@ final class SidebarViewModel: ObservableObject {
             }.store(in: &cancellables)
 
         NotificationCenter.default
-            .publisher(for: .init(rawValue: WordPressAuthenticator.WPSigninDidFinishNotification))
+            .publisher(for: .init(rawValue: WordPressAuthenticationManager.WPSigninDidFinishNotification))
             .sink { [weak self] _ in self?.resetSelection() }
             .store(in: &cancellables)
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -30,7 +30,7 @@ extension WPTabBarController {
     }
 
     @objc public class var wpSigninDidFinishNotification: String {
-        WordPressAuthenticator.WPSigninDidFinishNotification
+        WordPressAuthenticationManager.WPSigninDidFinishNotification
     }
 
     private static let tabIndexToStatMap: [WPTab: WPAnalyticsStat] = [.mySites: .mySitesTabAccessed, .reader: .readerAccessed]

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -1,5 +1,3 @@
-import WordPressAuthenticator
-
 // MARK: - Tab Access Tracking
 
 fileprivate extension WPTab {

--- a/WordPress/WordPressTest/Classes/Stores/StatsWidgetsStoreTests.swift
+++ b/WordPress/WordPressTest/Classes/Stores/StatsWidgetsStoreTests.swift
@@ -1,4 +1,3 @@
-import WordPressAuthenticator
 import XCTest
 
 @testable import WordPress

--- a/WordPress/WordPressTest/Classes/Stores/StatsWidgetsStoreTests.swift
+++ b/WordPress/WordPressTest/Classes/Stores/StatsWidgetsStoreTests.swift
@@ -23,7 +23,7 @@ class StatsWidgetsStoreTests: CoreDataTestCase {
             .build()
         XCTAssertFalse(statsWidgetsHaveData())
 
-        NotificationCenter.default.post(name: NSNotification.Name(rawValue: WordPressAuthenticator.WPSigninDidFinishNotification), object: nil)
+        NotificationCenter.default.post(name: NSNotification.Name(rawValue: WordPressAuthenticationManager.WPSigninDidFinishNotification), object: nil)
 
         XCTAssertTrue(statsWidgetsHaveData())
     }
@@ -33,7 +33,7 @@ class StatsWidgetsStoreTests: CoreDataTestCase {
             .withAnAccount()
             .isHostedAtWPcom()
             .build()
-        NotificationCenter.default.post(name: NSNotification.Name(rawValue: WordPressAuthenticator.WPSigninDidFinishNotification), object: nil)
+        NotificationCenter.default.post(name: NSNotification.Name(rawValue: WordPressAuthenticationManager.WPSigninDidFinishNotification), object: nil)
 
         NotificationCenter.default.post(name: .WPAccountDefaultWordPressComAccountChanged, object: nil)
 


### PR DESCRIPTION


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
