### PR TITLE
Add missing access control modifiers

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -140,13 +140,13 @@ extension WPStyleGuide {
     }
 
     @objc
-    class func configureTableViewActionCell(_ cell: UITableViewCell?) {
+    public class func configureTableViewActionCell(_ cell: UITableViewCell?) {
         configureTableViewCell(cell)
         cell?.textLabel?.textColor = UIAppColor.primary
     }
 
     @objc
-    class func configureTableViewDestructiveActionCell(_ cell: UITableViewCell) {
+    public class func configureTableViewDestructiveActionCell(_ cell: UITableViewCell) {
         configureTableViewCell(cell)
 
         cell.textLabel?.textAlignment = .center

--- a/WordPress/Classes/Extensions/SVProgressHUD+Extensions.swift
+++ b/WordPress/Classes/Extensions/SVProgressHUD+Extensions.swift
@@ -1,13 +1,13 @@
 import SVProgressHUD
 
 extension SVProgressHUD {
-    @objc class func showDismissibleError(status: String) {
+    @objc public class func showDismissibleError(status: String) {
         registerForHUDNotifications()
         SVProgressHUD.setDefaultMaskType(.clear)
         SVProgressHUD.showError(withStatus: status)
     }
 
-    @objc class func showDismissibleSuccess(status: String) {
+    @objc public class func showDismissibleSuccess(status: String) {
         registerForHUDNotifications()
         SVProgressHUD.setDefaultMaskType(.clear)
         SVProgressHUD.showSuccess(withStatus: status)

--- a/WordPress/Classes/Models/Blog/Blog+WordPressComRestAPI.swift
+++ b/WordPress/Classes/Models/Blog/Blog+WordPressComRestAPI.swift
@@ -1,7 +1,7 @@
 import WordPressData
 import WordPressKit
 
-public extension Blog {
+extension Blog {
 
     /// Returns a REST API client, if available
     ///

--- a/WordPress/Classes/Services/CommentServiceRemoteFactory.swift
+++ b/WordPress/Classes/Services/CommentServiceRemoteFactory.swift
@@ -2,13 +2,13 @@ import Foundation
 import WordPressKit
 
 /// Provides service remote instances for CommentService
-@objc class CommentServiceRemoteFactory: NSObject {
+@objc public class CommentServiceRemoteFactory: NSObject {
 
     /// Returns a CommentServiceRemote for a given Blog object
     ///
     /// - Parameter blog: A valid Blog object
     /// - Returns: A CommentServiceRemote instance
-    @objc func remote(blog: Blog) -> CommentServiceRemote? {
+    @objc public func remote(blog: Blog) -> CommentServiceRemote? {
         if blog.supports(.wpComRESTAPI),
            let api = blog.wordPressComRestApi,
            let dotComID = blog.dotComID {
@@ -30,7 +30,7 @@ import WordPressKit
     ///   - siteID: A valid siteID
     ///   - api: An instance of WordPressComRestAPI
     /// - Returns: An instance of CommentServiceRemoteREST
-    @objc func restRemote(siteID: NSNumber, api: WordPressComRestApi) -> CommentServiceRemoteREST {
+    @objc public func restRemote(siteID: NSNumber, api: WordPressComRestApi) -> CommentServiceRemoteREST {
         return CommentServiceRemoteREST(wordPressComRestApi: api, siteID: siteID)
     }
 

--- a/WordPress/Classes/Services/JetpackCapabilitiesService.swift
+++ b/WordPress/Classes/Services/JetpackCapabilitiesService.swift
@@ -1,6 +1,6 @@
 import WordPressKit
 
-@objc class JetpackCapabilitiesService: NSObject {
+@objc public class JetpackCapabilitiesService: NSObject {
 
     let capabilitiesServiceRemote: JetpackCapabilitiesServiceRemote
 
@@ -16,7 +16,7 @@ import WordPressKit
         }
     }
 
-    override convenience init() {
+    public override convenience init() {
         self.init(coreDataStack: ContextManager.shared, capabilitiesServiceRemote: nil)
     }
 
@@ -24,7 +24,7 @@ import WordPressKit
     /// - Parameters:
     ///   - blogs: An array of RemoteBlog
     ///   - success: A block that accepts an array of RemoteBlog
-    @objc func sync(blogs: [RemoteBlog], success: @escaping ([RemoteBlog]) -> Void) {
+    @objc public func sync(blogs: [RemoteBlog], success: @escaping ([RemoteBlog]) -> Void) {
         capabilitiesServiceRemote.for(siteIds: blogs.compactMap { $0.blogID as? Int },
                  success: { capabilities in
                     blogs.forEach { blog in

--- a/WordPress/Classes/Services/MediaHelper.swift
+++ b/WordPress/Classes/Services/MediaHelper.swift
@@ -1,10 +1,10 @@
 import UIKit
 import AsyncImageKit
 
-class MediaHelper: NSObject {
+public class MediaHelper: NSObject {
 
     @objc(updateMedia:withRemoteMedia:)
-    static func update(media: Media, with remoteMedia: RemoteMedia) {
+    public static func update(media: Media, with remoteMedia: RemoteMedia) {
         if media.mediaID != remoteMedia.mediaID {
             media.mediaID = remoteMedia.mediaID
         }

--- a/WordPress/Classes/Services/SharingService.swift
+++ b/WordPress/Classes/Services/SharingService.swift
@@ -6,7 +6,7 @@ import WordPressKit
 /// SharingService is responsible for wrangling publicize services, publicize
 /// connections, and keyring connections.
 ///
-@objc class SharingService: NSObject {
+@objc public class SharingService: NSObject {
     let SharingAPIErrorNotFound = "not_found"
 
     private let coreDataStack: CoreDataStackSwift
@@ -15,7 +15,7 @@ import WordPressKit
     ///
     /// Using `ContextManager` as the argument becuase `CoreDataStackSwift` is not accessible from Objective-C code.
     @objc
-    init(contextManager: ContextManager) {
+    public init(contextManager: ContextManager) {
         self.coreDataStack = contextManager
     }
 
@@ -32,7 +32,7 @@ import WordPressKit
     ///     - success: An optional success block accepting no parameters
     ///     - failure: An optional failure block accepting an `NSError` parameter
     ///
-    @objc func syncPublicizeServicesForBlog(_ blog: Blog, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
+    @objc public func syncPublicizeServicesForBlog(_ blog: Blog, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
         guard let remote = remoteForBlog(blog),
               let blogID = blog.dotComID else {
             failure?(nil)
@@ -53,7 +53,7 @@ import WordPressKit
     ///     - success: An optional success block accepting an array of `KeyringConnection` objects
     ///     - failure: An optional failure block accepting an `NSError` parameter
     ///
-    @objc func fetchKeyringConnectionsForBlog(_ blog: Blog, success: (([KeyringConnection]) -> Void)?, failure: ((NSError?) -> Void)?) {
+    @objc public func fetchKeyringConnectionsForBlog(_ blog: Blog, success: (([KeyringConnection]) -> Void)?, failure: ((NSError?) -> Void)?) {
         guard let remote = remoteForBlog(blog) else {
             return
         }
@@ -74,7 +74,7 @@ import WordPressKit
     ///     - success: An optional success block accepting a `PublicizeConnection` parameter.
     ///     - failure: An optional failure block accepting an NSError parameter.
     ///
-    @objc func createPublicizeConnectionForBlog(_ blog: Blog,
+    @objc public func createPublicizeConnectionForBlog(_ blog: Blog,
         keyring: KeyringConnection,
         externalUserID: String?,
         success: ((PublicizeConnection) -> Void)?,
@@ -126,7 +126,7 @@ import WordPressKit
     ///     - success: An optional success block accepting no parameters.
     ///     - failure: An optional failure block accepting an NSError parameter.
     ///
-    @objc func updateSharedForBlog(
+    @objc public func updateSharedForBlog(
         _ blog: Blog,
         shared: Bool,
         forPublicizeConnection pubConn: PublicizeConnection,
@@ -203,7 +203,7 @@ import WordPressKit
     ///     - success: An optional success block accepting no parameters.
     ///     - failure: An optional failure block accepting an NSError parameter.
     ///
-    @objc func updateExternalID(_ externalID: String,
+    @objc public func updateExternalID(_ externalID: String,
         forBlog blog: Blog,
         forPublicizeConnection pubConn: PublicizeConnection,
         success: (() -> Void)?,
@@ -246,7 +246,7 @@ import WordPressKit
     ///     - success: An optional success block accepting no parameters.
     ///     - failure: An optional failure block accepting an NSError parameter.
     ///
-    @objc func deletePublicizeConnectionForBlog(_ blog: Blog, pubConn: PublicizeConnection, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
+    @objc public func deletePublicizeConnectionForBlog(_ blog: Blog, pubConn: PublicizeConnection, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
         // optimistically delete the connection locally.
         coreDataStack.performAndSave({ context in
             let blogInContext = try context.existingObject(with: blog.objectID) as! Blog
@@ -374,7 +374,7 @@ import WordPressKit
     ///     - success: An optional success block accepting no parameters.
     ///     - failure: An optional failure block accepting an `NSError` parameter.
     ///
-    @objc func syncSharingButtonsForBlog(_ blog: Blog, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
+    @objc public func syncSharingButtonsForBlog(_ blog: Blog, success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
         let blogObjectID = blog.objectID
         guard let remote = remoteForBlog(blog) else {
             return
@@ -395,7 +395,7 @@ import WordPressKit
     ///     - success: An optional success block accepting no parameters.
     ///     - failure: An optional failure block accepting an `NSError` parameter.
     ///
-    @objc func updateSharingButtonsForBlog(_ blog: Blog, sharingButtons: [SharingButton], success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
+    @objc public func updateSharingButtonsForBlog(_ blog: Blog, sharingButtons: [SharingButton], success: (() -> Void)?, failure: ((NSError?) -> Void)?) {
 
         let blogObjectID = blog.objectID
         guard let remote = remoteForBlog(blog) else {

--- a/WordPress/Classes/Services/SharingSyncService.swift
+++ b/WordPress/Classes/Services/SharingSyncService.swift
@@ -5,11 +5,11 @@ import WordPressKit
 /// SharingService is responsible for wrangling publicize services, publicize
 /// connections, and keyring connections.
 ///
-@objc class SharingSyncService: NSObject {
+@objc public class SharingSyncService: NSObject {
 
     let coreDataStack: CoreDataStack
 
-    @objc init(coreDataStack: CoreDataStack) {
+    @objc public init(coreDataStack: CoreDataStack) {
         self.coreDataStack = coreDataStack
     }
 

--- a/WordPress/Classes/Utility/Animator.swift
+++ b/WordPress/Classes/Utility/Animator.swift
@@ -41,7 +41,7 @@ import UIKit
 ///
 /// Animator is heavily inspired by the final demo on WWDC 2014 Session 236
 /// [Building Interruptible and Responsive Interactions](https://developer.apple.com/videos/play/wwdc2014-236/).
-class Animator: NSObject {
+public class Animator: NSObject {
     fileprivate var animationsInProgress = 0
 
     /// Animates changes to one or more views using the specified duration.
@@ -51,7 +51,7 @@ class Animator: NSObject {
     ///     - animations: A block object containing the changes to commit to the views.
     ///     - cleanup: A block called after the animations complete if there are no more pending animations.
     ///
-    @objc func animateWithDuration(_ duration: TimeInterval, preamble: (() -> Void)? = nil, animations: @escaping () -> Void, cleanup: (() -> Void)? = nil) {
+    @objc public func animateWithDuration(_ duration: TimeInterval, preamble: (() -> Void)? = nil, animations: @escaping () -> Void, cleanup: (() -> Void)? = nil) {
         precondition(Thread.isMainThread, "Animator only works on the main (UI) thread")
 
         if animationsInProgress == 0 {

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -3,7 +3,7 @@ import BuildSettingsKit
 /// FeatureFlag exposes a series of features to be conditionally enabled on
 /// different builds.
 @objc
-enum FeatureFlag: Int, CaseIterable {
+public enum FeatureFlag: Int, CaseIterable {
     case signUp
     case customAppIcons
     case domainRegistration
@@ -90,16 +90,16 @@ enum FeatureFlag: Int, CaseIterable {
 /// Objective-C bridge for FeatureFlag.
 ///
 /// Since we can't expose properties on Swift enums we use a class instead
-class Feature: NSObject {
+public class Feature: NSObject {
     /// Returns a boolean indicating if the feature is enabled
-    @objc static func enabled(_ feature: FeatureFlag) -> Bool {
+    @objc public static func enabled(_ feature: FeatureFlag) -> Bool {
         return feature.enabled
     }
 }
 
 extension FeatureFlag {
     /// Descriptions used to display the feature flag override menu in debug builds
-    var description: String {
+    public var description: String {
         return switch self {
         case .signUp: "Sign Up"
         case .customAppIcons: "Custom App Icons"

--- a/WordPress/Classes/Utility/Logging/CustomLogFormatter.swift
+++ b/WordPress/Classes/Utility/Logging/CustomLogFormatter.swift
@@ -1,8 +1,7 @@
 import Foundation
 import CocoaLumberjack
 
-class CustomLogFormatter: NSObject, DDLogFormatter {
-
+public class CustomLogFormatter: NSObject, DDLogFormatter {
     let logTimeStampFormatter: DateFormatter = {
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
@@ -11,10 +10,9 @@ class CustomLogFormatter: NSObject, DDLogFormatter {
         return formatter
     }()
 
-    func format(message logMessage: DDLogMessage) -> String? {
+    public func format(message logMessage: DDLogMessage) -> String? {
         let timestamp = logTimeStampFormatter.string(from: logMessage.timestamp)
         let message = logMessage.message
         return ("\(timestamp) \(message)")
     }
-
 }

--- a/WordPress/Classes/Utility/MessageAnimator.swift
+++ b/WordPress/Classes/Utility/MessageAnimator.swift
@@ -18,18 +18,18 @@ import WordPressUI
 ///  - `animateMessage(_)` when you want to change the message displayed. Pass
 /// nil if you want to hide the error view.
 ///
-class MessageAnimator: Animator {
+public class MessageAnimator: Animator {
 
     // MARK: - Private Constants
-    fileprivate struct Defaults {
+    private struct Defaults {
         static let animationDuration = 0.3
         static let padding = UIOffset(horizontal: 15, vertical: 20)
         static let labelFont = WPStyleGuide.regularTextFont()
     }
 
     // MARK: - Private properties
-    fileprivate var previousHeight: CGFloat = 0
-    fileprivate var message: String? {
+    private var previousHeight: CGFloat = 0
+    private var message: String? {
         get {
             return noticeLabel.label.text
         }
@@ -39,8 +39,8 @@ class MessageAnimator: Animator {
     }
 
     // MARK: - Private Immutable Properties
-    fileprivate let targetView: UIView
-    fileprivate let noticeLabel: PaddedLabel = {
+    private let targetView: UIView
+    private let noticeLabel: PaddedLabel = {
         let label = PaddedLabel()
         label.backgroundColor = UIAppColor.primary(.shade40)
         label.clipsToBounds = true
@@ -52,28 +52,28 @@ class MessageAnimator: Animator {
     }()
 
     // MARK: - Private Computed Properties
-    fileprivate var shouldDisplayMessage: Bool {
+    private var shouldDisplayMessage: Bool {
         return message != nil
     }
-    fileprivate var targetTableView: UITableView? {
+    private var targetTableView: UITableView? {
         return targetView as? UITableView
     }
 
     // MARK: - Initializers
-    @objc init(target: UIView) {
+    @objc public init(target: UIView) {
         targetView = target
         super.init()
     }
 
     // MARK: - Public Methods
-    @objc func layout() {
+    @objc public func layout() {
         var targetFrame = noticeLabel.frame
         targetFrame.size.width = targetView.bounds.width
         targetFrame.size.height = heightForMessage(message)
         noticeLabel.frame = targetFrame
     }
 
-    @objc func animateMessage(_ message: String?) {
+    @objc public func animateMessage(_ message: String?) {
         let shouldAnimate = self.message != message
         self.message = message
 
@@ -83,7 +83,7 @@ class MessageAnimator: Animator {
     }
 
     // MARK: - Animation Methods
-    fileprivate func preamble() {
+    private func preamble() {
         UIView.performWithoutAnimation { [weak self] in
             self?.targetView.layoutIfNeeded()
         }
@@ -95,7 +95,7 @@ class MessageAnimator: Animator {
         }
     }
 
-    fileprivate func animations() {
+    private func animations() {
         let height = heightForMessage(message)
 
         if shouldDisplayMessage {
@@ -122,7 +122,7 @@ class MessageAnimator: Animator {
         previousHeight = height
     }
 
-    fileprivate func cleanup() {
+    private func cleanup() {
         if shouldDisplayMessage == false {
             noticeLabel.removeFromSuperview()
             previousHeight = CGSize.zero.height
@@ -130,7 +130,7 @@ class MessageAnimator: Animator {
     }
 
     // MARK: - Helpers
-    fileprivate func heightForMessage(_ message: String?) -> CGFloat {
+    private func heightForMessage(_ message: String?) -> CGFloat {
         guard let message else {
             return CGSize.zero.height
         }

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/PublicizeServicesState.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/PublicizeServicesState.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-@objc final class PublicizeServicesState: NSObject {
+@objc public final class PublicizeServicesState: NSObject {
     private var connections = Set<PublicizeConnection>()
 }
 
 // MARK: - Public Methods
-@objc extension PublicizeServicesState {
+@objc public extension PublicizeServicesState {
     func addInitialConnections(_ connections: [PublicizeConnection]) {
         connections.forEach { self.connections.insert($0) }
     }

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+Swift.swift
@@ -2,7 +2,7 @@ import WordPressShared
 
 // MARK: - Tab Access Tracking
 
-@objc enum WPTab: Int {
+@objc public enum WPTab: Int {
     case mySites
     case reader
     case notifications


### PR DESCRIPTION
Same deal as https://github.com/wordpress-mobile/WordPress-iOS/pull/24388. Only `public` adds.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
