### PR TITLE
Remove WordPress-Swift.h

### DIFF
--- a/WordPress/Classes/Services/ReaderTopicService.h
+++ b/WordPress/Classes/Services/ReaderTopicService.h
@@ -1,6 +1,8 @@
 #import <Foundation/Foundation.h>
 #import "CoreDataStack.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
 
 @class ReaderAbstractTopic;
@@ -12,11 +14,11 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
 
 @property (nonatomic, strong, readonly) id<CoreDataStack> coreDataStack;
 
-- (nonnull instancetype)initWithCoreDataStack:(id<CoreDataStack>)coreDataStack NS_DESIGNATED_INITIALIZER;
+- (instancetype)initWithCoreDataStack:(id<CoreDataStack>)coreDataStack NS_DESIGNATED_INITIALIZER;
 
 - (instancetype)init NS_UNAVAILABLE;
 
-- (ReaderAbstractTopic *)currentTopicInContext:(NSManagedObjectContext *)context;
+- (nullable ReaderAbstractTopic *)currentTopicInContext:(NSManagedObjectContext *)context;
 
 - (void)setCurrentTopic:(ReaderAbstractTopic *)topic;
 
@@ -26,7 +28,7 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
  @param success block called on a successful fetch.
  @param failure block called if there is any error. `error` can be any underlying network error.
  */
-- (void)fetchReaderMenuWithSuccess:(void (^)(void))success failure:(void (^)(NSError *error))failure;
+- (void)fetchReaderMenuWithSuccess:(void (^)(void))success failure:(void (^)(NSError * _Nullable error))failure;
 
 /**
  Deletes all search topics from core data and saves the context.
@@ -61,7 +63,7 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
  @param phrase: The search phrase.
  @param completion: A completion callback to receive the created ReaderSearchTopic instance.
  */
-- (void)createSearchTopicForSearchPhrase:(NSString *)phrase completion:(void (^)(NSManagedObjectID *))completion;
+- (void)createSearchTopicForSearchPhrase:(NSString *)phrase completion:(void (^)(NSManagedObjectID * _Nullable objectID))completion;
 
 /**
  Unfollows the specified topic
@@ -70,7 +72,7 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
  @param success block called on a successful fetch.
  @param failure block called if there is any error. `error` can be any underlying network error.
  */
-- (void)unfollowTag:(ReaderTagTopic *)topic withSuccess:(void (^)(void))success failure:(void (^)(NSError *error))failure;
+- (void)unfollowTag:(ReaderTagTopic *)topic withSuccess:(void (^)(void))success failure:(void (^)(NSError * _Nullable error))failure;
 
 /**
  Follow the tag with the specified name
@@ -81,7 +83,7 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
  */
 - (void)followTagNamed:(NSString *)tagName
            withSuccess:(void (^)(void))success
-               failure:(void (^)(NSError *error))failure
+               failure:(void (^)(NSError * _Nullable error))failure
                 source:(NSString *)source;
 
 /**
@@ -91,7 +93,7 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
  @param success block called on a successful change.
  @param failure block called if there is any error. `error` can be any underlying network error.
  */
-- (void)toggleFollowingForTag:(ReaderTagTopic *)topic success:(void (^)(void))success failure:(void (^)(NSError *error))failure;
+- (void)toggleFollowingForTag:(ReaderTagTopic *)topic success:(void (^)(void))success failure:(void (^)(NSError * _Nullable error))failure;
 
 /**
  Toggle the following status of the site for the specified site topic
@@ -102,7 +104,7 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
  */
 - (void)toggleFollowingForSite:(ReaderSiteTopic *)topic
                        success:(void (^)(BOOL follow))success
-                       failure:(void (^)(BOOL follow, NSError *error))failure;
+                       failure:(void (^)(BOOL follow, NSError * _Nullable error))failure;
 
 /**
  Fetch a tag topic for a tag with the specified slug.
@@ -112,8 +114,8 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
  @param failure block called if there is any error. `error` can be any underlying network error.
  */
 - (void)tagTopicForTagWithSlug:(NSString *)slug
-                       success:(void(^)(NSManagedObjectID *objectID))success
-                       failure:(void (^)(NSError *error))failure;
+                       success:(void(^)(NSManagedObjectID * _Nullable objectID))success
+                       failure:(void (^)(NSError * _Nullable error))failure;
 
 /**
  Fetch a site topic for a site with the specified ID.
@@ -125,8 +127,8 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
  */
 - (void)siteTopicForSiteWithID:(NSNumber *)siteID
                         isFeed:(BOOL)isFeed
-                       success:(void (^)(NSManagedObjectID *objectID, BOOL isFollowing))success
-                       failure:(void (^)(NSError *error))failure;
+                       success:(void (^)(NSManagedObjectID * _Nullable objectID, BOOL isFollowing))success
+                       failure:(void (^)(NSError * _Nullable error))failure;
 
 @end
 
@@ -136,3 +138,5 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
 - (void)mergeMenuTopics:(NSArray *)topics isLoggedIn:(BOOL)isLoggedIn withSuccess:(void (^)(void))success;
 - (NSString *)formatTitle:(NSString *)str;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Services/ReaderTopicService.h
+++ b/WordPress/Classes/Services/ReaderTopicService.h
@@ -20,7 +20,7 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
 
 - (nullable ReaderAbstractTopic *)currentTopicInContext:(NSManagedObjectContext *)context;
 
-- (void)setCurrentTopic:(ReaderAbstractTopic *)topic;
+- (void)setCurrentTopic:(ReaderAbstractTopic * _Nullable)topic;
 
 /**
  Fetches the topics for the reader's menu.

--- a/WordPress/Classes/Services/ThemeService.h
+++ b/WordPress/Classes/Services/ThemeService.h
@@ -1,13 +1,15 @@
 #import "CoreDataStack.h"
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class Blog;
 @class Theme;
 @class WPAccount;
 
 typedef void(^ThemeServiceSuccessBlock)(void);
-typedef void(^ThemeServiceThemeRequestSuccessBlock)(Theme *theme);
-typedef void(^ThemeServiceThemesRequestSuccessBlock)(NSArray<Theme *> *themes, BOOL hasMore, NSInteger totalThemeCount);
-typedef void(^ThemeServiceFailureBlock)(NSError *error);
+typedef void(^ThemeServiceThemeRequestSuccessBlock)(Theme * _Nullable theme);
+typedef void(^ThemeServiceThemesRequestSuccessBlock)(NSArray<Theme *> * _Nullable themes, BOOL hasMore, NSInteger totalThemeCount);
+typedef void(^ThemeServiceFailureBlock)(NSError * _Nullable error);
 
 @interface ThemeService : NSObject
 
@@ -42,7 +44,7 @@ typedef void(^ThemeServiceFailureBlock)(NSError *error);
  */
 - (NSProgress *)getActiveThemeForBlog:(Blog *)blog
                               success:(ThemeServiceThemeRequestSuccessBlock)success
-                              failure:(ThemeServiceFailureBlock)failure;
+                              failure:(nullable ThemeServiceFailureBlock)failure;
 
 /**
  *  @brief      Gets the list of available themes for a blog.
@@ -66,12 +68,12 @@ typedef void(^ThemeServiceFailureBlock)(NSError *error);
                           search:(NSString *)search
                             sync:(BOOL)sync
                          success:(ThemeServiceThemesRequestSuccessBlock)success
-                         failure:(ThemeServiceFailureBlock)failure;
+                         failure:(nullable ThemeServiceFailureBlock)failure;
 
 - (NSProgress *)getCustomThemesForBlog:(Blog *)blog
                                   sync:(BOOL)sync
                                success:(ThemeServiceThemesRequestSuccessBlock)success
-                               failure:(ThemeServiceFailureBlock)failure;
+                               failure:(nullable ThemeServiceFailureBlock)failure;
 
 #pragma mark - Remote queries: Activating themes
 
@@ -88,7 +90,7 @@ typedef void(^ThemeServiceFailureBlock)(NSError *error);
 - (NSProgress *)activateTheme:(Theme *)theme
                       forBlog:(Blog *)blog
                       success:(ThemeServiceThemeRequestSuccessBlock)success
-                      failure:(ThemeServiceFailureBlock)failure;
+                      failure:(nullable ThemeServiceFailureBlock)failure;
 
 #pragma mark - Remote queries: Installing themes
 
@@ -105,8 +107,10 @@ typedef void(^ThemeServiceFailureBlock)(NSError *error);
 - (NSProgress *)installTheme:(Theme *)theme
                       forBlog:(Blog *)blog
                       success:(ThemeServiceSuccessBlock)success
-                      failure:(ThemeServiceFailureBlock)failure;
+                      failure:(nullable ThemeServiceFailureBlock)failure;
 
 
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/Services/ThemeService.h
+++ b/WordPress/Classes/Services/ThemeService.h
@@ -65,7 +65,7 @@ typedef void(^ThemeServiceFailureBlock)(NSError * _Nullable error);
  */
 - (NSProgress *)getThemesForBlog:(Blog *)blog
                             page:(NSInteger)page
-                          search:(NSString *)search
+                          search:(nullable NSString *)search
                             sync:(BOOL)sync
                          success:(nullable ThemeServiceThemesRequestSuccessBlock)success
                          failure:(nullable ThemeServiceFailureBlock)failure;

--- a/WordPress/Classes/Services/ThemeService.h
+++ b/WordPress/Classes/Services/ThemeService.h
@@ -43,7 +43,7 @@ typedef void(^ThemeServiceFailureBlock)(NSError * _Nullable error);
  *  @returns    The progress object.
  */
 - (NSProgress *)getActiveThemeForBlog:(Blog *)blog
-                              success:(ThemeServiceThemeRequestSuccessBlock)success
+                              success:(nullable ThemeServiceThemeRequestSuccessBlock)success
                               failure:(nullable ThemeServiceFailureBlock)failure;
 
 /**
@@ -67,12 +67,12 @@ typedef void(^ThemeServiceFailureBlock)(NSError * _Nullable error);
                             page:(NSInteger)page
                           search:(NSString *)search
                             sync:(BOOL)sync
-                         success:(ThemeServiceThemesRequestSuccessBlock)success
+                         success:(nullable ThemeServiceThemesRequestSuccessBlock)success
                          failure:(nullable ThemeServiceFailureBlock)failure;
 
 - (NSProgress *)getCustomThemesForBlog:(Blog *)blog
                                   sync:(BOOL)sync
-                               success:(ThemeServiceThemesRequestSuccessBlock)success
+                               success:(nullable ThemeServiceThemesRequestSuccessBlock)success
                                failure:(nullable ThemeServiceFailureBlock)failure;
 
 #pragma mark - Remote queries: Activating themes
@@ -89,7 +89,7 @@ typedef void(^ThemeServiceFailureBlock)(NSError * _Nullable error);
  */
 - (NSProgress *)activateTheme:(Theme *)theme
                       forBlog:(Blog *)blog
-                      success:(ThemeServiceThemeRequestSuccessBlock)success
+                      success:(nullable ThemeServiceThemeRequestSuccessBlock)success
                       failure:(nullable ThemeServiceFailureBlock)failure;
 
 #pragma mark - Remote queries: Installing themes
@@ -106,7 +106,7 @@ typedef void(^ThemeServiceFailureBlock)(NSError * _Nullable error);
  */
 - (NSProgress *)installTheme:(Theme *)theme
                       forBlog:(Blog *)blog
-                      success:(ThemeServiceSuccessBlock)success
+                      success:(nullable ThemeServiceSuccessBlock)success
                       failure:(nullable ThemeServiceFailureBlock)failure;
 
 

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
@@ -435,23 +435,21 @@ import AutomatticTracks
         if isViewLoaded {
             displayLoadingStream()
         }
-        assert(tagSlug != nil, "A tag slug is requred before fetching a tag topic")
+        guard let tagSlug else {
+            return wpAssertionFailure("tag slug is missing")
+        }
         let service = ReaderTopicService(coreDataStack: ContextManager.shared)
-        service.tagTopicForTag(withSlug: tagSlug,
-            success: { [weak self] (objectID: NSManagedObjectID?) in
-
-                let context = ContextManager.shared.mainContext
-                guard let objectID, let topic = (try? context.existingObject(with: objectID)) as? ReaderAbstractTopic else {
-                    DDLogError("Reader: Error retriving an existing tag topic by its objectID")
-                    self?.displayLoadingStreamFailed()
-                    return
-                }
-                self?.readerTopic = topic
-
-            },
-            failure: { [weak self] (error: Error?) in
+        service.tagTopicForTag(withSlug: tagSlug, success: { [weak self] objectID in
+            let context = ContextManager.shared.mainContext
+            guard let objectID, let topic = (try? context.existingObject(with: objectID)) as? ReaderAbstractTopic else {
+                DDLogError("Reader: Error retriving an existing tag topic by its objectID")
                 self?.displayLoadingStreamFailed()
-            })
+                return
+            }
+            self?.readerTopic = topic
+        }, failure: { [weak self] _ in
+            self?.displayLoadingStreamFailed()
+        })
     }
 
     // MARK: - Setup

--- a/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Manage/ReaderTagsTableViewModel.swift
@@ -209,7 +209,9 @@ extension ReaderTagsTableViewModel {
     ///     - topic: The tag topic that is to be unfollowed.
     private func unfollow(_ topic: ReaderTagTopic) {
         let service = ReaderTopicService(coreDataStack: ContextManager.shared)
-        service.unfollowTag(topic, withSuccess: nil) { (error) in
+        service.unfollowTag(topic, withSuccess: {
+            // Do nothing
+        }, failure: { error in
             DDLogError("Could not unfollow topic \(topic), \(String(describing: error))")
 
             let title = NSLocalizedString("Could Not Remove Topic", comment: "Title of a prompt informing the user there was a probem unsubscribing from a topic in the reader.")
@@ -217,7 +219,7 @@ extension ReaderTagsTableViewModel {
             let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
             alert.addCancelActionWithTitle(SharedStrings.Button.ok)
             alert.presentFromRootViewController()
-        }
+        })
     }
 
     /// Scrolls the tableView so the specified tag is in view and flashes that row

--- a/WordPress/WordPress-Swift.h
+++ b/WordPress/WordPress-Swift.h
@@ -1,7 +1,0 @@
-/// Due to a known issue, the compiler produces warnings on the Swift code that an intent definition file generates.
-/// Ref: https://developer.apple.com/forums/thread/686448
-/// As a workaround, we ignore all multiple method declarations warnings when importing WordPress-Swift.h
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wduplicate-method-match"
-#import "WordPress-Swift-XcodeGenerated.h"
-#pragma clang diagnostic pop

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1450,7 +1450,6 @@
 		7EC9FE0A22C627DB00C5A888 /* PostEditorAnalyticsSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostEditorAnalyticsSessionTests.swift; sourceTree = "<group>"; };
 		7EF2EE9F210A67B60007A76B /* notifications-unapproved-comment.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = "notifications-unapproved-comment.json"; sourceTree = "<group>"; };
 		801D951C291ADB7E0051993E /* OverlayFrequencyTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayFrequencyTrackerTests.swift; sourceTree = "<group>"; };
-		80293CF6284450AD0083F946 /* WordPress-Swift.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WordPress-Swift.h"; sourceTree = "<group>"; };
 		80379C6D2A5C0D8F00D924AC /* PostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostTests.swift; sourceTree = "<group>"; };
 		803BB99329667CF700B3F6D6 /* JetpackBrandingTextProviderTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = JetpackBrandingTextProviderTests.swift; sourceTree = "<group>"; };
 		803DE81828FFB7B5007D4E9C /* RemoteParameterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteParameterTests.swift; sourceTree = "<group>"; };
@@ -2561,7 +2560,6 @@
 				8D1107310486CEB800E47090 /* Info.plist */,
 				931DF4D818D09A2F00540BDD /* InfoPlist.strings */,
 				E1D91454134A853D0089019C /* Localizable.strings */,
-				80293CF6284450AD0083F946 /* WordPress-Swift.h */,
 				4A690C142BA790BC00A8E0C5 /* PrivacyInfo.xcprivacy */,
 			);
 			name = Resources;
@@ -6848,7 +6846,6 @@
 				PRODUCT_NAME = WordPress;
 				PROVISIONING_PROFILE_SPECIFIER = "WordPress Development";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(SWIFT_MODULE_NAME)-Swift-XcodeGenerated.h";
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -6904,7 +6901,6 @@
 				PRODUCT_NAME = WordPress;
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore org.wordpress";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(SWIFT_MODULE_NAME)-Swift-XcodeGenerated.h";
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -8088,7 +8084,6 @@
 				PRODUCT_NAME = WordPress;
 				PROVISIONING_PROFILE_SPECIFIER = "match InHouse org.wordpress.alpha";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(SWIFT_MODULE_NAME)-Swift-XcodeGenerated.h";
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -8657,7 +8652,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "Jetpack iOS Development";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(SWIFT_MODULE_NAME)-Swift-XcodeGenerated.h";
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -8713,7 +8707,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore com.automattic.jetpack";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(SWIFT_MODULE_NAME)-Swift-XcodeGenerated.h";
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
@@ -8765,7 +8758,6 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match InHouse com.jetpack.alpha";
 				SWIFT_OBJC_BRIDGING_HEADER = "Classes/System/WordPress-Bridging-Header.h";
-				SWIFT_OBJC_INTERFACE_HEADER_NAME = "$(SWIFT_MODULE_NAME)-Swift-XcodeGenerated.h";
 				SWIFT_TREAT_WARNINGS_AS_ERRORS = NO;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/WordPress/WordPressTest/ReaderTopicServiceTest.swift
+++ b/WordPress/WordPressTest/ReaderTopicServiceTest.swift
@@ -331,12 +331,12 @@ final class ReaderTopicSwiftTest: CoreDataTestCase {
         let results = try! mainContext.fetch(request)
 
         var topic = results.last as! ReaderAbstractTopic
-        XCTAssertEqual(service.currentTopic(in: mainContext).type, ReaderDefaultTopic.TopicType, "The curent topic should have been a default topic")
+        XCTAssertEqual(service.currentTopic(in: mainContext)?.type, ReaderDefaultTopic.TopicType, "The curent topic should have been a default topic")
 
         topic = results.first as! ReaderAbstractTopic
         service.setCurrentTopic(topic)
 
-        XCTAssertEqual(service.currentTopic(in: mainContext).path, topic.path, "The current topic did not match the topic we assiged to it")
+        XCTAssertEqual(service.currentTopic(in: mainContext)?.path, topic.path, "The current topic did not match the topic we assiged to it")
     }
 
     /**

--- a/WordPress/WordPressTest/ThemeServiceTests.m
+++ b/WordPress/WordPressTest/ThemeServiceTests.m
@@ -82,16 +82,6 @@
                                             failure:nil]);
 }
 
-- (void)testThatGetActiveThemeForBlogThrowsExceptionWithoutBlog
-{
-    ThemeService *service = nil;
-    
-    XCTAssertNoThrow(service = [[ThemeService alloc] initWithCoreDataStack:self.manager]);
-    XCTAssertThrows([service getActiveThemeForBlog:nil
-                                           success:nil
-                                           failure:nil]);
-}
-
 - (void)testThatGetThemesForBlogWorks
 {
     NSManagedObjectContext *context = self.manager.mainContext;
@@ -116,19 +106,6 @@
                                           sync:NO
                                        success:nil
                                        failure:nil]);
-}
-
-- (void)testThatGetThemesForBlogThrowsExceptionWithoutBlog
-{
-    ThemeService *service = nil;
-    
-    XCTAssertNoThrow(service = [[ThemeService alloc] initWithCoreDataStack:self.manager]);
-    XCTAssertThrows([service getThemesForBlog:nil
-                                         page:1
-                                       search:nil
-                                         sync:NO
-                                      success:nil
-                                      failure:nil]);
 }
 
 - (void)testThatActivateThemeWorks
@@ -156,24 +133,6 @@
                                     forBlog:blog
                                     success:nil
                                     failure:nil]);
-}
-
-- (void)testThatActivateThemeThrowsExceptionWithoutTheme
-{
-    NSManagedObjectContext *context = self.manager.mainContext;
-    Blog *blog = [ModelTestHelper insertDotComBlogWithContext:context];
-    NSNumber *blogId = @1;
-    WordPressComRestApi *api = OCMStrictClassMock([WordPressComRestApi class]);
-    ThemeService *service = nil;
-
-    blog.dotComID = blogId;
-    blog.account._private_wordPressComRestApi = api;
-
-    XCTAssertNoThrow(service = [[ThemeService alloc] initWithCoreDataStack:self.manager]);
-    XCTAssertThrows([service activateTheme:nil
-                                   forBlog:blog
-                                   success:nil
-                                   failure:nil]);
 }
 
 - (void)testThatActivateThemeThrowsExceptionWithoutBlog

--- a/WordPress/WordPressTest/ThemeServiceTests.m
+++ b/WordPress/WordPressTest/ThemeServiceTests.m
@@ -135,20 +135,5 @@
                                     failure:nil]);
 }
 
-- (void)testThatActivateThemeThrowsExceptionWithoutBlog
-{
-    NSManagedObjectContext *context = self.manager.mainContext;
-    Theme *theme = [NSEntityDescription insertNewObjectForEntityForName:[Theme entityName] inManagedObjectContext:context];
-    ThemeService *service = nil;
-
-    theme.themeId = @"SomeThemeId";
-
-    XCTAssertNoThrow(service = [[ThemeService alloc] initWithCoreDataStack:self.manager]);
-    XCTAssertThrows([service activateTheme:theme
-                                   forBlog:nil
-                                   success:nil
-                                   failure:nil]);
-}
-
 @end
 


### PR DESCRIPTION
This PR removes the following workaround/indirection:

```objc
/// Due to a known issue, the compiler produces warnings on the Swift code that an intent definition file generates.
/// Ref: https://developer.apple.com/forums/thread/686448
/// As a workaround, we ignore all multiple method declarations warnings when importing WordPress-Swift.h
#pragma clang diagnostic push
#pragma clang diagnostic ignored "-Wduplicate-method-match"
#import "WordPress-Swift-XcodeGenerated.h"
#pragma clang diagnostic pop
```

It doesn't appear to generate any new warnings. I did saw tow nullability warnings, which for some reason popped up, and I fixed them.

I removed this file because a) it's an unwanted indirection and b) it prevents me from temporarily changing Keystone module name to WordPress (the header it generates gets confused with this one)

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
