### PR TITLE
Revert "Convert `ReaderGapMarker` no-op subclass to Swift"

### DIFF
--- a/WordPress/Classes/Models/ReaderGapMarker.h
+++ b/WordPress/Classes/Models/ReaderGapMarker.h
@@ -1,0 +1,10 @@
+#import <CoreData/CoreData.h>
+#import "ReaderPost.h"
+
+/**
+ The ReaderGapMarker is a subclass of ReaderrPost whose purpose is to act as a 
+ marker for gaps in synced content, but not show any content itself.
+ */
+@interface ReaderGapMarker : ReaderPost
+
+@end

--- a/WordPress/Classes/Models/ReaderGapMarker.m
+++ b/WordPress/Classes/Models/ReaderGapMarker.m
@@ -1,0 +1,5 @@
+#import "ReaderGapMarker.h"
+
+@implementation ReaderGapMarker
+
+@end

--- a/WordPress/Classes/Models/ReaderGapMarker.swift
+++ b/WordPress/Classes/Models/ReaderGapMarker.swift
@@ -1,1 +1,0 @@
-class ReaderGapMarker: ReaderPost {}

--- a/WordPress/Classes/Services/Reader Post/ReaderPostService.m
+++ b/WordPress/Classes/Services/Reader Post/ReaderPostService.m
@@ -2,6 +2,7 @@
 
 #import "AccountService.h"
 #import "CoreDataStack.h"
+#import "ReaderGapMarker.h"
 #import "ReaderPost.h"
 #import "ReaderSiteService.h"
 #import "SourcePostAttribution.h"

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -46,6 +46,7 @@
 
 #import "ReachabilityUtils.h"
 #import "ReaderCommentsViewController.h"
+#import "ReaderGapMarker.h"
 #import "ReaderPost.h"
 #import "ReaderPostService.h"
 #import "ReaderSiteService.h"


### PR DESCRIPTION
Reverts wordpress-mobile/WordPress-iOS#24147 (new crash).

Modularization/refactoring PRs will need to start merging only after 25.8 is shipped.