### PR TITLE
Build and test Keystone and WordPressData in CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -71,6 +71,20 @@ steps:
         notify:
           - github_commit_status:
               context: "Reader Unit Tests"
+      - label: "🔬 Keystone Unit Tests"
+        command: |
+          .buildkite/commands/shared-set-up.sh
+          xcodebuild \
+            -scheme Keystone \
+            -destination 'platform=iOS Simulator,OS=18.3.1,name=iPhone 16' \
+            test \
+            | xcbeautify
+        plugins: [$CI_TOOLKIT_PLUGIN]
+        artifact_paths:
+          - "build/results/*"
+        notify:
+          - github_commit_status:
+              context: "Unit Tests Keystone"
       - label: "🔬 WordPressData Unit Tests"
         command: |
           .buildkite/commands/shared-set-up.sh

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -71,6 +71,20 @@ steps:
         notify:
           - github_commit_status:
               context: "Reader Unit Tests"
+      - label: "🔬 WordPressData Unit Tests"
+        command: |
+          .buildkite/commands/shared-set-up.sh
+          xcodebuild \
+            -scheme WordPressData \
+            -destination 'platform=iOS Simulator,OS=18.3.1,name=iPhone 16' \
+            test \
+            | xcbeautify
+        plugins: [$CI_TOOLKIT_PLUGIN]
+        artifact_paths:
+          - "build/results/*"
+        notify:
+          - github_commit_status:
+              context: "Unit Tests WordPressData"
 
   #################
   # UI Tests

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -76,7 +76,7 @@ steps:
           .buildkite/commands/shared-set-up.sh
           xcodebuild \
             -scheme Keystone \
-            -destination 'platform=iOS Simulator,OS=18.3.1,name=iPhone 16' \
+            -destination 'platform=iOS Simulator,OS=18.2,name=iPhone 16' \
             test \
             | xcbeautify
         plugins: [$CI_TOOLKIT_PLUGIN]
@@ -90,7 +90,7 @@ steps:
           .buildkite/commands/shared-set-up.sh
           xcodebuild \
             -scheme WordPressData \
-            -destination 'platform=iOS Simulator,OS=18.3.1,name=iPhone 16' \
+            -destination 'platform=iOS Simulator,OS=18.2,name=iPhone 16' \
             test \
             | xcbeautify
         plugins: [$CI_TOOLKIT_PLUGIN]

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Keystone.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Keystone.xcscheme
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "0CED016F2D95B897003015CF"
+               BuildableName = "Keystone.framework"
+               BlueprintName = "Keystone"
+               ReferencedContainer = "container:WordPress.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "0CED016F2D95B897003015CF"
+            BuildableName = "Keystone.framework"
+            BlueprintName = "Keystone"
+            ReferencedContainer = "container:WordPress.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>


### PR DESCRIPTION
While neither framework is good to go, I find it useful to have CI feedback on their compilation and unit tests status.

Granted, Keystone has no tests at the moment, but at least we have the step in place.

![image](https://github.com/user-attachments/assets/e2f94eb2-c939-4370-ad5c-391c20a28874)

As for WordPressData, there are only two dummy tests, but, again, at least it's in place. https://github.com/wordpress-mobile/WordPress-iOS/pull/24378 and its follow ups will changes this.

<img width="1569" alt="image" src="https://github.com/user-attachments/assets/e0b58021-3f9b-4674-974b-7f6d9e2705fe" />
