### PR TITLE
Update iconography in Reader

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -72,7 +72,7 @@ private final class ReaderPostCellView: UIView {
     let buttonAuthor = makeAuthorButton()
     let timeLabel = UILabel()
     let seenCheckmark = UIImageView()
-    let buttonMore = makeButton(image: UIImage(systemName:"ellipsis"), font: .systemFont(ofSize: 13))
+    let buttonMore = makeButton(image: UIImage(systemName: "ellipsis"), font: .systemFont(ofSize: 13))
 
     // Content
     let titleLabel = UILabel()
@@ -342,17 +342,25 @@ private final class ReaderPostCellView: UIView {
             return configuration
         }()
 
+        let font = UIFont.preferredFont(forTextStyle: .footnote).withWeight(.medium)
+
         buttons.comment.isHidden = !viewModel.isCommentsEnabled
         if viewModel.isCommentsEnabled {
-            buttons.comment.configuration?.attributedTitle = AttributedString(kFormatted(viewModel.commentCount), attributes: Self.toolbarAttributes)
+            buttons.comment.configuration?.attributedTitle = AttributedString(kFormatted(viewModel.commentCount), attributes: AttributeContainer([
+                .font: font,
+                .foregroundColor: UIColor.secondaryLabel
+            ]))
         }
         buttons.like.isHidden = !viewModel.isLikesEnabled
         if viewModel.isLikesEnabled {
             buttons.like.configuration = {
                 var configuration = buttons.like.configuration ?? .plain()
-                configuration.attributedTitle = AttributedString(kFormatted(viewModel.likeCount), attributes: Self.toolbarAttributes)
+                configuration.attributedTitle = AttributedString(kFormatted(viewModel.likeCount), attributes: AttributeContainer([
+                    .font: font,
+                    .foregroundColor: viewModel.isLiked ? UIAppColor.primary : UIColor.secondaryLabel
+                ]))
                 configuration.image = viewModel.isLiked ? WPStyleGuide.ReaderDetail.likeSelectedToolbarIcon : WPStyleGuide.ReaderDetail.likeToolbarIcon
-                configuration.baseForegroundColor = viewModel.isLiked ? .systemYellow : .secondaryLabel
+                configuration.baseForegroundColor = viewModel.isLiked ? UIAppColor.primary : .secondaryLabel
                 return configuration
             }()
         }
@@ -416,7 +424,7 @@ private func makeButton(image: UIImage? = nil, font: UIFont = UIFont.preferredFo
     configuration.imagePadding = 6
     configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(font: font)
     configuration.baseForegroundColor = .secondaryLabel
-    configuration.contentInsets = .init(top: 16, leading: 12, bottom: 16, trailing: 12)
+    configuration.contentInsets = .init(top: 12, leading: 12, bottom: 16, trailing: 12)
 
     let button = UIButton(configuration: configuration)
     if #available(iOS 17.0, *) {

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -72,7 +72,7 @@ private final class ReaderPostCellView: UIView {
     let buttonAuthor = makeAuthorButton()
     let timeLabel = UILabel()
     let seenCheckmark = UIImageView()
-    let buttonMore = makeButton(systemImage: "ellipsis", font: .systemFont(ofSize: 13))
+    let buttonMore = makeButton(image: UIImage(systemName:"ellipsis"), font: .systemFont(ofSize: 13))
 
     // Content
     let titleLabel = UILabel()
@@ -337,7 +337,7 @@ private final class ReaderPostCellView: UIView {
     private func configureToolbar(with viewModel: ReaderPostToolbarViewModel) {
         buttons.bookmark.configuration = {
             var configuration = buttons.bookmark.configuration ?? .plain()
-            configuration.image = UIImage(systemName: viewModel.isBookmarked ? "bookmark.fill" : "bookmark")
+            configuration.image = viewModel.isBookmarked ? WPStyleGuide.ReaderDetail.saveSelectedToolbarIcon : WPStyleGuide.ReaderDetail.saveToolbarIcon
             configuration.baseForegroundColor = viewModel.isBookmarked ? UIAppColor.primary : .secondaryLabel
             return configuration
         }()
@@ -351,7 +351,7 @@ private final class ReaderPostCellView: UIView {
             buttons.like.configuration = {
                 var configuration = buttons.like.configuration ?? .plain()
                 configuration.attributedTitle = AttributedString(kFormatted(viewModel.likeCount), attributes: Self.toolbarAttributes)
-                configuration.image = UIImage(systemName: viewModel.isLiked ? "star.fill" : "star")
+                configuration.image = viewModel.isLiked ? WPStyleGuide.ReaderDetail.likeSelectedToolbarIcon : WPStyleGuide.ReaderDetail.likeToolbarIcon
                 configuration.baseForegroundColor = viewModel.isLiked ? .systemYellow : .secondaryLabel
                 return configuration
             }()
@@ -395,10 +395,10 @@ private final class ReaderPostCellView: UIView {
 // MARK: - Helpers
 
 private struct ReaderPostToolbarButtons {
-    let bookmark = makeButton(systemImage: "bookmark")
-    let reblog = makeButton(systemImage: "arrow.2.squarepath")
-    let comment = makeButton(systemImage: "message")
-    let like = makeButton(systemImage: "star")
+    let bookmark = makeButton()
+    let reblog = makeButton(image: WPStyleGuide.ReaderDetail.reblogToolbarIcon)
+    let comment = makeButton(image: WPStyleGuide.ReaderDetail.commentToolbarIcon)
+    let like = makeButton()
 
     var allButtons: [UIButton] { [bookmark, reblog, comment, like] }
 }
@@ -410,9 +410,9 @@ private func makeAuthorButton() -> UIButton {
     return UIButton(configuration: configuration)
 }
 
-private func makeButton(systemImage: String, font: UIFont = UIFont.preferredFont(forTextStyle: .footnote)) -> UIButton {
+private func makeButton(image: UIImage? = nil, font: UIFont = UIFont.preferredFont(forTextStyle: .footnote)) -> UIButton {
     var configuration = UIButton.Configuration.plain()
-    configuration.image = UIImage(systemName: systemImage)
+    configuration.image = image
     configuration.imagePadding = 6
     configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(font: font)
     configuration.baseForegroundColor = .secondaryLabel

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -424,7 +424,7 @@ private func makeButton(image: UIImage? = nil, font: UIFont = UIFont.preferredFo
     configuration.imagePadding = 6
     configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(font: font)
     configuration.baseForegroundColor = .secondaryLabel
-    configuration.contentInsets = .init(top: 12, leading: 12, bottom: 16, trailing: 12)
+    configuration.contentInsets = .init(top: 12, leading: 12, bottom: 14, trailing: 12)
 
     let button = UIButton(configuration: configuration)
     if #available(iOS 17.0, *) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -37,11 +37,11 @@ class ReaderDetailToolbar: UIView, NibLoadable {
         }
     }
 
-    private var likeButtonTitle: String {
-        guard let post else {
-            return likeLabel(count: likeCount)
+    private func likeButtonTitle(likeCount: Int) -> String {
+        if likeCount > 0 {
+            return likeCount.formatted(.number.notation(.compactName))
         }
-        return post.isLiked ? Constants.likedButtonTitle : Constants.likeButtonTitle
+        return Constants.likeButtonTitle
     }
 
     private var likeCount: Int {
@@ -119,7 +119,7 @@ class ReaderDetailToolbar: UIView, NibLoadable {
             return
         }
         if !post.isLiked {
-            likeButton.setTitle(Constants.likedButtonTitle, for: [])
+            likeButton.setTitle(likeButtonTitle(likeCount: likeCount + 1), for: [])
             likeButton.isSelected = true
             UINotificationFeedbackGenerator().notificationOccurred(.success)
             likeButton.imageView?.fadeInWithRotationAnimation { _ in
@@ -250,7 +250,7 @@ class ReaderDetailToolbar: UIView, NibLoadable {
 
         configureActionButton(
             likeButton,
-            title: likeButtonTitle,
+            title: likeButtonTitle(likeCount: likeCount),
             image: WPStyleGuide.ReaderDetail.likeToolbarIcon,
             highlightedImage: WPStyleGuide.ReaderDetail.likeSelectedToolbarIcon,
             selected: selected
@@ -271,6 +271,11 @@ class ReaderDetailToolbar: UIView, NibLoadable {
     }
 
     private func configureCommentActionButton() {
+        commentButton.setTitle({
+            let count = post?.commentCount.intValue ?? 0
+            return count == 0 ? Constants.commentButtonTitle : count.formatted(.number.notation(.compactName))
+        }(), for: [])
+
         commentButton.isEnabled = shouldShowCommentActionButton
 
         commentButton.setImage(WPStyleGuide.ReaderDetail.commentToolbarIcon, for: .normal)
@@ -312,24 +317,8 @@ class ReaderDetailToolbar: UIView, NibLoadable {
     }
 
     fileprivate func configureButtonTitles() {
-        let commentTitle = Constants.commentButtonTitle
-
-        likeButton.setTitle(likeButtonTitle, for: .normal)
-        likeButton.setTitle(likeButtonTitle, for: .highlighted)
-
-        commentButton.setTitle(commentTitle, for: .normal)
-        commentButton.setTitle(commentTitle, for: .highlighted)
-
         WPStyleGuide.applyReaderSaveForLaterButtonTitles(saveForLaterButton, showTitle: true)
         WPStyleGuide.applyReaderReblogActionButtonTitle(reblogButton, showTitle: true)
-    }
-
-    private func likeLabel(count: Int) -> String {
-        if traitCollection.horizontalSizeClass == .compact {
-            return count > 0 ? String(count) : ""
-        } else {
-            return WPStyleGuide.likeCountForDisplay(count)
-        }
     }
 
     // MARK: - Analytics


### PR DESCRIPTION
- Use WordPress iconography in the feed
- Show like and comment count in Post Details toolbar to match the web

<img width="320" alt="Screenshot 2025-02-27 at 11 39 55 AM" src="https://github.com/user-attachments/assets/4a2a5485-dda5-4f89-bd85-5a7538ae5108" /> <img width="320" alt="Screenshot 2025-02-27 at 11 47 44 AM" src="https://github.com/user-attachments/assets/670e6719-3240-4461-ae5c-1461c7417175" />


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
