### PR TITLE
refactor: Fetch and cache GutenbergKit editor settings

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250411"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "fc369073730384c8946bee15ec8ff7c763cf69c9"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "9092f64e3346a998ed652def5efef01b8b3b84f6"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", from: "1.20.0"),
     ],

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250411"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "9092f64e3346a998ed652def5efef01b8b3b84f6"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "cf5773f9f463d464d1f34bbab839a1a8b6c0833a"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", from: "1.20.0"),
     ],

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250411"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "cf5773f9f463d464d1f34bbab839a1a8b6c0833a"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "170d68265cda8d360e58aece4b9faf7ee2726dea"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", from: "1.20.0"),
     ],

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250411"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "170d68265cda8d360e58aece4b9faf7ee2726dea"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "a1c456afd2e873700ad742535cefd1a5f95c9306"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", from: "1.20.0"),
     ],

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250411"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "a1c456afd2e873700ad742535cefd1a5f95c9306"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "fa72e630203e7472d55f4abedfd5c462d2333584"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", from: "1.20.0"),
     ],

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5798ddaf4845488f6935e7f5e7e50c607e70ab571da3ad4aeaf198ed82975e75",
+  "originHash" : "8ed966263b0e58dfaa8e186784f474fac0c0ea68c15a1a6eb1d8c26ae1c46a27",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,7 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "9092f64e3346a998ed652def5efef01b8b3b84f6"
+        "revision" : "cf5773f9f463d464d1f34bbab839a1a8b6c0833a"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "645dd3ef573ab8e20ff04cddccb0ffcc29b7a5f354c0eb4d8f44d125b5a8694d",
+  "originHash" : "5798ddaf4845488f6935e7f5e7e50c607e70ab571da3ad4aeaf198ed82975e75",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,7 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "fc369073730384c8946bee15ec8ff7c763cf69c9"
+        "revision" : "9092f64e3346a998ed652def5efef01b8b3b84f6"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3e4dc68b43ea48afc0ea0cc78b65ead27a1c670f1eaac891c609860328aa0abf",
+  "originHash" : "c7fc894bd07cdfaf1241217c60af90ce11e6474d9488e6d63dd1e81668a87272",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,7 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "a1c456afd2e873700ad742535cefd1a5f95c9306"
+        "revision" : "fa72e630203e7472d55f4abedfd5c462d2333584"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8ed966263b0e58dfaa8e186784f474fac0c0ea68c15a1a6eb1d8c26ae1c46a27",
+  "originHash" : "dd9b1083a3c310f3ae1856ebbcac1d23a5e730c699c98da5026a2ac36f8a791d",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,7 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "cf5773f9f463d464d1f34bbab839a1a8b6c0833a"
+        "revision" : "170d68265cda8d360e58aece4b9faf7ee2726dea"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dd9b1083a3c310f3ae1856ebbcac1d23a5e730c699c98da5026a2ac36f8a791d",
+  "originHash" : "3e4dc68b43ea48afc0ea0cc78b65ead27a1c670f1eaac891c609860328aa0abf",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,7 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "170d68265cda8d360e58aece4b9faf7ee2726dea"
+        "revision" : "a1c456afd2e873700ad742535cefd1a5f95c9306"
       }
     },
     {

--- a/WordPress/Classes/Models/Blog/Blog+RawBlockEditorSettings.swift
+++ b/WordPress/Classes/Models/Blog/Blog+RawBlockEditorSettings.swift
@@ -1,0 +1,27 @@
+import Foundation
+import CoreData
+
+extension Blog {
+    private static let rawBlockEditorSettingsKey = "rawBlockEditorSettings"
+    private static let rawBlockEditorSettingsLastFetchTimeKey = "rawBlockEditorSettingsLastFetchTime"
+
+    /// Stores the raw block editor settings dictionary
+    var rawBlockEditorSettings: [String: Any]? {
+        get {
+            return getOptionValue(Self.rawBlockEditorSettingsKey) as? [String: Any]
+        }
+        set {
+            setValue(newValue, forOption: Self.rawBlockEditorSettingsKey)
+        }
+    }
+
+    /// Stores the last time the raw block editor settings were fetched
+    var rawBlockEditorSettingsLastFetchTime: Date? {
+        get {
+            return getOptionValue(Self.rawBlockEditorSettingsLastFetchTimeKey) as? Date
+        }
+        set {
+            setValue(newValue, forOption: Self.rawBlockEditorSettingsLastFetchTimeKey)
+        }
+    }
+}

--- a/WordPress/Classes/Models/Blog/Blog+RawBlockEditorSettings.swift
+++ b/WordPress/Classes/Models/Blog/Blog+RawBlockEditorSettings.swift
@@ -3,7 +3,6 @@ import CoreData
 
 extension Blog {
     private static let rawBlockEditorSettingsKey = "rawBlockEditorSettings"
-    private static let rawBlockEditorSettingsLastFetchTimeKey = "rawBlockEditorSettingsLastFetchTime"
 
     /// Stores the raw block editor settings dictionary
     var rawBlockEditorSettings: [String: Any]? {
@@ -12,16 +11,6 @@ extension Blog {
         }
         set {
             setValue(newValue, forOption: Self.rawBlockEditorSettingsKey)
-        }
-    }
-
-    /// Stores the last time the raw block editor settings were fetched
-    var rawBlockEditorSettingsLastFetchTime: Date? {
-        get {
-            return getOptionValue(Self.rawBlockEditorSettingsLastFetchTimeKey) as? Date
-        }
-        set {
-            setValue(newValue, forOption: Self.rawBlockEditorSettingsLastFetchTimeKey)
         }
     }
 }

--- a/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
+++ b/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
@@ -17,33 +17,7 @@ class RawBlockEditorSettingsService {
     }
 
     @MainActor
-    func fetchSettings() async throws -> [String: Any] {
-        // Start a background refresh if needed
-        if !isRefreshing && (blog.rawBlockEditorSettingsLastFetchTime == nil || Date().timeIntervalSince(blog.rawBlockEditorSettingsLastFetchTime!) >= 0) {
-            isRefreshing = true
-            Task {
-                do {
-                    let result = await self.remoteAPI.get(path: "/wp-block-editor/v1/settings")
-                    switch result {
-                    case .success(let response):
-                        if let dictionary = response as? [String: Any] {
-                            blog.rawBlockEditorSettings = dictionary
-                            blog.rawBlockEditorSettingsLastFetchTime = Date()
-                        }
-                    case .failure(let error):
-                        DDLogError("Error refreshing block editor settings: \(error)")
-                    }
-                    isRefreshing = false
-                }
-            }
-        }
-
-        // Return cached settings if available, otherwise fetch fresh
-        if let cachedSettings = blog.rawBlockEditorSettings {
-            return cachedSettings
-        }
-
-        // If no cache, fetch synchronously
+    private func fetchSettingsFromAPI() async throws -> [String: Any] {
         let result = await self.remoteAPI.get(path: "/wp-block-editor/v1/settings")
         switch result {
         case .success(let response):
@@ -56,5 +30,43 @@ class RawBlockEditorSettingsService {
         case .failure(let error):
             throw error
         }
+    }
+
+    @MainActor
+    func fetchSettings() async throws -> [String: Any] {
+        // Start a background refresh if needed
+        if !isRefreshing && (blog.rawBlockEditorSettingsLastFetchTime == nil || Date().timeIntervalSince(blog.rawBlockEditorSettingsLastFetchTime!) >= 300) {
+            isRefreshing = true
+            Task {
+                do {
+                    _ = try await fetchSettingsFromAPI()
+                } catch {
+                    DDLogError("Error refreshing block editor settings: \(error)")
+                }
+                isRefreshing = false
+            }
+        }
+
+        // Return cached settings if available
+        if let cachedSettings = blog.rawBlockEditorSettings {
+            return cachedSettings
+        }
+
+        // If no cache and no background refresh in progress, fetch synchronously
+        if !isRefreshing {
+            return try await fetchSettingsFromAPI()
+        }
+
+        // If we're here, it means a background refresh is in progress
+        // Wait for it to complete and return the cached result
+        while isRefreshing {
+            try await Task.sleep(nanoseconds: 100_000_000) // 100ms
+            if let cachedSettings = blog.rawBlockEditorSettings {
+                return cachedSettings
+            }
+        }
+
+        // If we still don't have settings after the refresh completed, throw an error
+        throw NSError(domain: "RawBlockEditorSettingsService", code: 2, userInfo: [NSLocalizedDescriptionKey: "Failed to fetch block editor settings"])
     }
 }

--- a/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
+++ b/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
@@ -3,8 +3,6 @@ import WordPressKit
 import WordPressShared
 
 class RawBlockEditorSettingsService {
-    typealias CompletionHandler = (Result<[String: Any], Error>) -> Void
-
     private let blog: Blog
     private let remoteAPI: WordPressOrgRestApi
 
@@ -17,29 +15,9 @@ class RawBlockEditorSettingsService {
         self.remoteAPI = remoteAPI
     }
 
-    func fetchSettings(completion: @escaping CompletionHandler) {
-        Task { @MainActor in
-            do {
-                let result = await self.remoteAPI.get(path: "/wp-block-editor/v1/settings")
-                switch result {
-                case .success(let response):
-                    guard let dictionary = response as? [String: Any] else {
-                        completion(.failure(NSError(domain: "RawBlockEditorSettingsService", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid response format"])))
-                        return
-                    }
-                    completion(.success(dictionary))
-                case .failure(let error):
-                    completion(.failure(error))
-                }
-            } catch {
-                completion(.failure(error))
-            }
-        }
-    }
-
     @MainActor
     func fetchSettings() async throws -> [String: Any] {
-        let result = await self.remoteAPI.get(path: "/wp-block-editor/v1/settings", parameters: ["context": "mobile"])
+        let result = await self.remoteAPI.get(path: "/wp-block-editor/v1/settings")
         switch result {
         case .success(let response):
             guard let dictionary = response as? [String: Any] else {

--- a/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
+++ b/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
@@ -1,0 +1,53 @@
+import Foundation
+import WordPressKit
+import WordPressShared
+
+class RawBlockEditorSettingsService {
+    typealias CompletionHandler = (Result<[String: Any], Error>) -> Void
+
+    private let blog: Blog
+    private let remoteAPI: WordPressOrgRestApi
+
+    init?(blog: Blog) {
+        guard let remoteAPI = WordPressOrgRestApi(blog: blog) else {
+            return nil
+        }
+
+        self.blog = blog
+        self.remoteAPI = remoteAPI
+    }
+
+    func fetchSettings(completion: @escaping CompletionHandler) {
+        Task { @MainActor in
+            do {
+                let result = await self.remoteAPI.get(path: "/wp-block-editor/v1/settings", parameters: ["context": "mobile"])
+                switch result {
+                case .success(let response):
+                    guard let dictionary = response as? [String: Any] else {
+                        completion(.failure(NSError(domain: "RawBlockEditorSettingsService", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid response format"])))
+                        return
+                    }
+                    completion(.success(dictionary))
+                case .failure(let error):
+                    completion(.failure(error))
+                }
+            } catch {
+                completion(.failure(error))
+            }
+        }
+    }
+
+    @MainActor
+    func fetchSettings() async throws -> [String: Any] {
+        let result = await self.remoteAPI.get(path: "/wp-block-editor/v1/settings", parameters: ["context": "mobile"])
+        switch result {
+        case .success(let response):
+            guard let dictionary = response as? [String: Any] else {
+                throw NSError(domain: "RawBlockEditorSettingsService", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid response format"])
+            }
+            return dictionary
+        case .failure(let error):
+            throw error
+        }
+    }
+}

--- a/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
+++ b/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
@@ -9,6 +9,7 @@ class RawBlockEditorSettingsService {
     // Cache for the settings
     private var cachedSettings: [String: Any]?
     private var lastFetchTime: Date?
+    private var isRefreshing: Bool = false
 
     init?(blog: Blog) {
         guard let remoteAPI = WordPressOrgRestApi(blog: blog) else {
@@ -21,20 +22,38 @@ class RawBlockEditorSettingsService {
 
     @MainActor
     func fetchSettings() async throws -> [String: Any] {
-        // If we have cached settings and they're less than 5 minutes old, return them
-        if let cachedSettings = cachedSettings,
-           let lastFetchTime = lastFetchTime,
-           Date().timeIntervalSince(lastFetchTime) < 300 { // 5 minutes
+        // Start a background refresh if needed
+        if !isRefreshing && (lastFetchTime == nil || Date().timeIntervalSince(lastFetchTime!) >= 300) {
+            isRefreshing = true
+            Task {
+                do {
+                    let result = await self.remoteAPI.get(path: "/wp-block-editor/v1/settings")
+                    switch result {
+                    case .success(let response):
+                        if let dictionary = response as? [String: Any] {
+                            cachedSettings = dictionary
+                            lastFetchTime = Date()
+                        }
+                    case .failure(let error):
+                        DDLogError("Error refreshing block editor settings: \(error)")
+                    }
+                    isRefreshing = false
+                }
+            }
+        }
+
+        // Return cached settings if available, otherwise fetch fresh
+        if let cachedSettings = cachedSettings {
             return cachedSettings
         }
 
+        // If no cache, fetch synchronously
         let result = await self.remoteAPI.get(path: "/wp-block-editor/v1/settings")
         switch result {
         case .success(let response):
             guard let dictionary = response as? [String: Any] else {
                 throw NSError(domain: "RawBlockEditorSettingsService", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid response format"])
             }
-            // Cache the successful response
             cachedSettings = dictionary
             lastFetchTime = Date()
             return dictionary

--- a/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
+++ b/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
@@ -43,7 +43,7 @@ class RawBlockEditorSettingsService {
         }
 
         // Return cached settings if available, otherwise fetch fresh
-        if let cachedSettings = cachedSettings {
+        if let cachedSettings {
             return cachedSettings
         }
 

--- a/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
+++ b/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
@@ -5,10 +5,6 @@ import WordPressShared
 class RawBlockEditorSettingsService {
     private let blog: Blog
     private let remoteAPI: WordPressOrgRestApi
-
-    // Cache for the settings
-    private var cachedSettings: [String: Any]?
-    private var lastFetchTime: Date?
     private var isRefreshing: Bool = false
 
     init?(blog: Blog) {
@@ -23,7 +19,7 @@ class RawBlockEditorSettingsService {
     @MainActor
     func fetchSettings() async throws -> [String: Any] {
         // Start a background refresh if needed
-        if !isRefreshing && (lastFetchTime == nil || Date().timeIntervalSince(lastFetchTime!) >= 300) {
+        if !isRefreshing && (blog.rawBlockEditorSettingsLastFetchTime == nil || Date().timeIntervalSince(blog.rawBlockEditorSettingsLastFetchTime!) >= 0) {
             isRefreshing = true
             Task {
                 do {
@@ -31,8 +27,8 @@ class RawBlockEditorSettingsService {
                     switch result {
                     case .success(let response):
                         if let dictionary = response as? [String: Any] {
-                            cachedSettings = dictionary
-                            lastFetchTime = Date()
+                            blog.rawBlockEditorSettings = dictionary
+                            blog.rawBlockEditorSettingsLastFetchTime = Date()
                         }
                     case .failure(let error):
                         DDLogError("Error refreshing block editor settings: \(error)")
@@ -43,7 +39,7 @@ class RawBlockEditorSettingsService {
         }
 
         // Return cached settings if available, otherwise fetch fresh
-        if let cachedSettings {
+        if let cachedSettings = blog.rawBlockEditorSettings {
             return cachedSettings
         }
 
@@ -54,8 +50,8 @@ class RawBlockEditorSettingsService {
             guard let dictionary = response as? [String: Any] else {
                 throw NSError(domain: "RawBlockEditorSettingsService", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid response format"])
             }
-            cachedSettings = dictionary
-            lastFetchTime = Date()
+            blog.rawBlockEditorSettings = dictionary
+            blog.rawBlockEditorSettingsLastFetchTime = Date()
             return dictionary
         case .failure(let error):
             throw error

--- a/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
+++ b/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
@@ -25,7 +25,6 @@ class RawBlockEditorSettingsService {
                 throw NSError(domain: "RawBlockEditorSettingsService", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid response format"])
             }
             blog.rawBlockEditorSettings = dictionary
-            blog.rawBlockEditorSettingsLastFetchTime = Date()
             return dictionary
         case .failure(let error):
             throw error
@@ -34,8 +33,8 @@ class RawBlockEditorSettingsService {
 
     @MainActor
     func fetchSettings() async throws -> [String: Any] {
-        // Start a background refresh if needed
-        if !isRefreshing && (blog.rawBlockEditorSettingsLastFetchTime == nil || Date().timeIntervalSince(blog.rawBlockEditorSettingsLastFetchTime!) >= 300) {
+        // Start a background refresh if not already refreshing
+        if !isRefreshing {
             isRefreshing = true
             Task {
                 do {

--- a/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
+++ b/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
@@ -20,7 +20,7 @@ class RawBlockEditorSettingsService {
     func fetchSettings(completion: @escaping CompletionHandler) {
         Task { @MainActor in
             do {
-                let result = await self.remoteAPI.get(path: "/wp-block-editor/v1/settings", parameters: ["context": "mobile"])
+                let result = await self.remoteAPI.get(path: "/wp-block-editor/v1/settings")
                 switch result {
                 case .success(let response):
                     guard let dictionary = response as? [String: Any] else {

--- a/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
+++ b/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
@@ -6,6 +6,10 @@ class RawBlockEditorSettingsService {
     private let blog: Blog
     private let remoteAPI: WordPressOrgRestApi
 
+    // Cache for the settings
+    private var cachedSettings: [String: Any]?
+    private var lastFetchTime: Date?
+
     init?(blog: Blog) {
         guard let remoteAPI = WordPressOrgRestApi(blog: blog) else {
             return nil
@@ -17,12 +21,22 @@ class RawBlockEditorSettingsService {
 
     @MainActor
     func fetchSettings() async throws -> [String: Any] {
+        // If we have cached settings and they're less than 5 minutes old, return them
+        if let cachedSettings = cachedSettings,
+           let lastFetchTime = lastFetchTime,
+           Date().timeIntervalSince(lastFetchTime) < 300 { // 5 minutes
+            return cachedSettings
+        }
+
         let result = await self.remoteAPI.get(path: "/wp-block-editor/v1/settings")
         switch result {
         case .success(let response):
             guard let dictionary = response as? [String: Any] else {
                 throw NSError(domain: "RawBlockEditorSettingsService", code: 1, userInfo: [NSLocalizedDescriptionKey: "Invalid response format"])
             }
+            // Cache the successful response
+            cachedSettings = dictionary
+            lastFetchTime = Date()
             return dictionary
         case .failure(let error):
             throw error

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -70,6 +70,10 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
     // MARK: - Dependencies
 
     private let overlaysCoordinator: MySiteOverlaysCoordinator
+    private lazy var editorSettingsService: RawBlockEditorSettingsService? = {
+        guard let blog, FeatureFlag.newGutenberg.enabled || RemoteFeatureFlag.newGutenberg.enabled() else { return nil }
+        return RawBlockEditorSettingsService(blog: blog)
+    }()
 
     // TODO: (reader) factor if out of `MySiteVC` for a production version
     var isReaderAppModeEnabled = false
@@ -380,6 +384,24 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
 
             hideBlogDetails()
             showDashboard(for: blog)
+        }
+
+        if FeatureFlag.newGutenberg.enabled || RemoteFeatureFlag.newGutenberg.enabled() {
+            // Update editor settings service with new blog and fetch settings
+            editorSettingsService = RawBlockEditorSettingsService(blog: blog)
+            fetchEditorSettings()
+        }
+    }
+
+    private func fetchEditorSettings() {
+        guard let service = editorSettingsService else { return }
+
+        Task { @MainActor in
+            do {
+                _ = try await service.fetchSettings()
+            } catch {
+                DDLogError("Error fetching editor settings: \(error)")
+            }
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -172,7 +172,7 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         subscribeToPostPublished()
         subscribeToWillEnterForeground()
 
-        if FeatureFlag.newGutenberg.enabled {
+        if FeatureFlag.newGutenberg.enabled || RemoteFeatureFlag.newGutenberg.enabled() {
             GutenbergKit.EditorViewController.warmup()
         }
     }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -358,23 +358,18 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
             return
         }
 
-        service.fetchSettings { [weak self] result in
-            guard let self else { return }
-
-            DispatchQueue.main.async {
-                switch result {
-                case .success(let settings):
-                    // Update the editor configuration with the fetched settings
-                    var updatedConfig = self.editorViewController.configuration
-                    updatedConfig.updateEditorSettings(settings)
-                    self.editorViewController.updateConfiguration(updatedConfig)
-                    self.editorViewController.startEditorSetup()
-
-                case .failure(let error):
-                    // Start the editor with the default settings
-                    DDLogError("Error fetching block editor settings: \(error)")
-                    self.editorViewController.startEditorSetup()
-                }
+        Task { @MainActor in
+            do {
+                let settings = try await service.fetchSettings()
+                // Update the editor configuration with the fetched settings
+                var updatedConfig = self.editorViewController.configuration
+                updatedConfig.updateEditorSettings(settings)
+                self.editorViewController.updateConfiguration(updatedConfig)
+                self.editorViewController.startEditorSetup()
+            } catch {
+                // Start the editor with the default settings
+                DDLogError("Error fetching block editor settings: \(error)")
+                self.editorViewController.startEditorSetup()
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -74,6 +74,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
     private var editorViewController: GutenbergKit.EditorViewController
     private var activityIndicator: UIActivityIndicatorView?
+    private var hasEditorStarted = false
 
     lazy var autosaver = Autosaver() {
         self.performAutoSave()
@@ -354,22 +355,44 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
     private func fetchBlockEditorSettings() {
         guard let service = rawBlockEditorSettingsService else {
-            hideActivityIndicator()
+            self.editorViewController.startEditorSetup()
             return
         }
 
         Task { @MainActor in
+            // Start the editor with default settings after 3 seconds
+            let timeoutTask = Task {
+                try await Task.sleep(nanoseconds: 3_000_000_000) // 3 seconds
+                if !Task.isCancelled && !self.hasEditorStarted {
+                    self.hasEditorStarted = true
+                    self.editorViewController.startEditorSetup()
+                }
+            }
+
             do {
                 let settings = try await service.fetchSettings()
-                // Update the editor configuration with the fetched settings
-                var updatedConfig = self.editorViewController.configuration
-                updatedConfig.updateEditorSettings(settings)
-                self.editorViewController.updateConfiguration(updatedConfig)
-                self.editorViewController.startEditorSetup()
+                // Cancel the timeout task since we got settings in time
+                timeoutTask.cancel()
+
+                // Only start the editor if it hasn't been started yet
+                if !self.hasEditorStarted {
+                    self.hasEditorStarted = true
+                    // Update the editor configuration with the fetched settings
+                    var updatedConfig = self.editorViewController.configuration
+                    updatedConfig.updateEditorSettings(settings)
+                    self.editorViewController.updateConfiguration(updatedConfig)
+                    self.editorViewController.startEditorSetup()
+                }
             } catch {
-                // Start the editor with the default settings
-                DDLogError("Error fetching block editor settings: \(error)")
-                self.editorViewController.startEditorSetup()
+                // Cancel the timeout task since we got an error
+                timeoutTask.cancel()
+
+                // Only start the editor if it hasn't been started yet
+                if !self.hasEditorStarted {
+                    self.hasEditorStarted = true
+                    // Start the editor with the default settings
+                    self.editorViewController.startEditorSetup()
+                }
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -72,8 +72,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
     // MARK: - GutenbergKit
 
-    private var editorViewController: GutenbergKit.EditorViewController?
-    private var configuration: EditorConfiguration
+    private var editorViewController: GutenbergKit.EditorViewController
     private var activityIndicator: UIActivityIndicatorView?
 
     lazy var autosaver = Autosaver() {
@@ -122,6 +121,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         editorSession: PostEditorAnalyticsSession? = nil,
         navigationBarManager: PostEditorNavigationBarManager? = nil
     ) {
+
         self.post = post
 
         self.replaceEditor = replaceEditor
@@ -184,10 +184,11 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
             }
         }
 
-        self.configuration = conf
+        self.editorViewController = GutenbergKit.EditorViewController(configuration: conf)
 
         super.init(nibName: nil, bundle: nil)
 
+        self.editorViewController.delegate = self
         self.navigationBarManager.delegate = self
     }
 
@@ -232,8 +233,6 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     private func setupEditorView() {
         view.tintColor = UIAppColor.editorPrimary
 
-        guard let editorViewController = editorViewController else { return }
-
         addChild(editorViewController)
         view.addSubview(editorViewController.view)
         view.pinSubviewToAllEdges(editorViewController.view)
@@ -271,7 +270,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         let content = post.content ?? String()
 
         setTitle(post.postTitle ?? "")
-        editorViewController?.setContent(content)
+        editorViewController.setContent(content)
 
         // TODO: reimplement
 //        SiteSuggestionService.shared.prefetchSuggestionsIfNeeded(for: post.blog) { [weak self] in
@@ -287,7 +286,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     }
 
     func toggleEditingMode() {
-        editorViewController?.isCodeEditorEnabled.toggle()
+        editorViewController.isCodeEditorEnabled.toggle()
     }
 
     private func performAutoSave() {
@@ -298,7 +297,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
     private func getLatestContent() async {
         let startTime = CFAbsoluteTimeGetCurrent()
-        let editorData = try? await editorViewController?.getTitleAndContent()
+        let editorData = try? await editorViewController.getTitleAndContent()
         let duration = CFAbsoluteTimeGetCurrent() - startTime
         print("gutenbergkit-measure_get-latest-content:", duration)
 
@@ -367,17 +366,26 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
                 switch result {
                 case .success(let settings):
-                    // Update the configuration with the fetched settings
-                    var updatedConfig = self.configuration
+                    // Update the editor configuration with the fetched settings
+                    var updatedConfig = self.editorViewController.configuration
                     updatedConfig.blockEditorSettings = settings
 
-                    // Create the editor view controller with the updated configuration
-                    let editorVC = GutenbergKit.EditorViewController(configuration: updatedConfig)
-                    editorVC.delegate = self
-                    self.editorViewController = editorVC
+                    // Create a new editor view controller with the updated configuration
+                    let newEditorVC = GutenbergKit.EditorViewController(configuration: updatedConfig)
+                    newEditorVC.delegate = self
 
-                    // Setup the editor view
-                    self.setupEditorView()
+                    // Replace the old editor view controller with the new one
+                    self.editorViewController.willMove(toParent: nil)
+                    self.editorViewController.view.removeFromSuperview()
+                    self.editorViewController.removeFromParent()
+
+                    self.addChild(newEditorVC)
+                    self.view.addSubview(newEditorVC.view)
+                    self.view.pinSubviewToAllEdges(newEditorVC.view)
+                    newEditorVC.didMove(toParent: self)
+
+                    // Update the reference to the editor view controller
+                    self.editorViewController = newEditorVC
 
                 case .failure(let error):
                     DDLogError("Error fetching block editor settings: \(error)")
@@ -441,7 +449,7 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
 
         mediaPickerHelper.presentSiteMediaPicker(filter: flags, allowMultipleSelection: config.multiple, initialSelection: initialSelectionArray) { [weak self] assets in
             guard let self, let media = assets as? [Media] else {
-                self?.editorViewController?.setMediaUploadAttachment("[]")
+                self?.editorViewController.setMediaUploadAttachment("[]")
                 return
             }
             let mediaInfos = media.map { item in
@@ -454,7 +462,7 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
             if let jsonString = convertMediaInfoArrayToJSONString(mediaInfos) {
                 // Escape the string for JavaScript
                 let escapedJsonString = jsonString.replacingOccurrences(of: "'", with: "\\'")
-                editorViewController?.setMediaUploadAttachment(escapedJsonString)
+                editorViewController.setMediaUploadAttachment(escapedJsonString)
             }
         }
     }
@@ -663,11 +671,11 @@ extension NewGutenbergViewController: PostEditorNavigationBarManagerDelegate {
     }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, undoWasPressed sender: UIButton) {
-        editorViewController?.undo()
+        editorViewController.undo()
     }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, redoWasPressed sender: UIButton) {
-        editorViewController?.redo()
+        editorViewController.redo()
     }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, moreWasPressed sender: UIButton) {
@@ -754,8 +762,8 @@ extension NewGutenbergViewController {
     private func makeMoreMenuActions() -> [UIAction] {
         var actions: [UIAction] = []
 
-        let toggleModeTitle = editorViewController?.isCodeEditorEnabled ?? false ? Strings.visualEditor : Strings.codeEditor
-        let toggleModeIconName = editorViewController?.isCodeEditorEnabled ?? false ? "doc.richtext" : "curlybraces"
+        let toggleModeTitle = editorViewController.isCodeEditorEnabled ? Strings.visualEditor : Strings.codeEditor
+        let toggleModeIconName = editorViewController.isCodeEditorEnabled ? "doc.richtext" : "curlybraces"
         actions.append(UIAction(title: toggleModeTitle, image: UIImage(systemName: toggleModeIconName)) { [weak self] _ in
             self?.toggleEditingMode()
         })

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -72,7 +72,8 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
     // MARK: - GutenbergKit
 
-    private var editorViewController: GutenbergKit.EditorViewController
+    private var editorViewController: GutenbergKit.EditorViewController?
+    private var configuration: EditorConfiguration
     private var activityIndicator: UIActivityIndicatorView?
 
     lazy var autosaver = Autosaver() {
@@ -121,7 +122,6 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         editorSession: PostEditorAnalyticsSession? = nil,
         navigationBarManager: PostEditorNavigationBarManager? = nil
     ) {
-
         self.post = post
 
         self.replaceEditor = replaceEditor
@@ -184,11 +184,10 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
             }
         }
 
-        self.editorViewController = GutenbergKit.EditorViewController(configuration: conf)
+        self.configuration = conf
 
         super.init(nibName: nil, bundle: nil)
 
-        self.editorViewController.delegate = self
         self.navigationBarManager.delegate = self
     }
 
@@ -233,6 +232,8 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     private func setupEditorView() {
         view.tintColor = UIAppColor.editorPrimary
 
+        guard let editorViewController = editorViewController else { return }
+
         addChild(editorViewController)
         view.addSubview(editorViewController.view)
         view.pinSubviewToAllEdges(editorViewController.view)
@@ -270,7 +271,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         let content = post.content ?? String()
 
         setTitle(post.postTitle ?? "")
-        editorViewController.setContent(content)
+        editorViewController?.setContent(content)
 
         // TODO: reimplement
 //        SiteSuggestionService.shared.prefetchSuggestionsIfNeeded(for: post.blog) { [weak self] in
@@ -286,7 +287,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     }
 
     func toggleEditingMode() {
-        editorViewController.isCodeEditorEnabled.toggle()
+        editorViewController?.isCodeEditorEnabled.toggle()
     }
 
     private func performAutoSave() {
@@ -297,7 +298,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
     private func getLatestContent() async {
         let startTime = CFAbsoluteTimeGetCurrent()
-        let editorData = try? await editorViewController.getTitleAndContent()
+        let editorData = try? await editorViewController?.getTitleAndContent()
         let duration = CFAbsoluteTimeGetCurrent() - startTime
         print("gutenbergkit-measure_get-latest-content:", duration)
 
@@ -366,26 +367,17 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
                 switch result {
                 case .success(let settings):
-                    // Update the editor configuration with the fetched settings
-                    var updatedConfig = self.editorViewController.configuration
+                    // Update the configuration with the fetched settings
+                    var updatedConfig = self.configuration
                     updatedConfig.blockEditorSettings = settings
 
-                    // Create a new editor view controller with the updated configuration
-                    let newEditorVC = GutenbergKit.EditorViewController(configuration: updatedConfig)
-                    newEditorVC.delegate = self
+                    // Create the editor view controller with the updated configuration
+                    let editorVC = GutenbergKit.EditorViewController(configuration: updatedConfig)
+                    editorVC.delegate = self
+                    self.editorViewController = editorVC
 
-                    // Replace the old editor view controller with the new one
-                    self.editorViewController.willMove(toParent: nil)
-                    self.editorViewController.view.removeFromSuperview()
-                    self.editorViewController.removeFromParent()
-
-                    self.addChild(newEditorVC)
-                    self.view.addSubview(newEditorVC.view)
-                    self.view.pinSubviewToAllEdges(newEditorVC.view)
-                    newEditorVC.didMove(toParent: self)
-
-                    // Update the reference to the editor view controller
-                    self.editorViewController = newEditorVC
+                    // Setup the editor view
+                    self.setupEditorView()
 
                 case .failure(let error):
                     DDLogError("Error fetching block editor settings: \(error)")
@@ -449,7 +441,7 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
 
         mediaPickerHelper.presentSiteMediaPicker(filter: flags, allowMultipleSelection: config.multiple, initialSelection: initialSelectionArray) { [weak self] assets in
             guard let self, let media = assets as? [Media] else {
-                self?.editorViewController.setMediaUploadAttachment("[]")
+                self?.editorViewController?.setMediaUploadAttachment("[]")
                 return
             }
             let mediaInfos = media.map { item in
@@ -462,7 +454,7 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
             if let jsonString = convertMediaInfoArrayToJSONString(mediaInfos) {
                 // Escape the string for JavaScript
                 let escapedJsonString = jsonString.replacingOccurrences(of: "'", with: "\\'")
-                editorViewController.setMediaUploadAttachment(escapedJsonString)
+                editorViewController?.setMediaUploadAttachment(escapedJsonString)
             }
         }
     }
@@ -671,11 +663,11 @@ extension NewGutenbergViewController: PostEditorNavigationBarManagerDelegate {
     }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, undoWasPressed sender: UIButton) {
-        editorViewController.undo()
+        editorViewController?.undo()
     }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, redoWasPressed sender: UIButton) {
-        editorViewController.redo()
+        editorViewController?.redo()
     }
 
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, moreWasPressed sender: UIButton) {
@@ -762,8 +754,8 @@ extension NewGutenbergViewController {
     private func makeMoreMenuActions() -> [UIAction] {
         var actions: [UIAction] = []
 
-        let toggleModeTitle = editorViewController.isCodeEditorEnabled ? Strings.visualEditor : Strings.codeEditor
-        let toggleModeIconName = editorViewController.isCodeEditorEnabled ? "doc.richtext" : "curlybraces"
+        let toggleModeTitle = editorViewController?.isCodeEditorEnabled ?? false ? Strings.visualEditor : Strings.codeEditor
+        let toggleModeIconName = editorViewController?.isCodeEditorEnabled ?? false ? "doc.richtext" : "curlybraces"
         actions.append(UIAction(title: toggleModeTitle, image: UIImage(systemName: toggleModeIconName)) { [weak self] _ in
             self?.toggleEditingMode()
         })

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -359,36 +359,21 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         }
 
         service.fetchSettings { [weak self] result in
-            guard let self = self else { return }
+            guard let self else { return }
 
             DispatchQueue.main.async {
-                self.hideActivityIndicator()
-
                 switch result {
                 case .success(let settings):
                     // Update the editor configuration with the fetched settings
                     var updatedConfig = self.editorViewController.configuration
-                    updatedConfig.blockEditorSettings = settings
-
-                    // Create a new editor view controller with the updated configuration
-                    let newEditorVC = GutenbergKit.EditorViewController(configuration: updatedConfig)
-                    newEditorVC.delegate = self
-
-                    // Replace the old editor view controller with the new one
-                    self.editorViewController.willMove(toParent: nil)
-                    self.editorViewController.view.removeFromSuperview()
-                    self.editorViewController.removeFromParent()
-
-                    self.addChild(newEditorVC)
-                    self.view.addSubview(newEditorVC.view)
-                    self.view.pinSubviewToAllEdges(newEditorVC.view)
-                    newEditorVC.didMove(toParent: self)
-
-                    // Update the reference to the editor view controller
-                    self.editorViewController = newEditorVC
+                    updatedConfig.updateEditorSettings(settings)
+                    self.editorViewController.updateConfiguration(updatedConfig)
+                    self.editorViewController.startEditorSetup()
 
                 case .failure(let error):
+                    // Start the editor with the default settings
                     DDLogError("Error fetching block editor settings: \(error)")
+                    self.editorViewController.startEditorSetup()
                 }
             }
         }
@@ -404,6 +389,7 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
             // is still reflecting the actual startup time of the editor
             editorSession.start()
         }
+        self.hideActivityIndicator()
     }
 
     func editor(_ viewContoller: GutenbergKit.EditorViewController, didDisplayInitialContent content: String) {

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -65,9 +65,15 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         BlockEditorSettingsService(blog: post.blog, coreDataStack: ContextManager.shared)
     }()
 
+    // New service for fetching raw block editor settings
+    lazy var rawBlockEditorSettingsService: RawBlockEditorSettingsService? = {
+        return RawBlockEditorSettingsService(blog: post.blog)
+    }()
+
     // MARK: - GutenbergKit
 
-    private let editorViewController: GutenbergKit.EditorViewController
+    private var editorViewController: GutenbergKit.EditorViewController
+    private var activityIndicator: UIActivityIndicatorView?
 
     lazy var autosaver = Autosaver() {
         self.performAutoSave()
@@ -202,7 +208,11 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         configureNavigationBar()
         refreshInterface()
 
-        fetchBlockSettings()
+        // Show activity indicator while fetching settings
+        showActivityIndicator()
+
+        // Fetch block editor settings
+        fetchBlockEditorSettings()
 
         // TODO: reimplement
 //        service?.syncJetpackSettingsForBlog(post.blog, success: { [weak self] in
@@ -314,6 +324,73 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     func logException(_ exception: GutenbergJSException, with callback: @escaping () -> Void) {
         DispatchQueue.main.async {
             WordPressAppDelegate.crashLogging?.logJavaScriptException(exception, callback: callback)
+        }
+    }
+
+    // MARK: - Activity Indicator
+
+    private func showActivityIndicator() {
+        let indicator = UIActivityIndicatorView(style: .large)
+        indicator.color = .gray
+        indicator.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(indicator)
+
+        NSLayoutConstraint.activate([
+            indicator.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            indicator.centerYAnchor.constraint(equalTo: view.centerYAnchor)
+        ])
+
+        indicator.startAnimating()
+        self.activityIndicator = indicator
+    }
+
+    private func hideActivityIndicator() {
+        activityIndicator?.stopAnimating()
+        activityIndicator?.removeFromSuperview()
+        activityIndicator = nil
+    }
+
+    // MARK: - Block Editor Settings
+
+    private func fetchBlockEditorSettings() {
+        guard let service = rawBlockEditorSettingsService else {
+            hideActivityIndicator()
+            return
+        }
+
+        service.fetchSettings { [weak self] result in
+            guard let self = self else { return }
+
+            DispatchQueue.main.async {
+                self.hideActivityIndicator()
+
+                switch result {
+                case .success(let settings):
+                    // Update the editor configuration with the fetched settings
+                    var updatedConfig = self.editorViewController.configuration
+                    updatedConfig.blockEditorSettings = settings
+
+                    // Create a new editor view controller with the updated configuration
+                    let newEditorVC = GutenbergKit.EditorViewController(configuration: updatedConfig)
+                    newEditorVC.delegate = self
+
+                    // Replace the old editor view controller with the new one
+                    self.editorViewController.willMove(toParent: nil)
+                    self.editorViewController.view.removeFromSuperview()
+                    self.editorViewController.removeFromParent()
+
+                    self.addChild(newEditorVC)
+                    self.view.addSubview(newEditorVC.view)
+                    self.view.pinSubviewToAllEdges(newEditorVC.view)
+                    newEditorVC.didMove(toParent: self)
+
+                    // Update the reference to the editor view controller
+                    self.editorViewController = newEditorVC
+
+                case .failure(let error):
+                    DDLogError("Error fetching block editor settings: \(error)")
+                }
+            }
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -355,7 +355,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
     private func fetchBlockEditorSettings() {
         guard let service = rawBlockEditorSettingsService else {
-            self.editorViewController.startEditorSetup()
+            startEditor()
             return
         }
 
@@ -363,38 +363,33 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
             // Start the editor with default settings after 3 seconds
             let timeoutTask = Task {
                 try await Task.sleep(nanoseconds: 3_000_000_000) // 3 seconds
-                if !Task.isCancelled && !self.hasEditorStarted {
-                    self.hasEditorStarted = true
-                    self.editorViewController.startEditorSetup()
+                if !Task.isCancelled {
+                    startEditor()
                 }
             }
 
             do {
                 let settings = try await service.fetchSettings()
-                // Cancel the timeout task since we got settings in time
                 timeoutTask.cancel()
-
-                // Only start the editor if it hasn't been started yet
-                if !self.hasEditorStarted {
-                    self.hasEditorStarted = true
-                    // Update the editor configuration with the fetched settings
-                    var updatedConfig = self.editorViewController.configuration
-                    updatedConfig.updateEditorSettings(settings)
-                    self.editorViewController.updateConfiguration(updatedConfig)
-                    self.editorViewController.startEditorSetup()
-                }
+                startEditor(with: settings)
             } catch {
-                // Cancel the timeout task since we got an error
                 timeoutTask.cancel()
-
-                // Only start the editor if it hasn't been started yet
-                if !self.hasEditorStarted {
-                    self.hasEditorStarted = true
-                    // Start the editor with the default settings
-                    self.editorViewController.startEditorSetup()
-                }
+                DDLogError("Error fetching block editor settings: \(error)")
+                startEditor()
             }
         }
+    }
+
+    private func startEditor(with settings: [String: Any]? = nil) {
+        guard !hasEditorStarted else { return }
+        hasEditorStarted = true
+
+        if let settings {
+            var updatedConfig = self.editorViewController.configuration
+            updatedConfig.updateEditorSettings(settings)
+            self.editorViewController.updateConfiguration(updatedConfig)
+        }
+        self.editorViewController.startEditorSetup()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -366,11 +366,27 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
                 switch result {
                 case .success(let settings):
-                    // Update the editor settings using the bridge method
-                    let settingsJSON = try? JSONSerialization.data(withJSONObject: settings, options: [])
-                    if let jsonString = settingsJSON.flatMap({ String(data: $0, encoding: .utf8) }) {
-                        self.editorViewController.webView.evaluateJavaScript("window.editor.updateSettings(\(jsonString));")
-                    }
+                    // Update the editor configuration with the fetched settings
+                    var updatedConfig = self.editorViewController.configuration
+                    updatedConfig.blockEditorSettings = settings
+
+                    // Create a new editor view controller with the updated configuration
+                    let newEditorVC = GutenbergKit.EditorViewController(configuration: updatedConfig)
+                    newEditorVC.delegate = self
+
+                    // Replace the old editor view controller with the new one
+                    self.editorViewController.willMove(toParent: nil)
+                    self.editorViewController.view.removeFromSuperview()
+                    self.editorViewController.removeFromParent()
+
+                    self.addChild(newEditorVC)
+                    self.view.addSubview(newEditorVC.view)
+                    self.view.pinSubviewToAllEdges(newEditorVC.view)
+                    newEditorVC.didMove(toParent: self)
+
+                    // Update the reference to the editor view controller
+                    self.editorViewController = newEditorVC
+
                 case .failure(let error):
                     DDLogError("Error fetching block editor settings: \(error)")
                 }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -366,27 +366,11 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
                 switch result {
                 case .success(let settings):
-                    // Update the editor configuration with the fetched settings
-                    var updatedConfig = self.editorViewController.configuration
-                    updatedConfig.blockEditorSettings = settings
-
-                    // Create a new editor view controller with the updated configuration
-                    let newEditorVC = GutenbergKit.EditorViewController(configuration: updatedConfig)
-                    newEditorVC.delegate = self
-
-                    // Replace the old editor view controller with the new one
-                    self.editorViewController.willMove(toParent: nil)
-                    self.editorViewController.view.removeFromSuperview()
-                    self.editorViewController.removeFromParent()
-
-                    self.addChild(newEditorVC)
-                    self.view.addSubview(newEditorVC.view)
-                    self.view.pinSubviewToAllEdges(newEditorVC.view)
-                    newEditorVC.didMove(toParent: self)
-
-                    // Update the reference to the editor view controller
-                    self.editorViewController = newEditorVC
-
+                    // Update the editor settings using the bridge method
+                    let settingsJSON = try? JSONSerialization.data(withJSONObject: settings, options: [])
+                    if let jsonString = settingsJSON.flatMap({ String(data: $0, encoding: .utf8) }) {
+                        self.editorViewController.webView.evaluateJavaScript("window.editor.updateSettings(\(jsonString));")
+                    }
                 case .failure(let error):
                     DDLogError("Error fetching block editor settings: \(error)")
                 }


### PR DESCRIPTION
Fetch and cache editor settings before providing them to the editor, as it
allows improving offline support. The changes also communicate the 
background activity with an activity indicator. 

Ref CMM-200.

Related: 

* CMM-200-linear-issue
* https://github.com/wordpress-mobile/GutenbergKit/issues/105
* https://github.com/wordpress-mobile/GutenbergKit/pull/114
* https://github.com/wordpress-mobile/WordPress-Android/pull/21791

To test:

> [!Important]
> Ensure the following experimental features are enabled:
> * Experimental block editor
> * Experimental block editor styles

**1: Initial editor fallbacks to default settings**
1. Enable airplane mode. 
2. Open the post editor. 
3. Verify the editor loads, using default settings—e.g., white background with black text. 

**2: Editor fetches site-specific settings**
1. Disable airplane mode. 
2. Open the post editor. 
3. Verify the editor loads with site-specific settings—e.g., the theme's background and foreground colors. 

**3: Editor fallback to cached settings**
1. Enable airplane mode. 
2. Open the post editor. 
3. Verify the editor loads with site-specific settings—e.g., the theme's background and foreground colors. 


## Regression Notes
1. Potential unintended areas of impact
  Regressions in Gutenberg Mobile or Aztec editors. 
1. What I did to test those areas of impact (or what existing automated tests I relied on)
  Manually smoke tested the editors. 
1. What automated tests I added (or what prevented me from doing so)
  Deemed unnecessary for the experimental editor. 
PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)