### PR TITLE
Add placeholder step in CI for Reader unit tests

### DIFF
--- a/.buildkite/commands/run-unit-tests-reader.sh
+++ b/.buildkite/commands/run-unit-tests-reader.sh
@@ -1,0 +1,12 @@
+#!/bin/bash -eu
+
+# Run this at the start to fail early if value not available
+# TODO: We'll need to create a token for Reader
+# echo '--- :test-analytics: Configuring Test Analytics'
+# export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS
+
+"$(dirname "${BASH_SOURCE[0]}")/shared-set-up.sh"
+
+# For the moment, run code signing here just to show it works
+# TODO: This will move to the prototype and production builds steps eventually...
+bundle exec fastlane update_certs_and_profiles_app_store_reader

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -52,15 +52,17 @@ steps:
   #################
   # Run Unit Tests
   #################
-  - label: "🔬 :wordpress: Unit Tests"
-    command: ".buildkite/commands/run-unit-tests.sh"
-    depends_on: "build_wordpress"
-    plugins: [$CI_TOOLKIT_PLUGIN]
-    artifact_paths:
-      - "build/results/*"
-    notify:
-      - github_commit_status:
-          context: "Unit Tests"
+  - group: "🔬 Unit Tests"
+    steps:
+      - label: "🔬 :wordpress: Unit Tests"
+        command: ".buildkite/commands/run-unit-tests.sh"
+        depends_on: "build_wordpress"
+        plugins: [$CI_TOOLKIT_PLUGIN]
+        artifact_paths:
+          - "build/results/*"
+        notify:
+          - github_commit_status:
+              context: "Unit Tests"
 
   #################
   # UI Tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -63,6 +63,14 @@ steps:
         notify:
           - github_commit_status:
               context: "Unit Tests"
+      - label: "🔬 Reader Unit Tests"
+        command: ".buildkite/commands/run-unit-tests-reader.sh"
+        plugins: [$CI_TOOLKIT_PLUGIN]
+        artifact_paths:
+          - "build/results/*"
+        notify:
+          - github_commit_status:
+              context: "Reader Unit Tests"
 
   #################
   # UI Tests

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -47,6 +47,10 @@ JETPACK_EXTENSIONS_BUNDLE_IDENTIFIERS = %w[
 ].map { |suffix| "#{JETPACK_BUNDLE_IDENTIFIER}.#{suffix}" }
 ALL_JETPACK_BUNDLE_IDENTIFIERS = [JETPACK_BUNDLE_IDENTIFIER, *JETPACK_EXTENSIONS_BUNDLE_IDENTIFIERS].freeze
 
+READER_BUNDLE_IDENTIFIER = 'com.automattic.reader'
+# Redundant but handy for consistency, especially in codesign.rb
+ALL_READER_BUNDLE_IDENTIFIERS = [READER_BUNDLE_IDENTIFIER].freeze
+
 # Environment Variables — used by lanes but also potentially actions
 Dotenv.load(USER_ENV_FILE_PATH)
 Dotenv.load(PROJECT_ENV_FILE_PATH)

--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -87,6 +87,18 @@ platform :ios do
     )
   end
 
+  # Downloads all the required certificates and profiles (using `match``) for the Reader App Store builds.
+  # Optionally, it can create any new necessary certificate or profile.
+  #
+  # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
+  #
+  lane :update_certs_and_profiles_app_store_reader do |readonly: true|
+    update_code_signing_app_store(
+      app_identifiers: ALL_READER_BUNDLE_IDENTIFIERS,
+      readonly: readonly
+    )
+  end
+
   # Downloads all the required certificates and profiles (using `match`) for both Jetpack and WordPress App Store variants.
   # Optionally, it can create any new necessary certificate or profile.
   #


### PR DESCRIPTION
Currently only runs code signing sync to validate that bit of the process, see code comments.

There's a lot to discuss regarding infra and release process, but we don't have to have a plan for that to add a walking skeleton.

<img width="899" alt="image" src="https://github.com/user-attachments/assets/9272fe96-034e-4bdf-b71f-b3a7e5aeac95" />
