### PR TITLE
Update access level for types that will go into WordPressData

### DIFF
--- a/WordPress/Classes/Extensions/Array+Page.swift
+++ b/WordPress/Classes/Extensions/Array+Page.swift
@@ -2,7 +2,7 @@ import Foundation
 
 // Array etension to handle Pages on a Page list
 //
-extension Array where Element == Page {
+public extension Array where Element == Page {
     /// Return the first index
     var firstIndex: Int {
         return 0

--- a/WordPress/Classes/Models/AbstractPost+Autosave.swift
+++ b/WordPress/Classes/Models/AbstractPost+Autosave.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension AbstractPost {
+public extension AbstractPost {
     /// An autosave revision may include post title, content and/or excerpt.
     var hasAutosaveRevision: Bool {
         guard let autosaveRevisionIdentifier = autosaveIdentifier?.intValue else {

--- a/WordPress/Classes/Models/AbstractPost+Blaze.swift
+++ b/WordPress/Classes/Models/AbstractPost+Blaze.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension AbstractPost {
+public extension AbstractPost {
 
     var canBlaze: Bool {
         return blog.canBlaze && status == .publish && password == nil

--- a/WordPress/Classes/Models/AbstractPost+Local.swift
+++ b/WordPress/Classes/Models/AbstractPost+Local.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension AbstractPost {
+public extension AbstractPost {
     /// Count posts that have never been uploaded to the server.
     ///
     /// - Parameter context: A `NSManagedObjectContext` in which to count the posts

--- a/WordPress/Classes/Models/AbstractPost+Searchable.swift
+++ b/WordPress/Classes/Models/AbstractPost+Searchable.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 extension AbstractPost: SearchableItemConvertable {
-    var searchItemType: SearchItemType {
+    public var searchItemType: SearchItemType {
         return .abstractPost
     }
 
-    var isSearchable: Bool {
+    public var isSearchable: Bool {
         guard status != .trash else {
             // Don't index trashed posts
             return false
@@ -13,14 +13,14 @@ extension AbstractPost: SearchableItemConvertable {
         return true
     }
 
-    var searchIdentifier: String? {
+    public var searchIdentifier: String? {
         guard let postID, postID.intValue > 0 else {
             return nil
         }
         return postID.stringValue
     }
 
-    var searchDomain: String? {
+    public var searchDomain: String? {
         if let dotComID = blog.dotComID, dotComID.intValue > 0 {
             return dotComID.stringValue
         } else {
@@ -29,22 +29,22 @@ extension AbstractPost: SearchableItemConvertable {
         }
     }
 
-    var searchTitle: String? {
+    public var searchTitle: String? {
         return generateTitle(from: postTitle)
     }
 
-    var searchDescription: String? {
+    public var searchDescription: String? {
         guard let postPreview = contentPreviewForDisplay(), !postPreview.isEmpty else {
             return blog.displayURL as String? ?? contentForDisplay()
         }
         return postPreview
     }
 
-    var searchKeywords: [String]? {
+    public var searchKeywords: [String]? {
         return generateKeywordsFromContent()
     }
 
-    var searchExpirationDate: Date? {
+    public var searchExpirationDate: Date? {
         // Use the default expiration in spotlight.
         return nil
     }

--- a/WordPress/Classes/Models/BasePost.swift
+++ b/WordPress/Classes/Models/BasePost.swift
@@ -7,13 +7,13 @@ extension BasePost {
     // We can't use #keyPath on a non-@objc property, and we can't expose
     // status to Objc-C since it returns an optional enum.
     // I'd prefer #keyPath over a string constant, but the enum brings way more value.
-    static let statusKeyPath = "status"
+    public static let statusKeyPath = "status"
 
     /// The status of the post.
     ///
     /// - warning: The only component that can change the post status is
     /// ``PostRepository``. Never change the status of the post directly.
-    var status: Status? {
+    public var status: Status? {
         get {
             return rawValue(forKey: BasePost.statusKeyPath)
         }
@@ -24,7 +24,7 @@ extension BasePost {
 
     /// For Obj-C compatibility only
     @objc(status)
-    var statusString: String? {
+    public var statusString: String? {
         get {
             return status?.rawValue
         }
@@ -33,7 +33,7 @@ extension BasePost {
         }
     }
 
-    enum Status: String {
+    public enum Status: String {
         case draft = "draft"
         case pending = "pending"
         case publishPrivate = "private"
@@ -43,7 +43,7 @@ extension BasePost {
         case deleted = "deleted" // Returned by wpcom REST API when a post is permanently deleted.
     }
 
-    @objc var featuredImageURL: URL? {
+    @objc public var featuredImageURL: URL? {
         guard let pathForDisplayImage,
             let url = URL(string: pathForDisplayImage) else {
             return nil

--- a/WordPress/Classes/Models/Blocking/BlockedAuthor.swift
+++ b/WordPress/Classes/Models/Blocking/BlockedAuthor.swift
@@ -1,13 +1,14 @@
 import Foundation
+import CocoaLumberjackSwift
 
 @objc(BlockedAuthor)
-final class BlockedAuthor: NSManagedObject {
+public final class BlockedAuthor: NSManagedObject {
 
-    @NSManaged var accountID: NSNumber
-    @NSManaged var authorID: NSNumber
+    @NSManaged public var accountID: NSNumber
+    @NSManaged public var authorID: NSNumber
 }
 
-extension BlockedAuthor {
+public extension BlockedAuthor {
 
     // MARK: Fetch Elements
 

--- a/WordPress/Classes/Models/Blocking/BlockedSite.swift
+++ b/WordPress/Classes/Models/Blocking/BlockedSite.swift
@@ -1,13 +1,14 @@
 import Foundation
+import CocoaLumberjackSwift
 
 @objc(BlockedSite)
-final class BlockedSite: NSManagedObject {
+public final class BlockedSite: NSManagedObject {
 
-    @NSManaged var accountID: NSNumber
-    @NSManaged var blogID: NSNumber
+    @NSManaged public var accountID: NSNumber
+    @NSManaged public var blogID: NSNumber
 }
 
-extension BlockedSite {
+public extension BlockedSite {
 
     // MARK: Fetch Elements
 

--- a/WordPress/Classes/Models/Blog/Blog+BlockEditorSettings.swift
+++ b/WordPress/Classes/Models/Blog/Blog+BlockEditorSettings.swift
@@ -9,7 +9,7 @@ extension Blog {
     @NSManaged public var blockEditorSettings: BlockEditorSettings?
 
     @objc
-    func supportsBlockEditorSettings() -> Bool {
+    public func supportsBlockEditorSettings() -> Bool {
         return hasRequiredWordPressVersion("5.8")
     }
 }

--- a/WordPress/Classes/Models/Blog/Blog+BlogAuthors.swift
+++ b/WordPress/Classes/Models/Blog/Blog+BlogAuthors.swift
@@ -1,20 +1,20 @@
 import Foundation
 import CoreData
 
-extension Blog {
-    @NSManaged public var authors: Set<BlogAuthor>?
+public extension Blog {
+    @NSManaged var authors: Set<BlogAuthor>?
 
     @objc(addAuthorsObject:)
-    @NSManaged public func addToAuthors(_ value: BlogAuthor)
+    @NSManaged func addToAuthors(_ value: BlogAuthor)
 
     @objc(removeAuthorsObject:)
-    @NSManaged public func removeFromAuthors(_ value: BlogAuthor)
+    @NSManaged func removeFromAuthors(_ value: BlogAuthor)
 
     @objc(addAuthors:)
-    @NSManaged public func addToAuthors(_ values: NSSet)
+    @NSManaged func addToAuthors(_ values: NSSet)
 
     @objc(removeAuthors:)
-    @NSManaged public func removeFromAuthors(_ values: NSSet)
+    @NSManaged func removeFromAuthors(_ values: NSSet)
 
     @objc
     func getAuthorWith(id: NSNumber) -> BlogAuthor? {

--- a/WordPress/Classes/Models/Blog/Blog+Capabilities.swift
+++ b/WordPress/Classes/Models/Blog/Blog+Capabilities.swift
@@ -79,7 +79,7 @@ extension Blog {
         return isUserCapableOf(.EditPosts) && JetpackNotificationMigrationService.shared.shouldPresentNotifications()
     }
 
-    var userCanUploadMedia: Bool {
+    public var userCanUploadMedia: Bool {
         // Self-hosted non-Jetpack blogs have no capabilities, so we'll just assume that users can post media
         capabilities != nil ? isUploadingFilesAllowed() : true
     }

--- a/WordPress/Classes/Models/Blog/Blog+HomepageSettings.swift
+++ b/WordPress/Classes/Models/Blog/Blog+HomepageSettings.swift
@@ -1,10 +1,11 @@
 import Foundation
+import WordPressKit
 
-enum HomepageType: String {
+public enum HomepageType: String {
     case page
     case posts
 
-    var title: String {
+    public var title: String {
         switch self {
         case .page:
             return NSLocalizedString("Static Homepage", comment: "Name of setting configured when a site uses a static page as its homepage")
@@ -13,7 +14,7 @@ enum HomepageType: String {
         }
     }
 
-    var remoteType: RemoteHomepageType {
+    public var remoteType: RemoteHomepageType {
         switch self {
         case .page:
             return .page
@@ -23,7 +24,7 @@ enum HomepageType: String {
     }
 }
 
-extension Blog {
+public extension Blog {
     private enum OptionsKeys {
         static let homepageType = "show_on_front"
         static let homepageID = "page_on_front"

--- a/WordPress/Classes/Models/Blog/Blog+Jetpack.swift
+++ b/WordPress/Classes/Models/Blog/Blog+Jetpack.swift
@@ -1,4 +1,4 @@
-extension Blog {
+public extension Blog {
     func getOption<T>(name: String) -> T? {
         return getOptionValue(name) as? T
     }

--- a/WordPress/Classes/Models/Blog/Blog+Plans.swift
+++ b/WordPress/Classes/Models/Blog/Blog+Plans.swift
@@ -1,18 +1,18 @@
 @objc extension Blog {
-    @objc var hasBusinessPlan: Bool {
+    @objc public var hasBusinessPlan: Bool {
         return [1008, // 1y Business Plan
                 1018, // Month-to-Month Business Plan,
                 1028] // 2y Business Plan
         .contains(planID?.intValue)
     }
 
-    @objc var hasBloggerPlan: Bool {
+    @objc public var hasBloggerPlan: Bool {
         return [1010, // 1y Blogger Plan,
                 1030] // 2y Blogger Plan
         .contains(planID?.intValue)
     }
 
-    @objc var hasEcommercePlan: Bool {
+    @objc public var hasEcommercePlan: Bool {
         return [1011, // 1y Ecommerce Plan
                 1031] // 2y Ecommerce Plan
         .contains(planID?.intValue)

--- a/WordPress/Classes/Models/Blog/Blog+Post.swift
+++ b/WordPress/Classes/Models/Blog/Blog+Post.swift
@@ -1,3 +1,4 @@
+import CoreData
 import Foundation
 
 // MARK: - Lookup posts
@@ -8,7 +9,7 @@ extension Blog {
     /// - Parameter postID: The ID associated with the post.
     /// - Returns: The `AbstractPost` associated with the given post ID.
     @objc(lookupPostWithID:inContext:)
-    func lookupPost(withID postID: NSNumber, in context: NSManagedObjectContext) -> AbstractPost? {
+    public func lookupPost(withID postID: NSNumber, in context: NSManagedObjectContext) -> AbstractPost? {
         lookupPost(withID: postID.int64Value, in: context)
     }
 
@@ -16,7 +17,7 @@ extension Blog {
     ///
     /// - Parameter postID: The ID associated with the post.
     /// - Returns: The `AbstractPost` associated with the given post ID.
-    func lookupPost(withID postID: Int, in context: NSManagedObjectContext) -> AbstractPost? {
+    public func lookupPost(withID postID: Int, in context: NSManagedObjectContext) -> AbstractPost? {
         lookupPost(withID: Int64(postID), in: context)
     }
 
@@ -49,7 +50,7 @@ extension Blog {
 
     /// Create a post in the blog.
     @objc
-    func createPost() -> Post {
+    public func createPost() -> Post {
         guard let context = managedObjectContext else {
             fatalError("The `Blog` instance is not associated with an `NSManagedObjectContext`")
         }
@@ -80,7 +81,7 @@ extension Blog {
     }
 
     /// Create a draft post in the blog.
-    func createDraftPost() -> Post {
+    public func createDraftPost() -> Post {
         let post = createPost()
         markAsDraft(post)
         return post
@@ -88,7 +89,7 @@ extension Blog {
 
     /// Create a page in the blog.
     @objc
-    func createPage() -> Page {
+    public func createPage() -> Page {
         guard let context = managedObjectContext else {
             fatalError("The `Blog` instance is not associated with a `NSManagedObjectContext`")
         }
@@ -111,7 +112,7 @@ extension Blog {
     }
 
     /// Create a draft page in the blog.
-    func createDraftPage() -> Page {
+    public func createDraftPage() -> Page {
         let page = createPage()
         markAsDraft(page)
         return page

--- a/WordPress/Classes/Models/Blog/Blog+Quota.swift
+++ b/WordPress/Classes/Models/Blog/Blog+Quota.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// This extension add methods to make the manipulation of disk quota values for a blog easier
-extension Blog {
+public extension Blog {
 
     /// Returns true if quota values are available for the site
     @objc var isQuotaAvailable: Bool {

--- a/WordPress/Classes/Models/Blog/BlogSettings.swift
+++ b/WordPress/Classes/Models/Blog/BlogSettings.swift
@@ -1,3 +1,4 @@
+import CoreData
 import Foundation
 
 /// This class encapsulates all of the settings available for a Blog entity
@@ -7,67 +8,67 @@ open class BlogSettings: NSManagedObject {
 
     /// Maps to the related Blog.
     ///
-    @NSManaged var blog: Blog?
+    @NSManaged public var blog: Blog?
 
     // MARK: - General
 
     /// Represents the Blog Name.
     ///
-    @NSManaged var name: String?
+    @NSManaged public var name: String?
 
     /// Stores the Blog's Tagline setting.
     ///
-    @NSManaged var tagline: String?
+    @NSManaged public var tagline: String?
 
     /// Stores the Blog's Privacy Preferences Settings
     ///
-    @NSManaged var privacy: NSNumber?
+    @NSManaged public var privacy: NSNumber?
 
     /// Stores the Blog's Language ID Setting
     ///
-    @NSManaged var languageID: NSNumber
+    @NSManaged public var languageID: NSNumber
 
     /// Stores the Blog's Icon Media ID
     ///
-    @NSManaged var iconMediaID: NSNumber?
+    @NSManaged public var iconMediaID: NSNumber?
 
     /// Stores the Blog's GMT offset
     ///
-    @NSManaged var gmtOffset: NSNumber?
+    @NSManaged public var gmtOffset: NSNumber?
 
     /// Stores the Blog's timezone
     ///
-    @NSManaged var timezoneString: String?
+    @NSManaged public var timezoneString: String?
 
     // MARK: - Writing
 
     /// Contains the Default Category ID. Used when creating new posts.
     ///
-    @NSManaged var defaultCategoryID: NSNumber?
+    @NSManaged public var defaultCategoryID: NSNumber?
 
     /// Contains the Default Post Format. Used when creating new posts.
     ///
-    @NSManaged var defaultPostFormat: String?
+    @NSManaged public var defaultPostFormat: String?
 
     /// The blog's date format setting
     ///
-    @NSManaged var dateFormat: String
+    @NSManaged public var dateFormat: String
 
     /// The blog's time format setting
     ///
-    @NSManaged var timeFormat: String
+    @NSManaged public var timeFormat: String
 
     /// The blog's chosen day to start the week setting
     ///
-    @NSManaged var startOfWeek: String
+    @NSManaged public var startOfWeek: String
 
     /// The number of posts displayed per blog's page
     ///
-    @NSManaged var postsPerPage: NSNumber?
+    @NSManaged public var postsPerPage: NSNumber?
 
     /// Jetpack Setting: serve images from our servers.
     ///
-    @NSManaged var jetpackServeImagesFromOurServers: Bool
+    @NSManaged public var jetpackServeImagesFromOurServers: Bool
 
     /// Jetpack Setting: lazy load images.
     ///
@@ -78,166 +79,166 @@ open class BlogSettings: NSManagedObject {
 
     /// Represents whether comments are allowed, or not.
     ///
-    @NSManaged var commentsAllowed: Bool
+    @NSManaged public var commentsAllowed: Bool
 
     /// Contains a list of words, space separated, that would cause a comment to be automatically blocklisted.
     ///
-    @NSManaged var commentsBlocklistKeys: Set<String>?
+    @NSManaged public var commentsBlocklistKeys: Set<String>?
 
     /// If true, comments will be automatically closed after the number of days, specified by `commentsCloseAutomaticallyAfterDays`.
     ///
-    @NSManaged var commentsCloseAutomatically: Bool
+    @NSManaged public var commentsCloseAutomatically: Bool
 
     /// Represents the number of days comments will be enabled, granted that the `commentsCloseAutomatically`
     /// property is set to true.
     ///
-    @NSManaged var commentsCloseAutomaticallyAfterDays: NSNumber?
+    @NSManaged public var commentsCloseAutomaticallyAfterDays: NSNumber?
 
     /// When enabled, comments from known users will be allowlisted.
     ///
-    @NSManaged var commentsFromKnownUsersAllowlisted: Bool
+    @NSManaged public var commentsFromKnownUsersAllowlisted: Bool
 
     /// Indicates the maximum number of links allowed per comment. When a new comment exceeds this number,
     /// it'll be held in queue for moderation.
     ///
-    @NSManaged var commentsMaximumLinks: NSNumber?
+    @NSManaged public var commentsMaximumLinks: NSNumber?
 
     /// Contains a list of words, space separated, that cause a comment to require moderation.
     ///
-    @NSManaged var commentsModerationKeys: Set<String>?
+    @NSManaged public var commentsModerationKeys: Set<String>?
 
     /// If true, comment pagination will be enabled.
     ///
-    @NSManaged var commentsPagingEnabled: Bool
+    @NSManaged public var commentsPagingEnabled: Bool
 
     /// Specifies the number of comments per page. This will be used only if the property `commentsPagingEnabled`
     /// is set to true.
     ///
-    @NSManaged var commentsPageSize: NSNumber?
+    @NSManaged public var commentsPageSize: NSNumber?
 
     /// When enabled, new comments will require Manual Moderation, before showing up.
     ///
-    @NSManaged var commentsRequireManualModeration: Bool
+    @NSManaged public var commentsRequireManualModeration: Bool
 
     /// If set to true, commenters will be required to enter their name and email.
     ///
-    @NSManaged var commentsRequireNameAndEmail: Bool
+    @NSManaged public var commentsRequireNameAndEmail: Bool
 
     /// Specifies whether commenters should be registered or not.
     ///
-    @NSManaged var commentsRequireRegistration: Bool
+    @NSManaged public var commentsRequireRegistration: Bool
 
     /// Indicates the sorting order of the comments. Ascending / Descending, based on the date.
     ///
-    @NSManaged var commentsSortOrder: NSNumber?
+    @NSManaged public var commentsSortOrder: NSNumber?
 
     /// Indicates the number of levels allowed per comment.
     ///
-    @NSManaged var commentsThreadingDepth: NSNumber?
+    @NSManaged public var commentsThreadingDepth: NSNumber?
 
     /// When enabled, comment threading will be supported.
     ///
-    @NSManaged var commentsThreadingEnabled: Bool
+    @NSManaged public var commentsThreadingEnabled: Bool
 
     /// *LOCAL* flag (non stored remotely) indicating whether post geolocation is enabled or not.
     /// This can be overriden on a per-post basis.
     ///
-    @NSManaged var geolocationEnabled: Bool
+    @NSManaged public var geolocationEnabled: Bool
 
     /// If set to true, 3rd party sites will be allowed to post pingbacks.
     ///
-    @NSManaged var pingbackInboundEnabled: Bool
+    @NSManaged public var pingbackInboundEnabled: Bool
 
     /// When Outbound Pingbacks are enabled, 3rd party sites that get linked will be notified.
     ///
-    @NSManaged var pingbackOutboundEnabled: Bool
+    @NSManaged public var pingbackOutboundEnabled: Bool
 
     // MARK: - Related Posts
 
     /// When set to true, Related Posts will be allowed.
     ///
-    @NSManaged var relatedPostsAllowed: Bool
+    @NSManaged public var relatedPostsAllowed: Bool
 
     /// When set to true, Related Posts will be enabled.
     ///
-    @NSManaged var relatedPostsEnabled: Bool
+    @NSManaged public var relatedPostsEnabled: Bool
 
     /// Indicates whether related posts should show a headline.
     ///
-    @NSManaged var relatedPostsShowHeadline: Bool
+    @NSManaged public var relatedPostsShowHeadline: Bool
 
     /// Indicates whether related posts should show thumbnails.
     ///
-    @NSManaged var relatedPostsShowThumbnails: Bool
+    @NSManaged public var relatedPostsShowThumbnails: Bool
 
     // MARK: - Sharing
 
     /// Indicates the style to use for the sharing buttons on a particular blog
     ///
-    @NSManaged var sharingButtonStyle: String
+    @NSManaged public var sharingButtonStyle: String
 
     /// The title of the sharing label on the user's blog.
     ///
-    @NSManaged var sharingLabel: String
+    @NSManaged public var sharingLabel: String
 
     /// Indicates the twitter username to use when sharing via Twitter
     ///
-    @NSManaged var sharingTwitterName: String
+    @NSManaged public var sharingTwitterName: String
 
     /// Indicates whether related posts should show thumbnails.
     ///
-    @NSManaged var sharingCommentLikesEnabled: Bool
+    @NSManaged public var sharingCommentLikesEnabled: Bool
 
     /// Indicates whether sharing via post likes has been disabled
     ///
-    @NSManaged var sharingDisabledLikes: Bool
+    @NSManaged public var sharingDisabledLikes: Bool
 
     /// Indicates whether sharing by reblogging has been disabled
     ///
-    @NSManaged var sharingDisabledReblogs: Bool
+    @NSManaged public var sharingDisabledReblogs: Bool
 
     // MARK: AMP
 
     /// Indicates whether AMP is supported
     ///
-    @NSManaged var ampSupported: Bool
+    @NSManaged public var ampSupported: Bool
 
     /// Indicates whether AMP is enabled
     ///
-    @NSManaged var ampEnabled: Bool
+    @NSManaged public var ampEnabled: Bool
 
     // MARK: - Jetpack Settings
 
     /// Indicates whether the Jetpack site's monitor is on or off
     ///
-    @NSManaged var jetpackMonitorEnabled: Bool
+    @NSManaged public var jetpackMonitorEnabled: Bool
 
     /// Indicates whether the Jetpack site's monitor notifications should be sent by email
     ///
-    @NSManaged var jetpackMonitorEmailNotifications: Bool
+    @NSManaged public var jetpackMonitorEmailNotifications: Bool
 
     /// Indicates whether the Jetpack site's monitor notifications should be sent by push notifications
     ///
-    @NSManaged var jetpackMonitorPushNotifications: Bool
+    @NSManaged public var jetpackMonitorPushNotifications: Bool
 
     /// Indicates whether Jetpack will block malicious login attemps
     ///
-    @NSManaged var jetpackBlockMaliciousLoginAttempts: Bool
+    @NSManaged public var jetpackBlockMaliciousLoginAttempts: Bool
 
     /// List of IP addresses that will never be blocked for logins by Jetpack
     ///
-    @NSManaged var jetpackLoginAllowListedIPAddresses: Set<String>?
+    @NSManaged public var jetpackLoginAllowListedIPAddresses: Set<String>?
 
     /// Indicates whether WordPress.com SSO is enabled for the Jetpack site
     ///
-    @NSManaged var jetpackSSOEnabled: Bool
+    @NSManaged public var jetpackSSOEnabled: Bool
 
     /// Indicates whether SSO will try to match accounts by email address
     ///
-    @NSManaged var jetpackSSOMatchAccountsByEmail: Bool
+    @NSManaged public var jetpackSSOMatchAccountsByEmail: Bool
 
     /// Indicates whether to force or not two-step authentication when users log in via WordPress.com
     ///
-    @NSManaged var jetpackSSORequireTwoStepAuthentication: Bool
+    @NSManaged public var jetpackSSORequireTwoStepAuthentication: Bool
 
 }

--- a/WordPress/Classes/Models/Gutenberg/BlockEditorSettingElement+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/Gutenberg/BlockEditorSettingElement+CoreDataProperties.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CoreData
 
-enum BlockEditorSettingElementTypes: String {
+public enum BlockEditorSettingElementTypes: String {
     case color
     case gradient
     case experimentalFeatures
@@ -44,7 +44,7 @@ extension BlockEditorSettingElement {
 }
 
 extension BlockEditorSettingElement: Identifiable {
-    var rawRepresentation: [String: String]? {
+    public var rawRepresentation: [String: String]? {
         guard let type = BlockEditorSettingElementTypes(rawValue: self.type) else { return nil }
         return [
             #keyPath(BlockEditorSettingElement.slug): self.slug,
@@ -53,7 +53,7 @@ extension BlockEditorSettingElement: Identifiable {
         ]
     }
 
-    convenience init(fromRawRepresentation rawObject: [String: String], type: BlockEditorSettingElementTypes, order: Int, context: NSManagedObjectContext) {
+    public convenience init(fromRawRepresentation rawObject: [String: String], type: BlockEditorSettingElementTypes, order: Int, context: NSManagedObjectContext) {
         self.init(name: rawObject[ #keyPath(BlockEditorSettingElement.name)],
                   value: rawObject[type.valueKey],
                   slug: rawObject[#keyPath(BlockEditorSettingElement.slug)],
@@ -62,7 +62,7 @@ extension BlockEditorSettingElement: Identifiable {
                   context: context)
     }
 
-    convenience init(name: String?, value: String?, slug: String?, type: BlockEditorSettingElementTypes, order: Int, context: NSManagedObjectContext) {
+    public convenience init(name: String?, value: String?, slug: String?, type: BlockEditorSettingElementTypes, order: Int, context: NSManagedObjectContext) {
         self.init(context: context)
 
         self.type = type.rawValue

--- a/WordPress/Classes/Models/JetpackState.swift
+++ b/WordPress/Classes/Models/JetpackState.swift
@@ -1,14 +1,14 @@
-@objcMembers class JetpackState: NSObject {
-    static let minimumVersionRequired = "3.4.3"
+@objcMembers public class JetpackState: NSObject {
+    public static let minimumVersionRequired = "3.4.3"
 
-    var siteID: NSNumber?
-    var version: String?
-    var connectedUsername: String?
-    var connectedEmail: String?
+    public var siteID: NSNumber?
+    public var version: String?
+    public internal(set) var connectedUsername: String?
+    public internal(set) var connectedEmail: String?
     var automatedTransfer: Bool = false
 
     /// Returns true if Jetpack is installed and activated on the site.
-    var isInstalled: Bool {
+    public var isInstalled: Bool {
         return version != nil
     }
 
@@ -16,7 +16,7 @@
     ///
     /// - Warning: Before Jetpack 3.6, a site might appear connected if it was connected and then disconnected. See https://github.com/Automattic/jetpack/issues/2137
     ///
-    var isConnected: Bool {
+    public var isConnected: Bool {
         guard isInstalled,
             let siteID,
             siteID.intValue > 0 else {
@@ -26,7 +26,7 @@
     }
 
     /// Return true is Jetpack has site-connection (Jetpack plugin connected to the site but not connected to WP.com account)
-    var isSiteConnection: Bool {
+    public var isSiteConnection: Bool {
         let isUserConnected = connectedUsername != nil || connectedEmail != nil
 
         return isConnected && !isUserConnected
@@ -36,14 +36,14 @@
 
     /// - SeeAlso: JetpackVersionMinimumRequired
     ///
-    var isUpdatedToRequiredVersion: Bool {
+    public var isUpdatedToRequiredVersion: Bool {
         guard let version else {
             return false
         }
         return version.compare(JetpackState.minimumVersionRequired, options: .numeric) != .orderedAscending
     }
 
-    override var description: String {
+    public override var description: String {
         if isConnected {
             let connectedAs = connectedUsername?.nonEmptyString()
                 ?? connectedEmail?.nonEmptyString()

--- a/WordPress/Classes/Models/Page.swift
+++ b/WordPress/Classes/Models/Page.swift
@@ -2,12 +2,12 @@ import Foundation
 import CoreData
 
 @objc(Page)
-class Page: AbstractPost {
+public class Page: AbstractPost {
     /// Returns if the Page has a visible parent Page
-    @objc var hasVisibleParent: Bool = true
+    @objc public var hasVisibleParent: Bool = true
 
     /// The hierarchy index within a Pages list
-    @objc var hierarchyIndex: Int = 0
+    @objc public var hierarchyIndex: Int = 0
 
     /// Returns if the Page is a top level
     @objc var isTopLevelPage: Bool {
@@ -43,7 +43,7 @@ class Page: AbstractPost {
 
     // MARK: - Homepage Settings
 
-    @objc var isSiteHomepage: Bool {
+    @objc public var isSiteHomepage: Bool {
         guard let postID,
             let homepageID = blog.homepagePageID,
             let homepageType = blog.homepageType,
@@ -54,7 +54,7 @@ class Page: AbstractPost {
         return homepageID == postID.intValue
     }
 
-    @objc var isSitePostsPage: Bool {
+    @objc public var isSitePostsPage: Bool {
         guard let postID,
             let postsPageID = blog.homepagePostsPageID,
             let homepageType = blog.homepageType,

--- a/WordPress/Classes/Models/Post.swift
+++ b/WordPress/Classes/Models/Post.swift
@@ -1,19 +1,20 @@
 import Foundation
 import CoreData
+import CocoaLumberjackSwift
 
 @objc(Post)
-class Post: AbstractPost {
+public class Post: AbstractPost {
     @objc static let typeDefaultIdentifier = "post"
 
-    struct Constants {
-        static let publicizeIdKey = "id"
+    public struct Constants {
+        public static let publicizeIdKey = "id"
         static let publicizeValueKey = "value"
-        static let publicizeKeyKey = "key"
+        public static let publicizeKeyKey = "key"
         static let publicizeDisabledValue = "1"
         static let publicizeEnabledValue = "0"
     }
 
-    enum PublicizeMetadataSkipPrefix: String {
+    public enum PublicizeMetadataSkipPrefix: String {
         case keyring = "_wpas_skip_"
         case connection = "_wpas_skip_publicize_"
 
@@ -21,7 +22,7 @@ class Post: AbstractPost {
         ///
         /// - Parameter key: String.
         /// - Returns: A `PublicizeMetadataSkipPrefix` value, or nil if nothing matched.
-        static func prefix(of key: String) -> PublicizeMetadataSkipPrefix? {
+        public static func prefix(of key: String) -> PublicizeMetadataSkipPrefix? {
             // try to match the `keyring` format first, since it's a substring of the `connection` format.
             guard key.hasPrefix(Self.keyring.rawValue) else {
                 return nil
@@ -32,17 +33,17 @@ class Post: AbstractPost {
 
     // MARK: - NSManagedObject
 
-    override class func entityName() -> String {
+    public override class func entityName() -> String {
         return "Post"
     }
 
     // MARK: - Format
 
-    @objc func postFormatText() -> String? {
+    @objc public func postFormatText() -> String? {
         return blog.postFormatText(fromSlug: postFormat)
     }
 
-    @objc func setPostFormatText(_ postFormatText: String) {
+    @objc public func setPostFormatText(_ postFormatText: String) {
 
         assert(blog.postFormats is [String: String])
         guard let postFormats = blog.postFormats as? [String: String] else {
@@ -66,7 +67,7 @@ class Post: AbstractPost {
 
     /// Returns categories as a comma-separated list
     ///
-    @objc func categoriesText() -> String {
+    @objc public func categoriesText() -> String {
 
         guard let allStrings = categories?.map({ return $0.categoryName as String }) else {
             return ""
@@ -84,7 +85,7 @@ class Post: AbstractPost {
     /// - Parameter categoryNames: a `NSArray` with the names of the categories for this post. If
     ///                     a given category name doesn't exist it's ignored.
     ///
-    @objc func setCategoriesFromNames(_ categoryNames: [String]) {
+    @objc public func setCategoriesFromNames(_ categoryNames: [String]) {
 
         var newCategories = Set<PostCategory>()
 
@@ -108,13 +109,13 @@ class Post: AbstractPost {
 
     // MARK: - Sharing
 
-    @objc func canEditPublicizeSettings() -> Bool {
+    @objc public func canEditPublicizeSettings() -> Bool {
         return !self.hasRemote() || self.status != .publish
     }
 
     // MARK: - PublicizeConnections
 
-    @objc func publicizeConnectionDisabledForKeyringID(_ keyringID: NSNumber) -> Bool {
+    @objc public func publicizeConnectionDisabledForKeyringID(_ keyringID: NSNumber) -> Bool {
         let isKeyringEntryDisabled = disabledPublicizeConnections?[keyringID]?[Constants.publicizeValueKey] == Constants.publicizeDisabledValue
 
         // try to check in case there's an entry for the PublicizeConnection that's keyed by the connectionID.
@@ -129,7 +130,7 @@ class Post: AbstractPost {
         return isConnectionEntryDisabled || isKeyringEntryDisabled
     }
 
-    @objc func enablePublicizeConnectionWithKeyringID(_ keyringID: NSNumber) {
+    @objc public func enablePublicizeConnectionWithKeyringID(_ keyringID: NSNumber) {
         // if there's another entry keyed by connectionID references to the same connection,
         // we need to make sure that the values are kept in sync.
         if let connections = blog.connections as? Set<PublicizeConnection>,
@@ -141,7 +142,7 @@ class Post: AbstractPost {
         enablePublicizeConnection(keyedBy: keyringID)
     }
 
-    @objc func disablePublicizeConnectionWithKeyringID(_ keyringID: NSNumber) {
+    @objc public func disablePublicizeConnectionWithKeyringID(_ keyringID: NSNumber) {
         // if there's another entry keyed by connectionID references to the same connection,
         // we need to make sure that the values are kept in sync.
         if let connections = blog.connections as? Set<PublicizeConnection>,
@@ -199,33 +200,33 @@ class Post: AbstractPost {
 
     // MARK: - Comments
 
-    @objc func numberOfComments() -> Int {
+    @objc public func numberOfComments() -> Int {
         return commentCount?.intValue ?? 0
     }
 
     // MARK: - Likes
 
-    @objc func numberOfLikes() -> Int {
+    @objc public func numberOfLikes() -> Int {
         return likeCount?.intValue ?? 0
     }
 
     // MARK: - AbstractPost
 
-    override func hasCategories() -> Bool {
+    override public func hasCategories() -> Bool {
         categories?.isEmpty == false
     }
 
-    override func hasTags() -> Bool {
+    override public func hasTags() -> Bool {
         tags?.trim().isEmpty == false
     }
 
-    override func authorForDisplay() -> String? {
+    override public func authorForDisplay() -> String? {
         author ?? blog.account?.displayName
     }
 
     // MARK: - BasePost
 
-    override func contentPreviewForDisplay() -> String {
+    override public func contentPreviewForDisplay() -> String {
         if let excerpt = mt_excerpt, excerpt.count > 0 {
             if let preview = PostPreviewCache.shared.excerpt[excerpt] {
                 return preview
@@ -245,7 +246,7 @@ class Post: AbstractPost {
         }
     }
 
-    override func titleForDisplay() -> String {
+    override public func titleForDisplay() -> String {
         var title = postTitle?.trimmingCharacters(in: CharacterSet.whitespaces) ?? ""
         title = title
             .stringByDecodingXMLCharacters()

--- a/WordPress/Classes/Services/BloggingPrompts/BloggingPromptRemoteObject.swift
+++ b/WordPress/Classes/Services/BloggingPrompts/BloggingPromptRemoteObject.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Encapsulates a single blogging prompt object from the v3 API.
-struct BloggingPromptRemoteObject {
+public struct BloggingPromptRemoteObject {
     let promptID: Int
     let text: String
     let attribution: String
@@ -14,7 +14,7 @@ struct BloggingPromptRemoteObject {
     let bloganuaryId: String?
 
     /// Used for comparison on import
-    var dateString: String {
+    public var dateString: String {
         Self.dateFormatter.string(from: date)
     }
 }
@@ -50,7 +50,7 @@ extension BloggingPromptRemoteObject: Decodable {
         return formatter
     }()
 
-    init(from decoder: Decoder) throws {
+    public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
         self.promptID = try container.decode(Int.self, forKey: .id)

--- a/WordPress/Classes/Utility/BlogQuery.swift
+++ b/WordPress/Classes/Utility/BlogQuery.swift
@@ -1,3 +1,4 @@
+import CoreData
 import Foundation
 
 /// A helper to query `Blog` from given `NSManagedObjectContext`.
@@ -5,60 +6,60 @@ import Foundation
 /// Note: the implementation here isn't meant to be a standard way to perform query. But it might be valuable
 /// to explore a standard way to perform query. https://github.com/wordpress-mobile/WordPress-iOS/pull/19394 made
 /// an attempt, but still has lots of unknowns.
-struct BlogQuery {
+public struct BlogQuery {
     private var predicates = [NSPredicate]()
 
-    func blogID(_ id: Int) -> Self {
+    public func blogID(_ id: Int) -> Self {
         blogID(Int64(id))
     }
 
-    func blogID(_ id: NSNumber) -> Self {
+    public func blogID(_ id: NSNumber) -> Self {
         blogID(id.int64Value)
     }
 
-    func blogID(_ id: Int64) -> Self {
+    public func blogID(_ id: Int64) -> Self {
         and(NSPredicate(format: "blogID = %ld", id))
     }
 
-    func dotComAccountUsername(_ username: String) -> Self {
+    public func dotComAccountUsername(_ username: String) -> Self {
         and(NSPredicate(format: "account.username = %@", username))
     }
 
-    func selfHostedBlogUsername(_ username: String) -> Self {
+    public func selfHostedBlogUsername(_ username: String) -> Self {
         and(NSPredicate(format: "username = %@", username))
     }
 
-    func hostname(containing hostname: String) -> Self {
+    public func hostname(containing hostname: String) -> Self {
         and(NSPredicate(format: "url CONTAINS %@", hostname))
     }
 
-    func hostname(matching hostname: String) -> Self {
+    public func hostname(matching hostname: String) -> Self {
         and(NSPredicate(format: "url = %@", hostname))
     }
 
-    func hostedByWPCom(_ flag: Bool) -> Self {
+    public func hostedByWPCom(_ flag: Bool) -> Self {
         and(NSPredicate(format: flag ? "account != NULL" : "account == NULL"))
     }
 
-    func xmlrpc(matching xmlrpc: String) -> Self {
+    public func xmlrpc(matching xmlrpc: String) -> Self {
         and(NSPredicate(format: "xmlrpc = %@", xmlrpc))
     }
 
-    func apiKey(is string: String) -> Self {
+    public func apiKey(is string: String) -> Self {
         and(NSPredicate(format: "apiKey = %@", string))
     }
 
-    func count(in context: NSManagedObjectContext) -> Int {
+    public func count(in context: NSManagedObjectContext) -> Int {
         (try? context.count(for: buildFetchRequest())) ?? 0
     }
 
-    func blog(in context: NSManagedObjectContext) throws -> Blog? {
+    public func blog(in context: NSManagedObjectContext) throws -> Blog? {
         let request = buildFetchRequest()
         request.fetchLimit = 1
         return (try context.fetch(request).first)
     }
 
-    func blogs(in context: NSManagedObjectContext) throws -> [Blog] {
+    public func blogs(in context: NSManagedObjectContext) throws -> [Blog] {
         try context.fetch(buildFetchRequest())
     }
 

--- a/WordPress/Classes/Utility/CoreData/Migrator/CoreDataIterativeMigrator.swift
+++ b/WordPress/Classes/Utility/CoreData/Migrator/CoreDataIterativeMigrator.swift
@@ -1,9 +1,11 @@
+import CocoaLumberjackSwift
 import Foundation
 import CoreData
 
 /// CoreDataIterativeMigrator: Migrates through a series of models to allow for users to skip app versions without risk.
 ///
-class CoreDataIterativeMigrator: NSObject {
+// FIXME: public access-level needed for unit tests because of no @testable support in Objective-C.
+public class CoreDataIterativeMigrator: NSObject {
 
     private static func error(with code: IterativeMigratorErrorCodes, description: String) -> NSError {
         return NSError(domain: "IterativeMigrator", code: code.rawValue, userInfo: [NSLocalizedDescriptionKey: description])
@@ -21,7 +23,8 @@ class CoreDataIterativeMigrator: NSObject {
     ///
     /// - Throws: A whole bunch of crap is possible to be thrown between Core Data and FileManager.
     ///
-    @objc static func iterativeMigrate(sourceStore: URL, storeType: String, to targetModel: NSManagedObjectModel, using modelNames: [String]) throws {
+    // FIXME: public access-level needed for unit tests because of no @testable support in Objective-C.
+    @objc public static func iterativeMigrate(sourceStore: URL, storeType: String, to targetModel: NSManagedObjectModel, using modelNames: [String]) throws {
         // If the persistent store does not exist at the given URL,
         // assume that it hasn't yet been created and return success immediately.
         guard FileManager.default.fileExists(atPath: sourceStore.path) == true else {

--- a/WordPress/Classes/Utility/Spotlight/Protocols/SearchableItemConvertable.swift
+++ b/WordPress/Classes/Utility/Spotlight/Protocols/SearchableItemConvertable.swift
@@ -2,7 +2,7 @@ import CoreSpotlight
 import MobileCoreServices
 import UniformTypeIdentifiers
 
-@objc enum SearchItemType: Int {
+@objc public enum SearchItemType: Int {
     case abstractPost
     case readerPost
     case none


### PR DESCRIPTION
This comes from the "workbench" work from #24242. It basically adds `public` to a bunch of model-related files, so that when we'll move them to WordPressData, the PR diff will be easier to parse.

Part of #24165