### PR TITLE
Add remaining files to the shared codebase

### DIFF
--- a/WordPress/Classes/System/Root View/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/Root View/SplitViewRootPresenter.swift
@@ -135,16 +135,10 @@ final class SplitViewRootPresenter: RootViewPresenter {
         case .addSite(let selection):
             showAddSiteScreen(selection: selection)
         case .domains:
-#if IS_JETPACK
             let domainsVC = AllDomainsListViewController()
             let navigationVC = UINavigationController(rootViewController: domainsVC)
             navigationVC.modalPresentationStyle = .formSheet
             splitVC.present(navigationVC, animated: true)
-#endif
-
-#if IS_WORDPRESS
-            wpAssertionFailure("domains are not supported in wpios")
-#endif
         case .help:
             let supportVC = SupportTableViewController()
             let navigationVC = UINavigationController(rootViewController: supportVC)

--- a/WordPress/Classes/ViewRelated/Domains/Views/SiteDomainsView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/SiteDomainsView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import BuildSettingsKit
 import WordPressKit
 import DesignSystem
 
@@ -274,7 +275,9 @@ final class SiteDomainsViewController: UIHostingController<SiteDomainsView> {
     // MARK: - Setup
 
     private func setupAllDomainsBarButtonItem() {
-#if IS_JETPACK
+        guard BuildSettings.current.brand == .jetpack else {
+            return
+        }
         guard domainManagementFeatureFlag.enabled() else {
             return
         }
@@ -287,6 +290,5 @@ final class SiteDomainsViewController: UIHostingController<SiteDomainsView> {
             WPAnalytics.track(.domainsDashboardAllDomainsTapped)
         }
         self.navigationItem.rightBarButtonItem = .init(title: title, primaryAction: action)
-#endif
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Me Main/MeViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import BuildSettingsKit
 import WordPressShared
 import AutomatticAbout
 
@@ -191,8 +192,7 @@ class MeViewController: UITableViewController {
             ImmuTableSection(rows: [helpAndSupportIndicator]),
         ])
 
-#if IS_JETPACK
-        if RemoteFeatureFlag.domainManagement.enabled() && loggedIn && !isSidebarModeEnabled {
+        if BuildSettings.current.brand == .jetpack, RemoteFeatureFlag.domainManagement.enabled() && loggedIn && !isSidebarModeEnabled {
             sections.append(.init(rows: [
                 NavigationItemRow(
                     title: AllDomainsListViewController.Strings.title,
@@ -208,7 +208,6 @@ class MeViewController: UITableViewController {
             ])
             )
         }
-#endif
 
         sections.append(
             ImmuTableSection(rows: [
@@ -363,9 +362,7 @@ class MeViewController: UITableViewController {
     /// Selects the All Domains row and pushes the All Domains view controller
     ///
     public func navigateToAllDomains() {
-    #if IS_JETPACK
         navigateToTarget(for: AllDomainsListViewController.Strings.title)
-    #endif
     }
 
     /// Selects the App Settings row and pushes the App Settings view controller

--- a/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SidebarViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import BuildSettingsKit
 import SwiftUI
 import Combine
 import WordPressKit
@@ -126,43 +127,44 @@ struct SidebarView: View {
 
     @ViewBuilder
     private var more: some View {
-#if IS_JETPACK
-        if AccountHelper.isDotcomAvailable() {
-            Label {
-                Text(Strings.notifications)
-            } icon: {
-                if notificationsButtonViewModel.counter > 0 {
-                    Image(systemName: "bell.badge")
-                        .foregroundStyle(.red, .primary)
-                } else {
-                    Image(systemName: "bell")
+        switch BuildSettings.current.brand {
+        case .wordpress:
+            Button(action: { viewModel.navigate(.help) }) {
+                Label(Strings.help, systemImage: "questionmark.circle")
+            }
+            .accessibilityIdentifier("sidebar_help")
+        case .jetpack:
+            if AccountHelper.isDotcomAvailable() {
+                Label {
+                    Text(Strings.notifications)
+                } icon: {
+                    if notificationsButtonViewModel.counter > 0 {
+                        Image(systemName: "bell.badge")
+                            .foregroundStyle(.red, .primary)
+                    } else {
+                        Image(systemName: "bell")
+                    }
+                }
+                .accessibilityIdentifier("sidebar_notifications")
+                .tag(SidebarSelection.notifications)
+
+                Label(Strings.reader, systemImage: "eyeglasses")
+                    .tag(SidebarSelection.reader)
+                    .accessibilityIdentifier("sidebar_reader")
+
+                if RemoteFeatureFlag.domainManagement.enabled() {
+                    Button(action: { viewModel.navigate(.domains) }) {
+                        Label(Strings.domains, systemImage: "network")
+                    }
+                    .accessibilityIdentifier("sidebar_domains")
                 }
             }
-            .accessibilityIdentifier("sidebar_notifications")
-            .tag(SidebarSelection.notifications)
 
-            Label(Strings.reader, systemImage: "eyeglasses")
-                .tag(SidebarSelection.reader)
-                .accessibilityIdentifier("sidebar_reader")
-
-            if RemoteFeatureFlag.domainManagement.enabled() {
-                Button(action: { viewModel.navigate(.domains) }) {
-                    Label(Strings.domains, systemImage: "network")
-                }
-                .accessibilityIdentifier("sidebar_domains")
+            Button(action: { viewModel.navigate(.help) }) {
+                Label(Strings.help, systemImage: "questionmark.circle")
             }
+            .accessibilityIdentifier("sidebar_help")
         }
-
-        Button(action: { viewModel.navigate(.help) }) {
-            Label(Strings.help, systemImage: "questionmark.circle")
-        }
-        .accessibilityIdentifier("sidebar_help")
-#else
-        Button(action: { viewModel.navigate(.help) }) {
-            Label(Strings.help, systemImage: "questionmark.circle")
-        }
-        .accessibilityIdentifier("sidebar_help")
-#endif
     }
 }
 

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2987,19 +2987,6 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFileSystemSynchronizedBuildFileExceptionSet section */
-		24CE68AE2CD3375300C7B37D /* Exceptions for "Classes" folder in "WordPress" target */ = {
-			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
-			membershipExceptions = (
-				"ViewRelated/Me/All Domains/Coordinators/AllDomainsAddDomainCoordinator.swift",
-				"ViewRelated/Me/All Domains/View Models/AllDomainsListViewModel.swift",
-				"ViewRelated/Me/All Domains/View Models/AllDomainsListViewModel+Strings.swift",
-				"ViewRelated/Me/All Domains/Views/AllDomainsListActivityIndicatorTableViewCell.swift",
-				"ViewRelated/Me/All Domains/Views/AllDomainsListEmptyView.swift",
-				"ViewRelated/Me/All Domains/Views/AllDomainsListTableViewCell.swift",
-				"ViewRelated/Me/All Domains/Views/AllDomainsListViewController.swift",
-			);
-			target = 1D6058900D05DD3D006BFB54 /* WordPress */;
-		};
 		24CE68B42CD3375300C7B37D /* Exceptions for "Classes" folder in "WordPressUITests" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
@@ -3033,7 +3020,6 @@
 		24CE57C42CD3375200C7B37D /* Classes */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
-				24CE68AE2CD3375300C7B37D /* Exceptions for "Classes" folder in "WordPress" target */,
 				24CE68B42CD3375300C7B37D /* Exceptions for "Classes" folder in "WordPressUITests" target */,
 				24CE68B52CD3375300C7B37D /* Exceptions for "Classes" folder in "Jetpack" target */,
 				24CE68BB2CD3375300C7B37D /* Exceptions for "Classes" folder in "JetpackUITests" target */,


### PR DESCRIPTION
The code for managing domains, which is insignificantly small, was not part of the shared codebase, so I added it.

The change allowed me to remove more of the conditional compilation. When https://github.com/wordpress-mobile/WordPress-iOS/pull/24292 is also merged, the `IS_JETPACK` flag will become unused. This is great because now when you make changes, you know they will compile for both apps.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
