### PR TITLE
Ignore an Objective-C exception

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -100,8 +100,13 @@ class MySitesCoordinator: NSObject {
     }
 
     @objc func signinDidFinish() {
-        mySiteViewController = makeMySiteViewController()
-        navigationController.viewControllers = [rootContentViewController]
+        // The code below raises an exception during unit tests. Adding a `try?` to ignore the error.
+        // The exception is Error Domain=NSRangeException Code=0 "(null)". I'm not exactly sure what code (probably
+        // deep in UIKit) throws this exception, but I don't see any reason the code below would cause crash in production.
+        try? WPException.objcTry {
+            self.mySiteViewController = self.makeMySiteViewController()
+            self.navigationController.viewControllers = [self.rootContentViewController]
+        }
     }
 
     func displayJetpackOverlayForDisabledEntryPoint() {


### PR DESCRIPTION
Fixes #24247.

See the inline code comment for details.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
