### PR TITLE
Remove WordPressDataObjC and WordPressData modules

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -15,9 +15,6 @@ let package = Package(
         .library(name: "NotificationServiceExtensionCore", targets: ["NotificationServiceExtensionCore"]),
         .library(name: "ShareExtensionCore", targets: ["ShareExtensionCore"]),
         .library(name: "SFHFKeychainUtils", targets: ["SFHFKeychainUtils"]),
-        // Note: WordPressData the Swift package is currently unused.
-        // We are leaving it here to be ready for the future when we'll be able to write the current WordPressData framework as a Swift package.
-        .library(name: "WordPressData", targets: ["WordPressData"]),
         .library(name: "WordPressFlux", targets: ["WordPressFlux"]),
         .library(name: "WordPressShared", targets: ["WordPressShared"]),
         .library(name: "WordPressUI", targets: ["WordPressUI"]),
@@ -123,12 +120,6 @@ let package = Package(
             .product(name: "ScreenObject", package: "ScreenObject"),
             .product(name: "XCUITestHelpers", package: "ScreenObject"),
         ], swiftSettings: [.swiftLanguageMode(.v5)]),
-        .target(
-            name: "WordPressData",
-            dependencies: [
-                .target(name: "WordPressSharedObjC")
-            ]
-        ),
         .target(name: "WordPressFlux", swiftSettings: [.swiftLanguageMode(.v5)]),
         .target(name: "WordPressCore", dependencies: [.target(name: "WordPressShared"), .product(name: "WordPressAPI", package: "wordpress-rs")]),
         .target(name: "WordPressSharedObjC", resources: [.process("Resources")], swiftSettings: [.swiftLanguageMode(.v5)]),

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -123,11 +123,9 @@ let package = Package(
             .product(name: "ScreenObject", package: "ScreenObject"),
             .product(name: "XCUITestHelpers", package: "ScreenObject"),
         ], swiftSettings: [.swiftLanguageMode(.v5)]),
-        .target(name: "WordPressDataObjC"),
         .target(
             name: "WordPressData",
             dependencies: [
-                .target(name: "WordPressDataObjC"),
                 .target(name: "WordPressSharedObjC")
             ]
         ),
@@ -255,7 +253,6 @@ enum XcodeSupport {
                 "SFHFKeychainUtils",
                 "ShareExtensionCore",
                 "WordPressFlux",
-                "WordPressDataObjC", // Currently empty, here for future proofing
                 "WordPressShared",
                 "WordPressReader",
                 "WordPressUI",
@@ -292,7 +289,6 @@ enum XcodeSupport {
             ]),
             .xcodeTarget("XcodeTarget_WordPressTests", dependencies: testDependencies + [
                 "SFHFKeychainUtils",
-                "WordPressDataObjC", // Currently empty, here for future proofing
                 "WordPressShared",
                 "WordPressUI",
                 .product(name: "Gravatar", package: "Gravatar-SDK-iOS"),

--- a/Modules/Sources/WordPressData/WordPressData.swift
+++ b/Modules/Sources/WordPressData/WordPressData.swift
@@ -1,1 +1,0 @@
-@_exported import WordPressDataObjC

--- a/Modules/Sources/WordPressDataObjC/Empty.m
+++ b/Modules/Sources/WordPressDataObjC/Empty.m
@@ -1,3 +1,0 @@
-#import "Empty.h"
-
-NSString * const Empty = @"Empty";

--- a/Modules/Sources/WordPressDataObjC/include/Empty.h
+++ b/Modules/Sources/WordPressDataObjC/include/Empty.h
@@ -1,3 +1,0 @@
-#import <Foundation/Foundation.h>
-
-extern NSString * const Empty;

--- a/WordPress/Classes/Categories/Media+Extensions.m
+++ b/WordPress/Classes/Categories/Media+Extensions.m
@@ -1,7 +1,6 @@
 #import "Media+Extensions.h"
 #import "MediaService.h"
 #import "Blog.h"
-@import WordPressDataObjC;
 @import WordPressShared;
 #ifdef KEYSTONE
 #import "Keystone-Swift.h"

--- a/WordPress/Classes/Models/AbstractPost.m
+++ b/WordPress/Classes/Models/AbstractPost.m
@@ -1,6 +1,5 @@
 #import "AbstractPost.h"
 #import "Media.h"
-@import WordPressDataObjC;
 #ifdef KEYSTONE
 #import "Keystone-Swift.h"
 #else

--- a/WordPress/Classes/Models/BasePost.m
+++ b/WordPress/Classes/Models/BasePost.m
@@ -1,6 +1,5 @@
 #import "BasePost.h"
 #import "Media.h"
-@import WordPressDataObjC;
 
 @import WordPressShared;
 

--- a/WordPress/Classes/Models/Blog/Blog.m
+++ b/WordPress/Classes/Models/Blog/Blog.m
@@ -1,7 +1,6 @@
 #import "Blog.h"
 #import "WPAccount.h"
 #import "AccountService.h"
-@import WordPressDataObjC;
 @import WordPressShared;
 #ifdef KEYSTONE
 #import "Keystone-Swift.h"
@@ -155,7 +154,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 
 - (NSNumber *)organizationID {
     NSNumber *organizationID = [self primitiveValueForKey:@"organizationID"];
-    
+
     if (organizationID == nil) {
         return @0;
     } else {
@@ -188,7 +187,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
         DDLogInfo(@"Blog display URL is nil");
         return nil;
     }
-    
+
     NSError *error = nil;
     NSRegularExpression *protocol = [NSRegularExpression regularExpressionWithPattern:@"http(s?)://" options:NSRegularExpressionCaseInsensitive error:&error];
     NSString *result = [NSString stringWithFormat:@"%@", [protocol stringByReplacingMatchesInString:self.url options:0 range:NSMakeRange(0, [self.url length]) withTemplate:@""]];
@@ -306,7 +305,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 }
 
 - (NSArray *)sortedPostFormatNames
-{    
+{
     return [[self sortedPostFormats] wp_map:^id(NSString *key) {
         return self.postFormats[key];
     }];
@@ -794,7 +793,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
     if (!allowedFileTypes || allowedFileTypes.count == 0) {
         return nil;
     }
-    
+
     return [NSSet setWithArray:allowedFileTypes];
 }
 

--- a/WordPress/Classes/Models/CoreDataStack/CoreDataStackSwift.swift
+++ b/WordPress/Classes/Models/CoreDataStack/CoreDataStackSwift.swift
@@ -1,5 +1,4 @@
 import CoreData
-import WordPressDataObjC
 
 public protocol CoreDataStackSwift: CoreDataStack {
 

--- a/WordPress/Classes/Models/Media.m
+++ b/WordPress/Classes/Models/Media.m
@@ -1,5 +1,4 @@
 #import "Media.h"
-@import WordPressDataObjC;
 #ifdef KEYSTONE
 #import "Keystone-Swift.h"
 #else

--- a/WordPress/Classes/Models/ReaderPost.m
+++ b/WordPress/Classes/Models/ReaderPost.m
@@ -1,5 +1,4 @@
 #import "ReaderPost.h"
-@import WordPressDataObjC;
 #import "SourcePostAttribution.h"
 #import "WPAccount.h"
 #ifdef KEYSTONE

--- a/WordPress/Classes/Models/Theme.m
+++ b/WordPress/Classes/Models/Theme.m
@@ -1,6 +1,5 @@
 #import "Theme.h"
 #import "Blog.h"
-@import WordPressDataObjC;
 #import "WPAccount.h"
 #import "AccountService.h"
 #ifdef KEYSTONE

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -3,7 +3,6 @@
 #import "Blog.h"
 #import "BlogService.h"
 
-@import WordPressDataObjC;
 @import WordPressKit;
 @import WordPressShared;
 

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -2,7 +2,6 @@
 #import "Blog.h"
 #import "WPAccount.h"
 #import "AccountService.h"
-@import WordPressDataObjC;
 #import "WPError.h"
 #import "Media.h"
 #import "PostCategoryService.h"

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -1,7 +1,6 @@
 #import "CommentService.h"
 #import "AccountService.h"
 #import "Blog.h"
-@import WordPressDataObjC;
 #import "ReaderPost.h"
 #import "WPAccount.h"
 #import "PostService.h"

--- a/WordPress/Classes/Services/Facades/BlogSyncFacade.m
+++ b/WordPress/Classes/Services/Facades/BlogSyncFacade.m
@@ -1,5 +1,4 @@
 #import "BlogSyncFacade.h"
-@import WordPressDataObjC;
 #import "BlogService.h"
 #import "AccountService.h"
 #import "Blog.h"

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -2,7 +2,6 @@
 #import "AccountService.h"
 #import "Media.h"
 #import "WPAccount.h"
-@import WordPressDataObjC;
 @import WordPressShared;
 #import "Blog.h"
 #import <MobileCoreServices/MobileCoreServices.h>

--- a/WordPress/Classes/Services/MenusService.m
+++ b/WordPress/Classes/Services/MenusService.m
@@ -4,7 +4,6 @@
 #import "Menu.h"
 #import "MenuItem.h"
 #import "MenuLocation.h"
-@import WordPressDataObjC;
 #import "PostService.h"
 #ifdef KEYSTONE
 #import "Keystone-Swift.h"

--- a/WordPress/Classes/Services/PostCategoryService.m
+++ b/WordPress/Classes/Services/PostCategoryService.m
@@ -1,7 +1,6 @@
 #import "PostCategoryService.h"
 #import "PostCategory.h"
 #import "Blog.h"
-@import WordPressDataObjC;
 #ifdef KEYSTONE
 #import "Keystone-Swift.h"
 #else

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -1,7 +1,6 @@
 #import "PostService.h"
 #import "PostCategory.h"
 #import "PostCategoryService.h"
-@import WordPressDataObjC;
 #import "CommentService.h"
 #import "MediaService.h"
 #import "Media.h"

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -1,7 +1,6 @@
 #import "PostTagService.h"
 #import "Blog.h"
 #import "PostTag.h"
-@import WordPressDataObjC;
 #ifdef KEYSTONE
 #import "Keystone-Swift.h"
 #else

--- a/WordPress/Classes/Services/Reader Post/ReaderPostService.m
+++ b/WordPress/Classes/Services/Reader Post/ReaderPostService.m
@@ -1,7 +1,6 @@
 #import "ReaderPostService.h"
 
 #import "AccountService.h"
-@import WordPressDataObjC;
 #import "ReaderGapMarker.h"
 #import "ReaderPost.h"
 #import "ReaderSiteService.h"

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -1,7 +1,6 @@
 #import "ReaderSiteService.h"
 
 #import "AccountService.h"
-@import WordPressDataObjC;
 #import "ReaderPostService.h"
 #import "ReaderPost.h"
 #import "WPAccount.h"

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -1,7 +1,6 @@
 #import "ReaderTopicService.h"
 
 #import "AccountService.h"
-@import WordPressDataObjC;
 #import "ReaderPost.h"
 #import "ReaderPostService.h"
 #import "WPAccount.h"

--- a/WordPress/Classes/Services/ThemeService.m
+++ b/WordPress/Classes/Services/ThemeService.m
@@ -3,7 +3,6 @@
 #import "Blog.h"
 #import "Theme.h"
 #import "WPAccount.h"
-@import WordPressDataObjC;
 #ifdef KEYSTONE
 #import "Keystone-Swift.h"
 #else

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsTrackerAutomatticTracks.m
@@ -1,5 +1,4 @@
 #import "WPAnalyticsTrackerAutomatticTracks.h"
-@import WordPressDataObjC;
 #import "AccountService.h"
 #import "BlogService.h"
 #import "WPAccount.h"

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -1,4 +1,3 @@
-@import WordPressDataObjC;
 @import NSObject_SafeExpectations;
 
 #import "WPAppAnalytics.h"

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -3,7 +3,6 @@
 #import "AccountService.h"
 #import "BlogService.h"
 #import "CommentsViewController.h"
-@import WordPressDataObjC;
 #import "SiteSettingsViewController.h"
 #import "SharingViewController.h"
 #import "StatsViewController.h"

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -2,7 +2,6 @@
 
 #import "Blog.h"
 #import "BlogService.h"
-@import WordPressDataObjC;
 #import "PostCategory.h"
 #import "PostCategoryService.h"
 #import "SettingsSelectionViewController.h"

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemEditingViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemEditingViewController.m
@@ -6,7 +6,6 @@
 #import "MenuItemEditingFooterView.h"
 #import "MenuItemSourceViewController.h"
 #import "MenuItemTypeViewController.h"
-@import WordPressDataObjC;
 #ifdef KEYSTONE
 #import "Keystone-Swift.h"
 #else

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemsViewController.m
@@ -5,7 +5,6 @@
 #import "MenuItemView.h"
 #import "MenuItemInsertionView.h"
 #import "MenuItemsVisualOrderingView.h"
-@import WordPressDataObjC;
 #import "Menu+ViewDesign.h"
 #ifdef KEYSTONE
 #import "Keystone-Swift.h"

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenusViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenusViewController.m
@@ -9,7 +9,6 @@
 #import "MenuItemsViewController.h"
 #import "MenuItemEditingViewController.h"
 #import "Menu+ViewDesign.h"
-@import WordPressDataObjC;
 #import "WPAppAnalytics.h"
 #ifdef KEYSTONE
 #import "Keystone-Swift.h"

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -3,7 +3,6 @@
 #import "Media.h"
 #import "SettingsSelectionViewController.h"
 #import "SharingDetailViewController.h"
-@import WordPressDataObjC;
 #import "MediaService.h"
 #ifdef KEYSTONE
 #import "Keystone-Swift.h"

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -9,7 +9,6 @@
 #endif
 #import "WPAppAnalytics.h"
 
-@import WordPressDataObjC;
 @import WordPressShared;
 @import Reachability;
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -1,7 +1,6 @@
 #import "WPTabBarController.h"
 
 #import "AccountService.h"
-@import WordPressDataObjC;
 #import "BlogService.h"
 #import "Blog.h"
 

--- a/WordPress/WordPressTest/BlogServiceTest.m
+++ b/WordPress/WordPressTest/BlogServiceTest.m
@@ -1,7 +1,6 @@
 #import <XCTest/XCTest.h>
 #import "AccountService.h"
 #import "BlogService.h"
-@import WordPressDataObjC;
 #import "Blog.h"
 #import "WPAccount.h"
 #import "WordPressTest-Swift.h"

--- a/WordPress/WordPressTest/ReaderPostServiceTest.m
+++ b/WordPress/WordPressTest/ReaderPostServiceTest.m
@@ -1,4 +1,3 @@
-@import WordPressDataObjC;
 
 #import <XCTest/XCTest.h>
 


### PR DESCRIPTION
It was good to have them there as placeholders, but `WordPressDataObjC` in particular was giving me some odd compilation issue in #24378 where the extensions seem to think they need it as a dependency. And once I remove that, it made no sense to keep `WordPressData`.

It was empty anyway, so effectively dead weight. It'll be easy enough to recreate it when the time comes.

Part of #24165