### PR TITLE
Fix broken header view visible when post is loading

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * [*] Prevent a intermittent crash when opening the experimental editor's "more" menu [#24065]
 * [*] Fix incorrect background color for draft post cells on dashboard [#24080]
 * [*] Fix an issue with comments sometimes displaying black text on black background in dark mode [#23536]
+* [*] Fix broken header view visible when post is loading [#24123]
 * [*] Fix incorrect sizing of images and other attachments in comments [#19943]
 * [*] Fix P2 Comments: Empty list item appears after embedded lists [#18690]
 * [*] Fix Reader Comments: Reply button is hidden when pasting long text (the ap now uses a sheet) [#17964]

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -296,8 +296,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             scrollView.addSubview(activityIndicator)
             activityIndicator.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
-                activityIndicator.centerXAnchor.constraint(equalTo: webView.centerXAnchor),
-                activityIndicator.topAnchor.constraint(equalTo: webView.topAnchor, constant: 64),
+                activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
             ])
             activityIndicator.startAnimating()
         }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -295,10 +295,17 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             }
             scrollView.addSubview(activityIndicator)
             activityIndicator.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-                activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
-            ])
+            if post == nil {
+                NSLayoutConstraint.activate([
+                    activityIndicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+                    activityIndicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+                ])
+            } else {
+                NSLayoutConstraint.activate([
+                    activityIndicator.centerXAnchor.constraint(equalTo: webView.centerXAnchor),
+                    activityIndicator.topAnchor.constraint(equalTo: webView.topAnchor, constant: 64),
+                ])
+            }
             activityIndicator.startAnimating()
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -187,6 +187,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
+
         updateLeftBarButtonItem()
         setupFeaturedImage()
         updateFollowButtonState()
@@ -286,6 +287,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     func showLoading() {
         if activityIndicator.superview == nil {
+            if post == nil {
+                header.alpha = 0
+            }
             for view in allContentViews {
                 view.alpha = 0
             }
@@ -307,6 +311,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         activityIndicator.stopAnimating()
         activityIndicator.removeFromSuperview()
         UIView.animate(withDuration: 0.25) {
+            self.header.alpha = 1
             for view in self.allContentViews {
                 view.alpha = 1
             }


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/24069.

To test:

https://github.com/user-attachments/assets/b6ab4c98-0c7e-474f-b1a1-86864aeed26e


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
