### PR TITLE
Fix Xcode warnings

### DIFF
--- a/WordPress/Classes/Login/LoginWithUrlView.swift
+++ b/WordPress/Classes/Login/LoginWithUrlView.swift
@@ -182,6 +182,8 @@ private extension UrlDiscoveryError {
 #Preview {
     LoginWithUrlView(
         client: .init(session: .shared),
-        anchor: ASPresentationAnchor()
+        anchor: mockAnchor
     ) { _ in }
 }
+
+private let mockAnchor = ASPresentationAnchor()

--- a/WordPress/Classes/Models/Media.swift
+++ b/WordPress/Classes/Models/Media.swift
@@ -1,7 +1,7 @@
 import Foundation
 import UniformTypeIdentifiers
 
-public extension Media {
+extension Media {
     // MARK: - AutoUpload Failure Count
 
     static let maxAutoUploadFailureCount = 3

--- a/WordPress/Classes/Models/WPAccount+AccountSettings.swift
+++ b/WordPress/Classes/Models/WPAccount+AccountSettings.swift
@@ -28,7 +28,7 @@ extension WPAccount {
 
     var logDescription: String {
         let coreDataID = objectID.uriRepresentation().absoluteString
-        return "<Account username: \(username ?? "-") ID: \(userID?.stringValue ?? "-"), Email: \(verificationStatus.rawValue) ObjectID: \(coreDataID)>"
+        return "<Account username: \(username) ID: \(userID?.stringValue ?? "-"), Email: \(verificationStatus.rawValue) ObjectID: \(coreDataID)>"
     }
 
     var needsEmailVerification: Bool {

--- a/WordPress/Classes/Plugins/Views/AddNewPluginView.swift
+++ b/WordPress/Classes/Plugins/Views/AddNewPluginView.swift
@@ -95,7 +95,7 @@ struct AddNewPluginView: View {
             .foregroundColor(.secondary)
             .frame(maxWidth: .infinity, alignment: .center)
 
-        case .error(let errorMessage):
+        case .error:
             Text(Strings.loadError)
 
         case let .plugin(plugin, isInstalled):

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/TwitterDeprecationTableFooterView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/TwitterDeprecationTableFooterView.swift
@@ -66,7 +66,7 @@ private extension TwitterDeprecationTableFooterView {
         contentView.pinSubviewToAllEdgeMargins(label)
     }
 
-    @objc public func labelTapped(_ sender: UITapGestureRecognizer) {
+    @objc func labelTapped(_ sender: UITapGestureRecognizer) {
         guard let presentingViewController,
               let source,
               let attributedText = label.attributedText else {

--- a/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Jetpack Scan/JetpackScanCoordinator.swift
@@ -274,8 +274,6 @@ class JetpackScanCoordinator {
         with error: Error? = nil,
         connectionAvailable: Bool = ReachabilityUtils.connectionAvailable
     ) {
-        let appDelegate = WordPressAppDelegate.shared
-
         guard connectionAvailable else {
             view.showNoConnectionError()
             actionButtonState = .tryAgain

--- a/WordPress/Classes/ViewRelated/Me/Views/MeHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Me/Views/MeHeaderView.swift
@@ -112,7 +112,7 @@ struct MeHeaderViewModel {
 
     init(account: WPAccount) {
         self.gravatarEmail = account.email
-        let username = account.username ?? ""
+        let username = account.username
         self.username = "\(username.contains("@") ? "" : "@")\(username)"
         self.displayName = account.displayName ?? ""
     }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -789,7 +789,6 @@ extension NewGutenbergViewController {
             return // TODO: when can it happen?
         }
         service.fetchSettings({ [weak self] result in
-            guard let `self` = self else { return }
             switch result {
             case .success(let response):
                 if response.hasChanges {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -2,7 +2,7 @@ import UIKit
 import WordPressUI
 import AutomatticTracks
 import WordPressReader
-import WebKit
+@preconcurrency import WebKit
 
 typealias RelatedPostsSection = (postType: RemoteReaderSimplePost.PostType, posts: [RemoteReaderSimplePost])
 


### PR DESCRIPTION
Fix a few recently introduced warnings.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
