### PR TITLE
Fix an issue with WordPressComRestApi instance not being cached by WPAccount

### DIFF
--- a/WordPress/Classes/Models/WPAccount+RestApi.swift
+++ b/WordPress/Classes/Models/WPAccount+RestApi.swift
@@ -10,23 +10,18 @@ extension WPAccount {
     /// This used to be defined in the Objective-C layer, but we moved it here in a Swift extension in an attempt to decouple the model code from it.
     /// This was done in the context of https://github.com/wordpress-mobile/WordPress-iOS/pull/24165 .
     @objc var wordPressComRestApi: WordPressComRestApi? {
-        get {
-            if let api = objc_getAssociatedObject(self, &apiAssociatedKey) as? WordPressComRestApi {
-                return api
-            }
-            guard !authToken.isEmpty else {
-                DispatchQueue.main.async {
-                    WordPressAuthenticationManager.showSigninForWPComFixingAuthToken()
-                }
-                return nil
-            }
-            let api = makeWordPressComRestApi()
-            self.wordPressComRestApi = api
+        if let api = _private_wordPressComRestApi {
             return api
         }
-        set(api) {
-            objc_setAssociatedObject(self, &apiAssociatedKey, api, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        guard !authToken.isEmpty else {
+            DispatchQueue.main.async {
+                WordPressAuthenticationManager.showSigninForWPComFixingAuthToken()
+            }
+            return nil
         }
+        let api = makeWordPressComRestApi()
+        self._private_wordPressComRestApi = api
+        return api
     }
 
     private func makeWordPressComRestApi() -> WordPressComRestApi {
@@ -78,5 +73,3 @@ extension WPAccount {
     }
 
 }
-
-private var apiAssociatedKey: UInt8 = 0

--- a/WordPress/Classes/Models/WPAccount+RestApi.swift
+++ b/WordPress/Classes/Models/WPAccount+RestApi.swift
@@ -11,47 +11,52 @@ extension WPAccount {
     /// This was done in the context of https://github.com/wordpress-mobile/WordPress-iOS/pull/24165 .
     @objc var wordPressComRestApi: WordPressComRestApi? {
         get {
-            guard let api = objc_getAssociatedObject(self, &apiAssociatedKey) as? WordPressComRestApi else {
-                guard authToken.isEmpty else {
-                    let api = WordPressComRestApi.defaultApi(
-                        oAuthToken: authToken,
-                        userAgent: WPUserAgent.defaultUserAgent(),
-                        localeKey: WordPressComRestApi.LocaleKeyDefault
-                    )
-
-                    api.setInvalidTokenHandler { [weak self] in
-                        guard let self else { return }
-
-                        self.authToken = nil
-                        WordPressAuthenticationManager.showSigninForWPComFixingAuthToken()
-
-                        guard self.isDefaultWordPressComAccount else { return }
-
-                        // At the time of writing, there is an implicit assumption on what the object parameter value means.
-                        // For example, the WordPressAppDelegate.handleDefaultAccountChangedNotification(_:) subscriber inspects the object parameter to decide whether the notification was sent as a result of a login.
-                        // If the object is non-nil, then the method considers the source a login.
-                        //
-                        // The code path in which we are is that of an invalid token, and that's neither a login nor a logout, it's more appropriate to consider it a logout.
-                        // That's because if the token is invalid the app will soon received errors from the API and it's therefore better to force the user to login again.
-                        NotificationCenter.default.post(
-                            name: NSNotification.Name.WPAccountDefaultWordPressComAccountChanged,
-                            object: nil
-                        )
-                    }
-
-                    return api
-                }
-
+            if let api = objc_getAssociatedObject(self, &apiAssociatedKey) as? WordPressComRestApi {
+                return api
+            }
+            guard !authToken.isEmpty else {
                 DispatchQueue.main.async {
                     WordPressAuthenticationManager.showSigninForWPComFixingAuthToken()
                 }
                 return nil
             }
+            let api = makeWordPressComRestApi()
+            self.wordPressComRestApi = api
             return api
         }
         set(api) {
             objc_setAssociatedObject(self, &apiAssociatedKey, api, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
         }
+    }
+
+    private func makeWordPressComRestApi() -> WordPressComRestApi {
+        let api = WordPressComRestApi.defaultApi(
+            oAuthToken: authToken,
+            userAgent: WPUserAgent.defaultUserAgent(),
+            localeKey: WordPressComRestApi.LocaleKeyDefault
+        )
+
+        api.setInvalidTokenHandler { [weak self] in
+            guard let self else { return }
+
+            self.authToken = nil
+            WordPressAuthenticationManager.showSigninForWPComFixingAuthToken()
+
+            if self.isDefaultWordPressComAccount {
+                // At the time of writing, there is an implicit assumption on what the object parameter value means.
+                // For example, the WordPressAppDelegate.handleDefaultAccountChangedNotification(_:) subscriber inspects the object parameter to decide whether the notification was sent as a result of a login.
+                // If the object is non-nil, then the method considers the source a login.
+                //
+                // The code path in which we are is that of an invalid token, and that's neither a login nor a logout, it's more appropriate to consider it a logout.
+                // That's because if the token is invalid the app will soon received errors from the API and it's therefore better to force the user to login again.
+                NotificationCenter.default.post(
+                    name: NSNotification.Name.WPAccountDefaultWordPressComAccountChanged,
+                    object: nil
+                )
+            }
+        }
+
+        return api
     }
 
     /// Returns an instance of the WPCOM REST API suitable for v2 endpoints.

--- a/WordPress/Classes/Models/WPAccount.h
+++ b/WordPress/Classes/Models/WPAccount.h
@@ -39,7 +39,7 @@
 /// Important: Do not set this directly!
 ///
 /// It's reserved for Objective-C to Swift interoperability in the context of separating this model from the app target and will be removed at some point.
-@property (nonatomic, strong) WordPressComRestApi *wordPressComRestApi;
+@property (nonatomic, strong) WordPressComRestApi *_private_wordPressComRestApi;
 
 @end
 

--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -22,7 +22,7 @@
 @dynamic userID;
 @dynamic avatarURL;
 @dynamic settings;
-@synthesize wordPressComRestApi;
+@synthesize _private_wordPressComRestApi;
 @synthesize cachedToken;
 
 #pragma mark - NSManagedObject subclass methods
@@ -34,15 +34,15 @@
         return;
     }
 
-    [self.wordPressComRestApi invalidateAndCancelTasks];
-    self.wordPressComRestApi = nil;
+    [_private_wordPressComRestApi invalidateAndCancelTasks];
+    _private_wordPressComRestApi = nil;
     self.authToken = nil;
 }
 
 - (void)didTurnIntoFault
 {
     [super didTurnIntoFault];
-    self.wordPressComRestApi = nil;
+    _private_wordPressComRestApi = nil;
     self.cachedToken = nil;
 }
 
@@ -114,7 +114,7 @@
     }
 
     // Make sure to release any RestAPI alloc'ed, since it might have an invalid token
-    self.wordPressComRestApi = nil;
+    _private_wordPressComRestApi = nil;
 }
 
 - (BOOL)hasAtomicSite {

--- a/WordPress/WordPressTest/AccountSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/AccountSettingsServiceTests.swift
@@ -15,7 +15,7 @@ class AccountSettingsServiceTests: CoreDataTestCase {
 
         service = AccountSettingsService(
             userID: account.userID.intValue,
-            remote: AccountSettingsRemote(wordPressComRestApi: account.wordPressComRestApi),
+            remote: AccountSettingsRemote(wordPressComRestApi: account.wordPressComRestApi!),
             coreDataStack: contextManager
         )
     }
@@ -112,7 +112,7 @@ extension AccountSettingsServiceTests {
     private func makeService(contextManager: ContextManager, account: WPAccount) -> AccountSettingsService {
         AccountSettingsService(
             userID: account.userID.intValue,
-            remote: AccountSettingsRemote(wordPressComRestApi: account.wordPressComRestApi),
+            remote: AccountSettingsRemote(wordPressComRestApi: account.wordPressComRestApi!),
             coreDataStack: contextManager
         )
     }

--- a/WordPress/WordPressTest/MediaServiceUpdateTests.m
+++ b/WordPress/WordPressTest/MediaServiceUpdateTests.m
@@ -36,7 +36,7 @@
     WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
     
     Blog *blog = [ModelTestHelper insertDotComBlogWithContext:self.manager.mainContext];
-    blog.account.wordPressComRestApi = api;
+    blog.account._private_wordPressComRestApi = api;
     blog.dotComID = @1;
     self.blog = blog;
     

--- a/WordPress/WordPressTest/MenusServiceTests.m
+++ b/WordPress/WordPressTest/MenusServiceTests.m
@@ -31,7 +31,7 @@
     NSManagedObjectContext *context = self.manager.mainContext;
     Blog *blog = [ModelTestHelper insertDotComBlogWithContext:context];
     WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
-    blog.account.wordPressComRestApi = api;
+    blog.account._private_wordPressComRestApi = api;
     blog.dotComID = @1;
     blog.isAdmin = YES;
 
@@ -47,7 +47,7 @@
     NSManagedObjectContext *context = self.manager.mainContext;
     Blog *blog = [ModelTestHelper insertDotComBlogWithContext:context];
     WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
-    blog.account.wordPressComRestApi = api;
+    blog.account._private_wordPressComRestApi = api;
     blog.dotComID = @1;
     blog.isAdmin = NO;
     
@@ -63,7 +63,7 @@
     NSManagedObjectContext *context = self.manager.mainContext;
     Blog *blog = [ModelTestHelper insertDotComBlogWithContext:context];
     WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
-    blog.account.wordPressComRestApi = api;
+    blog.account._private_wordPressComRestApi = api;
     blog.dotComID = @1;
     blog.isAdmin = YES;
 
@@ -85,7 +85,7 @@
     NSManagedObjectContext *context = self.manager.mainContext;
     Blog *blog = [ModelTestHelper insertDotComBlogWithContext:context];
     WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
-    blog.account.wordPressComRestApi = api;
+    blog.account._private_wordPressComRestApi = api;
     blog.dotComID = @1;
     blog.isAdmin = YES;
     
@@ -118,7 +118,7 @@
     NSManagedObjectContext *context = self.manager.mainContext;
     Blog *blog = [ModelTestHelper insertDotComBlogWithContext:context];
     WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
-    blog.account.wordPressComRestApi = api;
+    blog.account._private_wordPressComRestApi = api;
     blog.dotComID = @1;
     blog.isAdmin = YES;
     
@@ -167,7 +167,7 @@
     NSManagedObjectContext *context = self.manager.mainContext;
     Blog *blog = [ModelTestHelper insertDotComBlogWithContext:context];
     WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
-    blog.account.wordPressComRestApi = api;
+    blog.account._private_wordPressComRestApi = api;
     blog.dotComID = @1;
     blog.isAdmin = YES;
 
@@ -194,7 +194,7 @@
     NSManagedObjectContext *context = self.manager.mainContext;
     Blog *blog = [ModelTestHelper insertDotComBlogWithContext:context];
     WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
-    blog.account.wordPressComRestApi = api;
+    blog.account._private_wordPressComRestApi = api;
     blog.dotComID = @1;
     blog.isAdmin = YES;
 

--- a/WordPress/WordPressTest/PostCategoryServiceTests.m
+++ b/WordPress/WordPressTest/PostCategoryServiceTests.m
@@ -40,7 +40,7 @@
     WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
 
     Blog *blog = [ModelTestHelper insertDotComBlogWithContext:self.manager.mainContext];
-    blog.account.wordPressComRestApi = api;
+    blog.account._private_wordPressComRestApi = api;
     blog.dotComID = @1;
     self.blog = blog;
 

--- a/WordPress/WordPressTest/PostTagServiceTests.m
+++ b/WordPress/WordPressTest/PostTagServiceTests.m
@@ -40,7 +40,7 @@
     WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
 
     Blog *blog = [ModelTestHelper insertDotComBlogWithContext:self.manager.mainContext];
-    blog.account.wordPressComRestApi = api;
+    blog.account._private_wordPressComRestApi = api;
     blog.dotComID = @1;
     
     self.blog = blog;

--- a/WordPress/WordPressTest/ThemeServiceTests.m
+++ b/WordPress/WordPressTest/ThemeServiceTests.m
@@ -64,7 +64,7 @@
     NSManagedObjectContext *context = self.manager.mainContext;
     Blog *blog = [ModelTestHelper insertDotComBlogWithContext:context];
     WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
-    blog.account.wordPressComRestApi = api;
+    blog.account._private_wordPressComRestApi = api;
     ThemeService *service = nil;
     NSNumber *blogId = @1;
     NSString *url = [NSString stringWithFormat:@"rest/v1.1/sites/%@/themes/mine", blogId];
@@ -102,7 +102,7 @@
     NSString *url = [NSString stringWithFormat:@"rest/v1.2/sites/%@/themes", blogId];
 
     blog.dotComID = blogId;
-    blog.account.wordPressComRestApi = api;
+    blog.account._private_wordPressComRestApi = api;
 
     OCMStub([api get:[OCMArg isEqual:url]
           parameters:[OCMArg isNotNil]
@@ -142,7 +142,7 @@
     theme.themeId = @"SomeThemeId";
 
     blog.dotComID = blogId;
-    blog.account.wordPressComRestApi = api;
+    blog.account._private_wordPressComRestApi = api;
 
     OCMStub([api post:[OCMArg isEqual:url]
            parameters:[OCMArg isNotNil]
@@ -165,7 +165,7 @@
     ThemeService *service = nil;
 
     blog.dotComID = blogId;
-    blog.account.wordPressComRestApi = api;
+    blog.account._private_wordPressComRestApi = api;
 
     XCTAssertNoThrow(service = [[ThemeService alloc] initWithCoreDataStack:self.manager]);
     XCTAssertThrows([service activateTheme:nil


### PR DESCRIPTION
The previous implementation was retaining it:

```
_wordPressComRestApi = [WordPressComRestAp...
```

Fixes https://github.com/wordpress-mobile/WordPress-iOS/issues/24320

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
