### PR TITLE
Update some imports in preparation for WordPressData

### DIFF
--- a/WordPress/Classes/Jetpack/Utility/SharedDataIssueSolver.swift
+++ b/WordPress/Classes/Jetpack/Utility/SharedDataIssueSolver.swift
@@ -29,7 +29,7 @@ public final class SharedDataIssueSolver: NSObject {
         return SharedDataIssueSolver()
     }
 
-    func migrateAuthKey() {
+    public func migrateAuthKey() {
         guard let account = try? WPAccount.lookupDefaultWordPressComAccount(in: contextManager.mainContext) else {
             return
         }

--- a/WordPress/Classes/Models/Media.swift
+++ b/WordPress/Classes/Models/Media.swift
@@ -9,14 +9,14 @@ public extension Media {
     /// Increments the AutoUpload failure count for this Media object.
     ///
     @objc
-    public func incrementAutoUploadFailureCount() {
+    func incrementAutoUploadFailureCount() {
         autoUploadFailureCount = NSNumber(value: autoUploadFailureCount.intValue + 1)
     }
 
     /// Resets the AutoUpload failure count for this Media object.
     ///
     @objc
-    public func resetAutoUploadFailureCount() {
+    func resetAutoUploadFailureCount() {
         autoUploadFailureCount = 0
     }
     /// Returns true if a new attempt to upload the media will be done later.
@@ -44,7 +44,7 @@ public extension Media {
     // MARK: - Media Type
 
     /// Returns the MIME type, e.g. "image/png".
-    @objc public var mimeType: String? {
+    @objc var mimeType: String? {
         guard let fileExtension = self.fileExtension(),
               let type = UTType(filenameExtension: fileExtension),
               let mimeType = type.preferredMIMEType else {

--- a/WordPress/Classes/Models/Theme.m
+++ b/WordPress/Classes/Models/Theme.m
@@ -1,7 +1,6 @@
 #import "Theme.h"
 #import "Blog.h"
 #import "WPAccount.h"
-#import "AccountService.h"
 #ifdef KEYSTONE
 #import "Keystone-Swift.h"
 #else

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -1,5 +1,4 @@
 #import "MediaService.h"
-#import "AccountService.h"
 #import "Media.h"
 #import "WPAccount.h"
 @import WordPressShared;

--- a/WordPress/Classes/Services/PostService.h
+++ b/WordPress/Classes/Services/PostService.h
@@ -1,6 +1,5 @@
 #import <Foundation/Foundation.h>
 #import "LocalCoreDataService.h"
-#import "PostServiceOptions.h"
 
 @class AbstractPost;
 @class Blog;

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -1,8 +1,5 @@
 #import "PostService.h"
 #import "PostCategory.h"
-#import "PostCategoryService.h"
-#import "CommentService.h"
-#import "MediaService.h"
 #import "Media.h"
 #ifdef KEYSTONE
 #import "Keystone-Swift.h"

--- a/WordPress/Classes/Services/PostService.m
+++ b/WordPress/Classes/Services/PostService.m
@@ -1,4 +1,6 @@
+#import "Blog.h"
 #import "PostService.h"
+#import "PostServiceOptions.h"
 #import "PostCategory.h"
 #import "Media.h"
 #ifdef KEYSTONE

--- a/WordPress/Classes/Services/ReaderSiteService.h
+++ b/WordPress/Classes/Services/ReaderSiteService.h
@@ -1,5 +1,4 @@
 #import <Foundation/Foundation.h>
-#import "ReaderTopicService.h"
 #import "CoreDataStack.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/WordPress/Classes/System/WordPress-Bridging-Header.h
+++ b/WordPress/Classes/System/WordPress-Bridging-Header.h
@@ -25,7 +25,6 @@
 #import "NSObject+Helpers.h"
 
 #import "PageSettingsViewController.h"
-#import "PostContentProvider.h"
 #import "PostCategory.h"
 #import "PostCategoryService.h"
 #import "PostContentProvider.h"

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemAbstractPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemAbstractPostsViewController.m
@@ -1,5 +1,6 @@
 #import "MenuItemAbstractPostsViewController.h"
 #import "PostService.h"
+#import "PostServiceOptions.h"
 #import "AbstractPost.h"
 @import WordPressKit;
 

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemTypeViewController.h
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemTypeViewController.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import "MenuItem.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemTypeViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemTypeViewController.m
@@ -2,6 +2,7 @@
 #import "MenuItemTypeSelectionView.h"
 #import "BlogService.h"
 #import "Blog.h"
+#import "MenuItem.h"
 #import "PostType.h"
 #ifdef KEYSTONE
 #import "Keystone-Swift.h"

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import "MenuItem.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.m
@@ -1,5 +1,6 @@
 #import "MenuItemSourceHeaderView.h"
 #import "MenuItem+ViewDesign.h"
+#import "MenuItem.h"
 #ifdef KEYSTONE
 #import "Keystone-Swift.h"
 #else

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemTypeSelectionView.h
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemTypeSelectionView.h
@@ -1,5 +1,4 @@
 #import <UIKit/UIKit.h>
-#import "MenuItem.h"
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemTypeSelectionView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemTypeSelectionView.m
@@ -1,6 +1,7 @@
 #import "MenuItemTypeSelectionView.h"
 #import "Menu+ViewDesign.h"
 #import "MenuItem+ViewDesign.h"
+#import "MenuItem.h"
 #ifdef KEYSTONE
 #import "Keystone-Swift.h"
 #else


### PR DESCRIPTION
Same rationale as https://github.com/wordpress-mobile/WordPress-iOS/pull/24326 and https://github.com/wordpress-mobile/WordPress-iOS/pull/24348. Part of https://github.com/wordpress-mobile/WordPress-iOS/issues/24165, all these requirements have been discovered in https://github.com/wordpress-mobile/WordPress-iOS/pull/24378.