### PR TITLE
Remove nullability warning opt-out from `ReaderSiteService.h`

### DIFF
--- a/WordPress/Classes/Services/ReaderSiteService.h
+++ b/WordPress/Classes/Services/ReaderSiteService.h
@@ -2,9 +2,6 @@
 #import "ReaderTopicService.h"
 #import "CoreDataStack.h"
 
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wnullability-completeness"
-
 typedef NS_ENUM(NSUInteger, ReaderSiteServiceError) {
     ReaderSiteServiceErrorNotLoggedIn,
     ReaderSiteServiceErrorAlreadyFollowingSite
@@ -84,5 +81,3 @@ extern NSString * const ReaderSiteServiceErrorDomain;
 - (void)syncPostsForFollowedSites;
 
 @end
-
-#pragma clang diagnostic pop // -Wnullability-completeness

--- a/WordPress/Classes/Services/ReaderSiteService.h
+++ b/WordPress/Classes/Services/ReaderSiteService.h
@@ -76,12 +76,6 @@ extern NSString * const ReaderSiteServiceErrorDomain;
                   success:(void(^)(void))success
                   failure:(void(^)(NSError *error))failure;
 
-/**
- Sync posts for the 'sites I follow endpoint if it exists. Maybe called whenever
- a site/feed is followed or unfollowed.
- */
-- (void)syncPostsForFollowedSites;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Services/ReaderSiteService.h
+++ b/WordPress/Classes/Services/ReaderSiteService.h
@@ -2,6 +2,8 @@
 #import "ReaderTopicService.h"
 #import "CoreDataStack.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 typedef NS_ENUM(NSUInteger, ReaderSiteServiceError) {
     ReaderSiteServiceErrorNotLoggedIn,
     ReaderSiteServiceErrorAlreadyFollowingSite
@@ -13,7 +15,7 @@ extern NSString * const ReaderSiteServiceErrorDomain;
 
 @property (nonatomic, strong, readonly) id<CoreDataStack> coreDataStack;
 
-- (nonnull instancetype)initWithCoreDataStack:(id<CoreDataStack>)coreDataStack NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCoreDataStack:(id<CoreDataStack>)coreDataStack NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
 
@@ -81,3 +83,5 @@ extern NSString * const ReaderSiteServiceErrorDomain;
 - (void)syncPostsForFollowedSites;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -160,21 +160,7 @@ NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";
     } failure:failure];
 }
 
-- (void)syncPostsForFollowedSites
-{
-    [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
-        ReaderAbstractTopic *followedSites = [ReaderAbstractTopic lookupFollowedSitesTopicInContext:context];
-        if (!followedSites) {
-            return;
-        }
-
-        ReaderPostService *postService = [[ReaderPostService alloc] initWithCoreDataStack:self.coreDataStack];
-        [postService fetchPostsForTopic:followedSites earlierThan:[NSDate date] success:nil failure:nil];
-    }];
-}
-
 #pragma mark - Private Methods
-
 
 /**
  Fetch the topic after a site is followed

--- a/WordPress/WordPressTest/ReaderSiteServiceTests.swift
+++ b/WordPress/WordPressTest/ReaderSiteServiceTests.swift
@@ -35,7 +35,7 @@ class ReaderSiteServiceTests: CoreDataTestCase {
 
         let service = makeService()
         let success = expectation(description: "The success block should be called")
-        service.followSite(by: URL(string: "https://test.blog")!, success: success.fulfill, failure: nil)
+        service.followSite(by: URL(string: "https://test.blog")!, success: success.fulfill, failure: { _ in })
         wait(for: [success], timeout: 0.5)
     }
 
@@ -56,7 +56,7 @@ class ReaderSiteServiceTests: CoreDataTestCase {
 
         let service = makeService()
         let success = expectation(description: "The success block should be called")
-        service.followSite(withID: 42, success: success.fulfill, failure: nil)
+        service.followSite(withID: 42, success: success.fulfill, failure: { _ in })
         wait(for: [success], timeout: 0.5)
     }
 
@@ -67,7 +67,7 @@ class ReaderSiteServiceTests: CoreDataTestCase {
 
         let service = makeService()
         let success = expectation(description: "The success block should be called")
-        service.unfollowSite(withID: 42, success: success.fulfill, failure: nil)
+        service.unfollowSite(withID: 42, success: success.fulfill, failure: { _ in })
         wait(for: [success], timeout: 0.5)
     }
 


### PR DESCRIPTION
Follow up on @kean's suggestion from https://github.com/wordpress-mobile/WordPress-iOS/pull/24362#discussion_r2021689475

Turns out everything in the `ReaderSiteService` header is not null, so we can use the `NS_ASSUME_NONNULL_BEGIN|END` macro.