### PR TITLE
Remove `https://` from `Info.plist` to address compilation fail

### DIFF
--- a/Modules/Sources/BuildSettingsKit/BuildSettings+Live.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings+Live.swift
@@ -15,8 +15,8 @@ extension BuildSettings {
         appURLScheme = bundle.infoValue(forKey: "WPAppURLScheme")
         about = ProductAboutDetails(
             twitterHandle: bundle.infoValue(forKey: "WPProductTwitterHandle"),
-            twitterURL: URL(string: bundle.infoValue(forKey: "WPProductTwitterURL"))!,
-            blogURL: URL(string: bundle.infoValue(forKey: "WPProductBlogURL"))!
+            twitterURL: bundle.urlValue(forKey: "WPProductTwitterURL"),
+            blogURL: bundle.urlValue(forKey: "WPProductBlogURL")
         )
         zendeskSourcePlatform = bundle.infoValue(forKey: "WPZendeskSourcePlatform")
         mobileAnnounceAppID = bundle.infoValue(forKey: "WPMobileAnnounceAppID")
@@ -38,6 +38,11 @@ private extension Bundle {
         default:
             fatalError("unexpected value: \(object) for key: \(key)")
         }
+    }
+
+    func urlValue(forKey key: String) -> URL {
+        let urlWithoutScheme: String = infoValue(forKey: key)
+        return URL(string: "https://\(urlWithoutScheme)")!
     }
 }
 

--- a/WordPress/Info.plist
+++ b/WordPress/Info.plist
@@ -23,9 +23,9 @@
 	<key>WPProductTwitterHandle</key>
 	<string>@WordPressiOS</string>
 	<key>WPProductTwitterURL</key>
-	<string>https://twitter.com/WordPressiOS</string>
+	<string>twitter.com/WordPressiOS</string>
 	<key>WPProductBlogURL</key>
-	<string>https://wordpress.org/news/</string>
+	<string>wordpress.org/news/</string>
 	<key>WPZendeskSourcePlatform</key>
 	<string>mobile_-_ios</string>
 	<key>WPMobileAnnounceAppID</key>

--- a/WordPress/Jetpack/Info.plist
+++ b/WordPress/Jetpack/Info.plist
@@ -23,9 +23,9 @@
 	<key>WPProductTwitterHandle</key>
 	<string>@jetpack</string>
 	<key>WPProductTwitterURL</key>
-	<string>https://twitter.com/jetpack</string>
+	<string>twitter.com/jetpack</string>
 	<key>WPProductBlogURL</key>
-	<string>https://jetpack.com/blog</string>
+	<string>jetpack.com/blog</string>
 	<key>WPZendeskSourcePlatform</key>
 	<string>mobile_-_jp_ios</string>
 	<key>WPMobileAnnounceAppID</key>


### PR DESCRIPTION
Builds on top of #24294 to address a build failure seen in CI and reproducible locally running Fastlane.

Apparently, Xcode/`xcodebuild` fails to parse straight "https://" in `Info.plist`s, see how https://buildkite.com/automattic/wordpress-ios/builds/26578/steps?jid=0195bb59-1f1a-40ad-89c9-3964c36cff28#0195bb59-1f1a-40ad-89c9-3964c36cff28/973-5502 failed and notice the build for this commit passes.

