### PR TITLE
Rewrite BlogDetailsViewController navigation code in Swift

### DIFF
--- a/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blaze Campaigns/BlazeCampaignsViewController.swift
@@ -46,10 +46,6 @@ final class BlazeCampaignsViewController: UIViewController, NoResultsViewHost, B
         super.init(nibName: nil, bundle: nil)
     }
 
-    @objc class func makeWithSource(_ source: BlazeSource, blog: Blog) -> BlazeCampaignsViewController {
-        BlazeCampaignsViewController(source: source, blog: blog)
-    }
-
     required init?(coder: NSCoder) {
         // This VC is designed to be initialized programmatically.
         fatalError("init(coder:) has not been implemented")

--- a/WordPress/Classes/ViewRelated/Blaze/Webview/BlazeFlowCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Blaze/Webview/BlazeFlowCoordinator.swift
@@ -52,11 +52,12 @@ import UIKit
     ///   - post: `AbstractPost` object representing the specific post to blaze. If `nil` is passed,
     ///    a general blaze overlay or web flow is displayed. If a valid value is passed, a blaze overlay with a post preview
     ///    or detailed web flow is displayed.
-    @objc(presentBlazeInViewController:source:blog:post:)
-    static func presentBlaze(in viewController: UIViewController,
-                             source: BlazeSource,
-                             blog: Blog,
-                             post: AbstractPost? = nil) {
+    static func presentBlaze(
+        in viewController: UIViewController,
+        source: BlazeSource,
+        blog: Blog,
+        post: AbstractPost? = nil
+    ) {
         let frequencyTracker = OverlayFrequencyTracker(source: source, type: .blaze)
         if frequencyTracker.shouldShow(forced: false) {
             presentBlazeOverlay(in: viewController, source: source, blog: blog, post: post)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Dashboard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Dashboard.swift
@@ -1,9 +1,0 @@
-import Foundation
-
-extension BlogDetailsViewController {
-
-    @objc func isDashboardEnabled() -> Bool {
-        return JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() && blog.isAccessibleThroughWPCom()
-    }
-
-}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -55,25 +55,6 @@ extension BlogDetailsViewController {
         return .stats
     }
 
-    @objc func shouldShowStats() -> Bool {
-        return JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
-    }
-
-    /// Convenience method that returns the view controller for Stats based on the features removal state.
-    ///
-    /// - Returns: Either the actual Stats view, or the static poster for Stats.
-    @objc func viewControllerForStats() -> UIViewController {
-        guard shouldShowStats() else {
-            return MovedToJetpackViewController(source: .stats)
-        }
-
-        let statsView = StatsViewController()
-        statsView.blog = blog
-        statsView.hidesBottomBarWhenPushed = true
-        statsView.navigationItem.largeTitleDisplayMode = .never
-        return statsView
-    }
-
     @objc func shouldAddJetpackSection() -> Bool {
         guard JetpackFeaturesRemovalCoordinator.shouldShowJetpackFeatures() else {
             return false

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
@@ -1,0 +1,326 @@
+import Foundation
+import WordPressShared
+
+// MARK: - BlogDetailsViewController (Misc)
+
+extension BlogDetailsViewController {
+    @objc func isDashboardEnabled() -> Bool {
+        return JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() && blog.isAccessibleThroughWPCom()
+    }
+}
+
+// MARK: - BlogDetailsViewController (Navigation)
+
+extension BlogDetailsViewController {
+    @objc func showDashboard() {
+        if isSidebarModeEnabled {
+            let controller = MySiteViewController.make(forBlog: blog, isSidebarModeEnabled: true)
+            presentationDelegate?.presentBlogDetailsViewController(controller)
+        } else {
+            let controller = BlogDashboardViewController(blog: blog, embeddedInScrollView: false)
+            controller.navigationItem.largeTitleDisplayMode = .never
+            controller.extendedLayoutIncludesOpaqueBars = true
+            presentationDelegate?.presentBlogDetailsViewController(controller)
+        }
+    }
+
+    @objc(showPostListFromSource:)
+    func showPostList(from source: BlogDetailsNavigationSource) {
+        trackEvent(.openedPosts, from: source)
+        let controller = PostListViewController.controllerWithBlog(blog)
+        controller.navigationItem.largeTitleDisplayMode = .never
+        presentationDelegate?.presentBlogDetailsViewController(controller)
+    }
+
+    @objc(showPageListFromSource:)
+    func showPageList(from source: BlogDetailsNavigationSource) {
+        trackEvent(.openedPages, from: source)
+        let controller = PageListViewController.controllerWithBlog(blog)
+        controller.navigationItem.largeTitleDisplayMode = .never
+        presentationDelegate?.presentBlogDetailsViewController(controller)
+    }
+
+    @objc(showMediaLibraryFromSource:)
+    func showMediaLibrary(from source: BlogDetailsNavigationSource) {
+        showMediaLibrary(from: source, showPicker: false)
+    }
+
+    @objc(showMediaLibraryFromSource:showPicker:)
+    func showMediaLibrary(from source: BlogDetailsNavigationSource, showPicker: Bool) {
+        trackEvent(.openedMediaLibrary, from: source)
+        let controller = SiteMediaViewController(blog: blog, showPicker: showPicker)
+        presentationDelegate?.presentBlogDetailsViewController(controller)
+    }
+
+    @objc(showSettingsFromSource:)
+    func showSettings(from source: BlogDetailsNavigationSource) {
+        trackEvent(.openedSiteSettings, from: source)
+
+        guard let settingsVC = SiteSettingsViewController(blog: blog) else {
+            return wpAssertionFailure("failed to instantiate")
+        }
+        settingsVC.navigationItem.largeTitleDisplayMode = .never
+
+        if isSidebarModeEnabled {
+            let navigationController = UINavigationController(rootViewController: settingsVC)
+
+            settingsVC.navigationItem.rightBarButtonItem = UIBarButtonItem(
+                systemItem: .done,
+                primaryAction: UIAction { [weak self] _ in
+                    self?.tableView.deselectSelectedRowWithAnimation(true)
+                    self?.dismiss(animated: true, completion: nil)
+                }
+            )
+            navigationController.modalPresentationStyle = .formSheet
+            present(navigationController, animated: true, completion: nil)
+            presentedSiteSettingsViewController = navigationController
+            navigationController.presentationController?.delegate = self
+        } else {
+            presentationDelegate?.presentBlogDetailsViewController(settingsVC)
+        }
+    }
+
+    @objc
+    @discardableResult func showMe() -> MeViewController {
+        let controller = MeViewController()
+        presentationDelegate?.presentBlogDetailsViewController(controller)
+        return controller
+    }
+
+    @objc func showPeople() {
+        guard let controller = PeopleViewController.withJPBannerForBlog(blog) else {
+            return wpAssertionFailure("failed to instantiate")
+        }
+        presentationDelegate?.presentBlogDetailsViewController(controller)
+    }
+
+    @objc func showActivity() {
+        guard let controller = JetpackActivityLogViewController(blog: blog) else {
+            return wpAssertionFailure("failed to instantiate")
+        }
+        controller.navigationItem.largeTitleDisplayMode = .never
+        presentationDelegate?.presentBlogDetailsViewController(controller)
+
+        WPAnalytics.track(.activityLogViewed, withProperties: [WPAppAnalyticsKeyTapSource: "site_menu"])
+    }
+
+    @objc func showBlaze() {
+        BlazeEventsTracker.trackEntryPointTapped(for: .menuItem)
+
+        if RemoteFeature.enabled(.blazeManageCampaigns) {
+            let controller = BlazeCampaignsViewController(source: .menuItem, blog: blog)
+            presentationDelegate?.presentBlogDetailsViewController(controller)
+        } else {
+            BlazeFlowCoordinator.presentBlaze(in: self, source: .menuItem, blog: blog, post: nil)
+        }
+    }
+
+    @objc func showScan() {
+        let scanVC = JetpackScanViewController.withJPBannerForBlog(blog)
+        presentationDelegate?.presentBlogDetailsViewController(scanVC)
+    }
+
+    @objc func showBackup() {
+        guard let backupListVC = BackupListViewController.withJPBannerForBlog(blog) else {
+            return wpAssertionFailure("failed to instantiate")
+        }
+        presentationDelegate?.presentBlogDetailsViewController(backupListVC)
+    }
+
+    @objc func showThemes() {
+        WPAppAnalytics.track(.themesAccessedThemeBrowser, blog: blog)
+        let themesVC = ThemeBrowserViewController.browserWithBlog(blog)
+        themesVC.hidesBottomBarWhenPushed = true
+        let jpWrappedViewController = themesVC.withJPBanner()
+        presentationDelegate?.presentBlogDetailsViewController(jpWrappedViewController)
+    }
+
+    @objc func showMenus() {
+        WPAppAnalytics.track(.menusAccessed, blog: blog)
+        let menusVC = MenusViewController.withJPBannerForBlog(blog)
+        presentationDelegate?.presentBlogDetailsViewController(menusVC)
+    }
+
+    @objc(showCommentsFromSource:)
+    func showComments(from source: BlogDetailsNavigationSource) {
+        trackEvent(.openedComments, from: source)
+
+        guard let commentsVC = CommentsViewController(blog: blog) else {
+            return wpAssertionFailure("failed to instantiate")
+        }
+        commentsVC.navigationItem.largeTitleDisplayMode = .never
+
+        if isSidebarModeEnabled {
+            commentsVC.isSidebarModeEnabled = true
+
+            let splitVC = UISplitViewController(style: .doubleColumn)
+            splitVC.presentsWithGesture = false
+            splitVC.preferredDisplayMode = .oneBesideSecondary
+            splitVC.preferredPrimaryColumnWidth = 320
+            splitVC.minimumPrimaryColumnWidth = 375
+            splitVC.maximumPrimaryColumnWidth = 400
+            splitVC.setViewController(commentsVC, for: .primary)
+
+            let noSelectionVC = UIViewController()
+            noSelectionVC.view.backgroundColor = .systemBackground
+            splitVC.setViewController(noSelectionVC, for: .secondary)
+
+            presentationDelegate?.presentBlogDetailsViewController(splitVC)
+        } else {
+            presentationDelegate?.presentBlogDetailsViewController(commentsVC)
+        }
+    }
+
+    @objc func showPlugins() {
+        WPAppAnalytics.track(.openedPluginDirectory, blog: blog)
+
+        if Feature.enabled(.pluginManagementOverhaul) {
+            showManagePluginsScreen()
+            return
+        }
+
+        guard let site = JetpackSiteRef(blog: blog) else {
+            return wpAssertionFailure("unexpected blog")
+        }
+        let controller = PluginDirectoryViewController(site: site)
+        controller.navigationItem.largeTitleDisplayMode = .never
+        presentationDelegate?.presentBlogDetailsViewController(controller)
+    }
+
+    @objc(showStatsFromSource:)
+    func showStats(from source: BlogDetailsNavigationSource) {
+        trackEvent(.statsAccessed, from: source)
+
+        let statsVC = makeStatsVC()
+
+        // Calling `showDetailViewController:sender:` should do this automatically for us,
+        // but when showing stats from our 3D Touch shortcut iOS sometimes incorrectly
+        // presents the stats view controller as modal instead of pushing it. As a
+        // workaround for now, we'll manually decide whether to push or use `showDetail`.
+        // @frosty 2016-09-05
+        if let splitViewController, splitViewController.isCollapsed {
+            navigationController?.pushViewController(statsVC, animated: true)
+        } else {
+            presentationDelegate?.presentBlogDetailsViewController(statsVC)
+        }
+    }
+
+    private func makeStatsVC() -> UIViewController {
+        guard JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() else {
+            return MovedToJetpackViewController(source: .stats)
+        }
+
+        let statsVC = StatsViewController()
+        statsVC.blog = blog
+        statsVC.hidesBottomBarWhenPushed = true
+        statsVC.navigationItem.largeTitleDisplayMode = .never
+        return statsVC
+    }
+
+    @objc(showDomainsFromSource:)
+    func showDomains(from source: BlogDetailsNavigationSource) {
+        guard let presentationDelegate else {
+            return wpAssertionFailure("presentationDelegate mising")
+        }
+        DomainsDashboardCoordinator.presentDomainsDashboard(with: presentationDelegate, source: source.string, blog: blog)
+    }
+
+    @objc func showJetpackSettings() {
+        let controller = JetpackSettingsViewController(blog: blog)
+        controller.navigationItem.largeTitleDisplayMode = .never
+        presentationDelegate?.presentBlogDetailsViewController(controller)
+    }
+
+    @objc(showSharingFromSource:)
+    func showSharing(from source: BlogDetailsNavigationSource) {
+        let sharingVC: UIViewController
+
+        if !blog.supportsPublicize() {
+            // if publicize is disabled, show the sharing buttons settings.
+            sharingVC = SharingButtonsViewController(blog: blog)
+        } else {
+            sharingVC = SharingViewController(blog: blog, delegate: nil)
+        }
+
+        trackEvent(.openedSharingManagement, from: source)
+        sharingVC.navigationItem.largeTitleDisplayMode = .never
+        presentationDelegate?.presentBlogDetailsViewController(sharingVC)
+    }
+
+    @objc(showViewSiteFromSource:)
+    func showViewSite(from source: BlogDetailsNavigationSource) {
+        trackEvent(.openedViewSite, from: source)
+
+        guard let string = blog.homeURL, let homeURL = URL(string: string as String) else {
+            return wpAssertionFailure("homeURL missing")
+        }
+
+        let webViewController = WebViewControllerFactory.controller(
+            url: homeURL,
+            blog: blog,
+            source: "my_site_view_site",
+            withDeviceModes: true,
+            onClose: nil
+        )
+
+        let navigationController = UINavigationController(rootViewController: webViewController)
+        if traitCollection.userInterfaceIdiom == .pad {
+            navigationController.modalPresentationStyle = .fullScreen
+        }
+        present(navigationController, animated: true, completion: nil)
+    }
+
+    @objc func showViewAdmin() {
+        WPAppAnalytics.track(.openedViewAdmin, blog: blog)
+
+        let dashboardPath: String
+        if blog.isHostedAtWPcom, let hostname = blog.hostname {
+            dashboardPath = "\(Constants.calypsoDashboardPath)\(hostname)"
+        } else {
+            dashboardPath = blog.adminUrl(withPath: "")
+        }
+
+        guard let url = URL(string: dashboardPath) else { return }
+        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+    }
+}
+
+// MARK: - BlogDetailsViewController (Tracking)
+
+extension BlogDetailsViewController {
+    @objc func trackEvent(_ event: WPAnalyticsStat, from source: BlogDetailsNavigationSource) {
+        WPAppAnalytics.track(event, properties: [
+            WPAppAnalyticsKeyTapSource: source.string,
+            WPAppAnalyticsKeyTabSource: "site_menu"
+        ], blog: blog)
+    }
+}
+
+@objc enum BlogDetailsNavigationSource: Int {
+    case button = 0
+    case row = 1
+    case link = 2
+    case widget = 3
+    case onboarding = 4
+    case notification = 5
+    case shortcut = 6
+    case todayStatsCard = 7
+
+    var string: String {
+        switch self {
+        case .row: "row"
+        case .link: "link"
+        case .button: "button"
+        case .widget: "widget"
+        case .onboarding: "onboarding"
+        case .notification: "notification"
+        case .shortcut: "shortcut"
+        case .todayStatsCard: "todays_stats_card"
+        default: ""
+        }
+    }
+}
+
+private enum Constants {
+    static let calypsoDashboardPath = "https://wordpress.com/home/"
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -49,18 +49,6 @@ typedef NS_ENUM(NSUInteger, BlogDetailsSubsection) {
     BlogDetailsSubsectionSiteMonitoring
 };
 
-typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
-    BlogDetailsNavigationSourceButton = 0,
-    BlogDetailsNavigationSourceRow = 1,
-    BlogDetailsNavigationSourceLink = 2,
-    BlogDetailsNavigationSourceWidget = 3,
-    BlogDetailsNavigationSourceOnboarding = 4,
-    BlogDetailsNavigationSourceNotification = 5,
-    BlogDetailsNavigationSourceShortcut = 6,
-    BlogDetailsNavigationSourceTodayStatsCard = 7,
-};
-
-
 @interface BlogDetailsSection : NSObject
 
 @property (nonatomic, strong, nullable, readonly) NSString *title;
@@ -123,7 +111,7 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 - (void)presentBlogDetailsViewController:(UIViewController * __nonnull)viewController;
 @end
 
-@interface BlogDetailsViewController : UIViewController <UITableViewDelegate, UITableViewDataSource, UIViewControllerTransitioningDelegate>
+@interface BlogDetailsViewController : UIViewController <UITableViewDelegate, UITableViewDataSource, UIViewControllerTransitioningDelegate, UIAdaptivePresentationControllerDelegate>
 
 @property (nonatomic, strong, nonnull) Blog * blog;
 @property (nonatomic, strong, readonly) CreateButtonCoordinator * _Nullable createButtonCoordinator;
@@ -134,6 +122,8 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 
 /// A new display mode for the displaying it as part of the site menu.
 @property (nonatomic) BOOL isSidebarModeEnabled;
+
+@property (nonatomic, weak) UIViewController *presentedSiteSettingsViewController;
 
 - (id _Nonnull)init;
 - (void)showDetailViewForSubsection:(BlogDetailsSubsection)section;
@@ -146,10 +136,6 @@ typedef NS_ENUM(NSUInteger, BlogDetailsNavigationSource) {
 
 - (void)switchToBlog:(nonnull Blog *)blog;
 - (void)showInitialDetailsForBlog;
-- (void)showPostListFromSource:(BlogDetailsNavigationSource)source;
-- (void)showPageListFromSource:(BlogDetailsNavigationSource)source;
-- (void)showMediaLibraryFromSource:(BlogDetailsNavigationSource)source;
-- (void)showStatsFromSource:(BlogDetailsNavigationSource)source;
 - (void)updateTableView:(nullable void(^)(void))completion;
 - (void)preloadMetadata;
 - (void)pulledToRefreshWith:(nonnull UIRefreshControl *)refreshControl onCompletion:(nullable void(^)(void))completion;

--- a/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Views/DomainsDashboardCoordinator.swift
@@ -1,8 +1,7 @@
 import UIKit
 import WordPressShared
 
-@objc final class DomainsDashboardCoordinator: NSObject {
-    @objc(presentDomainsDashboardWithPresenter:source:blog:)
+final class DomainsDashboardCoordinator: NSObject {
     static func presentDomainsDashboard(with presenter: BlogDetailsPresentationDelegate,
                                         source: String,
                                         blog: Blog) {

--- a/WordPress/Classes/ViewRelated/Pages/Controllers/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/Controllers/PageListViewController.swift
@@ -53,7 +53,7 @@ final class PageListViewController: AbstractPostListViewController {
 
     // MARK: - Convenience constructors
 
-    @objc class func controllerWithBlog(_ blog: Blog) -> PageListViewController {
+    class func controllerWithBlog(_ blog: Blog) -> PageListViewController {
         let vc = PageListViewController()
         vc.blog = blog
         return vc

--- a/WordPress/Classes/ViewRelated/People/Controllers/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/Controllers/PeopleViewController.swift
@@ -111,6 +111,15 @@ class PeopleViewController: UITableViewController {
     @IBOutlet
     private var footerActivityIndicator: UIActivityIndicatorView!
 
+    class func controllerWithBlog(_ blog: Blog) -> PeopleViewController? {
+        let storyboard = UIStoryboard(name: "People", bundle: nil)
+        guard let viewController = storyboard.instantiateInitialViewController() as? PeopleViewController else {
+            return nil
+        }
+        viewController.blog = blog
+        return viewController
+    }
+
     // MARK: UITableViewDataSource
 
     override func numberOfSections(in tableView: UITableView) -> Int {
@@ -540,24 +549,8 @@ private extension PeopleViewController {
         setupFilterBar()
         setupTableView()
     }
-}
 
-// MARK: - Objective-C support
-
-@objc
-extension PeopleViewController {
-    class func controllerWithBlog(_ blog: Blog) -> PeopleViewController? {
-        let storyboard = UIStoryboard(name: "People", bundle: nil)
-        guard let viewController = storyboard.instantiateInitialViewController() as? PeopleViewController else {
-            return nil
-        }
-
-        viewController.blog = blog
-
-        return viewController
-    }
-
-    func selectedFilterDidChange(_ filterBar: FilterTabBar) {
+    @objc private func selectedFilterDidChange(_ filterBar: FilterTabBar) {
         let selectedFilter = Filter.allCases[filterBar.selectedIndex]
         filter = selectedFilter
 

--- a/WordPress/Classes/ViewRelated/Plugins/Controllers/PluginDirectoryViewController.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/Controllers/PluginDirectoryViewController.swift
@@ -188,14 +188,3 @@ extension PluginDirectoryViewController: PluginListPresenter {
         navigationController?.pushViewController(listVC, animated: true)
     }
 }
-
-extension BlogDetailsViewController {
-
-    @objc func makePluginDirectoryViewController(blog: Blog) -> PluginDirectoryViewController? {
-        guard let site = JetpackSiteRef(blog: blog) else {
-            return nil
-        }
-
-        return PluginDirectoryViewController(site: site)
-    }
-}

--- a/WordPress/Classes/ViewRelated/Post/Controllers/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Controllers/PostListViewController.swift
@@ -10,7 +10,7 @@ final class PostListViewController: AbstractPostListViewController, InteractiveP
 
     // MARK: - Convenience constructors
 
-    @objc class func controllerWithBlog(_ blog: Blog) -> PostListViewController {
+    class func controllerWithBlog(_ blog: Blog) -> PostListViewController {
         let vc = PostListViewController()
         vc.blog = blog
         return vc

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2011,17 +2011,17 @@
 			path = Sources;
 			sourceTree = "<group>";
 		};
+		0C5A1A042D9B080900C25301 /* WordPressAuthenticatorTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = WordPressAuthenticatorTests;
+			sourceTree = "<group>";
+		};
 		0C5A3FAB2D9B1EF400C25301 /* Reader */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				0C5A3FB42D9B214200C25301 /* Exceptions for "Reader" folder in "Reader" target */,
 			);
 			path = Reader;
-			sourceTree = "<group>";
-		};
-		0C5A1A042D9B080900C25301 /* WordPressAuthenticatorTests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = WordPressAuthenticatorTests;
 			sourceTree = "<group>";
 		};
 		0C5C46FE2D98397A00F2CD55 /* Keystone */ = {


### PR DESCRIPTION
One of the precursors for Keystone. It limits the number of Swift APIs used from Objective-C quite a bit.

Note: implemented with Claude, verified, and tested.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
