### PR TITLE
Remove TracksConfiguration

### DIFF
--- a/Modules/Sources/BuildSettingsKit/BuildSettings+Live.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings+Live.swift
@@ -7,7 +7,8 @@ extension BuildSettings {
         pushNotificationAppID = bundle.infoValue(forKey: "WPPushNotificationAppID")
         appGroupName = bundle.infoValue(forKey: "WPAppGroupName")
         appKeychainAccessGroup = bundle.infoValue(forKey: "WPAppKeychainAccessGroup")
-        tracksEventNamePrefix = bundle.infoValue(forKey: "WPTracksEventNamePrefix")
+        eventNamePrefix = bundle.infoValue(forKey: "WPEventNamePrefix")
+        explatPlatform = bundle.infoValue(forKey: "WPExplatPlatform")
     }
 }
 

--- a/Modules/Sources/BuildSettingsKit/BuildSettings+Live.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings+Live.swift
@@ -7,6 +7,7 @@ extension BuildSettings {
         pushNotificationAppID = bundle.infoValue(forKey: "WPPushNotificationAppID")
         appGroupName = bundle.infoValue(forKey: "WPAppGroupName")
         appKeychainAccessGroup = bundle.infoValue(forKey: "WPAppKeychainAccessGroup")
+        tracksEventNamePrefix = bundle.infoValue(forKey: "WPTracksEventNamePrefix")
     }
 }
 

--- a/Modules/Sources/BuildSettingsKit/BuildSettings+Preview.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings+Preview.swift
@@ -5,7 +5,8 @@ extension BuildSettings {
     nonisolated(unsafe) static var preview = BuildSettings(
         pushNotificationAppID: "xcpreview_push_notification_id",
         appGroupName: "xcpreview_app_group_name",
-        appKeychainAccessGroup: "xcpreview_app_keychain_access_group"
+        appKeychainAccessGroup: "xcpreview_app_keychain_access_group",
+        tracksEventNamePrefix: "xcpreview"
     )
 }
 

--- a/Modules/Sources/BuildSettingsKit/BuildSettings+Preview.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings+Preview.swift
@@ -6,7 +6,8 @@ extension BuildSettings {
         pushNotificationAppID: "xcpreview_push_notification_id",
         appGroupName: "xcpreview_app_group_name",
         appKeychainAccessGroup: "xcpreview_app_keychain_access_group",
-        tracksEventNamePrefix: "xcpreview"
+        eventNamePrefix: "xcpreview",
+        explatPlatform: "xcpreview"
     )
 }
 

--- a/Modules/Sources/BuildSettingsKit/BuildSettings.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings.swift
@@ -15,7 +15,8 @@ public struct BuildSettings: Sendable {
     public var pushNotificationAppID: String
     public var appGroupName: String
     public var appKeychainAccessGroup: String
-    public var tracksEventNamePrefix: String
+    public var eventNamePrefix: String
+    public var explatPlatform: String
 
     public static var current: BuildSettings {
         switch BuildSettingsEnvironment.current {

--- a/Modules/Sources/BuildSettingsKit/BuildSettings.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings.swift
@@ -15,6 +15,7 @@ public struct BuildSettings: Sendable {
     public var pushNotificationAppID: String
     public var appGroupName: String
     public var appKeychainAccessGroup: String
+    public var tracksEventNamePrefix: String
 
     public static var current: BuildSettings {
         switch BuildSettingsEnvironment.current {

--- a/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
@@ -3,11 +3,11 @@ import BuildSettingsKit
 
 extension WPAnalytics {
     @objc class var eventNamePrefix: String {
-        BuildSettings.current.eventNamePrefix
+        WPAnalyticsTesting.eventNamePrefix ?? BuildSettings.current.eventNamePrefix
     }
 
     @objc class var explatPlatform: String {
-        BuildSettings.current.explatPlatform
+        WPAnalyticsTesting.explatPlatform ?? BuildSettings.current.explatPlatform
     }
 
     /// Checks if the Domain Purchasing Feature Flag is enabled.
@@ -60,4 +60,10 @@ extension WPAnalytics {
 enum DomainsAnalyticsWebViewOrigin: String {
     case siteCreation = "site_creation"
     case menu
+}
+
+// TODO: remove when WPAppAnalyticsTests get rewritten, preferably in Swift
+@objc final class WPAnalyticsTesting: NSObject {
+    @objc static var eventNamePrefix: String?
+    @objc static var explatPlatform: String?
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
@@ -1,6 +1,14 @@
 import Foundation
+import BuildSettingsKit
 
 extension WPAnalytics {
+    @objc class var eventNamePrefix: String {
+        BuildSettings.current.eventNamePrefix
+    }
+
+    @objc class var explatPlatform: String {
+        BuildSettings.current.explatPlatform
+    }
 
     /// Checks if the Domain Purchasing Feature Flag is enabled.
     private static var domainPurchasingEnabled: Bool {

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.h
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.h
@@ -5,4 +5,6 @@
 
 + (NSString *)eventNameForStat:(WPAnalyticsStat)stat;
 
+- (instancetype)initWithEventNamePrefix:(NSString *)eventNamePrefix platform:(NSString *)platform;
+
 @end

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -48,8 +48,8 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
     if (self) {
         _contextManager = [TracksContextManager new];
         _tracksService = [[TracksService alloc] initWithContextManager:_contextManager];
-        _tracksService.eventNamePrefix = AppConstants.eventNamePrefix;
-        _tracksService.platform = AppConstants.explatPlatform;
+        _tracksService.eventNamePrefix = [WPAnalytics eventNamePrefix];
+        _tracksService.platform = [WPAnalytics explatPlatform];
     }
     return self;
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -42,14 +42,18 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
     return [self eventPairForStat:stat].eventName;
 }
 
-- (instancetype)init
+- (instancetype)init {
+    return [self initWithEventNamePrefix:[WPAnalytics eventNamePrefix] platform:[WPAnalytics explatPlatform]];
+}
+
+- (instancetype)initWithEventNamePrefix:(NSString *)eventNamePrefix platform:(NSString *)platform
 {
     self = [super init];
     if (self) {
         _contextManager = [TracksContextManager new];
         _tracksService = [[TracksService alloc] initWithContextManager:_contextManager];
-        _tracksService.eventNamePrefix = [WPAnalytics eventNamePrefix];
-        _tracksService.platform = [WPAnalytics explatPlatform];
+        _tracksService.eventNamePrefix = eventNamePrefix;
+        _tracksService.platform = platform;
     }
     return self;
 }

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -13,8 +13,6 @@ import WordPressKit
     static let zendeskSourcePlatform = "mobile_-_ios"
     static let shareAppName: ShareAppName = .wordpress
     static let mobileAnnounceAppId = "2"
-    @objc static let eventNamePrefix = "wpios"
-    @objc static let explatPlatform = "wpios"
     @objc static let authKeychainServiceName = "public-api.wordpress.com"
 }
 

--- a/WordPress/Info.plist
+++ b/WordPress/Info.plist
@@ -8,7 +8,9 @@
 	<string>${WP_APP_KEYCHAIN_ACCESS_GROUP}</string>
 	<key>WPPushNotificationAppID</key>
 	<string>${WP_PUSH_NOTIFICATION_APP_ID}</string>
-	<key>WPTracksEventNamePrefix</key>
+	<key>WPEventNamePrefix</key>
+	<string>wpios</string>
+	<key>WPExplatPlatform</key>
 	<string>wpios</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>

--- a/WordPress/Info.plist
+++ b/WordPress/Info.plist
@@ -8,6 +8,8 @@
 	<string>${WP_APP_KEYCHAIN_ACCESS_GROUP}</string>
 	<key>WPPushNotificationAppID</key>
 	<string>${WP_PUSH_NOTIFICATION_APP_ID}</string>
+	<key>WPTracksEventNamePrefix</key>
+	<string>wpios</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>org.wordpress.bgtask.weeklyroundup</string>

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -13,8 +13,6 @@ import WordPressKit
     static let zendeskSourcePlatform = "mobile_-_jp_ios"
     static let shareAppName: ShareAppName = .jetpack
     static let mobileAnnounceAppId = "6"
-    @objc static let eventNamePrefix = "jpios"
-    @objc static let explatPlatform = "wpios"
     @objc static let authKeychainServiceName = "jetpack.public-api.wordpress.com"
 }
 

--- a/WordPress/Jetpack/Info.plist
+++ b/WordPress/Jetpack/Info.plist
@@ -8,8 +8,10 @@
 	<string>${WP_APP_KEYCHAIN_ACCESS_GROUP}</string>
 	<key>WPPushNotificationAppID</key>
 	<string>${WP_PUSH_NOTIFICATION_APP_ID}</string>
-	<key>WPTracksEventNamePrefix</key>
+	<key>WPEventNamePrefix</key>
 	<string>jpios</string>
+	<key>WPExplatPlatform</key>
+	<string>wpios</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>org.wordpress.bgtask.weeklyroundup</string>

--- a/WordPress/Jetpack/Info.plist
+++ b/WordPress/Jetpack/Info.plist
@@ -8,6 +8,8 @@
 	<string>${WP_APP_KEYCHAIN_ACCESS_GROUP}</string>
 	<key>WPPushNotificationAppID</key>
 	<string>${WP_PUSH_NOTIFICATION_APP_ID}</string>
+	<key>WPTracksEventNamePrefix</key>
+	<string>jpios</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>org.wordpress.bgtask.weeklyroundup</string>

--- a/WordPress/Jetpack/TracksConfiguration.swift
+++ b/WordPress/Jetpack/TracksConfiguration.swift
@@ -1,3 +1,0 @@
-struct TracksConfiguration {
-    static let eventNamePrefix = "jpios"
-}

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -119,13 +119,6 @@
 		019C5B972BD6A49900A69DB0 /* StatsSubscribersViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019C5B962BD6A49900A69DB0 /* StatsSubscribersViewModelTests.swift */; };
 		019D699E2A5EA963003B676D /* RootViewCoordinatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 019D699D2A5EA963003B676D /* RootViewCoordinatorTests.swift */; };
 		01B7590E2B3EEEA400179AE6 /* SiteDomainsViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01B7590D2B3EEEA400179AE6 /* SiteDomainsViewModelTests.swift */; };
-		01CE5007290A889F00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */; };
-		01CE5008290A88BD00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */; };
-		01CE500E290A88C100A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */; };
-		01CE5012290A890B00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */; };
-		01CE5013290A890E00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */; };
-		01CE5014290A890E00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */; };
-		01CE5015290A890F00A9C2E0 /* TracksConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */; };
 		01D2FF5F2AA733690038E040 /* LockScreenFieldView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF5D2AA733690038E040 /* LockScreenFieldView.swift */; };
 		01D2FF622AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF602AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift */; };
 		01D2FF652AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = 01D2FF632AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift */; };
@@ -1872,8 +1865,6 @@
 		019C5B962BD6A49900A69DB0 /* StatsSubscribersViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatsSubscribersViewModelTests.swift; sourceTree = "<group>"; };
 		019D699D2A5EA963003B676D /* RootViewCoordinatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootViewCoordinatorTests.swift; sourceTree = "<group>"; };
 		01B7590D2B3EEEA400179AE6 /* SiteDomainsViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteDomainsViewModelTests.swift; sourceTree = "<group>"; };
-		01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksConfiguration.swift; sourceTree = "<group>"; };
-		01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TracksConfiguration.swift; sourceTree = "<group>"; };
 		01D2FF5D2AA733690038E040 /* LockScreenFieldView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenFieldView.swift; sourceTree = "<group>"; };
 		01D2FF602AA77C5F0038E040 /* LockScreenAllTimeViewsStatWidgetConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenAllTimeViewsStatWidgetConfig.swift; sourceTree = "<group>"; };
 		01D2FF632AA77F790038E040 /* LockScreenTodayViewsVisitorsStatWidgetConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LockScreenTodayViewsVisitorsStatWidgetConfig.swift; sourceTree = "<group>"; };
@@ -5946,7 +5937,6 @@
 			children = (
 				B5FA22821C99F6180016CA7C /* Tracks.swift */,
 				B504F5F41C9C2BD000F8B1C6 /* Tracks+ShareExtension.swift */,
-				01CE5006290A889F00A9C2E0 /* TracksConfiguration.swift */,
 			);
 			name = Tracks;
 			sourceTree = "<group>";
@@ -7098,7 +7088,6 @@
 				FAADE3F02615996E00BF29FE /* AppConstants.swift */,
 				C7F7BDBC26262A1B00CE547F /* AppDependency.swift */,
 				0107E15C28FFE99300DE87DB /* WidgetConfiguration.swift */,
-				01CE5010290A890300A9C2E0 /* TracksConfiguration.swift */,
 				800035C229230A0B007D2D26 /* ExtensionConfiguration.swift */,
 			);
 			name = "App Configuration";
@@ -8673,7 +8662,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				C9B4778729C85949008CBF49 /* LockScreenStatsWidgetEntry.swift in Sources */,
-				01CE5012290A890B00A9C2E0 /* TracksConfiguration.swift in Sources */,
 				C9C21D7C29BED18C009F68E5 /* LockScreenStatsWidgetsView.swift in Sources */,
 				C9FE382F29C204E700D39841 /* LockScreenSingleStatViewModel.swift in Sources */,
 				0107E0B528F97D5000DE87DB /* StatsWidgetEntry.swift in Sources */,
@@ -8982,7 +8970,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				7335AC6021220D550012EF2D /* RemoteNotificationActionParser.swift in Sources */,
-				01CE500E290A88C100A9C2E0 /* TracksConfiguration.swift in Sources */,
 				73F6DD42212BA54700CE447D /* RichNotificationContentFormatter.swift in Sources */,
 				7396FE66210F730600496D0D /* NotificationService.swift in Sources */,
 				73E40D8921238BF50012ABA6 /* Tracks.swift in Sources */,
@@ -9019,7 +9006,6 @@
 				CBF6201426E8FB8A0061A1F8 /* RemotePost+ShareData.swift in Sources */,
 				CE39E17320CB117B00CABA05 /* RemoteBlog+Capabilities.swift in Sources */,
 				74021A0F202E1370006CC39F /* ExtensionTransitioningManager.swift in Sources */,
-				01CE5008290A88BD00A9C2E0 /* TracksConfiguration.swift in Sources */,
 				741AF3A5202F3E2A00C771A5 /* Tracks+DraftAction.swift in Sources */,
 				74021A0B202E1330006CC39F /* WPStyleGuide+Share.swift in Sources */,
 				74021A16202E139A006CC39F /* ShareData.swift in Sources */,
@@ -9062,7 +9048,6 @@
 				809620F828E540D700940A5D /* CategoryTree.swift in Sources */,
 				809620F928E540D700940A5D /* ExtensionPresentationController.swift in Sources */,
 				8031F346292FF46100E8F95E /* ExtensionConfiguration.swift in Sources */,
-				01CE5015290A890F00A9C2E0 /* TracksConfiguration.swift in Sources */,
 				809620FB28E540D700940A5D /* RemoteBlog+Capabilities.swift in Sources */,
 				809620FC28E540D700940A5D /* ShareModularViewController.swift in Sources */,
 				809620FD28E540D700940A5D /* NSExtensionContext+Extensions.swift in Sources */,
@@ -9106,7 +9091,6 @@
 				8096215928E55C9400940A5D /* RemoteBlog+Capabilities.swift in Sources */,
 				8096215A28E55C9400940A5D /* ExtensionTransitioningManager.swift in Sources */,
 				8031F347292FF46200E8F95E /* ExtensionConfiguration.swift in Sources */,
-				01CE5014290A890E00A9C2E0 /* TracksConfiguration.swift in Sources */,
 				8096215C28E55C9400940A5D /* Tracks+DraftAction.swift in Sources */,
 				8096215E28E55C9400940A5D /* WPStyleGuide+Share.swift in Sources */,
 				8096216128E55C9400940A5D /* ShareData.swift in Sources */,
@@ -9130,7 +9114,6 @@
 				8031F348292FF46400E8F95E /* ExtensionConfiguration.swift in Sources */,
 				80F6D02328EE866A00953C1A /* RemoteNotificationActionParser.swift in Sources */,
 				0107E11428FD7FE300DE87DB /* AppConfiguration.swift in Sources */,
-				01CE5013290A890E00A9C2E0 /* TracksConfiguration.swift in Sources */,
 				80F6D03828EE866A00953C1A /* RichNotificationContentFormatter.swift in Sources */,
 				80F6D03C28EE866A00953C1A /* NotificationService.swift in Sources */,
 				80F6D03D28EE866A00953C1A /* Tracks.swift in Sources */,
@@ -9181,7 +9164,6 @@
 				CBF6201326E8FB520061A1F8 /* RemotePost+ShareData.swift in Sources */,
 				74448F542044BC7600BD4CDA /* CategoryTree.swift in Sources */,
 				74402F2A200528F200A1D4A2 /* ExtensionPresentationController.swift in Sources */,
-				01CE5007290A889F00A9C2E0 /* TracksConfiguration.swift in Sources */,
 				CE39E17220CB117B00CABA05 /* RemoteBlog+Capabilities.swift in Sources */,
 				BE6787F51FFF2886005D9F01 /* ShareModularViewController.swift in Sources */,
 				B5552D7E1CD101A600B26DF6 /* NSExtensionContext+Extensions.swift in Sources */,

--- a/WordPress/WordPressShareExtension/Tracks.swift
+++ b/WordPress/WordPressShareExtension/Tracks.swift
@@ -1,5 +1,6 @@
 import UIKit
 import OSLog
+import BuildSettingsKit
 
 open class Tracks {
     // MARK: - Public Properties
@@ -13,14 +14,18 @@ open class Tracks {
     fileprivate static let version = "1.0"
     fileprivate static let userAgent = "Nosara Extensions Client for iOS Mark " + version
 
+    private let eventNamePrefix: String
+
     // MARK: - Initializers
-    init(appGroupName: String) {
+    init(appGroupName: String,
+         eventNamePrefix: String = BuildSettings.current.tracksEventNamePrefix) {
         uploader = Uploader(appGroupName: appGroupName)
+        self.eventNamePrefix = eventNamePrefix
     }
 
     // MARK: - Public Methods
     open func track(_ eventName: String, properties: [String: Any]? = nil) {
-        let prefixedEventName = "\(TracksConfiguration.eventNamePrefix)_\(eventName)"
+        let prefixedEventName = "\(eventNamePrefix)_\(eventName)"
         let payload = payloadWithEventName(prefixedEventName, properties: properties)
         uploader.send(payload)
 

--- a/WordPress/WordPressShareExtension/Tracks.swift
+++ b/WordPress/WordPressShareExtension/Tracks.swift
@@ -18,7 +18,7 @@ open class Tracks {
 
     // MARK: - Initializers
     init(appGroupName: String,
-         eventNamePrefix: String = BuildSettings.current.tracksEventNamePrefix) {
+         eventNamePrefix: String = BuildSettings.current.eventNamePrefix) {
         uploader = Uploader(appGroupName: appGroupName)
         self.eventNamePrefix = eventNamePrefix
     }

--- a/WordPress/WordPressShareExtension/TracksConfiguration.swift
+++ b/WordPress/WordPressShareExtension/TracksConfiguration.swift
@@ -1,3 +1,0 @@
-struct TracksConfiguration {
-    static let eventNamePrefix = "wpios"
-}

--- a/WordPress/WordPressTest/WPAnalyticsTrackerAutomatticTracksTests.m
+++ b/WordPress/WordPressTest/WPAnalyticsTrackerAutomatticTracksTests.m
@@ -25,7 +25,7 @@
 - (void)setUp {
     [super setUp];
 
-    self.subject = [[WPAnalyticsTrackerAutomatticTracks alloc] init];
+    self.subject = [[WPAnalyticsTrackerAutomatticTracks alloc] initWithEventNamePrefix:@"xctest" platform:@"xctest"];
     self.serviceMock = OCMStrictClassMock([TracksService class]);
     self.subject.tracksService = self.serviceMock;
     self.subject.contextManager = nil;

--- a/WordPress/WordPressTest/WPAppAnalyticsTests.m
+++ b/WordPress/WordPressTest/WPAppAnalyticsTests.m
@@ -13,7 +13,19 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
 
 @implementation WPAppAnalyticsTests
 
+- (void)setUp {
+    [super setUp];
+
+    WPAnalyticsTesting.eventNamePrefix = @"xctest";
+    WPAnalyticsTesting.explatPlatform = @"xctest";
+}
+
 - (void)tearDown {
+    [super tearDown];
+
+    WPAnalyticsTesting.eventNamePrefix = nil;
+    WPAnalyticsTesting.explatPlatform = nil;
+
     [WPAnalytics clearTrackers];
 }
 
@@ -23,7 +35,7 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
 
     id analyticsMock = [OCMockObject mockForClass:[WPAnalytics class]];
     id apiCredentialsMock = [OCMockObject mockForClass:[ApiCredentials class]];
-    
+
     OCMockInvocationBlock registerTrackerInvocationBlock = ^(NSInvocation *invocation) {
         __unsafe_unretained id<WPAnalyticsTracker> tracker = nil;
         [invocation getArgument:&tracker atIndex:2];
@@ -39,7 +51,7 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
     WPAppAnalyticsLastVisibleScreenCallback lastVisibleScreenCallback = ^NSString*{
         return @"TEST";
     };
-    
+
     XCTAssertNoThrow(analytics = [[WPAppAnalytics alloc] initWithLastVisibleScreenBlock:lastVisibleScreenCallback],
                      @"Allocating or initializing this object shouldn't throw an exception");
     XCTAssert([analytics isKindOfClass:[WPAppAnalytics class]]);


### PR DESCRIPTION
Move to `BuildSettings`. Remove duplication (`TracksConfiguration.swift` for widgets and `AppConstants` for apps).

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
