### PR TITLE
Always use ephemeral session for WP.com login

### DIFF
--- a/WordPress/Classes/Login/WordPressDotComAuthenticator.swift
+++ b/WordPress/Classes/Login/WordPressDotComAuthenticator.swift
@@ -84,11 +84,24 @@ struct WordPressDotComAuthenticator {
     @MainActor
     func attemptSignIn(from viewController: UIViewController, context: SignInContext) async throws(SignInError) -> TaggedManagedObjectID<WPAccount> {
         let defaultAccount = try? WPAccount.lookupDefaultWordPressComAccount(in: coreDataStack.mainContext)
-        let hasAlreadySignedIn = defaultAccount != nil
 
         let token: String
         do {
-            token = try await authenticate(from: viewController, prefersEphemeralWebBrowserSession: hasAlreadySignedIn, accountEmail: context.accountEmail(in: coreDataStack.mainContext))
+            token = try await authenticate(
+                from: viewController,
+                // Always ask users to type username and password to login, instead of reusing the logged in user in Safari.
+                // We opt-in for ephemeral session under these assumptions:
+                // 1) Many users have multiple WP.com accounts (personal, business, etc).
+                // 2) The "Log in with a different account" button is not very discoverable.
+                //    If user can't find this button, they won't be able to log in to a different account than Safari.
+                // 3) Tapping "Log in with a different account" button signs out the logged in user in Safari. It is
+                //    not reasonable to force user signing out of Safari to log in to the app. They may want to use
+                //    different accounts in Safari and the app.
+                //
+                // Note: Set this value to `false` to speed up local development if needed.
+                prefersEphemeralWebBrowserSession: true,
+                accountEmail: context.accountEmail(in: coreDataStack.mainContext)
+            )
         } catch {
             throw .authentication(error)
         }


### PR DESCRIPTION
See the inline comments for detailed reasons.

At the moment, other than tapping the cancel buttons to abort logging in, tapping "deny" is the most common login failure. I wonder if that's because they want to sign in to a different account but couldn't find the button to do that.

I think we can try changing the `prefersEphemeralWebBrowserSession` value for the next release and see how that affects the login success rate.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
