### PR TITLE
Show Reader comments in a modal

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -146,9 +146,7 @@
 
 - (void)configureNavbar
 {
-    // Don't show 'Reader' in the next-view back button
-    UIBarButtonItem *backButton = [[UIBarButtonItem alloc] initWithTitle:@" " style:UIBarButtonItemStylePlain target:nil action:nil];
-    self.navigationItem.backBarButtonItem = backButton;
+    self.navigationItem.backButtonTitle = @"";
 
     self.title = NSLocalizedString(@"Comments", @"Title of the reader's comments screen");
     self.navigationItem.largeTitleDisplayMode = UINavigationItemLargeTitleDisplayModeNever;

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderCommentAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderCommentAction.swift
@@ -8,12 +8,21 @@ final class ReaderCommentAction {
         navigateToCommentID: Int? = nil,
         source: ReaderCommentsSource
     ) {
-        guard let controller = ReaderCommentsViewController(post: post, source: source) else {
+        guard let commentsVC = ReaderCommentsViewController(post: post, source: source) else {
             return
         }
-        controller.navigateToCommentID = navigateToCommentID as NSNumber?
-        controller.trackCommentsOpened()
-        controller.hidesBottomBarWhenPushed = true
-        origin.navigationController?.pushViewController(controller, animated: true)
+        commentsVC.navigateToCommentID = navigateToCommentID as NSNumber?
+        commentsVC.trackCommentsOpened()
+        commentsVC.hidesBottomBarWhenPushed = true
+
+        if origin.traitCollection.horizontalSizeClass == .compact {
+            let navigationVC = UINavigationController(rootViewController: commentsVC)
+            commentsVC.navigationItem.leftBarButtonItem = UIBarButtonItem(title: SharedStrings.Button.close, primaryAction: UIAction { [weak origin] _ in
+                origin?.dismiss(animated: true)
+            })
+            origin.present(navigationVC, animated: true)
+        } else {
+            origin.navigationController?.pushViewController(commentsVC, animated: true)
+        }
     }
 }


### PR DESCRIPTION
Comments will be shown in a modal. It feels much more natural after the tap on the bottom toolbar – that's where the screens appears from.

https://github.com/user-attachments/assets/525e8abb-3c5c-4709-8ad7-f46bff8de163


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
