### PR TITLE
Decouple `Blog` from `JetpackFeaturesRemovalCoordinator`

### DIFF
--- a/Modules/Sources/BuildSettingsKit/BuildSettings.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings.swift
@@ -31,6 +31,12 @@ public struct BuildSettings: Sendable {
         public var twitterHandle: String
         public var twitterURL: URL
         public var blogURL: URL
+
+        init(twitterHandle: String, twitterURL: URL, blogURL: URL) {
+            self.twitterHandle = twitterHandle
+            self.twitterURL = twitterURL
+            self.blogURL = blogURL
+        }
     }
 
     public static var current: BuildSettings {
@@ -43,6 +49,38 @@ public struct BuildSettings: Sendable {
             // TODO: update tests to ensure none of the rely on `BuildSettings` availability as it's incompatible with parallelized tests
             return .live
         }
+    }
+
+    init(
+        configuration: BuildConfiguration,
+        brand: AppBrand,
+        pushNotificationAppID: String,
+        appGroupName: String,
+        appKeychainAccessGroup: String,
+        eventNamePrefix: String,
+        explatPlatform: String,
+        itunesAppID: String,
+        appURLScheme: String,
+        jetpackAppURLScheme: String,
+        about: ProductAboutDetails,
+        zendeskSourcePlatform: String,
+        mobileAnnounceAppID: String,
+        authKeychainServiceName: String
+    ) {
+        self.configuration = configuration
+        self.brand = brand
+        self.pushNotificationAppID = pushNotificationAppID
+        self.appGroupName = appGroupName
+        self.appKeychainAccessGroup = appKeychainAccessGroup
+        self.eventNamePrefix = eventNamePrefix
+        self.explatPlatform = explatPlatform
+        self.itunesAppID = itunesAppID
+        self.appURLScheme = appURLScheme
+        self.jetpackAppURLScheme = jetpackAppURLScheme
+        self.about = about
+        self.zendeskSourcePlatform = zendeskSourcePlatform
+        self.mobileAnnounceAppID = mobileAnnounceAppID
+        self.authKeychainServiceName = authKeychainServiceName
     }
 }
 

--- a/WordPress/Classes/Models/Blog/Blog.m
+++ b/WordPress/Classes/Models/Blog/Blog.m
@@ -846,12 +846,6 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
     return _selfHostedSiteRestApi;
 }
 
-- (BOOL)supportsRestApi {
-    // We don't want to check for `restApi` as it can be `nil` when the token
-    // is missing from the keychain.
-    return self.account != nil;
-}
-
 #pragma mark - Jetpack
 
 - (BOOL)jetpackActiveModule:(NSString *)moduleName

--- a/WordPress/Classes/Models/Blog/Blog.m
+++ b/WordPress/Classes/Models/Blog/Blog.m
@@ -571,7 +571,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
         case BlogFeatureStockPhotos:
             return [self supportsStockPhotos];
         case BlogFeatureTenor:
-            return [JetpackFeaturesRemovalCoordinator jetpackFeaturesEnabled];
+            return [self supportsTenor];
         case BlogFeatureSharing:
             return [self supportsSharing];
         case BlogFeatureOAuth2Login:

--- a/WordPress/Classes/Models/Blog/Blog.m
+++ b/WordPress/Classes/Models/Blog/Blog.m
@@ -569,7 +569,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
         case BlogFeatureStats:
             return [self supportsRestApi] && [self isViewingStatsAllowed];
         case BlogFeatureStockPhotos:
-            return [self supportsRestApi] && [JetpackFeaturesRemovalCoordinator jetpackFeaturesEnabled];
+            return [self supportsStockPhotos];
         case BlogFeatureTenor:
             return [JetpackFeaturesRemovalCoordinator jetpackFeaturesEnabled];
         case BlogFeatureSharing:

--- a/WordPress/Classes/Models/Blog/Blog.swift
+++ b/WordPress/Classes/Models/Blog/Blog.swift
@@ -1,0 +1,11 @@
+import BuildSettingsKit
+
+extension Blog {
+
+    @objc
+    public func supportsRestApi() -> Bool {
+        // We don't want to check for `restApi` as it can be `nil` when the token is missing from
+        // the keychain
+        account != nil
+    }
+}

--- a/WordPress/Classes/Models/Blog/Blog.swift
+++ b/WordPress/Classes/Models/Blog/Blog.swift
@@ -13,6 +13,16 @@ extension Blog {
     }
 
     @objc
+    @available(*, unavailable)
+    public func supportsTenor() -> Bool {
+        supportsTenor(buildSettings: .current)
+    }
+
+    func supportsTenor(buildSettings: BuildSettings = .current) -> Bool {
+        return buildSettings.brand == .jetpack
+    }
+
+    @objc
     public func supportsRestApi() -> Bool {
         // We don't want to check for `restApi` as it can be `nil` when the token is missing from
         // the keychain

--- a/WordPress/Classes/Models/Blog/Blog.swift
+++ b/WordPress/Classes/Models/Blog/Blog.swift
@@ -3,6 +3,16 @@ import BuildSettingsKit
 extension Blog {
 
     @objc
+    @available(*, unavailable)
+    public func supportsStockPhotos() -> Bool {
+        supportsStockPhotos(buildSettings: .current)
+    }
+
+    func supportsStockPhotos(buildSettings: BuildSettings = .current) -> Bool {
+        return supportsRestApi() && buildSettings.brand == .jetpack
+    }
+
+    @objc
     public func supportsRestApi() -> Bool {
         // We don't want to check for `restApi` as it can be `nil` when the token is missing from
         // the keychain

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -184,6 +184,7 @@
 		3F0FD9FD2D9B92F700CD05D6 /* WordPressData.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3F7AE0B52D9B30A100AB4892 /* WordPressData.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		3F0FDA002D9B930100CD05D6 /* WordPressData.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3F7AE0B52D9B30A100AB4892 /* WordPressData.framework */; };
 		3F0FDA012D9B930100CD05D6 /* WordPressData.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 3F7AE0B52D9B30A100AB4892 /* WordPressData.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		3F16AF222D9CF991008BC606 /* BuildSettings+Fixture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F16AF212D9CF991008BC606 /* BuildSettings+Fixture.swift */; };
 		3F1B66A323A2F54B0075F09E /* ReaderReblogActionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1B66A223A2F54B0075F09E /* ReaderReblogActionTests.swift */; };
 		3F28CEA52A4ABB8800B79686 /* PrivacySettingsAnalyticsTrackerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F28CEA42A4ABB8800B79686 /* PrivacySettingsAnalyticsTrackerTests.swift */; };
 		3F28CEA92A4ACB1000B79686 /* AnalyticsEventTrackingSpy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F28CEA82A4ACB1000B79686 /* AnalyticsEventTrackingSpy.swift */; };
@@ -1324,6 +1325,7 @@
 		3236F7A024B61B950088E8F3 /* ReaderInterestsDataSourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderInterestsDataSourceTests.swift; sourceTree = "<group>"; };
 		32C6CDDA23A1FF0D002556FF /* SiteCreationRotatingMessageViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SiteCreationRotatingMessageViewTests.swift; sourceTree = "<group>"; };
 		374CB16115B93C0800DD0EBC /* AudioToolbox.framework */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = wrapper.framework; name = AudioToolbox.framework; path = System/Library/Frameworks/AudioToolbox.framework; sourceTree = SDKROOT; };
+		3F16AF212D9CF991008BC606 /* BuildSettings+Fixture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "BuildSettings+Fixture.swift"; sourceTree = "<group>"; };
 		3F1B66A223A2F54B0075F09E /* ReaderReblogActionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReaderReblogActionTests.swift; sourceTree = "<group>"; };
 		3F28CEA42A4ABB8800B79686 /* PrivacySettingsAnalyticsTrackerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrivacySettingsAnalyticsTrackerTests.swift; sourceTree = "<group>"; };
 		3F28CEA82A4ACB1000B79686 /* AnalyticsEventTrackingSpy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsEventTrackingSpy.swift; sourceTree = "<group>"; };
@@ -3843,6 +3845,7 @@
 				933D1F6B1EA7A3AB009FB462 /* TestingMode.storyboard */,
 				3F4A4C202AD39CB100DE5DF8 /* TruthTable.swift */,
 				24CDE3402C5863A1005E5E43 /* TestKeychain.swift */,
+				3F16AF212D9CF991008BC606 /* BuildSettings+Fixture.swift */,
 			);
 			name = Helpers;
 			sourceTree = "<group>";
@@ -5773,6 +5776,7 @@
 				0148CC2B2859C87000CF5D96 /* BlogServiceMock.swift in Sources */,
 				59ECF87B1CB7061D00E68F25 /* PostSharingControllerTests.swift in Sources */,
 				E157D5E01C690A6C00F04FB9 /* ImmuTableTestUtils.swift in Sources */,
+				3F16AF222D9CF991008BC606 /* BuildSettings+Fixture.swift in Sources */,
 				C81CCD86243C00E000A83E27 /* TenorPageableTests.swift in Sources */,
 				46F58501262605930010A723 /* BlockEditorSettingsServiceTests.swift in Sources */,
 				8BBBEBB224B8F8C0005E358E /* ReaderCardTests.swift in Sources */,

--- a/WordPress/WordPressTest/BlogTests.swift
+++ b/WordPress/WordPressTest/BlogTests.swift
@@ -319,4 +319,25 @@ final class BlogTests: CoreDataTestCase {
         XCTAssertNotNil(blog.account)
         XCTAssertTrue(blog.supportsRestApi())
     }
+
+    func testSupportsStockPhotos() {
+        func blog(withAccount: Bool) -> Blog {
+            var builder = BlogBuilder(mainContext)
+            if withAccount { builder = builder.withAnAccount() }
+            return builder.build()
+        }
+
+        XCTAssertTrue(
+            blog(withAccount: true).supportsStockPhotos(buildSettings: .fixture(brand: .jetpack))
+        )
+        XCTAssertFalse(
+            blog(withAccount: true).supportsStockPhotos(buildSettings: .fixture(brand: .wordpress))
+        )
+        XCTAssertFalse(
+            blog(withAccount: false).supportsStockPhotos(buildSettings: .fixture(brand: .jetpack))
+        )
+        XCTAssertFalse(
+            blog(withAccount: false).supportsStockPhotos(buildSettings: .fixture(brand: .wordpress))
+        )
+    }
 }

--- a/WordPress/WordPressTest/BlogTests.swift
+++ b/WordPress/WordPressTest/BlogTests.swift
@@ -305,4 +305,18 @@ final class BlogTests: CoreDataTestCase {
             try? XCTAssertNotNil(Blog.lookup(withID: 123, in: context))
         }
     }
+
+    func testWhenAccountNilDoesSupportRestApiFalse() {
+        let blog = BlogBuilder(mainContext).build()
+
+        XCTAssertNil(blog.account)
+        XCTAssertFalse(blog.supportsRestApi())
+    }
+
+    func testWhenAccountNotNilDoesSupportRestApiTrue() {
+        let blog = BlogBuilder(mainContext).withAnAccount().build()
+
+        XCTAssertNotNil(blog.account)
+        XCTAssertTrue(blog.supportsRestApi())
+    }
 }

--- a/WordPress/WordPressTest/BlogTests.swift
+++ b/WordPress/WordPressTest/BlogTests.swift
@@ -340,4 +340,13 @@ final class BlogTests: CoreDataTestCase {
             blog(withAccount: false).supportsStockPhotos(buildSettings: .fixture(brand: .wordpress))
         )
     }
+
+    func testSupportsTenor() {
+        func blog() -> Blog {
+            BlogBuilder(mainContext).build()
+        }
+
+        XCTAssertTrue(blog().supportsTenor(buildSettings: .fixture(brand: .jetpack)))
+        XCTAssertFalse(blog().supportsTenor(buildSettings: .fixture(brand: .wordpress)))
+    }
 }

--- a/WordPress/WordPressTest/BuildSettings+Fixture.swift
+++ b/WordPress/WordPressTest/BuildSettings+Fixture.swift
@@ -1,0 +1,53 @@
+@testable import BuildSettingsKit
+
+extension BuildSettings {
+
+    static func fixture(
+        configuration: BuildConfiguration = .debug,
+        brand: AppBrand = .wordpress,
+        pushNotificationAppID: String = "push-notification-app-id",
+        appGroupName: String = "app-group-name",
+        appKeychainAccessGroup: String = "app-keychain-access-group",
+        eventNamePrefix: String = "event-name-prefix",
+        explatPlatform: String = "explat-platform",
+        itunesAppID: String = "itunes-app-id",
+        appURLScheme: String = "app-url-scheme",
+        jetpackAppURLScheme: String = "jetpack-app-url-scheme",
+        about: ProductAboutDetails = .fixture(),
+        zendeskSourcePlatform: String = "zendesk-source-platform",
+        mobileAnnounceAppID: String = "mobile-announce-app-id",
+        authKeychainServiceName: String = "auth-keychain-service-name"
+    ) -> BuildSettings {
+        BuildSettings(
+            configuration: configuration,
+            brand: brand,
+            pushNotificationAppID: pushNotificationAppID,
+            appGroupName: appGroupName,
+            appKeychainAccessGroup: appKeychainAccessGroup,
+            eventNamePrefix: eventNamePrefix,
+            explatPlatform: explatPlatform,
+            itunesAppID: itunesAppID,
+            appURLScheme: appURLScheme,
+            jetpackAppURLScheme: jetpackAppURLScheme,
+            about: about,
+            zendeskSourcePlatform: zendeskSourcePlatform,
+            mobileAnnounceAppID: mobileAnnounceAppID,
+            authKeychainServiceName: authKeychainServiceName
+        )
+    }
+}
+
+extension BuildSettings.ProductAboutDetails {
+
+    static func fixture(
+        twitterHandle: String = "@twitter-handle",
+        twitterURL: URL = URL(string: "https://twitter.com/handle")!,
+        blogURL: URL = URL(string: "https://wordpress.com/blog")!
+    ) -> BuildSettings.ProductAboutDetails {
+        BuildSettings.ProductAboutDetails(
+            twitterHandle: twitterHandle,
+            twitterURL: twitterURL,
+            blogURL: blogURL
+        )
+    }
+}


### PR DESCRIPTION
I don't remember where, but we discussed that it was safe to replace `[JetpackFeaturesRemovalCoordinator jetpackFeaturesEnabled]` in `Blog` with a check for `BuildSettings.current.brand == .jetpack`.

However, `BuildSettings` is only available to Swift, which means moving the logic that accesses `JetpackFeaturesRemovalCoordinator` to Swift. I started down that route in https://github.com/wordpress-mobile/WordPress-iOS/pull/24332 but I run into UI test failures and got worried about the surface area and combine lack of unit tests.

This PR targets only the `JetpackFeaturesRemovalCoordinator` decoupling, and with tests.

Notice that to do this I added a fixture extension to `BuildSettings`, so we can create ad hoc values in the unit tests to inject.

Part of #24165.