### PR TITLE
Enhance the visibility of countries on the Country Map by adjusting the color spectrum

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -259,6 +259,10 @@ extension WPStyleGuide {
 
         static let mapBackground: UIColor = .systemGray4
 
+        static var mapLowColorSpectrum: UIColor {
+            UIAppColor.primary(.shade10)
+        }
+
         // MARK: - Posting Activity Collection View Styles
 
         // Value of PostingActivityMonth view width for five columns

--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -259,10 +259,6 @@ extension WPStyleGuide {
 
         static let mapBackground: UIColor = .systemGray4
 
-        static var mapLowColorSpectrum: UIColor {
-            UIAppColor.primary(.shade10)
-        }
-
         // MARK: - Posting Activity Collection View Styles
 
         // Value of PostingActivityMonth view width for five columns

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapView.swift
@@ -68,11 +68,7 @@ private extension CountriesMapView {
     }
 
     func mapColors() -> [UIColor] {
-        if traitCollection.userInterfaceStyle == .dark {
-            return [WPStyleGuide.Stats.mapBackground, UIAppColor.primary]
-        } else {
-            return [WPStyleGuide.Stats.mapBackground, UIAppColor.primary]
-        }
+        return [WPStyleGuide.Stats.mapLowColorSpectrum, UIAppColor.primary]
     }
 
     func setGradientColors() {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapView.swift
@@ -68,7 +68,7 @@ private extension CountriesMapView {
     }
 
     func mapColors() -> [UIColor] {
-        return [WPStyleGuide.Stats.mapLowColorSpectrum, UIAppColor.primary]
+        return [UIAppColor.primary(.shade10), UIAppColor.primary]
     }
 
     func setGradientColors() {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/Countries/Map/CountriesMapView.swift
@@ -68,7 +68,7 @@ private extension CountriesMapView {
     }
 
     func mapColors() -> [UIColor] {
-        return [UIAppColor.primary(.shade10), UIAppColor.primary]
+        return [UIAppColor.primary(.shade5), UIAppColor.primary]
     }
 
     func setGradientColors() {


### PR DESCRIPTION

Fixes #24109

When there are small numbers in stats, the color spectrum in the map of the Countries section uses the same background color as the map. This means that the highlighted states will not be visible. For this reason, the modification uses the same colors as the highlighted map (for Jetpack, green for example) but with shade 10. Note: It seems that the map, which uses under the hood the library `FSInteractiveMap`, on the other hand, does not support colors with alpha.

| Light mode             |  Dark mode |
:-------------------------:|:-------------------------:
![Simulator Screenshot - iPhone 16 Pro - 2025-04-01 at 18 58 54](https://github.com/user-attachments/assets/626f1839-85f8-4b95-8685-20061fadf498) | ![Simulator Screenshot - iPhone 16 Pro - 2025-04-01 at 18 59 17](https://github.com/user-attachments/assets/535be86c-f6d0-4cd4-b82c-6f2bf9b2385f)


To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
