### PR TITLE
Remove remaining internal build references

### DIFF
--- a/WordPress/Classes/Services/Page Layouts/PageLayoutService.swift
+++ b/WordPress/Classes/Services/Page Layouts/PageLayoutService.swift
@@ -64,7 +64,7 @@ class PageLayoutService {
     }
 
     private static let supportedBlocks: String = {
-        let isDevMode = BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+        let isDevMode = BuildConfiguration.current ~= [.localDeveloper, .alpha]
         return Gutenberg.supportedBlocks(isDev: isDevMode).joined(separator: ",")
     }()
 
@@ -73,7 +73,7 @@ class PageLayoutService {
     private static let type = "mobile"
 
     // Return "true" or "false" for isBeta that gets passed into the endpoint.
-    private static let isBeta = String(BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest])
+    private static let isBeta = String(BuildConfiguration.current ~= [.localDeveloper, .alpha])
 
 }
 

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -543,7 +543,7 @@ extension WordPressAppDelegate {
     /// Otherwise an anonymous remote will be used
     func updateFeatureFlags(authToken: String? = nil, completion: (() -> Void)? = nil) {
         // Enable certain feature flags on test builds.
-        if BuildConfiguration.current ~= [.a8cPrereleaseTesting, .a8cBranchTest, .localDeveloper] {
+        if BuildConfiguration.current ~= [.a8cBranchTest, .localDeveloper] {
             FeatureFlagOverrideStore().override(RemoteFeatureFlag.dotComWebLogin, withValue: true)
         }
 

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -543,7 +543,7 @@ extension WordPressAppDelegate {
     /// Otherwise an anonymous remote will be used
     func updateFeatureFlags(authToken: String? = nil, completion: (() -> Void)? = nil) {
         // Enable certain feature flags on test builds.
-        if BuildConfiguration.current ~= [.a8cBranchTest, .localDeveloper] {
+        if BuildConfiguration.current ~= [.alpha, .localDeveloper] {
             FeatureFlagOverrideStore().override(RemoteFeatureFlag.dotComWebLogin, withValue: true)
         }
 

--- a/WordPress/Classes/Utility/BuildInformation/BuildConfiguration.swift
+++ b/WordPress/Classes/Utility/BuildInformation/BuildConfiguration.swift
@@ -16,8 +16,6 @@ enum BuildConfiguration: String {
             return .localDeveloper
         #elseif ALPHA_BUILD
             return .a8cBranchTest
-        #elseif INTERNAL_BUILD
-            return .a8cPrereleaseTesting
         #else
             return .appStore
         #endif

--- a/WordPress/Classes/Utility/BuildInformation/BuildConfiguration.swift
+++ b/WordPress/Classes/Utility/BuildInformation/BuildConfiguration.swift
@@ -1,18 +1,18 @@
 enum BuildConfiguration: String {
-    /// Development build, usually run from Xcode
+    /// Development build, usually run from Xcode.
     case localDeveloper
 
-    /// Continuous integration builds for Automattic employees to test branches & PRs
-    case a8cBranchTest
+    /// Preproduction builds for Automattic employees.
+    case alpha
 
-    /// Production build released in the app store
+    /// Production build released in the app store.
     case appStore
 
     static var current: BuildConfiguration {
         #if DEBUG
             return .localDeveloper
         #elseif ALPHA_BUILD
-            return .a8cBranchTest
+            return .alpha
         #else
             return .appStore
         #endif
@@ -23,6 +23,6 @@ enum BuildConfiguration: String {
     }
 
     var isInternal: Bool {
-        self ~= [.localDeveloper, .a8cBranchTest]
+        self ~= [.localDeveloper, .alpha]
     }
 }

--- a/WordPress/Classes/Utility/BuildInformation/BuildConfiguration.swift
+++ b/WordPress/Classes/Utility/BuildInformation/BuildConfiguration.swift
@@ -5,9 +5,6 @@ enum BuildConfiguration: String {
     /// Continuous integration builds for Automattic employees to test branches & PRs
     case a8cBranchTest
 
-    /// Beta released internally for Automattic employees
-    case a8cPrereleaseTesting
-
     /// Production build released in the app store
     case appStore
 
@@ -26,6 +23,6 @@ enum BuildConfiguration: String {
     }
 
     var isInternal: Bool {
-        self ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
+        self ~= [.localDeveloper, .a8cBranchTest]
     }
 }

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -62,7 +62,7 @@ enum FeatureFlag: Int, CaseIterable {
         case .googleDomainsCard:
             return false
         case .voiceToContent:
-            return AppConfiguration.isJetpack && BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return AppConfiguration.isJetpack && BuildConfiguration.current ~= [.localDeveloper, .alpha]
         case .authenticateUsingApplicationPassword:
             return false
         case .newGutenberg:

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -83,7 +83,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .inAppUpdates:
             return false
         case .gravatarQuickEditor:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
+            return BuildConfiguration.current ~= [.localDeveloper, .alpha]
         case .dotComWebLogin:
             return false
         }

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -83,7 +83,7 @@ enum RemoteFeatureFlag: Int, CaseIterable {
         case .inAppUpdates:
             return false
         case .gravatarQuickEditor:
-            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest, .a8cPrereleaseTesting]
+            return BuildConfiguration.current ~= [.localDeveloper, .a8cBranchTest]
         case .dotComWebLogin:
             return false
         }

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackRedirector.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackRedirector.swift
@@ -14,8 +14,6 @@ class JetpackRedirector {
         return "jpdebug"
         #elseif ALPHA_BUILD
         return "jpalpha"
-        #elseif INTERNAL_BUILD
-        return "jpinternal"
         #else
         return "jetpack"
         #endif

--- a/WordPress/Classes/ViewRelated/NUX/Helpers/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Helpers/WordPressAuthenticationManager.swift
@@ -58,7 +58,7 @@ extension WordPressAuthenticationManager {
     private func authenticatorConfiguation() -> WordPressAuthenticatorConfiguration {
         // SIWA can not be enabled for internal builds
         // Ref https://github.com/wordpress-mobile/WordPress-iOS/pull/12332#issuecomment-521994963
-        let enableSignInWithApple = !(BuildConfiguration.current ~= [.a8cBranchTest])
+        let enableSignInWithApple = !(BuildConfiguration.current ~= [.alpha])
 
         return WordPressAuthenticatorConfiguration(
             wpcomClientId: ApiCredentials.client,

--- a/WordPress/Classes/ViewRelated/NUX/Helpers/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Helpers/WordPressAuthenticationManager.swift
@@ -58,7 +58,7 @@ extension WordPressAuthenticationManager {
     private func authenticatorConfiguation() -> WordPressAuthenticatorConfiguration {
         // SIWA can not be enabled for internal builds
         // Ref https://github.com/wordpress-mobile/WordPress-iOS/pull/12332#issuecomment-521994963
-        let enableSignInWithApple = !(BuildConfiguration.current ~= [.a8cBranchTest, .a8cPrereleaseTesting])
+        let enableSignInWithApple = !(BuildConfiguration.current ~= [.a8cBranchTest])
 
         return WordPressAuthenticatorConfiguration(
             wpcomClientId: ApiCredentials.client,

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -11218,7 +11218,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_SWIFT_FLAGS = "$(inherited) -D ALPHA_BUILD -D INTERNAL_BUILD";
+				OTHER_SWIFT_FLAGS = "$(inherited) -D ALPHA_BUILD";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jetpack.alpha.JetpackShare;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match InHouse com.jetpack.alpha.JetpackShare";
@@ -11766,7 +11766,7 @@
 					"-l\"sqlite3.0\"",
 					"-l\"z\"",
 				);
-				OTHER_SWIFT_FLAGS = "$(inherited) -D ALPHA_BUILD -D INTERNAL_BUILD";
+				OTHER_SWIFT_FLAGS = "$(inherited) -D ALPHA_BUILD";
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.alpha;
 				PRODUCT_NAME = WordPress;
 				PROVISIONING_PROFILE_SPECIFIER = "match InHouse org.wordpress.alpha";
@@ -12008,7 +12008,7 @@
 					"@executable_path/../../Frameworks",
 				);
 				MTL_ENABLE_DEBUG_INFO = NO;
-				OTHER_SWIFT_FLAGS = "$(inherited) -D ALPHA_BUILD -D INTERNAL_BUILD";
+				OTHER_SWIFT_FLAGS = "$(inherited) -D ALPHA_BUILD";
 				PRODUCT_BUNDLE_IDENTIFIER = org.wordpress.alpha.WordPressShare;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match InHouse org.wordpress.alpha.WordPressShare";
@@ -12548,7 +12548,7 @@
 					"-l\"sqlite3.0\"",
 					"-l\"z\"",
 				);
-				OTHER_SWIFT_FLAGS = "$(inherited) -D ALPHA_BUILD -D INTERNAL_BUILD";
+				OTHER_SWIFT_FLAGS = "$(inherited) -D ALPHA_BUILD";
 				PRODUCT_BUNDLE_IDENTIFIER = com.jetpack.alpha;
 				PRODUCT_MODULE_NAME = WordPress;
 				PRODUCT_NAME = "$(TARGET_NAME)";


### PR DESCRIPTION
## Changes

- Remove now unused `INTERNAL_BUILD` compiler flag
- Consolidate `.a8cBranchTest` and `.a8cPrereleaseTesting` cases into a single `.alpha` case for all pre-production builds

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
