### PR TITLE
task: Remote feature flag gates GutenbergKit plugins

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -21,7 +21,6 @@ public enum FeatureFlag: Int, CaseIterable {
     case authenticateUsingApplicationPassword
     case newGutenberg
     case newGutenbergThemeStyles
-    case newGutenbergPlugins
     case selfHostedSiteUserManagement
     case readerGutenbergCommentComposer
     case pluginManagementOverhaul
@@ -71,8 +70,6 @@ public enum FeatureFlag: Int, CaseIterable {
             return false
         case .newGutenbergThemeStyles:
             return false
-        case .newGutenbergPlugins:
-            return false
         case .selfHostedSiteUserManagement:
             return false
         case .readerGutenbergCommentComposer:
@@ -118,7 +115,6 @@ extension FeatureFlag {
         case .authenticateUsingApplicationPassword: "Application Passwords for self-hosted sites"
         case .newGutenberg: "Experimental Block Editor"
         case .newGutenbergThemeStyles: "Experimental Block Editor Styles"
-        case .newGutenbergPlugins: "Experimental Block Editor Plugins"
         case .selfHostedSiteUserManagement: "Self-hosted Site User Management"
         case .pluginManagementOverhaul: "Plugin Management Overhaul"
         case .readerGutenbergCommentComposer: "Gutenberg Comment Composer"

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -30,6 +30,7 @@ public enum RemoteFeatureFlag: Int, CaseIterable {
     case inAppUpdates
     case gravatarQuickEditor
     case dotComWebLogin
+    case newGutenbergPlugins
 
     var defaultValue: Bool {
         switch self {
@@ -86,6 +87,8 @@ public enum RemoteFeatureFlag: Int, CaseIterable {
         case .gravatarQuickEditor:
             return BuildConfiguration.current.isInternal
         case .dotComWebLogin:
+            return false
+        case .newGutenbergPlugins:
             return false
         }
     }
@@ -147,6 +150,8 @@ public enum RemoteFeatureFlag: Int, CaseIterable {
             return "gravatar_quick_editor"
         case .dotComWebLogin:
             return "jp_wpcom_web_login"
+        case .newGutenbergPlugins:
+            return "gutenberg_kit_plugins"
         }
     }
 
@@ -206,6 +211,8 @@ public enum RemoteFeatureFlag: Int, CaseIterable {
             return "Gravatar Quick Editor"
         case .dotComWebLogin:
             return "Log in to WordPress.com from web browser"
+        case .newGutenbergPlugins:
+            return "Experimental Block Editor Plugins"
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
@@ -8,7 +8,6 @@ class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvid
         FeatureFlag.authenticateUsingApplicationPassword,
         FeatureFlag.newGutenberg,
         FeatureFlag.newGutenbergThemeStyles,
-        FeatureFlag.newGutenbergPlugins,
     ]
 
     private let flagStore = FeatureFlagOverrideStore()

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -164,7 +164,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
         conf.themeStyles = FeatureFlag.newGutenbergThemeStyles.enabled
         // Limited to Simple sites until application password auth is supported
-        conf.plugins = FeatureFlag.newGutenbergPlugins.enabled && post.blog.isHostedAtWPcom
+        conf.plugins = RemoteFeatureFlag.newGutenbergPlugins.enabled() && post.blog.isHostedAtWPcom
 
         if !post.blog.isSelfHosted {
             let siteType: String = post.blog.isHostedAtWPcom ? "simple" : "atomic"


### PR DESCRIPTION
Allow remotely controlling the availability of GutenbergKit plugin
support. Ref CMM-277.

Related:

* CMM-277-linear-issue
* 180578-ghe-Automattic/wpcom
* https://github.com/wordpress-mobile/WordPress-Android/pull/21806

To test:

> [!Important]
> Requires applying the testing instructions setup found in 180578-ghe-Automattic/wpcom.

1. Enable the `Experimental block editor` feature flag.
1. Open the editor for a WordPress.com-hosted site.
1. Verify the expected presence of third-party blocks based on whether the
   logged in user account is an A11n or non-A11n.

## Regression Notes
1. Potential unintended areas of impact
    Unlikely for this feature flag change for an experimental feature.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    N/A.
3. What automated tests I added (or what prevented me from doing so)
    Deemed unnecessary for the experimental feature.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)