### PR TITLE
Specialize `scrollToTop` for `UICollectionView`

### DIFF
--- a/WordPress/Classes/Extensions/UIScrollView+Helpers.swift
+++ b/WordPress/Classes/Extensions/UIScrollView+Helpers.swift
@@ -15,3 +15,9 @@ extension UIScrollView {
         }
     }
 }
+
+extension UICollectionView {
+    @objc override func scrollToTop(animated: Bool) {
+        self.scrollToItem(at: IndexPath(item: 0, section: 0), at: .top, animated: animated)
+    }
+}


### PR DESCRIPTION
When a `UIScrollView` is actually a `UICollectionView` with a large title bar, the `scrollToTop` method couldn’t figure out the correct `adjustedContentInset` properly.

`UICollectionView` has `scrollToItem` which properly takes that into account, so we can cheat and just ask the collection view to scroll to the top item

Fixes #24021 

To test: See the original issue
