### PR TITLE
Remove unused code

### DIFF
--- a/WordPress/Classes/System/3D Touch/WP3DTouchShortcutCreator.swift
+++ b/WordPress/Classes/System/3D Touch/WP3DTouchShortcutCreator.swift
@@ -115,9 +115,7 @@ open class WP3DTouchShortcutCreator: NSObject {
                 visibleShortcutArray.append(entireShortcutArray[LoggedIn3DTouchShortcutIndex.stats.rawValue])
             }
 
-            if AppConfiguration.allowsNewPostShortcut {
-                visibleShortcutArray.append(entireShortcutArray[LoggedIn3DTouchShortcutIndex.newPost.rawValue])
-            }
+            visibleShortcutArray.append(entireShortcutArray[LoggedIn3DTouchShortcutIndex.newPost.rawValue])
 
             strongSelf.shortcutsProvider.shortcutItems = visibleShortcutArray
         }

--- a/WordPress/Classes/System/Constants/Constants.h
+++ b/WordPress/Classes/System/Constants/Constants.h
@@ -29,13 +29,6 @@ extern NSString *const WPPushNotificationAppId;
 extern NSString *const WPAppGroupName;
 extern NSString *const WPAppKeychainAccessGroup;
 
-/// Notification Service Extension Constants
-///
-extern NSString *const WPNotificationServiceExtensionKeychainServiceName;
-extern NSString *const WPNotificationServiceExtensionKeychainTokenKey;
-extern NSString *const WPNotificationServiceExtensionKeychainUsernameKey;
-extern NSString *const WPNotificationServiceExtensionKeychainUserIDKey;
-
 /// Share Extension Constants
 ///
 extern NSString *const WPShareExtensionKeychainUsernameKey;

--- a/WordPress/Classes/System/Constants/Constants.h
+++ b/WordPress/Classes/System/Constants/Constants.h
@@ -9,15 +9,12 @@ extern NSString *const WPComDefaultAccountUrlKey;
 /// WordPress URL's
 ///
 extern NSString *const WPMobileReaderURL;
-extern NSString *const WPMobileReaderDetailURL;
-extern NSString *const WPAutomatticMainURL;
 extern NSString *const WPAutomatticTermsOfServiceURL;
 extern NSString *const WPAutomatticPrivacyURL;
 extern NSString *const WPAutomatticCCPAPrivacyNoticeURL;
 extern NSString *const WPAutomatticCookiesURL;
 extern NSString *const WPGithubMainURL;
 extern NSString *const WPComReferrerURL;
-extern NSString *const AutomatticDomain;
 extern NSString *const WPComDomain;
 
 /// Notifications Constants

--- a/WordPress/Classes/System/Constants/Constants.h
+++ b/WordPress/Classes/System/Constants/Constants.h
@@ -26,18 +26,6 @@ extern NSString *const WPPushNotificationAppId;
 extern NSString *const WPAppGroupName;
 extern NSString *const WPAppKeychainAccessGroup;
 
-/// Share Extension Constants
-///
-extern NSString *const WPShareExtensionKeychainUsernameKey;
-extern NSString *const WPShareExtensionKeychainTokenKey;
-extern NSString *const WPShareExtensionKeychainServiceName;
-extern NSString *const WPShareExtensionUserDefaultsPrimarySiteName;
-extern NSString *const WPShareExtensionUserDefaultsPrimarySiteID;
-extern NSString *const WPShareExtensionUserDefaultsLastUsedSiteName;
-extern NSString *const WPShareExtensionUserDefaultsLastUsedSiteID;
-extern NSString *const WPShareExtensionMaximumMediaDimensionKey;
-extern NSString *const WPShareExtensionRecentSitesKey;
-
 /// Apple ID Constants
 ///
 extern NSString *const WPAppleIDKeychainUsernameKey;

--- a/WordPress/Classes/System/Constants/Constants.m
+++ b/WordPress/Classes/System/Constants/Constants.m
@@ -9,15 +9,12 @@ NSString *const WPComDefaultAccountUrlKey                           = @"AccountD
 /// WordPress URL's
 ///
 NSString *const WPMobileReaderURL                                   = @"https://en.wordpress.com/reader/mobile/v2/?chrome=no";
-NSString *const WPMobileReaderDetailURL                             = @"https://en.wordpress.com/reader/mobile/v2/?template=details";
-NSString *const WPAutomatticMainURL                                 = @"https://automattic.com/";
 NSString *const WPAutomatticTermsOfServiceURL                       = @"https://wordpress.com/tos/";
 NSString *const WPAutomatticPrivacyURL                              = @"https://automattic.com/privacy/";
 NSString *const WPAutomatticCCPAPrivacyNoticeURL                    = @"https://automattic.com/privacy/#california-consumer-privacy-act-ccpa";
 NSString *const WPAutomatticCookiesURL                              = @"https://automattic.com/cookies/";
 NSString *const WPGithubMainURL                                     = @"https://github.com/wordpress-mobile/WordPress-iOS/";
 NSString *const WPComReferrerURL                                    = @"https://wordpress.com";
-NSString *const AutomatticDomain                                    = @"automattic.com";
 NSString *const WPComDomain                                         = @"wordpress.com";
 
 /// Keychain Constants

--- a/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConfiguration.swift
@@ -9,14 +9,10 @@ import Foundation
 @objc class AppConfiguration: NSObject {
     @objc static let isJetpack: Bool = false
     @objc static let isWordPress: Bool = true
-    @objc static let allowsNewPostShortcut: Bool = true
-    @objc static let allowsConnectSite: Bool = true
     @objc static let allowSignUp: Bool = true
     @objc static let allowsCustomAppIcons: Bool = true
     @objc static let allowsDomainRegistration: Bool = false
-    @objc static let showsCreateButton: Bool = true
     @objc static let showAddSelfHostedSiteButton: Bool = true
-    @objc static let showsQuickActions: Bool = true
     @objc static let showsFollowedSitesSettings: Bool = true
     @objc static let showsWhatIsNew: Bool = true
     @objc static let qrLoginEnabled: Bool = false

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -1,5 +1,5 @@
 import Foundation
-import WordPressAuthenticator
+import WordPressKit
 
 /// - Warning:
 /// This configuration class has a **Jetpack** counterpart in the Jetpack bundle.
@@ -55,10 +55,6 @@ extension AppConstants {
         static let aboutTitle: String = NSLocalizedString("About WordPress", comment: "Link to About screen for WordPress for iOS")
         static let shareButtonTitle = NSLocalizedString("Share WordPress with a friend", comment: "Title for a button that recommends the app to others")
         static let whatIsNewTitle = NSLocalizedString("What's New in WordPress", comment: "Opens the What's New / Feature Announcement modal")
-    }
-
-    struct Login {
-        static let continueButtonTitle = WordPressAuthenticatorDisplayStrings.defaultStrings.continueWithWPButtonTitle
     }
 
     struct Logout {

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -47,10 +47,6 @@ extension AppConstants {
         static let prompt = NSLocalizedString("appRatings.wordpress.prompt", value: "What do you think about WordPress?", comment: "This is the string we display when prompting the user to review the WordPress app")
     }
 
-    struct PostSignUpInterstitial {
-        static let welcomeTitleText = NSLocalizedString("Welcome to WordPress", comment: "Post Signup Interstitial Title Text for WordPress iOS")
-    }
-
     struct Settings {
         static let aboutTitle: String = NSLocalizedString("About WordPress", comment: "Link to About screen for WordPress for iOS")
         static let shareButtonTitle = NSLocalizedString("Share WordPress with a friend", comment: "Title for a button that recommends the app to others")

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -34,14 +34,6 @@ import WordPressAuthenticator
     #endif
 }
 
-// MARK: - Tab bar order
-@objc enum WPTab: Int {
-    case mySites
-    case reader
-    case notifications
-    case me
-}
-
 // MARK: - Localized Strings
 extension AppConstants {
 

--- a/WordPress/Classes/ViewRelated/NUX/Helpers/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Helpers/WordPressAuthenticationManager.swift
@@ -44,7 +44,7 @@ extension WordPressAuthenticationManager {
     ///
     func initializeWordPressAuthenticator() {
         let displayStrings = WordPressAuthenticatorDisplayStrings(
-            continueWithWPButtonTitle: AppConstants.Login.continueButtonTitle
+            continueWithWPButtonTitle: NSLocalizedString("Continue With WordPress.com", comment: "Button title. Takes the user to the login with WordPress.com flow.")
         )
 
         WordPressAuthenticator.initialize(configuration: authenticatorConfiguation(),

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -1,6 +1,11 @@
 // MARK: - Tab Access Tracking
 
-fileprivate extension WPTab {
+@objc enum WPTab: Int {
+    case mySites
+    case reader
+    case notifications
+    case me
+
     var hasStaticScreen: Bool {
         switch self {
         case .reader:

--- a/WordPress/Jetpack/AppConfiguration.swift
+++ b/WordPress/Jetpack/AppConfiguration.swift
@@ -9,14 +9,10 @@ import Foundation
 @objc class AppConfiguration: NSObject {
     @objc static let isJetpack: Bool = true
     @objc static let isWordPress: Bool = false
-    @objc static let allowsNewPostShortcut: Bool = true
-    @objc static let allowsConnectSite: Bool = true
     @objc static let allowSignUp: Bool = true
     @objc static let allowsCustomAppIcons: Bool = true
     @objc static let allowsDomainRegistration: Bool = true
-    @objc static let showsCreateButton: Bool = true
     @objc static let showAddSelfHostedSiteButton: Bool = true
-    @objc static let showsQuickActions: Bool = true
     @objc static let showsFollowedSitesSettings: Bool = true
     @objc static let showsWhatIsNew: Bool = true
     @objc static let qrLoginEnabled: Bool = true

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -34,14 +34,6 @@ import WordPressKit
     #endif
 }
 
-// MARK: - Tab bar order
-@objc enum WPTab: Int {
-    case mySites
-    case reader
-    case notifications
-    case me
-}
-
 // MARK: - Localized Strings
 extension AppConstants {
 

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -57,13 +57,6 @@ extension AppConstants {
         static let whatIsNewTitle = NSLocalizedString("What's New in Jetpack", comment: "Opens the What's New / Feature Announcement modal")
     }
 
-    struct Login {
-        static let continueButtonTitle = NSLocalizedString(
-            "Continue With WordPress.com",
-            comment: "Button title. Takes the user to the login with WordPress.com flow."
-        )
-    }
-
     struct Logout {
         static let alertTitle = NSLocalizedString("Log out of Jetpack?", comment: "LogOut confirmation text, whenever there are no local changes")
     }

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -47,10 +47,6 @@ extension AppConstants {
         static let prompt = NSLocalizedString("appRatings.jetpack.prompt", value: "What do you think about Jetpack?", comment: "This is the string we display when prompting the user to review the Jetpack app")
     }
 
-    struct PostSignUpInterstitial {
-        static let welcomeTitleText = NSLocalizedString("Welcome to Jetpack", comment: "Post Signup Interstitial Title Text for Jetpack iOS")
-    }
-
     struct Settings {
         static let aboutTitle = NSLocalizedString("About Jetpack for iOS", comment: "Link to About screen for Jetpack for iOS")
         static let shareButtonTitle = NSLocalizedString("Share Jetpack with a friend", comment: "Title for a button that recommends the app to others")

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3319,7 +3319,6 @@
 			};
 			membershipExceptions = (
 				"Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift",
-				"Extensions/Colors and Styles/WPStyleGuide+Gridicon.swift",
 				"Extensions/NSAttributedStringKey+Conversion.swift",
 				"Extensions/String+RegEx.swift",
 				"Extensions/UIApplication+mainWindow.swift",
@@ -3356,7 +3355,6 @@
 			};
 			membershipExceptions = (
 				"Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift",
-				"Extensions/Colors and Styles/WPStyleGuide+Gridicon.swift",
 				"Extensions/NSAttributedStringKey+Conversion.swift",
 				"Extensions/String+RegEx.swift",
 				"Extensions/UIApplication+mainWindow.swift",
@@ -3465,7 +3463,6 @@
 			};
 			membershipExceptions = (
 				"Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift",
-				"Extensions/Colors and Styles/WPStyleGuide+Gridicon.swift",
 				"Extensions/NSAttributedStringKey+Conversion.swift",
 				"Extensions/String+RegEx.swift",
 				"Extensions/UIApplication+mainWindow.swift",
@@ -3500,7 +3497,6 @@
 			};
 			membershipExceptions = (
 				"Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift",
-				"Extensions/Colors and Styles/WPStyleGuide+Gridicon.swift",
 				"Extensions/NSAttributedStringKey+Conversion.swift",
 				"Extensions/String+RegEx.swift",
 				"Extensions/UIApplication+mainWindow.swift",


### PR DESCRIPTION
- Remove ununsed constants from Constants.h
- Remove duplicated `WPTab` (not app-specific)
- Remove `WordPressAuthenticator` dependency from `AppConstants.swift` (both apps will say "Continue with WordPress.com")
- ...

To test: n/a


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
