### PR TITLE
Remove WPDeviceIdentification.isRetina

### DIFF
--- a/Modules/Sources/WordPressSharedObjC/Utility/WPDeviceIdentification.m
+++ b/Modules/Sources/WordPressSharedObjC/Utility/WPDeviceIdentification.m
@@ -10,10 +10,6 @@
     return [UIDevice currentDevice].userInterfaceIdiom == UIUserInterfaceIdiomPad;
 }
 
-+ (BOOL)isRetina {
-    return ([[UIScreen mainScreen] respondsToSelector:@selector(scale)] && [[UIScreen mainScreen] scale] > 1);
-}
-
 + (BOOL)isUnzoomediPhonePlus
 {
     CGRect bounds = UIScreen.mainScreen.fixedCoordinateSpace.bounds;

--- a/Modules/Sources/WordPressSharedObjC/include/WPDeviceIdentification.h
+++ b/Modules/Sources/WordPressSharedObjC/include/WPDeviceIdentification.h
@@ -22,13 +22,6 @@
 + (BOOL)isiPad;
 
 /**
- *  @brief      Call this method to know if the current device has a retina screen.
- *
- *  @returns    YES if the device has a retina screen.  NO otherwise.
- */
-+ (BOOL)isRetina;
-
-/**
  *  @brief      Call this method to know if the current device is a Plus sized
  *              phone (6+, 6s+, 7+) , at its native scale.
  *

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemsViewController.m
@@ -50,10 +50,6 @@ static CGFloat const ItemOrderingTouchesDetectionInset = 10.0;
     self.view.backgroundColor = [UIColor murielListForeground];
     self.view.layer.borderColor = [[UIColor murielNeutral10] CGColor];
     self.view.layer.borderWidth = MenusDesignStrokeWidth;
-    if (![WPDeviceIdentification isRetina]) {
-        // Increase the stroke width on non-retina screens.
-        self.view.layer.borderWidth = MenusDesignStrokeWidth * 2;
-    }
 
     _itemViews = [NSMutableSet set];
     _insertionViews = [NSMutableSet setWithCapacity:3];

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTextBar.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTextBar.m
@@ -102,10 +102,6 @@
     contentView.translatesAutoresizingMaskIntoConstraints = NO;
     contentView.layer.borderColor = [[UIColor murielNeutral10] CGColor];
     contentView.layer.borderWidth = MenusDesignStrokeWidth;
-    if (![WPDeviceIdentification isRetina]) {
-        // Increase the stroke width on non-retina screens.
-        contentView.layer.borderWidth = MenusDesignStrokeWidth * 2;
-    }
     contentView.backgroundColor = [UIColor murielBasicBackground];
 
     NSAssert(_stackView != nil, @"stackView is nil");

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionView.m
@@ -30,10 +30,6 @@
     self.backgroundColor = [UIColor murielListForeground];
     self.layer.borderColor = [[UIColor murielNeutral10] CGColor];
     self.layer.borderWidth = MenusDesignStrokeWidth;
-    if (![WPDeviceIdentification isRetina]) {
-        // Increase the stroke width on non-retina screens.
-        self.layer.borderWidth = MenusDesignStrokeWidth * 2;
-    }
 
     _items = [NSMutableArray arrayWithCapacity:5];
     _itemViews = [NSMutableArray array];


### PR DESCRIPTION
Just something I noticed that can be safely removed now.

To test:

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
