### PR TITLE
Add missing modular imports

### DIFF
--- a/Modules/Sources/WordPressShared/Reachability/Notification+Reachability.swift
+++ b/Modules/Sources/WordPressShared/Reachability/Notification+Reachability.swift
@@ -5,11 +5,12 @@ public extension Notification {
 }
 
 public extension Notification.Name {
-    static var reachabilityChanged: Notification.Name {
-        return Notification.Name("\(Notification.reachabilityKey).changed")
+    /// - warning: Using a different name that auto-imported `kReachabilityChangedNotification`.
+    static var reachabilityUpdated: Notification.Name {
+        return Notification.Name("\(Notification.reachabilityKey).updated")
     }
 }
 
 @objc extension NSNotification {
-    public static let ReachabilityChangedNotification = Notification.Name.reachabilityChanged
+    public static let ReachabilityUpdatedNotification = Notification.Name.reachabilityUpdated
 }

--- a/Modules/Sources/WordPressShared/Reachability/ReachabilityUtils.swift
+++ b/Modules/Sources/WordPressShared/Reachability/ReachabilityUtils.swift
@@ -58,7 +58,7 @@ public class ReachabilityUtils: NSObject {
                 connectionAvailable = newValue
 
                 notificationCenter.post(
-                    name: .reachabilityChanged,
+                    name: .reachabilityUpdated,
                     object: self,
                     userInfo: [Notification.reachabilityKey: newValue]
                 )

--- a/WordPress/Classes/Extensions/UIButton+Extensions.swift
+++ b/WordPress/Classes/Extensions/UIButton+Extensions.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 extension UIButton {
     /// Creates a bar button item that looks like the native title menu

--- a/WordPress/Classes/Jetpack/JetpackMigration/Common/Navigation/MigrationNavigationController.swift
+++ b/WordPress/Classes/Jetpack/JetpackMigration/Common/Navigation/MigrationNavigationController.swift
@@ -1,5 +1,6 @@
 import Combine
 import UIKit
+import WordPressShared
 
 class MigrationNavigationController: UINavigationController {
     /// Navigation coordinator

--- a/WordPress/Classes/Jetpack/JetpackMigration/Common/Views/Configuration/MigrationCenterViewConfiguration.swift
+++ b/WordPress/Classes/Jetpack/JetpackMigration/Common/Views/Configuration/MigrationCenterViewConfiguration.swift
@@ -1,3 +1,6 @@
+import Foundation
+import WordPressShared
+
 struct MigrationCenterViewConfiguration {
 
     let attributedText: NSAttributedString

--- a/WordPress/Classes/Login/SelfHostedSiteAuthenticator.swift
+++ b/WordPress/Classes/Login/SelfHostedSiteAuthenticator.swift
@@ -5,6 +5,7 @@ import SwiftUI
 import AuthenticationServices
 import WordPressKit
 import WordPressAuthenticator
+import WordPressShared
 
 final actor SelfHostedSiteAuthenticator {
 

--- a/WordPress/Classes/Models/PublicizeService.swift
+++ b/WordPress/Classes/Models/PublicizeService.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreData
+import WordPressShared
 
 open class PublicizeService: NSManagedObject {
     @objc static let googlePlusServiceID = "google_plus"

--- a/WordPress/Classes/Services/AppUpdate/AppUpdatePresenter.swift
+++ b/WordPress/Classes/Services/AppUpdate/AppUpdatePresenter.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WordPressFlux
+import WordPressShared
 
 protocol AppUpdatePresenterProtocol {
     func showNotice(using appStoreInfo: AppStoreLookupResponse.AppStoreInfo)

--- a/WordPress/Classes/Services/BlockEditorSettingsService.swift
+++ b/WordPress/Classes/Services/BlockEditorSettingsService.swift
@@ -1,6 +1,7 @@
 import Foundation
 import WordPressData
 import WordPressKit
+import WordPressShared
 
 class BlockEditorSettingsService {
     struct SettingsServiceResult {

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -6,6 +6,7 @@ import Foundation
 import WordPressData
 import WordPressKit
 import WordPressFlux
+import WordPressShared
 
 protocol PostCoordinatorDelegate: AnyObject {
     func postCoordinator(_ postCoordinator: PostCoordinator, promptForPasswordForBlog blog: Blog)

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -70,7 +70,7 @@ class PostCoordinator: NSObject {
 
         super.init()
 
-        NotificationCenter.default.addObserver(self, selector: #selector(didUpdateReachability), name: .reachabilityChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didUpdateReachability), name: .reachabilityUpdated, object: nil)
     }
 
     struct PublishingOptions {

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -1,6 +1,7 @@
 import Foundation
 import WordPressData
 import WordPressKit
+import WordPressShared
 
 final class PostRepository {
 

--- a/WordPress/Classes/Services/Reader Post/ReaderPostService.h
+++ b/WordPress/Classes/Services/Reader Post/ReaderPostService.h
@@ -5,7 +5,6 @@
 #pragma clang diagnostic ignored "-Wnullability-completeness"
 
 @import WordPressKit;
-@import WordPressSharedObjC;
 
 @class ReaderPost;
 @class ReaderAbstractTopic;

--- a/WordPress/Classes/Services/ReaderSiteService.swift
+++ b/WordPress/Classes/Services/ReaderSiteService.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 @objc extension ReaderSiteService {
 

--- a/WordPress/Classes/System/Root View/MySitesCoordinator+RootViewPresenter.swift
+++ b/WordPress/Classes/System/Root View/MySitesCoordinator+RootViewPresenter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 /// `MySitesCoordinator` is used as the root presenter when Jetpack features are disabled
 /// and the app's UI is simplified.

--- a/WordPress/Classes/System/Root View/RootViewCoordinator.swift
+++ b/WordPress/Classes/System/Root View/RootViewCoordinator.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WordPressAuthenticator
+import WordPressShared
 
 extension NSNotification.Name {
     static let WPAppUITypeChanged = NSNotification.Name(rawValue: "WPAppUITypeChanged")

--- a/WordPress/Classes/System/Root View/RootViewPresenter+EditorNavigation.swift
+++ b/WordPress/Classes/System/Root View/RootViewPresenter+EditorNavigation.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 extension RootViewPresenter {
     func currentOrLastBlog() -> Blog? {

--- a/WordPress/Classes/System/Root View/WordPressAuthenticatorProtocol.swift
+++ b/WordPress/Classes/System/Root View/WordPressAuthenticatorProtocol.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import UIKit
 import SVProgressHUD
 import WordPressAuthenticator
+import WordPressShared
 
 protocol WordPressAuthenticatorProtocol {
     static func loginUI() -> UIViewController?

--- a/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
@@ -1,6 +1,7 @@
-import WordPressAuthenticator
 import AutomatticTracks
 import BuildSettingsKit
+import WordPressAuthenticator
+import WordPressShared
 
 @objc extension WordPressAppDelegate {
     public func application(_ app: UIApplication, open url: URL, options: [UIApplication.OpenURLOptionsKey: Any] = [:]) -> Bool {

--- a/WordPress/Classes/Utility/Analytics/EventTracker.swift
+++ b/WordPress/Classes/Utility/Analytics/EventTracker.swift
@@ -1,3 +1,5 @@
+import WordPressShared
+
 /// Convenient tracking abstraction, which allows this to be a visible and injectable dependency.
 ///
 protocol EventTracker {

--- a/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
@@ -1,5 +1,6 @@
 import Foundation
 import BuildSettingsKit
+import WordPressShared
 
 extension WPAnalytics {
     @objc class var eventNamePrefix: String {

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 // WPiOS-only events
 @objc enum WPAnalyticsEvent: Int {

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Swift.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Swift.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 /// Utility extension to track specific data for passing to on to WPAppAnalytics.
 extension WPAppAnalytics {

--- a/WordPress/Classes/Utility/Analytics/WidgetAnalytics.swift
+++ b/WordPress/Classes/Utility/Analytics/WidgetAnalytics.swift
@@ -1,6 +1,7 @@
 import Foundation
 import WidgetKit
 import JetpackStatsWidgetsCore
+import WordPressShared
 
 struct WidgetAnalytics {
     static func trackLoadedWidgetsOnApplicationOpened() {

--- a/WordPress/Classes/Utility/In-App Feedback/InAppFeedbackPromptCoordinator.swift
+++ b/WordPress/Classes/Utility/In-App Feedback/InAppFeedbackPromptCoordinator.swift
@@ -1,5 +1,6 @@
 import Foundation
 import StoreKit
+import WordPressShared
 
 protocol InAppFeedbackPromptPresenting {
     func presentIfNeeded(in controller: UIViewController) -> Bool

--- a/WordPress/Classes/Utility/Notifications/InteractiveNotificationsManager.swift
+++ b/WordPress/Classes/Utility/Notifications/InteractiveNotificationsManager.swift
@@ -2,6 +2,7 @@ import Foundation
 import UserNotifications
 import ShareExtensionCore
 import WordPressFlux
+import WordPressShared
 
 // MARK: - InteractiveNotificationsManager
 

--- a/WordPress/Classes/Utility/Reachability/ReachabilityUtils+OnlineActions.swift
+++ b/WordPress/Classes/Utility/Reachability/ReachabilityUtils+OnlineActions.swift
@@ -34,7 +34,7 @@ extension ReachabilityUtils {
     @discardableResult
     @objc class func observeOnceInternetAvailable(action: @escaping () -> Void) -> NSObjectProtocol {
         return NotificationCenter.default.observeOnce(
-            forName: .reachabilityChanged,
+            forName: .reachabilityUpdated,
             object: nil,
             queue: .main,
             using: { _ in action() },

--- a/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/UniversalLinkRouter.swift
@@ -1,5 +1,6 @@
 import Foundation
 import BuildSettingsKit
+import WordPressShared
 
 protocol LinkRouter {
     init(routes: [Route])

--- a/WordPress/Classes/Utility/WPInstrumentation.swift
+++ b/WordPress/Classes/Utility/WPInstrumentation.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Sentry
+import WordPressShared
 
 // MARK: - Assertions
 

--- a/WordPress/Classes/Utility/WPMediaEditor.swift
+++ b/WordPress/Classes/Utility/WPMediaEditor.swift
@@ -1,6 +1,7 @@
 import Foundation
 import MediaEditor
 import Gridicons
+import WordPressShared
 
 /**
  Displays the Media Editor with our custom styles and tracking

--- a/WordPress/Classes/ViewRelated/Activity/ActivityListSectionHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Activity/ActivityListSectionHeaderView.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 class ActivityListSectionHeaderView: UITableViewHeaderFooterView {
     @IBOutlet weak var titleLabel: UILabel!

--- a/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Backup/BackupListViewController.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import WordPressShared
 
 class BackupListViewController: BaseActivityListViewController {
 

--- a/WordPress/Classes/ViewRelated/Activity/Filter/FilterBarView.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Filter/FilterBarView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class FilterBarView: UIScrollView {
     let filterStackView = UIStackView()

--- a/WordPress/Classes/ViewRelated/Activity/Filter/FilterChipButton.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Filter/FilterChipButton.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 /// A button that represents a filter chip
 ///

--- a/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Activity/FormattableContent/ActivityContentStyles.swift
@@ -1,4 +1,5 @@
 import FormattableContentKit
+import WordPressShared
 
 class ActivityContentStyles: FormattableContentStyles {
     var attributes: [NSAttributedString.Key: Any] {

--- a/WordPress/Classes/ViewRelated/AppUpdate/BlockingUpdateView.swift
+++ b/WordPress/Classes/ViewRelated/AppUpdate/BlockingUpdateView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import DesignSystem
 import UIKit
 import StoreKit
+import WordPressShared
 
 final class BlockingUpdateViewController: UIHostingController<BlockingUpdateView> {
     init(viewModel: AppStoreInfoViewModel, onButtonTapped: @escaping () -> Void) {

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/SelectPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/SelectPostViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class SelectPostViewController: UITableViewController {
 

--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignSingleStatView.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignSingleStatView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 final class BlazeCampaignSingleStatView: UIView {
 

--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignTableViewCell.swift
@@ -1,5 +1,6 @@
 import UIKit
 import AsyncImageKit
+import WordPressShared
 
 final class BlazeCampaignTableViewCell: UITableViewCell, Reusable {
 

--- a/WordPress/Classes/ViewRelated/Blaze/Helpers/BlazeEventsTracker.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Helpers/BlazeEventsTracker.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 @objcMembers class BlazeEventsTracker: NSObject {
 

--- a/WordPress/Classes/ViewRelated/Blaze/Overlay/BlazePostPreviewView.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Overlay/BlazePostPreviewView.swift
@@ -1,5 +1,6 @@
 import UIKit
 import AsyncImageKit
+import WordPressShared
 
 final class BlazePostPreviewView: UIView {
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell+ActivityPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell+ActivityPresenter.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 // MARK: - ActivityPresenter
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 final class DashboardActivityLogCardCell: DashboardCollectionViewCell {
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazeCampaignView.swift
@@ -1,7 +1,8 @@
 import Foundation
 import UIKit
-import WordPressKit
 import AsyncImageKit
+import WordPressKit
+import WordPressShared
 
 final class DashboardBlazeCampaignView: UIView {
     private let statusView = BlazeCampaignStatusView()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazePromoCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Blaze/DashboardBlazePromoCardView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 final class DashboardBlazePromoCardView: UIView {
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/BlogDashboardEmptyStateCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/BlogDashboardEmptyStateCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 final class BlogDashboardEmptyStateCell: DashboardCollectionViewCell {
     // MARK: - Initializers

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/BlogDashboardPersonalizeCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/BlogDashboardPersonalizeCardCell.swift
@@ -1,5 +1,6 @@
 import UIKit
 import SwiftUI
+import WordPressShared
 
 final class BlogDashboardPersonalizeCardCell: DashboardCollectionViewCell {
     private var blog: Blog?

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardDomainRegistrationCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardDomainRegistrationCardCell.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressFlux
+import WordPressShared
 
 final class DashboardDomainRegistrationCardCell: BaseDashboardDomainsCardCell {
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackInstallCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackInstallCardCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class DashboardJetpackInstallCardCell: DashboardCollectionViewCell {
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/BaseDashboardDomainsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/BaseDashboardDomainsCardCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class BaseDashboardDomainsCardCell: DashboardCollectionViewCell {
     var blog: Blog?

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/GoogleDomains/DashboardGoogleDomainsCardView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Domains/GoogleDomains/DashboardGoogleDomainsCardView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import DesignSystem
+import WordPressShared
 
 struct DashboardGoogleDomainsCardView: View {
     private var buttonAction: () -> ()

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Dynamic/BlogDashboardDynamicCardCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Dynamic/BlogDashboardDynamicCardCoordinator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 final class BlogDashboardDynamicCardCoordinator {
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/PlansTracker.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Free to Paid Plans/PlansTracker.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 struct PlansTracker {
     enum PlanSelectionType: String {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPageCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPageCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class DashboardPageCell: UITableViewCell, Reusable {
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPageCreationCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Pages/DashboardPageCreationCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 final class DashboardPageCreationCompactCell: DashboardPageCreationCell, Reusable {
     override var isCompact: Bool {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/DashboardPostsListCardCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 final class DashboardDraftPostsCardCell: DashboardPostsListCardCell, BlogDashboardCardConfigurable {
     func configure(blog: Blog, viewController: BlogDashboardViewController?, apiResponse: BlogDashboardRemoteEntity?) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/Views/BlogDashboardPostCardGhostCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/Views/BlogDashboardPostCardGhostCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class BlogDashboardPostCardGhostCell: UITableViewCell, NibReusable {
     @IBOutlet weak var titleLabel: UILabel!

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/Views/DashboardPostListErrorCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/Views/DashboardPostListErrorCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class DashboardPostListErrorCell: UITableViewCell, Reusable {
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardBloganuaryCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Prompts/DashboardBloganuaryCardCell.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WordPressShared
 
 class DashboardBloganuaryCardCell: DashboardCollectionViewCell {
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardSingleStatView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Stats/DashboardSingleStatView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 final class DashboardSingleStatView: UIView {
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardAnalytics.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Helpers/BlogDashboardAnalytics.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 class BlogDashboardAnalytics {
     static let shared = BlogDashboardAnalytics()

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/Bloganuary/BloganuaryOverlayViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/Bloganuary/BloganuaryOverlayViewController.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WordPressShared
 
 class BloganuaryOverlayViewController: UIViewController {
 

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/Bloganuary/BloganuaryTracker.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/Bloganuary/BloganuaryTracker.swift
@@ -1,3 +1,5 @@
+import WordPressShared
+
 struct BloganuaryTracker {
 
     enum ModalAction: String {

--- a/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blogging Prompts/BloggingPromptTableViewCell.swift
@@ -1,3 +1,6 @@
+import UIKit
+import WordPressShared
+
 class BloggingPromptTableViewCell: UITableViewCell, NibReusable {
 
     // MARK: - Properties

--- a/WordPress/Classes/ViewRelated/Blog/My Site/Header/HomeSiteHeaderViewController+SiteActions.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/Header/HomeSiteHeaderViewController+SiteActions.swift
@@ -1,5 +1,6 @@
 import UIKit
 import SwiftUI
+import WordPressShared
 
 extension HomeSiteHeaderViewController {
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Monitoring/SiteMonitoringView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Monitoring/SiteMonitoringView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UIKit
+import WordPressShared
 
 struct SiteMonitoringView: View {
     @StateObject var viewModel: SiteMonitoringViewModel

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SettingTableViewCell.h
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SettingTableViewCell.h
@@ -1,9 +1,8 @@
 @import UIKit;
-@import WordPressSharedObjC;
 
 extern NSString * const SettingsTableViewCellReuseIdentifier;
 
-@interface SettingTableViewCell : WPTableViewCell
+@interface SettingTableViewCell : UITableViewCell
 
 - (instancetype)initWithLabel:(NSString *)label editable:(BOOL)editable reuseIdentifier:(NSString *)reuseIdentifier;
 

--- a/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 // UITableViewCell that displays a full width button with a border.
 // Properties:

--- a/WordPress/Classes/ViewRelated/Cells/CheckmarkTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/CheckmarkTableViewCell.swift
@@ -1,4 +1,5 @@
-import Foundation
+import UIKit
+import WordPressShared
 
 /// The purpose of this class is to simply display a regular TableViewCell, with a Checkmark as accessoryType.
 ///

--- a/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/InlineEditableNameValueCell.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressAuthenticator
+import WordPressShared
 
 @objc protocol InlineEditableNameValueCellDelegate: AnyObject {
     @objc optional func inlineEditableNameValueCell(_ cell: InlineEditableNameValueCell,

--- a/WordPress/Classes/ViewRelated/Comments/Analytics/CommentAnalytics.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Analytics/CommentAnalytics.swift
@@ -1,5 +1,6 @@
 import Foundation
 import FormattableContentKit
+import WordPressShared
 
 @objc class CommentAnalytics: NSObject {
 

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentsViewController+Filters.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentsViewController+Filters.swift
@@ -1,3 +1,5 @@
+import WordPressShared
+
 extension CommentsViewController {
 
     enum CommentFilter: Int, FilterTabBarItem, CaseIterable {

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentHeaderTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentHeaderTableViewCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class CommentHeaderTableViewCell: UITableViewCell, Reusable {
 

--- a/WordPress/Classes/ViewRelated/Comments/Views/ListTableViewCell+Comments.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/ListTableViewCell+Comments.swift
@@ -1,3 +1,5 @@
+import WordPressShared
+
 /// Encapsulates logic that configures `ListTableViewCell` with `Comment` models.
 ///
 extension ListTableViewCell {

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController+Cells.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController+Cells.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressUI
+import WordPressShared
 
 extension RegisterDomainDetailsViewController {
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewController/RegisterDomainDetailsViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 import SVProgressHUD
 import WordPressEditor
 import WordPressUI
+import WordPressShared
 
 class RegisterDomainDetailsViewController: UITableViewController {
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainDetails/ViewModel/RegisterDomainDetailsViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 class RegisterDomainDetailsViewModel {
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/RegisterDomainSuggestions/RegisterDomainCoordinator.swift
@@ -1,8 +1,9 @@
 import Foundation
 import AutomatticTracks
+import SwiftUI
 import SVProgressHUD
 import WordPressKit
-import SwiftUI
+import WordPressShared
 
 class RegisterDomainCoordinator {
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/SiteCreationPurchasingWebFlowController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/SiteCreationPurchasingWebFlowController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import AutomatticTracks
 import Sentry
+import WordPressShared
 
 final class SiteCreationPurchasingWebFlowController {
 

--- a/WordPress/Classes/ViewRelated/Domains/Domain registration/Views/RegisterDomainSectionHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Domain registration/Views/RegisterDomainSectionHeaderView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class RegisterDomainSectionHeaderView: UITableViewHeaderFooterView {
 

--- a/WordPress/Classes/ViewRelated/Domains/Views/DomainResultView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/DomainResultView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WordPressShared
 
 struct DomainResultView: View {
     @State private var subtitleHeight: CGFloat = .zero

--- a/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardCoordinator.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 @objc final class DomainsDashboardCoordinator: NSObject {
     @objc(presentDomainsDashboardWithPresenter:source:blog:)

--- a/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardFactory.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardFactory.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import WordPressShared
 
 struct DomainsDashboardFactory {
     static func makeDomainsDashboardViewController(blog: Blog) -> UIViewController {

--- a/WordPress/Classes/ViewRelated/Domains/Views/SiteDomainsView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/SiteDomainsView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import BuildSettingsKit
 import WordPressKit
+import WordPressShared
 import DesignSystem
 
 /// The Site Domains  screen, accessible from My Site

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsFeatureDescriptionView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class BloggingPromptsFeatureDescriptionView: UIView, NibLoadable {
 

--- a/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/Blogging Prompts/BloggingPromptsIntroductionPresenter.swift
@@ -1,5 +1,6 @@
 import Foundation
 import UIKit
+import WordPressShared
 
 /// Presents the BloggingPromptsFeatureIntroduction with actionable buttons
 /// and directs the flow according to which action button is tapped.

--- a/WordPress/Classes/ViewRelated/Feature Introduction/FeatureIntroductionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Feature Introduction/FeatureIntroductionViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 @objc protocol FeatureIntroductionDelegate: AnyObject {
     func primaryActionSelected()

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergFeaturedImageHelper.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergFeaturedImageHelper.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Gutenberg
+import WordPressShared
 
 class GutenbergFeaturedImageHelper: NSObject {
     fileprivate let post: AbstractPost

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebNavigationViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergWeb/GutenbergWebNavigationViewController.swift
@@ -1,4 +1,6 @@
+import UIKit
 import Gutenberg
+import WordPressShared
 
 class GutenbergWebNavigationController: UINavigationController {
     private let gutenbergWebController: GutenbergWebViewController

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/CategorySectionTableViewCell.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Gutenberg
+import WordPressShared
 
 protocol CategorySectionTableViewCellDelegate: AnyObject {
     func didSelectItemAt(_ position: Int, forCell cell: CategorySectionTableViewCell, slug: String)

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLightNavigationController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/GutenbergLightNavigationController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class GutenbergLightNavigationController: UINavigationController {
 

--- a/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/LayoutPickerAnalyticsEvent.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Layout Picker/LayoutPickerAnalyticsEvent.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 class LayoutPickerAnalyticsEvent {
     typealias PreviewDevice = PreviewDeviceSelectionViewController.PreviewDevice

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 /// A class containing convenience methods for the the Jetpack features removal experience
 class JetpackFeaturesRemovalCoordinator: NSObject {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel+Analytics.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel+Analytics.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AutomatticTracks
+import WordPressShared
 
 extension JetpackFullscreenOverlayGeneralViewModel {
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlayGeneralViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 /// Dynamic implementation of `JetpackFullscreenOverlayViewModel` based on the general phase
 /// Should be used for feature-specific and feature-collection overlays.

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel+Analytics.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackFullscreenOverlaySiteCreationViewModel+Analytics.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AutomatticTracks
+import WordPressShared
 
 extension JetpackFullscreenOverlaySiteCreationViewModel {
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackNewUsersOverlaySecondaryView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackNewUsersOverlaySecondaryView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class JetpackNewUsersOverlaySecondaryView: UIView {
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Fullscreen Overlay/JetpackPluginOverlayViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 class JetpackPluginOverlayViewModel: JetpackFullscreenOverlayViewModel {
     private enum Constants {

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/JetpackBrandingAnalyticsHelper.swift
@@ -1,5 +1,6 @@
 import Foundation
 import AutomatticTracks
+import WordPressShared
 
 struct JetpackBrandingAnalyticsHelper {
     private static let screenPropertyKey = "screen"

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackEventsTracker.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Moved To Jetpack/MovedToJetpackEventsTracker.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 struct MovedToJetpackEventsTracker {
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/View/JetpackRemoteInstallTableViewCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 @objcMembers
 class JetpackRemoteInstallTableViewCell: UITableViewCell {

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/SelfHostedJetpackRemoteInstallViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/ViewModel/SelfHostedJetpackRemoteInstallViewModel.swift
@@ -1,5 +1,6 @@
 import WordPressFlux
 import WordPressAuthenticator
+import WordPressShared
 
 class SelfHostedJetpackRemoteInstallViewModel: JetpackRemoteInstallViewModel {
     var onChangeState: ((JetpackRemoteInstallState, JetpackRemoteInstallStateViewModel) -> Void)?

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/Webview/JetpackConnectionWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/Webview/JetpackConnectionWebViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 @preconcurrency import WebKit
 import Gridicons
 import Combine
+import WordPressShared
 
 protocol JetpackConnectionWebDelegate: AnyObject {
     func jetpackConnectionCompleted()

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatCell.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanThreatCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class JetpackScanThreatCell: UITableViewCell, NibReusable {
     @IBOutlet weak var iconBackgroundImageView: UIImageView!

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/View Models/JetpackScanStatusViewModel.swift
@@ -1,3 +1,5 @@
+import WordPressShared
+
 struct JetpackScanStatusViewModel {
     let imageName: String
     let title: String

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackConnectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Settings/JetpackConnectionViewController.swift
@@ -1,4 +1,5 @@
-import Foundation
+import UIKit
+import WordPressShared
 
 @objc
 protocol JetpackConnectionDelegate {

--- a/WordPress/Classes/ViewRelated/Me/All Domains/View Models/AllDomainsListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/View Models/AllDomainsListViewModel.swift
@@ -1,6 +1,7 @@
 import Combine
 import Foundation
 import WordPressData
+import WordPressShared
 
 class AllDomainsListViewModel {
 

--- a/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/Views/AllDomainsListViewController.swift
@@ -2,6 +2,7 @@ import UIKit
 import Combine
 import AutomatticTracks
 import DesignSystem
+import WordPressShared
 
 final class AllDomainsListViewController: UIViewController {
 

--- a/WordPress/Classes/ViewRelated/Me/All Domains/Views/DomainPurchaseChoicesView.swift
+++ b/WordPress/Classes/ViewRelated/Me/All Domains/Views/DomainPurchaseChoicesView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import DesignSystem
+import WordPressShared
 
 class DomainPurchaseChoicesViewModel: ObservableObject {
     @Published var isGetDomainLoading: Bool = false

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutScreenTracker.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutScreenTracker.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 class AboutScreenTracker {
     enum Event: String {

--- a/WordPress/Classes/ViewRelated/Me/App Settings/MediaCacheSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/MediaCacheSettingsViewController.swift
@@ -1,4 +1,5 @@
-import Foundation
+import UIKit
+import WordPressShared
 
 class MediaCacheSettingsViewController: UITableViewController {
     fileprivate var handler: ImmuTableViewHandler?

--- a/WordPress/Classes/ViewRelated/Me/Domain Details/DomainDetailsWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Domain Details/DomainDetailsWebViewController.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 final class DomainDetailsWebViewController: WebKitViewController {
 

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/View Model/ChangeUsernameViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/View Model/ChangeUsernameViewModel.swift
@@ -1,5 +1,6 @@
 import Reachability
 import WordPressFlux
+import WordPressShared
 
 class ChangeUsernameViewModel {
     typealias Listener = () -> Void

--- a/WordPress/Classes/ViewRelated/Media/External/ExternalMediaPickerViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/External/ExternalMediaPickerViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import AsyncImageKit
+import WordPressShared
 
 protocol ExternalMediaPickerViewDelegate: AnyObject {
     /// If the user cancels the flow, the selection is empty.

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaAddMediaMenuController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaAddMediaMenuController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Photos
 import PhotosUI
+import WordPressShared
 
 final class SiteMediaAddMediaMenuController: NSObject, PHPickerViewControllerDelegate, ImagePickerControllerDelegate, ExternalMediaPickerViewDelegate, UIDocumentPickerDelegate, ImagePlaygroundPickerDelegate {
     let blog: Blog

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaPageViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 protocol SiteMediaPageViewControllerDelegate: AnyObject {
     func siteMediaPageViewController(_ viewController: SiteMediaPageViewController, getMediaBeforeMedia media: Media) -> Media?

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import PhotosUI
 import SVProgressHUD
+import WordPressShared
 
 /// The main Site Media screen.
 final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewControllerDelegate {

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaDocumentInfoView.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaDocumentInfoView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 struct SiteMediaDocumentInfoViewModel {
     let image: UIImage

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaSelectionTitleView.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaSelectionTitleView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 final class SiteMediaSelectionTitleView: UIView {
     private let textLabel = UILabel()

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosDataLoader.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosDataLoader.swift
@@ -1,3 +1,5 @@
+import WordPressShared
+
 /// Implementations of this protocol will be notified when data is loaded from the StockPhotosService
 protocol StockPhotosDataLoaderDelegate: AnyObject {
     func didLoad(media: [StockPhotosMedia], reset: Bool)

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosWelcomeView.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosWelcomeView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 final class StockPhotosWelcomeView: UIView {
     override init(frame: CGRect) {

--- a/WordPress/Classes/ViewRelated/Media/Tenor/TenorDataLoader.swift
+++ b/WordPress/Classes/ViewRelated/Media/Tenor/TenorDataLoader.swift
@@ -1,3 +1,5 @@
+import WordPressShared
+
 /// Implementations of this protocol will be notified when data is loaded from the TenorService
 protocol TenorDataLoaderDelegate: AnyObject {
     func didLoad(media: [TenorMedia], reset: Bool)

--- a/WordPress/Classes/ViewRelated/Media/Tenor/TenorWelcomeView.swift
+++ b/WordPress/Classes/ViewRelated/Media/Tenor/TenorWelcomeView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 final class TenorWelcomeView: UIView {
     override init(frame: CGRect) {

--- a/WordPress/Classes/ViewRelated/NUX/Controllers/Social Signup/SignupEpilogueTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Controllers/Social Signup/SignupEpilogueTableViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressAuthenticator
+import WordPressShared
 
 protocol SignupEpilogueTableViewControllerDelegate: AnyObject {
     func displayNameUpdated(newDisplayName: String)

--- a/WordPress/Classes/ViewRelated/NUX/Controllers/Social Signup/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Controllers/Social Signup/SignupEpilogueViewController.swift
@@ -1,6 +1,7 @@
 import UIKit
 import SVProgressHUD
 import WordPressAuthenticator
+import WordPressShared
 
 class SignupEpilogueViewController: UIViewController {
 

--- a/WordPress/Classes/ViewRelated/NUX/Controllers/Social Signup/SignupUsernameViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Controllers/Social Signup/SignupUsernameViewController.swift
@@ -1,4 +1,5 @@
 import SVProgressHUD
+import WordPressShared
 
 protocol SignupUsernameViewControllerDelegate: AnyObject {
     func usernameSelected(_ username: String)

--- a/WordPress/Classes/ViewRelated/NUX/Controllers/UnifiedPrologue/UnifiedProloguePages.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Controllers/UnifiedPrologue/UnifiedProloguePages.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UIKit
+import WordPressShared
 
 enum UnifiedProloguePageType: CaseIterable {
     case intro

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSiteSubscriptionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSiteSubscriptionViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressKit
+import WordPressShared
 
 /// The purpose of this class is to render a collection of notifications sunscriptions for a Site Topic,
 /// and to provide the user a simple interface to update those settings, as needed.

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+AppRatings.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController+AppRatings.swift
@@ -1,6 +1,7 @@
 import UIKit
 import BuildSettingsKit
 import StoreKit
+import WordPressShared
 
 // MARK: - App Ratings
 //

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/BadgeContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/BadgeContentStyles.swift
@@ -1,4 +1,5 @@
 import FormattableContentKit
+import WordPressShared
 
 class BadgeContentStyles: FormattableContentStyles {
 

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/FooterContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/FooterContentStyles.swift
@@ -1,4 +1,5 @@
 import FormattableContentKit
+import WordPressShared
 
 class FooterContentStyles: FormattableContentStyles {
     var attributes: [NSAttributedString.Key: Any] {

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/HeaderContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/HeaderContentStyles.swift
@@ -1,4 +1,5 @@
 import FormattableContentKit
+import WordPressShared
 
 class HeaderContentStyles: FormattableContentStyles {
     var attributes: [NSAttributedString.Key: Any] {

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/HeaderDetailsContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/HeaderDetailsContentStyles.swift
@@ -1,4 +1,5 @@
 import FormattableContentKit
+import WordPressShared
 
 class HeaderDetailsContentStyles: FormattableContentStyles {
     var attributes: [NSAttributedString.Key: Any] {

--- a/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/RichTextContentStyles.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/FormattableContent/Styles/RichTextContentStyles.swift
@@ -1,4 +1,5 @@
 import FormattableContentKit
+import WordPressShared
 
 class RichTextContentStyles: FormattableContentStyles {
 

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 // This facilitates showing the CommentDetailViewController within the context of Notifications.
 

--- a/WordPress/Classes/ViewRelated/Notifications/Views/LikeUserTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/LikeUserTableViewCell.swift
@@ -1,5 +1,6 @@
 import Foundation
 import FormattableContentKit
+import WordPressShared
 
 class LikeUserTableViewCell: UITableViewCell, NibReusable {
 

--- a/WordPress/Classes/ViewRelated/Notifications/Views/ListTableViewCell+Notifications.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/ListTableViewCell+Notifications.swift
@@ -1,3 +1,6 @@
+import Foundation
+import WordPressShared
+
 /// Encapsulates logic that configures `ListTableViewCell` with `Notification` models.
 ///
 extension ListTableViewCell {

--- a/WordPress/Classes/ViewRelated/Pages/Controllers/PageListViewController+Menu.swift
+++ b/WordPress/Classes/ViewRelated/Pages/Controllers/PageListViewController+Menu.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 extension PageListViewController: InteractivePostViewDelegate {
     func edit(_ apost: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Pages/Controllers/ParentPageSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/Controllers/ParentPageSettingsViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressUI
+import WordPressShared
 
 private struct Row: ImmuTableRow {
     static let cell = ImmuTableCell.class(CheckmarkTableViewCell.self)

--- a/WordPress/Classes/ViewRelated/Pages/Views/PageListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Pages/Views/PageListItemViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 final class PageListItemViewModel {
     let page: Page

--- a/WordPress/Classes/ViewRelated/Pages/Views/TemplatePageTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/Views/TemplatePageTableViewCell.swift
@@ -1,4 +1,6 @@
+import UIKit
 import SwiftUI
+import WordPressShared
 
 class TemplatePageTableViewCell: UITableViewCell {
 

--- a/WordPress/Classes/ViewRelated/People/Views/PersonHeaderCell.swift
+++ b/WordPress/Classes/ViewRelated/People/Views/PersonHeaderCell.swift
@@ -1,5 +1,5 @@
-
 import UIKit
+import WordPressShared
 
 class PersonHeaderCell: WPTableViewCell {
 

--- a/WordPress/Classes/ViewRelated/Plugins/Views/PluginDirectoryCollectionViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/Views/PluginDirectoryCollectionViewCell.swift
@@ -1,6 +1,7 @@
 import UIKit
-import WordPressKit
 import Gridicons
+import WordPressKit
+import WordPressShared
 
 class PluginDirectoryCollectionViewCell: UICollectionViewCell {
 

--- a/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Categories/PostCategoriesViewController.swift
@@ -1,5 +1,6 @@
-import Foundation
+import UIKit
 import SwiftUI
+import WordPressShared
 
 @objc protocol PostCategoriesViewControllerDelegate {
     @objc optional func postCategoriesViewController(_ controller: PostCategoriesViewController, didSelectCategory category: PostCategory)

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -2,6 +2,7 @@ import UIKit
 import CoreData
 import Combine
 import WordPressKit
+import WordPressShared
 import SwiftUI
 
 extension PostSettingsViewController {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import UIKit
 import WordPressData
+import WordPressShared
 
 /// Encapsulates logic related to Jetpack Social in the pre-publishing sheet.
 ///

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceSelectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceSelectionViewController.swift
@@ -1,4 +1,5 @@
-import Foundation
+import UIKit
+import WordPressShared
 
 class PreviewDeviceSelectionViewController: UIViewController {
     enum PreviewDevice: String, CaseIterable {

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Diffs/RevisionDiffViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Diffs/RevisionDiffViewController.swift
@@ -1,3 +1,6 @@
+import UIKit
+import WordPressShared
+
 // View Controller for the Revision HML preview
 //
 class RevisionDiffViewController: UIViewController, StoryboardLoadable {

--- a/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Preview/RevisionPreviewViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/Browser/Preview/RevisionPreviewViewController.swift
@@ -1,5 +1,7 @@
+import UIKit
 import Aztec
 import WordPressEditor
+import WordPressShared
 
 // View Controller for the Revision Visual preview
 //

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import WordPressShared
 
 final class PostSearchViewModel: NSObject, PostSearchServiceDelegate {
     @Published var searchTerm = ""

--- a/WordPress/Classes/ViewRelated/Post/Utils/PostNoticePublishSuccessView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Utils/PostNoticePublishSuccessView.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 import DesignSystem
+import WordPressShared
 
 struct PostNoticePublishSuccessView: View {
     let post: Post

--- a/WordPress/Classes/ViewRelated/Post/Views/AbstractPostHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/AbstractPostHelper.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 enum AbstractPostHelper {
     static func getLocalizedStatusWithDate(for post: AbstractPost) -> String? {

--- a/WordPress/Classes/ViewRelated/Post/Views/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PostListItemViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 final class PostListItemViewModel {
     let post: Post

--- a/WordPress/Classes/ViewRelated/Post/Views/PostMediaUploadsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PostMediaUploadsViewModel.swift
@@ -132,7 +132,7 @@ final class PostMediaUploadItemViewModel: ObservableObject, Identifiable {
         title = media.filename ?? "–"
         update()
 
-        NotificationCenter.default.addObserver(self, selector: #selector(didUpdateReachability), name: .reachabilityChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(didUpdateReachability), name: .reachabilityUpdated, object: nil)
     }
 
     fileprivate func update() {

--- a/WordPress/Classes/ViewRelated/Post/Views/ResolveConflictView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/ResolveConflictView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import UIKit
 import WordPressKit
+import WordPressShared
 
 struct ResolveConflictView: View {
     enum Source: String {

--- a/WordPress/Classes/ViewRelated/QR Login/Coordinators/QRLoginCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/QR Login/Coordinators/QRLoginCoordinator.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 struct QRLoginCoordinator: QRLoginParentCoordinator {
     enum QRLoginOrigin: String {

--- a/WordPress/Classes/ViewRelated/QR Login/Helpers/QRLoginCameraPermissionsHandler.swift
+++ b/WordPress/Classes/ViewRelated/QR Login/Helpers/QRLoginCameraPermissionsHandler.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 struct QRLoginCameraPermissionsHandler: QRCameraPermissionsHandler {
     func needsCameraAccess() -> Bool {

--- a/WordPress/Classes/ViewRelated/QR Login/View Controllers/QRLoginScanningViewController.swift
+++ b/WordPress/Classes/ViewRelated/QR Login/View Controllers/QRLoginScanningViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import AVFoundation
+import WordPressShared
 
 class QRLoginScanningViewController: UIViewController {
     @IBOutlet weak var overlayView: UIView!

--- a/WordPress/Classes/ViewRelated/QR Login/View Controllers/QRLoginVerifyAuthorizationViewController.swift
+++ b/WordPress/Classes/ViewRelated/QR Login/View Controllers/QRLoginVerifyAuthorizationViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class QRLoginVerifyAuthorizationViewController: UIViewController {
     @IBOutlet weak var stackView: UIStackView!

--- a/WordPress/Classes/ViewRelated/Reader/Cards/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressReader
+import WordPressShared
 
 enum ReaderTopicCollectionViewState {
     case collapsed

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderBlockSiteAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderBlockSiteAction.swift
@@ -1,3 +1,6 @@
+import CoreData
+import WordPressShared
+
 /// Encapsulates a command to flag a site
 final class ReaderBlockSiteAction {
     private let asBlocked: Bool

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderBlockUserAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderBlockUserAction.swift
@@ -1,4 +1,6 @@
 import Foundation
+import CoreData
+import WordPressShared
 
 /// Encapsulates a command to block a user
 final class ReaderBlockUserAction {

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderFollowAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderFollowAction.swift
@@ -1,3 +1,6 @@
+import CoreData
+import WordPressShared
+
 /// Encapsulates a command to toggle following a post
 final class ReaderFollowAction {
     func execute(with post: ReaderPost,

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderPostMenu.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderPostMenu.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 import SafariServices
+import WordPressShared
 
 struct ReaderPostMenu {
     let post: ReaderPost

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderReblogAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderReblogAction.swift
@@ -1,3 +1,6 @@
+import UIKit
+import WordPressShared
+
 /// Encapsulates a command to reblog a post
 class ReaderReblogAction {
     // tells if the origin is the reader list or detail, for analytics purposes

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderReportPostAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderReportPostAction.swift
@@ -1,3 +1,6 @@
+import UIKit
+import WordPressShared
+
 /// Encapsulates a command to report a post
 final class ReaderReportPostAction {
     func execute(with post: ReaderPost, target: Target = .post, context: NSManagedObjectContext, origin: UIViewController) {

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderShareAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderShareAction.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 /// Encapsulates a command share a post
 final class ReaderShareAction {

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderSubscribeCommentsAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderSubscribeCommentsAction.swift
@@ -1,3 +1,6 @@
+import UIKit
+import WordPressShared
+
 /// Encapsulates a command to subscribe or unsubscribe to a posts comments.
 final class ReaderSubscribeCommentsAction {
     func execute(with post: ReaderPost,

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderVisitSiteAction.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderVisitSiteAction.swift
@@ -1,3 +1,6 @@
+import UIKit
+import WordPressShared
+
 /// Encapsulates a command to visit a site
 final class ReaderVisitSiteAction {
     func execute(with post: ReaderPost, context: NSManagedObjectContext, origin: UIViewController) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderRelatedPostsSectionHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderRelatedPostsSectionHeaderView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class ReaderRelatedPostsSectionHeaderView: UITableViewHeaderFooterView, NibReusable {
 

--- a/WordPress/Classes/ViewRelated/Reader/ReaderButtonScrollToTop.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderButtonScrollToTop.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 final class ReaderButtonScrollToTop: UIButton {
     private var isButtonHidden = false

--- a/WordPress/Classes/ViewRelated/Reader/ReaderFollowButton.swift
+++ b/WordPress/Classes/ViewRelated/Reader/ReaderFollowButton.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import WordPressReader
+import WordPressShared
 
 struct ReaderFollowButton: View {
 

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import DesignSystem
 import WordPressReader
+import WordPressShared
 
 /// The tracking source values for the customization sheet.
 /// The values are kept in sync with Android.

--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteCreationRotatingMessageView.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteCreationRotatingMessageView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class SiteCreationRotatingMessageView: UIView {
     private struct Margins {

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/ErrorStates/ErrorStateViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/ErrorStates/ErrorStateViewController.swift
@@ -1,5 +1,5 @@
-
 import UIKit
+import WordPressShared
 
 // MARK: - ErrorStateViewController
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/SiteCreationAnalyticsHelper.swift
@@ -1,6 +1,7 @@
 import Foundation
-import WordPressKit
 import AutomatticTracks
+import WordPressKit
+import WordPressShared
 
 extension Variation {
     var tracksProperty: String {

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleHeader.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/TitleSubtitleHeader.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 final class TitleSubtitleHeader: UIView {
     struct Margins {

--- a/WordPress/Classes/ViewRelated/Site Creation/Shared/UIView+ContentLayout.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Shared/UIView+ContentLayout.swift
@@ -1,5 +1,5 @@
-
 import UIKit
+import WordPressShared
 
 // MARK: - UILabel
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Site Intent/IntentCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Site Intent/IntentCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 final class IntentCell: UITableViewCell, ModelSettableCell {
     @IBOutlet weak var title: UILabel!

--- a/WordPress/Classes/ViewRelated/Site Creation/Site Intent/SiteIntentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Site Intent/SiteIntentViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class SiteIntentViewController: CollapsableHeaderViewController {
     private let selection: SiteIntentStep.SiteIntentSelection

--- a/WordPress/Classes/ViewRelated/Site Creation/Site Segments/SiteSegmentsCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Site Segments/SiteSegmentsCell.swift
@@ -1,6 +1,7 @@
 import UIKit
 import Gridicons
 import WordPressKit
+import WordPressShared
 
 final class SiteSegmentsCell: UITableViewCell, ModelSettableCell {
     @IBOutlet weak var icon: UIImageView!

--- a/WordPress/Classes/ViewRelated/Site Creation/Wizard/WizardNavigation.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Wizard/WizardNavigation.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 // MARK: - WizardNavigation
 final class WizardNavigation: UINavigationController {

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsChartLegendView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsChartLegendView.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressUI
+import WordPressShared
 
 // MARK: StatsChartLegendView
 

--- a/WordPress/Classes/ViewRelated/Stats/Charts/StatsLineChartView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/StatsLineChartView.swift
@@ -1,5 +1,6 @@
 import UIKit
 import DGCharts
+import WordPressShared
 
 // MARK: - StatsLineChartView
 

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Gridicons
 import DesignSystem
+import WordPressShared
 
 extension WPStyleGuide {
     // MARK: - Styles Used by Stats

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/BottomScrollAnalyticsTracker.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/BottomScrollAnalyticsTracker.swift
@@ -1,5 +1,6 @@
 import Combine
 import Foundation
+import WordPressShared
 
 // MARK: - BottomScrollAnalyticsTracker
 

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatSection.swift
@@ -1,3 +1,5 @@
+import WordPressShared
+
 @objc enum StatSection: Int {
     case periodToday
     case periodOverviewViews

--- a/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Helpers/StatsDataHelper.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 /// Helper class for getting/modifying Stats data for display purposes.
 ///

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/CustomizeInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/CustomizeInsightsCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class CustomizeInsightsCell: UITableViewCell, NibLoadable, Accessible {
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Insights Management/InsightsManagementViewController.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Gridicons
+import WordPressShared
 
 // This exists in addition to `SiteStatsInsightsDelegate` because `[StatSection]`
 // can't be represented in an Obj-C protocol.

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class PostingActivityCell: StatsBaseCell, NibLoadable, Accessible {
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityDay.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityDay.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 protocol PostingActivityDayDelegate: AnyObject {
     func daySelected(_ day: PostingActivityDay)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityLegend.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityLegend.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class PostingActivityLegend: UIView, NibLoadable {
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityMonth.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityMonth.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class PostingActivityMonth: UIView, NibLoadable {
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Posting Activity/PostingActivityViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 struct PostingActivityViewModel {
     private let insightsStore: StatsInsightsStore

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WordPressFlux
+import WordPressShared
 
 enum StatsSummaryTimeIntervalDataAsAWeek {
     case thisWeek(data: StatsSummaryTimeIntervalData)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsBaseCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class StatsBaseCell: UITableViewCell {
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsLatestPostSummaryInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsLatestPostSummaryInsightsCell.swift
@@ -2,6 +2,7 @@ import UIKit
 import Gridicons
 import DesignSystem
 import AsyncImageKit
+import WordPressShared
 
 protocol LatestPostSummaryConfigurable {
     func configure(withInsightData lastPostInsight: StatsLastPostInsight?, andDelegate delegate: SiteStatsInsightsDelegate?)

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsMostPopularTimeInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsMostPopularTimeInsightsCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class StatsMostPopularTimeInsightsCell: StatsBaseCell {
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/StatsTotalInsightsCell.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressUI
+import WordPressShared
 
 struct StatsTotalInsightsData: Equatable {
     var count: Int

--- a/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/TabbedTotalsCell.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressUI
+import WordPressShared
 
 struct TabData: FilterTabBarItem, Equatable {
     var tabTitle: String

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/StatsTwoColumnRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/StatsTwoColumnRow.swift
@@ -1,5 +1,6 @@
 import UIKit
 import DesignSystem
+import WordPressShared
 
 struct StatsTwoColumnRowData: Equatable {
     var leftColumnName: String

--- a/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/Two Column Stats/TwoColumnCell.swift
@@ -1,5 +1,6 @@
 import UIKit
 import DesignSystem
+import WordPressShared
 
 class TwoColumnCell: StatsBaseCell, NibLoadable, Accessible {
 

--- a/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/ViewsVisitors/ViewsVisitorsLineChartCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 struct StatsSegmentedControlData: Equatable {
     var segmentTitle: String

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/CountriesCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 final class CountriesCell: StatsRowsCell, NibLoadable {
 

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class CountriesMapCell: StatsBaseCell, NibLoadable, Accessible {
     private let countriesMapView = CountriesMapView.loadFromNib()

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Overview/OverviewCell.swift
@@ -1,5 +1,6 @@
 import UIKit
 import WordPressUI
+import WordPressShared
 
 struct OverviewTabData: FilterTabBarItem, Hashable {
     var tabTitle: String

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import WordPressFlux
+import WordPressShared
 
 struct StatsTrafficSection: Hashable {
     let periodType: PeriodType

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 final class ReferrerDetailsCell: UITableViewCell {
     private let referrerLabel = UILabel()

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsHeaderCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 final class ReferrerDetailsHeaderCell: UITableViewCell {
     private let referrerLabel = UILabel()

--- a/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Referrer Details/ReferrerDetailsSpamActionCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 final class ReferrerDetailsSpamActionCell: UITableViewCell {
     private let actionLabel = UILabel()

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Date Chooser/SiteStatsTableHeaderView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 protocol SiteStatsTableHeaderDelegate: AnyObject {
     func dateChangedTo(_ newDate: Date?)

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostCells.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GhostViews/StatsGhostCells.swift
@@ -1,3 +1,6 @@
+import UIKit
+import WordPressShared
+
 class StatsGhostBaseCell: StatsBaseCell {
     private typealias Style = WPStyleGuide.Stats
     private(set) var topBorder: UIView?

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/GrowAudienceCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class GrowAudienceCell: UITableViewCell, NibLoadable {
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTitleCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class PostStatsTitleCell: UITableViewCell, NibLoadable {
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/DetailDataCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 /// This cell type displays data rows for Site Stats Details (SiteStatsDetailTableViewController).
 /// Ex: Period Post and Pages.

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import WordPressFlux
 import Combine
+import WordPressShared
 
 /// The view model used by SiteStatsDetailTableViewController to show
 /// all data for a selected stat.

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 import WordPressFlux
+import WordPressShared
 
 /// The view model used by SiteStatsDetailTableViewController to show
 /// all data for a selected stat.

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
@@ -1,5 +1,6 @@
 import UIKit
 import Gridicons
+import WordPressShared
 
 class StatsCellHeader: UITableViewCell, NibLoadable, Accessible {
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsChildRowsView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsChildRowsView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class StatsChildRowsView: UIView, NibLoadable {
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsNoDataRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsNoDataRow.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class StatsNoDataRow: UIView, NibLoadable, Accessible {
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsStackViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsStackViewCell.swift
@@ -1,3 +1,6 @@
+import UIKit
+import WordPressShared
+
 class StatsStackViewCell: StatsBaseCell, NibLoadable {
     private typealias Style = WPStyleGuide.Stats
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsTotalRow.swift
@@ -1,5 +1,6 @@
 import UIKit
 import AsyncImageKit
+import WordPressShared
 
 struct StatsTotalRowData: Equatable {
     var id: UUID?

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/TopTotalsCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 /// This cell type displays the top data rows for a Stat type, with optional subtitles for the items and data.
 /// Ex: Insights Tags and Categories, Period Post and Pages.

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/ViewMoreRow.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 protocol ViewMoreRowDelegate: AnyObject {
     func viewMoreSelectedForStatSection(_ statSection: StatSection)

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -1,12 +1,11 @@
 #import "StatsViewController.h"
 #import "Blog.h"
 #import "WPAccount.h"
-@import WordPressDataObjC;
 #import "BlogService.h"
 #import "WordPress-Swift.h"
 #import "WPAppAnalytics.h"
-@import WordPressShared;
 
+@import WordPressDataObjC;
 @import WordPressShared;
 @import Reachability;
 

--- a/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersChartCell.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersChartCell.swift
@@ -1,5 +1,5 @@
-
 import UIKit
+import WordPressShared
 
 class StatsSubscribersChartCell: StatsBaseCell, NibLoadable {
     private typealias Style = WPStyleGuide.Stats

--- a/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewController.swift
@@ -1,5 +1,6 @@
-import Foundation
+import UIKit
 import Combine
+import WordPressShared
 
 final class StatsSubscribersViewController: SiteStatsBaseTableViewController {
     private let viewModel: StatsSubscribersViewModel

--- a/WordPress/Classes/ViewRelated/Stats/Traffic/StatsTrafficDatePickerViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Traffic/StatsTrafficDatePickerViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 typealias SiteCurrentDateGetter = () -> Date
 

--- a/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Support/SupportChatBot/SupportChatBotViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 struct SupportChatBotViewModel {
     private let zendeskUtils: ZendeskUtilsProtocol

--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 class BloggingPromptsHeaderView: UIView, NibLoadable {
     @IBOutlet private weak var containerStackView: UIStackView!

--- a/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Coordinators/MySitesCoordinator.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 @objc
 class MySitesCoordinator: NSObject {

--- a/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
+++ b/WordPress/Classes/ViewRelated/System/FilterTabBar.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 /// Filter Tab Bar is a tabbed control (much like a segmented control), but
 /// has an appearance similar to Android tabs.

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/SheetActions.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/SheetActions.swift
@@ -1,3 +1,5 @@
+import WordPressShared
+
 /// Common Actions used by CreateButtonActionSheet
 
 struct PostAction: ActionSheetItem {

--- a/WordPress/Classes/ViewRelated/System/NetworkAware.swift
+++ b/WordPress/Classes/ViewRelated/System/NetworkAware.swift
@@ -85,7 +85,7 @@ fileprivate final class ReachabilityNotificationObserver: NSObject {
     }
 
     private func observeErrors() {
-        NotificationCenter.default.addObserver(self, selector: #selector(receive), name: .reachabilityChanged, object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(receive), name: .reachabilityUpdated, object: nil)
     }
 
     @objc func receive(notification: Foundation.Notification) {

--- a/WordPress/Classes/ViewRelated/System/Notices/NoticeStyle.swift
+++ b/WordPress/Classes/ViewRelated/System/Notices/NoticeStyle.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 public enum NoticeAnimationStyle {
     case moveIn

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -1,3 +1,5 @@
+import WordPressShared
+
 // MARK: - Tab Access Tracking
 
 @objc enum WPTab: Int {

--- a/WordPress/Classes/ViewRelated/Tools/SettingsCommon.swift
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsCommon.swift
@@ -1,6 +1,7 @@
 import UIKit
 import WordPressFlux
 import WordPressKit
+import WordPressShared
 
 protocol SettingsController: ImmuTableController {
     var trackingKey: String { get }

--- a/WordPress/Classes/ViewRelated/Tools/Time Zone/Views/TimeZoneRow.swift
+++ b/WordPress/Classes/ViewRelated/Tools/Time Zone/Views/TimeZoneRow.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 struct TimeZoneRow: ImmuTableRow {
     static let cell = ImmuTableCell.class(TimeZoneTableViewCell.self)

--- a/WordPress/Classes/ViewRelated/Tools/Time Zone/Views/TimeZoneTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Tools/Time Zone/Views/TimeZoneTableViewCell.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 final class TimeZoneTableViewCell: WPTableViewCell {
 

--- a/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileUserInfoCell.swift
+++ b/WordPress/Classes/ViewRelated/User Profile Sheet/UserProfileUserInfoCell.swift
@@ -1,3 +1,6 @@
+import UIKit
+import WordPressShared
+
 class UserProfileUserInfoCell: UITableViewCell, NibReusable {
 
     // MARK: - Properties

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableHeaderView.swift
@@ -1,3 +1,6 @@
+import UIKit
+import WordPressShared
+
 /// Renders a table header view with bottom separator, and meant to be used
 /// alongside `ListTableViewCell`.
 ///

--- a/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/ListTableViewCell.swift
@@ -1,5 +1,7 @@
+import UIKit
 import WordPressUI
 import Gravatar
+import WordPressShared
 
 /// Table view cell for the List component.
 ///

--- a/WordPress/Classes/ViewRelated/Views/List/WPStyleGuide+List.swift
+++ b/WordPress/Classes/ViewRelated/Views/List/WPStyleGuide+List.swift
@@ -1,3 +1,6 @@
+import UIKit
+import WordPressShared
+
 /// Convenience constants catalog related for styling List components.
 ///
 extension WPStyleGuide {

--- a/WordPress/Classes/ViewRelated/Views/RoundedButton.swift
+++ b/WordPress/Classes/ViewRelated/Views/RoundedButton.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 @IBDesignable
 class RoundedButton: UIButton {

--- a/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Voice/VoiceToContentViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AVFoundation
 import WordPressKit
+import WordPressShared
 
 final class VoiceToContentViewModel: NSObject, ObservableObject, AVAudioRecorderDelegate {
     @Published private(set) var title: String = ""

--- a/WordPress/Classes/ViewRelated/WhatsNew/Presenter/WhatIsNewScenePresenter.swift
+++ b/WordPress/Classes/ViewRelated/WhatsNew/Presenter/WhatIsNewScenePresenter.swift
@@ -1,6 +1,7 @@
 import UIKit
 import BuildSettingsKit
 import WordPressFlux
+import WordPressShared
 
 class WhatIsNewScenePresenter: ScenePresenter {
 

--- a/WordPress/WordPressTest/PostCoordinatorTests.swift
+++ b/WordPress/WordPressTest/PostCoordinatorTests.swift
@@ -232,7 +232,7 @@ class PostCoordinatorTests: CoreDataTestCase {
         // GIVEN the app quickly restoring connectivity after the first failure
         coordinator.syncEvents.sink {
             if case .finished(_, let result) = $0, case .failure = result {
-                NotificationCenter.default.post(name: .reachabilityChanged, object: nil, userInfo: [Foundation.Notification.reachabilityKey: true])
+                NotificationCenter.default.post(name: .reachabilityUpdated, object: nil, userInfo: [Foundation.Notification.reachabilityKey: true])
             }
         }.store(in: &cancellables)
 


### PR DESCRIPTION
These were the last remaining headers in `WordPress-Bridging-Header.h` with `@import WordPressShared`. The app now no longer imports it automatically in every single file.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
