### PR TITLE
Remove unused constants

### DIFF
--- a/WordPress/Classes/System/Constants/Constants.h
+++ b/WordPress/Classes/System/Constants/Constants.h
@@ -11,15 +11,7 @@ extern NSString *const WPGithubMainURL;
 extern NSString *const WPComReferrerURL;
 extern NSString *const WPComDomain;
 
-/// Notifications Constants
-///
-extern NSString *const WPPushNotificationAppId;
-
 /// Apple ID Constants
 ///
 extern NSString *const WPAppleIDKeychainUsernameKey;
 extern NSString *const WPAppleIDKeychainServiceName;
-
-/// iTunes Constants
-///
-extern NSString *const WPiTunesAppId;

--- a/WordPress/Classes/System/Constants/Constants.m
+++ b/WordPress/Classes/System/Constants/Constants.m
@@ -15,7 +15,3 @@ NSString *const WPComDomain                                         = @"wordpres
 ///
 NSString *const WPAppleIDKeychainUsernameKey                        = @"Username";
 NSString *const WPAppleIDKeychainServiceName                        = @"AppleID";
-
-/// iTunes Constants
-///
-NSString *const WPiTunesAppId                                       = @"335703880";


### PR DESCRIPTION
The usages were removed in the previous PRs.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
