### PR TITLE
Remove knowledge of `AppConfiguration` from `WPAccount` Objective-C

### DIFF
--- a/WordPress/Classes/Models/WPAccount+Lookup.swift
+++ b/WordPress/Classes/Models/WPAccount+Lookup.swift
@@ -15,6 +15,13 @@ public extension WPAccount {
         return self.uuid == uuid
     }
 
+    // This is here in an extension that belongs to the apps target so we can decouple WPAccount from AppConfiguration.
+    // Decoupling allows moving the type to WordPressData, see https://github.com/wordpress-mobile/WordPress-iOS/issues/24165.
+    @objc
+    static func tokenForUsername(_ username: String) -> String {
+        token(forUsername: username, isJetpack: AppConfiguration.isJetpack)
+    }
+
     /// Does this `WPAccount` object have any associated blogs?
     ///
     @objc

--- a/WordPress/Classes/Models/WPAccount+Lookup.swift
+++ b/WordPress/Classes/Models/WPAccount+Lookup.swift
@@ -18,7 +18,7 @@ public extension WPAccount {
     // This is here in an extension that belongs to the apps target so we can decouple WPAccount from AppConfiguration.
     // Decoupling allows moving the type to WordPressData, see https://github.com/wordpress-mobile/WordPress-iOS/issues/24165.
     @objc
-    static func tokenForUsername(_ username: String) -> String {
+    static func tokenForUsername(_ username: String) -> String? {
         token(forUsername: username, isJetpack: AppConfiguration.isJetpack)
     }
 

--- a/WordPress/Classes/Models/WPAccount.h
+++ b/WordPress/Classes/Models/WPAccount.h
@@ -49,7 +49,7 @@
 - (void)removeBlogsObject:(Blog *)value;
 - (void)addBlogs:(NSSet *)values;
 - (void)removeBlogs:(NSSet *)values;
-+ (NSString *)tokenForUsername:(NSString *)username;
++ (NSString *)tokenForUsername:(NSString *)username isJetpack:(BOOL)isJetpack;
 - (BOOL)hasAtomicSite;
 
 @end

--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -128,10 +128,13 @@
 
 #pragma mark - Static methods
 
-+ (NSString *)tokenForUsername:(NSString *)username
++ (NSString *)tokenForUsername:(NSString *)username isJetpack:(BOOL)isJetpack
 {
+    if (isJetpack) {
+        [WPAccount migrateAuthKeyForUsername:username];
+    }
+
     NSError *error = nil;
-    [WPAccount migrateAuthKeyForUsername:username];
     NSString *authToken = [SFHFKeychainUtils getPasswordForUsername:username
                                                      andServiceName:[WPAccount authKeychainServiceName]
                                                         accessGroup:nil
@@ -147,10 +150,8 @@
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        if ([AppConfiguration isJetpack]) {
-            SharedDataIssueSolver *sharedDataIssueSolver = [SharedDataIssueSolver instance];
-            [sharedDataIssueSolver migrateAuthKeyFor:username];
-        }
+        SharedDataIssueSolver *sharedDataIssueSolver = [SharedDataIssueSolver instance];
+        [sharedDataIssueSolver migrateAuthKeyFor:username];
     });
 }
 


### PR DESCRIPTION
Part of #24165.

Similarly to https://github.com/wordpress-mobile/WordPress-iOS/pull/24230 , pushing knowledge of app-target-related types out of `WPAccount` helps us cutting all the threads that prevent the type from being moved out of the app target and into WordPressData.

Tested by running on WordPress on device and smoke testing.