### PR TITLE
Remove `AppEnvironment` from `WordPressOrgRestApi`

### DIFF
--- a/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
+++ b/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
@@ -12,6 +12,14 @@ private func apiBase(blog: Blog) -> URL? {
 
 extension WordPressOrgRestApi {
     @objc
+    convenience init?(blog: Blog) {
+        self.init(
+            blog: blog,
+            userAgent: WPUserAgent.wordPress(),
+            wordPressComApiURL: WordPressComRestApi.apiBaseURL
+        )
+    }
+
     convenience init?(
         blog: Blog,
         userAgent: String = WPUserAgent.wordPress(),

--- a/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
+++ b/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
@@ -12,14 +12,17 @@ private func apiBase(blog: Blog) -> URL? {
 
 extension WordPressOrgRestApi {
     @objc
-    convenience init?(blog: Blog) {
+    convenience init?(
+        blog: Blog,
+        userAgent: String = WPUserAgent.wordPress()
+    ) {
         if let dotComID = blog.dotComID?.uint64Value,
            let token = blog.account?.authToken,
            token.count > 0 {
             self.init(
                 dotComSiteID: dotComID,
                 bearerToken: token,
-                userAgent: WPUserAgent.wordPress(),
+                userAgent: userAgent,
                 apiURL: AppEnvironment.current.wordPressComApiBase
             )
         } else if let apiBase = apiBase(blog: blog),
@@ -35,7 +38,7 @@ extension WordPressOrgRestApi {
                     password: password,
                     adminURL: adminURL
                 ),
-                userAgent: WPUserAgent.wordPress()
+                userAgent: userAgent
             )
         } else {
             return nil

--- a/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
+++ b/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
@@ -14,7 +14,8 @@ extension WordPressOrgRestApi {
     @objc
     convenience init?(
         blog: Blog,
-        userAgent: String = WPUserAgent.wordPress()
+        userAgent: String = WPUserAgent.wordPress(),
+        wordPressComApiURL: URL = AppEnvironment.current.wordPressComApiBase
     ) {
         if let dotComID = blog.dotComID?.uint64Value,
            let token = blog.account?.authToken,
@@ -23,7 +24,7 @@ extension WordPressOrgRestApi {
                 dotComSiteID: dotComID,
                 bearerToken: token,
                 userAgent: userAgent,
-                apiURL: AppEnvironment.current.wordPressComApiBase
+                apiURL: wordPressComApiURL
             )
         } else if let apiBase = apiBase(blog: blog),
                   let loginURL = try? blog.loginUrl().asURL(),

--- a/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
+++ b/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
@@ -15,7 +15,7 @@ extension WordPressOrgRestApi {
     convenience init?(
         blog: Blog,
         userAgent: String = WPUserAgent.wordPress(),
-        wordPressComApiURL: URL = AppEnvironment.current.wordPressComApiBase
+        wordPressComApiURL: URL = WordPressComRestApi.apiBaseURL
     ) {
         if let dotComID = blog.dotComID?.uint64Value,
            let token = blog.account?.authToken,


### PR DESCRIPTION
Follows up on the RFC from #24333, part of #24165.