### PR TITLE
Remove WPAppGroupName and WPAppKeychainAccessGroup from Constants.h (Part 2)

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -244,6 +244,7 @@ enum XcodeSupport {
                 "WordPressShared",
             ]),
             .xcodeTarget("XcodeTarget_StatsWidget", dependencies: [
+                "BuildSettingsKit",
                 "JetpackStatsWidgetsCore",
                 "SFHFKeychainUtils",
                 "WordPressShared",
@@ -253,6 +254,7 @@ enum XcodeSupport {
                 .product(name: "ColorStudio", package: "color-studio"),
             ]),
             .xcodeTarget("XcodeTarget_Intents", dependencies: [
+                "BuildSettingsKit",
                 "JetpackStatsWidgetsCore",
                 .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
             ]),

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -404,13 +404,14 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
     NSNumber *siteId    = defaultBlog.dotComID;
     NSString *blogName  = defaultBlog.settings.name;
 
-    ShareExtensionService* shareExtensionService = [ShareExtensionService new];
+    ShareExtensionService *shareExtensionService = [ShareExtensionService new];
+    NotificationSupportService *notificationSupportService = [NotificationSupportService new];
 
     if (defaultBlog == nil || defaultBlog.isDeleted) {
         dispatch_async(dispatch_get_main_queue(), ^{
             [shareExtensionService removeShareExtensionConfiguration];
 
-            [NotificationSupportService deleteServiceExtensionToken];
+            [notificationSupportService deleteServiceExtensionToken];
         });
     } else {
         dispatch_async(dispatch_get_main_queue(), ^{
@@ -420,9 +421,9 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
             [shareExtensionService configureShareExtensionToken:defaultAccount.authToken];
             [shareExtensionService configureShareExtensionUsername:defaultAccount.username];
 
-            [NotificationSupportService insertServiceExtensionToken:defaultAccount.authToken];
-            [NotificationSupportService insertServiceExtensionUsername:defaultAccount.username];
-            [NotificationSupportService insertServiceExtensionUserID:defaultAccount.userID.stringValue];
+            [notificationSupportService insertServiceExtensionToken:defaultAccount.authToken];
+            [notificationSupportService insertServiceExtensionUsername:defaultAccount.username];
+            [notificationSupportService insertServiceExtensionUserID:defaultAccount.userID.stringValue];
         });
     }
 }

--- a/WordPress/Classes/Services/NotificationSupportService.swift
+++ b/WordPress/Classes/Services/NotificationSupportService.swift
@@ -1,20 +1,31 @@
 import Foundation
+import BuildSettingsKit
 import SFHFKeychainUtils
 
 @objc
 open class NotificationSupportService: NSObject {
+    private let appKeychainAccessGroup: String
+
+    @objc convenience override init() {
+        self.init(appKeychainAccessGroup: BuildSettings.appKeychainAccessGroup)
+    }
+
+    init(appKeychainAccessGroup: String) {
+        self.appKeychainAccessGroup = appKeychainAccessGroup
+    }
+
     /// Sets the OAuth Token that should be used by the Notification Service Extension to access WPCOM.
     ///
     /// - Parameter oauth2Token: WordPress.com OAuth Token
     ///
     @objc
-    class func insertServiceExtensionToken(_ oauthToken: String) {
+    func insertServiceExtensionToken(_ oauthToken: String) {
         do {
             try SFHFKeychainUtils.storeUsername(
                 AppConfiguration.Extension.NotificationsService.keychainTokenKey,
                 andPassword: oauthToken,
                 forServiceName: AppConfiguration.Extension.NotificationsService.keychainServiceName,
-                accessGroup: WPAppKeychainAccessGroup,
+                accessGroup: appKeychainAccessGroup,
                 updateExisting: true
             )
         } catch {
@@ -27,13 +38,13 @@ open class NotificationSupportService: NSObject {
     /// - Parameter username: WordPress.com username
     ///
     @objc
-    class func insertServiceExtensionUsername(_ username: String) {
+    func insertServiceExtensionUsername(_ username: String) {
         do {
             try SFHFKeychainUtils.storeUsername(
                 AppConfiguration.Extension.NotificationsService.keychainUsernameKey,
                 andPassword: username,
                 forServiceName: AppConfiguration.Extension.NotificationsService.keychainServiceName,
-                accessGroup: WPAppKeychainAccessGroup,
+                accessGroup: appKeychainAccessGroup,
                 updateExisting: true
             )
         } catch {
@@ -46,13 +57,13 @@ open class NotificationSupportService: NSObject {
     /// - Parameter userID: WordPress.com userID
     ///
     @objc
-    class func insertServiceExtensionUserID(_ userID: String) {
+    func insertServiceExtensionUserID(_ userID: String) {
         do {
             try SFHFKeychainUtils.storeUsername(
                 AppConfiguration.Extension.NotificationsService.keychainUserIDKey,
                 andPassword: userID,
                 forServiceName: AppConfiguration.Extension.NotificationsService.keychainServiceName,
-                accessGroup: WPAppKeychainAccessGroup,
+                accessGroup: appKeychainAccessGroup,
                 updateExisting: true
             )
         } catch {
@@ -63,12 +74,12 @@ open class NotificationSupportService: NSObject {
     /// Attempts to delete the current WPCOM OAuth Token used by the Notification Service Extension.
     ///
     @objc
-    class func deleteServiceExtensionToken() {
+    func deleteServiceExtensionToken() {
         do {
             try SFHFKeychainUtils.deleteItem(
                 forUsername: AppConfiguration.Extension.NotificationsService.keychainTokenKey,
                 andServiceName: AppConfiguration.Extension.NotificationsService.keychainServiceName,
-                accessGroup: WPAppKeychainAccessGroup
+                accessGroup: appKeychainAccessGroup
             )
         } catch {
             DDLogDebug("Error while removing Notification Service Extension OAuth token: \(error)")
@@ -78,12 +89,12 @@ open class NotificationSupportService: NSObject {
     /// Attempts to delete the current WPCOM Username used by the Notification Service Extension.
     ///
     @objc
-    class func deleteServiceExtensionUsername() {
+    func deleteServiceExtensionUsername() {
         do {
             try SFHFKeychainUtils.deleteItem(
                 forUsername: AppConfiguration.Extension.NotificationsService.keychainUsernameKey,
                 andServiceName: AppConfiguration.Extension.NotificationsService.keychainServiceName,
-                accessGroup: WPAppKeychainAccessGroup
+                accessGroup: appKeychainAccessGroup
             )
         } catch {
             DDLogDebug("Error while removing Notification Service Extension username: \(error)")
@@ -93,12 +104,12 @@ open class NotificationSupportService: NSObject {
     /// Attempts to delete the current WPCOM Username used by the Notification Service Extension.
     ///
     @objc
-    class func deleteServiceExtensionUserID() {
+    func deleteServiceExtensionUserID() {
         do {
             try SFHFKeychainUtils.deleteItem(
                 forUsername: AppConfiguration.Extension.NotificationsService.keychainUserIDKey,
                 andServiceName: AppConfiguration.Extension.NotificationsService.keychainServiceName,
-                accessGroup: WPAppKeychainAccessGroup
+                accessGroup: appKeychainAccessGroup
             )
         } catch {
             DDLogDebug("Error while removing Notification Service Extension userID: \(error)")

--- a/WordPress/Classes/Stores/StatsWidgetsStore.swift
+++ b/WordPress/Classes/Stores/StatsWidgetsStore.swift
@@ -1,12 +1,16 @@
 import JetpackStatsWidgetsCore
+import BuildSettingsKit
 import SFHFKeychainUtils
 import WidgetKit
 
 class StatsWidgetsStore {
     private let coreDataStack: CoreDataStack
+    private let appGroupName: String
 
-    init(coreDataStack: CoreDataStack = ContextManager.shared) {
+    init(coreDataStack: CoreDataStack = ContextManager.shared,
+         appGroupName: String = BuildSettings.appGroupName) {
         self.coreDataStack = coreDataStack
+        self.appGroupName = appGroupName
 
         observeAccountChangesForWidgets()
         observeAccountSignInForWidgets()
@@ -36,8 +40,8 @@ class StatsWidgetsStore {
 
     /// Initialize the local cache for widgets, if it does not exist
     @objc func initializeStatsWidgetsIfNeeded() {
-        UserDefaults(suiteName: WPAppGroupName)?.setValue(AccountHelper.isLoggedIn, forKey: AppConfiguration.Widget.Stats.userDefaultsLoggedInKey)
-        UserDefaults(suiteName: WPAppGroupName)?.setValue(AccountHelper.defaultSiteId, forKey: AppConfiguration.Widget.Stats.userDefaultsSiteIdKey)
+        UserDefaults(suiteName: appGroupName)?.setValue(AccountHelper.isLoggedIn, forKey: AppConfiguration.Widget.Stats.userDefaultsLoggedInKey)
+        UserDefaults(suiteName: appGroupName)?.setValue(AccountHelper.defaultSiteId, forKey: AppConfiguration.Widget.Stats.userDefaultsSiteIdKey)
         storeCredentials()
 
         var isReloadRequired = false
@@ -268,7 +272,7 @@ private extension StatsWidgetsStore {
 
     @objc func handleAccountChangedNotification() {
         let isLoggedIn = AccountHelper.isLoggedIn
-        let userDefaults = UserDefaults(suiteName: WPAppGroupName)
+        let userDefaults = UserDefaults(suiteName: appGroupName)
         userDefaults?.setValue(isLoggedIn, forKey: AppConfiguration.Widget.Stats.userDefaultsLoggedInKey)
 
         guard !isLoggedIn else { return }
@@ -307,7 +311,7 @@ private extension StatsWidgetsStore {
         // If user is logged in but defaultSiteIdKey is not set
         guard let account = try? WPAccount.lookupDefaultWordPressComAccount(in: coreDataStack.mainContext),
               let siteId = account.defaultBlog?.dotComID,
-              let userDefaults = UserDefaults(suiteName: WPAppGroupName),
+              let userDefaults = UserDefaults(suiteName: appGroupName),
               userDefaults.value(forKey: AppConfiguration.Widget.Stats.userDefaultsSiteIdKey) == nil else {
             return
         }

--- a/WordPress/Classes/Stores/StatsWidgetsStore.swift
+++ b/WordPress/Classes/Stores/StatsWidgetsStore.swift
@@ -6,11 +6,14 @@ import WidgetKit
 class StatsWidgetsStore {
     private let coreDataStack: CoreDataStack
     private let appGroupName: String
+    private let appKeychainAccessGroup: String
 
     init(coreDataStack: CoreDataStack = ContextManager.shared,
-         appGroupName: String = BuildSettings.appGroupName) {
+         appGroupName: String = BuildSettings.appGroupName,
+         appKeychainAccessGroup: String = BuildSettings.appKeychainAccessGroup) {
         self.coreDataStack = coreDataStack
         self.appGroupName = appGroupName
+        self.appKeychainAccessGroup = appKeychainAccessGroup
 
         observeAccountChangesForWidgets()
         observeAccountSignInForWidgets()
@@ -336,7 +339,7 @@ private extension StatsWidgetsStore {
                 AppConfiguration.Widget.Stats.keychainTokenKey,
                 andPassword: token,
                 forServiceName: AppConfiguration.Widget.Stats.keychainServiceName,
-                accessGroup: WPAppKeychainAccessGroup,
+                accessGroup: appKeychainAccessGroup,
                 updateExisting: true
             )
         } catch {

--- a/WordPress/Classes/System/Constants/Constants.h
+++ b/WordPress/Classes/System/Constants/Constants.h
@@ -23,7 +23,6 @@ extern NSString *const WPPushNotificationAppId;
 
 /// Keychain + User Defaults Constants
 ///
-extern NSString *const WPAppGroupName;
 extern NSString *const WPAppKeychainAccessGroup;
 
 /// Apple ID Constants

--- a/WordPress/Classes/System/Constants/Constants.h
+++ b/WordPress/Classes/System/Constants/Constants.h
@@ -21,10 +21,6 @@ extern NSString *const WPComDomain;
 ///
 extern NSString *const WPPushNotificationAppId;
 
-/// Keychain + User Defaults Constants
-///
-extern NSString *const WPAppKeychainAccessGroup;
-
 /// Apple ID Constants
 ///
 extern NSString *const WPAppleIDKeychainUsernameKey;

--- a/WordPress/Classes/System/Constants/Constants.m
+++ b/WordPress/Classes/System/Constants/Constants.m
@@ -17,18 +17,6 @@ NSString *const WPGithubMainURL                                     = @"https://
 NSString *const WPComReferrerURL                                    = @"https://wordpress.com";
 NSString *const WPComDomain                                         = @"wordpress.com";
 
-/// Keychain Constants
-///
-/// Note: Multiple compiler flags are set for some builds, so conditional ordering matters.
-///
-#if defined(ALPHA_BUILD)
-NSString *const WPAppKeychainAccessGroup                            = @"99KV9Z6BKV.org.wordpress.alpha";
-#elif defined(INTERNAL_BUILD)
-NSString *const WPAppKeychainAccessGroup                            = @"99KV9Z6BKV.org.wordpress.internal";
-#else
-NSString *const WPAppKeychainAccessGroup                            = @"3TMU3BH3NK.org.wordpress";
-#endif
-
 /// Apple ID Constants
 ///
 NSString *const WPAppleIDKeychainUsernameKey                        = @"Username";

--- a/WordPress/Classes/System/Constants/Constants.m
+++ b/WordPress/Classes/System/Constants/Constants.m
@@ -22,13 +22,10 @@ NSString *const WPComDomain                                         = @"wordpres
 /// Note: Multiple compiler flags are set for some builds, so conditional ordering matters.
 ///
 #if defined(ALPHA_BUILD)
-NSString *const WPAppGroupName                                      = @"group.org.wordpress.alpha";
 NSString *const WPAppKeychainAccessGroup                            = @"99KV9Z6BKV.org.wordpress.alpha";
 #elif defined(INTERNAL_BUILD)
-NSString *const WPAppGroupName                                      = @"group.org.wordpress.internal";
 NSString *const WPAppKeychainAccessGroup                            = @"99KV9Z6BKV.org.wordpress.internal";
 #else
-NSString *const WPAppGroupName                                      = @"group.org.wordpress";
 NSString *const WPAppKeychainAccessGroup                            = @"3TMU3BH3NK.org.wordpress";
 #endif
 

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -1,5 +1,6 @@
 import SFHFKeychainUtils
 import UIKit
+import BuildSettingsKit
 import CocoaLumberjackSwift
 import Reachability
 import AutomatticTracks
@@ -202,8 +203,9 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     func application(_ application: UIApplication, handleEventsForBackgroundURLSession identifier: String, completionHandler: @escaping () -> Void) {
         // 21-Oct-2017: We are only handling background URLSessions initiated by the share extension so there
         // is no need to inspect the identifier beyond the simple check here.
-        if identifier.contains(WPAppGroupName) {
-            let manager = ShareExtensionSessionManager(appGroup: WPAppGroupName, backgroundSessionIdentifier: identifier)
+        let appGroupName = BuildSettings.appGroupName
+        if identifier.contains(appGroupName) {
+            let manager = ShareExtensionSessionManager(appGroup: appGroupName, backgroundSessionIdentifier: identifier)
             manager.backgroundSessionCompletionBlock = completionHandler
             manager.startBackgroundSession()
         }

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -757,16 +757,18 @@ extension WordPressAppDelegate {
     func configureNotificationExtension() {
 
         if let account = try? WPAccount.lookupDefaultWordPressComAccount(in: mainContext), let authToken = account.authToken {
-            NotificationSupportService.insertServiceExtensionToken(authToken)
-            NotificationSupportService.insertServiceExtensionUsername(account.username)
-            NotificationSupportService.insertServiceExtensionUserID(account.userID.stringValue)
+            let service = NotificationSupportService()
+            service.insertServiceExtensionToken(authToken)
+            service.insertServiceExtensionUsername(account.username)
+            service.insertServiceExtensionUserID(account.userID.stringValue)
         }
     }
 
     func removeNotificationExtensionConfiguration() {
-        NotificationSupportService.deleteServiceExtensionToken()
-        NotificationSupportService.deleteServiceExtensionUsername()
-        NotificationSupportService.deleteServiceExtensionUserID()
+        let service = NotificationSupportService()
+        service.deleteServiceExtensionToken()
+        service.deleteServiceExtensionUsername()
+        service.deleteServiceExtensionUserID()
     }
 }
 

--- a/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
+++ b/WordPress/Classes/Utility/Blogging Reminders/BloggingRemindersScheduler.swift
@@ -1,4 +1,5 @@
 import Foundation
+import BuildSettingsKit
 import WordPressData
 
 protocol NotificationScheduler {
@@ -148,7 +149,7 @@ class BloggingRemindersScheduler {
     }
 
     private static func sharedDataFileURL() -> URL? {
-        let sharedDirectory = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: WPAppGroupName)
+        let sharedDirectory = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: BuildSettings.appGroupName)
         return sharedDirectory?.appendingPathComponent(defaultDataFileName)
     }
 

--- a/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
+++ b/WordPress/Classes/Utility/Migration/ContentMigrationCoordinator.swift
@@ -1,4 +1,6 @@
+import Foundation
 import WordPressShared
+import BuildSettingsKit
 
 /// Encapsulates logic related to content migration from WordPress to Jetpack.
 ///
@@ -30,7 +32,7 @@ import WordPressShared
          dataMigrator: ContentDataMigrating = DataMigrator(),
          notificationCenter: NotificationCenter = .default,
          userPersistentRepository: UserPersistentRepository = UserDefaults.standard,
-         sharedPersistentRepository: UserPersistentRepository? = UserDefaults(suiteName: WPAppGroupName),
+         sharedPersistentRepository: UserPersistentRepository? = UserDefaults(suiteName: BuildSettings.appGroupName),
          eligibilityProvider: ContentMigrationEligibilityProvider = AppConfiguration(),
          tracker: MigrationAnalyticsTracker = .init()) {
         self.coreDataStack = coreDataStack

--- a/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
+++ b/WordPress/Jetpack/Classes/Utility/DataMigrator.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AutomatticTracks
+import BuildSettingsKit
 import WordPressShared
 
 protocol ContentDataMigrating {
@@ -26,10 +27,10 @@ final class DataMigrator {
     private let crashLogger: CrashLogging
 
     init(coreDataStack: CoreDataStack = ContextManager.shared,
-         backupLocation: URL? = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: WPAppGroupName)?.appendingPathComponent("WordPress.sqlite"),
+         backupLocation: URL? = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: BuildSettings.appGroupName)?.appendingPathComponent("WordPress.sqlite"),
          keychainUtils: KeychainUtils = KeychainUtils(),
          localDefaults: UserPersistentRepository = UserDefaults.standard,
-         sharedDefaults: UserPersistentRepository? = UserDefaults(suiteName: WPAppGroupName),
+         sharedDefaults: UserPersistentRepository? = UserDefaults(suiteName: BuildSettings.appGroupName),
          crashLogger: CrashLogging = .main) {
         self.coreDataStack = coreDataStack
         self.backupLocation = backupLocation

--- a/WordPress/Jetpack/Classes/Utility/SharedDataIssueSolver.swift
+++ b/WordPress/Jetpack/Classes/Utility/SharedDataIssueSolver.swift
@@ -1,4 +1,5 @@
 import WordPressShared
+import BuildSettingsKit
 
 @objcMembers
 final class SharedDataIssueSolver: NSObject {
@@ -10,7 +11,7 @@ final class SharedDataIssueSolver: NSObject {
 
     init(contextManager: CoreDataStack = ContextManager.shared,
          keychainUtils: KeychainUtils = KeychainUtils(),
-         sharedDefaults: UserPersistentRepository? = UserDefaults(suiteName: WPAppGroupName),
+         sharedDefaults: UserPersistentRepository? = UserDefaults(suiteName: BuildSettings.appGroupName),
          localFileStore: LocalFileStore = FileManager.default) {
         self.contextManager = contextManager
         self.keychainUtils = keychainUtils
@@ -147,8 +148,8 @@ private extension SharedDataIssueSolver {
         ]
 
         fileNames.forEach { fileName in
-            guard let sourceURL = localFileStore.containerURL(forAppGroup: WPAppGroupName)?.appendingPathComponent(fileName.rawValue),
-                  let targetURL = localFileStore.containerURL(forAppGroup: WPAppGroupName)?.appendingPathComponent(fileName.valueForJetpack),
+            guard let sourceURL = localFileStore.containerURL(forAppGroup: BuildSettings.appGroupName)?.appendingPathComponent(fileName.rawValue),
+                  let targetURL = localFileStore.containerURL(forAppGroup: BuildSettings.appGroupName)?.appendingPathComponent(fileName.valueForJetpack),
                   localFileStore.fileExists(at: sourceURL) else {
                 return
             }

--- a/WordPress/JetpackIntents/Info.plist
+++ b/WordPress/JetpackIntents/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>WPAppGroupName</key>
+	<string>${WP_APP_GROUP_NAME}</string>
+	<key>WPAppKeychainAccessGroup</key>
+	<string>${WP_APP_KEYCHAIN_ACCESS_GROUP}</string>
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>

--- a/WordPress/JetpackIntents/SitesDataProvider.swift
+++ b/WordPress/JetpackIntents/SitesDataProvider.swift
@@ -1,4 +1,5 @@
 import Intents
+import BuildSettingsKit
 
 class SitesDataProvider {
     private(set) var sites = [Site]()
@@ -59,7 +60,7 @@ class SitesDataProvider {
 
     private var defaultSiteID: Int? {
 
-        return UserDefaults(suiteName: WPAppGroupName)?.object(forKey: AppConfiguration.Widget.Stats.userDefaultsSiteIdKey) as? Int
+        return UserDefaults(suiteName: BuildSettings.appGroupName)?.object(forKey: AppConfiguration.Widget.Stats.userDefaultsSiteIdKey) as? Int
     }
 
     var defaultSite: Site? {

--- a/WordPress/JetpackStatsWidgets/Helpers/WidgetDataReader.swift
+++ b/WordPress/JetpackStatsWidgets/Helpers/WidgetDataReader.swift
@@ -1,11 +1,12 @@
 import Foundation
+import BuildSettingsKit
 import JetpackStatsWidgetsCore
 
 final class WidgetDataReader<T: HomeWidgetData> {
     let userDefaults: UserDefaults?
     let cacheReader: WidgetDataCacheReader
 
-    init(_ userDefaults: UserDefaults? = UserDefaults(suiteName: WPAppGroupName),
+    init(_ userDefaults: UserDefaults? = UserDefaults(suiteName: BuildSettings.appGroupName),
          _ cacheReader: any WidgetDataCacheReader = HomeWidgetDataFileReader()
     ) {
         self.userDefaults = userDefaults

--- a/WordPress/JetpackStatsWidgets/LockScreenWidgets/LockScreenSiteListProvider.swift
+++ b/WordPress/JetpackStatsWidgets/LockScreenWidgets/LockScreenSiteListProvider.swift
@@ -1,5 +1,6 @@
 import WidgetKit
 import SwiftUI
+import BuildSettingsKit
 import JetpackStatsWidgetsCore
 
 struct LockScreenSiteListProvider<T: HomeWidgetData>: IntentTimelineProvider {
@@ -12,7 +13,7 @@ struct LockScreenSiteListProvider<T: HomeWidgetData>: IntentTimelineProvider {
     let minElapsedTimeToRefresh = 1
 
     private var defaultSiteID: Int? {
-        UserDefaults(suiteName: WPAppGroupName)?.object(forKey: AppConfiguration.Widget.Stats.userDefaultsSiteIdKey) as? Int
+        UserDefaults(suiteName: BuildSettings.appGroupName)?.object(forKey: AppConfiguration.Widget.Stats.userDefaultsSiteIdKey) as? Int
     }
 
     private let widgetDataLoader = WidgetDataReader<T>()

--- a/WordPress/JetpackStatsWidgets/LockScreenWidgets/LockScreenStatsWidget.swift
+++ b/WordPress/JetpackStatsWidgets/LockScreenWidgets/LockScreenStatsWidget.swift
@@ -1,9 +1,10 @@
 import WidgetKit
+import BuildSettingsKit
 import SwiftUI
 import JetpackStatsWidgetsCore
 
 struct LockScreenStatsWidget<T: LockScreenStatsWidgetConfig>: Widget {
-    private let tracks = Tracks(appGroupName: WPAppGroupName)
+    private let tracks = Tracks(appGroupName: BuildSettings.appGroupName)
     private let config: T
 
     init(config: T) {

--- a/WordPress/JetpackStatsWidgets/Model/HomeWidgetData.swift
+++ b/WordPress/JetpackStatsWidgets/Model/HomeWidgetData.swift
@@ -1,4 +1,5 @@
 import JetpackStatsWidgetsCore
+import BuildSettingsKit
 
 // MARK: - Local cache
 
@@ -7,7 +8,7 @@ extension HomeWidgetData {
     static func read(from cache: HomeWidgetCache<Self>? = nil) -> [Int: Self]? {
 
         let cache = cache ?? HomeWidgetCache<Self>(fileName: Self.filename,
-                                                                  appGroup: WPAppGroupName)
+                                                                  appGroup: BuildSettings.appGroupName)
         do {
             return try cache.read()
         } catch {
@@ -19,7 +20,7 @@ extension HomeWidgetData {
     static func write(items: [Int: Self], to cache: HomeWidgetCache<Self>? = nil) {
 
         let cache = cache ?? HomeWidgetCache<Self>(fileName: Self.filename,
-                                                                  appGroup: WPAppGroupName)
+                                                                  appGroup: BuildSettings.appGroupName)
 
         do {
             try cache.write(items: items)
@@ -30,7 +31,7 @@ extension HomeWidgetData {
 
     static func delete(cache: HomeWidgetCache<Self>? = nil) {
         let cache = cache ?? HomeWidgetCache<Self>(fileName: Self.filename,
-                                                                  appGroup: WPAppGroupName)
+                                                                  appGroup: BuildSettings.appGroupName)
 
         do {
             try cache.delete()
@@ -41,7 +42,7 @@ extension HomeWidgetData {
 
     static func setItem(item: Self, to cache: HomeWidgetCache<Self>? = nil) {
         let cache = cache ?? HomeWidgetCache<Self>(fileName: Self.filename,
-                                                                  appGroup: WPAppGroupName)
+                                                                  appGroup: BuildSettings.appGroupName)
 
         do {
             try cache.setItem(item: item)

--- a/WordPress/JetpackStatsWidgets/Remote service/StatsWidgetsService.swift
+++ b/WordPress/JetpackStatsWidgets/Remote service/StatsWidgetsService.swift
@@ -1,4 +1,5 @@
 import SFHFKeychainUtils
+import BuildSettingsKit
 import WordPressKit
 import JetpackStatsWidgetsCore
 import WordPressShared
@@ -221,7 +222,7 @@ private extension StatsWidgetsService {
         let token = try SFHFKeychainUtils.getPasswordForUsername(
             AppConfiguration.Widget.Stats.keychainTokenKey,
             andServiceName: AppConfiguration.Widget.Stats.keychainServiceName,
-            accessGroup: WPAppKeychainAccessGroup
+            accessGroup: BuildSettings.appKeychainAccessGroup
         )
         let wpApi = WordPressComRestApi(oAuthToken: token)
         return StatsServiceRemoteV2(wordPressComRestApi: wpApi, siteID: widgetData.siteID, siteTimezone: widgetData.timeZone)

--- a/WordPress/JetpackStatsWidgets/SiteListProvider.swift
+++ b/WordPress/JetpackStatsWidgets/SiteListProvider.swift
@@ -1,4 +1,5 @@
 import WidgetKit
+import BuildSettingsKit
 import SwiftUI
 import JetpackStatsWidgetsCore
 
@@ -15,7 +16,7 @@ struct SiteListProvider<T: HomeWidgetData>: IntentTimelineProvider {
 
     private var defaultSiteID: Int? {
 
-        UserDefaults(suiteName: WPAppGroupName)?.object(forKey: AppConfiguration.Widget.Stats.userDefaultsSiteIdKey) as? Int
+        UserDefaults(suiteName: BuildSettings.appGroupName)?.object(forKey: AppConfiguration.Widget.Stats.userDefaultsSiteIdKey) as? Int
     }
 
     private let widgetDataLoader = WidgetDataReader<T>()

--- a/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetAllTime.swift
+++ b/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetAllTime.swift
@@ -1,8 +1,9 @@
 import WidgetKit
 import SwiftUI
+import BuildSettingsKit
 
 struct HomeWidgetAllTime: Widget {
-    private let tracks = Tracks(appGroupName: WPAppGroupName)
+    private let tracks = Tracks(appGroupName: BuildSettings.appGroupName)
 
     private let placeholderContent = HomeWidgetAllTimeData(siteID: 0,
                                                         siteName: "My WordPress Site",

--- a/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetThisWeek.swift
+++ b/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetThisWeek.swift
@@ -1,9 +1,10 @@
 import WidgetKit
 import SwiftUI
+import BuildSettingsKit
 import JetpackStatsWidgetsCore
 
 struct HomeWidgetThisWeek: Widget {
-    private let tracks = Tracks(appGroupName: WPAppGroupName)
+    private let tracks = Tracks(appGroupName: BuildSettings.appGroupName)
 
     static let secondsPerDay = 86400.0
 

--- a/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetToday.swift
+++ b/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetToday.swift
@@ -1,8 +1,9 @@
 import WidgetKit
 import SwiftUI
+import BuildSettingsKit
 
 struct HomeWidgetToday: Widget {
-    private let tracks = Tracks(appGroupName: WPAppGroupName)
+    private let tracks = Tracks(appGroupName: BuildSettings.appGroupName)
 
     private let placeholderContent = HomeWidgetTodayData(siteID: 0,
                                                         siteName: "My WordPress Site",

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -1,5 +1,6 @@
 import SFHFKeychainUtils
 import UserNotifications
+import BuildSettingsKit
 
 import WordPressKit
 
@@ -11,7 +12,7 @@ class NotificationService: UNNotificationServiceExtension {
     // MARK: Properties
 
     /// Manages analytics calls via Tracks
-    private let tracks = Tracks(appGroupName: WPAppGroupName)
+    private let tracks = Tracks(appGroupName: BuildSettings.appGroupName)
 
     /// The content handler received from the extension
     private var contentHandler: ((UNNotificationContent) -> Void)?

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -1,7 +1,6 @@
 import SFHFKeychainUtils
 import UserNotifications
 import BuildSettingsKit
-
 import WordPressKit
 
 // MARK: - NotificationService
@@ -281,7 +280,7 @@ private extension NotificationService {
     func readExtensionToken() -> String? {
         guard let oauthToken = try? SFHFKeychainUtils.getPasswordForUsername(AppConfiguration.Extension.NotificationsService.keychainTokenKey,
                                                                              andServiceName: AppConfiguration.Extension.NotificationsService.keychainServiceName,
-                                                                             accessGroup: WPAppKeychainAccessGroup) else {
+                                                                             accessGroup: BuildSettings.appKeychainAccessGroup) else {
             debugPrint("Unable to retrieve Notification Service Extension OAuth token")
             return nil
         }
@@ -296,7 +295,7 @@ private extension NotificationService {
     func readExtensionUsername() -> String? {
         guard let username = try? SFHFKeychainUtils.getPasswordForUsername(AppConfiguration.Extension.NotificationsService.keychainUsernameKey,
                                                                            andServiceName: AppConfiguration.Extension.NotificationsService.keychainServiceName,
-                                                                           accessGroup: WPAppKeychainAccessGroup) else {
+                                                                           accessGroup: BuildSettings.appKeychainAccessGroup) else {
             debugPrint("Unable to retrieve Notification Service Extension username")
             return nil
         }
@@ -311,7 +310,7 @@ private extension NotificationService {
     func readExtensionUserID() -> String? {
         guard let userID = try? SFHFKeychainUtils.getPasswordForUsername(AppConfiguration.Extension.NotificationsService.keychainUserIDKey,
                                                                          andServiceName: AppConfiguration.Extension.NotificationsService.keychainServiceName,
-                                                                         accessGroup: WPAppKeychainAccessGroup) else {
+                                                                         accessGroup: BuildSettings.appKeychainAccessGroup) else {
             debugPrint("Unable to retrieve Notification Service Extension userID")
             return nil
         }

--- a/WordPress/WordPressShareExtension/AppExtensionsService.swift
+++ b/WordPress/WordPressShareExtension/AppExtensionsService.swift
@@ -1,4 +1,5 @@
 import Aztec
+import BuildSettingsKit
 import CoreData
 import WordPressKit
 
@@ -22,7 +23,7 @@ class AppExtensionsService {
     /// Unique identifier for background sessions
     ///
     fileprivate lazy var backgroundSessionIdentifier: String = {
-        let identifier = WPAppGroupName + "." + UUID().uuidString
+        let identifier = BuildSettings.appGroupName + "." + UUID().uuidString
         return identifier
     }()
 
@@ -39,7 +40,7 @@ class AppExtensionsService {
                             userAgent: nil,
                             backgroundUploads: false,
                             backgroundSessionIdentifier: backgroundSessionIdentifier,
-                            sharedContainerIdentifier: WPAppGroupName)
+                            sharedContainerIdentifier: BuildSettings.appGroupName)
     }()
 
     /// Backgrounding Rest API
@@ -49,13 +50,13 @@ class AppExtensionsService {
                                    userAgent: nil,
                                    backgroundUploads: true,
                                    backgroundSessionIdentifier: backgroundSessionIdentifier,
-                                   sharedContainerIdentifier: WPAppGroupName)
+                                   sharedContainerIdentifier: BuildSettings.appGroupName)
     }()
 
     /// Tracks Instance
     ///
     fileprivate lazy var tracks: Tracks = {
-        Tracks(appGroupName: WPAppGroupName)
+        Tracks(appGroupName: BuildSettings.appGroupName)
     }()
 
     /// WordPress.com Username

--- a/WordPress/WordPressShareExtension/MainShareViewController.swift
+++ b/WordPress/WordPressShareExtension/MainShareViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import BuildSettingsKit
 import WordPressShared
 import WordPressUI
 
@@ -91,7 +92,7 @@ private extension MainShareViewController {
     }
 
     func trackExtensionLaunch() {
-        let tracks = Tracks(appGroupName: WPAppGroupName)
+        let tracks = Tracks(appGroupName: BuildSettings.appGroupName)
         let oauth2Token = ShareExtensionService().retrieveShareExtensionToken()
         tracks.trackExtensionLaunched(oauth2Token != nil)
     }

--- a/WordPress/WordPressShareExtension/ShareExtensionAbstractViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionAbstractViewController.swift
@@ -1,4 +1,5 @@
 import CoreData
+import BuildSettingsKit
 import UIKit
 import WordPressKit
 
@@ -109,7 +110,7 @@ class ShareExtensionAbstractViewController: UIViewController, ShareSegueHandler 
     /// Tracks Instance
     ///
     internal lazy var tracks: Tracks = {
-        Tracks(appGroupName: WPAppGroupName)
+        Tracks(appGroupName: BuildSettings.appGroupName)
     }()
 
     // MARK: - Lifecycle Methods

--- a/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionSessionManager.swift
@@ -1,4 +1,5 @@
 import Aztec
+import BuildSettingsKit
 import CoreData
 import Foundation
 import WordPressData
@@ -241,7 +242,7 @@ import WordPressFlux
                                    userAgent: nil,
                                    backgroundUploads: false,
                                    backgroundSessionIdentifier: backgroundSessionIdentifier,
-                                   sharedContainerIdentifier: WPAppGroupName)
+                                   sharedContainerIdentifier: BuildSettings.appGroupName)
     }
 
     private func token() -> String? {

--- a/WordPress/WordPressShareExtension/ShareMediaFileManager.swift
+++ b/WordPress/WordPressShareExtension/ShareMediaFileManager.swift
@@ -1,4 +1,5 @@
 import Foundation
+import BuildSettingsKit
 
 /// Encapsulates media file operations relative to the shared container's Media directory.
 ///
@@ -12,7 +13,7 @@ import Foundation
     ///
     @objc var mediaUploadDirectoryURL: URL? {
         let fileManager = FileManager.default
-        guard let sharedContainerRootURL = fileManager.containerURL(forSecurityApplicationGroupIdentifier: WPAppGroupName) else {
+        guard let sharedContainerRootURL = fileManager.containerURL(forSecurityApplicationGroupIdentifier: BuildSettings.appGroupName) else {
             return nil
         }
         let mediaDirectoryURL = sharedContainerRootURL.appendingPathComponent(mediaDirectoryName, isDirectory: true)

--- a/WordPress/WordPressShareExtension/SharedCoreDataStack.swift
+++ b/WordPress/WordPressShareExtension/SharedCoreDataStack.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreData
+import BuildSettingsKit
 import WordPressKit
 
 /// NSPersistentContainer subclass that defaults to the shared container directory
@@ -7,7 +8,7 @@ import WordPressKit
 final class SharedPersistentContainer: NSPersistentContainer {
     internal override class func defaultDirectoryURL() -> URL {
         var url = super.defaultDirectoryURL()
-        if let newURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: WPAppGroupName) {
+        if let newURL = FileManager.default.containerURL(forSecurityApplicationGroupIdentifier: BuildSettings.appGroupName) {
             url = newURL
         }
         return url


### PR DESCRIPTION
Follow-up for https://github.com/wordpress-mobile/WordPress-iOS/pull/24214.

This PR replaces the remaining usages of `WPAppGroupName` and `WPAppKeychainAccessGroup`. I also updates `Info.plist` for `JetpackIntents`.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
