### PR TITLE
Decouple some model implementations from the app targets - Round 2

### DIFF
--- a/WordPress/Classes/Models/Blog/Blog+Capabilities.swift
+++ b/WordPress/Classes/Models/Blog/Blog+Capabilities.swift
@@ -83,4 +83,12 @@ extension Blog {
         // Self-hosted non-Jetpack blogs have no capabilities, so we'll just assume that users can post media
         capabilities != nil ? isUploadingFilesAllowed() : true
     }
+
+    /// Only WordPress.com hosted sites we administer may be managed
+    ///
+    /// - Returns: Whether site management is permitted
+    ///
+    @objc func supportsSiteManagementServices() -> Bool {
+        return isHostedAtWPcom && isAdmin
+    }
 }

--- a/WordPress/Classes/Models/Comment/Comment+CoreDataClass.swift
+++ b/WordPress/Classes/Models/Comment/Comment+CoreDataClass.swift
@@ -17,7 +17,7 @@ public class Comment: NSManagedObject {
     }
 
     @objc func isApproved() -> Bool {
-        return status.isEqual(to: CommentStatusType.approved.description)
+        return status == CommentStatusType.approved.description
     }
 
     private func isReadOnly() -> Bool {
@@ -51,8 +51,8 @@ public class Comment: NSManagedObject {
     }
 
     @objc func deleteWillBePermanent() -> Bool {
-        return status.isEqual(to: Comment.descriptionFor(.spam)) || status.isEqual(to: Comment.descriptionFor(.unapproved))
-    }
+        return status == Comment.descriptionFor(.spam) || status == Comment.descriptionFor(.unapproved)
+   }
 
     func canEditAuthorData() -> Bool {
         // If the authorID is zero, the user is unregistered. Therefore, the data can be edited.

--- a/WordPress/Classes/Models/GravatarProfile.swift
+++ b/WordPress/Classes/Models/GravatarProfile.swift
@@ -1,14 +1,31 @@
-import Foundation
-
 public struct GravatarProfile {
 
-    var profileID = ""
-    var hash = ""
-    var requestHash = ""
-    var profileUrl = ""
-    var preferredUsername = ""
-    var thumbnailUrl = ""
-    var name = ""
-    var displayName = ""
+    public var profileID: String
+    public var hash: String
+    public var requestHash: String
+    public var profileUrl: String
+    public var preferredUsername: String
+    public var thumbnailUrl: String
+    public var name: String
+    public var displayName: String
 
+    public init(
+        profileID: String = "",
+        hash: String = "",
+        requestHash: String = "",
+        profileUrl: String = "",
+        preferredUsername: String = "",
+        thumbnailUrl: String = "",
+        name: String = "",
+        displayName: String = ""
+    ) {
+        self.profileID = profileID
+        self.hash = hash
+        self.requestHash = requestHash
+        self.profileUrl = profileUrl
+        self.preferredUsername = preferredUsername
+        self.thumbnailUrl = thumbnailUrl
+        self.name = name
+        self.displayName = displayName
+    }
 }

--- a/WordPress/Classes/Models/Notifications/Notification+AppsTargets.swift
+++ b/WordPress/Classes/Models/Notifications/Notification+AppsTargets.swift
@@ -1,0 +1,369 @@
+import FormattableContentKit
+
+extension Notification {
+
+    func renderSubject() -> NSAttributedString? {
+        guard let subjectContent = subjectContentGroup?.blocks.first else {
+            return nil
+        }
+        return formatter.render(content: subjectContent, with: SubjectContentStyles())
+    }
+
+    func renderSnippet() -> NSAttributedString? {
+        guard let snippetContent else {
+            return nil
+        }
+        return formatter.render(content: snippetContent, with: SnippetsContentStyles())
+    }
+
+    /// Returns the first BlockGroup of the specified type, if any.
+    ///
+    func contentGroup(ofKind kind: FormattableContentGroup.Kind) -> FormattableContentGroup? {
+        for contentGroup in bodyContentGroups where contentGroup.kind == kind {
+            return contentGroup
+        }
+
+        return nil
+    }
+
+    /// Attempts to find the Notification Range associated with a given URL.
+    ///
+    func contentRange(with url: URL) -> FormattableContentRange? {
+        var groups = bodyContentGroups
+        if let headerBlockGroup = headerContentGroup {
+            groups.append(headerBlockGroup)
+        }
+
+        let blocks = groups.flatMap { $0.blocks }
+        for block in blocks {
+            if let range = block.range(with: url) {
+                return range
+            }
+        }
+
+        return nil
+    }
+
+    private func indexOfBody(type: BodyType) -> Int? {
+        guard let body else {
+            return nil
+        }
+        return body.firstIndex { item in
+            guard let item = item as? [String: Any], let itemType = item[BodyKeys.type] as? String, itemType == type.rawValue else {
+                return false
+            }
+            return true
+        }
+    }
+
+    func body(ofType type: BodyType) -> [String: Any]? {
+        guard let body, let index = indexOfBody(type: type) else {
+            return nil
+        }
+        return body[index] as? [String: Any]
+    }
+
+    func updateBody(ofType type: BodyType, newValue: AnyObject) {
+        guard let index = indexOfBody(type: type) else {
+            return
+        }
+        self.body?[index] = newValue
+    }
+
+    func updateBody(ofType type: BodyType, newValue: [String: Any]) {
+        self.updateBody(ofType: type, newValue: newValue as AnyObject)
+    }
+
+    enum BodyType: String {
+        case post
+        case comment
+    }
+}
+
+// MARK: - Notification Computed Properties
+//
+extension Notification {
+
+    /// Verifies if the current notification is a Pingback.
+    ///
+    var isPingback: Bool {
+        guard subjectContentGroup?.blocks.count == 1 else {
+            return false
+        }
+        guard let ranges = subjectContentGroup?.blocks.first?.ranges, ranges.count == 2 else {
+            return false
+        }
+        return ranges.first?.kind == .site && ranges.last?.kind == .post
+    }
+
+    /// Verifies if the current notification is actually a Badge one.
+    /// Note: Sorry about the following snippet. I'm (and will always be) against Duck Typing.
+    ///
+    @objc var isBadge: Bool {
+        let blocks = bodyContentGroups.flatMap { $0.blocks }
+        for block in blocks where block is FormattableMediaContent {
+            guard let mediaBlock = block as? FormattableMediaContent else {
+                continue
+            }
+            for media in mediaBlock.media where media.kind == .badge {
+                return true
+            }
+        }
+        return false
+    }
+
+    /// Verifies if the current notification is a Comment-Y note, and if it has been replied to.
+    ///
+    @objc var isRepliedComment: Bool {
+        return kind == .comment && metaReplyID != nil
+    }
+
+    //// Check if this note is a comment and in 'Unapproved' status
+    ///
+    @objc var isUnapprovedComment: Bool {
+        guard let block: FormattableCommentContent = contentGroup(ofKind: .comment)?.blockOfKind(.comment) else {
+            return false
+        }
+        let commandId = ApproveCommentAction.actionIdentifier()
+        return block.isActionEnabled(id: commandId) && !block.isActionOn(id: commandId)
+    }
+
+    var isViewMilestone: Bool {
+        return type == "view_milestone"
+    }
+
+    /// Returns the Meta ID's collection, if any.
+    ///
+    fileprivate var metaIds: [String: AnyObject]? {
+        return meta?[MetaKeys.Ids] as? [String: AnyObject]
+    }
+
+    /// Comment ID, if any.
+    ///
+    @objc var metaCommentID: NSNumber? {
+        return metaIds?[MetaKeys.Comment] as? NSNumber
+    }
+
+    /// Comment Author ID, if any.
+    ///
+    @objc var metaCommentAuthorID: NSNumber? {
+        return metaIds?[MetaKeys.User] as? NSNumber
+    }
+
+    /// Comment Parent ID, if any.
+    ///
+    @objc var metaParentID: NSNumber? {
+        return metaIds?[MetaKeys.Parent] as? NSNumber
+    }
+
+    /// Post ID, if any.
+    ///
+    @objc var metaPostID: NSNumber? {
+        return metaIds?[MetaKeys.Post] as? NSNumber
+    }
+
+    /// Comment Reply ID, if any.
+    ///
+    @objc var metaReplyID: NSNumber? {
+        return metaIds?[MetaKeys.Reply] as? NSNumber
+    }
+
+    /// Site ID, if any.
+    ///
+    @objc var metaSiteID: NSNumber? {
+        return metaIds?[MetaKeys.Site] as? NSNumber
+    }
+
+    /// Icon URL
+    ///
+    @objc var iconURL: URL? {
+        guard let rawIconURL = icon, let iconURL = URL(string: rawIconURL) else {
+            return nil
+        }
+
+        return iconURL
+    }
+
+    /// Associated Resource URL
+    ///
+    @objc var resourceURL: URL? {
+        guard let rawURL = url, let resourceURL = URL(string: rawURL) else {
+            return nil
+        }
+
+        return resourceURL
+    }
+
+    var subjectContentGroup: FormattableContentGroup? {
+        if let group = cachedSubjectContentGroup {
+            return group
+        }
+
+        guard let subject = subject as? [[String: AnyObject]], subject.isEmpty == false else {
+            return nil
+        }
+
+        cachedSubjectContentGroup = SubjectContentGroup.createGroup(from: subject, parent: self)
+        return cachedSubjectContentGroup
+    }
+
+    var headerContentGroup: FormattableContentGroup? {
+        if let group = cachedHeaderContentGroup {
+            return group
+        }
+
+        guard let header = header as? [[String: AnyObject]], header.isEmpty == false else {
+            return nil
+        }
+
+        cachedHeaderContentGroup = HeaderContentGroup.createGroup(from: header, parent: self)
+        return cachedHeaderContentGroup
+    }
+
+    var bodyContentGroups: [FormattableContentGroup] {
+        if let group = cachedBodyContentGroups {
+            return group
+        }
+
+        guard let body = body as? [[String: AnyObject]], body.isEmpty == false else {
+            return []
+        }
+
+        cachedBodyContentGroups = BodyContentGroup.create(from: body, parent: self)
+        return cachedBodyContentGroups ?? []
+    }
+
+    var headerAndBodyContentGroups: [FormattableContentGroup] {
+        if let groups = cachedHeaderAndBodyContentGroups {
+            return groups
+        }
+
+        var mergedGroups = [FormattableContentGroup]()
+        if let header = headerContentGroup {
+            mergedGroups.append(header)
+        }
+
+        mergedGroups.append(contentsOf: bodyContentGroups)
+        cachedHeaderAndBodyContentGroups = mergedGroups
+
+        return mergedGroups
+    }
+
+    var snippetContent: FormattableContent? {
+        guard let content = subjectContentGroup?.blocks, content.count > 1 else {
+            return nil
+        }
+        return content.last
+    }
+
+    var allAvatarURLs: [URL] {
+        let users = body?.filter({ element in
+            let type = element["type"] as? String
+            return type == "user"
+        }) ?? []
+
+        let avatars: [URL] = users.compactMap {
+            guard let allMedia = $0["media"] as? [AnyObject],
+                  let firstMedia = allMedia.first,
+                  let urlString = firstMedia["url"] as? String else {
+                return nil
+            }
+            return URL(string: urlString)
+        }
+
+        return avatars
+    }
+}
+
+// MARK: - Notification Subtypes
+
+extension Notification {
+
+    /// Parses the meta data of the notification to extract key information like postID
+    /// Parsing logic and wrapper used depends on the notification kind
+    /// - Returns: An enum with it's associated value being a wrapper around the notification
+    func parsed() -> ParsedNotification {
+        switch kind {
+        case .newPost:
+            if let note = NewPostNotification(note: self) {
+                return .newPost(note)
+            }
+        case .comment:
+            if let note = CommentNotification(note: self) {
+                return .comment(note)
+            }
+        default:
+            break
+        }
+        return .other(self)
+    }
+
+    enum ParsedNotification {
+        case newPost(NewPostNotification)
+        case comment(CommentNotification)
+        case other(Notification)
+    }
+}
+
+// MARK: - Update Helpers
+//
+extension Notification {
+    /// Updates the local fields with the new values stored in a given Remote Notification
+    ///
+    func update(with remote: RemoteNotification) {
+        notificationId = remote.notificationId
+        notificationHash = remote.notificationHash
+        read = remote.read
+        icon = remote.icon
+        noticon = remote.noticon
+        timestamp = remote.timestamp
+        type = remote.type
+        url = remote.url
+        title = remote.title
+        subject = remote.subject
+        header = remote.header
+        body = remote.body
+        meta = remote.meta
+    }
+}
+
+// MARK: - Notification Types
+//
+extension Notification {
+    /// Meta Parsing Keys
+    ///
+    fileprivate enum MetaKeys {
+        static let Ids = "ids"
+        static let Links = "links"
+        static let Titles = "titles"
+        static let Site = "site"
+        static let Post = "post"
+        static let Comment = "comment"
+        static let User = "user"
+        static let Parent = "parent_comment"
+        static let Reply = "reply_comment"
+        static let Home = "home"
+    }
+
+    /// Body Parsing Keys
+    ///
+    enum BodyKeys {
+        static let type = "type"
+        static let actions = "actions"
+    }
+
+    /// Actions Parsing Keys
+    ///
+    enum ActionsKeys {
+        static let likePost = "like-post"
+        static let likeComment = "like-comment"
+    }
+}
+
+// MARK: - Notifiable
+
+extension Notification: Notifiable {
+    public var notificationIdentifier: String {
+        return notificationId
+    }
+}

--- a/WordPress/Classes/Models/Notifications/Notification.swift
+++ b/WordPress/Classes/Models/Notifications/Notification.swift
@@ -1,85 +1,87 @@
 import Foundation
+import CocoaLumberjackSwift
 import CoreData
 import WordPressKit
+import WordPressShared
 import FormattableContentKit
 
 // MARK: - Notification Entity
 //
 @objc(Notification)
-class Notification: NSManagedObject {
+public class Notification: NSManagedObject {
     /// Notification Primary Key!
     ///
-    @NSManaged var notificationId: String
+    @NSManaged public var notificationId: String
 
     /// Notification Hash!
     ///
-    @NSManaged var notificationHash: String?
+    @NSManaged public var notificationHash: String?
 
     /// Indicates whether the note was already read, or not
     ///
-    @NSManaged var read: Bool
+    @NSManaged public var read: Bool
 
     /// Associated Resource's Icon, as a plain string
     ///
-    @NSManaged var icon: String?
+    @NSManaged public var icon: String?
 
     /// Noticon resource, associated with this notification
     ///
-    @NSManaged var noticon: String?
+    @NSManaged public var noticon: String?
 
     /// Timestamp as a String
     ///
-    @NSManaged var timestamp: String?
+    @NSManaged public var timestamp: String?
 
     /// Notification Type
     ///
-    @NSManaged var type: String?
+    @NSManaged public var type: String?
 
     /// Associated Resource's URL
     ///
-    @NSManaged var url: String?
+    @NSManaged public var url: String?
 
     /// Plain Title ("1 Like" / Etc)
     ///
-    @NSManaged var title: String?
+    @NSManaged public var title: String?
 
     /// Raw Subject Blocks
     ///
-    @NSManaged var subject: [AnyObject]?
+    @NSManaged public var subject: [AnyObject]?
 
     /// Raw Header Blocks
     ///
-    @NSManaged var header: [AnyObject]?
+    @NSManaged public var header: [AnyObject]?
 
     /// Raw Body Blocks
     ///
-    @NSManaged var body: [AnyObject]?
+    @NSManaged public var body: [AnyObject]?
 
     /// Raw Associated Metadata
     ///
-    @NSManaged var meta: [String: AnyObject]?
+    @NSManaged public var meta: [String: AnyObject]?
 
     /// Timestamp As Date Transient Storage.
     ///
-    fileprivate var cachedTimestampAsDate: Date?
+    public private(set) var cachedTimestampAsDate: Date?
 
-    private let formatter = FormattableContentFormatter()
+    public let formatter = FormattableContentFormatter()
 
     /// Subject Blocks Transient Storage.
     ///
-    fileprivate var cachedSubjectContentGroup: FormattableContentGroup?
+    public var cachedSubjectContentGroup: FormattableContentGroup?
 
     /// Header Blocks Transient Storage.
     ///
-    fileprivate var cachedHeaderContentGroup: FormattableContentGroup?
+    public var cachedHeaderContentGroup: FormattableContentGroup?
 
     /// Body Blocks Transient Storage.
     ///
-    fileprivate var cachedBodyContentGroups: [FormattableContentGroup]?
+    public var cachedBodyContentGroups: [FormattableContentGroup]?
 
     /// Header + Body Blocks Transient Storage.
     ///
-    fileprivate var cachedHeaderAndBodyContentGroups: [FormattableContentGroup]?
+    public var cachedHeaderAndBodyContentGroups: [FormattableContentGroup]?
 
     private var cachedAttributesObserver: NotificationCachedAttributesObserver?
 
@@ -87,7 +89,7 @@ class Notification: NSManagedObject {
     ///
     fileprivate static let cachedAttributes = Set(arrayLiteral: "body", "header", "subject", "timestamp")
 
-    override func awakeFromFetch() {
+    public override func awakeFromFetch() {
         super.awakeFromFetch()
 
         if cachedAttributesObserver == nil {
@@ -107,23 +109,9 @@ class Notification: NSManagedObject {
         }
     }
 
-    func renderSubject() -> NSAttributedString? {
-        guard let subjectContent = subjectContentGroup?.blocks.first else {
-            return nil
-        }
-        return formatter.render(content: subjectContent, with: SubjectContentStyles())
-    }
-
-    func renderSnippet() -> NSAttributedString? {
-        guard let snippetContent else {
-            return nil
-        }
-        return formatter.render(content: snippetContent, with: SnippetsContentStyles())
-    }
-
     /// Nukes any cached values.
     ///
-    func resetCachedAttributes() {
+    public func resetCachedAttributes() {
         cachedTimestampAsDate = nil
 
         formatter.resetCache()
@@ -141,192 +129,9 @@ class Notification: NSManagedObject {
         read = readValue
     }
 
-    /// Returns the first BlockGroup of the specified type, if any.
-    ///
-    func contentGroup(ofKind kind: FormattableContentGroup.Kind) -> FormattableContentGroup? {
-        for contentGroup in bodyContentGroups where contentGroup.kind == kind {
-            return contentGroup
-        }
-
-        return nil
-    }
-
-    /// Attempts to find the Notification Range associated with a given URL.
-    ///
-    func contentRange(with url: URL) -> FormattableContentRange? {
-        var groups = bodyContentGroups
-        if let headerBlockGroup = headerContentGroup {
-            groups.append(headerBlockGroup)
-        }
-
-        let blocks = groups.flatMap { $0.blocks }
-        for block in blocks {
-            if let range = block.range(with: url) {
-                return range
-            }
-        }
-
-        return nil
-    }
-}
-
-// MARK: - Read / Write Body Objects
-
-extension Notification {
-
-    private func indexOfBody(type: BodyType) -> Int? {
-        guard let body else {
-            return nil
-        }
-        return body.firstIndex { item in
-            guard let item = item as? [String: Any], let itemType = item[BodyKeys.type] as? String, itemType == type.rawValue else {
-                return false
-            }
-            return true
-        }
-    }
-
-    func body(ofType type: BodyType) -> [String: Any]? {
-        guard let body, let index = indexOfBody(type: type) else {
-            return nil
-        }
-        return body[index] as? [String: Any]
-    }
-
-    func updateBody(ofType type: BodyType, newValue: AnyObject) {
-        guard let index = indexOfBody(type: type) else {
-            return
-        }
-        self.body?[index] = newValue
-    }
-
-    func updateBody(ofType type: BodyType, newValue: [String: Any]) {
-        self.updateBody(ofType: type, newValue: newValue as AnyObject)
-    }
-
-    enum BodyType: String {
-        case post
-        case comment
-    }
-}
-
-// MARK: - Notification Computed Properties
-//
-extension Notification {
-
-    /// Verifies if the current notification is a Pingback.
-    ///
-    var isPingback: Bool {
-        guard subjectContentGroup?.blocks.count == 1 else {
-            return false
-        }
-        guard let ranges = subjectContentGroup?.blocks.first?.ranges, ranges.count == 2 else {
-            return false
-        }
-        return ranges.first?.kind == .site && ranges.last?.kind == .post
-    }
-
-    /// Verifies if the current notification is actually a Badge one.
-    /// Note: Sorry about the following snippet. I'm (and will always be) against Duck Typing.
-    ///
-    @objc var isBadge: Bool {
-        let blocks = bodyContentGroups.flatMap { $0.blocks }
-        for block in blocks where block is FormattableMediaContent {
-            guard let mediaBlock = block as? FormattableMediaContent else {
-                continue
-            }
-            for media in mediaBlock.media where media.kind == .badge {
-                return true
-            }
-        }
-        return false
-    }
-
-    /// Verifies if the current notification is a Comment-Y note, and if it has been replied to.
-    ///
-    @objc var isRepliedComment: Bool {
-        return kind == .comment && metaReplyID != nil
-    }
-
-    //// Check if this note is a comment and in 'Unapproved' status
-    ///
-    @objc var isUnapprovedComment: Bool {
-        guard let block: FormattableCommentContent = contentGroup(ofKind: .comment)?.blockOfKind(.comment) else {
-            return false
-        }
-        let commandId = ApproveCommentAction.actionIdentifier()
-        return block.isActionEnabled(id: commandId) && !block.isActionOn(id: commandId)
-    }
-
-    var isViewMilestone: Bool {
-        return type == "view_milestone"
-    }
-
-    /// Returns the Meta ID's collection, if any.
-    ///
-    fileprivate var metaIds: [String: AnyObject]? {
-        return meta?[MetaKeys.Ids] as? [String: AnyObject]
-    }
-
-    /// Comment ID, if any.
-    ///
-    @objc var metaCommentID: NSNumber? {
-        return metaIds?[MetaKeys.Comment] as? NSNumber
-    }
-
-    /// Comment Author ID, if any.
-    ///
-    @objc var metaCommentAuthorID: NSNumber? {
-        return metaIds?[MetaKeys.User] as? NSNumber
-    }
-
-    /// Comment Parent ID, if any.
-    ///
-    @objc var metaParentID: NSNumber? {
-        return metaIds?[MetaKeys.Parent] as? NSNumber
-    }
-
-    /// Post ID, if any.
-    ///
-    @objc var metaPostID: NSNumber? {
-        return metaIds?[MetaKeys.Post] as? NSNumber
-    }
-
-    /// Comment Reply ID, if any.
-    ///
-    @objc var metaReplyID: NSNumber? {
-        return metaIds?[MetaKeys.Reply] as? NSNumber
-    }
-
-    /// Site ID, if any.
-    ///
-    @objc var metaSiteID: NSNumber? {
-        return metaIds?[MetaKeys.Site] as? NSNumber
-    }
-
-    /// Icon URL
-    ///
-    @objc var iconURL: URL? {
-        guard let rawIconURL = icon, let iconURL = URL(string: rawIconURL) else {
-            return nil
-        }
-
-        return iconURL
-    }
-
-    /// Associated Resource URL
-    ///
-    @objc var resourceURL: URL? {
-        guard let rawURL = url, let resourceURL = URL(string: rawURL) else {
-            return nil
-        }
-
-        return resourceURL
-    }
-
     /// Parse the Timestamp as a Cocoa Date Instance.
     ///
-    @objc var timestampAsDate: Date {
+    @objc public var timestampAsDate: Date {
         assert(timestamp != nil, "Notification Timestamp should not be nil [\(notificationId)]")
 
         if let timestampAsDate = cachedTimestampAsDate {
@@ -340,179 +145,6 @@ extension Notification {
 
         cachedTimestampAsDate = timestampAsDate
         return timestampAsDate
-    }
-
-    var subjectContentGroup: FormattableContentGroup? {
-        if let group = cachedSubjectContentGroup {
-            return group
-        }
-
-        guard let subject = subject as? [[String: AnyObject]], subject.isEmpty == false else {
-            return nil
-        }
-
-        cachedSubjectContentGroup = SubjectContentGroup.createGroup(from: subject, parent: self)
-        return cachedSubjectContentGroup
-    }
-
-    var headerContentGroup: FormattableContentGroup? {
-        if let group = cachedHeaderContentGroup {
-            return group
-        }
-
-        guard let header = header as? [[String: AnyObject]], header.isEmpty == false else {
-            return nil
-        }
-
-        cachedHeaderContentGroup = HeaderContentGroup.createGroup(from: header, parent: self)
-        return cachedHeaderContentGroup
-    }
-
-    var bodyContentGroups: [FormattableContentGroup] {
-        if let group = cachedBodyContentGroups {
-            return group
-        }
-
-        guard let body = body as? [[String: AnyObject]], body.isEmpty == false else {
-            return []
-        }
-
-        cachedBodyContentGroups = BodyContentGroup.create(from: body, parent: self)
-        return cachedBodyContentGroups ?? []
-    }
-
-    var headerAndBodyContentGroups: [FormattableContentGroup] {
-        if let groups = cachedHeaderAndBodyContentGroups {
-            return groups
-        }
-
-        var mergedGroups = [FormattableContentGroup]()
-        if let header = headerContentGroup {
-            mergedGroups.append(header)
-        }
-
-        mergedGroups.append(contentsOf: bodyContentGroups)
-        cachedHeaderAndBodyContentGroups = mergedGroups
-
-        return mergedGroups
-    }
-
-    var snippetContent: FormattableContent? {
-        guard let content = subjectContentGroup?.blocks, content.count > 1 else {
-            return nil
-        }
-        return content.last
-    }
-
-    var allAvatarURLs: [URL] {
-        let users = body?.filter({ element in
-            let type = element["type"] as? String
-            return type == "user"
-        }) ?? []
-
-        let avatars: [URL] = users.compactMap {
-            guard let allMedia = $0["media"] as? [AnyObject],
-                  let firstMedia = allMedia.first,
-                  let urlString = firstMedia["url"] as? String else {
-                return nil
-            }
-            return URL(string: urlString)
-        }
-
-        return avatars
-    }
-}
-
-// MARK: - Notification Subtypes
-
-extension Notification {
-
-    /// Parses the meta data of the notification to extract key information like postID
-    /// Parsing logic and wrapper used depends on the notification kind
-    /// - Returns: An enum with it's associated value being a wrapper around the notification
-    func parsed() -> ParsedNotification {
-        switch kind {
-        case .newPost:
-            if let note = NewPostNotification(note: self) {
-                return .newPost(note)
-            }
-        case .comment:
-            if let note = CommentNotification(note: self) {
-                return .comment(note)
-            }
-        default:
-            break
-        }
-        return .other(self)
-    }
-
-    enum ParsedNotification {
-        case newPost(NewPostNotification)
-        case comment(CommentNotification)
-        case other(Notification)
-    }
-}
-
-// MARK: - Update Helpers
-//
-extension Notification {
-    /// Updates the local fields with the new values stored in a given Remote Notification
-    ///
-    func update(with remote: RemoteNotification) {
-        notificationId = remote.notificationId
-        notificationHash = remote.notificationHash
-        read = remote.read
-        icon = remote.icon
-        noticon = remote.noticon
-        timestamp = remote.timestamp
-        type = remote.type
-        url = remote.url
-        title = remote.title
-        subject = remote.subject
-        header = remote.header
-        body = remote.body
-        meta = remote.meta
-    }
-}
-
-// MARK: - Notification Types
-//
-extension Notification {
-    /// Meta Parsing Keys
-    ///
-    fileprivate enum MetaKeys {
-        static let Ids = "ids"
-        static let Links = "links"
-        static let Titles = "titles"
-        static let Site = "site"
-        static let Post = "post"
-        static let Comment = "comment"
-        static let User = "user"
-        static let Parent = "parent_comment"
-        static let Reply = "reply_comment"
-        static let Home = "home"
-    }
-
-    /// Body Parsing Keys
-    ///
-    enum BodyKeys {
-        static let type = "type"
-        static let actions = "actions"
-    }
-
-    /// Actions Parsing Keys
-    ///
-    enum ActionsKeys {
-        static let likePost = "like-post"
-        static let likeComment = "like-comment"
-    }
-}
-
-// MARK: - Notifiable
-
-extension Notification: Notifiable {
-    var notificationIdentifier: String {
-        return notificationId
     }
 }
 

--- a/WordPress/Classes/Models/Revisions/DiffAbstractValue+Attributes.swift
+++ b/WordPress/Classes/Models/Revisions/DiffAbstractValue+Attributes.swift
@@ -44,3 +44,20 @@ extension Array where Element == DiffAbstractValue {
         return left
     }
 }
+
+extension RevisionDiff {
+
+    var contentToAttributedString: NSAttributedString? {
+        return (contentDiffs?.operations ?? []).toAttributedString()
+    }
+
+    var titleToAttributedString: NSAttributedString? {
+        return (titleDiffs?.operations ?? []).toAttributedString()
+    }
+}
+
+private extension NSSet {
+    var operations: [DiffAbstractValue]? {
+        return allObjects as? [DiffAbstractValue]
+    }
+}

--- a/WordPress/Classes/Models/Revisions/RevisionDiff.swift
+++ b/WordPress/Classes/Models/Revisions/RevisionDiff.swift
@@ -12,6 +12,9 @@ class RevisionDiff: NSManagedObject {
     @NSManaged var titleDiffs: NSSet?
 
     @NSManaged var revision: Revision?
+}
+
+extension RevisionDiff {
 
     var contentToAttributedString: NSAttributedString? {
         return (contentDiffs?.operations ?? []).toAttributedString()

--- a/WordPress/Classes/Models/Revisions/RevisionDiff.swift
+++ b/WordPress/Classes/Models/Revisions/RevisionDiff.swift
@@ -13,20 +13,3 @@ class RevisionDiff: NSManagedObject {
 
     @NSManaged var revision: Revision?
 }
-
-extension RevisionDiff {
-
-    var contentToAttributedString: NSAttributedString? {
-        return (contentDiffs?.operations ?? []).toAttributedString()
-    }
-
-    var titleToAttributedString: NSAttributedString? {
-        return (titleDiffs?.operations ?? []).toAttributedString()
-    }
-}
-
-private extension NSSet {
-    var operations: [DiffAbstractValue]? {
-        return allObjects as? [DiffAbstractValue]
-    }
-}

--- a/WordPress/Classes/Models/UserProfile.swift
+++ b/WordPress/Classes/Models/UserProfile.swift
@@ -1,14 +1,36 @@
-import Foundation
-
 public struct UserProfile {
-    var bio = ""
-    var displayName = ""
-    var email = ""
-    var firstName = ""
-    var lastName = ""
-    var nicename = ""
-    var nickname = ""
-    var url = ""
-    var userID = 0
-    var username = ""
+    public var bio: String
+    public var displayName: String
+    public var email: String
+    public var firstName: String
+    public var lastName: String
+    public var nicename: String
+    public var nickname: String
+    public var url: String
+    public var userID: Int
+    public var username: String
+
+    public init(
+        bio: String = "",
+        displayName: String = "",
+        email: String = "",
+        firstName: String = "",
+        lastName: String = "",
+        nicename: String = "",
+        nickname: String = "",
+        url: String = "",
+        userID: Int = 0,
+        username: String = ""
+    ) {
+        self.bio = bio
+        self.displayName = displayName
+        self.email = email
+        self.firstName = firstName
+        self.lastName = lastName
+        self.nicename = nicename
+        self.nickname = nickname
+        self.url = url
+        self.userID = userID
+        self.username = username
+    }
 }

--- a/WordPress/Classes/Models/WPAccount+AccountSettings.swift
+++ b/WordPress/Classes/Models/WPAccount+AccountSettings.swift
@@ -34,8 +34,4 @@ extension WPAccount {
     var needsEmailVerification: Bool {
         return verificationStatus == .unverified
     }
-
-    @objc class var authKeychainServiceName: String {
-        BuildSettings.current.authKeychainServiceName
-    }
 }

--- a/WordPress/Classes/Models/WPAccount+Keychain.swift
+++ b/WordPress/Classes/Models/WPAccount+Keychain.swift
@@ -1,0 +1,8 @@
+import BuildSettingsKit
+
+public extension WPAccount {
+
+    @objc class var authKeychainServiceName: String {
+        BuildSettings.current.authKeychainServiceName
+    }
+}

--- a/WordPress/Classes/Services/NotificationSyncMediator.swift
+++ b/WordPress/Classes/Services/NotificationSyncMediator.swift
@@ -19,18 +19,6 @@ import WordPressShared
 //
 let NotificationSyncMediatorDidUpdateNotifications = "NotificationSyncMediatorDidUpdateNotifications"
 
-protocol NotificationSyncMediatorProtocol {
-    func updateLastSeen(_ timestamp: String, completion: ((Error?) -> Void)?)
-    func toggleLikeForPostNotification(isLike: Bool,
-                                       postID: UInt,
-                                       siteID: UInt,
-                                       completion: @escaping (Result<Bool, Swift.Error>) -> Void)
-    func toggleLikeForCommentNotification(isLike: Bool,
-                                          commentID: UInt,
-                                          siteID: UInt,
-                                          completion: @escaping (Result<Bool, Swift.Error>) -> Void)
-}
-
 // MARK: - NotificationSyncMediator
 //
 final class NotificationSyncMediator: NotificationSyncMediatorProtocol {

--- a/WordPress/Classes/Services/NotificationSyncMediatorProtocol.swift
+++ b/WordPress/Classes/Services/NotificationSyncMediatorProtocol.swift
@@ -1,0 +1,17 @@
+public protocol NotificationSyncMediatorProtocol {
+    func updateLastSeen(_ timestamp: String, completion: ((Error?) -> Void)?)
+
+    func toggleLikeForPostNotification(
+        isLike: Bool,
+        postID: UInt,
+        siteID: UInt,
+        completion: @escaping (Result<Bool, Error>) -> Void
+    )
+
+    func toggleLikeForCommentNotification(
+        isLike: Bool,
+        commentID: UInt,
+        siteID: UInt,
+        completion: @escaping (Result<Bool, Error>) -> Void
+    )
+}

--- a/WordPress/Classes/Services/SiteManagementService.swift
+++ b/WordPress/Classes/Services/SiteManagementService.swift
@@ -1,16 +1,6 @@
 import CoreData
 import WordPressShared
 
-public extension Blog {
-    /// Only WordPress.com hosted sites we administer may be managed
-    ///
-    /// - Returns: Whether site management is permitted
-    ///
-    @objc func supportsSiteManagementServices() -> Bool {
-        return isHostedAtWPcom && isAdmin
-    }
-}
-
 /// Site Deletion Notification
 ///
 extension NSNotification.Name {

--- a/WordPress/Classes/Utility/BlogQuery.swift
+++ b/WordPress/Classes/Utility/BlogQuery.swift
@@ -7,7 +7,11 @@ import Foundation
 /// to explore a standard way to perform query. https://github.com/wordpress-mobile/WordPress-iOS/pull/19394 made
 /// an attempt, but still has lots of unknowns.
 public struct BlogQuery {
-    private var predicates = [NSPredicate]()
+    private var predicates: [NSPredicate]
+
+    public init() {
+        predicates = []
+    }
 
     public func blogID(_ id: Int) -> Self {
         blogID(Int64(id))

--- a/WordPress/Classes/Utility/CoreData/ContextManager.swift
+++ b/WordPress/Classes/Utility/CoreData/ContextManager.swift
@@ -222,7 +222,7 @@ private extension ContextManager {
 
 private extension ContextManager {
     static func createPersistentContainer(storeURL: URL, modelName: String) -> NSPersistentContainer {
-        guard var modelFileURL = Bundle.main.url(forResource: "WordPress", withExtension: "momd") else {
+        guard var modelFileURL = Bundle(for: ContextManager.self).url(forResource: "WordPress", withExtension: "momd") else {
             fatalError("Can't find WordPress.momd")
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderHelpers.swift
@@ -539,12 +539,3 @@ enum ReaderTopicType {
     case organization
     case noTopic
 }
-
-@objc enum SiteOrganizationType: Int {
-    // site does not belong to an organization
-    case none
-    // site is an A8C P2
-    case automattic
-    // site is a non-A8C P2
-    case p2
-}

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/SiteOrganizationType.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/SiteOrganizationType.swift
@@ -1,0 +1,8 @@
+@objc enum SiteOrganizationType: Int {
+    // site does not belong to an organization
+    case none
+    // site is an A8C P2
+    case automattic
+    // site is a non-A8C P2
+    case p2
+}


### PR DESCRIPTION
Same rationale as https://github.com/wordpress-mobile/WordPress-iOS/pull/24331. Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/24165. The end goal is to have the diff in #24242 to be as little as possible, so that we can easily identify issues.

I added rationales in the commit messages, and commit by commit is likely the best way to review the changes. 