### PR TITLE
Remove unused method from `WPUserAgent`

### DIFF
--- a/WordPress/Classes/Utility/WPUserAgent.h
+++ b/WordPress/Classes/Utility/WPUserAgent.h
@@ -16,9 +16,4 @@
  */
 + (NSString *)wordPressUserAgent;
 
-/**
- *  @brief      Sets User-Agent header of all web views to be the WordPress one.
- */
-+ (void)useWordPressUserAgentInWebViews;
-
 @end

--- a/WordPress/Classes/Utility/WPUserAgent.m
+++ b/WordPress/Classes/Utility/WPUserAgent.m
@@ -40,21 +40,4 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
     return _wordPressUserAgent;
 }
 
-+ (void)useWordPressUserAgentInWebViews
-{
-    // Cleanup unused NSUserDefaults keys from older WPUserAgent implementation
-    [[UserPersistentStoreFactory userDefaultsInstance] removeObjectForKey:@"DefaultUserAgent"];
-    [[UserPersistentStoreFactory userDefaultsInstance] removeObjectForKey:@"AppUserAgent"];
-
-    NSString *userAgent = [self wordPressUserAgent];
-
-    NSParameterAssert([userAgent isKindOfClass:[NSString class]]);
-    
-    NSDictionary *dictionary = @{WPUserAgentKeyUserAgent: userAgent};
-    // We have to call registerDefaults else the change isn't picked up by WKWebViews.
-    [[UserPersistentStoreFactory userDefaultsInstance] registerDefaults:dictionary];
-    
-    DDLogVerbose(@"User-Agent set to: %@", userAgent);
-}
-
 @end

--- a/WordPress/WordPressTest/WPUserAgentTests.m
+++ b/WordPress/WordPressTest/WPUserAgentTests.m
@@ -54,26 +54,6 @@ static NSString* const WPUserAgentKeyUserAgent = @"UserAgent";
     XCTAssertEqual([regex numberOfMatchesInString:userAgent options:0 range:NSMakeRange(0, userAgent.length)], 1);
 }
 
-- (void)testUseWordPressUserAgentInWebViews
-{
-    NSString *defaultUA = [WPUserAgent defaultUserAgent];
-    NSString *wordPressUA = [WPUserAgent wordPressUserAgent];
-
-    [[NSUserDefaults standardUserDefaults] removeObjectForKey:WPUserAgentKeyUserAgent];
-    [[NSUserDefaults standardUserDefaults] registerDefaults:@{WPUserAgentKeyUserAgent: defaultUA}];
-
-    XCTAssertEqualObjects([self currentUserAgentFromUserDefaults], defaultUA);
-    XCTAssertEqualObjects([self currentUserAgentFromWebView], defaultUA);
-
-    if (@available(iOS 17, *)) {
-        XCTSkip("In iOS 17, WKWebView no longer reads User Agent from UserDefaults. Skipping while working on an alternative setup.");
-    }
-
-    [WPUserAgent useWordPressUserAgentInWebViews];
-    XCTAssertEqualObjects([self currentUserAgentFromUserDefaults], wordPressUA);
-    XCTAssertEqualObjects([self currentUserAgentFromWebView], wordPressUA);
-}
-
 - (void)testThatOriginalRemovalOfWPUseKeyUserAgentDoesntWork {
     if (@available(iOS 17, *)) {
         XCTSkip("In iOS 17, WKWebView no longer reads User Agent from UserDefaults. Skipping while working on an alternative setup.");


### PR DESCRIPTION
Part of #24165

---

`Blog` uses `WPUserAgent`, so we need to move `WPUserAgent` to a shared location before being able to move `Blog` into WordPressData.

It's late in my day, but I noticed an unused method that we can remove in the meantime. Opening a dedicated PR also to double check it's okay to remove it.