### PR TITLE
Remove CocoaPods checks from releases

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -18,9 +18,6 @@ platform :ios do
     # Check out the up-to-date default branch, the designated starting point for the code freeze
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
 
-    # Checks if internal dependencies are on a stable version
-    check_pods_references
-
     release_branch_name = compute_release_branch_name(options: options, version: release_version_next)
     ensure_branch_does_not_exist!(release_branch_name)
 
@@ -621,12 +618,4 @@ def report_milestone_error(error_title:)
   UI.error(error_message)
 
   buildkite_annotate(style: 'warning', context: 'error-with-milestone', message: error_message) if is_ci
-end
-
-def check_pods_references
-  result = ios_check_beta_deps(lockfile: File.join(PROJECT_ROOT_FOLDER, 'Podfile.lock'))
-
-  style = result[:pods].nil? || result[:pods].empty? ? 'success' : 'warning'
-  message = "### Checking Internal Dependencies are all on a **stable** version\n\n#{result[:message]}"
-  buildkite_annotate(context: 'pods-check', style: style, message: message) if is_ci
 end


### PR DESCRIPTION
We don’t use it since https://github.com/wordpress-mobile/WordPress-iOS/pull/23958
