### PR TITLE
Remove unused `appRatingUtility` from `AppEnvironment`

### DIFF
--- a/WordPress/Classes/Utility/Environment/AppEnvironment.swift
+++ b/WordPress/Classes/Utility/Environment/AppEnvironment.swift
@@ -8,9 +8,6 @@ struct AppEnvironment {
 
     // MARK: - Globals
 
-    /// A type that helps tracking whether or not a user should be prompted for an app review
-    let appRatingUtility: AppRatingUtilityType
-
     /// A type to create derived context, save context, etc...
     let contextManager: CoreDataStack
 
@@ -32,11 +29,9 @@ struct AppEnvironment {
     // MARK: - Initialization
 
     private init(
-        appRatingUtility: AppRatingUtilityType = AppRatingUtility.shared,
         contextManager: CoreDataStack = ContextManager.shared,
         wordPressComApiBase: URL = WordPressComRestApi.apiBaseURL) {
 
-        self.appRatingUtility = appRatingUtility
         self.contextManager = contextManager
         self.wordPressComApiBase = wordPressComApiBase
     }
@@ -47,12 +42,10 @@ extension AppEnvironment {
     ///
     @discardableResult
     static func replaceEnvironment(
-        appRatingUtility: AppRatingUtilityType = AppEnvironment.current.appRatingUtility,
         contextManager: CoreDataStack = AppEnvironment.current.contextManager,
         wordPressComApiBase: URL = AppEnvironment.current.wordPressComApiBase) -> AppEnvironment {
 
         current = AppEnvironment(
-            appRatingUtility: appRatingUtility,
             contextManager: contextManager,
             wordPressComApiBase: wordPressComApiBase
         )


### PR DESCRIPTION
I noticed this unused property while working on #24351.

I'll acknowledge that we should ditch `AppEnvironment` altogether, but short of time to address that, this at least reduces its surface area.

Part of #24165.
