### PR TITLE
Update access for some methods soon to be in WordPressData

### DIFF
--- a/WordPress/Classes/Models/Blog/Blog+SelfHosted.swift
+++ b/WordPress/Classes/Models/Blog/Blog+SelfHosted.swift
@@ -3,7 +3,7 @@ import CryptoKit
 import WordPressAPI
 import WordPressShared
 
-extension Blog {
+public extension Blog {
 
     enum BlogCredentialsError: Error {
         case blogUrlMissing
@@ -64,7 +64,7 @@ extension Blog {
 
     @available(swift, obsoleted: 1.0)
     @objc(deleteApplicationToken)
-    public func objc_deleteApplicationToken() {
+    func objc_deleteApplicationToken() {
         _ = try? deleteApplicationToken()
     }
 
@@ -159,7 +159,7 @@ extension Blog {
     }
 }
 
-extension WpApiApplicationPasswordDetails {
+public extension WpApiApplicationPasswordDetails {
     var derivedXMLRPCRoot: URL {
         get throws {
             let url = try ParsedUrl.parse(input: siteUrl).asURL()

--- a/WordPress/Classes/Models/Blog/Blog.h
+++ b/WordPress/Classes/Models/Blog/Blog.h
@@ -14,7 +14,6 @@ NS_ASSUME_NONNULL_BEGIN
 @class UserSuggestion;
 @class SiteSuggestion;
 @class PageTemplateCategory;
-@class JetpackFeaturesRemovalCoordinator;
 @class PublicizeInfo;
 
 extern NSString * const BlogEntityName;

--- a/WordPress/Classes/Models/Blog/Blog.m
+++ b/WordPress/Classes/Models/Blog/Blog.m
@@ -1,6 +1,5 @@
 #import "Blog.h"
 #import "WPAccount.h"
-#import "AccountService.h"
 @import WordPressDataObjC;
 @import WordPressShared;
 #ifdef KEYSTONE

--- a/WordPress/Classes/Models/Media.swift
+++ b/WordPress/Classes/Models/Media.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UniformTypeIdentifiers
 
-extension Media {
+public extension Media {
     // MARK: - AutoUpload Failure Count
 
     static let maxAutoUploadFailureCount = 3

--- a/WordPress/Classes/Models/Site Creation/SiteInformation.swift
+++ b/WordPress/Classes/Models/Site Creation/SiteInformation.swift
@@ -1,9 +1,9 @@
-struct SiteInformation {
-    let title: String
-    let tagLine: String?
+public struct SiteInformation {
+    public let title: String
+    public let tagLine: String?
 
     /// if title is nil, then the corresponding SiteInformation value is nil
-    init?(title: String?, tagLine: String?) {
+    public init?(title: String?, tagLine: String?) {
         guard let title else {
             return nil
         }
@@ -13,7 +13,7 @@ struct SiteInformation {
 }
 
 extension SiteInformation: Equatable {
-    static func ==(lhs: SiteInformation, rhs: SiteInformation) -> Bool {
+    public static func ==(lhs: SiteInformation, rhs: SiteInformation) -> Bool {
         return lhs.title == rhs.title &&
                 lhs.tagLine == rhs.tagLine
     }


### PR DESCRIPTION
Same rationale as https://github.com/wordpress-mobile/WordPress-iOS/pull/24326 and https://github.com/wordpress-mobile/WordPress-iOS/pull/24348. Part of #24165, all these requirements have been discovered in https://github.com/wordpress-mobile/WordPress-iOS/pull/24378.

Also remove some unused lines from Objective-C headers.