### PR TITLE
Rewrite part of WPAppAnalytics in Swift

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -150,6 +150,8 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     func applicationDidEnterBackground(_ application: UIApplication) {
         DDLogInfo("\(self) \(#function)")
 
+        analytics?.trackApplicationDidEnterBackground(screenName: currentlySelectedScreen)
+
         let app = UIApplication.shared
 
         // Let the app finish any uploads that are in progress
@@ -191,6 +193,8 @@ class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
 
     func applicationDidBecomeActive(_ application: UIApplication) {
         DDLogInfo("\(self) \(#function)")
+
+        analytics?.trackApplicationDidBecomeActive()
 
         // This is done here so the check is done on app launch and app switching.
         checkAppleIDCredentialState()
@@ -364,9 +368,7 @@ extension WordPressAppDelegate {
 extension WordPressAppDelegate {
 
     func configureAnalytics() {
-        analytics = WPAppAnalytics(lastVisibleScreenBlock: { [weak self] in
-            return self?.currentlySelectedScreen
-        })
+        analytics = WPAppAnalytics()
     }
 
     func configureAppRatingUtility() {

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Swift.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Swift.swift
@@ -1,5 +1,71 @@
+import Foundation
+
 /// Utility extension to track specific data for passing to on to WPAppAnalytics.
-public extension WPAppAnalytics {
+extension WPAppAnalytics {
+    private enum Constants {
+        static let sessionCountKey = "session_count"
+        static let lastVisibleScreenKey = "last_visible_screen"
+        static let timeInAppKey = "time_in_app"
+    }
+
+    func trackApplicationDidBecomeActive() {
+        incrementSessionCount()
+        trackApplicationOpened()
+        WidgetAnalytics.trackLoadedWidgetsOnApplicationOpened()
+    }
+
+    func trackApplicationDidEnterBackground(screenName: String) {
+        trackApplicationClosed(screenName: screenName)
+    }
+
+    private func trackApplicationOpened() {
+        // UIApplicationDidBecomeActiveNotification will be dispatched if the user
+        // returns from a system overlay (like notification center) or when multi
+        // tasking on the iPad and adjusting the split screen divider. This happens
+        // without previously dispatching UIApplicationDidEnterBackgroundNotification.
+        // We don't want to track application opened in thise cases so check for a
+        // nil applicationOpenedTime first.
+        guard applicationOpenedTime == nil else {
+            return
+        }
+        self.applicationOpenedTime = Date()
+
+        // This stat is part of a funnel that provides critical information.  Before
+        // making ANY modification to this stat please refer to: p4qSXL-35X-p2
+        WPAnalytics.track(.applicationOpened)
+    }
+
+    private func trackApplicationClosed(screenName: String) {
+        var properties: [String: String] = [:]
+        properties[Constants.lastVisibleScreenKey] = screenName
+
+        if let applicationOpenedTime {
+            let applicationClosedTime = Date()
+            let timeInApp = applicationClosedTime.timeIntervalSince(applicationOpenedTime).rounded()
+            properties[Constants.timeInAppKey] = String(timeInApp)
+            self.applicationOpenedTime = nil
+        }
+
+        WPAnalytics.track(.applicationClosed, withProperties: properties)
+        WPAnalytics.endSession()
+    }
+
+    // MARK: Session
+
+    public static var sessionCount: Int {
+        UserDefaults.standard.integer(forKey: Constants.sessionCountKey)
+    }
+
+    private func incrementSessionCount() {
+        var sessionCount = WPAppAnalytics.sessionCount
+        sessionCount += 1
+        if sessionCount == 1 {
+            WPAnalytics.track(.appInstalled)
+        }
+        UserDefaults.standard.set(sessionCount, forKey: Constants.sessionCountKey)
+    }
+
+    // MARK: Misc
 
     /// Get a dictionary of tracking properties for a Media object with the media selection method.
     ///

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Swift.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Swift.swift
@@ -36,13 +36,13 @@ extension WPAppAnalytics {
     }
 
     private func trackApplicationClosed(screenName: String) {
-        var properties: [String: String] = [:]
+        var properties: [String: Any] = [:]
         properties[Constants.lastVisibleScreenKey] = screenName
 
         if let applicationOpenedTime {
             let applicationClosedTime = Date()
             let timeInApp = applicationClosedTime.timeIntervalSince(applicationOpenedTime).rounded()
-            properties[Constants.timeInAppKey] = String(timeInApp)
+            properties[Constants.timeInAppKey] = NSNumber(value: timeInApp)
             self.applicationOpenedTime = nil
         }
 

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -3,8 +3,6 @@
 
 @class Blog, AbstractPost, AccountService;
 
-typedef NSString*(^WPAppAnalyticsLastVisibleScreenCallback)(void);
-
 extern NSString * const WPAppAnalyticsDefaultsUserOptedOut;
 extern NSString * const WPAppAnalyticsDefaultsKeyUsageTracking_deprecated;
 extern NSString * const WPAppAnalyticsKeyBlogID;
@@ -13,7 +11,6 @@ extern NSString * const WPAppAnalyticsKeyPostAuthorID;
 extern NSString * const WPAppAnalyticsKeyFeedID;
 extern NSString * const WPAppAnalyticsKeyFeedItemID;
 extern NSString * const WPAppAnalyticsKeyIsJetpack;
-extern NSString * const WPAppAnalyticsKeySessionCount;
 extern NSString * const WPAppAnalyticsKeyEditorSource;
 extern NSString * const WPAppAnalyticsKeyCommentID;
 extern NSString * const WPAppAnalyticsKeyLegacyQuickAction;
@@ -38,23 +35,19 @@ extern NSString * const WPAppAnalyticsValueSiteTypeP2;
  */
 @interface WPAppAnalytics : NSObject
 
+/**
+ *  @brief      Timestamp of the app's opening time.
+ */
+@property (nonatomic, strong, readwrite) NSDate* applicationOpenedTime;
+
 #pragma mark - Init
 
 /**
  *  @brief      Default initializer.
  *
- *  @param      lastVisibleScreenCallback       This block will be executed whenever this object
- *                                              needs to know the last visible screen for tracking
- *                                              purposes.
- *
  *  @returns    The initialized object.
  */
-- (instancetype)initWithLastVisibleScreenBlock:(WPAppAnalyticsLastVisibleScreenCallback)lastVisibleScreenCallback;
-
-/**
- *  @brief      The current session count.
- */
-+ (NSInteger)sessionCount;
+- (instancetype)init;
 
 /**
  *  @brief      Returns the site type for the blogID. Default is "blog".

--- a/WordPress/Classes/Utility/Analytics/WidgetAnalytics.swift
+++ b/WordPress/Classes/Utility/Analytics/WidgetAnalytics.swift
@@ -2,7 +2,7 @@ import Foundation
 import WidgetKit
 import JetpackStatsWidgetsCore
 
-@objcMembers class WidgetAnalytics: NSObject {
+struct WidgetAnalytics {
     static func trackLoadedWidgetsOnApplicationOpened() {
         guard AppConfiguration.isJetpack else { return }
 

--- a/WordPress/WordPressTest/WPAppAnalyticsTests.m
+++ b/WordPress/WordPressTest/WPAppAnalyticsTests.m
@@ -50,12 +50,8 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
     [[analyticsMock expect] beginSession];
     
     WPAppAnalytics *analytics = nil;
-    WPAppAnalyticsLastVisibleScreenCallback lastVisibleScreenCallback = ^NSString*{
-        return @"TEST";
-    };
 
-    XCTAssertNoThrow(analytics = [[WPAppAnalytics alloc] initWithLastVisibleScreenBlock:lastVisibleScreenCallback],
-                     @"Allocating or initializing this object shouldn't throw an exception");
+    XCTAssertNoThrow(analytics = [WPAppAnalytics new], @"Allocating or initializing this object shouldn't throw an exception");
     XCTAssert([analytics isKindOfClass:[WPAppAnalytics class]]);
     
     [apiCredentialsMock verify];
@@ -72,12 +68,8 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
     [[analyticsMock reject] beginSession];
     
     WPAppAnalytics *analytics = nil;
-    WPAppAnalyticsLastVisibleScreenCallback lastVisibleScreenCallback = ^NSString*{
-        return @"TEST";
-    };
-    
-    XCTAssertNoThrow(analytics = [[WPAppAnalytics alloc] initWithLastVisibleScreenBlock:lastVisibleScreenCallback],
-                     @"Allocating or initializing this object shouldn't throw an exception");
+
+    XCTAssertNoThrow(analytics = [WPAppAnalytics new], @"Allocating or initializing this object shouldn't throw an exception");
     XCTAssert([analytics isKindOfClass:[WPAppAnalytics class]]);
 
     [apiCredentialsMock verify];
@@ -90,12 +82,8 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
 - (void)testUserOptedOut
 {
     WPAppAnalytics *analytics = nil;
-    WPAppAnalyticsLastVisibleScreenCallback lastVisibleScreenCallback = ^NSString*{
-        return @"TEST";
-    };
 
-    XCTAssertNoThrow(analytics = [[WPAppAnalytics alloc] initWithLastVisibleScreenBlock:lastVisibleScreenCallback],
-                     @"Allocating or initializing this object shouldn't throw an exception");
+    XCTAssertNoThrow(analytics = [WPAppAnalytics new], @"Allocating or initializing this object shouldn't throw an exception");
     XCTAssert([analytics isKindOfClass:[WPAppAnalytics class]]);
 
     [analytics setUserHasOptedOut:YES];
@@ -106,12 +94,8 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
 - (void)testUserHasNotOptedOut
 {
     WPAppAnalytics *analytics = nil;
-    WPAppAnalyticsLastVisibleScreenCallback lastVisibleScreenCallback = ^NSString*{
-        return @"TEST";
-    };
 
-    XCTAssertNoThrow(analytics = [[WPAppAnalytics alloc] initWithLastVisibleScreenBlock:lastVisibleScreenCallback],
-                     @"Allocating or initializing this object shouldn't throw an exception");
+    XCTAssertNoThrow(analytics = [WPAppAnalytics new], @"Allocating or initializing this object shouldn't throw an exception");
     XCTAssert([analytics isKindOfClass:[WPAppAnalytics class]]);
 
     [analytics setUserHasOptedOut:NO];
@@ -125,12 +109,8 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
     [[NSUserDefaults standardUserDefaults] setBool:YES forKey:WPAppAnalyticsDefaultsKeyUsageTracking_deprecated];
 
     WPAppAnalytics *analytics = nil;
-    WPAppAnalyticsLastVisibleScreenCallback lastVisibleScreenCallback = ^NSString*{
-        return @"TEST";
-    };
 
-    XCTAssertNoThrow(analytics = [[WPAppAnalytics alloc] initWithLastVisibleScreenBlock:lastVisibleScreenCallback],
-                     @"Allocating or initializing this object shouldn't throw an exception");
+    XCTAssertNoThrow(analytics = [WPAppAnalytics new], @"Allocating or initializing this object shouldn't throw an exception");
     XCTAssert([analytics isKindOfClass:[WPAppAnalytics class]]);
 
     XCTAssertFalse([WPAppAnalytics userHasOptedOut]);
@@ -142,12 +122,8 @@ typedef void(^OCMockInvocationBlock)(NSInvocation* invocation);
     [[NSUserDefaults standardUserDefaults] setBool:NO forKey:WPAppAnalyticsDefaultsKeyUsageTracking_deprecated];
 
     WPAppAnalytics *analytics = nil;
-    WPAppAnalyticsLastVisibleScreenCallback lastVisibleScreenCallback = ^NSString*{
-        return @"TEST";
-    };
 
-    XCTAssertNoThrow(analytics = [[WPAppAnalytics alloc] initWithLastVisibleScreenBlock:lastVisibleScreenCallback],
-                     @"Allocating or initializing this object shouldn't throw an exception");
+    XCTAssertNoThrow(analytics = [WPAppAnalytics new], @"Allocating or initializing this object shouldn't throw an exception");
     XCTAssert([analytics isKindOfClass:[WPAppAnalytics class]]);
 
     XCTAssertTrue([WPAppAnalytics userHasOptedOut]);


### PR DESCRIPTION
The previous implementation won't fly due to the required `WordPressSharedObjC` imports in the bridging header. I'll update the rest tomorrow.

## To test:

Test evens after opening and closing the app.

```
🔵 Tracked: application_opened <>
🔵 Tracked: application_closed <last_visible_screen: Blog List, time_in_app: 3.0>
🔵 Tracked: application_opened <>
```

Note: the `last_visible_screen` doesn't seem accurate but that's none of my business right now.


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
