### PR TITLE
Add `NO_ESCAPE` to the block argument in objcTry

### DIFF
--- a/Modules/Sources/WordPressSharedObjC/Utility/WPException.m
+++ b/Modules/Sources/WordPressSharedObjC/Utility/WPException.m
@@ -2,7 +2,7 @@
 
 @implementation WPException
 
-+ (BOOL)objcTryBlock:(void (^)(void))block error:(NSError * __autoreleasing *)outError;
++ (BOOL)objcTryBlock:(void (NS_NOESCAPE ^)(void))block error:(NSError * __autoreleasing *)outError;
 {
     @try {
         if (block) {

--- a/Modules/Sources/WordPressSharedObjC/include/WPException.h
+++ b/Modules/Sources/WordPressSharedObjC/include/WPException.h
@@ -11,7 +11,7 @@ NS_ASSUME_NONNULL_BEGIN
  @param outError If an exception is raised this variable returns the an error that wraps the exception.
  @return return true if no exception is raised and false otherwise.
  */
-+ (BOOL)objcTryBlock:(void (^)(void))block error:(NSError * __autoreleasing *)outError;
++ (BOOL)objcTryBlock:(void (NS_NOESCAPE ^)(void))block error:(NSError * __autoreleasing *)outError;
 
 @end
 


### PR DESCRIPTION
This change would make the Swift closure a non-`@escaping` closure, so we don't have to add `self.` in it.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
