### PR TITLE
Remove duplicated view-in-browser button

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -1046,8 +1046,7 @@ private extension ReaderDetailViewController {
         // If a Related post fails to load, disable the More and Share buttons as they won't do anything.
         let rightItems = [
             moreButtonItem(enabled: enableRightBarButtons),
-            shareButtonItem(enabled: enableRightBarButtons),
-            safariButtonItem()
+            shareButtonItem(enabled: enableRightBarButtons)
         ]
         navigationItem.largeTitleDisplayMode = .never
         navigationItem.rightBarButtonItems = rightItems.compactMap({ $0 })
@@ -1088,13 +1087,6 @@ private extension ReaderDetailViewController {
 
     @objc func didTapDismissButton(_ sender: UIButton) {
         dismiss(animated: true)
-    }
-
-    func safariButtonItem() -> UIBarButtonItem? {
-        let button = barButtonItem(with: .gridicon(.globe), action: #selector(didTapBrowserButton(_:)))
-        button.accessibilityLabel = Strings.safariButtonAccessibilityLabel
-
-        return button
     }
 
     func moreButtonItem(enabled: Bool = true) -> UIBarButtonItem? {


### PR DESCRIPTION
This PR is a proposal to remove the duplicated "View in Browser" action from the "Post Details" page. 

## Before

In the current version, the button is in the right navigation items, but it is also present in the "More" menu. Based on analytics, only ~2% of users use it, so it's not a primary action on the screen. 

<img width="320" alt="Screenshot 2025-02-28 at 1 31 53 PM" src="https://github.com/user-attachments/assets/933fe72a-b5c3-49fc-972e-15229ac1d613" /> <img width="320" alt="Screenshot 2025-02-28 at 1 32 07 PM" src="https://github.com/user-attachments/assets/69baa717-9fb8-4ea4-91fb-edad4869c4ae" />

## After

In the new version, the button is removed. It makes the top right corner visually much less heavy. 

The idea is also is to discourage the users from leaving the app. If there are scenarios where the app does not serve the users, such as a [missing "Follow" button](https://github.com/wordpress-mobile/WordPress-iOS/issues/20953), we should eliminate most of them.

<img width="320" alt="Screenshot 2025-02-28 at 1 37 54 PM" src="https://github.com/user-attachments/assets/e9c2df0d-ca58-4d21-bad2-60a8f3435327" /> <img width="320" alt="Screenshot 2025-02-28 at 1 37 51 PM" src="https://github.com/user-attachments/assets/0daac5ef-d9f5-4c2c-a51e-37c778e705c3" />


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
