### PR TITLE
Fix WP_PUSH_NOTIFICATION_APP_ID

### DIFF
--- a/config/Jetpack.alpha.xcconfig
+++ b/config/Jetpack.alpha.xcconfig
@@ -1,6 +1,6 @@
 #include "Common.enterprise.xcconfig"
 
 BUILD_SCHEME = Jetpack
-WP_PUSH_NOTIFICATION_APP_ID = "com.jetpack.alpha"
+WP_PUSH_NOTIFICATION_APP_ID = com.jetpack.alpha
 WP_BUILD_CONFIGURATION = alpha
 WP_APP_URL_SCHEME = jpalpha

--- a/config/Jetpack.debug.xcconfig
+++ b/config/Jetpack.debug.xcconfig
@@ -1,6 +1,6 @@
 #include "Common.debug.xcconfig"
 
 BUILD_SCHEME = Jetpack
-WP_PUSH_NOTIFICATION_APP_ID = "com.jetpack.appstore.dev"
+WP_PUSH_NOTIFICATION_APP_ID = com.jetpack.appstore.dev
 WP_BUILD_CONFIGURATION = debug
 WP_APP_URL_SCHEME = jpdebug

--- a/config/Jetpack.release.xcconfig
+++ b/config/Jetpack.release.xcconfig
@@ -1,4 +1,4 @@
 BUILD_SCHEME = Jetpack
-WP_PUSH_NOTIFICATION_APP_ID = "com.jetpack.appstore"
+WP_PUSH_NOTIFICATION_APP_ID = com.jetpack.appstore
 WP_BUILD_CONFIGURATION = release
 WP_APP_URL_SCHEME = jetpack

--- a/config/WordPress.alpha.xcconfig
+++ b/config/WordPress.alpha.xcconfig
@@ -2,6 +2,6 @@
 #include "Common.enterprise.xcconfig"
 
 BUILD_SCHEME = WordPress Alpha
-WP_PUSH_NOTIFICATION_APP_ID = "org.wordpress.alpha"
+WP_PUSH_NOTIFICATION_APP_ID = org.wordpress.alpha
 WP_BUILD_CONFIGURATION = alpha
 WP_APP_URL_SCHEME = wpalpha

--- a/config/WordPress.debug.xcconfig
+++ b/config/WordPress.debug.xcconfig
@@ -2,6 +2,6 @@
 #include "Common.debug.xcconfig"
 
 BUILD_SCHEME = WordPress
-WP_PUSH_NOTIFICATION_APP_ID = "org.wordpress.appstore.dev"
+WP_PUSH_NOTIFICATION_APP_ID = org.wordpress.appstore.dev
 WP_BUILD_CONFIGURATION = debug
 WP_APP_URL_SCHEME = wpdebug

--- a/config/WordPress.release.xcconfig
+++ b/config/WordPress.release.xcconfig
@@ -2,6 +2,6 @@
 #include "Common.xcconfig"
 
 BUILD_SCHEME = WordPress
-WP_PUSH_NOTIFICATION_APP_ID = "org.wordpress.appstore"
+WP_PUSH_NOTIFICATION_APP_ID = org.wordpress.appstore
 WP_BUILD_CONFIGURATION = release
 WP_APP_URL_SCHEME = wordpress


### PR DESCRIPTION
This was one of the first keys we moved. I noticed I accidentally included the quotation marks.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
