### PR TITLE
feat: Allow remote editor for WPCOM Simple sites

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250127"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "947c5315198eea96e3e8c32fcc6afa59ef242638"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "11b9c2ec7d75bb68dcdebeff0ffe6034a7784544"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", from: "1.20.0"),
     ],

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250127"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "74bc5eefe939632d3087ff408944ec23d5d780b2"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "62e3f0da9fb9c3bdcc4a900cd34014928bc194ea"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", from: "1.20.0"),
     ],

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250127"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "11b9c2ec7d75bb68dcdebeff0ffe6034a7784544"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "74bc5eefe939632d3087ff408944ec23d5d780b2"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", from: "1.20.0"),
     ],

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250127"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "62e3f0da9fb9c3bdcc4a900cd34014928bc194ea"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "a03e0dae10a404c88c215bfcee3176df951302f5"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", from: "1.20.0"),
     ],

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "de808abb3f655586dc594faa9dca32ce6380434f0f2d722d3ab927f4f2426c55",
+  "originHash" : "08fa6ac3e13aea1ea93f1de830bfb3e2cdd70844d443a4e2b5e7d2130685d562",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,7 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "62e3f0da9fb9c3bdcc4a900cd34014928bc194ea"
+        "revision" : "a03e0dae10a404c88c215bfcee3176df951302f5"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5d2f0bd0f46ebc30565c1b6c7b47c171f924f35aaa919d4b781e2f45b353ae51",
+  "originHash" : "de808abb3f655586dc594faa9dca32ce6380434f0f2d722d3ab927f4f2426c55",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,7 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "74bc5eefe939632d3087ff408944ec23d5d780b2"
+        "revision" : "62e3f0da9fb9c3bdcc4a900cd34014928bc194ea"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "30d28689f1ff892c21d4ac727128fc2287c04c6efc8f821e677c057bbfd820c5",
+  "originHash" : "5d2f0bd0f46ebc30565c1b6c7b47c171f924f35aaa919d4b781e2f45b353ae51",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,7 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "11b9c2ec7d75bb68dcdebeff0ffe6034a7784544"
+        "revision" : "74bc5eefe939632d3087ff408944ec23d5d780b2"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b637515cdb9c1c25894b401b59b20ad56c195cd52aa6bee2ada1b56cd753ece8",
+  "originHash" : "30d28689f1ff892c21d4ac727128fc2287c04c6efc8f821e677c057bbfd820c5",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,7 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "947c5315198eea96e3e8c32fcc6afa59ef242638"
+        "revision" : "11b9c2ec7d75bb68dcdebeff0ffe6034a7784544"
       }
     },
     {

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -30,6 +30,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case inAppUpdates
     case gravatarQuickEditor
     case dotComWebLogin
+    case newGutenbergPluginsAvailability
 
     var defaultValue: Bool {
         switch self {
@@ -86,6 +87,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .gravatarQuickEditor:
             return BuildConfiguration.current.isInternal
         case .dotComWebLogin:
+            return false
+        case .newGutenbergPluginsAvailability:
             return false
         }
     }
@@ -147,6 +150,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "gravatar_quick_editor"
         case .dotComWebLogin:
             return "jp_wpcom_web_login"
+        case .newGutenbergPluginsAvailability:
+            return "new_gutenberg_plugins_availability"
         }
     }
 
@@ -206,6 +211,8 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Gravatar Quick Editor"
         case .dotComWebLogin:
             return "Log in to WordPress.com from web browser"
+        case .newGutenbergPluginsAvailability:
+            return "Experimental Block Editor Plugins Availability"
         }
     }
 

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -30,7 +30,6 @@ enum RemoteFeatureFlag: Int, CaseIterable {
     case inAppUpdates
     case gravatarQuickEditor
     case dotComWebLogin
-    case newGutenbergPluginsAvailability
 
     var defaultValue: Bool {
         switch self {
@@ -87,8 +86,6 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .gravatarQuickEditor:
             return BuildConfiguration.current.isInternal
         case .dotComWebLogin:
-            return false
-        case .newGutenbergPluginsAvailability:
             return false
         }
     }
@@ -150,8 +147,6 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "gravatar_quick_editor"
         case .dotComWebLogin:
             return "jp_wpcom_web_login"
-        case .newGutenbergPluginsAvailability:
-            return "gutenberg_kit_plugins_availability"
         }
     }
 
@@ -211,8 +206,6 @@ enum RemoteFeatureFlag: Int, CaseIterable {
             return "Gravatar Quick Editor"
         case .dotComWebLogin:
             return "Log in to WordPress.com from web browser"
-        case .newGutenbergPluginsAvailability:
-            return "Experimental Block Editor Plugins Availability"
         }
     }
 

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -151,7 +151,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .dotComWebLogin:
             return "jp_wpcom_web_login"
         case .newGutenbergPluginsAvailability:
-            return "new_gutenberg_plugins_availability"
+            return "gutenberg_kit_plugins_availability"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
@@ -8,6 +8,7 @@ class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvid
         FeatureFlag.authenticateUsingApplicationPassword,
         FeatureFlag.newGutenberg,
         FeatureFlag.newGutenbergThemeStyles,
+        FeatureFlag.newGutenbergPlugins,
     ]
 
     private let flagStore = FeatureFlagOverrideStore()

--- a/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
@@ -8,7 +8,8 @@ class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvid
         FeatureFlag.authenticateUsingApplicationPassword,
         FeatureFlag.newGutenberg,
         FeatureFlag.newGutenbergThemeStyles,
-    ] + (RemoteFeatureFlag.newGutenbergPluginsAvailability.enabled() ? [FeatureFlag.newGutenbergPlugins] : [])
+        FeatureFlag.newGutenbergPlugins,
+    ]
 
     private let flagStore = FeatureFlagOverrideStore()
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
@@ -8,8 +8,7 @@ class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvid
         FeatureFlag.authenticateUsingApplicationPassword,
         FeatureFlag.newGutenberg,
         FeatureFlag.newGutenbergThemeStyles,
-        FeatureFlag.newGutenbergPlugins,
-    ]
+    ] + (RemoteFeatureFlag.newGutenbergPluginsAvailability.enabled() ? [FeatureFlag.newGutenbergPlugins] : [])
 
     private let flagStore = FeatureFlagOverrideStore()
 

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -123,8 +123,8 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         self.navigationBarManager = navigationBarManager ?? PostEditorNavigationBarManager()
 
         let selfHostedApiUrl = post.blog.url(withPath: "wp-json/")
-        let isSelfHosted = !post.blog.isHostedAtWPcom && !post.blog.isAtomic()
-        let siteApiRoot = post.blog.isAccessibleThroughWPCom() && !isSelfHosted ? post.blog.wordPressComRestApi?.baseURL.absoluteString : selfHostedApiUrl
+        let isWPComSite = post.blog.isHostedAtWPcom || post.blog.isAtomic()
+        let siteApiRoot = post.blog.isAccessibleThroughWPCom() && isWPComSite ? post.blog.wordPressComRestApi?.baseURL.absoluteString : selfHostedApiUrl
         let siteId = post.blog.dotComID?.stringValue
         let authToken = post.blog.authToken ?? ""
         var authHeader = "Bearer \(authToken)"
@@ -154,7 +154,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         conf.authHeader = authHeader
 
         conf.themeStyles = FeatureFlag.newGutenbergThemeStyles.enabled
-        conf.plugins = FeatureFlag.newGutenbergPlugins.enabled && isSelfHosted
+        conf.plugins = FeatureFlag.newGutenbergPlugins.enabled && isWPComSite
 
         self.editorViewController = GutenbergKit.EditorViewController(configuration: conf)
 

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -163,7 +163,8 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         conf.authHeader = authHeader
 
         conf.themeStyles = FeatureFlag.newGutenbergThemeStyles.enabled
-        conf.plugins = FeatureFlag.newGutenbergPlugins.enabled && isWPComSite
+        // Limited to Simple sites until application password auth is supported
+        conf.plugins = FeatureFlag.newGutenbergPlugins.enabled && post.blog.isHostedAtWPcom
 
         if !post.blog.isSelfHosted {
             let siteType: String = post.blog.isHostedAtWPcom ? "simple" : "atomic"

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -159,6 +159,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         conf.siteURL = post.blog.url ?? ""
         conf.siteApiRoot = siteApiRoot ?? ""
         conf.siteApiNamespace = siteApiNamespace
+        conf.namespaceExcludedPaths = ["/wpcom/v2/following/recommendations", "/wpcom/v2/following/mine"]
         conf.authHeader = authHeader
 
         conf.themeStyles = FeatureFlag.newGutenbergThemeStyles.enabled

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -126,6 +126,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         let isWPComSite = post.blog.isHostedAtWPcom || post.blog.isAtomic()
         let siteApiRoot = post.blog.isAccessibleThroughWPCom() && isWPComSite ? post.blog.wordPressComRestApi?.baseURL.absoluteString : selfHostedApiUrl
         let siteId = post.blog.dotComID?.stringValue
+        let siteDomain = post.blog.primaryDomainAddress
         let authToken = post.blog.authToken ?? ""
         var authHeader = "Bearer \(authToken)"
 
@@ -139,7 +140,14 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
             }
         }
 
-        let siteApiNamespace = post.blog.dotComID != nil && !isSelfHosted && applicationPassword == nil ? "sites/\(siteId ?? "")" : ""
+        // Must provide both namespace forms to detect usages of both forms in third-party code
+        var siteApiNamespace: [String] = []
+        if isWPComSite {
+            if let siteId {
+                siteApiNamespace.append("sites/\(siteId)")
+            }
+            siteApiNamespace.append("sites/\(siteDomain)")
+        }
 
         var conf = EditorConfiguration(
             title: post.postTitle ?? "",

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -164,7 +164,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
         conf.themeStyles = FeatureFlag.newGutenbergThemeStyles.enabled
         // Limited to Simple sites until application password auth is supported
-        conf.plugins = FeatureFlag.newGutenbergPlugins.enabled && RemoteFeatureFlag.newGutenbergPluginsAvailability.enabled() && post.blog.isHostedAtWPcom
+        conf.plugins = FeatureFlag.newGutenbergPlugins.enabled && post.blog.isHostedAtWPcom
 
         if !post.blog.isSelfHosted {
             let siteType: String = post.blog.isHostedAtWPcom ? "simple" : "atomic"

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -165,6 +165,13 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         conf.themeStyles = FeatureFlag.newGutenbergThemeStyles.enabled
         conf.plugins = FeatureFlag.newGutenbergPlugins.enabled && isWPComSite
 
+        if !post.blog.isSelfHosted {
+            let siteType: String = post.blog.isHostedAtWPcom ? "simple" : "atomic"
+            conf.webViewGlobals = [
+                WebViewGlobal(name: "_currentSiteType", value: .string(siteType))
+            ]
+        }
+
         self.editorViewController = GutenbergKit.EditorViewController(configuration: conf)
 
         super.init(nibName: nil, bundle: nil)

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -164,7 +164,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
         conf.themeStyles = FeatureFlag.newGutenbergThemeStyles.enabled
         // Limited to Simple sites until application password auth is supported
-        conf.plugins = FeatureFlag.newGutenbergPlugins.enabled && post.blog.isHostedAtWPcom
+        conf.plugins = FeatureFlag.newGutenbergPlugins.enabled && RemoteFeatureFlag.newGutenbergPluginsAvailability.enabled() && post.blog.isHostedAtWPcom
 
         if !post.blog.isSelfHosted {
             let siteType: String = post.blog.isHostedAtWPcom ? "simple" : "atomic"


### PR DESCRIPTION
Allow WPCOM Simple sites to use the experimental remote, site-specific editor. Close CMM-222.

Related: 

- CMM-222-linear-issue
- 177481-ghe-Automattic/wpcom
- https://github.com/Automattic/jetpack/pull/42314
- https://github.com/wordpress-mobile/GutenbergKit/pull/109
- https://github.com/wordpress-mobile/WordPress-Android/pull/21773

To test:

1. Navigate to Me → App Settings → Experimental Features and enable `Experimental Block Editor Plugins`
1. Open a post on a WPCOM Simple site. 
1. Insert non-core Jetpacks blocks. 
1. Verify they function as expected. 

## Regression Notes
1. Potential unintended areas of impact
    The local, bundled experimental editor. 
6. What I did to test those areas of impact (or what existing automated tests I relied on)
    Manually smoke tested. 
7. What automated tests I added (or what prevented me from doing so)
    Deemed unnecessary for this experimental feature. 

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)