### PR TITLE
Reader: Show site description in search

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderFeedCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderFeedCell.swift
@@ -11,16 +11,31 @@ struct ReaderFeedCell: View {
                 .frame(width: 40, height: 40)
 
             VStack(alignment: .leading) {
-                Text(feed.title.stringByDecodingXMLCharacters())
+                Text(title)
                     .font(.body)
                     .lineLimit(1)
 
-                Text(feed.urlForDisplay)
+                Text(subtitle)
                     .font(.footnote)
                     .foregroundStyle(.secondary)
-                    .lineLimit(1)
+                    .lineLimit(2)
             }
         }
+    }
+
+    var title: String {
+        let title = feed.title.stringByDecodingXMLCharacters()
+        if !title.isEmpty {
+            return title
+        }
+        return feed.urlForDisplay
+    }
+
+    var subtitle: String {
+        if let description = feed.feedDescription, !description.isEmpty {
+            return description.stringByDecodingXMLCharacters()
+        }
+        return feed.urlForDisplay
     }
 }
 


### PR DESCRIPTION
Updates to match the web. The URL is a tertiary piece of information. You can find it on the details screen if you need to.

Before / After

<img width="320" alt="Screenshot 2025-02-26 at 1 58 12 PM" src="https://github.com/user-attachments/assets/b296db35-bde1-4f23-bcd5-30383ec74c9e" />
<img width="320" alt="Screenshot 2025-02-26 at 1 34 21 PM" src="https://github.com/user-attachments/assets/28678ffd-81b9-4b23-b91b-dc4ba3d81879" />

We probably need to ideally redesign this a bit later: add more stats, add context menus, button to subscribe right from search, etc.


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
