### PR TITLE
Fix: Stats showing stale unique visitors count when views are updated

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodViewModel.swift
@@ -318,21 +318,21 @@ private extension SiteStatsPeriodViewModel {
         if mostRecentChartData == nil {
             mostRecentChartData = periodSummary
         } else if let mostRecentChartData,
-            let periodSummary,
-            mostRecentChartData.periodEndDate == periodSummary.periodEndDate {
+                  let periodSummary,
+                  mostRecentChartData.periodEndDate == periodSummary.periodEndDate {
             self.mostRecentChartData = periodSummary
-        } else if let periodSummary,   // when there is API data that has more recent API period date
-                  let chartData = mostRecentChartData, // than our local chartData
-                  periodSummary.periodEndDate > chartData.periodEndDate {
+        } else if let periodSummary,   // when there is API data that has more recent API period date than our local chartData
+                  let chartData = mostRecentChartData {
 
-            // we validate if our periodDates match and if so we set the currentEntryIndex to the last index of the summaryData
-            // fixes issue #19688
-            if let lastSummaryDataEntry = summaryData.last,
-               periodSummary.periodEndDate == lastSummaryDataEntry.periodStartDate {
+            // Always prefer newer data
+            if periodSummary.periodEndDate >= chartData.periodEndDate {
                 mostRecentChartData = periodSummary
-                currentEntryIndex = summaryData.count - 1
-            } else {
-                mostRecentChartData = chartData
+
+                // Update currentEntryIndex if needed
+                let lastIndex = summaryData.count - 1
+                if lastIndex >= 0 {
+                    currentEntryIndex = min(currentEntryIndex, lastIndex)
+                }
             }
         }
 


### PR DESCRIPTION
Fixes #24114

While I was not able to reproduce the issue mentioned here https://github.com/wordpress-mobile/WordPress-iOS/issues/24114 and while it seems it's not a specific issue related to the app because of this https://github.com/Automattic/jetpack/issues/42176 I noticed that the login for updating stats with `mostRecentChartData` was too restrictive. Even when new API data was available, the existing code would sometimes keep using old cached data due to specific date matching requirements.

So, I revised the conditional logic that now prioritizes using the newest data by simplifying the conditions and always choosing the most recent data available. In this way, we ensure that both views and unique visitors metrics update simultaneously when new data arrives from the API.

## Testing
Verified that both views and unique visitors data update synchronously when new stats data is fetched. Please, also check that this change does not introduce any regression, like reintroducing this issue #19688


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
