### PR TITLE
Add missing access control modifiers for Keystone

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+ApplicationStyles.swift
@@ -117,7 +117,7 @@ extension WPStyleGuide {
     }
 
     @objc
-    class func configureTableViewCell(_ cell: UITableViewCell?) {
+    public class func configureTableViewCell(_ cell: UITableViewCell?) {
         guard let cell else {
             return
         }

--- a/WordPress/Classes/Extensions/UITableViewCell+enableDisable.swift
+++ b/WordPress/Classes/Extensions/UITableViewCell+enableDisable.swift
@@ -4,7 +4,7 @@ import WordPressUI
 
 extension UITableViewCell {
     /// Enable cell interaction
-    @objc func enable() {
+    @objc public func enable() {
         isUserInteractionEnabled = true
         textLabel?.isEnabled = true
         textLabel?.textColor = .label
@@ -12,7 +12,7 @@ extension UITableViewCell {
     }
 
     /// Disable cell interaction
-    @objc func disable() {
+    @objc public func disable() {
         accessoryType = .none
         isUserInteractionEnabled = false
         textLabel?.isEnabled = false

--- a/WordPress/Classes/Models/Media.swift
+++ b/WordPress/Classes/Models/Media.swift
@@ -9,14 +9,14 @@ extension Media {
     /// Increments the AutoUpload failure count for this Media object.
     ///
     @objc
-    func incrementAutoUploadFailureCount() {
+    public func incrementAutoUploadFailureCount() {
         autoUploadFailureCount = NSNumber(value: autoUploadFailureCount.intValue + 1)
     }
 
     /// Resets the AutoUpload failure count for this Media object.
     ///
     @objc
-    func resetAutoUploadFailureCount() {
+    public func resetAutoUploadFailureCount() {
         autoUploadFailureCount = 0
     }
     /// Returns true if a new attempt to upload the media will be done later.
@@ -44,7 +44,7 @@ extension Media {
     // MARK: - Media Type
 
     /// Returns the MIME type, e.g. "image/png".
-    @objc var mimeType: String? {
+    @objc public var mimeType: String? {
         guard let fileExtension = self.fileExtension(),
               let type = UTType(filenameExtension: fileExtension),
               let mimeType = type.preferredMIMEType else {

--- a/WordPress/Classes/Models/ReaderTagTopic+Lookup.swift
+++ b/WordPress/Classes/Models/ReaderTagTopic+Lookup.swift
@@ -21,7 +21,7 @@ extension ReaderTagTopic {
     /// - Parameter slug: The slug of the topic to find in core data.
     /// - Returns: A matching `ReaderTagTopic` instance or nil.
     @objc(lookupWithSlug:inContext:)
-    static func objc_lookup(withSlug slug: String, in context: NSManagedObjectContext) -> ReaderTagTopic? {
+    public static func objc_lookup(withSlug slug: String, in context: NSManagedObjectContext) -> ReaderTagTopic? {
         try? lookup(withSlug: slug, in: context)
     }
 
@@ -44,7 +44,7 @@ extension ReaderTagTopic {
     /// - Parameter tagID: The tag id of the topic to find in core data.
     /// - Returns: A matching `ReaderTagTopic` instance or nil.
     @objc(lookupWithTagID:inContext:)
-    static func objc_lookup(withTagID tagID: NSNumber, in context: NSManagedObjectContext) -> ReaderTagTopic? {
+    public static func objc_lookup(withTagID tagID: NSNumber, in context: NSManagedObjectContext) -> ReaderTagTopic? {
         try? lookup(withTagID: tagID, in: context)
     }
 

--- a/WordPress/Classes/Models/WPAccount+DeduplicateBlogs.swift
+++ b/WordPress/Classes/Models/WPAccount+DeduplicateBlogs.swift
@@ -10,8 +10,8 @@ extension WPAccount {
     /// If there's more than one blog in each group with local drafts, those will be reassigned
     /// to the remaining blog.
     ///
-    @objc(deduplicateBlogs)
-    func deduplicateBlogs() {
+    @objc
+    public func deduplicateBlogs() {
         let context = managedObjectContext!
         // Group all the account blogs by ID so it's easier to find duplicates
         let blogsById = Dictionary(grouping: blogs ?? [], by: { $0.dotComID?.intValue ?? 0 })

--- a/WordPress/Classes/Models/WPAccount+RestApi.swift
+++ b/WordPress/Classes/Models/WPAccount+RestApi.swift
@@ -9,7 +9,7 @@ extension WPAccount {
     ///
     /// This used to be defined in the Objective-C layer, but we moved it here in a Swift extension in an attempt to decouple the model code from it.
     /// This was done in the context of https://github.com/wordpress-mobile/WordPress-iOS/pull/24165 .
-    @objc var wordPressComRestApi: WordPressComRestApi? {
+    @objc public var wordPressComRestApi: WordPressComRestApi? {
         if let api = _private_wordPressComRestApi {
             return api
         }

--- a/WordPress/Classes/Services/EditorSettingsService.swift
+++ b/WordPress/Classes/Services/EditorSettingsService.swift
@@ -6,7 +6,7 @@ import WordPressKit
     case mobileEditorNotSet
 }
 
-@objc class EditorSettingsService: NSObject {
+@objc public class EditorSettingsService: NSObject {
 
     let coreDataStack: CoreDataStackSwift
 
@@ -16,12 +16,12 @@ import WordPressKit
 
     // For Objective-C compatibility, but we don't want Swift code to use it
     @available(swift, obsoleted: 1.0)
-    @objc init(coreDataStack: CoreDataStack) {
+    @objc public init(coreDataStack: CoreDataStack) {
         self.coreDataStack = coreDataStack as! CoreDataStackSwift
     }
 
     @objc(syncEditorSettingsForBlog:success:failure:)
-    func syncEditorSettings(for blog: Blog, success: @escaping () -> Void, failure: @escaping (Swift.Error) -> Void) {
+    public func syncEditorSettings(for blog: Blog, success: @escaping () -> Void, failure: @escaping (Swift.Error) -> Void) {
         guard let api = api(for: blog) else {
             // SelfHosted non-jetpack sites won't sync with remote.
             return success()

--- a/WordPress/Classes/Services/JetpackSocialService.swift
+++ b/WordPress/Classes/Services/JetpackSocialService.swift
@@ -2,7 +2,7 @@ import CoreData
 import WordPressData
 import WordPressKit
 
-@objc class JetpackSocialService: NSObject {
+@objc public class JetpackSocialService: NSObject {
 
     // MARK: Properties
 
@@ -19,7 +19,7 @@ import WordPressKit
 
     /// Init method for Objective-C.
     ///
-    @objc init(contextManager: ContextManager) {
+    @objc public init(contextManager: ContextManager) {
         self.coreDataStack = contextManager
     }
 
@@ -77,7 +77,7 @@ import WordPressKit
     ///   - dotComID: The WP.com ID of the blog.
     ///   - success: Closure called when the sync process succeeds.
     ///   - failure: Closure called when the sync process fails.
-    @objc func syncSharingLimit(dotComID: NSNumber?,
+    @objc public func syncSharingLimit(dotComID: NSNumber?,
                                 success: (() -> Void)?,
                                 failure: ((NSError?) -> Void)?) {
         guard let blogID = dotComID?.intValue else {

--- a/WordPress/Classes/Services/PlanService.swift
+++ b/WordPress/Classes/Services/PlanService.swift
@@ -5,7 +5,7 @@ open class PlanService: NSObject {
 
     private let coreDataStack: CoreDataStack
 
-    @objc init(coreDataStack: CoreDataStack) {
+    @objc public init(coreDataStack: CoreDataStack) {
         self.coreDataStack = coreDataStack
     }
 

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -2,7 +2,7 @@ import Foundation
 import BuildSettingsKit
 
 @objc
-enum RemoteFeatureFlag: Int, CaseIterable {
+public enum RemoteFeatureFlag: Int, CaseIterable {
     case jetpackFeaturesRemovalPhaseOne
     case jetpackFeaturesRemovalPhaseTwo
     case jetpackFeaturesRemovalPhaseThree
@@ -242,9 +242,9 @@ extension RemoteFeatureFlag: OverridableFlag {
 /// Objective-C bridge for RemoteFeatureFlag.
 ///
 /// Since we can't expose properties on Swift enums we use a class instead
-class RemoteFeature: NSObject {
+public class RemoteFeature: NSObject {
     /// Returns a boolean indicating if the feature is enabled
-    @objc static func enabled(_ feature: RemoteFeatureFlag) -> Bool {
-        return feature.enabled()
+    @objc public static func enabled(_ feature: RemoteFeatureFlag) -> Bool {
+        feature.enabled()
     }
 }

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -150,7 +150,7 @@ public enum RemoteFeatureFlag: Int, CaseIterable {
         }
     }
 
-    var description: String {
+    public var description: String {
         switch self {
         case .jetpackMigrationPreventDuplicateNotifications:
             return "Jetpack Migration prevent duplicate WordPress app notifications when Jetpack is installed"

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -234,7 +234,6 @@ CGFloat const BlogDetailReminderSectionFooterHeight = 1.0;
 @property (nonatomic, strong) NSArray<BlogDetailsSection *> *tableSections;
 @property (nonatomic, strong) BlogService *blogService;
 @property (nonatomic, strong) SiteIconPickerPresenter *siteIconPickerPresenter;
-@property (nonatomic, strong) ImageCropViewController *imageCropViewController;
 
 /// Used to restore the tableview selection during state restoration, and
 /// also when switching between a collapsed and expanded split view controller presentation

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/TwitterDeprecationTableFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/TwitterDeprecationTableFooterView.swift
@@ -66,7 +66,7 @@ private extension TwitterDeprecationTableFooterView {
         contentView.pinSubviewToAllEdgeMargins(label)
     }
 
-    @objc func labelTapped(_ sender: UITapGestureRecognizer) {
+    @objc public func labelTapped(_ sender: UITapGestureRecognizer) {
         guard let presentingViewController,
               let source,
               let attributedText = label.attributedText else {

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/IntrinsicTableView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/IntrinsicTableView.swift
@@ -7,14 +7,14 @@ import UIKit
 ///     -   https://developer.apple.com/library/ios/technotes/tn2154/_index.html#//apple_ref/doc/uid/DTS40013309
 ///     -   http://stackoverflow.com/questions/17334478/uitableview-within-uiscrollview-using-autolayout
 ///
-@objc class IntrinsicTableView: UITableView {
-    override var contentSize: CGSize {
+@objc public class IntrinsicTableView: UITableView {
+    public override var contentSize: CGSize {
         didSet {
             self.invalidateIntrinsicContentSize()
         }
     }
 
-    override var intrinsicContentSize: CGSize {
+    public override var intrinsicContentSize: CGSize {
         layoutIfNeeded()
         return CGSize(width: UIView.noIntrinsicMetric, height: contentSize.height)
     }


### PR DESCRIPTION
Same deal as https://github.com/wordpress-mobile/WordPress-iOS/pull/24390; no functional changes.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
