### PR TITLE
Move `areBloggingRemindersAllowed()` to dedicated file

### DIFF
--- a/WordPress/Classes/Models/Blog/Blog+Capabilities.swift
+++ b/WordPress/Classes/Models/Blog/Blog+Capabilities.swift
@@ -75,10 +75,6 @@ extension Blog {
         return capabilities?[capability] as? Bool ?? false
     }
 
-    public func areBloggingRemindersAllowed() -> Bool {
-        return isUserCapableOf(.EditPosts) && JetpackNotificationMigrationService.shared.shouldPresentNotifications()
-    }
-
     public var userCanUploadMedia: Bool {
         // Self-hosted non-Jetpack blogs have no capabilities, so we'll just assume that users can post media
         capabilities != nil ? isUploadingFilesAllowed() : true

--- a/WordPress/Classes/ViewRelated/Blog/BloggingReminders/Blog+BloggingRemindersFlow.swift
+++ b/WordPress/Classes/ViewRelated/Blog/BloggingReminders/Blog+BloggingRemindersFlow.swift
@@ -1,0 +1,8 @@
+extension Blog {
+
+    func areBloggingRemindersAllowed(
+        jetpackNotificationMigrationService: JetpackNotificationMigrationService = .shared
+    ) -> Bool {
+        return isUserCapableOf(.EditPosts) && jetpackNotificationMigrationService.shouldPresentNotifications()
+    }
+}


### PR DESCRIPTION
Splitting it from `Blog+Capabilities.swift` will allow us to leave this method, which is only used in the app target, outside of WordPressData which in turn saves us from having to bring `JetpackNotificationMigrationService` along.

Internal ref p1743116078903789/1743090023.463689-slack-C08HQR4C2TS

Part of #24165