### PR TITLE
Fix notification settings issues and add settings to Site Details

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -23,6 +23,9 @@
 * [*] Fix Reader: Opening comments is slow [#21887]
 * [*] Fix an issue with comments button being disabled when shown from Comments or Notifications [#24120]
 * [*] Fix unexpected "unsaved changes" notice when closing an un-edited post containing media in the experimental editor [#24102]
+* [*] Add "Notification Settings" bell to the "Site Details" screen [#24134]
+* [*] Fix an issue where the "Notifications Settings" bell for site subscriptions was not updated after the changes [#24134]
+* [*] Update the logic behind the bell. It now show the "bell with waves" when push notifications are enabled [#24134]
 
 25.7
 -----

--- a/WordPress/Classes/Models/ReaderSiteTopic.swift
+++ b/WordPress/Classes/Models/ReaderSiteTopic.swift
@@ -48,6 +48,10 @@ import Foundation
         return postSubscription?.sendPosts ?? false
     }
 
+    var canManageNotifications: Bool {
+        !isExternal
+    }
+
     /// Creates a new ReaderTagTopic object from a RemoteReaderInterest
     convenience init(remoteInfo: RemoteReaderSiteInfo, context: NSManagedObjectContext) {
         self.init(context: context)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSiteSubscriptionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSiteSubscriptionViewController.swift
@@ -132,6 +132,8 @@ class NotificationSiteSubscriptionViewController: UITableViewController {
         // Hide the separators, whenever the table is empty
         tableView.tableFooterView = UIView()
 
+        tableView.sectionHeaderHeight = 8
+
         // Style!
         WPStyleGuide.configureColors(view: view, tableView: tableView)
         WPStyleGuide.configureAutomaticHeightRows(for: tableView)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSiteSubscriptionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSiteSubscriptionViewController.swift
@@ -132,7 +132,8 @@ class NotificationSiteSubscriptionViewController: UITableViewController {
         // Hide the separators, whenever the table is empty
         tableView.tableFooterView = UIView()
 
-        tableView.sectionHeaderHeight = 8
+        tableView.tableHeaderView = UIView(frame: CGRect(x: 0.0, y: 0.0, width: 0.0, height: 8))
+        tableView.sectionHeaderHeight = 12
 
         // Style!
         WPStyleGuide.configureColors(view: view, tableView: tableView)

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController+Sharing.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController+Sharing.swift
@@ -15,7 +15,7 @@ extension ReaderStreamViewController {
             removeShareButton()
             return
         }
-        let button = UIBarButtonItem(title: nil, image: UIImage(systemName: "square.and.arrow.up"), target: self, action: #selector(shareButtonTapped))
+        let button = UIBarButtonItem(title: nil, image: UIImage(named: "wpl-share"), target: self, action: #selector(shareButtonTapped))
         button.tag = NavigationItemTag.share.rawValue
         button.accessibilityLabel = SharedStrings.Button.share
         addRightBarButtonItem(button)

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -1133,7 +1133,7 @@ private extension ReaderDetailViewController {
     }
 
     func shareButtonItem(enabled: Bool = true) -> UIBarButtonItem? {
-        let button = barButtonItem(with: .gridicon(.shareiOS), action: #selector(didTapShareButton(_:)))
+        let button = barButtonItem(with: UIImage(named: "wpl-share") ?? UIImage(), action: #selector(didTapShareButton(_:)))
         button.accessibilityLabel = SharedStrings.Button.share
         button.isEnabled = enabled
 

--- a/WordPress/Classes/ViewRelated/Reader/Headers/ReaderSiteHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Headers/ReaderSiteHeaderView.swift
@@ -45,7 +45,6 @@ class ReaderSiteHeaderView: ReaderBaseHeaderView, ReaderStreamHeader {
 // MARK: - ReaderSiteHeader
 
 private struct ReaderSiteHeader: View {
-
     @ObservedObject var viewModel: ReaderSiteHeaderViewModel
 
     var body: some View {
@@ -74,10 +73,15 @@ private struct ReaderSiteHeader: View {
             if viewModel.site?.isExternal == false {
                 countsDisplay
             }
-            ReaderFollowButton(isFollowing: viewModel.isFollowingSite,
-                               isEnabled: viewModel.isFollowEnabled,
-                               size: .regular) {
-                viewModel.updateFollowStatus()
+            HStack {
+                ReaderFollowButton(isFollowing: viewModel.isFollowingSite,
+                                   isEnabled: viewModel.isFollowEnabled,
+                                   size: .regular) {
+                    viewModel.updateFollowStatus()
+                }
+                if let site = viewModel.site, site.following {
+                    ReaderSiteHeaderNotificationSettings(site: site)
+                }
             }
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
@@ -107,7 +111,22 @@ private struct ReaderSiteHeader: View {
                                                     "'%2$@' is a placeholder for the blog subscriber count. " +
                                                     "Example: `5,000 posts • 10M subscribers`")
     }
+}
 
+private struct ReaderSiteHeaderNotificationSettings: View {
+    @ObservedObject var site: ReaderSiteTopic
+
+    var body: some View {
+        if let status = ReaderSubscriptionNotificationsStatus(site: site) {
+            ReaderSubscriptionNotificationSettingsButton(site: site, status: status)
+                .padding(.horizontal, 2)
+                .padding(.vertical, 8)
+                .overlay(
+                    RoundedRectangle(cornerRadius: 5)
+                        .stroke(Color(.separator), lineWidth: 1)
+                )
+        }
+    }
 }
 
 // MARK: - ReaderSiteHeaderViewModel
@@ -148,5 +167,4 @@ private final class ReaderSiteHeaderViewModel: ObservableObject {
             self?.isFollowEnabled = true
         }
     }
-
 }

--- a/WordPress/Classes/ViewRelated/Reader/Headers/ReaderSiteHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Headers/ReaderSiteHeaderView.swift
@@ -79,8 +79,14 @@ private struct ReaderSiteHeader: View {
                                    size: .regular) {
                     viewModel.updateFollowStatus()
                 }
-                if let site = viewModel.site, site.following {
-                    ReaderSiteHeaderNotificationSettings(site: site)
+                if let site = viewModel.site, site.canManageNotifications {
+                    ReaderSubscriptionNotificationSettingsButton(site: site)
+                        .padding(.horizontal, 2)
+                        .padding(.vertical, 8)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 5)
+                                .stroke(Color(.separator), lineWidth: 1)
+                        )
                 }
             }
         }
@@ -110,22 +116,6 @@ private struct ReaderSiteHeader: View {
                                                     "'%1$@' is a placeholder for the blog post count. " +
                                                     "'%2$@' is a placeholder for the blog subscriber count. " +
                                                     "Example: `5,000 posts • 10M subscribers`")
-    }
-}
-
-private struct ReaderSiteHeaderNotificationSettings: View {
-    @ObservedObject var site: ReaderSiteTopic
-
-    var body: some View {
-        if let status = ReaderSubscriptionNotificationsStatus(site: site) {
-            ReaderSubscriptionNotificationSettingsButton(site: site, status: status)
-                .padding(.horizontal, 2)
-                .padding(.vertical, 8)
-                .overlay(
-                    RoundedRectangle(cornerRadius: 5)
-                        .stroke(Color(.separator), lineWidth: 1)
-                )
-        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
@@ -40,7 +40,7 @@ struct ReaderSubscriptionCell: View {
 
             HStack(spacing: 0) {
                 if let status = ReaderSubscriptionNotificationsStatus(site: site) {
-                    makeButtonNotificationSettings(with: status)
+                    ReaderSubscriptionNotificationSettingsButton(site: site, status: status)
                 }
                 buttonMore
             }
@@ -51,36 +51,6 @@ struct ReaderSubscriptionCell: View {
         }, preview: {
             ReaderTopicPreviewView(topic: site)
         })
-    }
-
-    private func makeButtonNotificationSettings(with status: ReaderSubscriptionNotificationsStatus) -> some View {
-        Button {
-            isShowingSettings = true
-        } label: {
-            Group {
-                switch status {
-                case .all:
-                    Image(systemName: "bell.and.waves.left.and.right")
-                        .foregroundStyle(AppColor.primary)
-                case .personalized:
-                    Image(systemName: "bell")
-                        .foregroundStyle(AppColor.primary)
-                case .none:
-                    Image(systemName: "bell.slash")
-                        .foregroundStyle(.secondary)
-                        .opacity(0.6)
-                }
-            }
-            .font(.subheadline)
-            .frame(width: 34, alignment: .center)
-            .contentShape(Rectangle())
-        }
-        .buttonStyle(.plain)
-        .sheet(isPresented: $isShowingSettings) {
-            ReaderSubscriptionNotificationSettingsView(siteID: site.siteID.intValue)
-                .presentationDetents([.medium, .large])
-                .edgesIgnoringSafeArea(.bottom)
-        }
     }
 
     private var buttonMore: some View {

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
@@ -39,8 +39,8 @@ struct ReaderSubscriptionCell: View {
             Spacer()
 
             HStack(spacing: 0) {
-                if let status = ReaderSubscriptionNotificationsStatus(site: site) {
-                    ReaderSubscriptionNotificationSettingsButton(site: site, status: status)
+                if site.canManageNotifications {
+                    ReaderSubscriptionNotificationSettingsButton(site: site)
                 }
                 buttonMore
             }

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionHelper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionHelper.swift
@@ -98,30 +98,3 @@ private func makeURL(fromUserInput string: String) -> URL? {
     }
     return nil
 }
-
-enum ReaderSubscriptionNotificationsStatus {
-    /// Receives both posts and notifications
-    case all
-    /// Receives some notifications
-    case personalized
-    /// Receives none
-    case none
-
-    init?(site: ReaderSiteTopic) {
-        guard !site.isExternal else {
-            return nil
-        }
-        let posts = site.postSubscription
-        let emails = site.emailSubscription
-
-        let sendPosts = (posts?.sendPosts ?? false) || (emails?.sendPosts ?? false)
-        let sendComments = emails?.sendComments ?? false
-        if sendPosts && sendComments {
-            self = .all
-        } else if sendPosts || sendComments {
-            self = .personalized
-        } else {
-            self = .none
-        }
-    }
-}

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionNotificationSettingsButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionNotificationSettingsButton.swift
@@ -1,9 +1,10 @@
 import SwiftUI
 
 struct ReaderSubscriptionNotificationSettingsButton: View {
-    let site: ReaderSiteTopic
-    let status: ReaderSubscriptionNotificationsStatus
-    @State var isShowingSettings = false
+    @ObservedObject var site: ReaderSiteTopic
+
+    @State private var isShowingSettings = false
+    @State private var status: ReaderSubscriptionNotificationsStatus = .none
 
     var body: some View {
         Button {
@@ -32,6 +33,41 @@ struct ReaderSubscriptionNotificationSettingsButton: View {
             ReaderSubscriptionNotificationSettingsView(siteID: site.siteID.intValue)
                 .presentationDetents([.medium, .large])
                 .edgesIgnoringSafeArea(.bottom)
+        }
+        .onReceive(site.emailSubscription?.objectWillChange ?? .init()) {
+            refresh()
+        }
+        .onReceive(site.postSubscription?.objectWillChange ?? .init()) {
+            refresh()
+        }
+        .onAppear { refresh() }
+    }
+
+    private func refresh() {
+        status = ReaderSubscriptionNotificationsStatus(site: site)
+    }
+}
+
+private enum ReaderSubscriptionNotificationsStatus {
+    /// Receives both posts and notifications
+    case all
+    /// Receives some notifications
+    case personalized
+    /// Receives none
+    case none
+
+    init(site: ReaderSiteTopic) {
+        let posts = site.postSubscription
+        let emails = site.emailSubscription
+
+        let sendPosts = (posts?.sendPosts ?? false) || (emails?.sendPosts ?? false)
+        let sendComments = emails?.sendComments ?? false
+        if sendPosts && sendComments {
+            self = .all
+        } else if sendPosts || sendComments {
+            self = .personalized
+        } else {
+            self = .none
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionNotificationSettingsButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionNotificationSettingsButton.swift
@@ -12,7 +12,7 @@ struct ReaderSubscriptionNotificationSettingsButton: View {
         } label: {
             Group {
                 switch status {
-                case .all:
+                case .notify:
                     Image(systemName: "bell.and.waves.left.and.right")
                         .foregroundStyle(AppColor.primary)
                 case .personalized:
@@ -49,22 +49,23 @@ struct ReaderSubscriptionNotificationSettingsButton: View {
 }
 
 private enum ReaderSubscriptionNotificationsStatus {
-    /// Receives both posts and notifications
-    case all
-    /// Receives some notifications
+    /// Receive push notifications.
+    case notify
+    /// Receives emails notifications.
     case personalized
-    /// Receives none
+    /// Receives none.
     case none
 
     init(site: ReaderSiteTopic) {
-        let posts = site.postSubscription
+        let notifications = site.postSubscription
         let emails = site.emailSubscription
 
-        let sendPosts = (posts?.sendPosts ?? false) || (emails?.sendPosts ?? false)
-        let sendComments = emails?.sendComments ?? false
-        if sendPosts && sendComments {
-            self = .all
-        } else if sendPosts || sendComments {
+        let sendNotifications = notifications?.sendPosts ?? false
+        let sendEmails = (emails?.sendPosts ?? false) || (emails?.sendComments ?? false)
+
+        if sendNotifications {
+            self = .notify
+        } else if sendEmails {
             self = .personalized
         } else {
             self = .none

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionNotificationSettingsButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionNotificationSettingsButton.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct ReaderSubscriptionNotificationSettingsButton: View {
+    let site: ReaderSiteTopic
+    let status: ReaderSubscriptionNotificationsStatus
+    @State var isShowingSettings = false
+
+    var body: some View {
+        Button {
+            isShowingSettings = true
+        } label: {
+            Group {
+                switch status {
+                case .all:
+                    Image(systemName: "bell.and.waves.left.and.right")
+                        .foregroundStyle(AppColor.primary)
+                case .personalized:
+                    Image(systemName: "bell")
+                        .foregroundStyle(AppColor.primary)
+                case .none:
+                    Image(systemName: "bell.slash")
+                        .foregroundStyle(.secondary)
+                        .opacity(0.6)
+                }
+            }
+            .font(.subheadline)
+            .frame(width: 34, alignment: .center)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .sheet(isPresented: $isShowingSettings) {
+            ReaderSubscriptionNotificationSettingsView(siteID: site.siteID.intValue)
+                .presentationDetents([.medium, .large])
+                .edgesIgnoringSafeArea(.bottom)
+        }
+    }
+}


### PR DESCRIPTION
## Changes

- Add "Notification Settings" bell to the "Site Details" screen to match the web – it's the primary place where it should've always been
- Fix an issue where the "Notifications Settings" bell for site subscriptions was not updated after the changes (**RCA:** you need to observe managed object relationships)
- Update the logic behind the bell. It now show the "bell with waves" when push notifications are enabled. The default state when you subscribed to a new site is "pushes disabled", so it's an important indicator.

**Note**: I'm not a huge fan of the design on this page, but changing it wasn't in the scope.

<img width="320" alt="Screenshot 2025-02-28 at 3 48 40 PM" src="https://github.com/user-attachments/assets/45657d97-6690-4c7a-997c-f598d9947a75" />

https://github.com/user-attachments/assets/1e6d8e82-260e-453f-964b-3537b96efc1d



To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
