### PR TITLE
Update access level for types that will go into WordPressData – Round 2

### DIFF
--- a/WordPress/Classes/Extensions/NSManagedObject.swift
+++ b/WordPress/Classes/Extensions/NSManagedObject.swift
@@ -1,6 +1,6 @@
 import CoreData
 
-extension NSManagedObject {
+public extension NSManagedObject {
     func setRawValue<ValueType: RawRepresentable>(_ value: ValueType?, forKey key: String) {
         willChangeValue(forKey: key)
         setPrimitiveValue(value?.rawValue, forKey: key)

--- a/WordPress/Classes/Jetpack/Utility/SharedDataIssueSolver.swift
+++ b/WordPress/Classes/Jetpack/Utility/SharedDataIssueSolver.swift
@@ -2,7 +2,7 @@ import WordPressShared
 import BuildSettingsKit
 
 @objcMembers
-final class SharedDataIssueSolver: NSObject {
+public final class SharedDataIssueSolver: NSObject {
 
     private let contextManager: CoreDataStack
     private let keychainUtils: KeychainUtils
@@ -10,7 +10,7 @@ final class SharedDataIssueSolver: NSObject {
     private let localFileStore: LocalFileStore
     private let appGroupName: String
 
-    init(contextManager: CoreDataStack = ContextManager.shared,
+    public init(contextManager: CoreDataStack = ContextManager.shared,
          keychainUtils: KeychainUtils = KeychainUtils(),
          sharedDefaults: UserPersistentRepository? = UserDefaults(suiteName: BuildSettings.current.appGroupName),
          localFileStore: LocalFileStore = FileManager.default,
@@ -28,7 +28,7 @@ final class SharedDataIssueSolver: NSObject {
         return SharedDataIssueSolver()
     }
 
-    func migrateAuthKey() {
+    public func migrateAuthKey() {
         guard let account = try? WPAccount.lookupDefaultWordPressComAccount(in: contextManager.mainContext),
               let username = account.username else {
             return
@@ -40,7 +40,7 @@ final class SharedDataIssueSolver: NSObject {
     /// To be safe, the method only "migrates" the data when the user is logged in, and there's a good chance that
     /// both apps are logged in with the same account.
     ///
-    func migrateAuthKey(for username: String) {
+    public func migrateAuthKey(for username: String) {
         guard AppConfiguration.isJetpack,
               let token = try? keychainUtils.getPassword(for: username, serviceName: WPAccountConstants.authToken.rawValue) else {
             return
@@ -60,7 +60,7 @@ final class SharedDataIssueSolver: NSObject {
                                  updateExisting: true)
     }
 
-    func migrateExtensionsData() {
+    public func migrateExtensionsData() {
         copyTodayWidgetDataToJetpack()
         copyShareExtensionDataToJetpack()
     }

--- a/WordPress/Classes/Models/AbstractPost.swift
+++ b/WordPress/Classes/Models/AbstractPost.swift
@@ -1,7 +1,8 @@
 import Foundation
+import WordPressKit
 import WordPressShared
 
-extension AbstractPost {
+public extension AbstractPost {
     /// Returns the original post by navigating the entire list of revisions
     /// until it reaches the head.
     func original() -> AbstractPost {
@@ -106,7 +107,7 @@ extension AbstractPost {
 
         /// The keyPath to access the underlying property.
         ///
-        var keyPath: String {
+        public var keyPath: String {
             switch self {
             case .dateCreated:
                 return #keyPath(AbstractPost.date_created_gmt)
@@ -140,7 +141,7 @@ extension AbstractPost {
         }
     }
 
-    @objc override open func featuredImageURLForDisplay() -> URL? {
+    @objc override func featuredImageURLForDisplay() -> URL? {
         return featuredImageURL
     }
 

--- a/WordPress/Classes/Models/Account Settings/ManagedAccountSettings+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/Account Settings/ManagedAccountSettings+CoreDataProperties.swift
@@ -3,7 +3,7 @@ import CoreData
 
 // MARK: - Encapsulates all of the ManagedAccountSettings Core Data properties.
 //
-extension ManagedAccountSettings {
+public extension ManagedAccountSettings {
     @NSManaged var firstName: String
     @NSManaged var lastName: String
     @NSManaged var displayName: String

--- a/WordPress/Classes/Models/Account Settings/ManagedAccountSettings.swift
+++ b/WordPress/Classes/Models/Account Settings/ManagedAccountSettings.swift
@@ -4,15 +4,15 @@ import WordPressKit
 
 // MARK: - Reflects the user's Account Settings, as stored in Core Data.
 //
-class ManagedAccountSettings: NSManagedObject {
+public class ManagedAccountSettings: NSManagedObject {
 
     // MARK: - NSManagedObject
 
-    override class func entityName() -> String {
+    public override class func entityName() -> String {
         return "AccountSettings"
     }
 
-    func updateWith(_ accountSettings: AccountSettings) {
+    public func updateWith(_ accountSettings: AccountSettings) {
         firstName = accountSettings.firstName
         lastName = accountSettings.lastName
         displayName = accountSettings.displayName
@@ -38,7 +38,7 @@ class ManagedAccountSettings: NSManagedObject {
     ///
     /// - Returns: the change object needed to revert this change
     ///
-    func applyChange(_ change: AccountSettingsChange) -> AccountSettingsChange {
+    public func applyChange(_ change: AccountSettingsChange) -> AccountSettingsChange {
         let reverse = reverseChange(change)
 
         switch change {
@@ -95,7 +95,7 @@ class ManagedAccountSettings: NSManagedObject {
     }
 }
 
-extension AccountSettings {
+public extension AccountSettings {
     init(managed: ManagedAccountSettings) {
         self.init(firstName: managed.firstName.stringByDecodingXMLCharacters(),
                   lastName: managed.lastName.stringByDecodingXMLCharacters(),

--- a/WordPress/Classes/Models/Blog/Blog+Capabilities.swift
+++ b/WordPress/Classes/Models/Blog/Blog+Capabilities.swift
@@ -84,7 +84,7 @@ extension Blog {
     ///
     /// - Returns: Whether site management is permitted
     ///
-    @objc func supportsSiteManagementServices() -> Bool {
+    @objc public func supportsSiteManagementServices() -> Bool {
         return isHostedAtWPcom && isAdmin
     }
 }

--- a/WordPress/Classes/Models/BloggingPrompt+CoreDataClass.swift
+++ b/WordPress/Classes/Models/BloggingPrompt+CoreDataClass.swift
@@ -17,7 +17,7 @@ public class BloggingPrompt: NSManagedObject {
         self.displayAvatarURLs = []
     }
 
-    var promptAttribution: BloggingPromptsAttribution? {
+    public var promptAttribution: BloggingPromptsAttribution? {
         BloggingPromptsAttribution(rawValue: attribution.lowercased())
     }
 
@@ -26,7 +26,7 @@ public class BloggingPrompt: NSManagedObject {
     /// - Parameters:
     ///   - remotePrompt: The remote prompt model to convert
     ///   - siteID: The ID of the site that the prompt is intended for
-    func configure(with remotePrompt: BloggingPromptRemoteObject, for siteID: Int32) {
+    public func configure(with remotePrompt: BloggingPromptRemoteObject, for siteID: Int32) {
         self.promptID = Int32(remotePrompt.promptID)
         self.siteID = siteID
         self.text = remotePrompt.text
@@ -42,7 +42,7 @@ public class BloggingPrompt: NSManagedObject {
         }
     }
 
-    func textForDisplay() -> String {
+    public func textForDisplay() -> String {
         return text.stringByDecodingXMLCharacters().trim()
     }
 
@@ -54,24 +54,24 @@ public class BloggingPrompt: NSManagedObject {
     /// - Parameters:
     ///   - localDate: The date to compare against in local timezone.
     /// - Returns: True if the year, month, and day components of the `localDate` matches the prompt's localized date.
-    func inSameDay(as dateToCompare: Date) -> Bool {
+    public func inSameDay(as dateToCompare: Date) -> Bool {
         return DateFormatters.utc.string(from: date) == DateFormatters.local.string(from: dateToCompare)
     }
 
     /// Used for comparison on upsert  – there can't be two `BloggingPrompt` objects with the same date, so we can use it as a unique identifier
     @objc
-    var dateString: String {
+    public var dateString: String {
         DateFormatters.local.string(from: date)
     }
 }
 
 // MARK: - Notification Payload
 
-extension BloggingPrompt {
+public extension BloggingPrompt {
 
     struct NotificationKeys {
-        static let promptID = "prompt_id"
-        static let siteID = "site_id"
+        public static let promptID = "prompt_id"
+        public static let siteID = "site_id"
     }
 
 }

--- a/WordPress/Classes/Models/BloggingPromptSettings+CoreDataClass.swift
+++ b/WordPress/Classes/Models/BloggingPromptSettings+CoreDataClass.swift
@@ -4,7 +4,7 @@ import WordPressKit
 
 public class BloggingPromptSettings: NSManagedObject {
 
-    static func of(_ blog: Blog) throws -> BloggingPromptSettings? {
+    public static func of(_ blog: Blog) throws -> BloggingPromptSettings? {
         guard let context = blog.managedObjectContext else { return nil }
 
         // This getting site id logic is copied from the BloggingPromptsService initializer.
@@ -20,14 +20,14 @@ public class BloggingPromptSettings: NSManagedObject {
         return try lookup(withSiteID: siteID, in: context)
     }
 
-    static func lookup(withSiteID siteID: NSNumber, in context: NSManagedObjectContext) throws -> BloggingPromptSettings? {
+    public static func lookup(withSiteID siteID: NSNumber, in context: NSManagedObjectContext) throws -> BloggingPromptSettings? {
         let fetchRequest = BloggingPromptSettings.fetchRequest()
         fetchRequest.predicate = NSPredicate(format: "\(#keyPath(BloggingPromptSettings.siteID)) = %@", siteID)
         fetchRequest.fetchLimit = 1
         return try context.fetch(fetchRequest).first
     }
 
-    func reminderTimeDate() -> Date? {
+    public func reminderTimeDate() -> Date? {
         guard let reminderTime else {
             return nil
         }
@@ -37,7 +37,7 @@ public class BloggingPromptSettings: NSManagedObject {
     }
 }
 
-extension RemoteBloggingPromptsSettings {
+public extension RemoteBloggingPromptsSettings {
 
     init(with model: BloggingPromptSettings) {
         self.init(promptCardEnabled: model.promptCardEnabled,

--- a/WordPress/Classes/Models/BloggingPromptSettingsReminderDays+CoreDataClass.swift
+++ b/WordPress/Classes/Models/BloggingPromptSettingsReminderDays+CoreDataClass.swift
@@ -4,7 +4,7 @@ import WordPressKit
 
 public class BloggingPromptSettingsReminderDays: NSManagedObject {
 
-    func configure(with remoteReminderDays: RemoteBloggingPromptsSettings.ReminderDays) {
+    public func configure(with remoteReminderDays: RemoteBloggingPromptsSettings.ReminderDays) {
         self.monday = remoteReminderDays.monday
         self.tuesday = remoteReminderDays.tuesday
         self.wednesday = remoteReminderDays.wednesday

--- a/WordPress/Classes/Models/Comment/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment/Comment+CoreDataClass.swift
@@ -4,19 +4,19 @@ import CoreData
 @objc(Comment)
 public class Comment: NSManagedObject {
 
-    @objc static func descriptionFor(_ commentStatus: CommentStatusType) -> String {
+    @objc public static func descriptionFor(_ commentStatus: CommentStatusType) -> String {
         return commentStatus.description
     }
 
-    @objc func authorUrlForDisplay() -> String {
+    @objc public func authorUrlForDisplay() -> String {
         return authorURL()?.host ?? String()
     }
 
-    @objc func contentForEdit() -> String {
+    @objc public func contentForEdit() -> String {
         return availableContent()
     }
 
-    @objc func isApproved() -> Bool {
+    @objc public func isApproved() -> Bool {
         return status == CommentStatusType.approved.description
     }
 
@@ -31,7 +31,7 @@ public class Comment: NSManagedObject {
 
     // This can be removed when `unifiedCommentsAndNotificationsList` is permanently enabled
     // as it's replaced by Comment+Interface:relativeDateSectionIdentifier.
-    @objc func sectionIdentifier() -> String? {
+    @objc public func sectionIdentifier() -> String? {
         guard let dateCreated else {
             return nil
         }
@@ -42,7 +42,7 @@ public class Comment: NSManagedObject {
         return formatter.string(from: dateCreated)
     }
 
-    @objc func commentURL() -> URL? {
+    @objc public func commentURL() -> URL? {
         guard !link.isEmpty else {
             return nil
         }
@@ -50,22 +50,22 @@ public class Comment: NSManagedObject {
         return URL(string: link)
     }
 
-    @objc func deleteWillBePermanent() -> Bool {
+    @objc public func deleteWillBePermanent() -> Bool {
         return status == Comment.descriptionFor(.spam) || status == Comment.descriptionFor(.unapproved)
    }
 
-    func canEditAuthorData() -> Bool {
+    public func canEditAuthorData() -> Bool {
         // If the authorID is zero, the user is unregistered. Therefore, the data can be edited.
         return authorID == 0
     }
 
-    func hasParentComment() -> Bool {
+    public func hasParentComment() -> Bool {
         return parentID > 0
     }
 
     /// Convenience method to check if the current user can actually moderate.
     /// `canModerate` is only applicable when the site is dotcom-related (hosted or atomic). For self-hosted sites, default to true.
-    @objc func allowsModeration() -> Bool {
+    @objc public func allowsModeration() -> Bool {
         if let _ = post as? ReaderPost {
             return canModerate
         }
@@ -76,7 +76,7 @@ public class Comment: NSManagedObject {
         return canModerate
     }
 
-    func canReply() -> Bool {
+    public func canReply() -> Bool {
         if let post = post as? ReaderPost {
             return post.commentsOpen
         }
@@ -84,7 +84,7 @@ public class Comment: NSManagedObject {
     }
 
     // NOTE: Comment Likes could be disabled, but the API doesn't have that info yet. Let's update this once it's available.
-    func canLike() -> Bool {
+    public func canLike() -> Bool {
         if (post as? ReaderPost) != nil {
             return true
         }
@@ -95,11 +95,11 @@ public class Comment: NSManagedObject {
         return !isReadOnly() && blog.supports(.commentLikes)
     }
 
-    @objc func isTopLevelComment() -> Bool {
+    @objc public func isTopLevelComment() -> Bool {
         return depth == 0
     }
 
-    func isFromPostAuthor() -> Bool {
+    public func isFromPostAuthor() -> Bool {
         guard let postAuthorID = post?.authorID?.int32Value,
               postAuthorID > 0,
               authorID > 0 else {
@@ -181,7 +181,7 @@ extension Comment: PostContentProvider {
 }
 
 // When CommentViewController and CommentService are converted to Swift, this can be simplified to a String enum.
-@objc enum CommentStatusType: Int {
+@objc public enum CommentStatusType: Int {
     case pending
     case approved
     case unapproved
@@ -190,7 +190,7 @@ extension Comment: PostContentProvider {
     // We can use this status to restore comment replies that the user has written.
     case draft
 
-    var description: String {
+    public var description: String {
         switch self {
         case .pending:
             return "hold"
@@ -205,7 +205,7 @@ extension Comment: PostContentProvider {
         }
     }
 
-    static func typeForStatus(_ status: String?) -> CommentStatusType? {
+    public static func typeForStatus(_ status: String?) -> CommentStatusType? {
         switch status {
         case "hold":
             return .pending

--- a/WordPress/Classes/Models/Domain.swift
+++ b/WordPress/Classes/Models/Domain.swift
@@ -4,7 +4,7 @@ import WordPressKit
 
 public typealias Domain = RemoteDomain
 
-extension Domain {
+public extension Domain {
     init(managedDomain: ManagedDomain) {
         self.init(domainName: managedDomain.domainName,
                   isPrimaryDomain: managedDomain.isPrimary,
@@ -17,16 +17,16 @@ extension Domain {
     }
 }
 
-class ManagedDomain: NSManagedObject {
+public class ManagedDomain: NSManagedObject {
 
     // MARK: - NSManagedObject
 
-    override class func entityName() -> String {
+    public override class func entityName() -> String {
         return "Domain"
     }
 
-    struct Attributes {
-        static let domainName = "domainName"
+    public struct Attributes {
+        public static let domainName = "domainName"
         static let isPrimary = "isPrimary"
         static let domainType = "domainType"
         static let autoRenewing = "autoRenewing"
@@ -36,21 +36,21 @@ class ManagedDomain: NSManagedObject {
         static let expiryDate = "expiryDate"
     }
 
-    struct Relationships {
-        static let blog = "blog"
+    public struct Relationships {
+        public static let blog = "blog"
     }
 
-    @NSManaged var domainName: String
-    @NSManaged var isPrimary: Bool
-    @NSManaged var domainType: DomainType
-    @NSManaged var blog: Blog
-    @NSManaged var autoRenewing: Bool
-    @NSManaged var autoRenewalDate: String
-    @NSManaged var expirySoon: Bool
-    @NSManaged var expired: Bool
-    @NSManaged var expiryDate: String
+    @NSManaged public var domainName: String
+    @NSManaged public var isPrimary: Bool
+    @NSManaged public var domainType: DomainType
+    @NSManaged public var blog: Blog
+    @NSManaged public var autoRenewing: Bool
+    @NSManaged public var autoRenewalDate: String
+    @NSManaged public var expirySoon: Bool
+    @NSManaged public var expired: Bool
+    @NSManaged public var expiryDate: String
 
-    func updateWith(_ domain: Domain, blog: Blog) {
+    public func updateWith(_ domain: Domain, blog: Blog) {
         self.domainName = domain.domainName
         self.isPrimary = domain.isPrimaryDomain
         self.domainType = domain.domainType

--- a/WordPress/Classes/Models/Gutenberg/PageTemplateCategory+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/Gutenberg/PageTemplateCategory+CoreDataProperties.swift
@@ -43,7 +43,7 @@ extension PageTemplateCategory {
 
 }
 
-extension PageTemplateCategory {
+public extension PageTemplateCategory {
 
     convenience init(context: NSManagedObjectContext, category: RemoteLayoutCategory, ordinal: Int) {
         self.init(context: context)

--- a/WordPress/Classes/Models/Gutenberg/PageTemplateLayout+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/Gutenberg/PageTemplateLayout+CoreDataProperties.swift
@@ -34,7 +34,7 @@ extension PageTemplateLayout {
     @NSManaged public func removeFromCategories(_ values: Set<PageTemplateCategory>)
 }
 
-extension PageTemplateLayout {
+public extension PageTemplateLayout {
 
     convenience init(context: NSManagedObjectContext, layout: RemoteLayout) {
         self.init(context: context)

--- a/WordPress/Classes/Models/Page+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/Page+CoreDataProperties.swift
@@ -3,6 +3,6 @@ import CoreData
 
 extension Page {
 
-    @NSManaged var parentID: NSNumber?
+    @NSManaged public var parentID: NSNumber?
 
 }

--- a/WordPress/Classes/Models/People Management/ManagedPerson+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/People Management/ManagedPerson+CoreDataProperties.swift
@@ -3,7 +3,7 @@ import CoreData
 
 // MARK: - Encapsulates all of the ManagedPerson Core Data properties.
 //
-extension ManagedPerson {
+public extension ManagedPerson {
     @NSManaged var avatarURL: String?
     @NSManaged var displayName: String
     @NSManaged var firstName: String?

--- a/WordPress/Classes/Models/People Management/ManagedPerson.swift
+++ b/WordPress/Classes/Models/People Management/ManagedPerson.swift
@@ -8,9 +8,9 @@ public typealias Person = RemotePerson
 
 // MARK: - Reflects a Person, stored in Core Data
 //
-class ManagedPerson: NSManagedObject {
+public class ManagedPerson: NSManagedObject {
 
-    func updateWith<T: Person>(_ person: T) {
+    public func updateWith<T: Person>(_ person: T) {
         let canonicalAvatarURL = person.avatarURL.flatMap { AvatarURL(url: $0)?.canonicalURL }
 
         avatarURL = canonicalAvatarURL?.absoluteString
@@ -26,7 +26,7 @@ class ManagedPerson: NSManagedObject {
         kind = Int16(type(of: person).kind.rawValue)
     }
 
-    func toUnmanaged() -> Person {
+    public func toUnmanaged() -> Person {
         switch Int(kind) {
         case PersonKind.user.rawValue:
             return User(managedPerson: self)
@@ -42,7 +42,7 @@ class ManagedPerson: NSManagedObject {
 
 // MARK: - Extensions
 //
-extension Person {
+public extension Person {
     init(managedPerson: ManagedPerson) {
         self.init(ID: Int(managedPerson.userID),
                   username: managedPerson.username,
@@ -57,7 +57,7 @@ extension Person {
     }
 }
 
-extension User {
+public extension User {
     init(managedPerson: ManagedPerson) {
         self.init(ID: Int(managedPerson.userID),
                   username: managedPerson.username,
@@ -72,7 +72,7 @@ extension User {
     }
 }
 
-extension Follower {
+public extension Follower {
     init(managedPerson: ManagedPerson) {
         self.init(ID: Int(managedPerson.userID),
                   username: managedPerson.username,
@@ -87,7 +87,7 @@ extension Follower {
     }
 }
 
-extension Viewer {
+public extension Viewer {
     init(managedPerson: ManagedPerson) {
         self.init(ID: Int(managedPerson.userID),
                   username: managedPerson.username,
@@ -102,7 +102,7 @@ extension Viewer {
     }
 }
 
-extension EmailFollower {
+public extension EmailFollower {
     init(managedPerson: ManagedPerson) {
         self.init(ID: Int(managedPerson.userID),
                   username: managedPerson.username,

--- a/WordPress/Classes/Models/Post+CoreDataProperties.swift
+++ b/WordPress/Classes/Models/Post+CoreDataProperties.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CoreData
 
-extension Post {
+public extension Post {
 
     @NSManaged var commentCount: NSNumber?
     @NSManaged var disabledPublicizeConnections: [NSNumber: [String: String]]?

--- a/WordPress/Classes/Models/PostCategory+Creation.swift
+++ b/WordPress/Classes/Models/PostCategory+Creation.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension PostCategory {
+public extension PostCategory {
 
     static func create(withBlogID id: NSManagedObjectID, in context: NSManagedObjectContext) throws -> PostCategory {
         let object = try context.existingObject(with: id)

--- a/WordPress/Classes/Models/PostCategory+Lookup.swift
+++ b/WordPress/Classes/Models/PostCategory+Lookup.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension PostCategory {
+public extension PostCategory {
 
     static func lookup(withBlogID id: NSManagedObjectID, categoryID: NSNumber, in context: NSManagedObjectContext) throws -> PostCategory? {
         try lookup(withBlogID: id, predicate: NSPredicate(format: "categoryID == %@", categoryID), in: context)
@@ -28,7 +28,7 @@ extension PostCategory {
 
 // MARK: - Objective-C API
 
-extension PostCategory {
+public extension PostCategory {
 
     @objc(lookupWithBlogObjectID:categoryID:inContext:)
     static func objc_lookup(withBlogID id: NSManagedObjectID, categoryID: NSNumber, in context: NSManagedObjectContext) -> PostCategory? {

--- a/WordPress/Classes/Models/PublicizeInfo+CoreDataClass.swift
+++ b/WordPress/Classes/Models/PublicizeInfo+CoreDataClass.swift
@@ -10,7 +10,7 @@ import WordPressKit
 ///
 @objc public class PublicizeInfo: NSManagedObject {
 
-    var sharingLimit: SharingLimit {
+    public var sharingLimit: SharingLimit {
         SharingLimit(remaining: Int(sharesRemaining), limit: Int(shareLimit))
     }
 
@@ -22,7 +22,7 @@ import WordPressKit
         return NSEntityDescription.insertNewObject(forEntityName: Self.classNameWithoutNamespaces(), into: context) as? PublicizeInfo
     }
 
-    func configure(with remote: RemotePublicizeInfo) {
+    public func configure(with remote: RemotePublicizeInfo) {
         self.shareLimit = Int64(remote.shareLimit)
         self.toBePublicizedCount = Int64(remote.toBePublicizedCount)
         self.sharedPostsCount = Int64(remote.sharedPostsCount)
@@ -30,11 +30,11 @@ import WordPressKit
     }
 
     /// A value-type representation for Publicize auto-sharing usage.
-    struct SharingLimit {
+    public struct SharingLimit {
         /// The remaining shares available for use.
-        let remaining: Int
+        public let remaining: Int
 
         /// Maximum number of shares allowed for the site.
-        let limit: Int
+        public let limit: Int
     }
 }

--- a/WordPress/Classes/Models/PublicizeService.swift
+++ b/WordPress/Classes/Models/PublicizeService.swift
@@ -3,10 +3,10 @@ import CoreData
 import WordPressShared
 
 open class PublicizeService: NSManagedObject {
-    @objc static let googlePlusServiceID = "google_plus"
-    @objc static let facebookServiceID = "facebook"
-    @objc static let defaultStatus = "ok"
-    @objc static let unsupportedStatus = "unsupported"
+    @objc public static let googlePlusServiceID = "google_plus"
+    @objc public static let facebookServiceID = "facebook"
+    @objc public static let defaultStatus = "ok"
+    @objc public static let unsupportedStatus = "unsupported"
 
     @NSManaged open var connectURL: String
     @NSManaged open var detail: String
@@ -28,7 +28,7 @@ open class PublicizeService: NSManagedObject {
 
 // MARK: - Convenience Methods
 
-extension PublicizeService {
+public extension PublicizeService {
 
     /// A convenient value-type representation for the destination sharing service.
     enum ServiceName: String {
@@ -47,7 +47,7 @@ extension PublicizeService {
         }
 
         /// A string describing the service in a human-readable format.
-        var description: String {
+        public var description: String {
             rawValue.split(separator: "-").joined(separator: " ").localizedCapitalized
         }
     }

--- a/WordPress/Classes/Models/ReaderAbstractTopic+Lookup.swift
+++ b/WordPress/Classes/Models/ReaderAbstractTopic+Lookup.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension ReaderAbstractTopic {
+public extension ReaderAbstractTopic {
 
     /// Fetch all `ReaderAbstractTopics` currently in Core Data.
     ///

--- a/WordPress/Classes/Models/ReaderCard+CoreDataClass.swift
+++ b/WordPress/Classes/Models/ReaderCard+CoreDataClass.swift
@@ -2,14 +2,14 @@ import Foundation
 import CoreData
 
 public class ReaderCard: NSManagedObject {
-    enum CardType {
+    public enum CardType {
         case post
         case topics
         case sites
         case unknown
     }
 
-    var type: CardType {
+   public var type: CardType {
         if post != nil {
             return .post
         }
@@ -25,7 +25,7 @@ public class ReaderCard: NSManagedObject {
         return .unknown
     }
 
-    var isRecommendationCard: Bool {
+    public var isRecommendationCard: Bool {
         switch type {
         case .topics, .sites:
             return true
@@ -34,15 +34,15 @@ public class ReaderCard: NSManagedObject {
         }
     }
 
-    var topicsArray: [ReaderTagTopic] {
+    public var topicsArray: [ReaderTagTopic] {
         topics?.array as? [ReaderTagTopic] ?? []
     }
 
-    var sitesArray: [ReaderSiteTopic] {
+    public var sitesArray: [ReaderSiteTopic] {
         sites?.array as? [ReaderSiteTopic] ?? []
     }
 
-    convenience init?(context: NSManagedObjectContext, from remoteCard: RemoteReaderCard) {
+    public convenience init?(context: NSManagedObjectContext, from remoteCard: RemoteReaderCard) {
         guard remoteCard.type != .unknown else {
             return nil
         }

--- a/WordPress/Classes/Models/ReaderPost+Searchable.swift
+++ b/WordPress/Classes/Models/ReaderPost+Searchable.swift
@@ -1,29 +1,29 @@
 import Foundation
 
 extension ReaderPost: SearchableItemConvertable {
-    var searchItemType: SearchItemType {
+    public var searchItemType: SearchItemType {
         return .readerPost
     }
 
-    var isSearchable: Bool {
+    public var isSearchable: Bool {
         return true
     }
 
-    var searchIdentifier: String? {
+    public var searchIdentifier: String? {
         guard let postID, postID.intValue > 0 else {
             return nil
         }
         return postID.stringValue
     }
 
-    var searchDomain: String? {
+    public var searchDomain: String? {
         guard let siteID, siteID.intValue > 0 else {
             return nil
         }
         return siteID.stringValue
     }
 
-    var searchTitle: String? {
+    public var searchTitle: String? {
         var title = titleForDisplay() ?? ""
         if title.isEmpty {
             // If titleForDisplay() happens to be empty, try using the content preview instead...
@@ -32,18 +32,18 @@ extension ReaderPost: SearchableItemConvertable {
         return title
     }
 
-    var searchDescription: String? {
+    public var searchDescription: String? {
         guard let readerPostPreview = contentPreviewForDisplay(), !readerPostPreview.isEmpty else {
             return blogURL ?? contentForDisplay()
         }
         return readerPostPreview
     }
 
-    var searchKeywords: [String]? {
+    public var searchKeywords: [String]? {
         return generateKeywordsFromContent()
     }
 
-    var searchExpirationDate: Date? {
+    public var searchExpirationDate: Date? {
         let oneWeekFromNow = Calendar.current.date(byAdding: .weekOfYear, value: 1, to: Date())
         return oneWeekFromNow
     }

--- a/WordPress/Classes/Models/ReaderSiteTopic+Lookup.swift
+++ b/WordPress/Classes/Models/ReaderSiteTopic+Lookup.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension ReaderSiteTopic {
+public extension ReaderSiteTopic {
 
     /// Find a site topic by its site id
     ///

--- a/WordPress/Classes/Models/ReaderSiteTopic.swift
+++ b/WordPress/Classes/Models/ReaderSiteTopic.swift
@@ -32,7 +32,7 @@ import Foundation
         }
     }
 
-    var organizationType: SiteOrganizationType {
+    public var organizationType: SiteOrganizationType {
         SiteOrganizationType(rawValue: organizationID) ?? .none
     }
 

--- a/WordPress/Classes/Models/ReaderSiteTopic.swift
+++ b/WordPress/Classes/Models/ReaderSiteTopic.swift
@@ -36,7 +36,7 @@ import Foundation
         SiteOrganizationType(rawValue: organizationID) ?? .none
     }
 
-    var isP2Type: Bool {
+    public var isP2Type: Bool {
         return organizationType == .p2 || organizationType == .automattic
     }
 
@@ -48,7 +48,7 @@ import Foundation
         return postSubscription?.sendPosts ?? false
     }
 
-    var canManageNotifications: Bool {
+    public var canManageNotifications: Bool {
         !isExternal
     }
 

--- a/WordPress/Classes/Models/ReaderTagTopic.swift
+++ b/WordPress/Classes/Models/ReaderTagTopic.swift
@@ -13,19 +13,19 @@ import Foundation
     // MARK: - Computed Properties
 
     /// The `slug` property is URL encoded. Use this property for display instead.
-    var slugForDisplay: String? {
+    public var slugForDisplay: String? {
         return slug.removingPercentEncoding
     }
 
     // MARK: - Logged Out Helpers
 
     /// The tagID used if an interest was added locally and not sync'd with the server
-    class var loggedOutTagID: NSNumber {
+    public class var loggedOutTagID: NSNumber {
         return NSNotFound as NSNumber
     }
 
     /// Creates a new ReaderTagTopic object from a RemoteReaderInterest
-    convenience init(remoteInterest: RemoteReaderInterest, context: NSManagedObjectContext, isFollowing: Bool = false) {
+    convenience public init(remoteInterest: RemoteReaderInterest, context: NSManagedObjectContext, isFollowing: Bool = false) {
         self.init(context: context)
 
         title = remoteInterest.title
@@ -38,7 +38,7 @@ import Foundation
 
     /// Returns an existing ReaderTagTopic or creates a new one based on remote interest
     /// If an existing topic is returned, the title will be updated with the remote interest
-    class func createOrUpdateIfNeeded(from remoteInterest: RemoteReaderInterest, context: NSManagedObjectContext) -> ReaderTagTopic {
+    public class func createOrUpdateIfNeeded(from remoteInterest: RemoteReaderInterest, context: NSManagedObjectContext) -> ReaderTagTopic {
         let fetchRequest = NSFetchRequest<NSFetchRequestResult>(entityName: self.classNameWithoutNamespaces())
         fetchRequest.predicate = NSPredicate(format: "slug = %@", remoteInterest.slug)
         let topics = try? context.fetch(fetchRequest) as? [ReaderTagTopic]
@@ -52,17 +52,17 @@ import Foundation
         return topic
     }
 
-    var formattedTitle: String {
+    public var formattedTitle: String {
         title.split(separator: "-").map(\.capitalized).joined(separator: " ")
     }
 
     /// Convenience method to update the tag's `following` state and also updates `showInMenu`.
-    @objc func toggleFollowing(_ isFollowing: Bool) {
+    @objc public func toggleFollowing(_ isFollowing: Bool) {
         following = isFollowing
         showInMenu = (following || isRecommended)
     }
 }
 
-extension ReaderTagTopic {
+public extension ReaderTagTopic {
     static let dailyPromptTag = "dailyprompt"
 }

--- a/WordPress/Classes/Models/Revisions/DiffAbstractValue.swift
+++ b/WordPress/Classes/Models/Revisions/DiffAbstractValue.swift
@@ -1,15 +1,15 @@
 import Foundation
 import CoreData
 
-class DiffAbstractValue: NSManagedObject {
-    enum Operation: String {
+public class DiffAbstractValue: NSManagedObject {
+    public enum Operation: String {
         case add
         case copy
         case del
         case unknown
     }
 
-    enum DiffType: String {
+    public enum DiffType: String {
         case title
         case content
         case unknown
@@ -18,10 +18,10 @@ class DiffAbstractValue: NSManagedObject {
     @NSManaged private var diffOperation: String
     @NSManaged private var diffType: String
 
-    @NSManaged var index: Int
-    @NSManaged var value: String?
+    @NSManaged public var index: Int
+    @NSManaged public var value: String?
 
-    var operation: Operation {
+    public var operation: Operation {
         get {
             return Operation(rawValue: diffOperation) ?? .unknown
         }
@@ -30,7 +30,7 @@ class DiffAbstractValue: NSManagedObject {
         }
     }
 
-    var type: DiffType {
+    public var type: DiffType {
         get {
             return DiffType(rawValue: diffType) ?? .unknown
         }

--- a/WordPress/Classes/Models/Revisions/DiffContentValue.swift
+++ b/WordPress/Classes/Models/Revisions/DiffContentValue.swift
@@ -1,6 +1,6 @@
 import Foundation
 import CoreData
 
-class DiffContentValue: DiffAbstractValue {
+public class DiffContentValue: DiffAbstractValue {
     @NSManaged var revisionDiff: RevisionDiff?
 }

--- a/WordPress/Classes/Models/Revisions/DiffTitleValue.swift
+++ b/WordPress/Classes/Models/Revisions/DiffTitleValue.swift
@@ -1,6 +1,6 @@
 import Foundation
 import CoreData
 
-class DiffTitleValue: DiffAbstractValue {
+public class DiffTitleValue: DiffAbstractValue {
     @NSManaged var revisionDiff: RevisionDiff?
 }

--- a/WordPress/Classes/Models/Revisions/Revision.swift
+++ b/WordPress/Classes/Models/Revisions/Revision.swift
@@ -1,21 +1,21 @@
 import Foundation
 import CoreData
 
-class Revision: NSManagedObject {
-    @NSManaged var siteId: NSNumber
-    @NSManaged var revisionId: NSNumber
-    @NSManaged var postId: NSNumber
+public class Revision: NSManagedObject {
+    @NSManaged public var siteId: NSNumber
+    @NSManaged public var revisionId: NSNumber
+    @NSManaged public var postId: NSNumber
 
-    @NSManaged var postAuthorId: NSNumber?
+    @NSManaged public var postAuthorId: NSNumber?
 
-    @NSManaged var postTitle: String?
-    @NSManaged var postContent: String?
-    @NSManaged var postExcerpt: String?
+    @NSManaged public var postTitle: String?
+    @NSManaged public var postContent: String?
+    @NSManaged public var postExcerpt: String?
 
-    @NSManaged var postDateGmt: String?
-    @NSManaged var postModifiedGmt: String?
+    @NSManaged public var postDateGmt: String?
+    @NSManaged public var postModifiedGmt: String?
 
-    @NSManaged var diff: RevisionDiff?
+    @NSManaged public var diff: RevisionDiff?
 
     private lazy var revisionFormatter: DateFormatter = {
         let formatter = DateFormatter()
@@ -25,11 +25,11 @@ class Revision: NSManagedObject {
         return formatter
     }()
 
-    var revisionDate: Date {
+    public var revisionDate: Date {
         return revisionFormatter.date(from: postDateGmt ?? "") ?? Date()
     }
 
-    @objc var revisionDateForSection: String {
+    @objc public var revisionDateForSection: String {
         return revisionDate.longUTCStringWithoutTime()
     }
 }

--- a/WordPress/Classes/Models/Revisions/RevisionDiff+CoreData.swift
+++ b/WordPress/Classes/Models/Revisions/RevisionDiff+CoreData.swift
@@ -32,7 +32,7 @@ extension RevisionDiff {
     @NSManaged public func removeFromTitleDiffs(_ values: NSSet)
 }
 
-extension RevisionDiff {
+public extension RevisionDiff {
     func remove<T: DiffAbstractValue>(_ type: T.Type) -> RevisionDiff {
         guard let set = (type is DiffContentValue.Type ? contentDiffs : titleDiffs) else {
             return self

--- a/WordPress/Classes/Models/Revisions/RevisionDiff.swift
+++ b/WordPress/Classes/Models/Revisions/RevisionDiff.swift
@@ -1,15 +1,15 @@
 import Foundation
 import CoreData
 
-class RevisionDiff: NSManagedObject {
-    @NSManaged var fromRevisionId: NSNumber
-    @NSManaged var toRevisionId: NSNumber
+public class RevisionDiff: NSManagedObject {
+    @NSManaged public var fromRevisionId: NSNumber
+    @NSManaged public var toRevisionId: NSNumber
 
-    @NSManaged var totalAdditions: NSNumber
-    @NSManaged var totalDeletions: NSNumber
+    @NSManaged public var totalAdditions: NSNumber
+    @NSManaged public var totalDeletions: NSNumber
 
-    @NSManaged var contentDiffs: NSSet?
-    @NSManaged var titleDiffs: NSSet?
+    @NSManaged public var contentDiffs: NSSet?
+    @NSManaged public var titleDiffs: NSSet?
 
-    @NSManaged var revision: Revision?
+    @NSManaged public var revision: Revision?
 }

--- a/WordPress/Classes/Models/Role.swift
+++ b/WordPress/Classes/Models/Role.swift
@@ -8,7 +8,7 @@ public class Role: NSManagedObject {
     @NSManaged public var order: NSNumber!
 }
 
-extension Role {
+public extension Role {
     func toUnmanaged() -> RemoteRole {
         return RemoteRole(slug: slug, name: name)
     }

--- a/WordPress/Classes/Models/SharingButton+Lookup.swift
+++ b/WordPress/Classes/Models/SharingButton+Lookup.swift
@@ -1,4 +1,4 @@
-extension SharingButton {
+public extension SharingButton {
 
     /// Returns an array of all cached `SharingButtons` objects.
     ///

--- a/WordPress/Classes/Models/SharingButton.swift
+++ b/WordPress/Classes/Models/SharingButton.swift
@@ -2,8 +2,8 @@ import Foundation
 import CoreData
 
 @objc open class SharingButton: NSManagedObject {
-    @objc static let visible = "visible"
-    @objc static let hidden = "hidden"
+    @objc public static let visible = "visible"
+    @objc public static let hidden = "hidden"
 
     // Relations
     @NSManaged open var blog: Blog
@@ -17,7 +17,7 @@ import CoreData
     @NSManaged open var visibility: String?
     @NSManaged open var order: NSNumber
 
-    @objc var visible: Bool {
+    @objc public var visible: Bool {
         return visibility == SharingButton.visible
     }
 }

--- a/WordPress/Classes/Models/SiteSuggestion+CoreDataClass.swift
+++ b/WordPress/Classes/Models/SiteSuggestion+CoreDataClass.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CoreData
 
-extension CodingUserInfoKey {
+public extension CodingUserInfoKey {
     static let managedObjectContext = CodingUserInfoKey(rawValue: "managedObjectContext")!
 }
 

--- a/WordPress/Classes/Models/ThemeIdHelper.swift
+++ b/WordPress/Classes/Models/ThemeIdHelper.swift
@@ -2,14 +2,15 @@ import Foundation
 
 /// Helper class for adding and removing the '-wpcom' suffix from themeIds
 ///
-class ThemeIdHelper: NSObject {
+@objc
+public class ThemeIdHelper: NSObject {
     private static let WPComThemesIDSuffix = "-wpcom"
 
-    @objc static func themeIdWithWPComSuffix(_ themeId: String) -> String {
+    @objc public static func themeIdWithWPComSuffix(_ themeId: String) -> String {
         return themeId.appending(WPComThemesIDSuffix)
     }
 
-    @objc static func themeIdWithWPComSuffixRemoved(_ themeId: String, forBlog blog: Blog) -> String {
+    @objc public static func themeIdWithWPComSuffixRemoved(_ themeId: String, forBlog blog: Blog) -> String {
         if blog.supports(.customThemes) && themeIdHasWPComSuffix(themeId) {
             // When a WP.com theme is used on a JP site, its themeId is modified to themeId-wpcom,
             // we need to remove this to be able to match it on the theme list
@@ -19,7 +20,7 @@ class ThemeIdHelper: NSObject {
         return themeId
     }
 
-    @objc static func themeIdHasWPComSuffix(_ themeId: String) -> Bool {
+    @objc public static func themeIdHasWPComSuffix(_ themeId: String) -> Bool {
         return themeId.hasSuffix(WPComThemesIDSuffix)
     }
 }

--- a/WordPress/Classes/Models/UserSettings.swift
+++ b/WordPress/Classes/Models/UserSettings.swift
@@ -1,7 +1,7 @@
 import Foundation
 import WordPressShared
 
-struct UserSettings {
+public struct UserSettings {
     /// Stores all `UserSettings` keys.
     ///
     /// The additional level of indirection allows these keys to be retrieved from tests.
@@ -10,20 +10,20 @@ struct UserSettings {
     ///
     /// Any change to these keys is a breaking change without some kind of migration.
     /// It's probably best never to change them.
-    enum Keys: String, CaseIterable {
+    public enum Keys: String, CaseIterable {
         case crashLoggingOptOutKey = "crashlytics_opt_out"
         case forceCrashLoggingKey = "force-crash-logging"
         case defaultDotComUUIDKey = "AccountDefaultDotcomUUID"
     }
 
     @UserDefault(Keys.crashLoggingOptOutKey.rawValue, defaultValue: false)
-    static var userHasOptedOutOfCrashLogging: Bool
+    public static var userHasOptedOutOfCrashLogging: Bool
 
     @UserDefault(Keys.forceCrashLoggingKey.rawValue, defaultValue: false)
-    static var userHasForcedCrashLoggingEnabled: Bool
+    public static var userHasForcedCrashLoggingEnabled: Bool
 
     @NullableUserDefault(Keys.defaultDotComUUIDKey.rawValue)
-    static var defaultDotComUUID: String?
+    public static var defaultDotComUUID: String?
 
     /// Reset all UserSettings back to their defaults
     static func reset() {
@@ -33,22 +33,23 @@ struct UserSettings {
 
 /// Objective-C Wrapper for UserSettings
 @objc(UserSettings)
-class ObjcCUserSettings: NSObject {
+// FIXME: public access-level required only for the unit tests, which means that this is unused in prod. Let's migrate those tests soon!
+public class ObjcCUserSettings: NSObject {
     @objc
-    static var defaultDotComUUID: String? {
+    public static var defaultDotComUUID: String? {
         get { UserSettings.defaultDotComUUID }
         set { UserSettings.defaultDotComUUID = newValue }
     }
 
     @objc
-    static func reset() {
+    public static func reset() {
         UserSettings.reset()
     }
 }
 
 /// A property wrapper for UserDefaults access
 @propertyWrapper
-struct UserDefault<T> {
+public struct UserDefault<T> {
     let key: String
     let defaultValue: T
 
@@ -57,7 +58,7 @@ struct UserDefault<T> {
         self.defaultValue = defaultValue
     }
 
-    var wrappedValue: T {
+    public var wrappedValue: T {
         get {
             return UserPersistentStoreFactory.instance().object(forKey: key) as? T ?? defaultValue
         }
@@ -69,14 +70,14 @@ struct UserDefault<T> {
 
 /// A property wrapper for optional UserDefaults that return `nil` by default
 @propertyWrapper
-struct NullableUserDefault<T> {
+public struct NullableUserDefault<T> {
     let key: String
 
     init(_ key: String) {
         self.key = key
     }
 
-    var wrappedValue: T? {
+    public var wrappedValue: T? {
         get {
             return UserPersistentStoreFactory.instance().object(forKey: key) as? T
         }

--- a/WordPress/Classes/Models/UserSuggestion+CoreDataClass.swift
+++ b/WordPress/Classes/Models/UserSuggestion+CoreDataClass.swift
@@ -4,7 +4,7 @@ import CoreData
 @objc(UserSuggestion)
 public class UserSuggestion: NSManagedObject {
 
-    convenience init?(dictionary: [String: Any], context: NSManagedObjectContext) {
+    public convenience init?(dictionary: [String: Any], context: NSManagedObjectContext) {
         let userLoginValue = dictionary["user_login"] as? String
         let displayNameValue = dictionary["display_name"] as? String
 

--- a/WordPress/Classes/Services/NullBlogPropertySanitizer.swift
+++ b/WordPress/Classes/Services/NullBlogPropertySanitizer.swift
@@ -33,7 +33,8 @@ import WordPressShared
 
         store.set(currentBuildVersion(), forKey: Self.lastSanitizationVersionNumber)
 
-        let entityNamesWithRequiredBlogProperties = [
+        // FIXME: Not sure why it's necessary to define [String] as the type. Without it, the NSFetchRequest<NSManagedObject>(entityName: entityName) below does not compile.
+        let entityNamesWithRequiredBlogProperties: [String] = [
             Post.entityName(),
             Page.entityName(),
             Media.entityName(),

--- a/WordPress/Classes/Services/PostHelper+Metadata.swift
+++ b/WordPress/Classes/Services/PostHelper+Metadata.swift
@@ -1,7 +1,7 @@
 import Foundation
 import WordPressShared
 
-extension PostHelper {
+public extension PostHelper {
     @objc static let foreignIDKey = "wp_jp_foreign_id"
 
     static func mapDictionaryToMetadataItems(_ dictionary: [String: Any]) -> RemotePostMetadataItem? {

--- a/WordPress/Classes/Services/PostRepository+Helpers.swift
+++ b/WordPress/Classes/Services/PostRepository+Helpers.swift
@@ -4,7 +4,7 @@ import WordPressShared
 
 extension RemotePostCreateParameters {
     /// Initializes the parameters required to create the given post.
-    init(post: AbstractPost) {
+    public init(post: AbstractPost) {
         self.init(
             type: post is Post ? "post" : "page",
             status: (post.status ?? .draft).rawValue
@@ -53,7 +53,8 @@ private func makeTags(from tags: String) -> [String] {
         .filter { !$0.isEmpty }
 }
 
-extension RemotePostUpdateParameters {
+public extension RemotePostUpdateParameters {
+
     var isEmpty: Bool {
         self == RemotePostUpdateParameters()
     }

--- a/WordPress/Classes/Services/PostServiceRemoteFactory.swift
+++ b/WordPress/Classes/Services/PostServiceRemoteFactory.swift
@@ -2,8 +2,8 @@ import Foundation
 import WordPressKit
 import WordPressShared
 
-@objc class PostServiceRemoteFactory: NSObject {
-    @objc func forBlog(_ blog: Blog) -> PostServiceRemote? {
+@objc public class PostServiceRemoteFactory: NSObject {
+    @objc public func forBlog(_ blog: Blog) -> PostServiceRemote? {
         if blog.supports(.wpComRESTAPI),
            let api = blog.wordPressComRestApi(),
            let dotComID = blog.dotComID {
@@ -19,7 +19,7 @@ import WordPressShared
         return nil
     }
 
-    @objc func restRemoteFor(siteID: NSNumber, context: NSManagedObjectContext) -> PostServiceRemoteREST? {
+    @objc public func restRemoteFor(siteID: NSNumber, context: NSManagedObjectContext) -> PostServiceRemoteREST? {
         guard let api = apiForRESTRequest(using: context) else {
             return nil
         }

--- a/WordPress/Classes/Utility/CoreData/ContextManager.swift
+++ b/WordPress/Classes/Utility/CoreData/ContextManager.swift
@@ -282,7 +282,7 @@ extension ContextManager {
     /// Tests purpose only
     static var overrideInstance: ContextManager?
 
-    @objc class func sharedInstance() -> ContextManager {
+    @objc public class func sharedInstance() -> ContextManager {
         if let overrideInstance {
             return overrideInstance
         }
@@ -290,14 +290,14 @@ extension ContextManager {
         return ContextManager.internalSharedInstance
     }
 
-    static var shared: ContextManager {
+    public static var shared: ContextManager {
         return sharedInstance()
     }
 }
 
 extension ContextManager {
     /// - warning: This is designed to be used only for testing purposes.
-    func resetEverything() {
+    public func resetEverything() {
         let container = persistentContainer.persistentStoreCoordinator
         assert(container.persistentStores.count == 1)
         guard let store = container.persistentStores.first, let storeURL = store.url else {

--- a/WordPress/Classes/Utility/CoreData/CoreDataHelper.swift
+++ b/WordPress/Classes/Utility/CoreData/CoreDataHelper.swift
@@ -4,7 +4,7 @@ import WordPressShared
 
 // MARK: - NSManagedObject Default entityName Helper
 //
-extension NSManagedObject {
+public extension NSManagedObject {
 
     /// Returns the Entity Name, if available, as specified in the NSEntityDescription. Otherwise, will return
     /// the subclass name.
@@ -30,7 +30,7 @@ extension NSManagedObject {
 
 // MARK: - NSManagedObjectContext Helpers!
 //
-extension NSManagedObjectContext {
+public extension NSManagedObjectContext {
 
     /// Returns all of the entities that match with a given predicate.
     ///
@@ -191,7 +191,7 @@ extension ContextManager.ContextManagerError: LocalizedError, CustomDebugStringC
     }
 }
 
-extension CoreDataStack {
+public extension CoreDataStack {
     /// Perform a query using the `mainContext` and return the result.
     ///
     /// - Warning: Do not return `NSManagedObject` instances from the closure.
@@ -387,7 +387,7 @@ extension CoreDataStack {
 ///     return account.username
 /// }
 /// ```
-extension CoreDataStack {
+public extension CoreDataStack {
     @available(*, deprecated, message: "Returning `NSManagedObject` instances may introduce Core Data concurrency issues.")
     func performQuery<T>(_ block: @escaping (NSManagedObjectContext) -> T) -> T where T: NSManagedObject {
         mainContext.performAndWait { [mainContext] in

--- a/WordPress/Classes/Utility/CoreData/NSManagedObject+Lookup.swift
+++ b/WordPress/Classes/Utility/CoreData/NSManagedObject+Lookup.swift
@@ -1,6 +1,6 @@
 import CoreData
 
-extension NSManagedObject {
+public extension NSManagedObject {
 
     /// Lookup an object by its NSManagedObjectID
     ///

--- a/WordPress/Classes/Utility/CoreData/TaggedManagedObjectID.swift
+++ b/WordPress/Classes/Utility/CoreData/TaggedManagedObjectID.swift
@@ -27,11 +27,11 @@ import WordPressShared
 /// we can't perform the validation described in `init(objectID:)`.
 ///
 /// - SeeAlso: swift-tagged: https://github.com/pointfreeco/swift-tagged
-struct TaggedManagedObjectID<Model: NSManagedObject>: Hashable {
-    let objectID: NSManagedObjectID
+public struct TaggedManagedObjectID<Model: NSManagedObject>: Hashable {
+    public let objectID: NSManagedObjectID
 
     /// Create an `TaggedManagedObjectID` instance of the given object.
-    init(_ object: Model) {
+    public init(_ object: Model) {
         var objectID = object.objectID
 
         if objectID.isTemporaryID {
@@ -69,7 +69,7 @@ struct TaggedManagedObjectID<Model: NSManagedObject>: Hashable {
     }
 }
 
-extension NSManagedObjectContext {
+public extension NSManagedObjectContext {
 
     /// Find the object associated with this object id in the given `context`.
     ///

--- a/WordPress/Classes/Utility/Media/MediaFileManager.swift
+++ b/WordPress/Classes/Utility/Media/MediaFileManager.swift
@@ -3,7 +3,7 @@ import WordPressShared
 
 /// Type of the local Media directory URL in implementation.
 ///
-enum MediaDirectory {
+public enum MediaDirectory {
     /// Default, system Documents directory, for persisting media files for upload.
     case uploads
     /// System Caches directory, for creating discardable media files, such as thumbnails.
@@ -12,11 +12,11 @@ enum MediaDirectory {
     case temporary(id: UUID)
 
     /// Use a new ID for every test scenario to make sure all tests are isolated.
-    static var temporary: MediaDirectory { .temporary(id: UUID()) }
+    public static var temporary: MediaDirectory { .temporary(id: UUID()) }
 
     /// Returns the directory URL for the directory type.
     ///
-    var url: URL {
+    public var url: URL {
         let fileManager = FileManager.default
         // Get a parent directory, based on the type.
         let parentDirectory: URL
@@ -34,7 +34,8 @@ enum MediaDirectory {
 
 /// Encapsulates Media functions relative to the local Media directory.
 ///
-class MediaFileManager: NSObject {
+@objc
+public class MediaFileManager: NSObject {
 
     fileprivate static let mediaDirectoryName = "Media"
 
@@ -64,7 +65,7 @@ class MediaFileManager: NSObject {
     ///   We shouldn't change this default directory lightly as older versions of the app may rely on Media files being in
     ///   the documents directory for upload.
     ///
-    init(directory: MediaDirectory = .uploads) {
+    public init(directory: MediaDirectory = .uploads) {
         self.directory = directory
     }
 
@@ -90,7 +91,7 @@ class MediaFileManager: NSObject {
     /// - Note: if a file already exists with the same name, the file name is appended with a number
     ///   and incremented until a unique filename is found.
     ///
-    @objc func makeLocalMediaURL(withFilename filename: String, fileExtension: String?, incremented: Bool = true) throws -> URL {
+    @objc public func makeLocalMediaURL(withFilename filename: String, fileExtension: String?, incremented: Bool = true) throws -> URL {
         let baseURL = try directoryURL()
         var url: URL
         if let fileExtension {
@@ -107,7 +108,7 @@ class MediaFileManager: NSObject {
 
     /// Objc friendly signature without specifying the `incremented` parameter.
     ///
-    @objc func makeLocalMediaURL(withFilename filename: String, fileExtension: String?) throws -> URL {
+    @objc public func makeLocalMediaURL(withFilename filename: String, fileExtension: String?) throws -> URL {
         return try makeLocalMediaURL(withFilename: filename, fileExtension: fileExtension, incremented: true)
     }
 
@@ -188,13 +189,13 @@ class MediaFileManager: NSObject {
 
     /// Helper method for clearing unused Media upload files.
     ///
-    @objc class func clearUnusedMediaUploadFiles(onCompletion: (() -> Void)?, onError: ((Error) -> Void)?) {
+    @objc public class func clearUnusedMediaUploadFiles(onCompletion: (() -> Void)?, onError: ((Error) -> Void)?) {
         MediaFileManager.default.clearUnusedFilesFromDirectory(onCompletion: onCompletion, onError: onError)
     }
 
     /// Helper method for calculating the size of the Media directories.
     ///
-    class func calculateSizeOfMediaDirectories(onCompletion: @escaping (Int64?) -> Void) {
+    public class func calculateSizeOfMediaDirectories(onCompletion: @escaping (Int64?) -> Void) {
         let cacheManager = MediaFileManager(directory: .cache)
         cacheManager.calculateSizeOfDirectory { (cacheSize) in
             let defaultManager = MediaFileManager.default
@@ -206,7 +207,7 @@ class MediaFileManager: NSObject {
 
     /// Helper method for clearing the Media cache directory.
     ///
-    @objc class func clearAllMediaCacheFiles(onCompletion: (() -> Void)?, onError: ((Error) -> Void)?) {
+    @objc public class func clearAllMediaCacheFiles(onCompletion: (() -> Void)?, onError: ((Error) -> Void)?) {
         let cacheManager = MediaFileManager(directory: .cache)
         cacheManager.clearFilesFromDirectory(onCompletion: {
             MediaFileManager.clearUnusedMediaUploadFiles(onCompletion: onCompletion, onError: onError)

--- a/WordPress/Classes/Utility/Spotlight/Protocols/SearchableActivityConvertable.swift
+++ b/WordPress/Classes/Utility/Spotlight/Protocols/SearchableActivityConvertable.swift
@@ -6,7 +6,7 @@ import UniformTypeIdentifiers
 
 /// Custom NSUSerActivity types for the WPiOS. Primarily used for navigation points.
 ///
-enum WPActivityType: String {
+public enum WPActivityType: String {
     case siteList = "org.wordpress.mysites"
     case siteDetails = "org.wordpress.mysites.details"
     case reader = "org.wordpress.reader"
@@ -42,11 +42,11 @@ extension WPActivityType {
 
 /// NSUserActivity userInfo keys
 ///
-enum WPActivityUserInfoKeys: String {
+public enum WPActivityUserInfoKeys: String {
     case siteId = "siteid"
 }
 
-@objc protocol SearchableActivityConvertable {
+@objc public protocol SearchableActivityConvertable {
     /// Type name used to uniquly indentify this activity.
     ///
     @objc var activityType: String {get}
@@ -75,8 +75,8 @@ enum WPActivityUserInfoKeys: String {
     @objc optional var activityDescription: String? {get}
 }
 
-extension SearchableActivityConvertable where Self: UIViewController {
-    internal func registerUserActivity() {
+public extension SearchableActivityConvertable where Self: UIViewController {
+    func registerUserActivity() {
         let activity = NSUserActivity(activityType: activityType)
         activity.title = activityTitle
 

--- a/WordPress/Classes/Utility/Spotlight/Protocols/SearchableItemConvertable.swift
+++ b/WordPress/Classes/Utility/Spotlight/Protocols/SearchableItemConvertable.swift
@@ -32,7 +32,7 @@ import UniformTypeIdentifiers
 
 // MARK: - SearchableItemConvertable
 
-@objc protocol SearchableItemConvertable {
+@objc public protocol SearchableItemConvertable {
     /// Identifies the item type this is
     ///
     var searchItemType: SearchItemType {get}
@@ -74,15 +74,15 @@ import UniformTypeIdentifiers
     @objc optional var searchExpirationDate: Date? {get}
 }
 
-extension SearchableItemConvertable {
-    internal var uniqueIdentifier: String? {
+public extension SearchableItemConvertable {
+    var uniqueIdentifier: String? {
         guard let searchDomain, let searchIdentifier else {
             return nil
         }
         return SearchIdentifierGenerator.composeUniqueIdentifier(itemType: searchItemType, domain: searchDomain, identifier: searchIdentifier)
     }
 
-    internal func indexableItem() -> CSSearchableItem? {
+    func indexableItem() -> CSSearchableItem? {
         guard isSearchable == true,
             let uniqueIdentifier,
             let searchTitle,

--- a/WordPress/Classes/Utility/Spotlight/Utils/SearchIdentifierGenerator.swift
+++ b/WordPress/Classes/Utility/Spotlight/Utils/SearchIdentifierGenerator.swift
@@ -1,13 +1,13 @@
 import Foundation
 
-struct SearchIdentifierGenerator {
+public struct SearchIdentifierGenerator {
     internal static let separator = "|~~~|"
 
     internal static func composeUniqueIdentifier(itemType: SearchItemType, domain: String, identifier: String) -> String {
         return "\(itemType.stringValue())\(separator)\(domain)\(separator)\(identifier)"
     }
 
-    internal static func decomposeFromUniqueIdentifier(_ combined: String) -> (itemType: SearchItemType, domain: String, identifier: String) {
+    public static func decomposeFromUniqueIdentifier(_ combined: String) -> (itemType: SearchItemType, domain: String, identifier: String) {
         let components = combined.components(separatedBy: separator)
 
         return (SearchItemType(index: components[0]), components[1], components[2])

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Activity.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Activity.swift
@@ -1,11 +1,11 @@
 import Foundation
 
 extension BlogDetailsViewController: SearchableActivityConvertable {
-    var activityType: String {
+    public var activityType: String {
         return WPActivityType.siteDetails.rawValue
     }
 
-    var activityTitle: String {
+    public var activityTitle: String {
         if let siteName {
             return siteName
         } else if let displayURL {
@@ -15,7 +15,7 @@ extension BlogDetailsViewController: SearchableActivityConvertable {
         return NSLocalizedString("My Site", comment: "Generic name for the detail screen for specific site - used for spotlight indexing on iOS. Note: this is only used if we cannot determine a name chances of this being used are small.")
     }
 
-    var activityKeywords: Set<String>? {
+    public var activityKeywords: Set<String>? {
         let keyWordString = NSLocalizedString("wordpress, sites, site, blogs, blog", comment: "This is a comma separated list of keywords used for spotlight indexing of the 'My Sites' tab.")
         var keywordArray = keyWordString.arrayOfTags()
 
@@ -34,7 +34,7 @@ extension BlogDetailsViewController: SearchableActivityConvertable {
         return Set(keywordArray)
     }
 
-    var activityUserInfo: [String: String]? {
+    public var activityUserInfo: [String: String]? {
         var siteID: String
         if let dotComID = blog.dotComID, dotComID.intValue > 0 {
             siteID = dotComID.stringValue
@@ -46,7 +46,7 @@ extension BlogDetailsViewController: SearchableActivityConvertable {
         return [WPActivityUserInfoKeys.siteId.rawValue: siteID]
     }
 
-    var activityDescription: String? {
+    public var activityDescription: String? {
         guard let displayURL else {
             return nil
         }

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/SiteOrganizationType.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/SiteOrganizationType.swift
@@ -1,4 +1,4 @@
-@objc enum SiteOrganizationType: Int {
+@objc public enum SiteOrganizationType: Int {
     // site does not belong to an organization
     case none
     // site is an A8C P2


### PR DESCRIPTION
Same rationale as https://github.com/wordpress-mobile/WordPress-iOS/pull/24326. Made possible by #24331. Part of #24165.