### PR TITLE
Fix #21856: Support the 'Order' setting in pages list

### DIFF
--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "deb4f4363dd5a33662b5ec5a3a4f73206abbb0a3392b6d7ead912fb9dc81f6e0",
+  "originHash" : "e6a9163ae536e498cb3b486db128b446499c8e937abda18922b097bae4378a80",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -392,7 +392,7 @@
       "location" : "https://github.com/wordpress-mobile/WordPressKit-iOS",
       "state" : {
         "branch" : "wpios-edition",
-        "revision" : "ed050d069df10d5f3aa35df25641f8c415b1e4a5"
+        "revision" : "94cbe7ed4ec184f104cc8e3c4c525c26e639c932"
       }
     },
     {

--- a/WordPress/Classes/Models/AbstractPost.h
+++ b/WordPress/Classes/Models/AbstractPost.h
@@ -34,6 +34,7 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 @property (weak, readonly) AbstractPost *revision;
 @property (nonatomic, strong) NSSet *comments;
 @property (nonatomic, strong, nullable) Media *featuredImage;
+@property (nonatomic, assign) NSInteger order;
 
 /// This array will contain a list of revision IDs.
 @property (nonatomic, strong, nullable) NSArray *revisions;

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -26,6 +26,7 @@
 @dynamic autosaveModifiedDate;
 @dynamic autosaveIdentifier;
 @dynamic foreignID;
+@dynamic order;
 @synthesize voiceContent;
 
 #pragma mark - Life Cycle Methods

--- a/WordPress/Classes/Services/PostHelper.m
+++ b/WordPress/Classes/Services/PostHelper.m
@@ -34,6 +34,7 @@
     post.content = remotePost.content;
     post.status = remotePost.status;
     post.password = remotePost.password;
+    post.order = remotePost.order;
 
     if (remotePost.postThumbnailID != nil) {
         post.featuredImage = [Media existingOrStubMediaWithMediaID: remotePost.postThumbnailID inBlog:post.blog];

--- a/WordPress/Classes/Utility/PageTree.swift
+++ b/WordPress/Classes/Utility/PageTree.swift
@@ -2,10 +2,6 @@ final class PageTree {
 
     // A node in a tree, which of course is also a tree itself.
     private class TreeNode {
-        struct PageData {
-            var postID: NSNumber?
-            var parentID: NSNumber?
-        }
         let page: Page
         var children = [TreeNode]()
         var parentNode: TreeNode?
@@ -16,7 +12,7 @@ final class PageTree {
 
         func dfsList() -> [Page] {
             var pages = [Page]()
-            _ = depthFirstSearch { level, node in
+            _ = depthFirstSearch(sortByPageOrder: true) { level, node in
                 let page = node.page
                 page.hierarchyIndex = level
                 page.hasVisibleParent = node.parentNode != nil
@@ -32,18 +28,19 @@ final class PageTree {
         ///     a boolean value indicate whether the search should be stopped.
         /// - Returns: `true` if search has been stopped by the closure.
         @discardableResult
-        func depthFirstSearch(using closure: (Int, TreeNode) -> Bool) -> Bool {
-            depthFirstSearch(level: 0, using: closure)
+        func depthFirstSearch(sortByPageOrder: Bool, using closure: (Int, TreeNode) -> Bool) -> Bool {
+            depthFirstSearch(level: 0, sortByPageOrder: sortByPageOrder, using: closure)
         }
 
-        private func depthFirstSearch(level: Int, using closure: (Int, TreeNode) -> Bool) -> Bool {
+        private func depthFirstSearch(level: Int, sortByPageOrder: Bool, using closure: (Int, TreeNode) -> Bool) -> Bool {
             let shouldStop = closure(level, self)
             if shouldStop {
                 return true
             }
 
-            for child in children {
-                let shouldStop = child.depthFirstSearch(level: level + 1, using: closure)
+            let pages = sortByPageOrder ? children.sorted(using: KeyPathComparator(\TreeNode.page.order)) : children
+            for child in pages {
+                let shouldStop = child.depthFirstSearch(level: level + 1, sortByPageOrder: sortByPageOrder, using: closure)
                 if shouldStop {
                     return true
                 }

--- a/WordPress/Classes/WordPress.xcdatamodeld/WordPress 155.xcdatamodel/contents
+++ b/WordPress/Classes/WordPress.xcdatamodeld/WordPress 155.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24D81" minimumToolsVersion="Xcode 9.0" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="23788" systemVersion="24E248" minimumToolsVersion="Xcode 9.0" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="AbstractPost" representedClassName="AbstractPost" isAbstract="YES" parentEntity="BasePost">
         <attribute name="autosaveContent" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="autosaveExcerpt" optional="YES" attributeType="String" syncable="YES"/>
@@ -13,6 +13,7 @@
         <attribute name="foreignID" optional="YES" attributeType="UUID" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="metaIsLocal" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="metaPublishImmediately" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="NO" syncable="YES"/>
+        <attribute name="order" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="revisions" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" syncable="YES"/>
         <attribute name="statusAfterSync" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="blog" minCount="1" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="posts" inverseEntity="Blog" syncable="YES"/>


### PR DESCRIPTION
Fixes #21856.

Requires https://github.com/wordpress-mobile/WordPressKit-iOS/pull/832.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
