### PR TITLE
Show "Verify you email" if needed before creating a site

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -138,6 +138,7 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
         if let account = try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext) {
             BlogSyncFacade().syncBlogs(for: account, success: { /* Do nothing */ }, failure: { _ in /* Do nothing */ })
+            AccountService(coreDataStack: ContextManager.shared).updateUserDetails(for: account, success: nil, failure: nil)
         }
 
         return true
@@ -178,6 +179,10 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
         updateFeatureFlags()
         updateRemoteConfig()
+
+        if let account = try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext) {
+            AccountService(coreDataStack: ContextManager.shared).updateUserDetails(for: account, success: nil, failure: nil)
+        }
 
 #if IS_JETPACK
         // JetpackWindowManager is only available in the Jetpack target.

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/AddSiteController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/AddSiteController.swift
@@ -15,6 +15,12 @@ struct AddSiteController {
     }
 
     func showDotComSiteCreationScreen() {
+        if let account = try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext),
+           account.needsEmailVerification {
+            VerifyEmailModal.present(on: viewController)
+            return
+        }
+
         JetpackFeaturesRemovalCoordinator.presentSiteCreationOverlayIfNeeded(in: viewController, source: source, onDidDismiss: { [weak viewController] in
             guard JetpackFeaturesRemovalCoordinator.siteCreationPhase() != .two else {
                 return

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -268,6 +268,12 @@ class JetpackFeaturesRemovalCoordinator: NSObject {
                                                    source: String,
                                                    onWillDismiss: JetpackOverlayDismissCallback? = nil,
                                                    onDidDismiss: JetpackOverlayDismissCallback? = nil) {
+        if let account = try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext),
+           account.needsEmailVerification {
+            VerifyEmailModal.present(on: viewController)
+            return
+        }
+
         let phase = siteCreationPhase()
         let coordinator = JetpackDefaultOverlayCoordinator()
         //

--- a/WordPress/Classes/ViewRelated/Me/Me Main/VerifyEmailRow.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/VerifyEmailRow.swift
@@ -34,7 +34,33 @@ final class VerifyEmailCell: UITableViewCell {
     }
 }
 
+struct VerifyEmailModal: View {
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        NavigationStack {
+            VerifyEmailView(largeTitle: true, fillVerticalSpace: false)
+                .padding(.bottom, 44)
+                .toolbar {
+                    ToolbarItem {
+                        Button(SharedStrings.Button.close, role: .cancel) {
+                            dismiss()
+                        }
+                    }
+                }
+        }
+    }
+
+    static func present(on viewController: UIViewController) {
+        let modal = UIHostingController(rootView: Self())
+        viewController.present(modal, animated: true)
+    }
+}
+
 private struct VerifyEmailView: View {
+    var largeTitle: Bool = false
+    var fillVerticalSpace: Bool = true
+
     @StateObject private var viewModel = VerifyEmailViewModel()
 
     var body: some View {
@@ -44,13 +70,15 @@ private struct VerifyEmailView: View {
                 Text(Strings.verifyEmailTitle)
             }
             .foregroundStyle(Color(uiColor: #colorLiteral(red: 0.8392476439, green: 0.2103677094, blue: 0.2182099223, alpha: 1)))
-            .font(.subheadline.weight(.semibold))
+            .font((largeTitle ? Font.title : .subheadline).weight(.semibold))
 
             Text(viewModel.state.message)
                 .font(.callout)
                 .foregroundStyle(.primary)
 
-            Spacer()
+            if fillVerticalSpace {
+                Spacer()
+            }
 
             Button {
                 viewModel.sendVerificationEmail()
@@ -67,6 +95,7 @@ private struct VerifyEmailView: View {
             }
             .buttonStyle(.borderless)
             .disabled(!viewModel.state.isButtonEnabled)
+            .padding(.top, fillVerticalSpace ? 0 : 8)
         }
         .padding()
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)


### PR DESCRIPTION
Alternative solution of https://github.com/wordpress-mobile/WordPress-iOS/pull/24211. The same "verify your email" content on the me screen is presented as a modal when users with an unverified account tap the "Create a WordPress.com site" button.

<img width="400" alt="Screenshot 2025-03-21 at 2 17 32 PM" src="https://github.com/user-attachments/assets/7b979a1f-44d6-4f24-8d55-5ee1fe854109" />

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
