### PR TITLE
[25.8] Fix highlighted comment design

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -47,6 +47,7 @@ final class CommentContentTableViewCell: UITableViewCell, NibReusable {
     private var effectiveDepth: Int = 0 {
         didSet {
             guard oldValue != effectiveDepth else { return }
+            highlightBarLeadingSpacingConstraint.constant = effectiveDepth == 0 ? 0 : (Self.depthInset * CGFloat(effectiveDepth))
             containerStackLeadingConstraint?.constant = (Self.depthInset * CGFloat(effectiveDepth)) + 16
             configureDepthSeparators(depth: effectiveDepth)
         }
@@ -59,7 +60,7 @@ final class CommentContentTableViewCell: UITableViewCell, NibReusable {
     @objc var isEmphasized: Bool = false {
         didSet {
             guard oldValue != isEmphasized else { return }
-            backgroundColor = isEmphasized ? Style.highlightedBackgroundColor : nil
+            setHighlightedBackgroundViewHidden(!isEmphasized)
             highlightBarView.backgroundColor = isEmphasized ? Style.highlightedBarBackgroundColor : .clear
         }
     }
@@ -84,6 +85,9 @@ final class CommentContentTableViewCell: UITableViewCell, NibReusable {
     @IBOutlet private weak var likeButton: UIButton!
 
     @IBOutlet private weak var highlightBarView: UIView!
+    @IBOutlet private weak var highlightBarLeadingSpacingConstraint: NSLayoutConstraint!
+
+    private var highlightedBackgroundView: UIView?
 
     // MARK: Private Properties
 
@@ -228,6 +232,23 @@ final class CommentContentTableViewCell: UITableViewCell, NibReusable {
                 return separatorView
             }()
             separatorView.isHidden = false
+        }
+    }
+
+    private func setHighlightedBackgroundViewHidden(_ isHidden: Bool) {
+        if isHidden {
+            highlightedBackgroundView?.isHidden = true
+        } else {
+            if let view = highlightedBackgroundView {
+                view.isHidden = false
+            } else {
+                let backgroundView = UIView()
+                backgroundView.backgroundColor = Style.highlightedBackgroundColor
+                contentView.insertSubview(backgroundView, belowSubview: containerStackView)
+                backgroundView.pinEdges([.vertical, .trailing], to: contentView)
+                backgroundView.leadingAnchor.constraint(equalTo: containerStackView.leadingAnchor, constant: -16).isActive = true
+                highlightedBackgroundView = backgroundView
+            }
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.xib
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.xib
@@ -21,10 +21,10 @@
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="mNJ-fg-sKO" userLabel="Highlighted Bar View">
-                        <rect key="frame" x="0.0" y="0.0" width="5" height="340"/>
+                        <rect key="frame" x="0.0" y="0.0" width="4" height="340"/>
                         <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                         <constraints>
-                            <constraint firstAttribute="width" constant="5" id="zU4-st-LVq"/>
+                            <constraint firstAttribute="width" constant="4" id="zU4-st-LVq"/>
                         </constraints>
                     </view>
                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="hcN-S7-sLG" userLabel="Container Stack View">
@@ -175,6 +175,7 @@
                 <outlet property="contentContainerView" destination="M0y-BK-TEh" id="bC5-Hn-XRQ"/>
                 <outlet property="dateLabel" destination="ghT-Xy-q8c" id="ffa-qV-3tn"/>
                 <outlet property="headerView" destination="f2E-yC-BJS" id="d5t-k4-d2B"/>
+                <outlet property="highlightBarLeadingSpacingConstraint" destination="eId-Od-5wj" id="jKm-f7-sqd"/>
                 <outlet property="highlightBarView" destination="mNJ-fg-sKO" id="fjf-gA-HoE"/>
                 <outlet property="likeButton" destination="X2J-8b-R5F" id="6w2-io-GXb"/>
                 <outlet property="nameLabel" destination="HpE-B7-6wr" id="MLa-k9-IlC"/>


### PR DESCRIPTION
Overlooked how it looked with depth indicators. 

Before → After

<img width="320" alt="Screenshot 2025-03-12 at 1 58 13 PM" src="https://github.com/user-attachments/assets/2277f848-1110-409f-a9fe-2f0cc027571c" />  <img width="320" alt="Screenshot 2025-03-12 at 2 55 13 PM" src="https://github.com/user-attachments/assets/5fe7c1d8-130b-4f89-9d8f-391e3c88aef6" />

Not a huge fan of the background because it doesn't work well with certain blocks like quotes, but without it's hard to see what's highlighted. Changing it not in the scope.

Zero-depth works fine:

<img width="320" alt="Screenshot 2025-03-12 at 2 48 14 PM" src="https://github.com/user-attachments/assets/effb0649-e1eb-4482-ac3c-6c7daa59ad76" />

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
