### PR TITLE
Remove the reduandant `wordPressComRestApi` ObjC property

### DIFF
--- a/WordPress/Classes/Models/WPAccount.h
+++ b/WordPress/Classes/Models/WPAccount.h
@@ -34,13 +34,6 @@
 /// @name API Helpers
 ///------------------
 
-/// A WordPressRestComApi object if the account is a WordPress.com account. Otherwise, it returns `nil`.
-///
-/// Important: Do not set this directly!
-///
-/// It's reserved for Objective-C to Swift interoperability in the context of separating this model from the app target and will be removed at some point.
-@property (nonatomic, strong) WordPressComRestApi *wordPressComRestApi;
-
 @end
 
 @interface WPAccount (CoreDataGeneratedAccessors)

--- a/WordPress/Classes/Models/WPAccount.m
+++ b/WordPress/Classes/Models/WPAccount.m
@@ -22,7 +22,6 @@
 @dynamic userID;
 @dynamic avatarURL;
 @dynamic settings;
-@synthesize wordPressComRestApi;
 @synthesize cachedToken;
 
 #pragma mark - NSManagedObject subclass methods

--- a/WordPress/WordPressTest/AccountSettingsServiceTests.swift
+++ b/WordPress/WordPressTest/AccountSettingsServiceTests.swift
@@ -15,7 +15,7 @@ class AccountSettingsServiceTests: CoreDataTestCase {
 
         service = AccountSettingsService(
             userID: account.userID.intValue,
-            remote: AccountSettingsRemote(wordPressComRestApi: account.wordPressComRestApi),
+            remote: AccountSettingsRemote(wordPressComRestApi: account.wordPressComRestApi!),
             coreDataStack: contextManager
         )
     }
@@ -112,7 +112,7 @@ extension AccountSettingsServiceTests {
     private func makeService(contextManager: ContextManager, account: WPAccount) -> AccountSettingsService {
         AccountSettingsService(
             userID: account.userID.intValue,
-            remote: AccountSettingsRemote(wordPressComRestApi: account.wordPressComRestApi),
+            remote: AccountSettingsRemote(wordPressComRestApi: account.wordPressComRestApi!),
             coreDataStack: contextManager
         )
     }


### PR DESCRIPTION
Currently `WPAccount` has two `wordPressComRestApi` properties declaration and in memory, one is a synthesized property in Objective-C, and the other is in Swift [that's stored as an ObjC associated object](https://github.com/wordpress-mobile/WordPress-iOS/blob/83594d31c6d2dd8ed62e1358514797ce33d701d7/WordPress/Classes/Models/WPAccount%2BRestApi.swift#L12).

This PR removes the Objective-C one, because it no longer needed.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
