### PR TITLE
Remove modular imports in future public headers

### DIFF
--- a/WordPress/Classes/Categories/Media+Extensions.h
+++ b/WordPress/Classes/Categories/Media+Extensions.h
@@ -1,6 +1,7 @@
-#import "Media.h"
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
+
+#import "Media.h"
 
 @interface Media (Extensions)
 

--- a/WordPress/Classes/Services/MenusService.h
+++ b/WordPress/Classes/Services/MenusService.h
@@ -1,6 +1,5 @@
+#import <CoreData/CoreData.h>
 #import "LocalCoreDataService.h"
-
-@import CoreData;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -9,7 +9,7 @@
 #import "BlogDetailsViewController.h"
 
 #import "CommentService.h"
-#import "CommentsViewController+Network.h"
+#import "CommentsViewController.h"
 #import "Constants.h"
 
 #import "LocalCoreDataService.h"
@@ -34,7 +34,6 @@
 #import "PostService.h"
 #import "PostServiceOptions.h"
 #import "PostSettingsViewController.h"
-#import "PostSettingsViewController_Internal.h"
 #import "PostTag.h"
 #import "PostTagService.h"
 

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.h
@@ -1,4 +1,5 @@
-@import Foundation;
+#import <Foundation/Foundation.h>
+
 @import WordPressSharedObjC;
 
 @class Blog, AbstractPost, AccountService;

--- a/WordPress/Classes/Utility/UIAlertControllerProxy.h
+++ b/WordPress/Classes/Utility/UIAlertControllerProxy.h
@@ -1,4 +1,4 @@
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 typedef void (^UIAlertControllerCompletionBlock) (UIAlertController *alertController, NSInteger buttonIndex);
 

--- a/WordPress/Classes/Utility/WPError.h
+++ b/WordPress/Classes/Utility/WPError.h
@@ -1,4 +1,4 @@
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/Utility/WPTableViewHandler.h
+++ b/WordPress/Classes/Utility/WPTableViewHandler.h
@@ -1,5 +1,5 @@
-@import UIKit;
-@import CoreData;
+#import <UIKit/UIKit.h>
+#import <CoreData/CoreData.h>
 
 @class WPTableViewHandler;
 

--- a/WordPress/Classes/Utility/WebViewController/WPWebViewController.h
+++ b/WordPress/Classes/Utility/WebViewController/WPWebViewController.h
@@ -1,5 +1,5 @@
 #import <UIKit/UIKit.h>
-@import WebKit;
+#import <WebKit/WebKit.h>
 
 @class Blog;
 @class WPAccount;

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.h
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.h
@@ -1,4 +1,4 @@
-@import UIKit;
+#import <UIKit/UIKit.h>
 
 @class Blog;
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.h
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.h
@@ -1,9 +1,7 @@
 #import <UIKit/UIKit.h>
 
-
 typedef void (^SettingsMultiTextAction)(void);
 typedef void (^SettingsMultiTextChanged)(NSString * _Nonnull);
-
 
 /// Reusable component that renders a UITextView + Hint onscreen. Useful for Text / Password.
 ///

--- a/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.h
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.h
@@ -1,6 +1,5 @@
 #import <UIKit/UIKit.h>
 
-
 #pragma mark - External Constants
 extern NSString * const SettingsSelectionTitleKey;
 extern NSString * const SettingsSelectionTitlesKey;


### PR DESCRIPTION
These won't fly in Keystone (`-Watimport-in-framework-header`)

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
