### PR TITLE
Remove unused values from Constants.h

### DIFF
--- a/WordPress/Classes/System/Constants/Constants.h
+++ b/WordPress/Classes/System/Constants/Constants.h
@@ -1,11 +1,5 @@
 #import <Foundation/Foundation.h>
 
-
-/// XMLRPC Constants
-///
-extern NSString *const WPComXMLRPCUrl;
-extern NSString *const WPComDefaultAccountUrlKey;
-
 /// WordPress URL's
 ///
 extern NSString *const WPMobileReaderURL;

--- a/WordPress/Classes/System/Constants/Constants.m
+++ b/WordPress/Classes/System/Constants/Constants.m
@@ -1,11 +1,5 @@
 #import "Constants.h"
 
-
-/// XMLRPC Constants
-///
-NSString *const WPComXMLRPCUrl                                      = @"https://wordpress.com/xmlrpc.php";
-NSString *const WPComDefaultAccountUrlKey                           = @"AccountDefaultDotcom";
-
 /// WordPress URL's
 ///
 NSString *const WPMobileReaderURL                                   = @"https://en.wordpress.com/reader/mobile/v2/?chrome=no";


### PR DESCRIPTION
These values are no longer used as the usages were removed in https://github.com/wordpress-mobile/WordPress-iOS/pull/24208.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
