### PR TITLE
Convert a number of interconnected `Blog` methods to Swift

### DIFF
--- a/WordPress/Classes/Models/Blog/Blog.h
+++ b/WordPress/Classes/Models/Blog/Blog.h
@@ -122,8 +122,6 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 @interface Blog : NSManagedObject
 
 @property (nonatomic, strong, readwrite, nullable) NSNumber *blogID __deprecated_msg("Use dotComID instead");
-/// WordPress.com site ID stored as signed 32-bit integer.
-@property (nonatomic, strong, readwrite, nullable) NSNumber *dotComID;
 @property (nonatomic, strong, readwrite, nullable) NSString *xmlrpc;
 @property (nonatomic, strong, readwrite, nullable) NSString *apiKey;
 @property (nonatomic, strong, readwrite, nonnull) NSNumber *organizationID;
@@ -159,7 +157,6 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 @property (nonatomic, assign, readwrite) BOOL isHostedAtWPcom;
 @property (nonatomic, assign, readwrite) BOOL hasDomainCredit;
 @property (nonatomic, strong, readwrite, nullable) NSString *icon;
-@property (nonatomic, assign, readwrite) SiteVisibility siteVisibility;
 @property (nonatomic, strong, readwrite, nullable) NSNumber *planID;
 @property (nonatomic, strong, readwrite, nullable) NSString *planTitle;
 @property (nonatomic, strong, readwrite, nullable) NSArray<NSString *> *planActiveFeatures;
@@ -250,8 +247,6 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 - (NSString *)adminUrlWithPath:(NSString *)path;
 - (NSDictionary *) getImageResizeDimensions;
 - (BOOL)supportsFeaturedImages;
-- (BOOL)supports:(BlogFeature)feature;
-- (BOOL)supportsPublicize;
 - (BOOL)supportsShareButtons;
 - (BOOL)isStatsActive;
 - (BOOL)hasMappedDomain;
@@ -282,6 +277,13 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 /// Checks the blogs installed WordPress version is more than or equal to the requiredVersion
 /// @param requiredVersion The minimum version to check for
 - (BOOL)hasRequiredWordPressVersion:(NSString *)requiredVersion;
+
+#pragma mark - Exposed to ease Swift migration
+
+- (BOOL)supportsRestApi;
+- (BOOL)supportsJetpackImageSettings;
+- (BOOL)supportsJetpackSettings;
+- (BOOL)jetpackSharingButtonsModuleEnabled;
 
 @end
 

--- a/WordPress/Classes/Models/Blog/Blog.swift
+++ b/WordPress/Classes/Models/Blog/Blog.swift
@@ -1,0 +1,235 @@
+extension Blog {
+
+    static let jetpackProfessionalYearlyPlanId = 2004
+    static let jetpackProfessionalMonthlyPlanId = 2001
+
+    /// WordPress.com site ID stored as signed 32-bit integer
+    @objc
+    public var dotComID: NSNumber? {
+        get {
+            let key = "blogID"
+            willAccessValue(forKey: key)
+
+            guard var id = primitiveValue(forKey: key) as? NSNumber else {
+                didAccessValue(forKey: key)
+                return nil
+            }
+
+            if id.intValue == 0 {
+                if let id = jetpack?.siteID {
+                    self.dotComID = id
+                }
+                id = 0
+            }
+
+            didAccessValue(forKey: key)
+            return id
+        }
+        set(value) {
+            let key = "blogID"
+            willChangeValue(forKey: key)
+            setPrimitiveValue(value, forKey: key)
+            didChangeValue(forKey: key)
+        }
+    }
+
+    @objc
+    public var siteVisibility: SiteVisibility {
+        get {
+            guard let privacy = settings?.privacy?.intValue else {
+                return .unknown
+            }
+
+            guard let visibility = SiteVisibility(rawValue: privacy) else {
+                return .unknown
+            }
+
+            return visibility
+        }
+        set(value) {
+            settings?.privacy = NSNumber(value: value.rawValue)
+        }
+    }
+
+    open override func willSave() {
+        super.willSave()
+
+        // The `dotComID` getter has a speicial code to _update_ `blogID` value.
+        // This is a weird patch to make sure `blogID` is set to a correct value.
+        //
+        // It's important that calling `[self dotComID]` repeatedly only updates
+        // `Blog` instance once, which is the case at the moment.
+        _ = dotComID
+    }
+
+    @objc
+    public func supports(_ feature: BlogFeature) -> Bool {
+        switch feature {
+        case .removable:
+            return accountIsDefaultAccount
+        case .visibility:
+            // See -[BlogListViewController fetchRequestPredicateForHideableBlogs]
+            // If the logic for this changes that needs to be updated as well
+            return accountIsDefaultAccount
+        case .people:
+            return supportsRestApi() && isListingUsersAllowed()
+        case .wpComRESTAPI, .commentLikes:
+            return supportsRestApi()
+        case .stats:
+            return supportsRestApi() && isViewingStatsAllowed()
+        case .stockPhotos:
+            return supportsRestApi() && JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
+        case .tenor:
+            return JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
+        case .sharing:
+            return supportsSharing
+        case .oAuth2Login:
+            return isHostedAtWPcom
+        case .mentions, .xposts:
+            return isAccessibleThroughWPCom()
+        case .reblog, .plans:
+            return isHostedAtWPcom && isAdmin
+        case .pluginManagement:
+            return supportsPluginManagement && isAdmin
+        case .jetpackImageSettings:
+            return supportsJetpackImageSettings()
+        case .jetpackSettings:
+            return supportsJetpackSettings()
+        case .pushNotifications:
+            return supportsPushNotifications
+        case .themeBrowsing:
+            return supportsRestApi() && isAdmin
+        case .activity:
+            return supportsRestApi() && isAdmin
+        case .customThemes:
+            return supportsRestApi() && isAdmin && !isHostedAtWPcom
+        case .premiumThemes:
+            guard supports(.customThemes) else { return false }
+            guard let planID else { return false }
+
+            return planID.intValue == Blog.jetpackProfessionalYearlyPlanId || planID.intValue == Blog.jetpackProfessionalMonthlyPlanId
+        case .menus:
+            return supportsRestApi() && isAdmin
+        case .private:
+            return isHostedAtWPcom
+        case .siteManagement:
+            return supportsSiteManagementServices()
+        case .domains:
+            return (isHostedAtWPcom || isAtomic()) && isAdmin && !isWPForTeams()
+        case .noncePreviews:
+            return supportsRestApi() && !isHostedAtWPcom
+        case .mediaMetadataEditing:
+            return isAdmin
+        case .mediaAltEditing:
+            // See:
+            // - https://core.trac.wordpress.org/ticket/58582
+            // - https://github.com/wordpress-mobile/WordPress-Android/issues/18514#issuecomment-1589752274
+            return supportsRestApi()
+        case .mediaDeletion:
+            return isAdmin
+        case .homepageSettings:
+            return supportsRestApi() && isAdmin
+        case .contactInfo:
+            return hasRequiredWordPressVersion("5.6")
+        case .blockEditorSettings:
+            return supportsBlockEditorSettings()
+        case .layoutGrid:
+            return isHostedAtWPcom || isAtomic()
+        case .tiledGallery:
+            return isHostedAtWPcom
+        case .videoPress:
+            return isHostedAtWPcom
+        case .videoPressV5:
+            return isHostedAtWPcom && isAtomic() && hasRequiredWordPressVersion("5.8")
+        case .facebookEmbed:
+            return supportsEmbedVariation("9.0")
+        case .instagramEmbed:
+            return supportsEmbedVariation("9.0")
+        case .loomEmbed:
+            return supportsEmbedVariation("9.0")
+        case .smartframeEmbed:
+            return supportsEmbedVariation("10.2")
+        case .fileDownloadsStats:
+            return isHostedAtWPcom
+        case .blaze:
+            return canBlaze
+        case .pages:
+            return isListingPagesAllowed()
+        case .siteMonitoring:
+            return isAdmin && isAtomic()
+        @unknown default:
+            fatalError()
+        }
+    }
+
+    @objc
+    public func supportsPublicize() -> Bool {
+        guard supports(.wpComRESTAPI) else { return false }
+        guard isPublishingPostsAllowed() else { return false }
+
+        if isHostedAtWPcom {
+            return !((getOptionValue(OptionsKeys.publicizeDisabled) as? Bool) ?? true)
+        } else {
+            return isJetpackModuleActive(name: ModuleKeys.publicize)
+        }
+    }
+
+    private var accountIsDefaultAccount: Bool {
+        account?.isDefaultWordPressComAccount ?? false
+    }
+
+    private var supportsPushNotifications: Bool {
+        accountIsDefaultAccount
+    }
+
+    private func hasRequiredJetpackVersion(_ version: String) -> Bool {
+        guard let jetpackVersion = jetpack?.version else { return false }
+
+        return supportsRestApi()
+        && !isHostedAtWPcom
+        && jetpackVersion.compare(version, options: .numeric) != .orderedAscending
+    }
+
+    private func supportsEmbedVariation(_ variation: String) -> Bool {
+        hasRequiredJetpackVersion(variation) || isHostedAtWPcom
+    }
+
+    private var supportsSharing: Bool {
+        supportsPublicize() || supportsShareButtons()
+    }
+
+    private func supportsShareButtons() -> Bool {
+        guard isAdmin else { return false }
+        guard supports(.wpComRESTAPI) else { return false }
+
+        return isHostedAtWPcom ? true : jetpackSharingButtonsModuleEnabled()
+    }
+
+    private var supportsPluginManagement: Bool {
+        let isTransferrable = isHostedAtWPcom && hasBusinessPlan && siteVisibility != .private
+
+        var supports = isTransferrable || hasRequiredJetpackVersion("5.6")
+
+        // If the site is not hosted on WP.com we can still manage plugins directly using the WP.org rest API
+        // Reference: https://make.wordpress.org/core/2020/07/16/new-and-modified-rest-api-endpoints-in-wordpress-5-5/
+        if (supports == false) && (account == nil) {
+            supports = !isHostedAtWPcom && (selfHostedSiteRestApi != nil) && hasRequiredWordPressVersion("5.5")
+        }
+
+        return supports
+    }
+
+    private func isJetpackModuleActive(name: String) -> Bool {
+        let activeModules = getOptionValue(OptionsKeys.activeModules) as? [String] ?? []
+        return activeModules.contains(name)
+    }
+
+    private struct OptionsKeys {
+        static let activeModules = "active_modules"
+        static let publicizeDisabled = "publicize_permanently_disabled"
+    }
+
+    private struct ModuleKeys {
+        static let publicize = "publicize"
+    }
+}

--- a/WordPress/Classes/Models/Blog/Blog.swift
+++ b/WordPress/Classes/Models/Blog/Blog.swift
@@ -1,3 +1,5 @@
+import BuildSettingsKit
+
 extension Blog {
 
     static let jetpackProfessionalYearlyPlanId = 2004
@@ -64,6 +66,10 @@ extension Blog {
 
     @objc
     public func supports(_ feature: BlogFeature) -> Bool {
+        supports(feature, buildSettings: .current)
+    }
+
+    public func supports(_ feature: BlogFeature, buildSettings: BuildSettings = .current) -> Bool {
         switch feature {
         case .removable:
             return accountIsDefaultAccount
@@ -78,9 +84,9 @@ extension Blog {
         case .stats:
             return supportsRestApi() && isViewingStatsAllowed()
         case .stockPhotos:
-            return supportsRestApi() && JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
+            return supportsRestApi() && buildSettings.brand == .jetpack
         case .tenor:
-            return JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
+            return buildSettings.brand == .jetpack
         case .sharing:
             return supportsSharing
         case .oAuth2Login:


### PR DESCRIPTION
As part of #24165, it's convenient to re-implement part of the Objective-C models to Swift, to remove code in Objective-C that accesses logic defined in the Swift layer.

Regardless of where WordPressData will end up, this kind of rewrites are advantageous because they bring us a few inches closer to our goal of no longer having Objective-C code, with all the implementation benefits that will produce.