### PR TITLE
Move `+classNameWithoutNamespaces` to WordPressSharedObjC

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -65,7 +65,13 @@ let package = Package(
             .product(name: "XCUITestHelpers", package: "ScreenObject"),
         ], swiftSettings: [.swiftLanguageMode(.v5)]),
         .target(name: "WordPressDataObjC"),
-        .target(name: "WordPressData", dependencies: [.target(name: "WordPressDataObjC")]),
+        .target(
+            name: "WordPressData",
+            dependencies: [
+                .target(name: "WordPressDataObjC"),
+                .target(name: "WordPressSharedObjC")
+            ]
+        ),
         .target(name: "WordPressFlux", swiftSettings: [.swiftLanguageMode(.v5)]),
         .target(name: "WordPressCore", dependencies: [.target(name: "WordPressShared"), .product(name: "WordPressAPI", package: "wordpress-rs")]),
         .target(name: "WordPressSharedObjC", resources: [.process("Resources")], swiftSettings: [.swiftLanguageMode(.v5)]),

--- a/Modules/Sources/WordPressSharedObjC/Utility/NSObject+ClassName.m
+++ b/Modules/Sources/WordPressSharedObjC/Utility/NSObject+ClassName.m
@@ -1,0 +1,11 @@
+#import "NSObject+ClassName.h"
+
+@implementation NSObject (ClassName)
+
++ (NSString *)classNameWithoutNamespaces
+{
+    // Note that Swift prepends the module name to the class name itself
+    return [[NSStringFromClass(self) componentsSeparatedByString:@"."] lastObject];
+}
+
+@end

--- a/Modules/Sources/WordPressSharedObjC/include/NSObject+ClassName.h
+++ b/Modules/Sources/WordPressSharedObjC/include/NSObject+ClassName.h
@@ -1,0 +1,11 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface NSObject (ClassName)
+
++ (NSString *)classNameWithoutNamespaces;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Categories/NSObject+Helpers.h
+++ b/WordPress/Classes/Categories/NSObject+Helpers.h
@@ -4,6 +4,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface NSObject (Helpers)
 
+// FIXME: Currently duplicated in WordPressSharedObjC because it'll be used in WordPressData (which depends on WordPressSharedObjc)
+// It's not convenient to replace all usages in the main targets at this time.
+// They should progressively diminish as we move all the Core Data related code into WordPressData.
+// At that point, we should be able to remove this method from the main target.
 + (NSString *)classNameWithoutNamespaces;
 
 - (void)debounce:(SEL)selector afterDelay:(NSTimeInterval)timeInterval;


### PR DESCRIPTION
I've been trying to move the Core Data model to WordPressData but got bogged with an `NSArray element failed to match the Swift Array Element type` exception — More details in #24166.

Given that work is still in progress, I thought we could at least merge this pre-condition change to move (actually duplicate for migration convenience) the `classNameWithoutNamespaces` method on `NSObject` that the models use to create their `NSFetchRequest`.

https://github.com/wordpress-mobile/WordPress-iOS/blob/85215d24488d8b5cb6895dd966b43fe76370604b/WordPress/Classes/Models/BloggingPrompt%2BCoreDataClass.swift#L5-L9