### PR TITLE
Fix missing auto-suggested featured images in Reader

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -44,7 +44,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/MediaEditor-iOS", branch: "task/spm-support"),
         .package(url: "https://github.com/wordpress-mobile/NSObject-SafeExpectations", from: "0.0.6"),
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", branch: "trunk"),
-        .package(url: "https://github.com/wordpress-mobile/WordPressKit-iOS", branch: "task/add-featured-image-auto"),
+        .package(url: "https://github.com/wordpress-mobile/WordPressKit-iOS", branch: "wpios-edition"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250127"),

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -44,7 +44,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/MediaEditor-iOS", branch: "task/spm-support"),
         .package(url: "https://github.com/wordpress-mobile/NSObject-SafeExpectations", from: "0.0.6"),
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", branch: "trunk"),
-        .package(url: "https://github.com/wordpress-mobile/WordPressKit-iOS", branch: "task/add-remote-comment-update-comment"),
+        .package(url: "https://github.com/wordpress-mobile/WordPressKit-iOS", branch: "task/add-featured-image-auto"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250127"),

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * [**] The comment composer now opens fullscreen, shows previews of the comment you are replying to, supports savings drafts, and clearly communicates the upload state and errors [#24075]
 * [*] Add depth indicators for comment threads to make them easier to follow [#24117]
 * [*] Enable dismissing the virtual keyboard in the experimental editor [#23988]
+* [*] Fix an issue with some featured images missing in Reader [#24137]
 * [*] Remove Submit Feedback form from the Me menu [#24020]
 * [*] Update iconography in Reader to match WordPress design system [#24132]
 * [*] Fix unselectable group blocks in the experimental editor [https://github.com/wordpress-mobile/GutenbergKit/pull/68]

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3cb369ca4b4bd32a3ee27b6222f4e6cf739585d921cdabf5666b246b87cdf1af",
+  "originHash" : "b048f2348f14b6f12b4a4b8588355abe499af3f8f4e91cacc054e98187a7746c",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -391,8 +391,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/WordPressKit-iOS",
       "state" : {
-        "branch" : "task/add-featured-image-auto",
-        "revision" : "30563e2b5e3fc1b009467a92b8282cbff30f79be"
+        "branch" : "wpios-edition",
+        "revision" : "ba542bae62a1d9b80b0baee44d610bfac55936ea"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "aeb249d45bcd791840c72bfdc053ebf3548e3e32b7ea494abf9af14b4fd96a3c",
+  "originHash" : "3cb369ca4b4bd32a3ee27b6222f4e6cf739585d921cdabf5666b246b87cdf1af",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -391,8 +391,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/WordPressKit-iOS",
       "state" : {
-        "branch" : "task/add-remote-comment-update-comment",
-        "revision" : "d46b5be685c9921e235d3135d03a7f51fb5fb4c1"
+        "branch" : "task/add-featured-image-auto",
+        "revision" : "30563e2b5e3fc1b009467a92b8282cbff30f79be"
       }
     },
     {

--- a/WordPress/Classes/Models/ReaderPost.m
+++ b/WordPress/Classes/Models/ReaderPost.m
@@ -190,6 +190,9 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     // assign the topic last.
     post.topic = topic;
 
+    // auto-suggested image, but NOT an explcitly specified featured image
+    post.pathForDisplayImage = remotePost.autoSuggestedFeaturedImage;
+
     return post;
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCellViewModel.swift
@@ -39,7 +39,7 @@ final class ReaderPostCellViewModel {
         self.title = post.titleForDisplay() ?? ""
         self.details = post.contentPreviewForDisplay() ?? ""
         self.isSeen = post.isSeenSupported ? post.isSeen : nil
-        self.imageURL = post.featuredImageURLForDisplay()
+        self.imageURL = post.featuredImageURLForDisplay() ?? post.pathForDisplayImage.flatMap(URL.init)
 
         self.toolbar = ReaderPostToolbarViewModel.make(post: post)
         if isP2 && post.primaryTag == "afk" {


### PR DESCRIPTION
Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/24045. The only change compared with the original implementation is that we are not going to use `suitableImageFromPostContent` because it returns completely arbitrary images. The media auto-suggested by the server seems to be perfectly fine and it now matches the web.

WordPressKit now no longer loses data by overriding a single `featuredImage` field, so the app can safely decide when to use `featuredImage` or `autoSuggestedFeaturedImage` or `suitableImageFromPostContent`. I ended up not needed the last item.

### Before

https://github.com/user-attachments/assets/1ac1ed52-613f-4b4e-a4fa-406db93a56a9

### After

https://github.com/user-attachments/assets/48d5fd82-2910-42ff-b6bd-131512f15001



To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
