### PR TITLE
Move pushNotificationAppID to BuildSettings

### DIFF
--- a/Modules/Sources/BuildSettingsKit/BuildSettings.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings.swift
@@ -6,6 +6,10 @@ import Foundation
 /// - warning: Most of these values exist only in Info.plist files for apps as
 /// app extensions only need a tiny subset of these settings.
 public enum BuildSettings {
+    public static var pushNotificationAppID: String {
+        infoPlistValue(forKey: "WPPushNotificationAppID")
+    }
+
     public static var appGroupName: String {
         infoPlistValue(forKey: "WPAppGroupName")
     }

--- a/WordPress/Classes/Services/NotificationSettingsService.swift
+++ b/WordPress/Classes/Services/NotificationSettingsService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import BuildSettingsKit
 import WordPressKit
 import WordPressShared
 
@@ -143,10 +144,12 @@ class NotificationSettingsService {
             return
         }
 
-        notificationsServiceRemote?.registerDeviceForPushNotifications(token,
-                                                                       pushNotificationAppId: AppConstants.pushNotificationAppId,
-                                                                       success: success,
-                                                                       failure: failure)
+        notificationsServiceRemote?.registerDeviceForPushNotifications(
+            token,
+            pushNotificationAppId: BuildSettings.pushNotificationAppID,
+            success: success,
+            failure: failure
+        )
     }
 
     /// Unregisters the given deviceID for Push Notification Events.

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -16,22 +16,6 @@ import WordPressKit
     @objc static let eventNamePrefix = "wpios"
     @objc static let explatPlatform = "wpios"
     @objc static let authKeychainServiceName = "public-api.wordpress.com"
-
-    /// Notifications Constants
-    ///
-    #if DEBUG
-    static let pushNotificationAppId = "org.wordpress.appstore.dev"
-    #else
-    #if INTERNAL_BUILD
-    static let pushNotificationAppId = "org.wordpress.internal"
-    #else
-    #if ALPHA_BUILD
-    static let pushNotificationAppId = "org.wordpress.alpha"
-    #else
-    static let pushNotificationAppId = "org.wordpress.appstore"
-    #endif
-    #endif
-    #endif
 }
 
 // MARK: - Localized Strings

--- a/WordPress/Info.plist
+++ b/WordPress/Info.plist
@@ -6,6 +6,8 @@
 	<string>${WP_APP_GROUP_NAME}</string>
 	<key>WPAppKeychainAccessGroup</key>
 	<string>${WP_APP_KEYCHAIN_ACCESS_GROUP}</string>
+	<key>WPPushNotificationAppID</key>
+	<string>${WP_PUSH_NOTIFICATION_APP_ID}</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>org.wordpress.bgtask.weeklyroundup</string>

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -16,22 +16,6 @@ import WordPressKit
     @objc static let eventNamePrefix = "jpios"
     @objc static let explatPlatform = "wpios"
     @objc static let authKeychainServiceName = "jetpack.public-api.wordpress.com"
-
-    /// Notifications Constants
-    ///
-    #if DEBUG
-    static let pushNotificationAppId = "com.jetpack.appstore.dev"
-    #else
-    #if INTERNAL_BUILD
-    static let pushNotificationAppId = "com.jetpack.internal"
-    #else
-    #if ALPHA_BUILD
-    static let pushNotificationAppId = "com.jetpack.alpha"
-    #else
-    static let pushNotificationAppId = "com.jetpack.appstore"
-    #endif
-    #endif
-    #endif
 }
 
 // MARK: - Localized Strings

--- a/WordPress/Jetpack/Info.plist
+++ b/WordPress/Jetpack/Info.plist
@@ -6,6 +6,8 @@
 	<string>${WP_APP_GROUP_NAME}</string>
 	<key>WPAppKeychainAccessGroup</key>
 	<string>${WP_APP_KEYCHAIN_ACCESS_GROUP}</string>
+	<key>WPPushNotificationAppID</key>
+	<string>${WP_PUSH_NOTIFICATION_APP_ID}</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>org.wordpress.bgtask.weeklyroundup</string>

--- a/config/Jetpack.alpha.xcconfig
+++ b/config/Jetpack.alpha.xcconfig
@@ -1,3 +1,4 @@
 #include "Common.enterprise.xcconfig"
 
-BUILD_SCHEME=Jetpack
+BUILD_SCHEME = Jetpack
+WP_PUSH_NOTIFICATION_APP_ID = "com.jetpack.alpha"

--- a/config/Jetpack.debug.xcconfig
+++ b/config/Jetpack.debug.xcconfig
@@ -1,3 +1,4 @@
 #include "Common.debug.xcconfig"
 
-BUILD_SCHEME=Jetpack
+BUILD_SCHEME = Jetpack
+WP_PUSH_NOTIFICATION_APP_ID = "com.jetpack.appstore.dev"

--- a/config/Jetpack.release.xcconfig
+++ b/config/Jetpack.release.xcconfig
@@ -1,1 +1,2 @@
-BUILD_SCHEME=Jetpack
+BUILD_SCHEME = Jetpack
+WP_PUSH_NOTIFICATION_APP_ID = "com.jetpack.appstore"

--- a/config/WordPress.alpha.xcconfig
+++ b/config/WordPress.alpha.xcconfig
@@ -1,4 +1,5 @@
 #include "Version.public.xcconfig"
 #include "Common.enterprise.xcconfig"
 
-BUILD_SCHEME=WordPress Alpha
+BUILD_SCHEME = WordPress Alpha
+WP_PUSH_NOTIFICATION_APP_ID = "org.wordpress.alpha"

--- a/config/WordPress.debug.xcconfig
+++ b/config/WordPress.debug.xcconfig
@@ -1,4 +1,5 @@
 #include "Version.public.xcconfig"
 #include "Common.debug.xcconfig"
 
-BUILD_SCHEME=WordPress
+BUILD_SCHEME = WordPress
+WP_PUSH_NOTIFICATION_APP_ID = "org.wordpress.appstore.dev"

--- a/config/WordPress.release.xcconfig
+++ b/config/WordPress.release.xcconfig
@@ -1,4 +1,5 @@
 #include "Version.public.xcconfig"
 #include "Common.xcconfig"
 
-BUILD_SCHEME=WordPress
+BUILD_SCHEME = WordPress
+WP_PUSH_NOTIFICATION_APP_ID = "org.wordpress.appstore"


### PR DESCRIPTION
## Changes

- Move the settings
- Remove the "internal" variants (`org.wordpress.internal`) as discussed

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
