### PR TITLE
Add AppURLScheme to BuildSettings

### DIFF
--- a/Modules/Sources/BuildSettingsKit/BuildSettings+Live.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings+Live.swift
@@ -12,6 +12,7 @@ extension BuildSettings {
         eventNamePrefix = bundle.infoValue(forKey: "WPEventNamePrefix")
         explatPlatform = bundle.infoValue(forKey: "WPExplatPlatform")
         itunesAppID = bundle.infoValue(forKey: "WPItunesAppID")
+        appURLScheme = bundle.infoValue(forKey: "WPAppURLScheme")
     }
 }
 

--- a/Modules/Sources/BuildSettingsKit/BuildSettings+Preview.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings+Preview.swift
@@ -10,7 +10,8 @@ extension BuildSettings {
         appKeychainAccessGroup: "xcpreview_app_keychain_access_group",
         eventNamePrefix: "xcpreview",
         explatPlatform: "xcpreview",
-        itunesAppID: "1234567890"
+        itunesAppID: "1234567890",
+        appURLScheme: "xcpreview"
     )
 }
 

--- a/Modules/Sources/BuildSettingsKit/BuildSettings.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings.swift
@@ -20,6 +20,7 @@ public struct BuildSettings: Sendable {
     public var eventNamePrefix: String
     public var explatPlatform: String
     public var itunesAppID: String
+    public var appURLScheme: String
 
     public static var current: BuildSettings {
         switch BuildSettingsEnvironment.current {

--- a/WordPress/Classes/System/Constants/Constants.h
+++ b/WordPress/Classes/System/Constants/Constants.h
@@ -23,7 +23,3 @@ extern NSString *const WPAppleIDKeychainServiceName;
 /// iTunes Constants
 ///
 extern NSString *const WPiTunesAppId;
-
-/// Scheme Constants
-///
-extern NSString *const WPComScheme;

--- a/WordPress/Classes/System/Constants/Constants.m
+++ b/WordPress/Classes/System/Constants/Constants.m
@@ -19,7 +19,3 @@ NSString *const WPAppleIDKeychainServiceName                        = @"AppleID"
 /// iTunes Constants
 ///
 NSString *const WPiTunesAppId                                       = @"335703880";
-
-/// Scheme Constants
-///
-NSString *const WPComScheme                                         = WPCOM_SCHEME;

--- a/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
@@ -1,5 +1,6 @@
 import WordPressAuthenticator
 import AutomatticTracks
+import BuildSettingsKit
 
 @objc extension WordPressAppDelegate {
     internal func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {
@@ -29,7 +30,7 @@ import AutomatticTracks
             return JetpackNotificationMigrationService.shared.handleNotificationMigrationOnWordPress()
         }
 
-        guard url.scheme == WPComScheme else {
+        guard url.scheme == BuildSettings.current.appURLScheme else {
             return false
         }
 
@@ -228,5 +229,11 @@ private extension URL {
                 return nil
         }
         return queryItems
+    }
+}
+
+extension WordPressAppDelegate {
+    @objc class var appURLScheme: String {
+        BuildSettings.current.appURLScheme
     }
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
@@ -66,4 +66,5 @@ enum DomainsAnalyticsWebViewOrigin: String {
 @objc final class WPAnalyticsTesting: NSObject {
     @objc static var eventNamePrefix: String?
     @objc static var explatPlatform: String?
+    @objc static var appURLScheme: String?
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -157,7 +157,7 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
     }];
 
     NSMutableDictionary *userProperties = [NSMutableDictionary new];
-    userProperties[@"app_scheme"] = WordPressAppDelegate.appURLScheme;
+    userProperties[@"app_scheme"] = WPAnalyticsTesting.appURLScheme ?: WordPressAppDelegate.appURLScheme;
     userProperties[@"platform"] = @"iOS";
     userProperties[@"dotcom_user"] = @(dotcom_user);
     userProperties[@"jetpack_user"] = @(jetpackBlogsPresent);

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -157,7 +157,7 @@ NSString *const TracksUserDefaultsLoggedInUserIDKey = @"TracksLoggedInUserID";
     }];
 
     NSMutableDictionary *userProperties = [NSMutableDictionary new];
-    userProperties[@"app_scheme"] = WPComScheme;
+    userProperties[@"app_scheme"] = WordPressAppDelegate.appURLScheme;
     userProperties[@"platform"] = @"iOS";
     userProperties[@"dotcom_user"] = @(dotcom_user);
     userProperties[@"jetpack_user"] = @(jetpackBlogsPresent);

--- a/WordPress/Classes/ViewRelated/NUX/Helpers/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Helpers/WordPressAuthenticationManager.swift
@@ -65,7 +65,7 @@ extension WordPressAuthenticationManager {
         return WordPressAuthenticatorConfiguration(
             wpcomClientId: ApiCredentials.client,
             wpcomSecret: ApiCredentials.secret,
-            wpcomScheme: WPComScheme,
+            wpcomScheme: BuildSettings.current.appURLScheme,
             wpcomTermsOfServiceURL: URL(string: WPAutomatticTermsOfServiceURL)!,
             wpcomBaseURL: WordPressComOAuthClient.WordPressComOAuthDefaultBaseURL,
             wpcomAPIBaseURL: AppEnvironment.current.wordPressComApiBase,

--- a/WordPress/Info.plist
+++ b/WordPress/Info.plist
@@ -18,6 +18,8 @@
 	<string>335703880</string>
 	<key>WPBuildConfiguration</key>
 	<string>${WP_BUILD_CONFIGURATION}</string>
+	<key>WPAppURLScheme</key>
+	<string>${WPCOM_SCHEME}</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>org.wordpress.bgtask.weeklyroundup</string>

--- a/WordPress/Info.plist
+++ b/WordPress/Info.plist
@@ -19,7 +19,7 @@
 	<key>WPBuildConfiguration</key>
 	<string>${WP_BUILD_CONFIGURATION}</string>
 	<key>WPAppURLScheme</key>
-	<string>${WPCOM_SCHEME}</string>
+	<string>${WP_APP_URL_SCHEME}</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>org.wordpress.bgtask.weeklyroundup</string>
@@ -494,7 +494,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>wordpress-oauth-v2</string>
-				<string>${WPCOM_SCHEME}</string>
+				<string>${WP_APP_URL_SCHEME}</string>
 				<string>wordpressmigration+v1</string>
 				<string>wordpressnotificationmigration</string>
 			</array>

--- a/WordPress/Jetpack/Info.plist
+++ b/WordPress/Jetpack/Info.plist
@@ -18,6 +18,8 @@
 	<string>1565481562</string>
 	<key>WPBuildConfiguration</key>
 	<string>${WP_BUILD_CONFIGURATION}</string>
+	<key>WPAppURLScheme</key>
+	<string>${WPCOM_SCHEME}</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>org.wordpress.bgtask.weeklyroundup</string>

--- a/WordPress/Jetpack/Info.plist
+++ b/WordPress/Jetpack/Info.plist
@@ -19,7 +19,7 @@
 	<key>WPBuildConfiguration</key>
 	<string>${WP_BUILD_CONFIGURATION}</string>
 	<key>WPAppURLScheme</key>
-	<string>${WPCOM_SCHEME}</string>
+	<string>${WP_APP_URL_SCHEME}</string>
 	<key>BGTaskSchedulerPermittedIdentifiers</key>
 	<array>
 		<string>org.wordpress.bgtask.weeklyroundup</string>
@@ -569,7 +569,7 @@
 			<key>CFBundleURLSchemes</key>
 			<array>
 				<string>wordpress-oauth-v2</string>
-				<string>${WPCOM_SCHEME}</string>
+				<string>${WP_APP_URL_SCHEME}</string>
 				<string>jetpacknotificationmigration</string>
 			</array>
 		</dict>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -9606,7 +9606,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
@@ -9626,7 +9625,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = jpdebug;
 			};
 			name = Debug;
 		};
@@ -9653,10 +9651,6 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
-				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = JetpackStatsWidgets/Info.plist;
@@ -9674,7 +9668,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = IS_JETPACK;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = jetpack;
 			};
 			name = Release;
 		};
@@ -9704,7 +9697,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					ALPHA_BUILD,
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
@@ -9723,7 +9715,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = IS_JETPACK;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = jpalpha;
 			};
 			name = "Release-Alpha";
 		};
@@ -9750,7 +9741,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"DEBUG=1",
 					"$(inherited)",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
@@ -9770,7 +9760,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = jpdebug;
 			};
 			name = Debug;
 		};
@@ -9795,10 +9784,6 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
-				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = JetpackIntents/Info.plist;
@@ -9816,7 +9801,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = IS_JETPACK;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = jetpack;
 			};
 			name = Release;
 		};
@@ -9844,7 +9828,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					ALPHA_BUILD,
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
@@ -9863,7 +9846,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = IS_JETPACK;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = jpalpha;
 			};
 			name = "Release-Alpha";
 		};
@@ -9913,7 +9895,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"NSLOGGER_BUILD_USERNAME=\"${USER}\"",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_THUMB_SUPPORT = NO;
@@ -9957,7 +9938,6 @@
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = wpdebug;
 			};
 			name = Debug;
 		};
@@ -9980,7 +9960,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					NS_BLOCK_ASSERTIONS,
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_THUMB_SUPPORT = NO;
@@ -10021,7 +10000,6 @@
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = wordpress;
 			};
 			name = Release;
 		};
@@ -10339,7 +10317,6 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 					"DEBUG=1",
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -10359,7 +10336,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = wpdebug;
 			};
 			name = Debug;
 		};
@@ -10383,10 +10359,6 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
-				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = WordPressNotificationServiceExtension/Info.plist;
@@ -10403,7 +10375,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = IS_WORDPRESS;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = wordpress;
 			};
 			name = Release;
 		};
@@ -10427,10 +10398,6 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
-				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = WordPressNotificationServiceExtension/Info.plist;
@@ -10447,7 +10414,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = IS_WORDPRESS;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = wpalpha;
 			};
 			name = "Release-Alpha";
 		};
@@ -10478,7 +10444,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"DEBUG=1",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
@@ -10498,7 +10463,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = wpdebug;
 			};
 			name = Debug;
 		};
@@ -10527,10 +10491,6 @@
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = WordPressDraftActionExtension/WordPressDraftPrefix.pch;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
-				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				INFOPLIST_FILE = WordPressDraftActionExtension/Info.plist;
@@ -10548,7 +10508,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = IS_WORDPRESS;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = wordpress;
 			};
 			name = Release;
 		};
@@ -10580,7 +10539,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					ALPHA_BUILD,
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
@@ -10599,7 +10557,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = IS_WORDPRESS;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = wpalpha;
 			};
 			name = "Release-Alpha";
 		};
@@ -10636,7 +10593,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"DEBUG=1",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -10667,7 +10623,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = IS_JETPACK;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				WPCOM_SCHEME = jpdebug;
 			};
 			name = Debug;
 		};
@@ -10701,10 +10656,6 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = WordPressShareExtension/WordPressSharePrefix.pch;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
-				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -10732,7 +10683,6 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = IS_JETPACK;
 				SWIFT_VERSION = 5.0;
-				WPCOM_SCHEME = jetpack;
 			};
 			name = Release;
 		};
@@ -10769,7 +10719,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					ALPHA_BUILD,
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -10799,7 +10748,6 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = IS_JETPACK;
 				SWIFT_VERSION = 5.0;
-				WPCOM_SCHEME = jpalpha;
 			};
 			name = "Release-Alpha";
 		};
@@ -10831,7 +10779,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"DEBUG=1",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
@@ -10851,7 +10798,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = jpdebug;
 			};
 			name = Debug;
 		};
@@ -10881,10 +10827,6 @@
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = WordPressDraftActionExtension/WordPressDraftPrefix.pch;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
-				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				INFOPLIST_FILE = JetpackDraftActionExtension/Info.plist;
@@ -10902,7 +10844,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = IS_JETPACK;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = jetpack;
 			};
 			name = Release;
 		};
@@ -10935,7 +10876,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					ALPHA_BUILD,
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
@@ -10954,7 +10894,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = IS_JETPACK;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = jpalpha;
 			};
 			name = "Release-Alpha";
 		};
@@ -10980,7 +10919,6 @@
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 					"DEBUG=1",
 				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -11000,7 +10938,6 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = jpdebug;
 			};
 			name = Debug;
 		};
@@ -11025,10 +10962,6 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
-				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = JetpackNotificationServiceExtension/Info.plist;
@@ -11045,7 +10978,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = IS_JETPACK;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = jetpack;
 			};
 			name = Release;
 		};
@@ -11070,10 +11002,6 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
-				);
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				INFOPLIST_FILE = JetpackNotificationServiceExtension/Info.plist;
@@ -11090,7 +11018,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = IS_JETPACK;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = jpalpha;
 			};
 			name = "Release-Alpha";
 		};
@@ -11307,7 +11234,6 @@
 				GCC_PREFIX_HEADER = WordPress_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 					ALPHA_BUILD,
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
@@ -11350,7 +11276,6 @@
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = wpalpha;
 			};
 			name = "Release-Alpha";
 		};
@@ -11428,7 +11353,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"DEBUG=1",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -11459,7 +11383,6 @@
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = IS_WORDPRESS;
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
-				WPCOM_SCHEME = wpdebug;
 			};
 			name = Debug;
 		};
@@ -11492,10 +11415,7 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = WordPressShareExtension/WordPressSharePrefix.pch;
-				GCC_PREPROCESSOR_DEFINITIONS = (
-					"$(inherited)",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
-				);
+				"GCC_PREPROCESSOR_DEFINITIONS[arch=*]" = "$(inherited)";
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -11523,7 +11443,6 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = IS_WORDPRESS;
 				SWIFT_VERSION = 5.0;
-				WPCOM_SCHEME = wordpress;
 			};
 			name = Release;
 		};
@@ -11559,7 +11478,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					ALPHA_BUILD,
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
@@ -11589,7 +11507,6 @@
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = IS_WORDPRESS;
 				SWIFT_VERSION = 5.0;
-				WPCOM_SCHEME = wpalpha;
 			};
 			name = "Release-Alpha";
 		};
@@ -11958,7 +11875,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					"NSLOGGER_BUILD_USERNAME=\"${USER}\"",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_THUMB_SUPPORT = NO;
@@ -12001,7 +11917,6 @@
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = jpdebug;
 			};
 			name = Debug;
 		};
@@ -12026,7 +11941,6 @@
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
 					NS_BLOCK_ASSERTIONS,
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				GCC_THUMB_SUPPORT = NO;
@@ -12067,7 +11981,6 @@
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = jetpack;
 			};
 			name = Release;
 		};
@@ -12091,7 +12004,6 @@
 				GCC_PREFIX_HEADER = WordPress_Prefix.pch;
 				GCC_PREPROCESSOR_DEFINITIONS = (
 					"$(inherited)",
-					"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\"",
 					ALPHA_BUILD,
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
@@ -12133,7 +12045,6 @@
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				WPCOM_SCHEME = jpalpha;
 			};
 			name = "Release-Alpha";
 		};

--- a/WordPress/WordPressDraftActionExtension/WordPressDraftPrefix.pch
+++ b/WordPress/WordPressDraftActionExtension/WordPressDraftPrefix.pch
@@ -1,8 +1,3 @@
-#ifndef WPCOM_SCHEME
-#warning WPCOM_SCHEME is not defined for this target configuration! Defaulting to "wordpress".
-#define WPCOM_SCHEME @"wordpress"
-#endif
-
 // CocoaLumberjack Default Logging Level
 #ifndef COCOA_LUMBERJACK
 #define COCOA_LUMBERJACK

--- a/WordPress/WordPressShareExtension/WordPressSharePrefix.pch
+++ b/WordPress/WordPressShareExtension/WordPressSharePrefix.pch
@@ -1,8 +1,3 @@
-#ifndef WPCOM_SCHEME
-#warning WPCOM_SCHEME is not defined for this target configuration! Defaulting to "wordpress".
-#define WPCOM_SCHEME @"wordpress"
-#endif
-
 // CocoaLumberjack Default Logging Level
 #ifndef COCOA_LUMBERJACK
 #define COCOA_LUMBERJACK

--- a/WordPress/WordPressTest/WPAppAnalyticsTests.m
+++ b/WordPress/WordPressTest/WPAppAnalyticsTests.m
@@ -18,6 +18,7 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
 
     WPAnalyticsTesting.eventNamePrefix = @"xctest";
     WPAnalyticsTesting.explatPlatform = @"xctest";
+    WPAnalyticsTesting.appURLScheme = @"xctest";
 }
 
 - (void)tearDown {
@@ -25,6 +26,7 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
 
     WPAnalyticsTesting.eventNamePrefix = nil;
     WPAnalyticsTesting.explatPlatform = nil;
+    WPAnalyticsTesting.appURLScheme = nil;
 
     [WPAnalytics clearTrackers];
 }

--- a/WordPress/WordPress_Prefix.pch
+++ b/WordPress/WordPress_Prefix.pch
@@ -9,11 +9,6 @@
 	// 3rd Party    
     @import CocoaLumberjack;
 
-#ifndef WPCOM_SCHEME
-#warning WPCOM_SCHEME is not defined for this target configuration! Defaulting to "wordpress".
-#define WPCOM_SCHEME @"wordpress"
-#endif
-
 #define AssertSubclassMethod() NSAssert(NO, @"You must override %@ in a subclass", NSStringFromSelector(_cmd))
 
 #define DDLogMethod() DDLogInfo(@"%@ %@", self, NSStringFromSelector(_cmd));

--- a/config/Jetpack.alpha.xcconfig
+++ b/config/Jetpack.alpha.xcconfig
@@ -3,3 +3,4 @@
 BUILD_SCHEME = Jetpack
 WP_PUSH_NOTIFICATION_APP_ID = "com.jetpack.alpha"
 WP_BUILD_CONFIGURATION = alpha
+WP_APP_URL_SCHEME = jpalpha

--- a/config/Jetpack.debug.xcconfig
+++ b/config/Jetpack.debug.xcconfig
@@ -3,3 +3,4 @@
 BUILD_SCHEME = Jetpack
 WP_PUSH_NOTIFICATION_APP_ID = "com.jetpack.appstore.dev"
 WP_BUILD_CONFIGURATION = debug
+WP_APP_URL_SCHEME = jpdebug

--- a/config/Jetpack.release.xcconfig
+++ b/config/Jetpack.release.xcconfig
@@ -1,3 +1,4 @@
 BUILD_SCHEME = Jetpack
 WP_PUSH_NOTIFICATION_APP_ID = "com.jetpack.appstore"
 WP_BUILD_CONFIGURATION = release
+WP_APP_URL_SCHEME = jetpack

--- a/config/WordPress.alpha.xcconfig
+++ b/config/WordPress.alpha.xcconfig
@@ -4,3 +4,4 @@
 BUILD_SCHEME = WordPress Alpha
 WP_PUSH_NOTIFICATION_APP_ID = "org.wordpress.alpha"
 WP_BUILD_CONFIGURATION = alpha
+WP_APP_URL_SCHEME = wpalpha

--- a/config/WordPress.debug.xcconfig
+++ b/config/WordPress.debug.xcconfig
@@ -4,3 +4,4 @@
 BUILD_SCHEME = WordPress
 WP_PUSH_NOTIFICATION_APP_ID = "org.wordpress.appstore.dev"
 WP_BUILD_CONFIGURATION = debug
+WP_APP_URL_SCHEME = wpdebug

--- a/config/WordPress.release.xcconfig
+++ b/config/WordPress.release.xcconfig
@@ -4,3 +4,4 @@
 BUILD_SCHEME = WordPress
 WP_PUSH_NOTIFICATION_APP_ID = "org.wordpress.appstore"
 WP_BUILD_CONFIGURATION = release
+WP_APP_URL_SCHEME = wordpress


### PR DESCRIPTION
This PR fixes massive duplication of `WPCOM_SCHEME` parameter.

In the previous implementation, the steps of getting it into the app were the following

1. In .pbproj, for every target add user-defined `WP_COM` values (duplicated 10 times, 30 defines total)
2. In .pbproj, for every target add the following compiler flag for every build configuration  `"WPCOM_SCHEME=\\@\\\"${WPCOM_SCHEME}\\\""`, (duplicated 30 times)
3. In `Constants.m`, map the value from the compiler flag to an Objective-C constant

<img width="820" alt="Screenshot 2025-03-20 at 9 22 32 PM" src="https://github.com/user-attachments/assets/6dc0e090-d475-42e6-99c2-3e058507bd2c" />

<br/>
<br/>

In the new implementation, the values for `WP_APP_URL_SCHEME` (replaces `WP_COM`) are defined exactly once and are included in the `Info.plist` file that's already parsed by `BuildSettingsKit`.

## To test:

Run a couple of configuration and verify that the runtime values are correct. I tested Jetpack Debug:

```
(lldb) po BuildSettings.current.appURLScheme
"jpdebug"
```

and Release:

```
(lldb) po BuildSettings.current.appURLScheme
"jetpack"
```

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


4. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
