### PR TITLE
Draft: Lazy Image Loading

### DIFF
--- a/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
@@ -1,6 +1,7 @@
 import WebKit
 import WordPressShared
 import WordPressUI
+import Combine
 
 /// Renders the comment body with a web view. Provides the best visual experience but has the highest performance cost.
 @MainActor
@@ -36,7 +37,15 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
     private var lastReloadDate: Date?
     private var isReloadNeeded = false
 
-    /// A shared web view context with resources that can be reused across
+    private var renderID: UUID?
+    private var previousWebViewContentSize: CGSize?
+    private var previousReportedContentHeight: CGFloat?
+    private var isHeightUpdateNeeded = false
+    private var isUpdatingHeight = false
+
+    private var cancellables: [AnyCancellable] = []
+
+        /// A shared web view context with resources that can be reused across
     /// mutliple web view instances.
     @MainActor
     public final class Context {
@@ -72,7 +81,14 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
 
     public func render(comment: String) {
         self.comment = comment
+
         actuallyRender(comment: comment)
+        let renderID = UUID()
+        self.renderID = renderID
+
+        webView.scrollView.publisher(for: \.contentSize, options: [.new]).sink { [weak self] in
+            self?.didChangeContentSize($0, renderID: renderID)
+        }.store(in: &cancellables)
     }
 
     private func actuallyRender(comment: String) {
@@ -80,7 +96,13 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
     }
 
     public func prepareForReuse() {
+        renderID = nil // Make sure previous callbacks are not calls/executed
         comment = nil
+        isUpdatingHeight = false
+        isHeightUpdateNeeded = false
+        previousWebViewContentSize = nil
+        previousReportedContentHeight = nil
+        cancellables = []
         webView.stopLoading()
     }
 
@@ -96,36 +118,56 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
         lastReloadDate = Date()
         actuallyRender(comment: comment)
     }
+
+    // MARK: - Content Size
+
+    private func didChangeContentSize(_ size: CGSize, renderID: UUID) {
+        guard renderID == self.renderID else { return } // Was reused
+
+        guard previousWebViewContentSize != size else { return }
+        previousWebViewContentSize = size
+        setNeedsHeightUpdate()
+    }
+
+    private func setNeedsHeightUpdate() {
+        isHeightUpdateNeeded = true
+        updateHeightIfNeeded()
+    }
+
+    private func updateHeightIfNeeded() {
+        guard let renderID else { return }
+
+        guard isHeightUpdateNeeded && !isUpdatingHeight else { return }
+        isUpdatingHeight = true
+        isHeightUpdateNeeded = false
+
+        // This is more accurate than WKWebView that has a minimum preferred height
+        // settings that is sometimes larger than the actual `s`crollHeight.
+        webView.evaluateJavaScript("document.body.scrollHeight") { [weak self] height, _ in
+            guard let height = height as? CGFloat else { return }
+            self?.didUpdateHeight(height, for: renderID)
+        }
+    }
+
+    private func didUpdateHeight(_ height: CGFloat, for renderID: UUID) { // for current comment
+        guard renderID == self.renderID, let comment else { return }  // Was reused
+
+        isUpdatingHeight = false
+        if previousReportedContentHeight != height {
+            previousReportedContentHeight = height
+            delegate?.renderer(self, asyncRenderCompletedWithHeight: height, comment: comment)
+        }
+        updateHeightIfNeeded()
+    }
 }
 
 // MARK: - WKNavigationDelegate
 
 extension WebCommentContentRenderer: WKNavigationDelegate {
+
     public func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
-        guard let comment else {
-            return
-        }
-        // Wait until the HTML document finished loading.
-        // This also waits for all of resources within the HTML (images, video thumbnail images) to be fully loaded.
-        webView.evaluateJavaScript("document.readyState") { complete, _ in
-            guard complete != nil, self.comment == comment else {
-                return
-            }
-
-            // To capture the content height, the methods to use is either `document.body.scrollHeight` or `document.documentElement.scrollHeight`.
-            // `document.body` does not capture margins on <body> tag, so we'll use `document.documentElement` instead.
-            webView.evaluateJavaScript("document.documentElement.scrollHeight") { [weak self] height, _ in
-                guard let self, let height = height as? CGFloat else {
-                    return
-                }
-
-                /// The display setting's custom size is applied through the HTML's initial-scale property
-                /// in the meta tag. The `scrollHeight` value seems to return the height as if it's at 1.0 scale,
-                /// so we'll need to add the custom scale into account.
-                let actualHeight = round(height * self.displaySetting.size.scale)
-                self.delegate?.renderer(self, asyncRenderCompletedWithHeight: actualHeight, comment: comment)
-            }
-        }
+        guard renderID != nil else { return }
+        setNeedsHeightUpdate()
     }
 
     public func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction) async -> WKNavigationActionPolicy {

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -431,7 +431,8 @@ private extension CommentContentTableViewCell {
         // - warning: It's important to set height to the minimum supported
         // value because `WKWebView` can only increase the content height and
         // never decreases it when the content changes.
-        contentContainerHeightConstraint?.constant = helper.getCachedContentHeight(for: content) ?? 20
+        let contentHeight = helper.getCachedContentHeight(for: content) ?? 20
+        contentContainerHeightConstraint?.constant = contentHeight
 
         let contentView = renderer.view
         if contentContainerView.subviews.first != contentView {

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -321,6 +321,7 @@ private extension CommentContentTableViewCell {
 
         nameLabel?.font = style.nameFont
         nameLabel?.textColor = style.nameTextColor
+        nameLabel?.numberOfLines = 1
 
         badgeLabel?.font = Style.badgeFont
         badgeLabel?.textColor = Style.badgeTextColor


### PR DESCRIPTION
In the current implementation, including the production version, when the comment that has media is loading, you can see part of the text but the height of the cell isn't updated until the image is loaded.

https://github.com/user-attachments/assets/15f41018-23cb-40e0-badb-b9beabe04e3e

It's possible to update the height dynamically as the page is loading by observing `webKit.scrollView.contentSize`. For best use experience, it should also show some kind of placeholders during loading.

This implementation should also enable correct rendering of features like dropdown or excerpts in comments that add/remove content from the "page".  Unfortunately, I couldn't quite get it to work reliably with the `WKWebView` reuse in place. This PR covered WIP.

https://github.com/user-attachments/assets/8fd8ac77-54f6-4d01-9056-554812ead993

## Notes

- `func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!)` gets called when all image are loaded
- `webView.scrollView.contentSize` reports incorrect size that almost never quite matches the scroll height of the page
- `ReaderDetailsViewController` implements something similar but it doesn't have the same constraints: reuse of `WKWebView`.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
