### PR TITLE
Extract TracksMini

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -77,6 +77,11 @@ let package = Package(
             cSettings: [.unsafeFlags(["-fno-objc-arc"])]
         ),
         .target(name: "TextBundle"),
+        .target(
+            name: "TracksMini",
+            dependencies: ["BuildSettingsKit"],
+            swiftSettings: [.swiftLanguageMode(.v5)]
+        ),
         .target(name: "UITestsFoundation", dependencies: [
             .product(name: "ScreenObject", package: "ScreenObject"),
             .product(name: "XCUITestHelpers", package: "ScreenObject"),
@@ -177,6 +182,7 @@ enum XcodeSupport {
             "WordPressShared",
             "WordPressUI",
             "TextBundle",
+            "TracksMini",
             .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
             .product(name: "Down", package: "Down"),
             .product(name: "Gridicons", package: "Gridicons-iOS"),
@@ -248,13 +254,15 @@ enum XcodeSupport {
             .xcodeTarget("XcodeTarget_DraftActionExtension", dependencies: shareAndDraftExtensionsDependencies),
             .xcodeTarget("XcodeTarget_NotificationServiceExtension", dependencies: [
                 "SFHFKeychainUtils",
-                "WordPressShared",
                 "BuildSettingsKit",
+                "WordPressShared",
+                "TracksMini",
             ]),
             .xcodeTarget("XcodeTarget_StatsWidget", dependencies: [
                 "BuildSettingsKit",
                 "JetpackStatsWidgetsCore",
                 "SFHFKeychainUtils",
+                "TracksMini",
                 "WordPressShared",
                 "WordPressUI",
                 .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),

--- a/Modules/Sources/TracksMini/Tracks.swift
+++ b/Modules/Sources/TracksMini/Tracks.swift
@@ -8,16 +8,16 @@ open class Tracks {
     open var wpcomUserID: String?
 
     // MARK: - Private Properties
-    fileprivate let uploader: Uploader
+    private let uploader: Uploader
 
     // MARK: - Constants
-    fileprivate static let version = "1.0"
-    fileprivate static let userAgent = "Nosara Extensions Client for iOS Mark " + version
+    private static let version = "1.0"
+    private static let userAgent = "Nosara Extensions Client for iOS Mark " + version
 
     private let eventNamePrefix: String
 
     // MARK: - Initializers
-    init(appGroupName: String = BuildSettings.current.appGroupName,
+    public init(appGroupName: String = BuildSettings.current.appGroupName,
          eventNamePrefix: String = BuildSettings.current.eventNamePrefix) {
         uploader = Uploader(appGroupName: appGroupName)
         self.eventNamePrefix = eventNamePrefix
@@ -33,7 +33,7 @@ open class Tracks {
     }
 
     // MARK: - Private Helpers
-    fileprivate func payloadWithEventName(_ eventName: String, properties: [String: Any]?) -> [String: Any] {
+    private func payloadWithEventName(_ eventName: String, properties: [String: Any]?) -> [String: Any] {
         let timestamp = NSNumber(value: Int64(Date().timeIntervalSince1970 * 1000) as Int64)
         let anonUserID = UUID().uuidString
         let device = UIDevice.current
@@ -80,16 +80,18 @@ open class Tracks {
     /// Private Internal Helper:
     /// Encapsulates all of the Backend Tracks Interaction, and deals with NSURLSession's API.
     ///
-    fileprivate class Uploader: NSObject, URLSessionDelegate {
+    private class Uploader: NSObject, URLSessionDelegate {
         // MARK: - Properties
-        fileprivate var session: Foundation.URLSession!
+        private var session: Foundation.URLSession!
 
         // MARK: - Constants
-        fileprivate let tracksURL = "https://public-api.wordpress.com/rest/v1.1/tracks/record"
-        fileprivate let httpMethod = "POST"
-        fileprivate let headers = [ "Content-Type": "application/json",
-                                    "Accept": "application/json",
-                                    "User-Agent": "WPiOS App Extension"]
+        private let tracksURL = "https://public-api.wordpress.com/rest/v1.1/tracks/record"
+        private let httpMethod = "POST"
+        private let headers = [
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+            "User-Agent": "WPiOS App Extension"
+        ]
 
         // MARK: - Deinitializers
         deinit {

--- a/WordPress/JetpackStatsWidgets/LockScreenWidgets/LockScreenStatsWidget.swift
+++ b/WordPress/JetpackStatsWidgets/LockScreenWidgets/LockScreenStatsWidget.swift
@@ -1,10 +1,9 @@
 import WidgetKit
-import BuildSettingsKit
 import SwiftUI
 import JetpackStatsWidgetsCore
 
 struct LockScreenStatsWidget<T: LockScreenStatsWidgetConfig>: Widget {
-    private let tracks = Tracks(appGroupName: BuildSettings.current.appGroupName)
+    private let tracks = Tracks()
     private let config: T
 
     init(config: T) {

--- a/WordPress/JetpackStatsWidgets/LockScreenWidgets/LockScreenStatsWidget.swift
+++ b/WordPress/JetpackStatsWidgets/LockScreenWidgets/LockScreenStatsWidget.swift
@@ -1,6 +1,7 @@
 import WidgetKit
 import SwiftUI
 import JetpackStatsWidgetsCore
+import TracksMini
 
 struct LockScreenStatsWidget<T: LockScreenStatsWidgetConfig>: Widget {
     private let tracks = Tracks()

--- a/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetAllTime.swift
+++ b/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetAllTime.swift
@@ -1,10 +1,9 @@
 import WidgetKit
 import SwiftUI
-import BuildSettingsKit
 import JetpackStatsWidgetsCore
 
 struct HomeWidgetAllTime: Widget {
-    private let tracks = Tracks(appGroupName: BuildSettings.current.appGroupName)
+    private let tracks = Tracks()
 
     private let placeholderContent = HomeWidgetAllTimeData(
         siteID: 0,

--- a/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetAllTime.swift
+++ b/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetAllTime.swift
@@ -1,6 +1,7 @@
 import WidgetKit
 import SwiftUI
 import JetpackStatsWidgetsCore
+import TracksMini
 
 struct HomeWidgetAllTime: Widget {
     private let tracks = Tracks()

--- a/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetThisWeek.swift
+++ b/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetThisWeek.swift
@@ -1,10 +1,9 @@
 import WidgetKit
 import SwiftUI
-import BuildSettingsKit
 import JetpackStatsWidgetsCore
 
 struct HomeWidgetThisWeek: Widget {
-    private let tracks = Tracks(appGroupName: BuildSettings.current.appGroupName)
+    private let tracks = Tracks()
 
     static let secondsPerDay = 86400.0
 

--- a/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetThisWeek.swift
+++ b/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetThisWeek.swift
@@ -1,6 +1,7 @@
 import WidgetKit
 import SwiftUI
 import JetpackStatsWidgetsCore
+import TracksMini
 
 struct HomeWidgetThisWeek: Widget {
     private let tracks = Tracks()

--- a/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetToday.swift
+++ b/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetToday.swift
@@ -2,6 +2,7 @@ import Foundation
 import WidgetKit
 import SwiftUI
 import JetpackStatsWidgetsCore
+import TracksMini
 
 struct HomeWidgetToday: Widget {
     private let tracks = Tracks()

--- a/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetToday.swift
+++ b/WordPress/JetpackStatsWidgets/Widgets/HomeWidgetToday.swift
@@ -1,11 +1,10 @@
 import Foundation
 import WidgetKit
 import SwiftUI
-import BuildSettingsKit
 import JetpackStatsWidgetsCore
 
 struct HomeWidgetToday: Widget {
-    private let tracks = Tracks(appGroupName: BuildSettings.current.appGroupName)
+    private let tracks = Tracks()
 
     private let placeholderContent = HomeWidgetTodayData(siteID: 0,
                                                         siteName: "My WordPress Site",

--- a/WordPress/Tracks+ShareExtension.swift
+++ b/WordPress/Tracks+ShareExtension.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TracksMini
 
 /// This extension implements helper tracking methods, meant for Share Extension Usage.
 ///

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3384,7 +3384,6 @@
 		24CE68B92CD3375300C7B37D /* Exceptions for "Classes" folder in "JetpackStatsWidgets" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
-				"Utility/App Configuration/AppStyleGuide.swift",
 				Utility/BuildInformation/BuildConfiguration.swift,
 			);
 			target = 0107E0B128F97D5000DE87DB /* JetpackStatsWidgets */;

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -3381,13 +3381,6 @@
 			);
 			target = 80F6D01F28EE866A00953C1A /* JetpackNotificationServiceExtension */;
 		};
-		24CE68B92CD3375300C7B37D /* Exceptions for "Classes" folder in "JetpackStatsWidgets" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				Utility/BuildInformation/BuildConfiguration.swift,
-			);
-			target = 0107E0B128F97D5000DE87DB /* JetpackStatsWidgets */;
-		};
 		24CE68BA2CD3375300C7B37D /* Exceptions for "Classes" folder in "JetpackIntents" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -3418,7 +3411,6 @@
 				24CE68B62CD3375300C7B37D /* Exceptions for "Classes" folder in "JetpackShareExtension" target */,
 				24CE68B72CD3375300C7B37D /* Exceptions for "Classes" folder in "JetpackDraftActionExtension" target */,
 				24CE68B82CD3375300C7B37D /* Exceptions for "Classes" folder in "JetpackNotificationServiceExtension" target */,
-				24CE68B92CD3375300C7B37D /* Exceptions for "Classes" folder in "JetpackStatsWidgets" target */,
 				24CE68BA2CD3375300C7B37D /* Exceptions for "Classes" folder in "JetpackIntents" target */,
 				24CE68BB2CD3375300C7B37D /* Exceptions for "Classes" folder in "JetpackUITests" target */,
 			);

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -76,7 +76,6 @@
 		0107E0D728F97D5000DE87DB /* Sites.intentdefinition in Sources */ = {isa = PBXBuildFile; fileRef = 3F46AB0225BF5D6300CE2E98 /* Sites.intentdefinition */; };
 		0107E0D828F97D5000DE87DB /* LocalizableStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE77C8225B0CA89007DE9E5 /* LocalizableStrings.swift */; };
 		0107E0DA28F97D5000DE87DB /* ListViewData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FE20C3625CF211F00A15525 /* ListViewData.swift */; };
-		0107E0DC28F97D5000DE87DB /* Tracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FA22821C99F6180016CA7C /* Tracks.swift */; };
 		0107E0DE28F97D5000DE87DB /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F526C4F2538CF2A0069706C /* SwiftUI.framework */; };
 		0107E0DF28F97D5000DE87DB /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F526C4D2538CF2A0069706C /* WidgetKit.framework */; };
 		0107E0E228F97D5000DE87DB /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3F526C552538CF2B0069706C /* Assets.xcassets */; };
@@ -676,7 +675,6 @@
 		7396FE66210F730600496D0D /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7396FE65210F730600496D0D /* NotificationService.swift */; };
 		73B6693A21CAD960008456C3 /* ErrorStateViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73B6693921CAD960008456C3 /* ErrorStateViewTests.swift */; };
 		73C8F06621BEF76B00DDDF7E /* SiteAssemblyViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73C8F06521BEF76B00DDDF7E /* SiteAssemblyViewTests.swift */; };
-		73E40D8921238BF50012ABA6 /* Tracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FA22821C99F6180016CA7C /* Tracks.swift */; };
 		73E40D8C21238C520012ABA6 /* Tracks+ServiceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E40D8B21238C520012ABA6 /* Tracks+ServiceExtension.swift */; };
 		73EDC70A212E5D6700E5E3ED /* RemoteNotificationStyles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73EDC709212E5D6700E5E3ED /* RemoteNotificationStyles.swift */; };
 		73F6DD42212BA54700CE447D /* RichNotificationContentFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F6DD41212BA54700CE447D /* RichNotificationContentFormatter.swift */; };
@@ -695,7 +693,6 @@
 		74021A0B202E1330006CC39F /* WPStyleGuide+Share.swift in Sources */ = {isa = PBXBuildFile; fileRef = B50248AE1C96FF6200AFBDED /* WPStyleGuide+Share.swift */; };
 		74021A0C202E1338006CC39F /* ShareExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CE41641E8D101A000CF5A4 /* ShareExtractor.swift */; };
 		74021A0D202E133D006CC39F /* ShareMediaFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7430C4481F97F23600E2673E /* ShareMediaFileManager.swift */; };
-		74021A0E202E1358006CC39F /* Tracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FA22821C99F6180016CA7C /* Tracks.swift */; };
 		74021A0F202E1370006CC39F /* ExtensionTransitioningManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74402F2B2005337D00A1D4A2 /* ExtensionTransitioningManager.swift */; };
 		74021A10202E1370006CC39F /* ExtensionPresentationController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74402F29200528F200A1D4A2 /* ExtensionPresentationController.swift */; };
 		74021A11202E1370006CC39F /* ExtensionPresentationAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74402F2D2005344700A1D4A2 /* ExtensionPresentationAnimator.swift */; };
@@ -842,7 +839,6 @@
 		8096210928E540D700940A5D /* RemotePostCategory+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74BC35B720499EEB00AC1525 /* RemotePostCategory+Extensions.swift */; };
 		8096211028E540D700940A5D /* MediaUploadOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74AF4D6D1FE417D200E3EBFE /* MediaUploadOperation.swift */; };
 		8096211228E540D700940A5D /* ShareMediaFileManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7430C4481F97F23600E2673E /* ShareMediaFileManager.swift */; };
-		8096211328E540D700940A5D /* Tracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FA22821C99F6180016CA7C /* Tracks.swift */; };
 		8096211728E540D700940A5D /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 740C7C4E202F4CD6001C31B0 /* MainInterface.storyboard */; };
 		8096211828E540D700940A5D /* WordPressShare.js in Resources */ = {isa = PBXBuildFile; fileRef = E1AFA8C21E8E34230004A323 /* WordPressShare.js */; };
 		8096211928E540D700940A5D /* ShareExtension.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 74F5CD371FE0646F00764E7C /* ShareExtension.storyboard */; };
@@ -875,7 +871,6 @@
 		8096216328E55C9400940A5D /* MainShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74337EDC20054D5500777997 /* MainShareViewController.swift */; };
 		8096216628E55C9400940A5D /* ShareModularViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6787F41FFF2886005D9F01 /* ShareModularViewController.swift */; };
 		8096216728E55C9400940A5D /* MediaUploadOperation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74AF4D6D1FE417D200E3EBFE /* MediaUploadOperation.swift */; };
-		8096216828E55C9400940A5D /* Tracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FA22821C99F6180016CA7C /* Tracks.swift */; };
 		8096216928E55C9400940A5D /* RemotePostCategory+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74BC35B720499EEB00AC1525 /* RemotePostCategory+Extensions.swift */; };
 		8096216A28E55C9400940A5D /* ShareNoticeConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74EA3B87202A0462004F802D /* ShareNoticeConstants.swift */; };
 		8096216E28E55C9400940A5D /* ShareExtractor.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1CE41641E8D101A000CF5A4 /* ShareExtractor.swift */; };
@@ -897,7 +892,6 @@
 		80F6D02328EE866A00953C1A /* RemoteNotificationActionParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7335AC5F21220D550012EF2D /* RemoteNotificationActionParser.swift */; };
 		80F6D03828EE866A00953C1A /* RichNotificationContentFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F6DD41212BA54700CE447D /* RichNotificationContentFormatter.swift */; };
 		80F6D03C28EE866A00953C1A /* NotificationService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7396FE65210F730600496D0D /* NotificationService.swift */; };
-		80F6D03D28EE866A00953C1A /* Tracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FA22821C99F6180016CA7C /* Tracks.swift */; };
 		80F6D04628EE866A00953C1A /* Tracks+ServiceExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73E40D8B21238C520012ABA6 /* Tracks+ServiceExtension.swift */; };
 		80F6D04728EE866A00953C1A /* UNNotificationContent+RemoteNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73768B6A212B4E4F005136A1 /* UNNotificationContent+RemoteNotification.swift */; };
 		80F6D04828EE866A00953C1A /* RichNotificationViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73F6DD43212C714F00CE447D /* RichNotificationViewModel.swift */; };
@@ -1014,7 +1008,6 @@
 		B5ECA6CD1DBAAD510062D7E0 /* CoreDataHelperTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5ECA6CC1DBAAD510062D7E0 /* CoreDataHelperTests.swift */; };
 		B5EFB1C91B333C5A007608A3 /* NotificationSettingsServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5EFB1C81B333C5A007608A3 /* NotificationSettingsServiceTests.swift */; };
 		B5EFB1D11B33630C007608A3 /* notifications-settings.json in Resources */ = {isa = PBXBuildFile; fileRef = B5EFB1D01B33630C007608A3 /* notifications-settings.json */; };
-		B5FA22831C99F6180016CA7C /* Tracks.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FA22821C99F6180016CA7C /* Tracks.swift */; };
 		B5FA868C1D10A4C400AB5F7E /* UIImage+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5FA868A1D10A41600AB5F7E /* UIImage+Extensions.swift */; };
 		BE2B4E9F1FD664F5007AE3E4 /* BaseScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE2B4E9E1FD664F5007AE3E4 /* BaseScreen.swift */; };
 		BE6787F51FFF2886005D9F01 /* ShareModularViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = BE6787F41FFF2886005D9F01 /* ShareModularViewController.swift */; };
@@ -2741,7 +2734,6 @@
 		B5ECA6CC1DBAAD510062D7E0 /* CoreDataHelperTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CoreDataHelperTests.swift; sourceTree = "<group>"; };
 		B5EFB1C81B333C5A007608A3 /* NotificationSettingsServiceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NotificationSettingsServiceTests.swift; sourceTree = "<group>"; };
 		B5EFB1D01B33630C007608A3 /* notifications-settings.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "notifications-settings.json"; sourceTree = "<group>"; };
-		B5FA22821C99F6180016CA7C /* Tracks.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Tracks.swift; path = WordPressShareExtension/Tracks.swift; sourceTree = SOURCE_ROOT; wrapsLines = 0; };
 		B5FA868A1D10A41600AB5F7E /* UIImage+Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "UIImage+Extensions.swift"; path = "WordPressShareExtension/UIImage+Extensions.swift"; sourceTree = SOURCE_ROOT; };
 		BE2B4E9E1FD664F5007AE3E4 /* BaseScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BaseScreen.swift; sourceTree = "<group>"; };
 		BE6787F41FFF2886005D9F01 /* ShareModularViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareModularViewController.swift; sourceTree = "<group>"; };
@@ -5887,7 +5879,6 @@
 		B5FA22841C99F6340016CA7C /* Tracks */ = {
 			isa = PBXGroup;
 			children = (
-				B5FA22821C99F6180016CA7C /* Tracks.swift */,
 				B504F5F41C9C2BD000F8B1C6 /* Tracks+ShareExtension.swift */,
 			);
 			name = Tracks;
@@ -8662,7 +8653,6 @@
 				C9FE383229C2053300D39841 /* LockScreenSingleStatView.swift in Sources */,
 				0107E0DA28F97D5000DE87DB /* ListViewData.swift in Sources */,
 				0188FE462AA624A40093EDA5 /* LockScreenSiteTitleView.swift in Sources */,
-				0107E0DC28F97D5000DE87DB /* Tracks.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8915,7 +8905,6 @@
 				7335AC6021220D550012EF2D /* RemoteNotificationActionParser.swift in Sources */,
 				73F6DD42212BA54700CE447D /* RichNotificationContentFormatter.swift in Sources */,
 				7396FE66210F730600496D0D /* NotificationService.swift in Sources */,
-				73E40D8921238BF50012ABA6 /* Tracks.swift in Sources */,
 				73E40D8C21238C520012ABA6 /* Tracks+ServiceExtension.swift in Sources */,
 				73768B6B212B4E4F005136A1 /* UNNotificationContent+RemoteNotification.swift in Sources */,
 				73F6DD45212C714F00CE447D /* RichNotificationViewModel.swift in Sources */,
@@ -8955,7 +8944,6 @@
 				F5EF481723ABCAD8004C3532 /* MainShareViewController.swift in Sources */,
 				74021A15202E1397006CC39F /* ShareModularViewController.swift in Sources */,
 				74021A00202E12F4006CC39F /* MediaUploadOperation.swift in Sources */,
-				74021A0E202E1358006CC39F /* Tracks.swift in Sources */,
 				74BC35BA20499EEB00AC1525 /* RemotePostCategory+Extensions.swift in Sources */,
 				74E44AD62031E85A00556205 /* ShareNoticeConstants.swift in Sources */,
 				74021A0C202E1338006CC39F /* ShareExtractor.swift in Sources */,
@@ -9003,7 +8991,6 @@
 				8096210928E540D700940A5D /* RemotePostCategory+Extensions.swift in Sources */,
 				8096211028E540D700940A5D /* MediaUploadOperation.swift in Sources */,
 				8096211228E540D700940A5D /* ShareMediaFileManager.swift in Sources */,
-				8096211328E540D700940A5D /* Tracks.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -9040,7 +9027,6 @@
 				8096216328E55C9400940A5D /* MainShareViewController.swift in Sources */,
 				8096216628E55C9400940A5D /* ShareModularViewController.swift in Sources */,
 				8096216728E55C9400940A5D /* MediaUploadOperation.swift in Sources */,
-				8096216828E55C9400940A5D /* Tracks.swift in Sources */,
 				0107E11328FD7FE300DE87DB /* AppConfiguration.swift in Sources */,
 				8096216928E55C9400940A5D /* RemotePostCategory+Extensions.swift in Sources */,
 				8096216A28E55C9400940A5D /* ShareNoticeConstants.swift in Sources */,
@@ -9059,7 +9045,6 @@
 				0107E11428FD7FE300DE87DB /* AppConfiguration.swift in Sources */,
 				80F6D03828EE866A00953C1A /* RichNotificationContentFormatter.swift in Sources */,
 				80F6D03C28EE866A00953C1A /* NotificationService.swift in Sources */,
-				80F6D03D28EE866A00953C1A /* Tracks.swift in Sources */,
 				80F6D04628EE866A00953C1A /* Tracks+ServiceExtension.swift in Sources */,
 				80F6D04728EE866A00953C1A /* UNNotificationContent+RemoteNotification.swift in Sources */,
 				80F6D04828EE866A00953C1A /* RichNotificationViewModel.swift in Sources */,
@@ -9118,7 +9103,6 @@
 				74BC35B920499EEB00AC1525 /* RemotePostCategory+Extensions.swift in Sources */,
 				74AF4D751FE417D200E3EBFE /* MediaUploadOperation.swift in Sources */,
 				7430C4491F97F23600E2673E /* ShareMediaFileManager.swift in Sources */,
-				B5FA22831C99F6180016CA7C /* Tracks.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WordPress/WordPressDraftActionExtension/Tracks+DraftAction.swift
+++ b/WordPress/WordPressDraftActionExtension/Tracks+DraftAction.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TracksMini
 
 /// This extension implements helper tracking methods, meant for Draft Action Extension usage.
 ///

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -1,6 +1,7 @@
 import SFHFKeychainUtils
 import UserNotifications
 import BuildSettingsKit
+import TracksMini
 import WordPressKit
 import WordPressShared
 

--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -12,7 +12,7 @@ class NotificationService: UNNotificationServiceExtension {
     // MARK: Properties
 
     /// Manages analytics calls via Tracks
-    private let tracks = Tracks(appGroupName: BuildSettings.current.appGroupName)
+    private let tracks = Tracks()
 
     /// The content handler received from the extension
     private var contentHandler: ((UNNotificationContent) -> Void)?

--- a/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/Tracks/Tracks+ServiceExtension.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TracksMini
 
 /// Characterizes the types of service extension events we're interested in tracking.
 /// The raw value corresponds to the event name in Tracks.

--- a/WordPress/WordPressShareExtension/AppExtensionsService.swift
+++ b/WordPress/WordPressShareExtension/AppExtensionsService.swift
@@ -1,6 +1,7 @@
 import Aztec
 import BuildSettingsKit
 import CoreData
+import TracksMini
 import WordPressKit
 
 /// Provides site fetching and post/media uploading functionality to app extensions.

--- a/WordPress/WordPressShareExtension/AppExtensionsService.swift
+++ b/WordPress/WordPressShareExtension/AppExtensionsService.swift
@@ -55,9 +55,7 @@ class AppExtensionsService {
 
     /// Tracks Instance
     ///
-    fileprivate lazy var tracks: Tracks = {
-        Tracks(appGroupName: BuildSettings.current.appGroupName)
-    }()
+    fileprivate lazy var tracks = Tracks()
 
     /// WordPress.com Username
     ///

--- a/WordPress/WordPressShareExtension/MainShareViewController.swift
+++ b/WordPress/WordPressShareExtension/MainShareViewController.swift
@@ -1,5 +1,4 @@
 import UIKit
-import BuildSettingsKit
 import WordPressShared
 import WordPressUI
 
@@ -92,7 +91,7 @@ private extension MainShareViewController {
     }
 
     func trackExtensionLaunch() {
-        let tracks = Tracks(appGroupName: BuildSettings.current.appGroupName)
+        let tracks = Tracks()
         let oauth2Token = ShareExtensionService().retrieveShareExtensionToken()
         tracks.trackExtensionLaunched(oauth2Token != nil)
     }

--- a/WordPress/WordPressShareExtension/MainShareViewController.swift
+++ b/WordPress/WordPressShareExtension/MainShareViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import TracksMini
 import WordPressShared
 import WordPressUI
 

--- a/WordPress/WordPressShareExtension/ShareExtensionAbstractViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionAbstractViewController.swift
@@ -1,6 +1,7 @@
 import CoreData
 import BuildSettingsKit
 import UIKit
+import TracksMini
 import WordPressKit
 import WordPressShared
 

--- a/WordPress/WordPressShareExtension/ShareExtensionAbstractViewController.swift
+++ b/WordPress/WordPressShareExtension/ShareExtensionAbstractViewController.swift
@@ -110,9 +110,7 @@ class ShareExtensionAbstractViewController: UIViewController, ShareSegueHandler 
 
     /// Tracks Instance
     ///
-    internal lazy var tracks: Tracks = {
-        Tracks(appGroupName: BuildSettings.current.appGroupName)
-    }()
+    internal lazy var tracks = Tracks()
 
     // MARK: - Lifecycle Methods
 

--- a/WordPress/WordPressShareExtension/Tracks.swift
+++ b/WordPress/WordPressShareExtension/Tracks.swift
@@ -17,7 +17,7 @@ open class Tracks {
     private let eventNamePrefix: String
 
     // MARK: - Initializers
-    init(appGroupName: String,
+    init(appGroupName: String = BuildSettings.current.appGroupName,
          eventNamePrefix: String = BuildSettings.current.eventNamePrefix) {
         uploader = Uploader(appGroupName: appGroupName)
         self.eventNamePrefix = eventNamePrefix


### PR DESCRIPTION
Follow-up for https://github.com/wordpress-mobile/WordPress-iOS/pull/24222. This PR removes the last remaining files in `JetpackStatsWidgets` target that were included in multiple targets. 

- Remove `AppStyleGuide`, `BuildConfiguration` from `JetpackStatsWidget` (unused now)
- Add default `Tracks` `appGroupName` parameter
- Move `Tracks` to a new `TracksMini` module – this is a "mini" version of Tracks used across app extensions. I'm not sure why we aren't using a full-blown version, but changing it isn't in the scope of the project.

To test: n/a (moving code, no functional changes)

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
