### PR TITLE
Use `wpAssertionFailure` in `TaggedManagedObjectID`

### DIFF
--- a/WordPress/Classes/Utility/CoreData/TaggedManagedObjectID.swift
+++ b/WordPress/Classes/Utility/CoreData/TaggedManagedObjectID.swift
@@ -39,17 +39,19 @@ public struct TaggedManagedObjectID<Model: NSManagedObject>: Hashable {
             do {
                 try context.obtainPermanentIDs(for: [object])
             } catch {
-                // It should be okay to let the app crash when `obtainPermanentIDs` fails. Because, we crash the app
-                // intentionally when `save()` fails (see the `ContextManager.internalSave` function). Also, if the
-                // `obtainPermanentIDs` call fails (which may mean SQLite failing to update the database file),
-                // then the save call followed (because we typically save newly added model objects) probably is going
-                // to fail too. Finally, there aren't many save crashes on Sentry and `obtainPermanentIDs` should be
-                // less likely to throw errors than `NSManagedObjectContext.save` function.
-                //
-                // However, just to be safe, we'll log and monitor this error (if it ever happens) for a few releases.
-                // We can decide later if we'd like to change the assertion to a fatal error.
-                WordPressAppDelegate.crashLogging?.logError(error)
-                assertionFailure("Failed to obtain permanent id for \(objectID). Error: \(error)")
+                // FIXME: Is it okay to use wpassertionFailure here?
+//                // It should be okay to let the app crash when `obtainPermanentIDs` fails. Because, we crash the app
+//                // intentionally when `save()` fails (see the `ContextManager.internalSave` function). Also, if the
+//                // `obtainPermanentIDs` call fails (which may mean SQLite failing to update the database file),
+//                // then the save call followed (because we typically save newly added model objects) probably is going
+//                // to fail too. Finally, there aren't many save crashes on Sentry and `obtainPermanentIDs` should be
+//                // less likely to throw errors than `NSManagedObjectContext.save` function.
+//                //
+//                // However, just to be safe, we'll log and monitor this error (if it ever happens) for a few releases.
+//                // We can decide later if we'd like to change the assertion to a fatal error.
+//                WordPressAppDelegate.crashLogging?.logError(error)
+//                assertionFailure("Failed to obtain permanent id for \(objectID). Error: \(error)")
+                wpAssertionFailure("Failed to obtain permanent id for an objet within TaggedManagedObjectID")
             }
             objectID = object.objectID
         }

--- a/WordPress/Classes/Utility/CoreData/TaggedManagedObjectID.swift
+++ b/WordPress/Classes/Utility/CoreData/TaggedManagedObjectID.swift
@@ -39,19 +39,13 @@ public struct TaggedManagedObjectID<Model: NSManagedObject>: Hashable {
             do {
                 try context.obtainPermanentIDs(for: [object])
             } catch {
-                // FIXME: Is it okay to use wpassertionFailure here?
-//                // It should be okay to let the app crash when `obtainPermanentIDs` fails. Because, we crash the app
-//                // intentionally when `save()` fails (see the `ContextManager.internalSave` function). Also, if the
-//                // `obtainPermanentIDs` call fails (which may mean SQLite failing to update the database file),
-//                // then the save call followed (because we typically save newly added model objects) probably is going
-//                // to fail too. Finally, there aren't many save crashes on Sentry and `obtainPermanentIDs` should be
-//                // less likely to throw errors than `NSManagedObjectContext.save` function.
-//                //
-//                // However, just to be safe, we'll log and monitor this error (if it ever happens) for a few releases.
-//                // We can decide later if we'd like to change the assertion to a fatal error.
-//                WordPressAppDelegate.crashLogging?.logError(error)
-//                assertionFailure("Failed to obtain permanent id for \(objectID). Error: \(error)")
-                wpAssertionFailure("Failed to obtain permanent id for an objet within TaggedManagedObjectID")
+                wpAssertionFailure(
+                    "Failed to obtain permanent id from NSManagedObject.",
+                    userInfo: [
+                        "objectID": String(describing: objectID),
+                        "error": String(describing: error),
+                    ]
+                )
             }
             objectID = object.objectID
         }


### PR DESCRIPTION
After all, the goal of the code was to log the error, which `wpAssertionFailure` allows to do.

Removing the app delegate access unblocks moving `TaggedManagedObjectID` away from the apps targets and into WordPressData.

Alternatively, we could just remove the logging entirely. The original comment did mention monitoring the error for a few releases, but that was some time ago...

Part of #24165.