### PR TITLE
Make some `@objc` methods public so WordPressData can access them

### DIFF
--- a/WordPress/Classes/Extensions/Media/Media+Blog.swift
+++ b/WordPress/Classes/Extensions/Media/Media+Blog.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-extension Media {
+public extension Media {
 
     /// Inserts and returns a new managed Media object, in the context.
     ///

--- a/WordPress/Classes/Jetpack/Utility/SharedDataIssueSolver.swift
+++ b/WordPress/Classes/Jetpack/Utility/SharedDataIssueSolver.swift
@@ -24,7 +24,8 @@ public final class SharedDataIssueSolver: NSObject {
 
     /// Helper method for creating an instance in Obj-C
     ///
-    class func instance() -> SharedDataIssueSolver {
+    @objc
+    public class func instance() -> SharedDataIssueSolver {
         return SharedDataIssueSolver()
     }
 

--- a/WordPress/Classes/Models/Blog/Blog+Post.swift
+++ b/WordPress/Classes/Models/Blog/Blog+Post.swift
@@ -36,7 +36,7 @@ extension Blog {
     /// - Parameter foreignID: The foreign ID associated with the post; used to deduplicate new posts.
     /// - Returns: The `AbstractPost` associated with the given foreign ID.
     @objc(lookupPostWithForeignID:inContext:)
-    func lookupPost(withForeignID foreignID: UUID, in context: NSManagedObjectContext) -> AbstractPost? {
+    public func lookupPost(withForeignID foreignID: UUID, in context: NSManagedObjectContext) -> AbstractPost? {
         let request = NSFetchRequest<AbstractPost>(entityName: NSStringFromClass(AbstractPost.self))
         request.predicate = NSPredicate(format: "blog = %@ AND original = NULL AND \(#keyPath(AbstractPost.foreignID)) == %@", self, foreignID as NSUUID)
         request.fetchLimit = 1

--- a/WordPress/Classes/Models/Blog/Blog+SelfHosted.swift
+++ b/WordPress/Classes/Models/Blog/Blog+SelfHosted.swift
@@ -64,7 +64,7 @@ extension Blog {
 
     @available(swift, obsoleted: 1.0)
     @objc(deleteApplicationToken)
-    func objc_deleteApplicationToken() {
+    public func objc_deleteApplicationToken() {
         _ = try? deleteApplicationToken()
     }
 

--- a/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
+++ b/WordPress/Classes/Networking/WordPressOrgRestApi+WordPress.swift
@@ -17,7 +17,7 @@ private func apiBase(blog: Blog) -> URL? {
 
 extension WordPressOrgRestApi {
     @objc
-    convenience init?(blog: Blog) {
+    public convenience init?(blog: Blog) {
         self.init(
             blog: blog,
             userAgent: WPUserAgent.wordPress(),

--- a/WordPress/Classes/RemotePost+Metadata.swift
+++ b/WordPress/Classes/RemotePost+Metadata.swift
@@ -2,7 +2,7 @@ import Foundation
 import WordPressShared
 
 @objc
-extension RemotePost {
+public extension RemotePost {
     var foreignID: UUID? {
         guard let metadata else {
             return nil

--- a/WordPress/Classes/Services/PostHelper+JetpackSocial.swift
+++ b/WordPress/Classes/Services/PostHelper+JetpackSocial.swift
@@ -1,5 +1,5 @@
 extension PostHelper {
-    typealias StringDictionary = [String: String]
+    public typealias StringDictionary = [String: String]
     typealias Keys = Post.Constants
     typealias SkipPrefix = Post.PublicizeMetadataSkipPrefix
 
@@ -15,7 +15,7 @@ extension PostHelper {
     ///   - metadata: The metadata dictionary for the post. Optional because Obj-C shouldn't be trusted.
     /// - Returns: A dictionary for the `Post`'s `disabledPublicizeConnections` property.
     @objc(disabledPublicizeConnectionsForPost:andMetadata:)
-    static func disabledPublicizeConnections(for post: AbstractPost?, metadata: [[String: Any]]?) -> [NSNumber: StringDictionary] {
+    public static func disabledPublicizeConnections(for post: AbstractPost?, metadata: [[String: Any]]?) -> [NSNumber: StringDictionary] {
         guard let post, let metadata else {
             return [:]
         }
@@ -70,7 +70,7 @@ extension PostHelper {
     /// - Parameter post: The associated `Post` object.
     /// - Returns: An array of metadata dictionaries representing the `Post`'s disabled connections.
     @objc(publicizeMetadataEntriesForPost:)
-    static func publicizeMetadataEntries(for post: Post?) -> [StringDictionary] {
+    public static func publicizeMetadataEntries(for post: Post?) -> [StringDictionary] {
         guard let post,
               let disabledConnectionsDictionary = post.disabledPublicizeConnections else {
             return []

--- a/WordPress/Classes/Utility/Media/MediaFileManager.swift
+++ b/WordPress/Classes/Utility/Media/MediaFileManager.swift
@@ -53,7 +53,7 @@ public class MediaFileManager: NSObject {
     /// Helper method for getting a MediaFileManager for the .cache directory.
     ///
     @objc(cacheManager)
-    class var cache: MediaFileManager {
+    public class var cache: MediaFileManager {
         return MediaFileManager(directory: .cache)
     }
 
@@ -73,7 +73,7 @@ public class MediaFileManager: NSObject {
 
     /// Returns filesystem URL for the local Media directory.
     ///
-    @objc func directoryURL() throws -> URL {
+    @objc public func directoryURL() throws -> URL {
         let fileManager = FileManager.default
         let mediaDirectory = directory.url
         // Check whether or not the file path exists for the Media directory.
@@ -216,7 +216,7 @@ public class MediaFileManager: NSObject {
 
     /// Helper method for getting the default upload directory URL.
     ///
-    @objc class func uploadsDirectoryURL() throws -> URL {
+    @objc public class func uploadsDirectoryURL() throws -> URL {
         return try MediaFileManager.default.directoryURL()
     }
 


### PR DESCRIPTION
I never looked into it, but apparently the `public` access level for `@objc` is required in a framework setup for those methods to be accessible through the `<framework name>-Swift.h` generated header.

We run into the same issue in Keystone, see https://github.com/wordpress-mobile/WordPress-iOS/pull/24383

Part of #24165