### PR TITLE
Remove localized strings from AppConstants

### DIFF
--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -17,10 +17,6 @@ import WordPressKit
 
 // MARK: - Localized Strings
 extension AppConstants {
-    struct Settings {
-        static let whatIsNewTitle = NSLocalizedString("What's New in WordPress", comment: "Opens the What's New / Feature Announcement modal")
-    }
-
     struct Logout {
         static let alertTitle = NSLocalizedString("Log out of WordPress?", comment: "LogOut confirmation text, whenever there are no local changes")
     }

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -17,13 +17,6 @@ import WordPressKit
 
 // MARK: - Localized Strings
 extension AppConstants {
-
-    struct AboutScreen {
-        static let blogName = NSLocalizedString("News", comment: "Title of a button that displays the WordPress.org blog")
-        static let workWithUs = NSLocalizedString("Contribute", comment: "Title of button that displays the WordPress.org contributor page")
-        static let workWithUsURL = "https://make.wordpress.org/mobile/handbook"
-    }
-
     struct AppRatings {
         static let prompt = NSLocalizedString("appRatings.wordpress.prompt", value: "What do you think about WordPress?", comment: "This is the string we display when prompting the user to review the WordPress app")
     }

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -17,10 +17,6 @@ import WordPressKit
 
 // MARK: - Localized Strings
 extension AppConstants {
-    struct AppRatings {
-        static let prompt = NSLocalizedString("appRatings.wordpress.prompt", value: "What do you think about WordPress?", comment: "This is the string we display when prompting the user to review the WordPress app")
-    }
-
     struct Settings {
         static let aboutTitle: String = NSLocalizedString("About WordPress", comment: "Link to About screen for WordPress for iOS")
         static let shareButtonTitle = NSLocalizedString("Share WordPress with a friend", comment: "Title for a button that recommends the app to others")

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -14,14 +14,3 @@ import WordPressKit
     static let mobileAnnounceAppId = "2"
     @objc static let authKeychainServiceName = "public-api.wordpress.com"
 }
-
-// MARK: - Localized Strings
-extension AppConstants {
-    struct Logout {
-        static let alertTitle = NSLocalizedString("Log out of WordPress?", comment: "LogOut confirmation text, whenever there are no local changes")
-    }
-
-    struct Zendesk {
-        static let ticketSubject = NSLocalizedString("WordPress for iOS Support", comment: "Subject of new Zendesk ticket.")
-    }
-}

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -19,7 +19,6 @@ import WordPressKit
 extension AppConstants {
     struct Settings {
         static let aboutTitle: String = NSLocalizedString("About WordPress", comment: "Link to About screen for WordPress for iOS")
-        static let shareButtonTitle = NSLocalizedString("Share WordPress with a friend", comment: "Title for a button that recommends the app to others")
         static let whatIsNewTitle = NSLocalizedString("What's New in WordPress", comment: "Opens the What's New / Feature Announcement modal")
     }
 

--- a/WordPress/Classes/Utility/App Configuration/AppConstants.swift
+++ b/WordPress/Classes/Utility/App Configuration/AppConstants.swift
@@ -18,7 +18,6 @@ import WordPressKit
 // MARK: - Localized Strings
 extension AppConstants {
     struct Settings {
-        static let aboutTitle: String = NSLocalizedString("About WordPress", comment: "Link to About screen for WordPress for iOS")
         static let whatIsNewTitle = NSLocalizedString("What's New in WordPress", comment: "Opens the What's New / Feature Announcement modal")
     }
 

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -1,4 +1,5 @@
 import Foundation
+import BuildSettingsKit
 import WordPressAuthenticator
 import WordPressKit
 import WordPressShared
@@ -1107,7 +1108,6 @@ private extension ZendeskUtils {
         static let unknownValue = "unknown"
         static let noValue = "none"
         static let platformTag = "iOS"
-        static let ticketSubject = AppConstants.Zendesk.ticketSubject
         static let blogSeperator = "\n----------\n"
         static let jetpackTag = "jetpack"
         static let wpComTag = "wpcom"
@@ -1121,6 +1121,15 @@ private extension ZendeskUtils {
         static let sourcePlatform = AppConstants.zendeskSourcePlatform
         static let gutenbergIsDefault = "mobile_gutenberg_is_default"
         static let mobileSelfHosted = "selected_site_self_hosted"
+
+        static var ticketSubject: String {
+            switch BuildSettings.current.brand {
+            case .wordpress:
+                NSLocalizedString("WordPress for iOS Support", comment: "Subject of new Zendesk ticket.")
+            case .jetpack:
+                NSLocalizedString("Jetpack for iOS Support", comment: "Subject of new Zendesk ticket.")
+            }
+        }
     }
 
     enum TicketFieldIDs {

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AppAboutScreenConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AppAboutScreenConfiguration.swift
@@ -1,4 +1,5 @@
 import Foundation
+import BuildSettingsKit
 import WordPressUI
 import UIKit
 import WordPressShared
@@ -48,7 +49,7 @@ class AppAboutScreenConfiguration: AboutScreenConfiguration {
                     self?.tracker.buttonPressed(.twitter)
                     self?.webViewPresenter.presentInNavigationControlller(url: Links.twitter, context: context)
                 }),
-                AboutItem(title: AppConstants.AboutScreen.blogName, subtitle: AppConstants.productBlogDisplayURL, cellStyle: .value1, action: { [weak self] context in
+                AboutItem(title: Strings.current.blogName, subtitle: AppConstants.productBlogDisplayURL, cellStyle: .value1, action: { [weak self] context in
                     self?.tracker.buttonPressed(.blog)
                     self?.webViewPresenter.presentInNavigationControlller(url: Links.blog, context: context)
                 })
@@ -68,7 +69,7 @@ class AppAboutScreenConfiguration: AboutScreenConfiguration {
                 AboutItem(title: "", cellStyle: .appLogos, accessoryType: .none)
             ] : nil,
             [
-                AboutItem(title: AppConstants.AboutScreen.workWithUs, subtitle: TextContent.workWithUsSubtitle, cellStyle: .subtitle, accessoryType: .disclosureIndicator, action: { [weak self] context in
+                AboutItem(title: Strings.current.workWithUs, subtitle: TextContent.workWithUsSubtitle, cellStyle: .subtitle, accessoryType: .disclosureIndicator, action: { [weak self] context in
                     self?.tracker.buttonPressed(.workWithUs)
                     self?.webViewPresenter.presentInNavigationControlller(url: Links.workWithUs, context: context)
                 }),
@@ -104,7 +105,7 @@ class AppAboutScreenConfiguration: AboutScreenConfiguration {
     private enum Links {
         static let twitter = URL(string: AppConstants.productTwitterURL)!
         static let blog = URL(string: AppConstants.productBlogURL)!
-        static let workWithUs = URL(string: AppConstants.AboutScreen.workWithUsURL)!
+        static let workWithUs = URL(string: Strings.current.workWithUsURL)!
         static let automattic = URL(string: "https://automattic.com")!
     }
 }
@@ -165,4 +166,29 @@ class LegalAndMoreSubmenuConfiguration: AboutScreenConfiguration {
         static let privacyPolicy = URL(string: WPAutomatticPrivacyURL)!
         static let sourceCode = URL(string: WPGithubMainURL)!
     }
+}
+
+private struct Strings {
+    var blogName: String
+    var workWithUs: String
+    var workWithUsURL: String
+
+    static var current: Strings {
+        switch BuildSettings.current.brand {
+        case .wordpress: .wordpress
+        case .jetpack: .jetpack
+        }
+    }
+
+    static let wordpress = Strings(
+        blogName: NSLocalizedString("News", comment: "Title of a button that displays the WordPress.org blog"),
+        workWithUs: NSLocalizedString("Contribute", comment: "Title of button that displays the WordPress.org contributor page"),
+        workWithUsURL: "https://make.wordpress.org/mobile/handbook"
+    )
+
+    static let jetpack = Strings(
+        blogName: NSLocalizedString("Blog", comment: "Title of a button that displays the WordPress.com blog"),
+        workWithUs: NSLocalizedString("Work With Us", comment: "Title of button that displays the Automattic Work With Us web page"),
+        workWithUsURL: "https://automattic.com/work-with-us"
+    )
 }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/AppSettingsViewController.swift
@@ -589,8 +589,7 @@ private extension AppSettingsViewController {
         if let presenter = RootViewCoordinator.shared.whatIsNewScenePresenter as? WhatIsNewScenePresenter,
             presenter.versionHasAnnouncements,
             FeatureFlag.whatsNew.enabled {
-            let whatIsNewRow = NavigationItemRow(title: AppConstants.Settings.whatIsNewTitle,
-                                                 action: presentWhatIsNew())
+            let whatIsNewRow = NavigationItemRow(title: WhatIsNewScenePresenter.title, action: presentWhatIsNew())
             rows.append(whatIsNewRow)
         }
 

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -560,7 +560,7 @@ extension MeViewController: SearchableActivityConvertable {
 
 // MARK: - Constants
 
-private extension MeViewController {
+extension MeViewController {
     enum RowTitles {
         static let appSettings = NSLocalizedString("App Settings", comment: "Link to App Settings section")
         static let myProfile = NSLocalizedString("My Profile", comment: "Link to My Profile section")
@@ -584,7 +584,15 @@ private extension MeViewController {
     }
 
     enum LogoutAlert {
-        static let defaultTitle = AppConstants.Logout.alertTitle
+        static var defaultTitle: String {
+            switch BuildSettings.current.brand {
+            case .wordpress:
+                NSLocalizedString("Log out of WordPress?", comment: "LogOut confirmation text, whenever there are no local changes")
+            case .jetpack:
+                NSLocalizedString("Log out of Jetpack?", comment: "LogOut confirmation text, whenever there are no local changes")
+            }
+        }
+
         static let unsavedTitleSingular = NSLocalizedString("You have changes to %d post that hasn't been uploaded to your site. Logging out now will delete those changes. Log out anyway?",
                                                             comment: "Warning displayed before logging out. The %d placeholder will contain the number of local posts (SINGULAR!)")
         static let unsavedTitlePlural = NSLocalizedString("You have changes to %d posts that haven’t been uploaded to your site. Logging out now will delete those changes. Log out anyway?",

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import BuildSettingsKit
 import WordPressShared
 import AutomatticAbout
 
@@ -568,7 +569,14 @@ private extension MeViewController {
         static let support = NSLocalizedString("Help & Support", comment: "Link to Help section")
         static let logIn = NSLocalizedString("Log In", comment: "Label for logging in to WordPress.com account")
         static let logOut = NSLocalizedString("Log Out", comment: "Label for logging out from WordPress.com account")
-        static let about = AppConstants.Settings.aboutTitle
+        static var about: String {
+            switch BuildSettings.current.brand {
+            case .wordpress:
+                NSLocalizedString("About WordPress", comment: "Link to About screen for WordPress for iOS")
+            case .jetpack:
+                NSLocalizedString("About Jetpack for iOS", comment: "Link to About screen for Jetpack for iOS")
+            }
+        }
     }
 
     enum HeaderTitles {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+AppRatings.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+AppRatings.swift
@@ -8,7 +8,7 @@ extension NotificationsViewController {
     static let contactURL = "https://support.wordpress.com/contact/"
 
     func setupAppRatings() {
-        inlinePromptView.setupHeading(Strings.ratingPrompt)
+        inlinePromptView.setupHeading(ratingPrompt)
         let yesTitle = NSLocalizedString("notifications.appRatings.prompt.yes.buttonTitle", value: "I like it",
                                          comment: "This is one of the buttons we display inside of the prompt to review the app")
         let noTitle = NSLocalizedString("notifications.appRatings.prompt.no.buttonTitle", value: "Could improve",
@@ -90,13 +90,11 @@ extension NotificationsViewController {
     }
 }
 
-private enum Strings {
-    static var ratingPrompt: String {
-        switch BuildSettings.current.brand {
-        case .wordpress:
-            NSLocalizedString("appRatings.wordpress.prompt", value: "What do you think about WordPress?", comment: "This is the string we display when prompting the user to review the WordPress app")
-        case .jetpack:
-            NSLocalizedString("appRatings.jetpack.prompt", value: "What do you think about Jetpack?", comment: "This is the string we display when prompting the user to review the Jetpack app")
-        }
+private var ratingPrompt: String {
+    switch BuildSettings.current.brand {
+    case .wordpress:
+        NSLocalizedString("appRatings.wordpress.prompt", value: "What do you think about WordPress?", comment: "This is the string we display when prompting the user to review the WordPress app")
+    case .jetpack:
+        NSLocalizedString("appRatings.jetpack.prompt", value: "What do you think about Jetpack?", comment: "This is the string we display when prompting the user to review the Jetpack app")
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+AppRatings.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+AppRatings.swift
@@ -1,3 +1,5 @@
+import UIKit
+import BuildSettingsKit
 import StoreKit
 
 // MARK: - App Ratings
@@ -6,7 +8,7 @@ extension NotificationsViewController {
     static let contactURL = "https://support.wordpress.com/contact/"
 
     func setupAppRatings() {
-        inlinePromptView.setupHeading(AppConstants.AppRatings.prompt)
+        inlinePromptView.setupHeading(Strings.ratingPrompt)
         let yesTitle = NSLocalizedString("notifications.appRatings.prompt.yes.buttonTitle", value: "I like it",
                                          comment: "This is one of the buttons we display inside of the prompt to review the app")
         let noTitle = NSLocalizedString("notifications.appRatings.prompt.no.buttonTitle", value: "Could improve",
@@ -85,5 +87,16 @@ extension NotificationsViewController {
         WPAnalytics.track(.appReviewsDeclinedToRateApp)
         AppRatingUtility.shared.declinedToRateCurrentVersion()
         hideInlinePrompt(delay: 0.0)
+    }
+}
+
+private enum Strings {
+    static var ratingPrompt: String {
+        switch BuildSettings.current.brand {
+        case .wordpress:
+            NSLocalizedString("appRatings.wordpress.prompt", value: "What do you think about WordPress?", comment: "This is the string we display when prompting the user to review the WordPress app")
+        case .jetpack:
+            NSLocalizedString("appRatings.jetpack.prompt", value: "What do you think about Jetpack?", comment: "This is the string we display when prompting the user to review the Jetpack app")
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Sharing/ShareAppContentPresenter+TableView.swift
+++ b/WordPress/Classes/ViewRelated/Sharing/ShareAppContentPresenter+TableView.swift
@@ -1,8 +1,19 @@
+import UIKit
+import BuildSettingsKit
+
 /// Constants for share app content interoperability with table view.
 ///
 extension ShareAppContentPresenter {
     struct RowConstants {
-        static let buttonTitle = AppConstants.Settings.shareButtonTitle
+        static var buttonTitle: String {
+            switch BuildSettings.current.brand {
+            case .wordpress:
+                NSLocalizedString("Share WordPress with a friend", comment: "Title for a button that recommends the app to others")
+            case .jetpack:
+                NSLocalizedString("Share Jetpack with a friend", comment: "Title for a button that recommends the app to others")
+            }
+        }
+
         static let buttonIconImage: UIImage? = .init(systemName: "square.and.arrow.up")
     }
 }

--- a/WordPress/Classes/ViewRelated/Support/LogOutActionHandler.swift
+++ b/WordPress/Classes/ViewRelated/Support/LogOutActionHandler.swift
@@ -1,4 +1,5 @@
 import UIKit
+import BuildSettingsKit
 
 struct LogOutActionHandler {
 
@@ -33,7 +34,10 @@ struct LogOutActionHandler {
     }
 
     private struct Strings {
-        static let alertDefaultTitle = AppConstants.Logout.alertTitle
+        static var alertDefaultTitle: String {
+            MeViewController.LogoutAlert.defaultTitle
+        }
+
         static let alertUnsavedTitleSingular = NSLocalizedString("You have changes to %d post that hasn't been uploaded to your site. Logging out now will delete those changes. Log out anyway?",
                                                             comment: "Warning displayed before logging out. The %d placeholder will contain the number of local posts (SINGULAR!)")
         static let alertUnsavedTitlePlural = NSLocalizedString("You have changes to %d posts that haven’t been uploaded to your site. Logging out now will delete those changes. Log out anyway?",

--- a/WordPress/Classes/ViewRelated/WhatsNew/Presenter/WhatIsNewScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/WhatsNew/Presenter/WhatIsNewScenePresenter.swift
@@ -1,3 +1,5 @@
+import UIKit
+import BuildSettingsKit
 import WordPressFlux
 
 class WhatIsNewScenePresenter: ScenePresenter {
@@ -9,6 +11,8 @@ class WhatIsNewScenePresenter: ScenePresenter {
     private var startPresenting: (() -> Void)?
 
     private let store: AnnouncementsStore
+
+    static var title: String { WhatIsNewStrings.title }
 
     private func shouldPresentWhatIsNew(on viewController: UIViewController) -> Bool {
         if UIDevice.isPad() && versionsDisabledForIpad.contains(self.store.appVersionName) {
@@ -142,7 +146,15 @@ private extension WhatIsNewScenePresenter {
     }
 
     enum WhatIsNewStrings {
-        static let title = AppConstants.Settings.whatIsNewTitle
+        static var title: String {
+            switch BuildSettings.current.brand {
+            case .wordpress:
+                NSLocalizedString("What's New in WordPress", comment: "Opens the What's New / Feature Announcement modal")
+            case .jetpack:
+                NSLocalizedString("What's New in Jetpack", comment: "Opens the What's New / Feature Announcement modal")
+            }
+        }
+
         static let versionPrefix = NSLocalizedString("Version ", comment: "Description for the version label in the What's new page.")
         static let continueButtonTitle = NSLocalizedString("Continue", comment: "Title for the continue button in the What's New page.")
         static let gotItButtonTitle = NSLocalizedString("Got it", comment: "Title for the continue button in the dashboard's custom What's New page.")

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -17,10 +17,6 @@ import WordPressKit
 
 // MARK: - Localized Strings
 extension AppConstants {
-    struct AppRatings {
-        static let prompt = NSLocalizedString("appRatings.jetpack.prompt", value: "What do you think about Jetpack?", comment: "This is the string we display when prompting the user to review the Jetpack app")
-    }
-
     struct Settings {
         static let aboutTitle = NSLocalizedString("About Jetpack for iOS", comment: "Link to About screen for Jetpack for iOS")
         static let shareButtonTitle = NSLocalizedString("Share Jetpack with a friend", comment: "Title for a button that recommends the app to others")

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -17,13 +17,6 @@ import WordPressKit
 
 // MARK: - Localized Strings
 extension AppConstants {
-
-    struct AboutScreen {
-        static let blogName = NSLocalizedString("Blog", comment: "Title of a button that displays the WordPress.com blog")
-        static let workWithUs = NSLocalizedString("Work With Us", comment: "Title of button that displays the Automattic Work With Us web page")
-        static let workWithUsURL = "https://automattic.com/work-with-us"
-    }
-
     struct AppRatings {
         static let prompt = NSLocalizedString("appRatings.jetpack.prompt", value: "What do you think about Jetpack?", comment: "This is the string we display when prompting the user to review the Jetpack app")
     }

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -14,14 +14,3 @@ import WordPressKit
     static let mobileAnnounceAppId = "6"
     @objc static let authKeychainServiceName = "jetpack.public-api.wordpress.com"
 }
-
-// MARK: - Localized Strings
-extension AppConstants {
-    struct Logout {
-        static let alertTitle = NSLocalizedString("Log out of Jetpack?", comment: "LogOut confirmation text, whenever there are no local changes")
-    }
-
-    struct Zendesk {
-        static let ticketSubject = NSLocalizedString("Jetpack for iOS Support", comment: "Subject of new Zendesk ticket.")
-    }
-}

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -18,7 +18,6 @@ import WordPressKit
 // MARK: - Localized Strings
 extension AppConstants {
     struct Settings {
-        static let aboutTitle = NSLocalizedString("About Jetpack for iOS", comment: "Link to About screen for Jetpack for iOS")
         static let whatIsNewTitle = NSLocalizedString("What's New in Jetpack", comment: "Opens the What's New / Feature Announcement modal")
     }
 

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -17,10 +17,6 @@ import WordPressKit
 
 // MARK: - Localized Strings
 extension AppConstants {
-    struct Settings {
-        static let whatIsNewTitle = NSLocalizedString("What's New in Jetpack", comment: "Opens the What's New / Feature Announcement modal")
-    }
-
     struct Logout {
         static let alertTitle = NSLocalizedString("Log out of Jetpack?", comment: "LogOut confirmation text, whenever there are no local changes")
     }

--- a/WordPress/Jetpack/AppConstants.swift
+++ b/WordPress/Jetpack/AppConstants.swift
@@ -19,7 +19,6 @@ import WordPressKit
 extension AppConstants {
     struct Settings {
         static let aboutTitle = NSLocalizedString("About Jetpack for iOS", comment: "Link to About screen for Jetpack for iOS")
-        static let shareButtonTitle = NSLocalizedString("Share Jetpack with a friend", comment: "Title for a button that recommends the app to others")
         static let whatIsNewTitle = NSLocalizedString("What's New in Jetpack", comment: "Opens the What's New / Feature Announcement modal")
     }
 


### PR DESCRIPTION
These can now be switched at runtime; no continual target membership. A `switch` will ensure we don't miss it when adding a new app. 

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
