### PR TITLE
Move a few utils shared with data layer to WordPressShared

### DIFF
--- a/Modules/Sources/WordPressShared/Utility/FileManager+FolderSize.swift
+++ b/Modules/Sources/WordPressShared/Utility/FileManager+FolderSize.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension FileManager {
+public extension FileManager {
 
     /// This method calculates the accumulated size of a directory on the volume in bytes.
     ///

--- a/Modules/Sources/WordPressShared/Utility/URL+IncrementalFileName.swift
+++ b/Modules/Sources/WordPressShared/Utility/URL+IncrementalFileName.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+public extension URL {
+
+    /// Returns an `URL` with an incremental file name, if a file already exists at the given `URL`.
+    ///
+    func incrementalFilename() -> URL {
+        var url = self
+        let pathExtension = url.pathExtension
+        let filename = url.deletingPathExtension().lastPathComponent
+        var index = 1
+        let fileManager = FileManager.default
+        while fileManager.fileExists(atPath: url.path) {
+            let incrementedName = "\(filename)-\(index)"
+            url.deleteLastPathComponent()
+            url.appendPathComponent(incrementedName, isDirectory: false)
+            url.appendPathExtension(pathExtension)
+            index += 1
+        }
+        return url
+    }
+}

--- a/Modules/Tests/WordPressSharedTests/URLIncrementalFilenameTests.swift
+++ b/Modules/Tests/WordPressSharedTests/URLIncrementalFilenameTests.swift
@@ -1,0 +1,58 @@
+import WordPressShared
+import XCTest
+
+class URLIncrementalFilenameTests: XCTestCase {
+
+    fileprivate lazy var tempTestDirectory: URL = {
+        return FileManager.default.temporaryDirectory.appendingPathComponent("URLIncrementalFilenameTests-\(UUID().uuidString)")
+    }()
+
+    override func setUp() {
+        super.setUp()
+        do {
+            try FileManager.default.createDirectory(at: tempTestDirectory, withIntermediateDirectories: true, attributes: nil)
+        } catch {
+            XCTFail("Error on setup writing test directory: \(error.localizedDescription)")
+        }
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        removeTemporaryTestDirectoryIfNeeded()
+    }
+
+    fileprivate func removeTemporaryTestDirectoryIfNeeded() {
+        let directory = tempTestDirectory
+        let fileManager = FileManager.default
+        guard fileManager.fileExists(atPath: directory.path) else {
+            return
+        }
+        do {
+            try fileManager.removeItem(at: directory)
+        } catch {
+            XCTFail("Error on removing test directory: \(error.localizedDescription)")
+        }
+    }
+
+    func testThatIncrementalFilenameURLWorks() {
+
+        let sampleData = "{\"sample\": \"yes\"}"
+        let filename = "sample.json"
+
+        let url = tempTestDirectory.appendingPathComponent(filename, isDirectory: false).incrementalFilename()
+        // Check that the first file name is unchanged, in the case that there no existing files of the same name
+        XCTAssertTrue(url.lastPathComponent == filename, "Error: initial URL filename did not match original filename")
+        do {
+            // Write the first sample file
+            try sampleData.write(to: url, atomically: true, encoding: .utf8)
+            let firstIncrement = url.incrementalFilename()
+            // Check that the increment matches what is expected when there is an existing file
+            XCTAssertTrue(firstIncrement.lastPathComponent == "sample-1.json", "Error: incremented URL filename was not incremented as expected")
+            try sampleData.write(to: firstIncrement, atomically: true, encoding: .utf8)
+            let secondIncrement = url.incrementalFilename()
+            XCTAssertTrue(secondIncrement.lastPathComponent == "sample-2.json", "Error: incremented URL filename was not incremented as expected")
+        } catch {
+            XCTFail("Error testing sample data: \(error.localizedDescription)")
+        }
+    }
+}

--- a/WordPress/Classes/Extensions/URL+Helpers.swift
+++ b/WordPress/Classes/Extensions/URL+Helpers.swift
@@ -46,26 +46,6 @@ extension URL {
         contentType?.preferredFilenameExtension
     }
 
-    /// Returns a URL with an incremental file name, if a file already exists at the given URL.
-    ///
-    /// Previously seen in MediaService.m within urlForMediaWithFilename:andExtension:
-    ///
-    func incrementalFilename() -> URL {
-        var url = self
-        let pathExtension = url.pathExtension
-        let filename = url.deletingPathExtension().lastPathComponent
-        var index = 1
-        let fileManager = FileManager.default
-        while fileManager.fileExists(atPath: url.path) {
-            let incrementedName = "\(filename)-\(index)"
-            url.deleteLastPathComponent()
-            url.appendPathComponent(incrementedName, isDirectory: false)
-            url.appendPathExtension(pathExtension)
-            index += 1
-        }
-        return url
-    }
-
     var mimeType: String {
         contentType?.preferredMIMEType ?? "application/octet-stream"
     }

--- a/WordPress/Classes/Utility/Media/MediaFileManager.swift
+++ b/WordPress/Classes/Utility/Media/MediaFileManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 /// Type of the local Media directory URL in implementation.
 ///


### PR DESCRIPTION
Run into these in the context of #24165.

I've been attempting to move files all morning and run into various dependencies to tackle. The standalone ones I encountered are in this PR which we can go ahead and merge for convenience.