### PR TITLE
Discover XMLRPC endpoint URL in the application-password login process

### DIFF
--- a/Tests/KeystoneTests/Tests/Models/Blog+RestAPITests.swift
+++ b/Tests/KeystoneTests/Tests/Models/Blog+RestAPITests.swift
@@ -14,7 +14,13 @@ final class Blog_RestAPITests: CoreDataTestCase {
     private var blog: Blog!
 
     override func setUp() async throws {
-        _ = try await Blog.createRestApiBlog(with: loginDetails, restApiRootURL: URL(string: "https://example.com/wp-json")!, in: contextManager, using: testKeychain)
+        _ = try await Blog.createRestApiBlog(
+            with: loginDetails,
+            restApiRootURL: URL(string: "https://example.com/wp-json")!,
+            xmlrpcEndpointURL: URL(string: "https://example.com/dir/xmlrpc.php")!,
+            in: contextManager,
+            using: testKeychain
+        )
         self.blog = try XCTUnwrap(contextManager.mainContext.fetch(NSFetchRequest<Blog>(entityName: "Blog")).first)
     }
 
@@ -35,7 +41,7 @@ final class Blog_RestAPITests: CoreDataTestCase {
     }
 
     func testThatCreateRestApiBlogStoresDerivedXMLRPCEndpoint() throws {
-        try XCTAssertEqual(blog.getXMLRPCEndpoint(), loginDetails.derivedXMLRPCRoot)
+        try XCTAssertEqual(blog.getXMLRPCEndpoint().absoluteString, "https://example.com/dir/xmlrpc.php")
     }
 
     func testThatExistingBlogWithInvalidUrlThrowsErrorOnAccess() throws {

--- a/WordPress/Classes/Models/Blog/Blog+SelfHosted.swift
+++ b/WordPress/Classes/Models/Blog/Blog+SelfHosted.swift
@@ -19,6 +19,7 @@ public extension Blog {
     static func createRestApiBlog(
         with details: WpApiApplicationPasswordDetails,
         restApiRootURL: URL,
+        xmlrpcEndpointURL: URL,
         in contextManager: ContextManager,
         using keychainImplementation: KeychainAccessible = KeychainUtils()
     ) async throws -> TaggedManagedObjectID<Blog> {
@@ -27,7 +28,7 @@ public extension Blog {
             blog.url = details.siteUrl
             blog.username = details.userLogin
             blog.restApiRootURL = restApiRootURL.absoluteString
-            try blog.setXMLRPCEndpoint(to: details.derivedXMLRPCRoot)
+            blog.setXMLRPCEndpoint(to: xmlrpcEndpointURL)
             blog.setSiteIdentifier(details.derivedSiteId)
 
             // `url` and `xmlrpc` need to be set before setting passwords.
@@ -162,13 +163,6 @@ public extension Blog {
 }
 
 public extension WpApiApplicationPasswordDetails {
-    var derivedXMLRPCRoot: URL {
-        get throws {
-            let url = try ParsedUrl.parse(input: siteUrl).asURL()
-            return url.appending(path: "xmlrpc.php")
-        }
-    }
-
     var derivedSiteId: String {
         SHA256.hash(data: Data(siteUrl.localizedLowercase.utf8))
             .compactMap { String(format: "%02x", $0) }


### PR DESCRIPTION
To be consistent with the current behaviour in WPAuthenticator.

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
