### PR TITLE
More Reader Comments Improvements

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -29,6 +29,10 @@
 * [*] Add "Notification Settings" bell to the "Site Details" screen [#24134]
 * [*] Fix an issue where the "Notifications Settings" bell for site subscriptions was not updated after the changes [#24134]
 * [*] Update the logic behind the bell. It now show the "bell with waves" when push notifications are enabled [#24134]
+* [*] Add a user profile view that shows when you tap on a comment author. [#24139]
+* [*] Add a "Comments Closed" view and disable the "Add Comment" button instead of hiding it in case the comments are closed [#24139]
+* [*] Fix an issue with subscribers fully reloading after closing details making the screen unusable. [#24139]
+* [*] Fix an issue with “Info” button on comments not available until your approve the comment, defeating the purpose [#24139]
 
 25.7
 -----

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
@@ -426,6 +426,7 @@ private extension CommentDetailViewController {
 
         // otherwise, if this is a comment to a post, show the post title instead.
         headerCell.configure(for: .post, subtitle: comment.titleForDisplay())
+        headerCell.contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 54).isActive = true
     }
 
     func configureContentCell(_ cell: CommentContentTableViewCell, comment: Comment) {
@@ -435,6 +436,8 @@ private extension CommentDetailViewController {
             self?.tableView.performBatchUpdates({})
         }
 
+        cell.configureForCommentDetails()
+
         cell.contentLinkTapAction = { [weak self] url in
             // open all tapped links in web view.
             // TODO: Explore reusing URL handling logic from ReaderDetailCoordinator.
@@ -442,6 +445,7 @@ private extension CommentDetailViewController {
         }
 
         cell.accessoryButtonType = .info
+        cell.isAccessoryButtonEnabled = true
         cell.accessoryButtonAction = { [weak self] senderView in
             self?.presentUserInfoSheet(senderView)
         }

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/Editor/CommentComposerReplyCommentView.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/Editor/CommentComposerReplyCommentView.swift
@@ -44,7 +44,7 @@ final class CommentComposerReplyCommentView: UIView, UITableViewDataSource {
     private func didUpdateHeight(_ cell: CommentContentTableViewCell) {
         UIView.performWithoutAnimation {
             tableView.performBatchUpdates({})
-            heightConstraints.constant = min(130, cell.systemLayoutSizeFitting(bounds.size)
+            heightConstraints.constant = min(145, cell.systemLayoutSizeFitting(bounds.size)
                 .height + 8) // bottom padding
         }
     }

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -111,7 +111,7 @@ final class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
     // MARK: Visibility Control
 
-    private var isAccessoryButtonEnabled: Bool = false {
+    var isAccessoryButtonEnabled: Bool = false {
         didSet {
             accessoryButton.isHidden = !isAccessoryButtonEnabled
         }
@@ -195,6 +195,11 @@ final class CommentContentTableViewCell: UITableViewCell, NibReusable {
         replyButton.isHidden = true
         likeButton.isHidden = true
         isAccessoryButtonEnabled = false
+    }
+
+    func configureForCommentDetails() {
+        containerStackView.isLayoutMarginsRelativeArrangement = true
+        containerStackView.layoutMargins = UIEdgeInsets(.vertical, 4)
     }
 
     private func configure(with state: CommentCellViewModel.State) {

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -3,6 +3,7 @@ import WordPressUI
 import WordPressReader
 import Gravatar
 import Combine
+import SwiftUI
 
 final class CommentContentTableViewCell: UITableViewCell, NibReusable {
     // all the available images for the accessory button.
@@ -64,6 +65,7 @@ final class CommentContentTableViewCell: UITableViewCell, NibReusable {
     }
 
     // MARK: Outlets
+    @IBOutlet private weak var headerView: UIView!
 
     @IBOutlet private weak var containerStackView: UIStackView!
     @IBOutlet private weak var containerStackLeadingConstraint: NSLayoutConstraint!
@@ -137,6 +139,7 @@ final class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
     override func awakeFromNib() {
         super.awakeFromNib()
+
         configureViews()
     }
 
@@ -308,6 +311,8 @@ private extension CommentContentTableViewCell {
     func configureViews() {
         selectionStyle = .none
 
+        headerView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(headerTapped)))
+
         nameLabel?.font = style.nameFont
         nameLabel?.textColor = style.nameTextColor
 
@@ -432,6 +437,20 @@ private extension CommentContentTableViewCell {
     }
 
     // MARK: Button Actions
+
+    @objc private func headerTapped() {
+        guard let comment = viewModel?.comment else {
+            return
+        }
+        let viewModel = ReaderUserProfileViewModel(comment: comment)
+        let profileVC = UIHostingController(rootView: ReaderUserProfileView(viewModel: viewModel))
+        let navigationVC = UINavigationController(rootViewController: profileVC)
+        profileVC.navigationItem.leftBarButtonItem = UIBarButtonItem(systemItem: .close, primaryAction: .init { [weak profileVC] _ in
+            profileVC?.presentingViewController?.dismiss(animated: true)
+        })
+        navigationVC.sheetPresentationController?.detents = [.medium()]
+        UIViewController.topViewController?.present(navigationVC, animated: true)
+    }
 
     @objc func accessoryButtonTapped() {
         accessoryButtonAction?(accessoryButton)

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -203,6 +203,7 @@ final class CommentContentTableViewCell: UITableViewCell, NibReusable {
 
         replyButton.isHidden = !state.isReplyEnabled
         likeButton.isHidden = !state.isLikeEnabled
+        likeButton?.configuration?.contentInsets.leading = state.isReplyEnabled ? 8 : 0
 
         updateLikeButton(isLiked: state.isLiked, likeCount: state.likeCount)
     }

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.xib
@@ -174,6 +174,7 @@
                 <outlet property="contentContainerHeightConstraint" destination="t5W-a4-bo7" id="2ox-vW-Kuh"/>
                 <outlet property="contentContainerView" destination="M0y-BK-TEh" id="bC5-Hn-XRQ"/>
                 <outlet property="dateLabel" destination="ghT-Xy-q8c" id="ffa-qV-3tn"/>
+                <outlet property="headerView" destination="f2E-yC-BJS" id="d5t-k4-d2B"/>
                 <outlet property="highlightBarView" destination="mNJ-fg-sKO" id="fjf-gA-HoE"/>
                 <outlet property="likeButton" destination="X2J-8b-R5F" id="6w2-io-GXb"/>
                 <outlet property="nameLabel" destination="HpE-B7-6wr" id="MLa-k9-IlC"/>

--- a/WordPress/Classes/ViewRelated/Notifications/Views/CommentLargeButton.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/CommentLargeButton.swift
@@ -7,6 +7,16 @@ final class CommentLargeButton: UIView {
     private var containerView = CommentLargeButtonContainerView()
     private let placeholderLabel = UILabel()
     private let button = UIButton()
+    private let commentsClosedView = makeCommentsClosedView()
+    private var contentStackView: UIStackView?
+
+    @objc var isCommentingClosed = false {
+        didSet {
+            contentStackView?.isHidden = isCommentingClosed
+            commentsClosedView.isHidden = !isCommentingClosed
+            isUserInteractionEnabled = !isCommentingClosed
+        }
+    }
 
     var onTap: (() -> Void)?
 
@@ -36,12 +46,12 @@ final class CommentLargeButton: UIView {
         placeholderLabel.text = CommentCreateViewModel.leaveCommentLocalizedPlaceholder
 
         containerView.addSubview(placeholderLabel)
-        containerView.backgroundColor = .secondarySystemBackground
         placeholderLabel.pinEdges(insets: UIEdgeInsets(horizontal: 14, vertical: 10))
 
         let stackView = UIStackView(alignment: .center, spacing: 8, [iconView, containerView])
         addSubview(stackView)
         stackView.pinEdges(to: safeAreaLayoutGuide, insets: UIEdgeInsets.init(top: 14, left: 20, bottom: 8, right: 20))
+        self.contentStackView = stackView
 
         let divider = SeparatorView.horizontal()
         addSubview(divider)
@@ -50,6 +60,10 @@ final class CommentLargeButton: UIView {
         addSubview(button)
         button.addTarget(self, action: #selector(buttonTapped), for: .primaryActionTriggered)
         button.pinEdges() // Make sure it covers everything
+
+        addSubview(commentsClosedView)
+        commentsClosedView.pinCenter(to: stackView)
+        commentsClosedView.isHidden = true
     }
 
     @objc private func buttonTapped() {
@@ -61,7 +75,32 @@ private final class CommentLargeButtonContainerView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
 
+        backgroundColor = .secondarySystemBackground
+
         layer.cornerRadius = bounds.height / 2
         layer.masksToBounds = true
     }
+}
+
+private func makeCommentsClosedView() -> UIView {
+    let font = UIFont.preferredFont(forTextStyle: .headline)
+
+    let imageView = UIImageView(image: UIImage(systemName: "xmark.circle")?.applyingSymbolConfiguration(.init(font: font)))
+    imageView.tintColor = .label
+
+    let titleLabel = UILabel()
+    titleLabel.font = font
+    titleLabel.text = Strings.commentsClosed
+
+    let stackView = UIStackView(spacing: 8, [imageView, titleLabel])
+
+    let containerView = CommentLargeButtonContainerView()
+    containerView.addSubview(stackView)
+    stackView.pinEdges(insets: UIEdgeInsets(horizontal: 14, vertical: 10))
+
+    return containerView
+}
+
+private enum Strings {
+    static let commentsClosed = NSLocalizedString("reader.comments.commentsClosed", value: "Comments Closed", comment: "Informational message, should be short.")
 }

--- a/WordPress/Classes/ViewRelated/People/Controllers/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/Controllers/PeopleViewController.swift
@@ -183,10 +183,6 @@ class PeopleViewController: UITableViewController {
             let configuration = WebViewControllerConfiguration(url: url)
             configuration.authenticateWithDefaultAccount()
             configuration.secureInteraction = true
-            configuration.onClose = { [weak self] in
-                self?.resetManagedPeople()
-                self?.refreshPeople()
-            }
             let viewController = WebKitViewController(configuration: configuration)
             let navWrapper = UINavigationController(rootViewController: viewController)
             navigationController?.present(navWrapper, animated: true)

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -342,7 +342,7 @@ private final class ReaderPostCellView: UIView {
             return configuration
         }()
 
-        let font = UIFont.preferredFont(forTextStyle: .footnote).withWeight(.medium)
+        let font = UIFont.preferredFont(forTextStyle: .footnote)
 
         buttons.comment.isHidden = !viewModel.isCommentsEnabled
         if viewModel.isCommentsEnabled {
@@ -421,7 +421,7 @@ private func makeAuthorButton() -> UIButton {
 private func makeButton(image: UIImage? = nil, font: UIFont = UIFont.preferredFont(forTextStyle: .footnote)) -> UIButton {
     var configuration = UIButton.Configuration.plain()
     configuration.image = image
-    configuration.imagePadding = 6
+    configuration.imagePadding = 2
     configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(font: font)
     configuration.baseForegroundColor = .secondaryLabel
     configuration.contentInsets = .init(top: 12, leading: 12, bottom: 14, trailing: 12)

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.h
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.h
@@ -16,6 +16,7 @@ typedef NS_ENUM(NSUInteger, ReaderCommentsSource) {
 @class Comment;
 @class CommentCellViewModel;
 @class CommentContentTableViewCell;
+@class CommentLargeButton;
 @class ReaderPost;
 @class ReaderCommentsHelper;
 
@@ -25,7 +26,7 @@ typedef NS_ENUM(NSUInteger, ReaderCommentsSource) {
 @property (nonatomic, assign, readwrite) BOOL allowsPushingPostDetails;
 @property (nonatomic, assign, readwrite) ReaderCommentsSource source;
 @property (nonatomic, strong, readonly) ReaderCommentsHelper *helper;
-@property (nonatomic, strong, readonly) UIView *buttonAddComment;
+@property (nonatomic, strong, readonly) CommentLargeButton *buttonAddComment;
 
 - (void)setupWithPostID:(NSNumber *)postID siteID:(NSNumber *)siteID;
 

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -18,9 +18,7 @@
 @property (nonatomic, strong) NSNumber *postSiteID;
 @property (nonatomic, strong) WPContentSyncHelper *syncHelper;
 @property (nonatomic, strong) UITableView *tableView;
-@property (nonatomic, strong) UIView *buttonAddComment;
-@property (nonatomic, strong) NSLayoutConstraint *replyTextViewHeightConstraint;
-@property (nonatomic) BOOL isLoggedIn;
+@property (nonatomic, strong) CommentLargeButton *buttonAddComment;
 @property (nonatomic) BOOL needsUpdateAttachmentsAfterScrolling;
 @property (nonatomic) BOOL needsRefreshTableViewAfterScrolling;
 @property (nonatomic, strong) NSError *fetchCommentsError;
@@ -73,11 +71,8 @@
     self.commentModified = NO;
     self.helper = [ReaderCommentsHelper new];
 
-    [self checkIfLoggedIn];
-
     [self configureNavbar];
     [self configureCommentButton];
-    [self configureViewConstraints];
     self.activityIndicator = [self makeActivityIndicator];
 
     [self listenForClipboardChanges];
@@ -159,18 +154,6 @@
     self.buttonAddComment = [self makeCommentButton];
 }
 
-#pragma mark - Autolayout Helpers
-
-- (void)configureViewConstraints
-{
-    self.buttonAddComment.translatesAutoresizingMaskIntoConstraints = false;
-
-    // TODO:
-    // This LayoutConstraint is just a helper, meant to hide / display the ReplyTextView, as needed.
-    // Whenever iOS 8 is set as the deployment target, let's always attach this one, and enable / disable it as needed!
-    self.replyTextViewHeightConstraint = [NSLayoutConstraint constraintWithItem:self.buttonAddComment attribute:NSLayoutAttributeHeight relatedBy:NSLayoutRelationEqual toItem:nil attribute:0 multiplier:1 constant:0];
-}
-
 #pragma mark - Helpers
 
 - (NSString *)noResultsTitleText
@@ -181,11 +164,6 @@
     } else {
         return NSLocalizedString(@"Be the first to leave a comment.", @"Message shown encouraging the user to leave a comment on a post in the reader.");
     }
-}
-
-- (void)checkIfLoggedIn
-{
-    self.isLoggedIn = [AccountHelper isDotcomAvailable];
 }
 
 - (void)setHighlightedIndexPath:(NSIndexPath *)highlightedIndexPath
@@ -290,19 +268,9 @@
     return self.post == nil;
 }
 
-- (BOOL)canComment
-{
-    return self.post.commentsOpen && self.isLoggedIn;
-}
-
 - (BOOL)canFollowConversation
 {
     return [self.followCommentsService canFollowConversation];
-}
-
-- (BOOL)shouldDisplayReplyTextView
-{
-    return self.canComment;
 }
 
 #pragma mark - View Refresh Helpers
@@ -341,14 +309,7 @@
 
 - (void)refreshReplyTextView
 {
-    BOOL showsReplyTextView = self.shouldDisplayReplyTextView;
-    self.buttonAddComment.hidden = !showsReplyTextView;
-    
-    if (showsReplyTextView) {
-        [self.view removeConstraint:self.replyTextViewHeightConstraint];
-    } else {
-        [self.view addConstraint:self.replyTextViewHeightConstraint];
-    }
+    self.buttonAddComment.isCommentingClosed = !self.post.commentsOpen;
 }
 
 - (void)refreshInfiniteScroll
@@ -425,7 +386,7 @@
 
 - (void)didTapReplyAtIndexPath:(NSIndexPath *)indexPath
 {
-    if (!indexPath || !self.canComment) {
+    if (!indexPath) {
         return;
     }
     Comment *comment = [self.tableViewController commentAt:indexPath];

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.m
@@ -309,7 +309,9 @@
 
 - (void)refreshReplyTextView
 {
-    self.buttonAddComment.isCommentingClosed = !self.post.commentsOpen;
+    if (self.post) {
+        self.buttonAddComment.isCommentingClosed = !self.post.commentsOpen;
+    }
 }
 
 - (void)refreshInfiniteScroll

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -18,7 +18,7 @@ extension NSNotification.Name {
         vc.didMove(toParent: self)
     }
 
-    func makeCommentButton() -> UIView {
+    func makeCommentButton() -> CommentLargeButton {
         let button = CommentLargeButton()
         button.onTap = { [weak self] in
             self?.buttonAddCommentTapped()

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -178,17 +178,15 @@ private extension ReaderDetailCommentsTableViewDelegate {
         let cell = BorderedButtonTableViewCell()
         let title = totalComments == 0 ? Constants.leaveCommentButtonTitle : Constants.viewAllButtonTitle
 
-        if ReaderDisplaySettings.customizationEnabled {
-            cell.configure(buttonTitle: title,
-                           titleFont: displaySetting.font(with: .body, weight: .semibold),
-                           normalColor: displaySetting.color.foreground,
-                           highlightedColor: displaySetting.color.background,
-                           borderColor: displaySetting.color.border,
-                           buttonInsets: showCommentsButtonInsets,
-                           backgroundColor: .clear)
-        } else {
-            cell.configure(buttonTitle: title, borderColor: .tertiaryLabel, buttonInsets: showCommentsButtonInsets)
-        }
+        cell.configure(
+            buttonTitle: title,
+            titleFont: displaySetting.font(with: .body, weight: .semibold),
+            normalColor: displaySetting.color.foreground,
+            highlightedColor: displaySetting.color.background,
+            borderColor: displaySetting.color.border,
+            buttonInsets: UIEdgeInsets(.vertical, 16),
+            backgroundColor: .clear
+        )
 
         cell.delegate = buttonDelegate
         cell.backgroundColor = .clear
@@ -204,17 +202,11 @@ private extension ReaderDetailCommentsTableViewDelegate {
         JetpackBrandingAnalyticsHelper.trackJetpackPoweredBadgeTapped(screen: .readerDetail)
     }
 
-    // The 'No comments' cell doesn't have a bottom padding. When displayed, we need to add top padding to the button.
-    var showCommentsButtonInsets: UIEdgeInsets {
-        comments.count > 0 ? .zero : Constants.buttonInsets
-    }
-
     struct Constants {
         static let noComments = NSLocalizedString("No comments yet", comment: "Displayed on the post details page when there are no post comments.")
         static let closedComments = NSLocalizedString("Comments are closed", comment: "Displayed on the post details page when there are no post comments and commenting is closed.")
         static let viewAllButtonTitle = NSLocalizedString("View all comments", comment: "Title for button on the post details page to show all comments when tapped.")
         static let leaveCommentButtonTitle = NSLocalizedString("Be the first to comment", comment: "Title for button on the post details page when there are no comments.")
-        static let buttonInsets = UIEdgeInsets(top: 20, left: 0, bottom: 0, right: 0)
         static let jetpackBadgeBottomPadding: CGFloat = 10
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/User/ReaderUserProfileView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/User/ReaderUserProfileView.swift
@@ -1,0 +1,61 @@
+import SwiftUI
+
+struct ReaderUserProfileView: View {
+    let viewModel: ReaderUserProfileViewModel
+
+    var body: some View {
+        List {
+            header
+                .frame(maxWidth: .infinity, alignment: .center)
+                .listRowSeparator(.hidden)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(Strings.site.uppercased())
+                    .font(.footnote.weight(.medium))
+                if let siteURL = viewModel.siteURL {
+                    Link(destination: siteURL) {
+                        Text(siteURL.host ?? siteURL.absoluteString)
+                            .foregroundColor(AppColor.primary)
+                            .lineLimit(2)
+                    }
+                } else {
+                    Text("–")
+                        .foregroundStyle(.secondary)
+                }
+            }
+            .listRowSeparator(.hidden)
+        }
+        .listStyle(.plain)
+    }
+
+    private var header: some View {
+        VStack(spacing: 12) {
+            AvatarView(style: .single(viewModel.avatarURL), diameter: 72, placeholderImage: Image("gravatar").resizable())
+
+            VStack(alignment: .leading, spacing: 3) {
+                HStack(alignment: .firstTextBaseline, spacing: 8) {
+                    Text(viewModel.name)
+                        .font(.title3.weight(.semibold))
+                        .textSelection(.enabled)
+                        .lineLimit(2)
+                }
+            }
+        }
+    }
+}
+
+struct ReaderUserProfileViewModel {
+    let avatarURL: URL?
+    let name: String
+    let siteURL: URL?
+
+    init(comment: Comment) {
+        self.avatarURL = comment.avatarURLForDisplay()
+        self.name = comment.author
+        self.siteURL = URL(string: comment.author_url)
+    }
+}
+
+private enum Strings {
+    static let site = NSLocalizedString("reader.userProfile.site", value: "Site", comment: "Field title")
+}


### PR DESCRIPTION
Changes:

- Minor tweak to buttons in Reader
- Add initial `ReaderUserProfileView` that will open when you tap on a comment author. It will show the link to the preferred user’s site and allow you to copy their name by long-pressing. That’s all information we have right now, but it’s at least something, and we can improve upon it later.
- Fix https://github.com/wordpress-mobile/WordPress-iOS/issues/22839 and inform the user when the comments are closed instead of simply hiding the “Add Comment” field
- Fix a couple of minor layouts issues here and there
- Fix https://github.com/wordpress-mobile/WordPress-iOS/issues/24049 an issue with subscribers fully reloading after closing details making the screen unusable. There ideally does need to be a way to check if the subscriber is removed after the web view is closed, bu this is absolutely not it.
- Fix an issue with “Info” button on comments not available until your approve the comment, defeating the purpose

<img width="320" alt="screenshot-comments-closed" src="https://github.com/user-attachments/assets/79c2a3ce-e12f-46c6-acb1-68fce5a6a9bc" /> <img width="320" alt="screenshot-user-profile" src="https://github.com/user-attachments/assets/d38a5485-44c9-4eea-855c-99cf0e11a311" />


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
