### PR TITLE
[Tooling] Remove duplicate logging on CI

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -158,31 +158,6 @@ def build_code_next
 end
 
 ########################################################################
-# Group buildkite logs by action
-########################################################################
-
-# A module that defines methods to be used as overrides to `Fastlane::Actions`
-# module methods.
-module FastlaneActionLogGroup
-  def print_group(action_name)
-    return if %w[is_ci].include?(action_name)
-
-    puts "~~~ :fastlane: #{ENV.fetch('FASTLANE_LANE_NAME', '[root]')} >> #{action_name}"
-  end
-
-  def execute_action(action_name)
-    print_group(action_name)
-    super
-  end
-end
-
-if ENV.key?('BUILDKITE')
-  Fastlane::Actions.singleton_class.class_eval do
-    prepend FastlaneActionLogGroup
-  end
-end
-
-########################################################################
 # Imports domain-specific lanes
 ########################################################################
 


### PR DESCRIPTION
### Why?

Now that we've [migrated to `release-toolkit` version `13.1`](https://github.com/wordpress-mobile/WordPress-iOS/pull/24309), which includes https://github.com/wordpress-mobile/release-toolkit/pull/638 that already handles inserting Buildkite-aware collapsible groups in CI logs for all repos, the custom logic that was added specifically in WPiOS `Fastfile` is no longer needed now that it's handled by the `release-toolkit` itself, and in fact keeping the existing logic in WPiOS' `Fastfile` duplicated the logs in CI

### Testing

Look at the CI logs for this PR and confirm that the collapsible groups inserted in CI logs are no longer duplicated.

[This is what it looked before, right after the project updated to `release-toolkit` version `13.1`](https://buildkite.com/automattic/wordpress-ios/builds/26960/steps?jid=0195eebe-02ad-4936-8a5b-b9efb1ec5913#0195eebe-02ad-4936-8a5b-b9efb1ec5913/1100):

<img width="372" alt="image" src="https://github.com/user-attachments/assets/8db24271-9a6f-42c6-87de-b468dbcbb40e" />

[This is what it looks like now, without any duplication anymore](https://buildkite.com/automattic/wordpress-ios/builds/27121/steps?sid=0196006e-13ff-42eb-a40d-b8e520291a7f#0196006e-146a-42a9-a4d7-102da9a54990/790):

<img width="382" alt="image" src="https://github.com/user-attachments/assets/e414f638-3178-4240-98b0-650b71dd2bf5" />
