### PR TITLE
Remove remaining modular imports

### DIFF
--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -9,6 +9,7 @@
 @class RemotePost;
 @class RemoteUser;
 @class PostServiceRemoteFactory;
+@class PostServiceSyncOptions;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/Services/Reader Post/ReaderPostService.h
+++ b/WordPress/Classes/Services/Reader Post/ReaderPostService.h
@@ -4,10 +4,9 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnullability-completeness"
 
-@import WordPressKit;
-
 @class ReaderPost;
 @class ReaderAbstractTopic;
+@class WordPressComRestApi;
 
 extern NSString * const ReaderPostServiceErrorDomain;
 extern NSString * const ReaderPostServiceToggleSiteFollowingState;

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentsViewController.h
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentsViewController.h
@@ -1,4 +1,4 @@
-#import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
 #import "CommentService.h"
 
 @class Blog;


### PR DESCRIPTION
Not good in a public framework umbrella header.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
