### PR TITLE
Remove unused More alert in Gutenberg

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -41,7 +41,6 @@ import Foundation
     case editorPostSlugChanged
     case editorPostExcerptChanged
     case editorPostSiteChanged
-    case editorPostLegacyMoreMenuShown
 
     // Resolve post version conflict
     case resolveConflictScreenShown
@@ -685,8 +684,6 @@ import Foundation
             return "editor_post_excerpt_changed"
         case .editorPostSiteChanged:
             return "editor_post_site_changed"
-        case .editorPostLegacyMoreMenuShown:
-            return "editor_post_legacy_more_menu_shown"
         case .resolveConflictScreenShown:
             return "resolve_conflict_screen_shown"
         case .resolveConflictSaveTapped:

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -5,83 +5,6 @@ import WordPressFlux
 /// This extension handles the "more" actions triggered by the top right
 /// navigation bar button of Gutenberg editor.
 extension GutenbergViewController {
-
-    enum ErrorCode: Int {
-        case expectedSecondaryAction = 1
-        case managedObjectContextMissing = 2
-    }
-
-    // - warning: deprecated (kahu-offline-mode)
-    // TODO: Remove when/if confirmed that this is never invoked by Gutenberg.
-    func displayMoreSheet() {
-        WPAnalytics.track(.editorPostLegacyMoreMenuShown)
-
-        // Dismisses and locks the Notices Store from displaying any new notices.
-        ActionDispatcher.dispatch(NoticeAction.lock)
-        let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
-
-        if mode == .richText, let contentInfo {
-            // NB : This is a candidate for plurality via .stringsdict, but is limited by https://github.com/wordpress-mobile/WordPress-iOS/issues/6327
-            let textCounterTitle = String(format: NSLocalizedString("Content Structure\nBlocks: %li, Words: %li, Characters: %li", comment: "Displays the number of blocks, words and characters in text"), contentInfo.blockCount, contentInfo.wordCount, contentInfo.characterCount)
-
-            alert.title = textCounterTitle
-        }
-
-        let toggleModeTitle: String = {
-            if mode == .richText {
-                return MoreSheetAlert.htmlTitle
-            } else {
-                return MoreSheetAlert.richTitle
-            }
-        }()
-
-        alert.addDefaultActionWithTitle(toggleModeTitle) { [unowned self] _ in
-            self.toggleEditingMode()
-            ActionDispatcher.dispatch(NoticeAction.unlock)
-        }
-
-        alert.addDefaultActionWithTitle(MoreSheetAlert.previewTitle) { [weak self] _ in
-            self?.displayPreview()
-            ActionDispatcher.dispatch(NoticeAction.unlock)
-        }
-
-        if (post.revisions ?? []).count > 0 {
-            alert.addDefaultActionWithTitle(MoreSheetAlert.historyTitle) { [weak self] _ in
-                self?.displayRevisionsList()
-                ActionDispatcher.dispatch(NoticeAction.unlock)
-            }
-        }
-
-        let settingsTitle = self.post is Page ? MoreSheetAlert.pageSettingsTitle : MoreSheetAlert.postSettingsTitle
-
-        alert.addDefaultActionWithTitle(settingsTitle) { [weak self] _ in
-            self?.displayPostSettings()
-            ActionDispatcher.dispatch(NoticeAction.unlock)
-        }
-
-        alert.addCancelActionWithTitle(MoreSheetAlert.keepEditingTitle) { _ in
-            ActionDispatcher.dispatch(NoticeAction.unlock)
-        }
-
-        let helpTitle = JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() ? MoreSheetAlert.editorHelpAndSupportTitle : MoreSheetAlert.editorHelpTitle
-        alert.addDefaultActionWithTitle(helpTitle) { [weak self] _ in
-            self?.showEditorHelp()
-            ActionDispatcher.dispatch(NoticeAction.unlock)
-        }
-
-        if let button = navigationBarManager.moreBarButtonItem.customView {
-            // Required to work around an issue present in iOS 14 beta 2
-            // https://github.com/wordpress-mobile/WordPress-iOS/issues/14460
-            alert.popoverPresentationController?.sourceRect = button.convert(button.bounds, to: navigationController?.navigationBar)
-            alert.popoverPresentationController?.sourceView = navigationController?.navigationBar
-            alert.view.accessibilityIdentifier = MoreSheetAlert.accessibilityIdentifier
-        } else {
-            alert.popoverPresentationController?.barButtonItem = navigationBarManager.moreBarButtonItem
-        }
-
-        present(alert, animated: true)
-    }
-
     func makeMoreMenu() -> UIMenu {
         UIMenu(title: "", image: nil, identifier: nil, options: [], children: [
             UIDeferredMenuElement.uncached { [weak self] callback in
@@ -163,24 +86,6 @@ extension GutenbergViewController {
             return nil
         }
         return String(format: Strings.contentStructure, contentInfo.blockCount, contentInfo.wordCount, contentInfo.characterCount)
-    }
-}
-
-// MARK: - Constants
-
-extension GutenbergViewController {
-    // - warning: deprecated (kahu-offline-mode)
-    struct MoreSheetAlert {
-        static let htmlTitle = NSLocalizedString("Switch to HTML Mode", comment: "Switches the Editor to HTML Mode")
-        static let richTitle = NSLocalizedString("Switch to Visual Mode", comment: "Switches the Editor to Rich Text Mode")
-        static let previewTitle = NSLocalizedString("Preview", comment: "Displays the Post Preview Interface")
-        static let historyTitle = NSLocalizedString("History", comment: "Displays the History screen from the editor's alert sheet")
-        static let postSettingsTitle = NSLocalizedString("Post Settings", comment: "Name of the button to open the post settings")
-        static let pageSettingsTitle = NSLocalizedString("Page Settings", comment: "Name of the button to open the page settings")
-        static let keepEditingTitle = NSLocalizedString("Keep Editing", comment: "Goes back to editing the post.")
-        static let accessibilityIdentifier = "MoreSheetAccessibilityIdentifier"
-        static let editorHelpAndSupportTitle = NSLocalizedString("Help & Support", comment: "Open editor help options")
-        static let editorHelpTitle = NSLocalizedString("Help", comment: "Open editor help options")
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -16,7 +16,6 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
     enum RequestHTMLReason {
         case publish
         case close
-        case more
         case autoSave
     }
 
@@ -375,7 +374,7 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
 
         // Required to work around an issue present in iOS 14 beta 2
         // https://github.com/wordpress-mobile/WordPress-iOS/issues/14460
-        if presentedViewController?.view.accessibilityIdentifier == MoreSheetAlert.accessibilityIdentifier {
+        if presentedViewController?.view.accessibilityIdentifier == "MoreSheetAccessibilityIdentifier" {
             dismiss(animated: true)
         }
     }
@@ -437,10 +436,6 @@ class GutenbergViewController: UIViewController, PostEditor, FeaturedImageDelega
 
         navigationBarManager.moreButton.menu = makeMoreMenu()
         navigationBarManager.moreButton.showsMenuAsPrimaryAction = true
-    }
-
-    @objc private func buttonMoreTapped() {
-        displayMoreSheet()
     }
 
     private func reloadBlogIconView() {
@@ -847,8 +842,6 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
             case .close:
                 isEditorClosing = true
                 cancelEditing()
-            case .more:
-                displayMoreSheet()
             case .autoSave:
                 break
             }
@@ -1272,7 +1265,7 @@ extension GutenbergViewController: PostEditorNavigationBarManagerDelegate {
     }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, moreWasPressed sender: UIButton) {
-        requestHTML(for: .more)
+        // No longer used. The menu is now shown as `UIMenu`.
     }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, publishButtonWasPressed sender: UIButton) {
@@ -1341,6 +1334,10 @@ extension GutenbergViewController {
                 DDLogError("Error fetching settings: \(err)")
             }
         })
+    }
+
+    private enum ErrorCode: Int {
+        case managedObjectContextMissing = 2
     }
 }
 


### PR DESCRIPTION
It was deprecated many-many releases ago.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
