### PR TITLE
Remove JetpackFeaturesRemovalCoordinator usage from Blog

### DIFF
--- a/WordPress/Classes/Models/Blog/Blog+MySite.swift
+++ b/WordPress/Classes/Models/Blog/Blog+MySite.swift
@@ -1,8 +1,0 @@
-import Foundation
-
-extension Blog {
-    /// If the blog should show the "Jetpack" or the "General" section
-    @objc var shouldShowJetpackSection: Bool {
-        (supports(.activity) && !isWPForTeams()) || supports(.jetpackSettings)
-    }
-}

--- a/WordPress/Classes/Models/Blog/Blog.h
+++ b/WordPress/Classes/Models/Blog/Blog.h
@@ -20,6 +20,9 @@ NS_ASSUME_NONNULL_BEGIN
 extern NSString * const BlogEntityName;
 extern NSString * const PostFormatStandard;
 
+/// - warning: These flags are app-agnostic and define whether the _blog_ supports
+/// the given feature. If the app needs to determine whether to show a feature or
+/// not, it has to implement additional logic on top of it.
 typedef NS_ENUM(NSUInteger, BlogFeature) {
     /// Can the blog be removed?
     BlogFeatureRemovable,

--- a/WordPress/Classes/Models/Blog/Blog.h
+++ b/WordPress/Classes/Models/Blog/Blog.h
@@ -79,8 +79,6 @@ typedef NS_ENUM(NSUInteger, BlogFeature) {
     BlogFeatureMediaDeletion,
     /// Does the blog support Stock Photos feature (free photos library)
     BlogFeatureStockPhotos,
-    /// Does the blog support Tenor feature (free GIF library)
-    BlogFeatureTenor,
     /// Does the blog support setting the homepage type and pages?
     BlogFeatureHomepageSettings,
     /// Does the blog support Jetpack contact info block?

--- a/WordPress/Classes/Models/Blog/Blog.m
+++ b/WordPress/Classes/Models/Blog/Blog.m
@@ -569,9 +569,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
         case BlogFeatureStats:
             return [self supportsRestApi] && [self isViewingStatsAllowed];
         case BlogFeatureStockPhotos:
-            return [self supportsRestApi] && [JetpackFeaturesRemovalCoordinator jetpackFeaturesEnabled];
-        case BlogFeatureTenor:
-            return [JetpackFeaturesRemovalCoordinator jetpackFeaturesEnabled];
+            return [self supportsRestApi];
         case BlogFeatureSharing:
             return [self supportsSharing];
         case BlogFeatureOAuth2Login:

--- a/WordPress/Classes/Models/Blog/Blog.m
+++ b/WordPress/Classes/Models/Blog/Blog.m
@@ -586,7 +586,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
         case BlogFeatureJetpackImageSettings:
             return [self supportsJetpackImageSettings];
         case BlogFeatureJetpackSettings:
-            return [self supportsJetpackSettings];
+            return [self supportsRestApi] && ![self isHostedAtWPcom] && [self isAdmin];
         case BlogFeaturePushNotifications:
             return [self supportsPushNotifications];
         case BlogFeatureThemeBrowsing:
@@ -760,14 +760,6 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 - (BOOL)supportsEmbedVariation:(NSString *)requiredJetpackVersion
 {
     return [self hasRequiredJetpackVersion:requiredJetpackVersion] || self.isHostedAtWPcom;
-}
-
-- (BOOL)supportsJetpackSettings
-{
-    return [JetpackFeaturesRemovalCoordinator jetpackFeaturesEnabled]
-    && [self supportsRestApi]
-    && ![self isHostedAtWPcom]
-    && [self isAdmin];
 }
 
 - (BOOL)accountIsDefaultAccount

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -215,3 +215,16 @@ struct ApplicationPasswordRequiredView<Content: View>: View {
         }
     }
 }
+
+private extension Blog {
+    /// If the blog should show the "Jetpack" or the "General" section
+    var shouldShowJetpackSection: Bool {
+        if supports(.activity) && !isWPForTeams() {
+            return true
+        }
+        if supports(.jetpackSettings) && JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() {
+            return true
+        }
+        return false
+    }
+}

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -1120,9 +1120,9 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
     func gutenbergMediaSources() -> [Gutenberg.MediaSource] {
         post.managedObjectContext?.performAndWait {
             [
-                MediaPickerMenu.isImagePlaygroundAvailable ? .imagePlayground : nil,
-                post.blog.supports(.stockPhotos) ? .stockPhotos : nil,
-                post.blog.supports(.tenor) ? .tenor : nil,
+                MediaPickerSource.playground.isEnabled ? .imagePlayground : nil,
+                MediaPickerSource.freePhotos(blog: post.blog).isEnabled ? .stockPhotos : nil,
+                MediaPickerSource.freeGIFs(blog: post.blog).isEnabled ? .tenor : nil,
                 .otherApps,
                 .allFiles
             ].compactMap { $0 }

--- a/WordPress/Classes/ViewRelated/Media/MediaPicker/MediaPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPicker/MediaPicker.swift
@@ -53,21 +53,20 @@ struct MediaPicker<Content: View>: View {
         controller.onSelection = onSelection
         viewModel.controller = controller // Needs to be retained
 
-        return configuration.sources.compactMap { source in
+        return configuration.sources.filter(\.isEnabled).compactMap { source in
             switch source {
             case .photos:
-                return menu.makePhotosAction(delegate: controller)
+                menu.makePhotosAction(delegate: controller)
             case .camera:
-                return menu.makeCameraAction(delegate: controller)
+                 menu.makeCameraAction(delegate: controller)
             case .siteMedia(let blog):
-                return menu.makeSiteMediaAction(blog: blog, delegate: controller)
+                menu.makeSiteMediaAction(blog: blog, delegate: controller)
             case .playground:
-                return menu.makeImagePlaygroundAction(delegate: controller)
+                menu.makeImagePlaygroundAction(delegate: controller)
             case .freePhotos(let blog):
-                return menu.makeStockPhotos(blog: blog, delegate: controller)
+                menu.makeStockPhotos(blog: blog, delegate: controller)
             case .freeGIFs(let blog):
-                return menu.makeFreeGIFAction(blog: blog, delegate: controller)
-
+                menu.makeFreeGIFAction(blog: blog, delegate: controller)
             }
         }
     }
@@ -90,6 +89,19 @@ enum MediaPickerSource {
     case playground // Image Playground
     case freePhotos(blog: Blog) // Pexels
     case freeGIFs(blog: Blog) // Tenor
+
+    var isEnabled: Bool {
+        switch self {
+        case .photos, .camera, .siteMedia:
+            true
+        case .playground:
+            MediaPickerMenu.isImagePlaygroundAvailable
+        case .freePhotos(let blog):
+            blog.supports(.stockPhotos) && JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
+        case .freeGIFs:
+            JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled()
+        }
+    }
 }
 
 struct MediaPickerSelection {

--- a/WordPress/Classes/ViewRelated/Media/MediaPicker/Menu/MediaPickerMenu+External.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPicker/Menu/MediaPickerMenu+External.swift
@@ -4,7 +4,7 @@ import UIKit
 
 extension MediaPickerMenu {
     func makeStockPhotos(blog: Blog, delegate: ExternalMediaPickerViewDelegate) -> UIAction? {
-        guard blog.supports(.stockPhotos) else {
+        guard MediaPickerSource.freePhotos(blog: blog).isEnabled else {
             return nil
         }
         return UIAction(
@@ -39,7 +39,7 @@ extension MediaPickerMenu {
 
 extension MediaPickerMenu {
     func makeFreeGIFAction(blog: Blog, delegate: ExternalMediaPickerViewDelegate) -> UIAction? {
-        guard blog.supports(.tenor) else {
+        guard MediaPickerSource.freePhotos(blog: blog).isEnabled else {
             return nil
         }
         return UIAction(

--- a/WordPress/Classes/ViewRelated/Media/MediaPicker/Menu/MediaPickerMenu+ImagePlayground.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPicker/Menu/MediaPickerMenu+ImagePlayground.swift
@@ -15,7 +15,7 @@ extension MediaPickerMenu {
     }
 
     func makeImagePlaygroundAction(delegate: ImagePlaygroundPickerDelegate) -> UIAction? {
-        guard MediaPickerMenu.isImagePlaygroundAvailable else {
+        guard MediaPickerSource.playground.isEnabled else {
             return nil
         }
         return UIAction(

--- a/WordPress/Classes/ViewRelated/Media/StockPhotos/AztecMediaPickingCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Media/StockPhotos/AztecMediaPickingCoordinator.swift
@@ -17,10 +17,10 @@ final class AztecMediaPickingCoordinator {
                                                 message: nil,
                                                 preferredStyle: UIDevice.isPad() ? .alert : .actionSheet)
 
-        if blog.supports(.stockPhotos) {
+        if MediaPickerSource.freePhotos(blog: blog).isEnabled {
             alertController.addAction(freePhotoAction(origin: origin, blog: blog))
         }
-        if blog.supports(.tenor) {
+        if MediaPickerSource.freeGIFs(blog: blog).isEnabled {
             alertController.addAction(tenorAction(origin: origin, blog: blog))
         }
 


### PR DESCRIPTION
The blog (and the upcoming WordPressData) should be app-agnostic. The app determines what features to show based on `JetpackFeaturesRemovalCoordinator` and other factors.

To test:

WordPress vs Jetpack

<img width="320" alt="Screenshot 2025-04-02 at 9 51 59 AM" src="https://github.com/user-attachments/assets/348fa618-39e5-415e-a15a-7d444a3b084d" /> <img width="320" alt="Screenshot 2025-04-02 at 9 41 31 AM" src="https://github.com/user-attachments/assets/ee0ba05b-8760-4d8d-848d-c90b3ac67ae8" />


## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
