### PR TITLE
Remove JP_SCHEME

### DIFF
--- a/WordPress/Info.plist
+++ b/WordPress/Info.plist
@@ -20,8 +20,8 @@
 	<string>${WP_BUILD_CONFIGURATION}</string>
 	<key>WPAppURLScheme</key>
 	<string>${WP_APP_URL_SCHEME}</string>
-  <key>WPJetpackAppURLScheme</key>
-  <string>${WP_JETPACK_APP_URL_SCHEME}</string>
+	<key>WPJetpackAppURLScheme</key>
+	<string>${WP_JETPACK_APP_URL_SCHEME}</string>
 	<key>WPProductTwitterHandle</key>
 	<string>@WordPressiOS</string>
 	<key>WPProductTwitterURL</key>
@@ -531,7 +531,7 @@
 	<key>LSApplicationQueriesSchemes</key>
 	<array>
 		<string>jetpacknotificationmigration</string>
-		<string>$(JP_SCHEME)</string>
+		<string>$(WP_JETPACK_APP_URL_SCHEME)</string>
 		<string>org-appextension-feature-password-management</string>
 		<string>twitter</string>
 		<string>whatsapp</string>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -8965,7 +8965,6 @@
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_PREPROCESS = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				JP_SCHEME = jpdebug;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -9029,7 +9028,6 @@
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_PREPROCESS = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				JP_SCHEME = jetpack;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -10280,7 +10278,6 @@
 				INFOPLIST_FILE = Info.plist;
 				INFOPLIST_PREPROCESS = YES;
 				IPHONEOS_DEPLOYMENT_TARGET = 16.0;
-				JP_SCHEME = jpalpha;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
This is a third place where these values were duplicated. We now moved it to `Common.*.xcconfig`.

<img width="509" alt="Screenshot 2025-03-27 at 10 25 47 AM" src="https://github.com/user-attachments/assets/ac6856f4-6fbf-4d15-ba60-8ca87e9e8dfc" />
<img width="336" alt="Screenshot 2025-03-27 at 10 25 36 AM" src="https://github.com/user-attachments/assets/1554bc7f-e1bc-4f5d-be44-ce9aaa046784" />


## To test:

I ran the app and verified that the value is still there in the plist:

```
      ▿ 2 : 2 elements
            - key : CFBundleURLSchemes
            ▿ value : 3 elements
              - 0 : wordpress-oauth-v2
              - 1 : jpdebug
              - 2 : jetpacknotificationmigration
```

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
