### PR TITLE
Move iTunesAppID to BuildSettings

### DIFF
--- a/Modules/Sources/BuildSettingsKit/BuildSettings+Live.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings+Live.swift
@@ -10,6 +10,7 @@ extension BuildSettings {
         appKeychainAccessGroup = bundle.infoValue(forKey: "WPAppKeychainAccessGroup")
         eventNamePrefix = bundle.infoValue(forKey: "WPEventNamePrefix")
         explatPlatform = bundle.infoValue(forKey: "WPExplatPlatform")
+        itunesAppID = bundle.infoValue(forKey: "WPItunesAppID")
     }
 }
 

--- a/Modules/Sources/BuildSettingsKit/BuildSettings+Preview.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings+Preview.swift
@@ -8,7 +8,8 @@ extension BuildSettings {
         appGroupName: "xcpreview_app_group_name",
         appKeychainAccessGroup: "xcpreview_app_keychain_access_group",
         eventNamePrefix: "xcpreview",
-        explatPlatform: "xcpreview"
+        explatPlatform: "xcpreview",
+        itunesAppID: "1234567890"
     )
 }
 

--- a/Modules/Sources/BuildSettingsKit/BuildSettings.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings.swift
@@ -18,6 +18,7 @@ public struct BuildSettings: Sendable {
     public var appKeychainAccessGroup: String
     public var eventNamePrefix: String
     public var explatPlatform: String
+    public var itunesAppID: String
 
     public static var current: BuildSettings {
         switch BuildSettingsEnvironment.current {

--- a/WordPress/Classes/Services/AppUpdate/AppStoreSearchService.swift
+++ b/WordPress/Classes/Services/AppUpdate/AppStoreSearchService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import BuildSettingsKit
 
 struct AppStoreLookupResponse: Decodable {
     let results: [AppStoreInfo]
@@ -29,7 +30,7 @@ protocol AppStoreSearchProtocol {
 final class AppStoreSearchService: AppStoreSearchProtocol {
     private(set) var appID: String
 
-    init(appID: String = AppConstants.itunesAppID) {
+    init(appID: String = BuildSettings.current.itunesAppID) {
         self.appID = appID
     }
 

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -5,7 +5,6 @@ import WordPressKit
 /// This configuration class has a **Jetpack** counterpart in the Jetpack bundle.
 /// Make sure to keep them in sync to avoid build errors when building the Jetpack target.
 @objc class AppConstants: NSObject {
-    static let itunesAppID = "335703880"
     static let productTwitterHandle = "@WordPressiOS"
     static let productTwitterURL = "https://twitter.com/WordPressiOS"
     static let productBlogURL = "https://wordpress.org/news/"

--- a/WordPress/Classes/Utility/In-App Feedback/AppRatingsUtility.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/AppRatingsUtility.swift
@@ -1,4 +1,5 @@
 import Foundation
+import BuildSettingsKit
 
 /// This class will help track whether or not a user should be prompted for an
 /// app review.  This class is loosely based on
@@ -337,6 +338,6 @@ class AppRatingUtility: NSObject {
     }
 
     private enum Constants {
-        static let defaultAppReviewURL = URL(string: "https://itunes.apple.com/app/id\(AppConstants.itunesAppID)?mt=8&action=write-review")!
+        static let defaultAppReviewURL = URL(string: "https://itunes.apple.com/app/id\(BuildSettings.current.itunesAppID)?mt=8&action=write-review")!
     }
 }

--- a/WordPress/Classes/Utility/In-App Feedback/AppRatingsUtility.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/AppRatingsUtility.swift
@@ -17,7 +17,7 @@ class AppRatingUtility: NSObject {
     /// The App Review URL that we send off to UIApplication to open up the app
     /// store review page.
     ///
-    @objc let appReviewUrl: URL = Constants.defaultAppReviewURL
+    @objc var appReviewUrl: URL { Constants.defaultAppReviewURL }
 
     /// Sets the number of days that have to pass between AppReview prompts
     /// Apple only allows 3 prompts per year. We're trying to be a bit more conservative and are doing

--- a/WordPress/Info.plist
+++ b/WordPress/Info.plist
@@ -14,6 +14,8 @@
 	<string>wpios</string>
 	<key>WPExplatPlatform</key>
 	<string>wpios</string>
+	<key>WPItunesAppID</key>
+	<string>335703880</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>org.wordpress.bgtask.weeklyroundup</string>

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -5,7 +5,6 @@ import WordPressKit
 /// This configuration class has a **WordPress** counterpart in the WordPress bundle.
 /// Make sure to keep them in sync to avoid build errors when building the WordPress target.
 @objc class AppConstants: NSObject {
-    static let itunesAppID = "1565481562"
     static let productTwitterHandle = "@jetpack"
     static let productTwitterURL = "https://twitter.com/jetpack"
     static let productBlogURL = "https://jetpack.com/blog"

--- a/WordPress/Jetpack/Info.plist
+++ b/WordPress/Jetpack/Info.plist
@@ -14,6 +14,8 @@
 	<string>jpios</string>
 	<key>WPExplatPlatform</key>
 	<string>wpios</string>
+	<key>WPItunesAppID</key>
+	<string>1565481562</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>org.wordpress.bgtask.weeklyroundup</string>


### PR DESCRIPTION
I'll move larger chunks in the future – just wrapping up for today.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
