### PR TITLE
RFC - Remove asURL() method and AppEnvironment base URL access

### DIFF
--- a/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
+++ b/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
@@ -7,7 +7,12 @@ private func apiBase(blog: Blog) -> URL? {
         assertionFailure(".com support has not been implemented yet")
         return nil
     }
-    return try? blog.url(withPath: "wp-json/")?.asURL()
+
+    guard let urlString = blog.url(withPath: "wp-json/") else {
+        return nil
+    }
+
+    return URL(string: urlString)
 }
 
 extension WordPressOrgRestApi {

--- a/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
+++ b/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
@@ -19,7 +19,8 @@ extension WordPressOrgRestApi {
     @objc
     convenience init?(
         blog: Blog,
-        userAgent: String = WPUserAgent.wordPress()
+        userAgent: String = WPUserAgent.wordPress(),
+        wordPressComApiURL: URL = AppEnvironment.current.wordPressComApiBase
     ) {
         if let dotComID = blog.dotComID?.uint64Value,
            let token = blog.account?.authToken,
@@ -28,7 +29,7 @@ extension WordPressOrgRestApi {
                 dotComSiteID: dotComID,
                 bearerToken: token,
                 userAgent: userAgent,
-                apiURL: AppEnvironment.current.wordPressComApiBase
+                apiURL: wordPressComApiURL
             )
         } else if let apiBase = apiBase(blog: blog),
                   let loginURL = try? blog.loginUrl().asURL(),

--- a/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
+++ b/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
@@ -20,7 +20,7 @@ extension WordPressOrgRestApi {
     convenience init?(
         blog: Blog,
         userAgent: String = WPUserAgent.wordPress(),
-        wordPressComApiURL: URL = AppEnvironment.current.wordPressComApiBase
+        wordPressComApiURL: URL = WordPressComRestApi.apiBaseURL
     ) {
         if let dotComID = blog.dotComID?.uint64Value,
            let token = blog.account?.authToken,

--- a/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
+++ b/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
@@ -17,14 +17,17 @@ private func apiBase(blog: Blog) -> URL? {
 
 extension WordPressOrgRestApi {
     @objc
-    convenience init?(blog: Blog) {
+    convenience init?(
+        blog: Blog,
+        userAgent: String = WPUserAgent.wordPress()
+    ) {
         if let dotComID = blog.dotComID?.uint64Value,
            let token = blog.account?.authToken,
            token.count > 0 {
             self.init(
                 dotComSiteID: dotComID,
                 bearerToken: token,
-                userAgent: WPUserAgent.wordPress(),
+                userAgent: userAgent,
                 apiURL: AppEnvironment.current.wordPressComApiBase
             )
         } else if let apiBase = apiBase(blog: blog),
@@ -40,7 +43,7 @@ extension WordPressOrgRestApi {
                     password: password,
                     adminURL: adminURL
                 ),
-                userAgent: WPUserAgent.wordPress()
+                userAgent: userAgent
             )
         } else {
             return nil

--- a/WordPress/WordPressTest/BlogTests.swift
+++ b/WordPress/WordPressTest/BlogTests.swift
@@ -4,6 +4,11 @@ import XCTest
 
 final class BlogTests: CoreDataTestCase {
 
+    func testAsURLBehavior() throws {
+        XCTAssertEqual(try "https://wordpress.com".asURL(), URL(string: "https://wordpress.com")!)
+        XCTAssertEqual(try "invalid".asURL(), URL(string: "invalid")!)
+    }
+
     // MARK: - Atomic Tests
     func testIsAtomic() {
         let blog = BlogBuilder(mainContext)


### PR DESCRIPTION
@kean @crazytonyli I need to move the convenience init for `WordPressOrgRestApi` `init?(blog:)` because it's implemented in Swift but used in Objective-C...

I have two suggestions:

- Remove the `asURL()` usages that come from Alamofire
- Bypass `AppEnvironment` to read the WordPress.com base URL

I open this PR as an RFC so it'll make more sense in code.

Keen to hear what you think..

---

_This is part of #24165_