### PR TITLE
Fix #24244: Dismiss the 'Delete Site' view controller

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Management/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/DeleteSiteViewController.swift
@@ -261,6 +261,9 @@ open class DeleteSiteViewController: UITableViewController {
 
             // Pop the primary navigation controller back to the sites list
             primaryNavigationController.popToRootViewController(animated: true)
+        } else if let presentingViewController {
+            // This view is presented as a modal on iPad.
+            presentingViewController.dismiss(animated: true)
         }
     }
 


### PR DESCRIPTION
> [!Note]
> This PR is built on top of https://github.com/wordpress-mobile/WordPress-iOS/pull/24243.

Fixes #24244.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
