### PR TITLE
Remove main.swift from Keystone

### DIFF
--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1906,6 +1906,7 @@
 		0C5C46F42D98343300F2CD55 /* Exceptions for "Classes" folder in "Keystone" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				System/main.swift,
 				"System/WordPress-Bridging-Header.h",
 			);
 			publicHeaders = (
@@ -2011,17 +2012,17 @@
 			path = Sources;
 			sourceTree = "<group>";
 		};
+		0C5A1A042D9B080900C25301 /* WordPressAuthenticatorTests */ = {
+			isa = PBXFileSystemSynchronizedRootGroup;
+			path = WordPressAuthenticatorTests;
+			sourceTree = "<group>";
+		};
 		0C5A3FAB2D9B1EF400C25301 /* Reader */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
 				0C5A3FB42D9B214200C25301 /* Exceptions for "Reader" folder in "Reader" target */,
 			);
 			path = Reader;
-			sourceTree = "<group>";
-		};
-		0C5A1A042D9B080900C25301 /* WordPressAuthenticatorTests */ = {
-			isa = PBXFileSystemSynchronizedRootGroup;
-			path = WordPressAuthenticatorTests;
 			sourceTree = "<group>";
 		};
 		0C5C46FE2D98397A00F2CD55 /* Keystone */ = {


### PR DESCRIPTION
I accidentally added it to the target together with other `Classes/`. I plan to move it outside of `Classes/` eventually.

**Note**: Keystone will no longer compile because with the removal of `main.swift`, it changed how `Keystone-Swift.h` gets generated (Swift APIs available from Objective-C). It now includes only public APIs, and I could not find any way to change it. It is what I would expect considering that the Objective-C umbrella header works the same way – it requires headers included in it to be public.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
