### PR TITLE
Update access of types required by Keystone for WordPressData link

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate+openURL.swift
@@ -237,7 +237,7 @@ private extension URL {
     }
 }
 
-extension WordPressAppDelegate {
+public extension WordPressAppDelegate {
     @objc class var appURLScheme: String {
         BuildSettings.current.appURLScheme
     }

--- a/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalytics+Domains.swift
@@ -64,8 +64,8 @@ enum DomainsAnalyticsWebViewOrigin: String {
 }
 
 // TODO: remove when WPAppAnalyticsTests get rewritten, preferably in Swift
-@objc final class WPAnalyticsTesting: NSObject {
+@objc public final class WPAnalyticsTesting: NSObject {
     @objc static var eventNamePrefix: String?
     @objc static var explatPlatform: String?
-    @objc static var appURLScheme: String?
+    @objc public static var appURLScheme: String?
 }

--- a/WordPress/Classes/Utility/WebViewController/CookieJar.swift
+++ b/WordPress/Classes/Utility/WebViewController/CookieJar.swift
@@ -4,7 +4,7 @@ import WebKit
 /// Provides a common interface to look for a logged-in WordPress cookie in different
 /// cookie storage systems.
 ///
-@objc protocol CookieJar {
+@objc public protocol CookieJar {
     func getCookies(url: URL, completion: @escaping ([HTTPCookie]) -> Void)
     func getCookies(completion: @escaping ([HTTPCookie]) -> Void)
     func hasWordPressSelfHostedAuthCookie(for url: URL, username: String, completion: @escaping (Bool) -> Void)
@@ -54,32 +54,32 @@ extension CookieJarSharedImplementation {
 }
 
 extension HTTPCookieStorage: CookieJarSharedImplementation {
-    func getCookies(url: URL, completion: @escaping ([HTTPCookie]) -> Void) {
+    public func getCookies(url: URL, completion: @escaping ([HTTPCookie]) -> Void) {
         completion(cookies(for: url) ?? [])
     }
 
-    func getCookies(completion: @escaping ([HTTPCookie]) -> Void) {
+    public func getCookies(completion: @escaping ([HTTPCookie]) -> Void) {
         completion(cookies ?? [])
     }
 
-    func hasWordPressComAuthCookie(username: String, atomicSite: Bool, completion: @escaping (Bool) -> Void) {
+    public func hasWordPressComAuthCookie(username: String, atomicSite: Bool, completion: @escaping (Bool) -> Void) {
         _hasWordPressComAuthCookie(username: username, atomicSite: atomicSite, completion: completion)
     }
 
-    func hasWordPressSelfHostedAuthCookie(for url: URL, username: String, completion: @escaping (Bool) -> Void) {
+    public func hasWordPressSelfHostedAuthCookie(for url: URL, username: String, completion: @escaping (Bool) -> Void) {
         _hasWordPressAuthCookie(for: url, username: username, atomicSite: false, completion: completion)
     }
 
-    func removeCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
+    public func removeCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
         cookies.forEach(deleteCookie(_:))
         completion()
     }
 
-    func removeWordPressComCookies(completion: @escaping () -> Void) {
+    public func removeWordPressComCookies(completion: @escaping () -> Void) {
         _removeWordPressComCookies(completion: completion)
     }
 
-    func setCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
+    public func setCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
         for cookie in cookies {
             setCookie(cookie)
         }
@@ -89,7 +89,7 @@ extension HTTPCookieStorage: CookieJarSharedImplementation {
 }
 
 extension WKHTTPCookieStore: CookieJarSharedImplementation {
-    func getCookies(url: URL, completion: @escaping ([HTTPCookie]) -> Void) {
+    public func getCookies(url: URL, completion: @escaping ([HTTPCookie]) -> Void) {
 
         // This fixes an issue with `getAllCookies` not calling its completion block (related: https://stackoverflow.com/q/55565188)
         // - adds timeout so the above failure will eventually return
@@ -123,19 +123,19 @@ extension WKHTTPCookieStore: CookieJarSharedImplementation {
         }
     }
 
-    func getCookies(completion: @escaping ([HTTPCookie]) -> Void) {
+    public func getCookies(completion: @escaping ([HTTPCookie]) -> Void) {
         getAllCookies(completion)
     }
 
-    func hasWordPressComAuthCookie(username: String, atomicSite: Bool, completion: @escaping (Bool) -> Void) {
+    public func hasWordPressComAuthCookie(username: String, atomicSite: Bool, completion: @escaping (Bool) -> Void) {
         _hasWordPressComAuthCookie(username: username, atomicSite: atomicSite, completion: completion)
     }
 
-    func hasWordPressSelfHostedAuthCookie(for url: URL, username: String, completion: @escaping (Bool) -> Void) {
+    public func hasWordPressSelfHostedAuthCookie(for url: URL, username: String, completion: @escaping (Bool) -> Void) {
         _hasWordPressAuthCookie(for: url, username: username, atomicSite: false, completion: completion)
     }
 
-    func removeCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
+    public func removeCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
         let group = DispatchGroup()
         cookies
             .forEach({ [unowned self] (cookie) in
@@ -151,11 +151,11 @@ extension WKHTTPCookieStore: CookieJarSharedImplementation {
         completion()
     }
 
-    func removeWordPressComCookies(completion: @escaping () -> Void) {
+    public func removeWordPressComCookies(completion: @escaping () -> Void) {
         _removeWordPressComCookies(completion: completion)
     }
 
-    func setCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
+    public func setCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
         guard let cookie = cookies.last else {
             return completion()
         }

--- a/WordPress/Classes/Utility/WebViewController/CookieJar.swift
+++ b/WordPress/Classes/Utility/WebViewController/CookieJar.swift
@@ -4,7 +4,7 @@ import WebKit
 /// Provides a common interface to look for a logged-in WordPress cookie in different
 /// cookie storage systems.
 ///
-@objc public protocol CookieJar {
+@objc protocol CookieJar {
     func getCookies(url: URL, completion: @escaping ([HTTPCookie]) -> Void)
     func getCookies(completion: @escaping ([HTTPCookie]) -> Void)
     func hasWordPressSelfHostedAuthCookie(for url: URL, username: String, completion: @escaping (Bool) -> Void)
@@ -54,32 +54,32 @@ extension CookieJarSharedImplementation {
 }
 
 extension HTTPCookieStorage: CookieJarSharedImplementation {
-    public func getCookies(url: URL, completion: @escaping ([HTTPCookie]) -> Void) {
+    func getCookies(url: URL, completion: @escaping ([HTTPCookie]) -> Void) {
         completion(cookies(for: url) ?? [])
     }
 
-    public func getCookies(completion: @escaping ([HTTPCookie]) -> Void) {
+    func getCookies(completion: @escaping ([HTTPCookie]) -> Void) {
         completion(cookies ?? [])
     }
 
-    public func hasWordPressComAuthCookie(username: String, atomicSite: Bool, completion: @escaping (Bool) -> Void) {
+    func hasWordPressComAuthCookie(username: String, atomicSite: Bool, completion: @escaping (Bool) -> Void) {
         _hasWordPressComAuthCookie(username: username, atomicSite: atomicSite, completion: completion)
     }
 
-    public func hasWordPressSelfHostedAuthCookie(for url: URL, username: String, completion: @escaping (Bool) -> Void) {
+    func hasWordPressSelfHostedAuthCookie(for url: URL, username: String, completion: @escaping (Bool) -> Void) {
         _hasWordPressAuthCookie(for: url, username: username, atomicSite: false, completion: completion)
     }
 
-    public func removeCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
+    func removeCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
         cookies.forEach(deleteCookie(_:))
         completion()
     }
 
-    public func removeWordPressComCookies(completion: @escaping () -> Void) {
+    func removeWordPressComCookies(completion: @escaping () -> Void) {
         _removeWordPressComCookies(completion: completion)
     }
 
-    public func setCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
+    func setCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
         for cookie in cookies {
             setCookie(cookie)
         }
@@ -89,7 +89,7 @@ extension HTTPCookieStorage: CookieJarSharedImplementation {
 }
 
 extension WKHTTPCookieStore: CookieJarSharedImplementation {
-    public func getCookies(url: URL, completion: @escaping ([HTTPCookie]) -> Void) {
+    func getCookies(url: URL, completion: @escaping ([HTTPCookie]) -> Void) {
 
         // This fixes an issue with `getAllCookies` not calling its completion block (related: https://stackoverflow.com/q/55565188)
         // - adds timeout so the above failure will eventually return
@@ -123,19 +123,19 @@ extension WKHTTPCookieStore: CookieJarSharedImplementation {
         }
     }
 
-    public func getCookies(completion: @escaping ([HTTPCookie]) -> Void) {
+    func getCookies(completion: @escaping ([HTTPCookie]) -> Void) {
         getAllCookies(completion)
     }
 
-    public func hasWordPressComAuthCookie(username: String, atomicSite: Bool, completion: @escaping (Bool) -> Void) {
+    func hasWordPressComAuthCookie(username: String, atomicSite: Bool, completion: @escaping (Bool) -> Void) {
         _hasWordPressComAuthCookie(username: username, atomicSite: atomicSite, completion: completion)
     }
 
-    public func hasWordPressSelfHostedAuthCookie(for url: URL, username: String, completion: @escaping (Bool) -> Void) {
+    func hasWordPressSelfHostedAuthCookie(for url: URL, username: String, completion: @escaping (Bool) -> Void) {
         _hasWordPressAuthCookie(for: url, username: username, atomicSite: false, completion: completion)
     }
 
-    public func removeCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
+    func removeCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
         let group = DispatchGroup()
         cookies
             .forEach({ [unowned self] (cookie) in
@@ -151,11 +151,11 @@ extension WKHTTPCookieStore: CookieJarSharedImplementation {
         completion()
     }
 
-    public func removeWordPressComCookies(completion: @escaping () -> Void) {
+    func removeWordPressComCookies(completion: @escaping () -> Void) {
         _removeWordPressComCookies(completion: completion)
     }
 
-    public func setCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
+    func setCookies(_ cookies: [HTTPCookie], completion: @escaping () -> Void) {
         guard let cookie = cookies.last else {
             return completion()
         }


### PR DESCRIPTION
I finally got to the point where WordPressData compiles in WordPress and Jetpack in https://github.com/wordpress-mobile/WordPress-iOS/pull/24378 and progressed to make it work from within Keystone.

Once I removed the WordPressData sources from Keystone, a few access level changes became necessary for Keystone to compile again, despite them looking unrelated to WordPressData.

While it's possible I made a mistake or that there was some caching issues going on, it seems safe to merge these `+ public` changes and move on.

Similar to https://github.com/wordpress-mobile/WordPress-iOS/pull/24326, https://github.com/wordpress-mobile/WordPress-iOS/pull/24348, and https://github.com/wordpress-mobile/WordPress-iOS/pull/24406. Part of #24165.
