### PR TITLE
Extract Swift-dependent logic from `Theme`

### DIFF
--- a/Sources/WordPressData/Theme+Swift.swift
+++ b/Sources/WordPressData/Theme+Swift.swift
@@ -1,0 +1,20 @@
+extension Theme {
+
+    public func customizeUrl() -> String {
+        let path = "customize.php?theme=\(themePathForCustomization)&hide_close=true"
+
+        return blog.adminUrl(withPath: path)
+    }
+
+    private var themePathForCustomization: String {
+        guard blog.supports(.customThemes) else {
+            return stylesheet
+        }
+
+        if custom {
+            return themeId
+        } else {
+            return ThemeIdHelper.themeIdWithWPComSuffix(themeId)
+        }
+    }
+}

--- a/WordPress/Classes/Models/Theme.h
+++ b/WordPress/Classes/Models/Theme.h
@@ -38,13 +38,6 @@
 + (NSString *)entityName;
 
 /**
- *  @brief      Link to customization page for this theme
- *
- *  @returns    The URL to present
- */
-- (NSString *)customizeUrl;
-
-/**
  *  @brief      Link to details page for this theme
  *
  *  @returns    The URL to present

--- a/WordPress/Classes/Models/Theme.m
+++ b/WordPress/Classes/Models/Theme.m
@@ -47,25 +47,6 @@ static NSString* const ThemeUrlDetails = @"https://wordpress.com/themes/%@/%@/?p
 
 #pragma mark - Links
 
-- (NSString *)customizeUrl
-{
-    NSString *themePath = [self themePathForCustomization];
-    NSString *path = [NSString stringWithFormat:ThemeAdminUrlCustomize, themePath];
-    
-    return [self.blog adminUrlWithPath:path];
-}
-
-- (NSString *)themePathForCustomization {
-    if ([self.blog supports:BlogFeatureCustomThemes]) {
-        if (self.custom) {
-            return self.themeId;
-        } else {
-            return [ThemeIdHelper themeIdWithWPComSuffix:self.themeId];
-        }
-    }
-    return self.stylesheet;
-}
-
 - (NSString *)detailsUrl
 {
     if (self.custom) {

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2011,8 +2011,32 @@
 			);
 			target = 0CED016F2D95B897003015CF /* Keystone */;
 		};
+		3F1A48232DA3B23900786B92 /* Exceptions for "WordPressData" folder in "Keystone" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"Theme+Swift.swift",
+			);
+			target = 0CED016F2D95B897003015CF /* Keystone */;
+		};
+		3F1A48252DA3C19100786B92 /* Exceptions for "WordPressData" folder in "WordPress" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"Theme+Swift.swift",
+			);
+			target = 1D6058900D05DD3D006BFB54 /* WordPress */;
+		};
+		3F1A48272DA3C19700786B92 /* Exceptions for "WordPressData" folder in "Jetpack" target */ = {
+			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"Theme+Swift.swift",
+			);
+			target = FABB1F8F2602FC2C00C8785C /* Jetpack */;
+		};
 		3F7AE0D02D9B30A200AB4892 /* Exceptions for "WordPressData" folder in "WordPressData" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
+			membershipExceptions = (
+				"Theme+Swift.swift",
+			);
 			publicHeaders = (
 				WordPressData.h,
 			);
@@ -2087,6 +2111,9 @@
 		3F7AE0B62D9B30A100AB4892 /* WordPressData */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
 			exceptions = (
+				3F1A48252DA3C19100786B92 /* Exceptions for "WordPressData" folder in "WordPress" target */,
+				3F1A48272DA3C19700786B92 /* Exceptions for "WordPressData" folder in "Jetpack" target */,
+				3F1A48232DA3B23900786B92 /* Exceptions for "WordPressData" folder in "Keystone" target */,
 				3F7AE0D02D9B30A200AB4892 /* Exceptions for "WordPressData" folder in "WordPressData" target */,
 			);
 			path = WordPressData;


### PR DESCRIPTION
This was a quick win I noticed while working on https://github.com/wordpress-mobile/WordPress-iOS/pull/24378.

Part of #24165.