### PR TITLE
Sync blogs upon launch

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/MediaEditor-iOS", branch: "task/spm-support"),
         .package(url: "https://github.com/wordpress-mobile/NSObject-SafeExpectations", from: "0.0.6"),
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", branch: "trunk"),
-        .package(url: "https://github.com/wordpress-mobile/WordPressKit-iOS", branch: "me-sites-exclude-deleted"),
+        .package(url: "https://github.com/wordpress-mobile/WordPressKit-iOS", branch: "wpios-edition"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250127"),

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -46,7 +46,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/MediaEditor-iOS", branch: "task/spm-support"),
         .package(url: "https://github.com/wordpress-mobile/NSObject-SafeExpectations", from: "0.0.6"),
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", branch: "trunk"),
-        .package(url: "https://github.com/wordpress-mobile/WordPressKit-iOS", branch: "wpios-edition"),
+        .package(url: "https://github.com/wordpress-mobile/WordPressKit-iOS", branch: "me-sites-exclude-deleted"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250127"),

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b048f2348f14b6f12b4a4b8588355abe499af3f8f4e91cacc054e98187a7746c",
+  "originHash" : "b637515cdb9c1c25894b401b59b20ad56c195cd52aa6bee2ada1b56cd753ece8",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -392,7 +392,7 @@
       "location" : "https://github.com/wordpress-mobile/WordPressKit-iOS",
       "state" : {
         "branch" : "wpios-edition",
-        "revision" : "ba542bae62a1d9b80b0baee44d610bfac55936ea"
+        "revision" : "554d3ef682af4cfd7888e33658789df48b67c408"
       }
     },
     {

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -135,6 +135,10 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
             WKWebView.warmup()
         }
 
+        if let account = try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext) {
+            BlogService(coreDataStack: ContextManager.shared).syncBlogs(for: account, success: { /* Do nothing */ }, failure: { _ in /* Do nothing */ })
+        }
+
         return true
     }
 

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -136,7 +136,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
         }
 
         if let account = try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext) {
-            BlogService(coreDataStack: ContextManager.shared).syncBlogs(for: account, success: { /* Do nothing */ }, failure: { _ in /* Do nothing */ })
+            BlogSyncFacade().syncBlogs(for: account, success: { /* Do nothing */ }, failure: { _ in /* Do nothing */ })
         }
 
         return true


### PR DESCRIPTION
This PR fixes two issues.

The first issue is the app does not sync blogs upon launch. That means the app continues to show the welcome screen after the user creates a new site from WordPress.com.

The second issue is #23344, which is the reverse: if the user deletes a site from WordPress.com, the app should not show the deleted site. Requires https://github.com/wordpress-mobile/WordPressKit-iOS/pull/833.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
