### PR TITLE
Move `URL` helpers to WordPressShared

### DIFF
--- a/Modules/Sources/WordPressShared/URL+Helpers.swift
+++ b/Modules/Sources/WordPressShared/URL+Helpers.swift
@@ -2,10 +2,10 @@ import Foundation
 import MobileCoreServices
 import UniformTypeIdentifiers
 
-extension URL {
+public extension URL {
 
     struct Helpers {
-        static func temporaryFile(named name: String = UUID().uuidString) -> URL {
+        public static func temporaryFile(named name: String = UUID().uuidString) -> URL {
             if #available(iOS 16.0, *) {
                 return URL.temporaryDirectory.appending(path: name)
             } else {
@@ -13,7 +13,7 @@ extension URL {
             }
         }
 
-        static func temporaryDirectory(named name: String) -> URL {
+        public static func temporaryDirectory(named name: String) -> URL {
             if #available(iOS 16.0, *) {
                 return URL.temporaryDirectory.appending(path: name, directoryHint: .isDirectory)
             } else {
@@ -106,7 +106,7 @@ extension URL {
     }
 }
 
-extension NSURL {
+public extension NSURL {
     @objc var isVideo: Bool {
         return (self as URL).isVideo
     }
@@ -120,7 +120,7 @@ extension NSURL {
 
 }
 
-extension URL {
+public extension URL {
     /// Appends query items to the URL.
     /// - Parameter newQueryItems: The new query items to add to the URL. These will **not** overwrite any existing items but are appended to the existing list.
     /// - Returns: The URL with added query items.
@@ -134,7 +134,7 @@ extension URL {
 
     /// Gravatar doesn't support "Cache-Control: none" header. So we add a random query parameter to
     /// bypass the backend cache and get the latest image.
-    public func appendingGravatarCacheBusterParam() -> URL {
+    func appendingGravatarCacheBusterParam() -> URL {
         var urlComponents = URLComponents(url: self, resolvingAgainstBaseURL: false)
         if urlComponents?.queryItems == nil {
             urlComponents?.queryItems = []

--- a/WordPress/Classes/Categories/Media+Extensions.m
+++ b/WordPress/Classes/Categories/Media+Extensions.m
@@ -2,6 +2,7 @@
 #import "MediaService.h"
 #import "Blog.h"
 @import WordPressDataObjC;
+@import WordPressShared;
 #import "WordPress-Swift.h"
 
 @implementation Media (Extensions)

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -3,6 +3,7 @@
 #import "Media.h"
 #import "WPAccount.h"
 @import WordPressDataObjC;
+@import WordPressShared;
 #import "Blog.h"
 #import <MobileCoreServices/MobileCoreServices.h>
 #import "WordPress-Swift.h"

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3289,7 +3289,6 @@
 			membershipExceptions = (
 				"Extensions/String+Helpers.swift",
 				"Extensions/UIImage+Extensions.swift",
-				"Extensions/URL+Helpers.swift",
 				"Utility/App Configuration/AppConfiguration.swift",
 				"Utility/App Configuration/ExtensionConfiguration.swift",
 				Utility/BuildInformation/BuildConfiguration.swift,
@@ -3391,7 +3390,6 @@
 			membershipExceptions = (
 				"Extensions/String+Helpers.swift",
 				"Extensions/UIImage+Extensions.swift",
-				"Extensions/URL+Helpers.swift",
 				Utility/BuildInformation/BuildConfiguration.swift,
 				Utility/FormattableContent/Actions/DefaultFormattableContentAction.swift,
 				Utility/FormattableContent/Actions/FormattableContentAction.swift,


### PR DESCRIPTION
I run into one of the computed variables added to `URL` as part of
 #24165 when trying to move something related to `Media`.

Moving to WordPressShared allows using the helpers in multiple modules and is a nice little standalone change that we can lock in already.
