### PR TITLE
Fix an issue with P2 sites and follow conversation

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -18,6 +18,8 @@
 * [*] Fix Reader Comments: Reply button is hidden when pasting long text (the ap now uses a sheet) [#17964]
 * [*] Fix Reader Comments: Cells could sometimes be displayed overlapping another cell [#17653]
 * [*] Fix Notifications: quote blocks in the Reply screen are not styled correctly [#13971]
+* [*] Fix an issue with "Follow Conversation" button not visible on some P2s [#24135]
+* [*] Fix an issue with "Enable Comments Notifications" button being visible and not working correctly on some P2s [#24135]
 * [*] Fix Notifications pointing to large threads sometimes break the app [#23993]
 * [*] Fix an issue with search results disappearing after returning from site details [#24121]
 * [*] Fix Reader: Opening comments is slow [#21887]

--- a/WordPress/Classes/Models/ReaderPost+Swift.swift
+++ b/WordPress/Classes/Models/ReaderPost+Swift.swift
@@ -3,6 +3,21 @@ import WordPressUI
 
 extension ReaderPost {
 
+    /// - note: this is a workaround for https://github.com/wordpress-mobile/WordPress-iOS/issues/18975 and
+    /// https://github.com/wordpress-mobile/WordPress-iOS/issues/20953. This code
+    /// makes sure that you see the "Follow Conversation" button on P2s
+    /// but not if you have "Emails me all comments" option enabled, which
+    /// matches the behavior on the web.
+    var canActuallySubscribeToComments: Bool {
+        if canSubscribeComments {
+            return true
+        }
+        if isP2Type() {
+            return !((topic as? ReaderSiteTopic)?.emailSubscription?.sendComments ?? false)
+        }
+        return false
+    }
+
     func getSiteIconURL(size: Int) -> URL? {
         SiteIconViewModel.makeReaderSiteIconURL(iconURL: siteIconURL, siteID: siteID?.intValue, size: CGSize(width: size, height: size))
     }

--- a/WordPress/Classes/Services/FollowCommentsService.swift
+++ b/WordPress/Classes/Services/FollowCommentsService.swift
@@ -35,7 +35,7 @@ class FollowCommentsService: NSObject {
     /// Returns a Bool indicating whether or not the comments on the post can be followed.
     ///
     @objc var canFollowConversation: Bool {
-        return post.canSubscribeComments
+        return post.canActuallySubscribeToComments
     }
 
     /// Fetches the subscription status of the specified post for the current user.

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsHeader.swift
@@ -46,7 +46,7 @@ class ReaderDetailCommentsHeader: UITableViewHeaderFooterView, NibReusable {
     ) {
         self.post = post
         self.totalComments = totalComments
-        self.followConversationEnabled = post.commentsOpen && post.canSubscribeComments
+        self.followConversationEnabled = post.commentsOpen && post.canActuallySubscribeToComments
         self.followButtonTappedClosure = followButtonTappedClosure
 
         configureTitle()


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/18975 and .https://github.com/wordpress-mobile/WordPress-iOS/issues/20953.

The "Follow Conversation" button will now appear for P2 sites where you don't already have the global "Email me new comments" option enabled, which matches how it works on the web. I'm

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
