### PR TITLE
Move `WPAccount` `wordPressComRestAPI` definition to Swift

### DIFF
--- a/WordPress/Classes/Models/WPAccount+RestApi.swift
+++ b/WordPress/Classes/Models/WPAccount+RestApi.swift
@@ -11,15 +11,8 @@ extension WPAccount {
     /// This was done in the context of https://github.com/wordpress-mobile/WordPress-iOS/pull/24165 .
     @objc var wordPressComRestApi: WordPressComRestApi? {
         get {
-            if let api = objc_getAssociatedObject(self, &apiAssociatedKey) as? WordPressComRestApi {
-                return api
-            } else {
-                if authToken.isEmpty {
-                    DispatchQueue.main.async {
-                        WordPressAuthenticationManager.showSigninForWPComFixingAuthToken()
-                    }
-                    return nil
-                } else {
+            guard let api = objc_getAssociatedObject(self, &apiAssociatedKey) as? WordPressComRestApi else {
+                guard authToken.isEmpty else {
                     let api = WordPressComRestApi.defaultApi(
                         oAuthToken: authToken,
                         userAgent: WPUserAgent.defaultUserAgent(),
@@ -48,7 +41,13 @@ extension WPAccount {
 
                     return api
                 }
+
+                DispatchQueue.main.async {
+                    WordPressAuthenticationManager.showSigninForWPComFixingAuthToken()
+                }
+                return nil
             }
+            return api
         }
         set(api) {
             objc_setAssociatedObject(self, &apiAssociatedKey, api, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)

--- a/WordPress/Classes/Models/WPAccount+RestApi.swift
+++ b/WordPress/Classes/Models/WPAccount+RestApi.swift
@@ -12,4 +12,11 @@ extension WPAccount {
 
         return WordPressComRestApi.defaultApi(oAuthToken: token, userAgent: userAgent, localeKey: localeKey)
     }
+
+    /// A `WordPressRestComApi` object if a default account exists in the giveng `NSManagedObjectContext` and is a WordPress.com account.
+    /// Otherwise, it returns `nil`
+    static func defaultWordPressComAccountRestAPI(in context: NSManagedObjectContext) throws -> WordPressComRestApi? {
+        let account = try WPAccount.lookupDefaultWordPressComAccount(in: context)
+        return account?.wordPressComRestApi
+    }
 }

--- a/WordPress/Classes/Models/WPAccount+RestApi.swift
+++ b/WordPress/Classes/Models/WPAccount+RestApi.swift
@@ -2,6 +2,59 @@ import WordPressKit
 import WordPressShared
 
 extension WPAccount {
+
+    /// A `WordPressRestComApi` object if the account is a WordPress.com account. Otherwise, `nil`.
+    ///
+    /// Warning: The getter has various side effects when there is no previous value set, including triggering the signup flow!
+    ///
+    /// This used to be defined in the Objective-C layer, but we moved it here in a Swift extension in an attempt to decouple the model code from it.
+    /// This was done in the context of https://github.com/wordpress-mobile/WordPress-iOS/pull/24165 .
+    @objc var wordPressComRestApi: WordPressComRestApi? {
+        get {
+            if let api = objc_getAssociatedObject(self, &apiAssociatedKey) as? WordPressComRestApi {
+                return api
+            } else {
+                if authToken.isEmpty {
+                    DispatchQueue.main.async {
+                        WordPressAuthenticationManager.showSigninForWPComFixingAuthToken()
+                    }
+                    return nil
+                } else {
+                    let api = WordPressComRestApi.defaultApi(
+                        oAuthToken: authToken,
+                        userAgent: WPUserAgent.defaultUserAgent(),
+                        localeKey: WordPressComRestApi.LocaleKeyDefault
+                    )
+
+                    api.setInvalidTokenHandler { [weak self] in
+                        guard let self else { return }
+
+                        self.authToken = nil
+                        WordPressAuthenticationManager.showSigninForWPComFixingAuthToken()
+
+                        guard self.isDefaultWordPressComAccount else { return }
+
+                        // At the time of writing, there is an implicit assumption on what the object parameter value means.
+                        // For example, the WordPressAppDelegate.handleDefaultAccountChangedNotification(_:) subscriber inspects the object parameter to decide whether the notification was sent as a result of a login.
+                        // If the object is non-nil, then the method considers the source a login.
+                        //
+                        // The code path in which we are is that of an invalid token, and that's neither a login nor a logout, it's more appropriate to consider it a logout.
+                        // That's because if the token is invalid the app will soon received errors from the API and it's therefore better to force the user to login again.
+                        NotificationCenter.default.post(
+                            name: NSNotification.Name.WPAccountDefaultWordPressComAccountChanged,
+                            object: nil
+                        )
+                    }
+
+                    return api
+                }
+            }
+        }
+        set(api) {
+            objc_setAssociatedObject(self, &apiAssociatedKey, api, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        }
+    }
+
     /// Returns an instance of the WPCOM REST API suitable for v2 endpoints.
     /// If the user is not authenticated, this will be anonymous.
     ///
@@ -19,4 +72,7 @@ extension WPAccount {
         let account = try WPAccount.lookupDefaultWordPressComAccount(in: context)
         return account?.wordPressComRestApi
     }
+
 }
+
+private var apiAssociatedKey: UInt8 = 0

--- a/WordPress/Classes/Models/WPAccount+RestApi.swift
+++ b/WordPress/Classes/Models/WPAccount+RestApi.swift
@@ -1,6 +1,5 @@
-import Foundation
-import WordPressShared
 import WordPressKit
+import WordPressShared
 
 extension WPAccount {
     /// Returns an instance of the WPCOM REST API suitable for v2 endpoints.

--- a/WordPress/Classes/Models/WPAccount.h
+++ b/WordPress/Classes/Models/WPAccount.h
@@ -34,10 +34,12 @@
 /// @name API Helpers
 ///------------------
 
-/**
- A WordPressRestComApi object if the account is a WordPress.com account. Otherwise, it returns `nil`
- */
-@property (nonatomic, readonly) WordPressComRestApi *wordPressComRestApi;
+/// A WordPressRestComApi object if the account is a WordPress.com account. Otherwise, it returns `nil`.
+///
+/// Important: Do not set this directly!
+///
+/// It's reserved for Objective-C to Swift interoperability in the context of separating this model from the app target and will be removed at some point.
+@property (nonatomic, strong) WordPressComRestApi *wordPressComRestApi;
 
 @end
 

--- a/WordPress/Classes/Services/PostServiceRemoteFactory.swift
+++ b/WordPress/Classes/Services/PostServiceRemoteFactory.swift
@@ -34,8 +34,7 @@ import WordPressShared
     /// - Returns: an instance of WordPressComRestApi
     private func apiForRESTRequest(using context: NSManagedObjectContext) -> WordPressComRestApi? {
 
-        guard let account = try? WPAccount.lookupDefaultWordPressComAccount(in: context),
-              let api = account.wordPressComRestApi else {
+        guard let api = try? WPAccount.defaultWordPressComAccountRestAPI(in: context) else {
             return nil
         }
 

--- a/WordPress/Classes/Services/PushAuthenticationService.swift
+++ b/WordPress/Classes/Services/PushAuthenticationService.swift
@@ -47,7 +47,7 @@ class PushAuthenticationService {
 
         var api: WordPressComRestApi? = nil
 
-        if let unwrappedRestApi = (try? WPAccount.lookupDefaultWordPressComAccount(in: context))?.wordPressComRestApi {
+        if let unwrappedRestApi = (try? WPAccount.defaultWordPressComAccountRestAPI(in: context)) {
             if unwrappedRestApi.hasCredentials() {
                 api = unwrappedRestApi
             }

--- a/WordPress/Classes/Services/ReaderSiteSearchService.swift
+++ b/WordPress/Classes/Services/ReaderSiteSearchService.swift
@@ -13,8 +13,7 @@ typealias ReaderSiteSearchFailureBlock = (_ error: Error?) -> Void
 
     private func apiRequest() -> WordPressComRestApi {
         let api = coreDataStack.performQuery {
-            let defaultAccount = try? WPAccount.lookupDefaultWordPressComAccount(in: $0)
-            return defaultAccount?.wordPressComRestApi
+            try? WPAccount.defaultWordPressComAccountRestAPI(in: $0)
         }
 
         if let api, api.hasCredentials() {

--- a/WordPress/Classes/Services/ReaderSiteService.swift
+++ b/WordPress/Classes/Services/ReaderSiteService.swift
@@ -10,8 +10,7 @@ import Foundation
     ///   - failure: Closure called when the request fails.
     func flagSite(withID id: NSNumber, asBlocked blocked: Bool, success: (() -> Void)? = nil, failure: ((Error?) -> Void)? = nil) {
         let queryResult: (NSNumber, WordPressComRestApi)? = self.coreDataStack.performQuery({
-            guard
-                let defaultAccount = try? WPAccount.lookupDefaultWordPressComAccount(in: $0),
+            guard let defaultAccount = try? WPAccount.lookupDefaultWordPressComAccount(in: $0),
                 let api = defaultAccount.wordPressComRestApi,
                 api.hasCredentials()
             else {

--- a/WordPress/Classes/Services/ReaderTopicService+Subscriptions.swift
+++ b/WordPress/Classes/Services/ReaderTopicService+Subscriptions.swift
@@ -14,7 +14,7 @@ extension ReaderTopicService {
 
     private func apiRequest() -> WordPressComRestApi {
         let api = coreDataStack.performQuery { context in
-            try? WPAccount.lookupDefaultWordPressComAccount(in: context)?.wordPressComRestApi
+            try? WPAccount.defaultWordPressComAccountRestAPI(in: context)
         }
         if let api, api.hasCredentials() {
             return api

--- a/WordPress/Classes/Services/SiteSuggestionService.swift
+++ b/WordPress/Classes/Services/SiteSuggestionService.swift
@@ -71,7 +71,7 @@ class SiteSuggestionService {
         // add this blog to currently being requested list
         blogsCurrentlyBeingRequested.append(blogId)
 
-        defaultAccount()?.wordPressComRestApi.GET(suggestPath, parameters: params, success: { [weak self] responseObject, httpResponse in
+        defaultAccount()?.wordPressComRestApi?.GET(suggestPath, parameters: params, success: { [weak self] responseObject, httpResponse in
             guard let `self` = self else { return }
 
             let context = ContextManager.shared.mainContext

--- a/WordPress/Classes/Services/SuggestionService.swift
+++ b/WordPress/Classes/Services/SuggestionService.swift
@@ -54,7 +54,7 @@ class SuggestionService {
         // add this blog to currently being requested list
         blogsCurrentlyBeingRequested.append(blogId)
 
-        defaultAccount()?.wordPressComRestApi.GET(suggestPath, parameters: params, success: { [weak self] responseObject, httpResponse in
+        defaultAccount()?.wordPressComRestApi?.GET(suggestPath, parameters: params, success: { [weak self] responseObject, httpResponse in
             guard let `self` = self else { return }
             guard let payload = responseObject as? [String: Any] else { return }
             guard let restSuggestions = payload["suggestions"] as? [[String: Any]] else { return }

--- a/WordPress/WordPressTest/MediaServiceUpdateTests.m
+++ b/WordPress/WordPressTest/MediaServiceUpdateTests.m
@@ -5,11 +5,6 @@
 @import WordPressKit;
 @import OCMock;
 
-// Redefine `WPAccount` to make `wordPressComRestApi` writable.
-@interface WPAccount ()
-@property (nonatomic, readwrite) WordPressComRestApi *wordPressComRestApi;
-@end
-
 // Re-implement `MediaService` to mock the remote service `MediaServiceRemote`.
 @interface MediaServiceForStubbing : MediaService
 @property (nonatomic, strong) MediaServiceRemoteREST *remoteForStubbing;

--- a/WordPress/WordPressTest/MenusServiceTests.m
+++ b/WordPress/WordPressTest/MenusServiceTests.m
@@ -8,10 +8,6 @@
 
 @import OCMock;
 
-@interface WPAccount ()
-@property (nonatomic, readwrite) WordPressComRestApi *wordPressComRestApi;
-@end
-
 @interface MenusServiceTests : XCTestCase
 @property (nonatomic, strong) id<CoreDataStack> manager;
 @end

--- a/WordPress/WordPressTest/PostCategoryServiceTests.m
+++ b/WordPress/WordPressTest/PostCategoryServiceTests.m
@@ -7,10 +7,6 @@
 @import WordPressKit;
 @import OCMock;
 
-@interface WPAccount ()
-@property (nonatomic, readwrite) WordPressComRestApi *wordPressComRestApi;
-@end
-
 @interface PostCategoryServiceForStubbing : PostCategoryService
 
 @property (nonatomic, strong) TaxonomyServiceRemoteREST *remoteForStubbing;

--- a/WordPress/WordPressTest/PostTagServiceTests.m
+++ b/WordPress/WordPressTest/PostTagServiceTests.m
@@ -13,10 +13,6 @@
 
 @end
 
-@interface WPAccount ()
-@property (nonatomic, readwrite) WordPressComRestApi *wordPressComRestApi;
-@end
-
 @implementation PostTagServiceForStubbing
 
 - (id <TaxonomyServiceRemote>)remoteForBlog:(Blog *)blog

--- a/WordPress/WordPressTest/ThemeServiceTests.m
+++ b/WordPress/WordPressTest/ThemeServiceTests.m
@@ -10,10 +10,6 @@
 
 #pragma mark - Support classes
 
-@interface WPAccount ()
-@property (nonatomic, readwrite) WordPressComRestApi *wordPressComRestApi;
-@end
-
 #pragma mark - Tests
 
 @interface ThemeServiceTests : XCTestCase

--- a/WordPress/WordPressTest/WPAccount+LookupTests.swift
+++ b/WordPress/WordPressTest/WPAccount+LookupTests.swift
@@ -96,6 +96,15 @@ class WPAccountLookupTests: CoreDataTestCase {
         try XCTAssertEqual(WPAccount.lookupNumberOfAccounts(in: contextManager.mainContext), 3)
     }
 
+    // MARK: - Default account WordPress.com REST API
+
+    func testNoAPIWhenNoDefaultAccount() throws {
+        makeAccount()
+        try XCTAssertNil(WPAccount.defaultWordPressComAccountRestAPI(in: contextManager.mainContext))
+    }
+
+    // MARK: -
+
     @discardableResult
     func makeAccount(_ additionalSetup: (AccountBuilder) -> (AccountBuilder) = { $0 }) -> WPAccount {
         additionalSetup(AccountBuilder(contextManager.mainContext)).build()


### PR DESCRIPTION
Part of #24165.

Following up on a suggestion by @kean internally, ref p1741953158905339-slack-C08HQR4C2TS, this PR splits the definition of the `wordPressComRestAPI` property in `WPAccount` from its implementation between the Objective-C and Swift layer in an attempt to allow moving `WPAccount` away from the app target(s) and into WordPressData.

The unit tests are green, which is encouraging.

I also tested this on device via Jetpack.