### PR TITLE
Update `.editorconfig` to indent Swift with 4 spaces outside Xcode

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,8 +1,22 @@
+root = true
+
 # Apply to all files
 [*]
+indent_style = space
+indent_size = 2
 end_of_line = lf
 insert_final_newline = true
+charset = utf-8
 trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.swift]
+indent_size = 4
+
+[{*.h,*.m}]
+indent_size = 4
 
 # Ruby specific rules
 [{*.rb,Fastfile,Gemfile}]


### PR DESCRIPTION
Xcode 16 supports `.editorconfig`, but if you are odd like me and have a global one that sets Swift indentation to 2 spaces, Xcode will use that in all your projects. Not a big deal unless you are collaborating in an established project with 4 spaces in use. 

The fix is to have the 4 spaces defined in the project's `.editorconfig` so Xcode can use it and play nice with existing formatting.