### PR TITLE
Abstract `ContextManager` usages behind `CoreDataStack` 

### DIFF
--- a/Modules/Sources/WordPressDataObjC/include/CoreDataStack.h
+++ b/Modules/Sources/WordPressDataObjC/include/CoreDataStack.h
@@ -7,6 +7,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (nonatomic, readonly, strong) NSManagedObjectContext *mainContext;
 
++ (id<CoreDataStack>)sharedInstance;
+
 - (NSManagedObjectContext *const)newDerivedContext DEPRECATED_MSG_ATTRIBUTE("Use `performAndSave` instead");
 
 - (void)saveContextAndWait:(NSManagedObjectContext *)context;

--- a/WordPress/Classes/Models/Blog/Blog+SelfHosted.swift
+++ b/WordPress/Classes/Models/Blog/Blog+SelfHosted.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CryptoKit
 import WordPressAPI
+import WordPressData
 
 extension Blog {
 
@@ -17,7 +18,7 @@ extension Blog {
 
     static func createRestApiBlog(
         with details: WpApiApplicationPasswordDetails,
-        in contextManager: ContextManager,
+        in contextManager: CoreDataStackSwift,
         using keychainImplementation: KeychainAccessible = KeychainUtils()
     ) async throws -> String {
         try await contextManager.performAndSave { context in

--- a/WordPress/Classes/Services/JetpackSocialService.swift
+++ b/WordPress/Classes/Services/JetpackSocialService.swift
@@ -19,8 +19,11 @@ import WordPressKit
 
     /// Init method for Objective-C.
     ///
-    @objc init(contextManager: ContextManager) {
-        self.coreDataStack = contextManager
+    @objc init(contextManager: CoreDataStack) {
+        guard let typeCastStack = contextManager as? CoreDataStackSwift else {
+            fatalError("Expected a CoreDataStackSwift-conforming type even though this initializer is marked @objc.")
+        }
+        self.coreDataStack = typeCastStack
     }
 
     init(coreDataStack: CoreDataStackSwift = ContextManager.shared) {

--- a/WordPress/Classes/Services/SharingService.swift
+++ b/WordPress/Classes/Services/SharingService.swift
@@ -12,11 +12,12 @@ import WordPressKit
     private let coreDataStack: CoreDataStackSwift
 
     /// The initialiser for Objective-C code.
-    ///
-    /// Using `ContextManager` as the argument becuase `CoreDataStackSwift` is not accessible from Objective-C code.
     @objc
-    init(contextManager: ContextManager) {
-        self.coreDataStack = contextManager
+    init(contextManager: CoreDataStack) {
+        guard let typeCastStack = contextManager as? CoreDataStackSwift else {
+            fatalError("Expected a CoreDataStackSwift-conforming type even though this initializer is marked @objc.")
+        }
+        self.coreDataStack = typeCastStack
     }
 
     init(coreDataStack: CoreDataStackSwift) {

--- a/WordPress/Classes/System/Root View/SplitViewRootPresenter+Welcome.swift
+++ b/WordPress/Classes/System/Root View/SplitViewRootPresenter+Welcome.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 import SwiftUI
+import WordPressData
 
 class WelcomeSplitViewContent: SplitViewDisplayable {
     let supplementary: UINavigationController
@@ -9,7 +10,7 @@ class WelcomeSplitViewContent: SplitViewDisplayable {
     init(addSite: @escaping (AddSiteMenuViewModel.Selection) -> Void) {
         supplementary = UINavigationController(rootViewController: UnifiedPrologueViewController())
 
-        let addSiteViewModel = AddSiteMenuViewModel(context: .shared, onSelection: addSite)
+        let addSiteViewModel = AddSiteMenuViewModel(context: ContextManager.shared, onSelection: addSite)
         let noSitesViewModel = NoSitesViewModel(appUIType: JetpackFeaturesRemovalCoordinator.currentAppUIType, account: nil)
         let noSiteView = NoSitesView(addSiteViewModel: addSiteViewModel, viewModel: noSitesViewModel)
         let noSitesVC = UIHostingController(rootView: noSiteView)

--- a/WordPress/Classes/System/UITesting/UITestConfigurator.swift
+++ b/WordPress/Classes/System/UITesting/UITestConfigurator.swift
@@ -37,7 +37,9 @@ struct UITestConfigurator {
 
     private static func resetEverything() {
         // Remove CoreData DB
-        ContextManager.shared.resetEverything()
+        //
+        // We can afford to force cast here because we are in a test-specific code
+        (ContextManager.shared as! ContextManager).resetEverything()
 
         // Clear user defaults.
         for key in UserDefaults.standard.dictionaryRepresentation().keys {

--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -330,14 +330,14 @@ class WeeklyRoundupBackgroundTask: BackgroundTask {
     private let eventTracker: NotificationEventTracker
     let runDateComponents: DateComponents
     let notificationScheduler: WeeklyRoundupNotificationScheduler
-    let coreDataStack: ContextManager
+    let coreDataStack: CoreDataStackSwift
 
     init(
         eventTracker: NotificationEventTracker = NotificationEventTracker(),
         runDateComponents: DateComponents? = nil,
         staticNotificationDateComponents: DateComponents? = nil,
         store: Store = Store(),
-        coreDataStack: ContextManager = .shared
+        coreDataStack: CoreDataStackSwift = ContextManager.shared
     ) {
         self.coreDataStack = coreDataStack
         self.eventTracker = eventTracker

--- a/WordPress/Classes/Utility/CoreData/ContextManager.swift
+++ b/WordPress/Classes/Utility/CoreData/ContextManager.swift
@@ -282,7 +282,7 @@ extension ContextManager {
     /// Tests purpose only
     static var overrideInstance: ContextManager?
 
-    @objc class func sharedInstance() -> ContextManager {
+    @objc public class func sharedInstance() -> CoreDataStack {
         if let overrideInstance {
             return overrideInstance
         }
@@ -290,8 +290,8 @@ extension ContextManager {
         return ContextManager.internalSharedInstance
     }
 
-    static var shared: ContextManager {
-        return sharedInstance()
+    static var shared: CoreDataStackSwift {
+        return sharedInstance() as! CoreDataStackSwift
     }
 }
 

--- a/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
+++ b/WordPress/Classes/Utility/Logging/WPCrashLoggingProvider.swift
@@ -2,6 +2,7 @@ import UIKit
 import Combine
 import AutomatticTracks
 import AutomatticEncryptedLogs
+import WordPressData
 
 /// A wrapper around the logging stack – provides shared initialization and configuration for Tracks Crash and Event Logging
 struct WPLoggingStack {
@@ -38,9 +39,9 @@ struct WPLoggingStack {
 }
 
 struct WPCrashLoggingDataProvider: CrashLoggingDataProvider {
-    private let contextManager: ContextManager
+    private let contextManager: CoreDataStackSwift
 
-    init(contextManager: ContextManager = .shared) {
+    init(contextManager: CoreDataStackSwift = ContextManager.shared) {
         self.contextManager = contextManager
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/AddSiteController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/AddSiteController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import SwiftUI
 import WordPressAuthenticator
+import WordPressData
 
 /// Manages the site creation flows.
 struct AddSiteController {
@@ -80,7 +81,7 @@ struct AddSiteMenuViewModel {
         }
     }
 
-    init(context: ContextManager = .shared, onSelection: @escaping (Selection) -> Void) {
+    init(context: CoreDataStackSwift = ContextManager.shared, onSelection: @escaping (Selection) -> Void) {
         let defaultAccount = try? WPAccount.lookupDefaultWordPressComAccount(in: context.mainContext)
         let canAddSelfHostedSite = AppConfiguration.showAddSelfHostedSiteButton
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListViewModel.swift
@@ -1,5 +1,6 @@
 import CoreData
 import SwiftUI
+import WordPressData
 import WordPressShared
 
 final class BlogListViewModel: NSObject, ObservableObject {
@@ -15,7 +16,7 @@ final class BlogListViewModel: NSObject, ObservableObject {
     private let configuration: BlogListConfiguration
     private var rawSites: [Blog] = []
     private let fetchedResultsController: NSFetchedResultsController<Blog>
-    private let contextManager: ContextManager
+    private let contextManager: CoreDataStackSwift
     private let blogService: BlogService
     private let eventTracker: EventTracker
     private let recentSitesService: RecentSitesService
@@ -24,7 +25,7 @@ final class BlogListViewModel: NSObject, ObservableObject {
     var onAddSiteTapped: (AddSiteMenuViewModel.Selection) -> Void = { _ in }
 
     init(configuration: BlogListConfiguration = .defaultConfig,
-         contextManager: ContextManager = ContextManager.shared,
+         contextManager: CoreDataStackSwift = ContextManager.shared,
          recentSitesService: RecentSitesService = RecentSitesService(),
          eventTracker: EventTracker = DefaultEventTracker()) {
         self.configuration = configuration

--- a/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewModel.swift
+++ b/WordPress/Classes/ViewRelated/EEUUSCompliance/CompliancePopoverViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import WordPressData
 import WordPressUI
 
 class CompliancePopoverViewModel: ObservableObject {
@@ -13,12 +14,12 @@ class CompliancePopoverViewModel: ObservableObject {
 
     private let analyticsTracker: PrivacySettingsAnalyticsTracking
     private let defaults: UserDefaults
-    private let contextManager: ContextManager
+    private let contextManager: CoreDataStackSwift
 
     // MARK: - Init
 
     init(defaults: UserDefaults,
-         contextManager: ContextManager,
+         contextManager: CoreDataStackSwift,
          analyticsTracker: PrivacySettingsAnalyticsTracking = PrivacySettingsAnalyticsTracker()) {
         self.defaults = defaults
         self.analyticsTracker = analyticsTracker

--- a/WordPress/WordPressTest/DataMigratorTests.swift
+++ b/WordPress/WordPressTest/DataMigratorTests.swift
@@ -209,27 +209,6 @@ class DataMigratorTests: XCTestCase {
     }
 }
 
-// MARK: - CoreDataStackMock
-
-private final class CoreDataStackMock: CoreDataStack {
-    var mainContext: NSManagedObjectContext
-
-    init(mainContext: NSManagedObjectContext) {
-        self.mainContext = mainContext
-    }
-
-    func newDerivedContext() -> NSManagedObjectContext {
-        return mainContext
-    }
-
-    func saveContextAndWait(_ context: NSManagedObjectContext) {}
-    func save(_ context: NSManagedObjectContext) {}
-    func save(_ context: NSManagedObjectContext, completion completionBlock: (() -> Void)?, on queue: DispatchQueue) {}
-
-    func performAndSave(_ aBlock: @escaping (NSManagedObjectContext) -> Void) {}
-    func performAndSave(_ aBlock: @escaping (NSManagedObjectContext) -> Void, completion: (() -> Void)?, on queue: DispatchQueue) {}
-}
-
 // MARK: - KeychainUtilsMock
 
 private final class KeychainUtilsMock: KeychainUtils {

--- a/WordPress/WordPressTest/SharedDataIssueSolverTests.swift
+++ b/WordPress/WordPressTest/SharedDataIssueSolverTests.swift
@@ -129,9 +129,14 @@ private extension SharedDataIssueSolverTests {
 final class CoreDataStackMock: CoreDataStack {
     private(set) var mainContext: NSManagedObjectContext
 
+    private static var shared: CoreDataStack?
+
     init(mainContext: NSManagedObjectContext) {
         self.mainContext = mainContext
+        CoreDataStackMock.shared = self
     }
+
+    static func sharedInstance() -> any CoreDataStack { CoreDataStackMock.shared! }
 
     func newDerivedContext() -> NSManagedObjectContext {
         return mainContext

--- a/WordPress/WordPressTest/SharedDataIssueSolverTests.swift
+++ b/WordPress/WordPressTest/SharedDataIssueSolverTests.swift
@@ -126,8 +126,8 @@ private extension SharedDataIssueSolverTests {
 
 // MARK: - CoreDataStackMock
 
-private final class CoreDataStackMock: CoreDataStack {
-    var mainContext: NSManagedObjectContext
+final class CoreDataStackMock: CoreDataStack {
+    private(set) var mainContext: NSManagedObjectContext
 
     init(mainContext: NSManagedObjectContext) {
         self.mainContext = mainContext


### PR DESCRIPTION
Part of #24165

---

**Problem** I can't move `AbstractPost` and other Objective-C models in WordPressDataObj because they access `ContextManager` which is defined in the Swift WordPressData.

**Solution** Decouple from knowing about a specific type (`ContextManager`) and use a `protocol` instead (`CoreDataStack`). This came with a few compromises (see inline comments) but I think it got the job done relatively clean.

I tested this by running Jetpack on my iPhone and doing a smoke test checking the various tabs.

---

An alternative solution if we run into more Swift leakages into Objective-C would be to backtrack and create a framework target where we can have mixed languages. I might set aside some time today to search for `#import "WordPress-Swift.h"` usages and see how much extra steps like this would be needed if we kept the packages setup.