### PR TITLE
Add initial Reader app top-level navigation

### DIFF
--- a/WordPress/Classes/Apps/Reader/ReaderRootViewPresenter.swift
+++ b/WordPress/Classes/Apps/Reader/ReaderRootViewPresenter.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+final class ReaderRootViewPresenter: RootViewPresenter {
+    // TODO: (reader) implement
+    let rootViewController: UIViewController = {
+        let vc = UIViewController()
+        vc.view.backgroundColor = .red
+        return vc
+    }()
+
+    func currentlySelectedScreen() -> String {
+        // TODO: (reader) implement
+        ""
+    }
+
+    func currentlyVisibleBlog() -> Blog? {
+        // TODO: (reader) this should be optional? what is it for?
+        nil
+    }
+
+    func showMySitesTab() {
+        // TODO: (reader) optional?
+    }
+
+    func showBlogDetails(for blog: Blog, then subsection: BlogDetailsSubsection?, userInfo: [AnyHashable: Any]) {
+        // TODO: (reader) optional?
+    }
+
+    func showReader(path: ReaderNavigationPath?) {
+        // TODO: (reader) implement
+    }
+
+    func showNotificationsTab(completion: ((NotificationsViewController) -> Void)?) {
+        // TODO: (reader) implement
+    }
+
+    func showMeScreen(completion: ((MeViewController) -> Void)?) {
+        // TODO: (reader) optional?
+    }
+}

--- a/WordPress/Classes/Apps/Reader/ReaderRootViewPresenter.swift
+++ b/WordPress/Classes/Apps/Reader/ReaderRootViewPresenter.swift
@@ -1,12 +1,7 @@
-import Foundation
+import UIKit
 
 final class ReaderRootViewPresenter: RootViewPresenter {
-    // TODO: (reader) implement
-    let rootViewController: UIViewController = {
-        let vc = UIViewController()
-        vc.view.backgroundColor = .red
-        return vc
-    }()
+    let rootViewController: UIViewController = ReaderTabViewController()
 
     func currentlySelectedScreen() -> String {
         // TODO: (reader) implement

--- a/WordPress/Classes/Apps/Reader/ReaderTabViewController.swift
+++ b/WordPress/Classes/Apps/Reader/ReaderTabViewController.swift
@@ -9,13 +9,35 @@ final class ReaderTabViewController: UITabBarController {
     }
 
     private func setupViewControllers() {
-        let homeVC = UIViewController()
+        self.viewControllers = [
+            makeHomeViewController(),
+            makeFollowingViewController(),
+            makeDiscoverViewController(),
+            makeNotificationsViewController(),
+            makeMeViewController()
+        ]
+    }
+
+    // MARK: - Tabs
+
+    private func makeHomeViewController() -> UIViewController {
+        let homeVC: UIViewController = {
+            // TODO: (reader) refactor to not require `topic`
+            if let topic = ReaderSidebarViewModel().getTopic(for: .following) {
+                ReaderStreamViewController.controllerWithTopic(topic)
+            } else {
+                UIViewController()
+            }
+        }()
         homeVC.tabBarItem = UITabBarItem(
             title: Strings.home,
             image: UIImage(named: "reader-menu-home"),
             selectedImage: nil
         )
+        return UINavigationController(rootViewController: homeVC)
+    }
 
+    private func makeFollowingViewController() -> UIViewController {
         // TODO: (reader) figure out where we show tags and lists
         let followingVC = UIHostingController(rootView: ReaderSubscriptionsView()
             .environment(\.managedObjectContext, ContextManager.shared.mainContext))
@@ -24,8 +46,12 @@ final class ReaderTabViewController: UITabBarController {
             image: UIImage(named: "reader-menu-subscriptions"),
             selectedImage: nil
         )
-        followingVC.navigationItem.largeTitleDisplayMode = .always
+        let navigationVC = UINavigationController(rootViewController: followingVC)
+        followingVC.enableLargeTitles()
+        return navigationVC
+    }
 
+    private func makeDiscoverViewController() -> UIViewController {
         let discoverVC: UIViewController = {
             // TODO: (reader) refactor to not require `topic`
             if let topic = ReaderSidebarViewModel().getTopic(for: .discover) {
@@ -39,32 +65,42 @@ final class ReaderTabViewController: UITabBarController {
             image: UIImage(named: "reader-menu-explorer"),
             selectedImage: nil
         )
+        return UINavigationController(rootViewController: discoverVC)
+    }
 
+    private func makeNotificationsViewController() -> UIViewController {
+        let notificationsVC = UIStoryboard(name: "Notifications", bundle: nil)
+            .instantiateInitialViewController() as! NotificationsViewController
         // TODO: (reader) bind notifications
-        let notificationsVC = UIViewController()
         notificationsVC.tabBarItem = UITabBarItem(
             title: Strings.notifications,
             image: UIImage(named: "tab-bar-notifications"),
             selectedImage: UIImage(named: "tab-bar-notifications")
         )
+        notificationsVC.isReaderModeEnabled = true
+        let navigationVC = UINavigationController(rootViewController: notificationsVC)
+        notificationsVC.enableLargeTitles()
+        return navigationVC
+    }
 
+    private func makeMeViewController() -> UIViewController {
+        // TODO: (reader) this requires a reader-speicifc profile, so it's just a placeholder
+        let meVC = MeViewController()
         // TODO: (reader) display your profile icons
-        let meVC = UIViewController()
         meVC.tabBarItem = UITabBarItem(
             title: Strings.me,
             image: UIImage(named: "tab-bar-me"),
             selectedImage: UIImage(named: "tab-bar-me")
         )
+        return UINavigationController(rootViewController: meVC)
+    }
+}
 
-        self.viewControllers = [
-            UINavigationController(rootViewController: homeVC),
-            UINavigationController(rootViewController: followingVC),
-            UINavigationController(rootViewController: discoverVC),
-            UINavigationController(rootViewController: notificationsVC),
-            UINavigationController(rootViewController: meVC)
-        ]
-
-        followingVC.navigationController?.navigationBar.prefersLargeTitles = true
+private extension UIViewController {
+    func enableLargeTitles() {
+        assert(navigationController != nil)
+        navigationItem.largeTitleDisplayMode = .always
+        navigationController?.navigationBar.prefersLargeTitles = true
     }
 }
 

--- a/WordPress/Classes/Apps/Reader/ReaderTabViewController.swift
+++ b/WordPress/Classes/Apps/Reader/ReaderTabViewController.swift
@@ -1,0 +1,77 @@
+import UIKit
+import SwiftUI
+
+final class ReaderTabViewController: UITabBarController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        setupViewControllers()
+    }
+
+    private func setupViewControllers() {
+        let homeVC = UIViewController()
+        homeVC.tabBarItem = UITabBarItem(
+            title: Strings.home,
+            image: UIImage(named: "reader-menu-home"),
+            selectedImage: nil
+        )
+
+        // TODO: (reader) figure out where we show tags and lists
+        let followingVC = UIHostingController(rootView: ReaderSubscriptionsView()
+            .environment(\.managedObjectContext, ContextManager.shared.mainContext))
+        followingVC.tabBarItem = UITabBarItem(
+            title: Strings.following,
+            image: UIImage(named: "reader-menu-subscriptions"),
+            selectedImage: nil
+        )
+        followingVC.navigationItem.largeTitleDisplayMode = .always
+
+        let discoverVC: UIViewController = {
+            // TODO: (reader) refactor to not require `topic`
+            if let topic = ReaderSidebarViewModel().getTopic(for: .discover) {
+                ReaderDiscoverViewController(topic: topic)
+            } else {
+                UIViewController()
+            }
+        }()
+        discoverVC.tabBarItem = UITabBarItem(
+            title: Strings.discover,
+            image: UIImage(named: "reader-menu-explorer"),
+            selectedImage: nil
+        )
+
+        // TODO: (reader) bind notifications
+        let notificationsVC = UIViewController()
+        notificationsVC.tabBarItem = UITabBarItem(
+            title: Strings.notifications,
+            image: UIImage(named: "tab-bar-notifications"),
+            selectedImage: UIImage(named: "tab-bar-notifications")
+        )
+
+        // TODO: (reader) display your profile icons
+        let meVC = UIViewController()
+        meVC.tabBarItem = UITabBarItem(
+            title: Strings.me,
+            image: UIImage(named: "tab-bar-me"),
+            selectedImage: UIImage(named: "tab-bar-me")
+        )
+
+        self.viewControllers = [
+            UINavigationController(rootViewController: homeVC),
+            UINavigationController(rootViewController: followingVC),
+            UINavigationController(rootViewController: discoverVC),
+            UINavigationController(rootViewController: notificationsVC),
+            UINavigationController(rootViewController: meVC)
+        ]
+
+        followingVC.navigationController?.navigationBar.prefersLargeTitles = true
+    }
+}
+
+private enum Strings {
+    static let home = NSLocalizedString("readerApp.tabBar.home", value: "Home", comment: "Reader app primary navigation tab bar")
+    static let following = NSLocalizedString("readerApp.tabBar.following", value: "Following", comment: "Reader app primary navigation tab bar")
+    static let discover = NSLocalizedString("readerApp.tabBar.discover", value: "Discover", comment: "Reader app primary navigation tab bar")
+    static let notifications = NSLocalizedString("readerApp.tabBar.notifications", value: "Notifications", comment: "Reader app primary navigation tab bar")
+    static let me = NSLocalizedString("readerApp.tabBar.me", value: "Me", comment: "Reader app primary navigation tab bar")
+}

--- a/WordPress/Classes/System/Root View/RootViewCoordinator.swift
+++ b/WordPress/Classes/System/Root View/RootViewCoordinator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import BuildSettingsKit
 import WordPressAuthenticator
 import WordPressShared
 
@@ -55,17 +56,21 @@ class RootViewCoordinator {
     private var featureFlagStore: RemoteFeatureFlagStore
     private var windowManager: WindowManager?
     private let wordPressAuthenticator: WordPressAuthenticatorProtocol.Type
+    private let app: AppBrand
+
     var isSiteCreationActive = false
     var isFullScreenOverlayBeingDisplayed = false
     // MARK: Initializer
 
     init(featureFlagStore: RemoteFeatureFlagStore,
          windowManager: WindowManager?,
-         wordPressAuthenticator: WordPressAuthenticatorProtocol.Type = WordPressAuthenticator.self) {
+         wordPressAuthenticator: WordPressAuthenticatorProtocol.Type = WordPressAuthenticator.self,
+         app: AppBrand = BuildSettings.current.brand) {
         self.featureFlagStore = featureFlagStore
         self.windowManager = windowManager
         self.currentAppUIType = Self.appUIType(featureFlagStore: featureFlagStore)
         self.wordPressAuthenticator = wordPressAuthenticator
+        self.app = app
         updateJetpackFeaturesRemovalCoordinatorState()
     }
 
@@ -92,6 +97,9 @@ class RootViewCoordinator {
     }
 
     private func createPresenter(_ appType: AppUIType) -> RootViewPresenter {
+        if app == .reader {
+            return ReaderRootViewPresenter()
+        }
         if UIDevice.isPad() {
             return SplitViewRootPresenter()
         }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -114,6 +114,7 @@ class NotificationsViewController: UIViewController, UITableViewDataSource, UITa
     }()
 
     var isSidebarModeEnabled = false
+    var isReaderModeEnabled = false
 
     // MARK: - View Lifecycle
 
@@ -450,8 +451,10 @@ class NotificationsViewController: UIViewController, UITableViewDataSource, UITa
 private extension NotificationsViewController {
 
     func setupNavigationBar() {
-        navigationController?.navigationBar.prefersLargeTitles = false
-        navigationItem.largeTitleDisplayMode = .never
+        if !isReaderModeEnabled {
+            navigationController?.navigationBar.prefersLargeTitles = false
+            navigationItem.largeTitleDisplayMode = .never
+        }
 
         // Don't show 'Notifications' in the next-view back button
         // we are using a space character because we need a non-empty string to ensure a smooth


### PR DESCRIPTION
This PR test some initial Reader top-level navigation going for iPhone.

**Limitations**: no deep linking, no iPad.

**To test**:

- Change `WPAppBrand` in `Info.plist` to `Reader`
- Run Jetpack
- Verify that the new Reader navigation it shown

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
