### PR TITLE
Remove BuildConfiguration.testingOverride

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/BuildConfiguration.swift
+++ b/WordPress/Classes/Utility/BuildInformation/BuildConfiguration.swift
@@ -13,7 +13,7 @@ enum BuildConfiguration: String {
 
     static var current: BuildConfiguration {
         #if DEBUG
-            return testingOverride ?? .localDeveloper
+            return .localDeveloper
         #elseif ALPHA_BUILD
             return .a8cBranchTest
         #elseif INTERNAL_BUILD
@@ -26,16 +26,6 @@ enum BuildConfiguration: String {
     static func ~=(a: BuildConfiguration, b: Set<BuildConfiguration>) -> Bool {
         return b.contains(a)
     }
-
-    #if DEBUG
-    private static var testingOverride: BuildConfiguration?
-
-    func test(_ closure: () -> ()) {
-        BuildConfiguration.testingOverride = self
-        closure()
-        BuildConfiguration.testingOverride = nil
-    }
-    #endif
 
     var isInternal: Bool {
         self ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]

--- a/WordPress/WordPressTest/GutenbergSettingsTests.swift
+++ b/WordPress/WordPressTest/GutenbergSettingsTests.swift
@@ -56,25 +56,17 @@ class GutenbergSettingsTests: CoreDataTestCase {
     }
 
     func testGutenbergDisabledByDefaultAndToggleEnablesInSecondLaunch() {
+        let database = EphemeralKeyValueDatabase()
+        let blog = self.newTestBlog()
+        // This simulates the first launch
+        let settings = GutenbergSettings(database: database)
+        settings.setGutenbergEnabled(false, for: blog)
 
-        let testClosure: () -> () = { () in
-            let database = EphemeralKeyValueDatabase()
-            let blog = self.newTestBlog()
-            // This simulates the first launch
-            let settings = GutenbergSettings(database: database)
-            settings.setGutenbergEnabled(false, for: blog)
+        XCTAssertFalse(blog.isGutenbergEnabled)
 
-            XCTAssertFalse(blog.isGutenbergEnabled)
+        settings.setGutenbergEnabled(true, for: blog)
 
-            settings.setGutenbergEnabled(true, for: blog)
-
-            XCTAssertTrue(blog.isGutenbergEnabled)
-        }
-
-        BuildConfiguration.localDeveloper.test(testClosure)
-        BuildConfiguration.a8cBranchTest.test(testClosure)
-        BuildConfiguration.a8cPrereleaseTesting.test(testClosure)
-        BuildConfiguration.appStore.test(testClosure)
+        XCTAssertTrue(blog.isGutenbergEnabled)
     }
 
     func testGutenbergAlwaysUsedForExistingGutenbergPosts() {


### PR DESCRIPTION
It was used in a single test with the same expected output, so I decided it wasn't worth keeping. 

**Note**: I'm planning to move it to `BuildSettingsKit`. It will have a generalized system for overriding any of the global build settings (in the future).

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
