### PR TITLE
Move `ImmuTable` to dedicated package

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,22 @@
+root = true
+
 # Apply to all files
 [*]
+indent_style = space
+indent_size = 2
 end_of_line = lf
 insert_final_newline = true
+charset = utf-8
 trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.swift]
+indent_size = 4
+
+[{*.h,*.m}]
+indent_size = 4
 
 # Ruby specific rules
 [{*.rb,Fastfile,Gemfile}]

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -10,6 +10,7 @@ let package = Package(
     products: XcodeSupport.products + [
         .library(name: "AsyncImageKit", targets: ["AsyncImageKit"]),
         .library(name: "DesignSystem", targets: ["DesignSystem"]),
+        .library(name: "ImmuTable", targets: ["ImmuTable"]),
         .library(name: "JetpackStatsWidgetsCore", targets: ["JetpackStatsWidgetsCore"]),
         .library(name: "WordPressFlux", targets: ["WordPressFlux"]),
         .library(name: "WordPressShared", targets: ["WordPressShared"]),
@@ -58,6 +59,7 @@ let package = Package(
             .product(name: "Gifu", package: "Gifu"),
         ]),
         .target(name: "DesignSystem", swiftSettings: [.swiftLanguageMode(.v5)]),
+        .target(name: "ImmuTable", swiftSettings: [.swiftLanguageMode(.v5)]),
         .target(name: "JetpackStatsWidgetsCore", swiftSettings: [.swiftLanguageMode(.v5)]),
         .target(name: "UITestsFoundation", dependencies: [
             .product(name: "ScreenObject", package: "ScreenObject"),
@@ -158,6 +160,7 @@ enum XcodeSupport {
         return [
             .xcodeTarget("XcodeTarget_App", dependencies: [
                 "DesignSystem",
+                "ImmuTable",
                 "JetpackStatsWidgetsCore",
                 "WordPressFlux",
                 "WordPressShared",

--- a/Modules/Sources/ImmuTable/AnyHashableImmuTableRow.swift
+++ b/Modules/Sources/ImmuTable/AnyHashableImmuTableRow.swift
@@ -1,0 +1,15 @@
+public struct AnyHashableImmuTableRow: Hashable {
+    let immuTableRow: any (ImmuTableRow & Hashable)
+
+    public init(immuTableRow: any (ImmuTableRow & Hashable)) {
+      self.immuTableRow = immuTableRow
+    }
+
+    public static func == (lhs: AnyHashableImmuTableRow, rhs: AnyHashableImmuTableRow) -> Bool {
+        return AnyHashable(lhs.immuTableRow) == AnyHashable(rhs.immuTableRow)
+    }
+
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(AnyHashable(immuTableRow))
+    }
+}

--- a/Modules/Sources/ImmuTable/AnyHashableImmuTableRow.swift
+++ b/Modules/Sources/ImmuTable/AnyHashableImmuTableRow.swift
@@ -1,5 +1,5 @@
 public struct AnyHashableImmuTableRow: Hashable {
-    let immuTableRow: any (ImmuTableRow & Hashable)
+    public let immuTableRow: any (ImmuTableRow & Hashable)
 
     public init(immuTableRow: any (ImmuTableRow & Hashable)) {
       self.immuTableRow = immuTableRow

--- a/Modules/Sources/ImmuTable/CellRegistrar.swift
+++ b/Modules/Sources/ImmuTable/CellRegistrar.swift
@@ -1,0 +1,3 @@
+protocol CellRegistrar {
+    func register(_ cell: ImmuTableCell, cellReuseIdentifier: String)
+}

--- a/Modules/Sources/ImmuTable/Hashable+Xcode16Workaround.swift
+++ b/Modules/Sources/ImmuTable/Hashable+Xcode16Workaround.swift
@@ -1,0 +1,3 @@
+// This conformance was added during the Xcode 16 migration to silence the
+// dozens of false-positive warnings (any @unchecked conformance is tech debt).
+extension AnyHashable: @retroactive @unchecked Sendable {}

--- a/Modules/Sources/ImmuTable/ImmuTable+Empty.swift
+++ b/Modules/Sources/ImmuTable/ImmuTable+Empty.swift
@@ -1,0 +1,6 @@
+public extension ImmuTable {
+    /// Alias for an ImmuTable with no sections
+    static var Empty: ImmuTable {
+        return ImmuTable(sections: [])
+    }
+}

--- a/Modules/Sources/ImmuTable/ImmuTable.swift
+++ b/Modules/Sources/ImmuTable/ImmuTable.swift
@@ -1,0 +1,74 @@
+import UIKit
+
+/**
+ ImmuTable represents the view model for a static UITableView.
+
+ ImmuTable consists of zero or more sections, each one containing zero or more rows,
+ and an optional header and footer text.
+
+ Each row contains the model necessary to configure a specific type of UITableViewCell.
+
+ To use ImmuTable, first you need to create some custom rows. An example row for a cell
+ that acts as a button which performs a destructive action could look like this:
+
+     struct DestructiveButtonRow: ImmuTableRow {
+         static let cell = ImmuTableCell.Class(UITableViewCell.self)
+         let title: String
+         let action: ImmuTableAction?
+
+         func configureCell(cell: UITableViewCell) {
+             cell.textLabel?.text = title
+             cell.textLabel?.textAlignment = .Center
+             cell.textLabel?.textColor = UIColor.redColor()
+         }
+     }
+
+ The easiest way to use ImmuTable is through ImmuTableViewHandler, which takes a
+ UITableViewController as an argument, and acts as the table view delegate and data
+ source. You would then assign an ImmuTable object to the handler's `viewModel`
+ property.
+
+ - attention: before using any ImmuTableRow type, you need to call `registerRows(_:tableView:)`
+ passing the row type. This is needed so ImmuTable can register the class or nib with the table view.
+ If you fail to do this, UIKit will raise an exception when it tries to load the row.
+ */
+public struct ImmuTable {
+    /// An array of the sections to be represented in the table view
+    public let sections: [ImmuTableSection]
+
+    /// Initializes an ImmuTable object with the given sections
+    public init(sections: [ImmuTableSection]) {
+        self.sections = sections
+    }
+
+    /// Returns the row model for a specific index path.
+    ///
+    /// - Precondition: `indexPath` should represent a valid section and row, otherwise this method
+    ///                 will raise an exception.
+    ///
+    public func rowAtIndexPath(_ indexPath: IndexPath) -> ImmuTableRow {
+        return sections[indexPath.section].rows[indexPath.row]
+    }
+
+    /// Registers the row custom class or nib with the table view so it can later be
+    /// dequeued with `dequeueReusableCellWithIdentifier(_:forIndexPath:)`
+    ///
+    public static func registerRows(_ rows: [ImmuTableRow.Type], tableView: UITableView) {
+        registerRows(rows, registrator: tableView)
+    }
+
+    /// This function exists for testing purposes
+    /// - seealso: registerRows(_:tableView:)
+    internal static func registerRows(_ rows: [ImmuTableRow.Type], registrator: CellRegistrar) {
+        let registrables = rows.reduce([:]) {
+            (classes, row) -> [String: ImmuTableCell] in
+
+            var classes = classes
+            classes[row.cell.reusableIdentifier] = row.cell
+            return classes
+        }
+        for (identifier, registrable) in registrables {
+            registrator.register(registrable, cellReuseIdentifier: identifier)
+        }
+    }
+}

--- a/Modules/Sources/ImmuTable/ImmuTableAction.swift
+++ b/Modules/Sources/ImmuTable/ImmuTableAction.swift
@@ -1,0 +1,1 @@
+public typealias ImmuTableAction = (ImmuTableRow) -> Void

--- a/Modules/Sources/ImmuTable/ImmuTableCell.swift
+++ b/Modules/Sources/ImmuTable/ImmuTableCell.swift
@@ -1,0 +1,41 @@
+import UIKit
+
+// ImmuTableCell describes cell types so they can be registered with a table view.
+///
+/// It supports two options:
+///    - Nib for Interface Builder defined cells.
+///    - Class for cells defined in code.
+/// Both cases presume a custom UITableViewCell subclass. If you aren't subclassing,
+/// you can also use UITableViewCell as the type.
+///
+/// - Note: If you need to use any cell style other than .Default we recommend you
+///  subclass UITableViewCell and override init(style:reuseIdentifier:).
+///
+public enum ImmuTableCell {
+
+    /// A cell using a UINib. Values are the UINib object and the custom cell class.
+    case nib(UINib, UITableViewCell.Type)
+
+    /// A cell using a custom class. The associated value is the custom cell class.
+    case `class`(UITableViewCell.Type)
+
+    /// A String that uniquely identifies the cell type
+    public var reusableIdentifier: String {
+        switch self {
+        case .class(let cellClass):
+            return NSStringFromClass(cellClass)
+        case .nib(_, let cellClass):
+            return NSStringFromClass(cellClass)
+        }
+    }
+
+    /// The class of the custom cell
+    public var cellClass: UITableViewCell.Type {
+        switch self {
+        case .class(let cellClass):
+            return cellClass
+        case .nib(_, let cellClass):
+            return cellClass
+        }
+    }
+}

--- a/Modules/Sources/ImmuTable/ImmuTableDiffableDataSource.swift
+++ b/Modules/Sources/ImmuTable/ImmuTableDiffableDataSource.swift
@@ -1,0 +1,3 @@
+import UIKit
+
+public typealias ImmuTableDiffableDataSource = UITableViewDiffableDataSource<AnyHashable, AnyHashableImmuTableRow>

--- a/Modules/Sources/ImmuTable/ImmuTableDiffableDataSourceSnapshot.swift
+++ b/Modules/Sources/ImmuTable/ImmuTableDiffableDataSourceSnapshot.swift
@@ -1,0 +1,3 @@
+import UIKit
+
+public typealias ImmuTableDiffableDataSourceSnapshot = NSDiffableDataSourceSnapshot<AnyHashable, AnyHashableImmuTableRow>

--- a/Modules/Sources/ImmuTable/ImmuTableDiffableViewHandler.swift
+++ b/Modules/Sources/ImmuTable/ImmuTableDiffableViewHandler.swift
@@ -1,0 +1,45 @@
+import UIKit
+
+public class ImmuTableDiffableViewHandler: ImmuTableViewHandler {
+    public lazy var diffableDataSource: ImmuTableDiffableDataSource = {
+        return ImmuTableDiffableDataSource(tableView: target.tableView) { tableView, indexPath, item in
+            let row = item.immuTableRow
+            let cell = tableView.dequeueReusableCell(withIdentifier: row.reusableIdentifier, for: indexPath)
+            row.configureCell(cell)
+            return cell
+        }
+    }()
+
+    public override init(takeOver target: UIViewControllerWithTableView, with passthroughScrollViewDelegate: UIScrollViewDelegate? = nil) {
+        super.init(takeOver: target, with: passthroughScrollViewDelegate)
+
+        self.target.tableView.dataSource = diffableDataSource
+        self.automaticallyReloadTableView = false
+    }
+
+    func item(for indexPath: IndexPath) -> ImmuTableRow? {
+        guard let diffableDataSource = target.tableView.dataSource as? UITableViewDiffableDataSource<AnyHashable, AnyHashableImmuTableRow> else {
+            return nil
+        }
+
+        return diffableDataSource.itemIdentifier(for: indexPath)?.immuTableRow
+    }
+
+    open override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        if target.responds(to: #selector(UITableViewDelegate.tableView(_:didSelectRowAt:))) {
+            target.tableView?(tableView, didSelectRowAt: indexPath)
+        } else if let item = item(for: indexPath) {
+            item.action?(item)
+        }
+        if automaticallyDeselectCells {
+            tableView.deselectRow(at: indexPath, animated: true)
+        }
+    }
+
+    open override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        if let item = item(for: indexPath), let customHeight = type(of: item).customHeight {
+            return CGFloat(customHeight)
+        }
+        return tableView.rowHeight
+    }
+}

--- a/Modules/Sources/ImmuTable/ImmuTableRow.swift
+++ b/Modules/Sources/ImmuTable/ImmuTableRow.swift
@@ -1,0 +1,73 @@
+import UIKit
+
+/// ImmuTableRow represents the minimum common elements of a row model.
+///
+/// You should implement your own types that conform to ImmuTableRow to define your custom rows.
+///
+public protocol ImmuTableRow {
+
+    /**
+     The closure to call when the row is tapped. The row is passed as an argument to the closure.
+
+     To improve readability, we recommend that you implement the action logic in one of
+     your view controller methods, instead of including the closure inline.
+
+     Also, be mindful of retain cycles. If your closure needs to reference `self` in
+     any way, make sure to use `[unowned self]` in the parameter list.
+
+     An example row with its action could look like this:
+
+         class ViewController: UITableViewController {
+
+             func buildViewModel() {
+                 let item1Row = NavigationItemRow(title: "Item 1", action: navigationAction())
+                 ...
+             }
+
+             func navigationAction() -> ImmuTableRow -> Void {
+                 return { [unowned self] row in
+                     let controller = self.controllerForRow(row)
+                     self.navigationController?.pushViewController(controller, animated: true)
+                 }
+             }
+
+             ...
+
+         }
+
+     */
+    var action: ImmuTableAction? { get }
+
+    /// This method is called when an associated cell needs to be configured.
+    ///
+    /// - Precondition: You can assume that the passed cell is of the type defined
+    ///   by cell.cellClass and force downcast accordingly.
+    ///
+    func configureCell(_ cell: UITableViewCell)
+
+    /// An ImmuTableCell value defining the associated cell type.
+    ///
+    /// - Seealso: See ImmuTableCell for possible options.
+    ///
+    static var cell: ImmuTableCell { get }
+
+    /// The desired row height (Optional)
+    ///
+    /// If not defined or nil, the default height will be used.
+    ///
+    static var customHeight: Float? { get }
+}
+
+extension ImmuTableRow {
+    public var reusableIdentifier: String {
+        return type(of: self).cell.reusableIdentifier
+    }
+
+    public var cellClass: UITableViewCell.Type {
+        return type(of: self).cell.cellClass
+    }
+
+    public static var customHeight: Float? {
+        return nil
+    }
+}

--- a/Modules/Sources/ImmuTable/ImmuTableSection.swift
+++ b/Modules/Sources/ImmuTable/ImmuTableSection.swift
@@ -1,0 +1,17 @@
+/// ImmuTableSection represents the view model for a table view section.
+///
+/// A section has an optional header and footer text, and zero or more rows.
+/// - seealso: ImmuTableRow
+///
+public struct ImmuTableSection {
+    public let headerText: String?
+    public let rows: [ImmuTableRow]
+    public let footerText: String?
+
+    /// Initializes a ImmuTableSection with the given rows and optionally header and footer text
+    public init(headerText: String? = nil, rows: [ImmuTableRow], footerText: String? = nil) {
+        self.headerText = headerText
+        self.rows = rows
+        self.footerText = footerText
+    }
+}

--- a/Modules/Sources/ImmuTable/ImmuTableViewHandler.swift
+++ b/Modules/Sources/ImmuTable/ImmuTableViewHandler.swift
@@ -1,14 +1,4 @@
-import ImmuTable
 import UIKit
-
-extension ImmuTable {
-    /// Alias for an ImmuTable with no sections
-    static var Empty: ImmuTable {
-        return ImmuTable(sections: [])
-    }
-}
-
-// MARK: -
 
 /// ImmuTableViewHandler is a helper to facilitate integration of ImmuTable in your
 /// table view controllers.
@@ -20,7 +10,6 @@ extension ImmuTable {
 ///         reference to the handler from your view controller.
 ///
 open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDelegate {
-    typealias UIViewControllerWithTableView = TableViewContainer & UITableViewDataSource & UITableViewDelegate & UIViewController
 
     @objc unowned let target: UIViewControllerWithTableView
     private weak var passthroughScrollViewDelegate: UIScrollViewDelegate?
@@ -28,7 +17,7 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
     /// Initializes the handler with a target table view controller.
     /// - postcondition: After initialization, it becomse the data source and
     ///   delegate for the the target's table view.
-    @objc init(takeOver target: UIViewControllerWithTableView, with passthroughScrollViewDelegate: UIScrollViewDelegate? = nil) {
+    @objc public init(takeOver target: UIViewControllerWithTableView, with passthroughScrollViewDelegate: UIScrollViewDelegate? = nil) {
         self.target = target
         self.passthroughScrollViewDelegate = passthroughScrollViewDelegate
 
@@ -48,10 +37,10 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
     }
 
     /// Configure the handler to automatically deselect any cell after tapping it.
-    @objc var automaticallyDeselectCells = false
+    @objc public var automaticallyDeselectCells = false
 
     /// Automatically reload table view when view model changes
-    @objc var automaticallyReloadTableView = true
+    @objc public var automaticallyReloadTableView = true
 
     // MARK: UITableViewDataSource
 
@@ -245,78 +234,5 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
 
     open func scrollViewDidChangeAdjustedContentInset(_ scrollView: UIScrollView) {
         passthroughScrollViewDelegate?.scrollViewDidChangeAdjustedContentInset?(scrollView)
-    }
-}
-
-// MARK: - UITableViewController conformance
-
-@objc public protocol TableViewContainer: AnyObject {
-    var tableView: UITableView! { get }
-}
-
-extension UITableViewController: TableViewContainer {}
-
-// MARK: - Diffable
-
-// This conformance was added during the Xcode 16 migration to silence the
-// dozens of false-positive warnings (any @unchecked conformance is tech debt).
-extension AnyHashable: @retroactive @unchecked Sendable {}
-
-typealias ImmuTableDiffableDataSourceSnapshot = NSDiffableDataSourceSnapshot<AnyHashable, AnyHashableImmuTableRow>
-typealias ImmuTableDiffableDataSource = UITableViewDiffableDataSource<AnyHashable, AnyHashableImmuTableRow>
-
-struct AnyHashableImmuTableRow: Hashable {
-    let immuTableRow: any (ImmuTableRow & Hashable)
-
-    static func == (lhs: AnyHashableImmuTableRow, rhs: AnyHashableImmuTableRow) -> Bool {
-        return AnyHashable(lhs.immuTableRow) == AnyHashable(rhs.immuTableRow)
-    }
-
-    func hash(into hasher: inout Hasher) {
-        hasher.combine(AnyHashable(immuTableRow))
-    }
-}
-
-class ImmuTableDiffableViewHandler: ImmuTableViewHandler {
-    lazy var diffableDataSource: ImmuTableDiffableDataSource = {
-        return ImmuTableDiffableDataSource(tableView: target.tableView) { tableView, indexPath, item in
-            let row = item.immuTableRow
-            let cell = tableView.dequeueReusableCell(withIdentifier: row.reusableIdentifier, for: indexPath)
-            row.configureCell(cell)
-            return cell
-        }
-    }()
-
-    override init(takeOver target: ImmuTableViewHandler.UIViewControllerWithTableView, with passthroughScrollViewDelegate: UIScrollViewDelegate? = nil) {
-        super.init(takeOver: target, with: passthroughScrollViewDelegate)
-
-        self.target.tableView.dataSource = diffableDataSource
-        self.automaticallyReloadTableView = false
-    }
-
-    func item(for indexPath: IndexPath) -> ImmuTableRow? {
-        guard let diffableDataSource = target.tableView.dataSource as? UITableViewDiffableDataSource<AnyHashable, AnyHashableImmuTableRow> else {
-            return nil
-        }
-
-        return diffableDataSource.itemIdentifier(for: indexPath)?.immuTableRow
-    }
-
-    open override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        if target.responds(to: #selector(UITableViewDelegate.tableView(_:didSelectRowAt:))) {
-            target.tableView?(tableView, didSelectRowAt: indexPath)
-        } else if let item = item(for: indexPath) {
-            item.action?(item)
-        }
-        if automaticallyDeselectCells {
-            tableView.deselectRow(at: indexPath, animated: true)
-        }
-    }
-
-    open override func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        if let item = item(for: indexPath), let customHeight = type(of: item).customHeight {
-            return CGFloat(customHeight)
-        }
-        return tableView.rowHeight
     }
 }

--- a/Modules/Sources/ImmuTable/TableViewContainer.swift
+++ b/Modules/Sources/ImmuTable/TableViewContainer.swift
@@ -1,0 +1,5 @@
+import UIKit
+
+@objc public protocol TableViewContainer: AnyObject {
+    var tableView: UITableView! { get }
+}

--- a/Modules/Sources/ImmuTable/UITableView+CellRegistrar.swift
+++ b/Modules/Sources/ImmuTable/UITableView+CellRegistrar.swift
@@ -1,0 +1,12 @@
+import UIKit
+
+extension UITableView: CellRegistrar {
+    public func register(_ cell: ImmuTableCell, cellReuseIdentifier: String) {
+        switch cell {
+        case .nib(let nib, _):
+            self.register(nib, forCellReuseIdentifier: cell.reusableIdentifier)
+        case .class(let cellClass):
+            self.register(cellClass, forCellReuseIdentifier: cell.reusableIdentifier)
+        }
+    }
+}

--- a/Modules/Sources/ImmuTable/UITableViewController+TableViewContainer.swift
+++ b/Modules/Sources/ImmuTable/UITableViewController+TableViewContainer.swift
@@ -1,0 +1,3 @@
+import UIKit
+
+extension UITableViewController: TableViewContainer {}

--- a/Modules/Sources/ImmuTable/UIViewControllerWithTableView.swift
+++ b/Modules/Sources/ImmuTable/UIViewControllerWithTableView.swift
@@ -1,0 +1,3 @@
+import UIKit
+
+public typealias UIViewControllerWithTableView = TableViewContainer & UITableViewDataSource & UITableViewDelegate & UIViewController

--- a/WordPress/Classes/Utility/ImmuTable/ImmuTable+Optional.swift
+++ b/WordPress/Classes/Utility/ImmuTable/ImmuTable+Optional.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 
 extension ImmuTableSection {
     /// Initializes a ImmuTableSection with the given rows (skipping nil ones)

--- a/WordPress/Classes/Utility/ImmuTable/ImmuTable+WordPress.swift
+++ b/WordPress/Classes/Utility/ImmuTable/ImmuTable+WordPress.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import WordPressShared
 
 /// This lives as an extension on a separate file because it's specific to our UI

--- a/WordPress/Classes/Utility/ImmuTable/ImmuTable.swift
+++ b/WordPress/Classes/Utility/ImmuTable/ImmuTable.swift
@@ -101,80 +101,6 @@ public struct ImmuTableSection {
     }
 }
 
-// MARK: - ImmuTableRow
-
-/// ImmuTableRow represents the minimum common elements of a row model.
-///
-/// You should implement your own types that conform to ImmuTableRow to define your custom rows.
-///
-public protocol ImmuTableRow {
-
-    /**
-     The closure to call when the row is tapped. The row is passed as an argument to the closure.
-
-     To improve readability, we recommend that you implement the action logic in one of
-     your view controller methods, instead of including the closure inline.
-
-     Also, be mindful of retain cycles. If your closure needs to reference `self` in
-     any way, make sure to use `[unowned self]` in the parameter list.
-
-     An example row with its action could look like this:
-
-         class ViewController: UITableViewController {
-
-             func buildViewModel() {
-                 let item1Row = NavigationItemRow(title: "Item 1", action: navigationAction())
-                 ...
-             }
-
-             func navigationAction() -> ImmuTableRow -> Void {
-                 return { [unowned self] row in
-                     let controller = self.controllerForRow(row)
-                     self.navigationController?.pushViewController(controller, animated: true)
-                 }
-             }
-
-             ...
-
-         }
-
-     */
-    var action: ImmuTableAction? { get }
-
-    /// This method is called when an associated cell needs to be configured.
-    ///
-    /// - Precondition: You can assume that the passed cell is of the type defined
-    ///   by cell.cellClass and force downcast accordingly.
-    ///
-    func configureCell(_ cell: UITableViewCell)
-
-    /// An ImmuTableCell value defining the associated cell type.
-    ///
-    /// - Seealso: See ImmuTableCell for possible options.
-    ///
-    static var cell: ImmuTableCell { get }
-
-    /// The desired row height (Optional)
-    ///
-    /// If not defined or nil, the default height will be used.
-    ///
-    static var customHeight: Float? { get }
-}
-
-extension ImmuTableRow {
-    public var reusableIdentifier: String {
-        return type(of: self).cell.reusableIdentifier
-    }
-
-    public var cellClass: UITableViewCell.Type {
-        return type(of: self).cell.cellClass
-    }
-
-    public static var customHeight: Float? {
-        return nil
-    }
-}
-
 // MARK: -
 
 /// ImmuTableViewHandler is a helper to facilitate integration of ImmuTable in your
@@ -414,10 +340,6 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
         passthroughScrollViewDelegate?.scrollViewDidChangeAdjustedContentInset?(scrollView)
     }
 }
-
-// MARK: - Type aliases
-
-public typealias ImmuTableAction = (ImmuTableRow) -> Void
 
 // MARK: - Internal testing helpers
 

--- a/WordPress/Classes/Utility/ImmuTable/ImmuTable.swift
+++ b/WordPress/Classes/Utility/ImmuTable/ImmuTable.swift
@@ -1,4 +1,6 @@
+import ImmuTable
 import UIKit
+
 /**
  ImmuTable represents the view model for a static UITableView.
 
@@ -170,48 +172,6 @@ extension ImmuTableRow {
 
     public static var customHeight: Float? {
         return nil
-    }
-}
-
-// MARK: - ImmuTableCell
-
-/// ImmuTableCell describes cell types so they can be registered with a table view.
-///
-/// It supports two options:
-///    - Nib for Interface Builder defined cells.
-///    - Class for cells defined in code.
-/// Both cases presume a custom UITableViewCell subclass. If you aren't subclassing,
-/// you can also use UITableViewCell as the type.
-///
-/// - Note: If you need to use any cell style other than .Default we recommend you
-///  subclass UITableViewCell and override init(style:reuseIdentifier:).
-///
-public enum ImmuTableCell {
-
-    /// A cell using a UINib. Values are the UINib object and the custom cell class.
-    case nib(UINib, UITableViewCell.Type)
-
-    /// A cell using a custom class. The associated value is the custom cell class.
-    case `class`(UITableViewCell.Type)
-
-    /// A String that uniquely identifies the cell type
-    public var reusableIdentifier: String {
-        switch self {
-        case .class(let cellClass):
-            return NSStringFromClass(cellClass)
-        case .nib(_, let cellClass):
-            return NSStringFromClass(cellClass)
-        }
-    }
-
-    /// The class of the custom cell
-    public var cellClass: UITableViewCell.Type {
-        switch self {
-        case .class(let cellClass):
-            return cellClass
-        case .nib(_, let cellClass):
-            return cellClass
-        }
     }
 }
 

--- a/WordPress/Classes/Utility/ImmuTable/ImmuTable.swift
+++ b/WordPress/Classes/Utility/ImmuTable/ImmuTable.swift
@@ -1,103 +1,10 @@
 import ImmuTable
 import UIKit
 
-/**
- ImmuTable represents the view model for a static UITableView.
-
- ImmuTable consists of zero or more sections, each one containing zero or more rows,
- and an optional header and footer text.
-
- Each row contains the model necessary to configure a specific type of UITableViewCell.
-
- To use ImmuTable, first you need to create some custom rows. An example row for a cell
- that acts as a button which performs a destructive action could look like this:
-
-     struct DestructiveButtonRow: ImmuTableRow {
-         static let cell = ImmuTableCell.Class(UITableViewCell.self)
-         let title: String
-         let action: ImmuTableAction?
-
-         func configureCell(cell: UITableViewCell) {
-             cell.textLabel?.text = title
-             cell.textLabel?.textAlignment = .Center
-             cell.textLabel?.textColor = UIColor.redColor()
-         }
-     }
-
- The easiest way to use ImmuTable is through ImmuTableViewHandler, which takes a
- UITableViewController as an argument, and acts as the table view delegate and data
- source. You would then assign an ImmuTable object to the handler's `viewModel`
- property.
-
- - attention: before using any ImmuTableRow type, you need to call `registerRows(_:tableView:)`
- passing the row type. This is needed so ImmuTable can register the class or nib with the table view.
- If you fail to do this, UIKit will raise an exception when it tries to load the row.
- */
-public struct ImmuTable {
-    /// An array of the sections to be represented in the table view
-    public let sections: [ImmuTableSection]
-
-    /// Initializes an ImmuTable object with the given sections
-    public init(sections: [ImmuTableSection]) {
-        self.sections = sections
-    }
-
-    /// Returns the row model for a specific index path.
-    ///
-    /// - Precondition: `indexPath` should represent a valid section and row, otherwise this method
-    ///                 will raise an exception.
-    ///
-    public func rowAtIndexPath(_ indexPath: IndexPath) -> ImmuTableRow {
-        return sections[indexPath.section].rows[indexPath.row]
-    }
-
-    /// Registers the row custom class or nib with the table view so it can later be
-    /// dequeued with `dequeueReusableCellWithIdentifier(_:forIndexPath:)`
-    ///
-    public static func registerRows(_ rows: [ImmuTableRow.Type], tableView: UITableView) {
-        registerRows(rows, registrator: tableView)
-    }
-
-    /// This function exists for testing purposes
-    /// - seealso: registerRows(_:tableView:)
-    internal static func registerRows(_ rows: [ImmuTableRow.Type], registrator: CellRegistrar) {
-        let registrables = rows.reduce([:]) {
-            (classes, row) -> [String: ImmuTableCell] in
-
-            var classes = classes
-            classes[row.cell.reusableIdentifier] = row.cell
-            return classes
-        }
-        for (identifier, registrable) in registrables {
-            registrator.register(registrable, cellReuseIdentifier: identifier)
-        }
-    }
-}
-
 extension ImmuTable {
     /// Alias for an ImmuTable with no sections
     static var Empty: ImmuTable {
         return ImmuTable(sections: [])
-    }
-}
-
-// MARK: -
-
-/// ImmuTableSection represents the view model for a table view section.
-///
-/// A section has an optional header and footer text, and zero or more rows.
-/// - seealso: ImmuTableRow
-///
-public struct ImmuTableSection {
-    let headerText: String?
-    let rows: [ImmuTableRow]
-    let footerText: String?
-
-    /// Initializes a ImmuTableSection with the given rows and optionally header and footer text
-    public init(headerText: String? = nil, rows: [ImmuTableRow], footerText: String? = nil) {
-        self.headerText = headerText
-        self.rows = rows
-        self.footerText = footerText
     }
 }
 
@@ -338,23 +245,6 @@ open class ImmuTableViewHandler: NSObject, UITableViewDataSource, UITableViewDel
 
     open func scrollViewDidChangeAdjustedContentInset(_ scrollView: UIScrollView) {
         passthroughScrollViewDelegate?.scrollViewDidChangeAdjustedContentInset?(scrollView)
-    }
-}
-
-// MARK: - Internal testing helpers
-
-protocol CellRegistrar {
-    func register(_ cell: ImmuTableCell, cellReuseIdentifier: String)
-}
-
-extension UITableView: CellRegistrar {
-    public func register(_ cell: ImmuTableCell, cellReuseIdentifier: String) {
-        switch cell {
-        case .nib(let nib, _):
-            self.register(nib, forCellReuseIdentifier: cell.reusableIdentifier)
-        case .class(let cellClass):
-            self.register(cellClass, forCellReuseIdentifier: cell.reusableIdentifier)
-        }
     }
 }
 

--- a/WordPress/Classes/Utility/ImmuTable/ImmuTableViewController.swift
+++ b/WordPress/Classes/Utility/ImmuTable/ImmuTableViewController.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 import WordPressShared
 

--- a/WordPress/Classes/Utility/ImmuTable/WPImmuTableRows.swift
+++ b/WordPress/Classes/Utility/ImmuTable/WPImmuTableRows.swift
@@ -1,6 +1,7 @@
 import Foundation
-import WordPressShared
 import Gridicons
+import ImmuTable
+import WordPressShared
 
 struct NavigationItemRow: ImmuTableRow {
     static let cell = ImmuTableCell.class(WPTableViewCellValue1.self)

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListRow.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListRow.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 
 struct ActivityListRow: ImmuTableRow {
     typealias CellType = ActivityTableViewCell

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListViewModel.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import WordPressFlux
 
 protocol ActivityPresenter: AnyObject {

--- a/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/BaseActivityListViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 import SVProgressHUD
 import WordPressShared
 import WordPressFlux

--- a/WordPress/Classes/ViewRelated/Activity/RewindStatusRow.swift
+++ b/WordPress/Classes/ViewRelated/Activity/RewindStatusRow.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 
 struct RewindStatusRow: ImmuTableRow {
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
@@ -1,7 +1,8 @@
+import Aztec
 import Foundation
+import ImmuTable
 import UIKit
 import WordPressShared
-import Aztec
 
 class AztecAttachmentViewController: UITableViewController {
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/LinkSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/LinkSettingsViewController.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 
 struct LinkSettings {

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingAccountViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingAccountViewController.swift
@@ -1,5 +1,6 @@
-import UIKit
+import ImmuTable
 import Gridicons
+import UIKit
 import WordPressShared
 
 /// Displays a list of available keyring connection accounts that can be used to

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/DateAndTimeFormatSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/DateAndTimeFormatSettingsViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 import WordPressShared
 
 /// This class will display the Blog's date and time settings, and will allow the user to modify them.

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/HomepageSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/HomepageSettingsViewController.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 import WordPressFlux
 import WordPressShared

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/LanguageSelectorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/LanguageSelectorViewController.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 import WordPressShared
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/BaseRestoreOptionsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Restore/Restore Options/BaseRestoreOptionsViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 import WordPressShared
 
 typealias HighlightedText = (substring: String, string: String)

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackConnectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackConnectionViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 
 @objc
 protocol JetpackConnectionDelegate {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSettingsViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 import WordPressShared
 
 /// The purpose of this class is to render and modify the Jetpack Settings associated to a site.

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSpeedUpSiteSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackSpeedUpSiteSettingsViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 import WordPressShared
 
 /// This class will display the Blog's "Speed you site" settings, and will allow the user to modify them.

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -1,6 +1,7 @@
 import Foundation
-import UIKit
+import ImmuTable
 import SwiftUI
+import UIKit
 import WordPressShared
 import WordPressFlux
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -1,11 +1,12 @@
-import Foundation
-import UIKit
-import SwiftUI
-import Gridicons
-import WordPressShared
-import SVProgressHUD
-import WordPressFlux
 import DesignSystem
+import Foundation
+import Gridicons
+import ImmuTable
+import SVProgressHUD
+import SwiftUI
+import UIKit
+import WordPressFlux
+import WordPressShared
 import WordPressUI
 
 class AppSettingsViewController: UITableViewController {

--- a/WordPress/Classes/ViewRelated/Me/App Settings/MediaCacheSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/MediaCacheSettingsViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 
 class MediaCacheSettingsViewController: UITableViewController {
     fileprivate var handler: ImmuTableViewHandler?

--- a/WordPress/Classes/ViewRelated/Me/App Settings/Privacy Settings/PrivacySettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/Privacy Settings/PrivacySettingsViewController.swift
@@ -1,6 +1,7 @@
-import Gridicons
-import UIKit
 import AutomatticTracks
+import Gridicons
+import ImmuTable
+import UIKit
 
 class PrivacySettingsViewController: UITableViewController {
     fileprivate var handler: ImmuTableViewHandler!

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -1,6 +1,7 @@
+import AutomatticAbout
+import ImmuTable
 import UIKit
 import WordPressShared
-import AutomatticAbout
 
 class MeViewController: UITableViewController {
     var handler: ImmuTableViewHandler!

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/GravatarInfoRow.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Gravatar/GravatarInfoRow.swift
@@ -1,6 +1,7 @@
-import Foundation
-import WordPressShared
 import DesignSystem
+import Foundation
+import ImmuTable
+import WordPressShared
 
 struct GravatarInfoRow: ImmuTableRow {
 

--- a/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/MyProfileViewController.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 import WordPressShared
 

--- a/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaItemViewController.swift
@@ -1,8 +1,9 @@
 import AVKit
 import Combine
-import UIKit
 import Gridicons
+import ImmuTable
 import SVProgressHUD
+import UIKit
 import WordPressShared
 
 /// Displays an image preview and metadata for a single Media asset.

--- a/WordPress/Classes/ViewRelated/Pages/Controllers/ParentPageSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/Controllers/ParentPageSettingsViewController.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 
 private struct Row: ImmuTableRow {

--- a/WordPress/Classes/ViewRelated/Plans/Controllers/PlanDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/Controllers/PlanDetailViewController.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 import WordPressShared
 

--- a/WordPress/Classes/ViewRelated/Plans/Controllers/PlanListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plans/Controllers/PlanListViewController.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 import WordPressShared
 

--- a/WordPress/Classes/ViewRelated/Plans/ViewModels/FeatureItemRow.swift
+++ b/WordPress/Classes/ViewRelated/Plans/ViewModels/FeatureItemRow.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 import WordPressShared
 

--- a/WordPress/Classes/ViewRelated/Plans/ViewModels/PlanDetailViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plans/ViewModels/PlanDetailViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 import WordPressShared
 
 struct PlanDetailViewModel {

--- a/WordPress/Classes/ViewRelated/Plans/ViewModels/PlanListRow.swift
+++ b/WordPress/Classes/ViewRelated/Plans/ViewModels/PlanListRow.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 import WordPressShared
 

--- a/WordPress/Classes/ViewRelated/Plans/ViewModels/PlanListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plans/ViewModels/PlanListViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 import WordPressShared
 import WordPressUI
 

--- a/WordPress/Classes/ViewRelated/Plugins/Controllers/PluginDirectoryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/Controllers/PluginDirectoryViewController.swift
@@ -1,6 +1,7 @@
+import Gridicons
+import ImmuTable
 import UIKit
 import WordPressFlux
-import Gridicons
 
 class PluginDirectoryViewController: UITableViewController {
 

--- a/WordPress/Classes/ViewRelated/Plugins/Controllers/PluginListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/Controllers/PluginListViewController.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 import WordPressKit
 import WordPressFlux

--- a/WordPress/Classes/ViewRelated/Plugins/Controllers/PluginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/Controllers/PluginViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 import WordPressFlux
 
 class PluginViewController: UITableViewController {

--- a/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginDirectoryViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginDirectoryViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
-import WordPressFlux
 import Gridicons
+import ImmuTable
+import WordPressFlux
 
 protocol PluginListPresenter: AnyObject {
     func present(site: JetpackSiteRef, query: PluginQuery)

--- a/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginListRow.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginListRow.swift
@@ -1,4 +1,5 @@
 import Gridicons
+import ImmuTable
 
 struct PluginListRow: ImmuTableRow {
     static let cell: ImmuTableCell = {

--- a/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginListViewModel.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import WordPressKit
 import WordPressFlux
 

--- a/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 import WordPressFlux
 
 class PluginViewModel: Observable {

--- a/WordPress/Classes/ViewRelated/Plugins/Views/CollectionViewContainerRow.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/Views/CollectionViewContainerRow.swift
@@ -1,3 +1,5 @@
+import ImmuTable
+
 /// A `ImmuTableRow` that contains a `UICollectionView`.
 /// Currently the `CollectionViewContainerCell` is fairly specific to needs of Plugin Directory,
 /// but it should be possible to make it more generic in the future if there's a need to — it was deliberately

--- a/WordPress/Classes/ViewRelated/Plugins/Views/PluginDetailViewHeaderCell.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/Views/PluginDetailViewHeaderCell.swift
@@ -1,6 +1,7 @@
+import Gridicons
+import ImmuTable
 import UIKit
 import WordPressShared
-import Gridicons
 
 class PluginDetailViewHeaderCell: UITableViewCell {
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
@@ -1,5 +1,6 @@
-import UIKit
 import Gridicons
+import ImmuTable
+import UIKit
 
 // This exists in addition to `SiteStatsInsightsDelegate` because `[StatSection]`
 // can't be represented in an Obj-C protocol.

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsBaseTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsBaseTableViewController.swift
@@ -1,5 +1,6 @@
-import UIKit
 import DesignSystem
+import ImmuTable
+import UIKit
 
 /// Base class for site stats table view controllers
 ///

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 import WordPressFlux
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 import WordPressFlux
 
 enum StatsSummaryTimeIntervalDataAsAWeek {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/HashableImmutableRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/HashableImmutableRow.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 
 protocol HashableImmutableRow: ImmuTableRow, Hashable {}
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -1,6 +1,7 @@
+import Combine
+import ImmuTable
 import UIKit
 import WordPressFlux
-import Combine
 
 @objc protocol SiteStatsPeriodDelegate {
     @objc optional func displayWebViewWithURL(_ url: URL)

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 import WordPressFlux
 
 struct StatsTrafficSection: Hashable {

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderRow.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 
 struct ReferrerDetailsHeaderRow: ImmuTableRow {
     private typealias CellType = ReferrerDetailsHeaderCell

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsRow.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 
 struct ReferrerDetailsRow: ImmuTableRow {
     private typealias CellType = ReferrerDetailsCell

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionRow.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 
 struct ReferrerDetailsSpamActionRow: ImmuTableRow {
     private typealias CellType = ReferrerDetailsSpamActionCell

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsTableViewController.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 
 final class ReferrerDetailsTableViewController: UITableViewController {

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 
 protocol ReferrerDetailsViewModelDelegate: AnyObject {
     func displayWebViewWithURL(_ url: URL)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostTableViewRows.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import WordPressUI
 
 protocol StatsRowGhostable: StatsHashableImmuTableRow {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 import WordPressFlux
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 import WordPressFlux
 
 /// The view model used by PostStatsTableViewController to show

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailTableViewController.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 import WordPressFlux
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -1,6 +1,7 @@
-import Foundation
-import WordPressFlux
 import Combine
+import Foundation
+import ImmuTable
+import WordPressFlux
 
 /// The view model used by SiteStatsDetailTableViewController to show
 /// all data for a selected stat.

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 import WordPressFlux
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 import UIKit
 import WordPressFlux
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsTableViewCells.swift
@@ -1,6 +1,7 @@
-import UIKit
-import Gridicons
 import DGCharts
+import Gridicons
+import ImmuTable
+import UIKit
 
 // MARK: - Shared Rows
 

--- a/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewController.swift
@@ -1,5 +1,6 @@
-import Foundation
 import Combine
+import Foundation
+import ImmuTable
 
 final class StatsSubscribersViewController: SiteStatsBaseTableViewController {
     private let viewModel: StatsSubscribersViewModel

--- a/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewModel.swift
@@ -1,5 +1,6 @@
-import Foundation
 import Combine
+import Foundation
+import ImmuTable
 import WordPressKit
 
 final class StatsSubscribersViewModel {

--- a/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportTableViewController.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 import WordPressAuthenticator
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsCommon.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 import WordPressFlux
 import WordPressKit

--- a/WordPress/Classes/ViewRelated/Tools/Time Zone/TimeZoneSelectorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Tools/Time Zone/TimeZoneSelectorViewController.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 import WordPressFlux
 

--- a/WordPress/Classes/ViewRelated/Tools/Time Zone/TimeZoneSelectorViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Tools/Time Zone/TimeZoneSelectorViewModel.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import WordPressFlux
 
 struct TimeZoneSelectorViewModel: Observable {

--- a/WordPress/Classes/ViewRelated/Tools/Time Zone/Views/TimeZoneRow.swift
+++ b/WordPress/Classes/ViewRelated/Tools/Time Zone/Views/TimeZoneRow.swift
@@ -1,3 +1,4 @@
+import ImmuTable
 import UIKit
 
 struct TimeZoneRow: ImmuTableRow {

--- a/WordPress/WordPressTest/ImmuTableTest.swift
+++ b/WordPress/WordPressTest/ImmuTableTest.swift
@@ -1,3 +1,5 @@
+// FIXME: Move to ImmuTable package tests
+import ImmuTable
 import XCTest
 @testable import WordPress
 

--- a/WordPress/WordPressTest/ImmuTableTest.swift
+++ b/WordPress/WordPressTest/ImmuTableTest.swift
@@ -1,6 +1,6 @@
 // FIXME: Move to ImmuTable package tests
-import ImmuTable
 import XCTest
+@testable import ImmuTable
 @testable import WordPress
 
 class ImmuTableTest: XCTestCase {

--- a/WordPress/WordPressTest/ImmuTableTestUtils.swift
+++ b/WordPress/WordPressTest/ImmuTableTestUtils.swift
@@ -1,4 +1,5 @@
 import Foundation
+import ImmuTable
 @testable import WordPress
 
 class MockImmuTablePresenter: ImmuTablePresenter {

--- a/WordPress/WordPressTest/ViewRelated/Stats/Traffic/SiteStatsPeriodViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Stats/Traffic/SiteStatsPeriodViewModelTests.swift
@@ -1,6 +1,7 @@
-import XCTest
-import WordPressFlux
 import DGCharts
+import ImmuTable
+import WordPressFlux
+import XCTest
 @testable import WordPress
 
 final class SiteStatsPeriodViewModelTests: XCTestCase {

--- a/WordPress/WordPressTest/ViewRelated/Tools/Time Zone/TimeZoneSelectorViewModelTests.swift
+++ b/WordPress/WordPressTest/ViewRelated/Tools/Time Zone/TimeZoneSelectorViewModelTests.swift
@@ -1,6 +1,7 @@
 import Foundation
-import XCTest
+import ImmuTable
 import WordPressKit
+import XCTest
 
 @testable import WordPress
 


### PR DESCRIPTION
I was looking around the codebase and saw what looked like a quick win for modularization: move the `ImmuTable` implementation in a dedicated package.

This is just a little step forward towards more modularization and less time spend compiling. 

WordPressUI could have been another destination for the logic. If you feel it's better to move it there, I'll follow up with a dedicated PR. The bulk of the work was to move it out of the main target anyway

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
