### PR TITLE
Move `JSONDecoderExtension` utils to WordPressShared

### DIFF
--- a/Modules/Sources/WordPressShared/Utility/JSONDecoderExtension.swift
+++ b/Modules/Sources/WordPressShared/Utility/JSONDecoderExtension.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension JSONDecoder.DateDecodingStrategy {
+public extension JSONDecoder.DateDecodingStrategy {
     static var supportMultipleDateFormats: JSONDecoder.DateDecodingStrategy {
         return JSONDecoder.DateDecodingStrategy.custom({ (decoder) -> Date in
             let container = try decoder.singleValueContainer()


### PR DESCRIPTION
Part of #24165.

Nothing to add to what the title says 😄 