### PR TITLE
Fix #21473: Do not show the login screen if the user is already logged in

### DIFF
--- a/WordPress/Classes/System/Root View/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/Root View/SplitViewRootPresenter.swift
@@ -199,8 +199,9 @@ final class SplitViewRootPresenter: RootViewPresenter {
 
         if let newSite = Blog.lastUsedOrFirst(in: ContextManager.shared.mainContext) {
             self.sidebarViewModel.selection = .blog(TaggedManagedObjectID(newSite))
-        } else {
+        } else if AccountHelper.isDotcomAvailable() {
             self.sidebarViewModel.selection = .welcome
+        } else {
             WordPressAppDelegate.shared?.windowManager.showSignInUI()
         }
     }


### PR DESCRIPTION
Fixes #21473

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
