### PR TITLE
Replace `asURL()` call with `URL(string:)`

### DIFF
--- a/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
+++ b/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
@@ -7,7 +7,12 @@ private func apiBase(blog: Blog) -> URL? {
         assertionFailure(".com support has not been implemented yet")
         return nil
     }
-    return try? blog.url(withPath: "wp-json/")?.asURL()
+
+    guard let urlString = blog.url(withPath: "wp-json/") else {
+        return nil
+    }
+
+    return URL(string: urlString)
 }
 
 extension WordPressOrgRestApi {
@@ -23,8 +28,8 @@ extension WordPressOrgRestApi {
                 apiURL: AppEnvironment.current.wordPressComApiBase
             )
         } else if let apiBase = apiBase(blog: blog),
-                  let loginURL = try? blog.loginUrl().asURL(),
-                  let adminURL = try? blog.adminUrl(withPath: "").asURL(),
+                  let loginURL = URL(string: blog.loginUrl()),
+                  let adminURL = URL(string: blog.adminUrl(withPath: "")),
                   let username = blog.username,
                   let password = blog.password {
             self.init(

--- a/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergMediaEditorImage.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Utils/GutenbergMediaEditorImage.swift
@@ -20,7 +20,7 @@ class GutenbergMediaEditorImage: AsyncImage {
 
         urlComponents.query = nil
 
-        return try? urlComponents.asURL()
+        return urlComponents.url
     }
 
     private lazy var mediaUtility: EditorMediaUtility = {

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosMedia.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/StockPhotosMedia.swift
@@ -47,17 +47,17 @@ extension StockPhotosMedia.ThumbnailCollection: Decodable {
 
     init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
-        largeURL = try values.decode(String.self, forKey: .large).asURL()
-        mediumURL = try values.decode(String.self, forKey: .medium).asURL()
-        postThumbnailURL = try values.decode(String.self, forKey: .postThumbnail).asURL()
-        thumbnailURL = try values.decode(String.self, forKey: .thumbnail).asURL()
+        largeURL = try values.decode(URL.self, forKey: .large)
+        mediumURL = try values.decode(URL.self, forKey: .medium)
+        postThumbnailURL = try values.decode(URL.self, forKey: .postThumbnail)
+        thumbnailURL = try values.decode(URL.self, forKey: .thumbnail)
     }
 }
 
 extension StockPhotosMedia: Decodable {
     enum CodingKeys: String, CodingKey {
-        case ID
-        case URL
+        case id = "ID"
+        case url = "URL"
         case title
         case name
         case thumbnails
@@ -66,14 +66,16 @@ extension StockPhotosMedia: Decodable {
 
     convenience init(from decoder: Decoder) throws {
         let values = try decoder.container(keyedBy: CodingKeys.self)
-        let id = try values.decode(String.self, forKey: .ID)
-        let URL = try values.decode(String.self, forKey: .URL).asURL()
+        let id = try values.decode(String.self, forKey: .id)
+        // Notice the Foundation namespace. It's required to disambiguate from the URL property.
+        // Will get to rename that eventually, but it's out of scope at the time of this change.
+        let url = try values.decode(Foundation.URL.self, forKey: .url)
         let title = try values.decode(String.self, forKey: .title)
         let name = try values.decode(String.self, forKey: .name)
         let caption = try values.decode(String.self, forKey: .caption)
         let size: CGSize = .zero
         let thumbnails = try values.decode(ThumbnailCollection.self, forKey: .thumbnails)
 
-        self.init(id: id, URL: URL, title: title, name: name, caption: caption, size: size, thumbnails: thumbnails)
+        self.init(id: id, URL: url, title: title, name: name, caption: caption, size: size, thumbnails: thumbnails)
     }
 }


### PR DESCRIPTION
Follows up to #24333, part of #24165.

The method comes from an old Alamofire version. Since its implementation, `URL(string:)` stopped failing on "invalid" strings such as "invalid-url". Between the different behavior and the cost of an additional dependency, the value of using that method is marginal at best.

Notice that the app still has an `asURL()` implementation, but that's part of the `ParsedUrl` custom type.