### PR TITLE
Comments: Minor Improvements

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
@@ -193,7 +193,7 @@ class CommentDetailViewController: UIViewController, NoResultsViewHost {
         let button = UIBarButtonItem(
             image: comment.allowsModeration()
             ? UIImage(systemName: "ellipsis")
-            : UIImage(systemName: Style.Content.shareIconImageName),
+            : UIImage(systemName: "square.and.arrow.up"),
             style: .plain,
             target: self,
             action: #selector(shareCommentURL)

--- a/WordPress/Classes/ViewRelated/Comments/Style/WPStyleGuide+CommentDetail.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Style/WPStyleGuide+CommentDetail.swift
@@ -41,11 +41,6 @@ extension WPStyleGuide {
             static let highlightedBarBackgroundColor = UIAppColor.blue(.shade40)
 
             static let placeholderImage = UIImage.gravatarPlaceholderImage
-
-            static let accessoryIconConfiguration = UIImage.SymbolConfiguration(font: CommentDetail.tertiaryTextFont, scale: .medium)
-            static let shareIconImageName = "square.and.arrow.up"
-            static let ellipsisIconImageName = "ellipsis.circle"
-            static let infoIconImageName = "info.circle"
         }
 
         public struct ReplyIndicator {

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -8,7 +8,6 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
     // all the available images for the accessory button.
     enum AccessoryButtonType {
-        case share
         case ellipsis
         case info
     }
@@ -23,9 +22,7 @@ class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
     @objc var contentLinkTapAction: ((URL) -> Void)? = nil
 
-    /// Encapsulate the accessory button image assignment through an enum, to apply a standardized image configuration.
-    /// See `accessoryIconConfiguration` in `WPStyleGuide+CommentDetail`.
-    var accessoryButtonType: AccessoryButtonType = .share {
+    var accessoryButtonType: AccessoryButtonType = .ellipsis {
         didSet {
             accessoryButton.setImage(accessoryButtonImage, for: .normal)
         }
@@ -287,12 +284,10 @@ private extension CommentContentTableViewCell {
 
     var accessoryButtonImage: UIImage? {
         switch accessoryButtonType {
-        case .share:
-            return .init(systemName: Style.shareIconImageName, withConfiguration: Style.accessoryIconConfiguration)
         case .ellipsis:
-            return .init(systemName: Style.ellipsisIconImageName, withConfiguration: Style.accessoryIconConfiguration)
+            return .init(systemName: "ellipsis", withConfiguration: UIImage.SymbolConfiguration(font: .preferredFont(forTextStyle: .footnote)))?.withTintColor(.secondaryLabel)
         case .info:
-            return .init(systemName: Style.infoIconImageName, withConfiguration: Style.accessoryIconConfiguration)
+            return .init(systemName: "info.circle", withConfiguration: UIImage.SymbolConfiguration(font: .preferredFont(forTextStyle: .footnote)))
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.xib
@@ -33,26 +33,26 @@
                             <view contentMode="scaleToFill" verticalHuggingPriority="251" verticalCompressionResistancePriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="f2E-yC-BJS" userLabel="Header View">
                                 <rect key="frame" x="0.0" y="0.0" width="288" height="53"/>
                                 <subviews>
-                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="9QY-3I-cxv" userLabel="Avatar Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
-                                        <rect key="frame" x="0.0" y="11.5" width="28" height="28"/>
+                                    <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" misplaced="YES" image="gravatar" translatesAutoresizingMaskIntoConstraints="NO" id="9QY-3I-cxv" userLabel="Avatar Image View" customClass="CircularImageView" customModule="WordPress" customModuleProvider="target">
+                                        <rect key="frame" x="0.0" y="11.5" width="30" height="28"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="9QY-3I-cxv" secondAttribute="height" multiplier="1:1" id="3HU-89-TeJ"/>
-                                            <constraint firstAttribute="width" constant="28" id="Apb-Vu-nw6"/>
+                                            <constraint firstAttribute="width" constant="30" id="Apb-Vu-nw6"/>
                                         </constraints>
                                     </imageView>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="1" translatesAutoresizingMaskIntoConstraints="NO" id="CzL-pe-Tnr" userLabel="Name Stack View">
-                                        <rect key="frame" x="38" y="8" width="218" height="35"/>
+                                        <rect key="frame" x="40" y="8" width="216" height="35"/>
                                         <subviews>
                                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="po6-3F-ppN" userLabel="Name Container View">
-                                                <rect key="frame" x="0.0" y="0.0" width="218" height="18"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="216" height="18"/>
                                                 <subviews>
                                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="761" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="0" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="HpE-B7-6wr" userLabel="Name Label">
-                                                        <rect key="frame" x="0.0" y="0.0" width="179.5" height="18"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="177.5" height="18"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleSubhead"/>
                                                         <nil key="highlightedColor"/>
                                                     </label>
                                                     <label hidden="YES" opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" text="Badge" textAlignment="natural" lineBreakMode="characterWrap" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hDo-cU-sWp" userLabel="Badge Label" customClass="BadgeLabel" customModule="WordPress" customModuleProvider="target">
-                                                        <rect key="frame" x="184.5" y="2" width="33.5" height="13.5"/>
+                                                        <rect key="frame" x="182.5" y="2" width="33.5" height="13.5"/>
                                                         <color key="backgroundColor" name="Blue50"/>
                                                         <fontDescription key="fontDescription" style="UICTFontTextStyleCaption2"/>
                                                         <color key="textColor" name="White"/>
@@ -82,7 +82,7 @@
                                                 </constraints>
                                             </view>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" numberOfLines="2" baselineAdjustment="alignBaselines" adjustsFontForContentSizeCategory="YES" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ghT-Xy-q8c" userLabel="Date Label">
-                                                <rect key="frame" x="0.0" y="19" width="218" height="16"/>
+                                                <rect key="frame" x="0.0" y="19" width="216" height="16"/>
                                                 <fontDescription key="fontDescription" style="UICTFontTextStyleFootnote"/>
                                                 <color key="textColor" systemColor="secondaryLabelColor"/>
                                                 <nil key="highlightedColor"/>

--- a/WordPress/Classes/ViewRelated/Gravatar/UIImageView+Gravatar.swift
+++ b/WordPress/Classes/ViewRelated/Gravatar/UIImageView+Gravatar.swift
@@ -58,7 +58,7 @@ extension UIImageView {
         // Calling `layoutIfNeeded()` forces UIKit to calculate the actual size.
         layoutIfNeeded()
 
-        let size = Int(ceil(frame.width * min(2, UIScreen.main.scale)))
+        let size = Int(ceil(max(28, frame.width) * traitCollection.displayScale))
         guard let url = gravatar.replacing(options: .init(preferredSize: .pixels(size)))?.url else { return }
         downloadGravatar(fullURL: url, placeholder: placeholder, animate: animate, forceRefresh: forceRefresh)
     }

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsTableViewController.swift
@@ -205,6 +205,10 @@ final class ReaderCommentsTableViewController: UIViewController, UITableViewData
         containerViewController?.cachedHeaderView()
     }
 
+    func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
+        containerViewController?.cachedHeaderView() == nil ? 0 : UITableView.automaticDimension
+    }
+
     // MARK: - UIScrollViewDelegate
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -206,6 +206,9 @@
 }
 
 - (UIView *)cachedHeaderView {
+    if (!self.allowsPushingPostDetails) {
+        return nil;
+    }
     if (!_cachedHeaderView) {
         _cachedHeaderView = [self configuredHeaderViewFor:self.tableView];
     }

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -116,12 +116,10 @@ extension NSNotification.Name {
         cell.badgeTitle = comment.isFromPostAuthor() ? .authorBadgeText : nil
         cell.indentationWidth = Constants.indentationWidth
         cell.indentationLevel = min(Constants.maxIndentationLevel, Int(comment.depth))
-        cell.accessoryButtonType = isModerationMenuEnabled(for: comment) ? .ellipsis : .share
 
-        // if the comment can be moderated, show the context menu when tapping the accessory button.
-        // Note that accessoryButtonAction will be ignored when the menu is assigned.
-        cell.accessoryButton.showsMenuAsPrimaryAction = isModerationMenuEnabled(for: comment)
-        cell.accessoryButton.menu = isModerationMenuEnabled(for: comment) ? menu(for: comment, indexPath: indexPath, tableView: tableView, sourceView: cell.accessoryButton) : nil
+        let isModerationEnabled = isModerationMenuEnabled(for: comment)
+        cell.accessoryButton.showsMenuAsPrimaryAction = isModerationEnabled
+        cell.accessoryButton.menu = isModerationEnabled ? menu(for: comment, indexPath: indexPath, tableView: tableView, sourceView: cell.accessoryButton) : nil
         cell.configure(viewModel: viewModel, helper: helper) { [weak tableView] _ in
             guard let tableView else { return }
 

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -130,12 +130,9 @@ extension NSNotification.Name {
                     tableView.alpha = 1
                 }
             }
-            // don't adjust cell height when it's out of the viewport.
-            if (tableView.indexPathsForVisibleRows ?? []).contains(indexPath) {
-                UIView.setAnimationsEnabled(false)
-                tableView.performBatchUpdates({})
-                UIView.setAnimationsEnabled(true)
-            }
+            UIView.setAnimationsEnabled(false)
+            tableView.performBatchUpdates({})
+            UIView.setAnimationsEnabled(true)
         }
     }
 


### PR DESCRIPTION
## Changes

**1. Remove the redundant non-interactive "Comments On:" table view header when opening the comments directly from the post**

From Notifications | From Post Directly
<img width="300" alt="Screenshot 2025-02-26 at 9 40 04 AM" src="https://github.com/user-attachments/assets/97447134-9503-4923-9165-5dfa8634bd22" /> <img width="300" alt="Screenshot 2025-02-26 at 9 40 14 AM" src="https://github.com/user-attachments/assets/c5c4e0d8-a415-4ae5-aaf1-629f9244eafe" />

**2. Fix an issue when comment height would sometimes be incorrect**

I removed the code that would skip resetting the table view cell sizes if the target cell was not visible on screen. It would occasionally lead to scenarios that some cells will have incorrect heights.

**3. Replace "Share" with "Ellipsis"**

Instead of the odd-looking odd-sizes "Share" button, the app will now simply show the ellipsis standard across screens.

https://github.com/user-attachments/assets/265f5364-f765-42e0-a282-4b4f3d9610a2

**4. Fix profile picture quality**

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
