### PR TITLE
Store self hosted sites REST API root URL

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -51,7 +51,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/WordPressKit-iOS", branch: "wpios-edition"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
-        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250409"),
+        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250411"),
         .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "a03e0dae10a404c88c215bfcee3176df951302f5"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", from: "1.20.0"),

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "e6a9163ae536e498cb3b486db128b446499c8e937abda18922b097bae4378a80",
+  "originHash" : "7d23f6aa4973099f8e7915f9978778d596fc1bcd896fb3338f0709459c0f6687",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -382,8 +382,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/wordpress-rs",
       "state" : {
-        "branch" : "alpha-20250409",
-        "revision" : "840c00b461cfd8e90697c7c5882ee7181d08fa39"
+        "branch" : "alpha-20250411",
+        "revision" : "0de58e944c075cf509d7e13a9b4625dae430d84f"
       }
     },
     {

--- a/WordPress/Classes/Login/LoginWithUrlView.swift
+++ b/WordPress/Classes/Login/LoginWithUrlView.swift
@@ -110,5 +110,3 @@ private extension LoginWithUrlView {
 #Preview {
     LoginWithUrlView(presenter: nil) { _ in }
 }
-
-private let mockAnchor = ASPresentationAnchor()

--- a/WordPress/Classes/Login/LoginWithUrlView.swift
+++ b/WordPress/Classes/Login/LoginWithUrlView.swift
@@ -3,32 +3,21 @@ import AuthenticationServices
 import WordPressAPI
 import WordPressAuthenticator
 import DesignSystem
+import WordPressShared
 
 struct LoginWithUrlView: View {
 
-    private let client: SelfHostedSiteAuthenticator
-    private let loginCompleted: (WordPressOrgCredentials) -> Void
-
-    // Since the anchor is a window that typically is the window this view is presented in,
-    // using a weak reference here to avoid retain cycle.
-    private weak var anchor: ASPresentationAnchor?
+    weak var presenter: UIViewController?
+    let loginCompleted: (TaggedManagedObjectID<Blog>) -> Void
 
     @State fileprivate var errorMessage: String?
     @State private var urlField: String = ""
     @State private var isLoading = false
 
+    @Environment(\.dismiss) var dismiss
+
     private var isContinueButtonDisabled: Bool {
         isLoading || urlField.trim().isEmpty
-    }
-
-    init(
-        client: SelfHostedSiteAuthenticator,
-        anchor: ASPresentationAnchor,
-        loginCompleted: @escaping (WordPressOrgCredentials) -> Void
-    ) {
-        self.client = client
-        self.anchor = anchor
-        self.loginCompleted = loginCompleted
     }
 
     var body: some View {
@@ -87,10 +76,17 @@ struct LoginWithUrlView: View {
         // The Swift compiler isn't happy about placing this do-catch function body inside a Task.
         // https://github.com/swiftlang/swift/issues/76807
         func login() async {
+            guard let presenter else {
+                wpAssertionFailure("No presenter assigned")
+                return
+            }
+
             do {
-                let anchor = self.anchor ?? UIWindow()
-                let credentials = try await client.signIn(site: urlField, from: anchor)
-                self.loginCompleted(credentials)
+                let blog = try await SelfHostedSiteAuthenticator()
+                    .signIn(site: urlField, from: presenter, context: .default)
+
+                dismiss()
+                self.loginCompleted(blog)
             } catch {
                 errorMessage = error.localizedDescription
             }
@@ -112,10 +108,7 @@ private extension LoginWithUrlView {
 // MARK: - SwiftUI Preview
 
 #Preview {
-    LoginWithUrlView(
-        client: .init(session: .shared),
-        anchor: mockAnchor
-    ) { _ in }
+    LoginWithUrlView(presenter: nil) { _ in }
 }
 
 private let mockAnchor = ASPresentationAnchor()

--- a/WordPress/Classes/Models/Blog/Blog+SelfHosted.swift
+++ b/WordPress/Classes/Models/Blog/Blog+SelfHosted.swift
@@ -18,13 +18,15 @@ public extension Blog {
 
     static func createRestApiBlog(
         with details: WpApiApplicationPasswordDetails,
+        restApiRootURL: URL,
         in contextManager: ContextManager,
         using keychainImplementation: KeychainAccessible = KeychainUtils()
-    ) async throws -> String {
+    ) async throws -> TaggedManagedObjectID<Blog> {
         try await contextManager.performAndSave { context in
             let blog = Blog.createBlankBlog(in: context)
             blog.url = details.siteUrl
             blog.username = details.userLogin
+            blog.restApiRootURL = restApiRootURL.absoluteString
             try blog.setXMLRPCEndpoint(to: details.derivedXMLRPCRoot)
             blog.setSiteIdentifier(details.derivedSiteId)
 
@@ -33,7 +35,7 @@ public extension Blog {
             // Application token can also be used in XMLRPC.
             try blog.setPassword(to: details.password, using: keychainImplementation)
 
-            return details.derivedSiteId
+            return TaggedManagedObjectID(blog)
         }
     }
 

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -415,6 +415,12 @@ extension WordPressAppDelegate {
         self.authManager?.presentDefaultAccountPrimarySite(from: navigationController)
     }
 
+    func present(selfHostedSite blog: Blog, from navigationController: UINavigationController) {
+        self.authManager?.presentLoginEpilogue(in: navigationController, forSelfHostedSite: blog, source: nil) {
+            // Do nothing.
+        }
+    }
+
     func handleWebActivity(_ activity: NSUserActivity) {
         // try to handle unauthenticated routes first.
         if activity.activityType == NSUserActivityTypeBrowsingWeb,

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/AddSiteController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/AddSiteController.swift
@@ -40,15 +40,10 @@ struct AddSiteController {
     }
 
     private func showApplicationPasswordAuthenticationForSelfHostedSite() {
-        guard let window = viewController.view.window else {
-            return wpAssertionFailure("window missing")
-        }
-        let client = SelfHostedSiteAuthenticator(session: URLSession(configuration: .ephemeral))
-        let view = LoginWithUrlView(client: client, anchor: window) { [weak viewController] credentials in
-            viewController?.dismiss(animated: true)
-            WordPressAuthenticator.shared.delegate!.sync(credentials: .init(wporg: credentials)) {
-                NotificationCenter.default.post(name: Foundation.Notification.Name(rawValue: WordPressAuthenticator.WPSigninDidFinishNotification), object: nil)
-            }
+        let view = LoginWithUrlView(presenter: viewController) { [weak viewController] _ in
+            // The `LoginWithUrlView` view is dismissed when this closure is called.
+            // We also need to dismiss the `viewController` if it's presented as a modal.
+            viewController?.presentingViewController?.dismiss(animated: true)
         }.toolbar {
             ToolbarItem(placement: .cancellationAction) {
                 Button(SharedStrings.Button.cancel) { [weak viewController] in

--- a/WordPress/Classes/ViewRelated/NUX/Helpers/WordPressAuthenticationManager.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Helpers/WordPressAuthenticationManager.swift
@@ -384,10 +384,16 @@ extension WordPressAuthenticationManager: WordPressAuthenticatorDelegate {
     ///
     func presentLoginEpilogue(in navigationController: UINavigationController, for credentials: AuthenticatorCredentials, source: SignInSource?, onDismiss: @escaping () -> Void) {
         let mainContext = ContextManager.shared.mainContext
+        let blog = credentials.wporg.flatMap { wporg in
+            Blog.lookup(username: wporg.username, xmlrpc: wporg.xmlrpc, in: mainContext)
+        }
 
+        presentLoginEpilogue(in: navigationController, forSelfHostedSite: blog, source: source, onDismiss: onDismiss)
+    }
+
+    func presentLoginEpilogue(in navigationController: UINavigationController, forSelfHostedSite blog: Blog?, source: SignInSource?, onDismiss: @escaping () -> Void) {
         // If adding a self-hosted site, skip the Epilogue
-        if let wporg = credentials.wporg,
-           let blog = Blog.lookup(username: wporg.username, xmlrpc: wporg.xmlrpc, in: mainContext) {
+        if let blog {
             if self.windowManager.isShowingFullscreenSignIn {
                 self.windowManager.dismissFullscreenSignIn(blogToShow: blog)
             } else {

--- a/WordPress/WordPressTest/Blog+RestAPITests.swift
+++ b/WordPress/WordPressTest/Blog+RestAPITests.swift
@@ -14,7 +14,7 @@ final class Blog_RestAPITests: CoreDataTestCase {
     private var blog: Blog!
 
     override func setUp() async throws {
-        _ = try await Blog.createRestApiBlog(with: loginDetails, in: contextManager, using: testKeychain)
+        _ = try await Blog.createRestApiBlog(with: loginDetails, restApiRootURL: URL(string: "https://example.com/wp-json")!, in: contextManager, using: testKeychain)
         self.blog = try XCTUnwrap(contextManager.mainContext.fetch(NSFetchRequest<Blog>(entityName: "Blog")).first)
     }
 


### PR DESCRIPTION
The app currently hard code `<site-url>/wp-json` as the REST API URL, which may be incorrect. This PR stores the API root URL returned by the API discovery process in wordpress-rs in the self-hosted site `Blog` instance.

The authenticator API is also slightly improved to be similar to the dotcom one.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
