### PR TITLE
Restore `DDLog` usages in ShareExtensionCore

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -95,6 +95,7 @@ let package = Package(
                 "BuildSettingsKit",
                 "SFHFKeychainUtils",
                 "WordPressShared",
+                .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
                 .product(name: "WordPressKit", package: "WordPressKit-iOS"),
             ],
             resources: [.process("Resources/Extensions.xcdatamodeld")]

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -95,6 +95,16 @@ let package = Package(
                 "BuildSettingsKit",
                 "SFHFKeychainUtils",
                 "WordPressShared",
+                // Even though the extension is all in Swift, we need to include the Objective-C
+                // version of CocoaLumberjack to avoid linking issues with other dependencies that
+                // use it.
+                //
+                // Example:
+                //
+                // Undefined symbols for architecture arm64:
+                //  "_OBJC_CLASS_$_DDLog", referenced from:
+                //       in SharedCoreDataStack.o
+                .product(name: "CocoaLumberjack", package: "CocoaLumberjack"),
                 .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
                 .product(name: "WordPressKit", package: "WordPressKit-iOS"),
             ],

--- a/Modules/Sources/ShareExtensionCore/Data/SharedCoreDataStack.swift
+++ b/Modules/Sources/ShareExtensionCore/Data/SharedCoreDataStack.swift
@@ -1,6 +1,6 @@
 import Foundation
 import CoreData
-// import CocoaLumberjackSwift
+import CocoaLumberjackSwift
 import BuildSettingsKit
 import WordPressKit
 
@@ -39,7 +39,7 @@ public final class SharedCoreDataStack {
         let container = SharedPersistentContainer(name: "SharedCoreDataStack", managedObjectModel: SharedCoreDataStack.model)
         container.loadPersistentStores { (storeDescription, error) in
             if let error = error as NSError? {
-                // DDLogError("Error loading persistent stores: \(error), \(error.userInfo)")
+                DDLogError("Error loading persistent stores: \(error), \(error.userInfo)")
             }
         }
         return container
@@ -71,7 +71,7 @@ public final class SharedCoreDataStack {
         do {
             try managedContext.save()
         } catch let error as NSError {
-            // DDLogError("Error saving context: \(error), \(error.userInfo)")
+            DDLogError("Error saving context: \(error), \(error.userInfo)")
         }
     }
 }
@@ -120,7 +120,7 @@ extension SharedCoreDataStack {
         do {
             postUploadOp = try managedContext.existingObject(with: postUploadOpObjectID) as? PostUploadOperation
         } catch {
-            // DDLogError("Error loading PostUploadOperation Object with ID: \(postUploadOpObjectID)")
+            DDLogError("Error loading PostUploadOperation Object with ID: \(postUploadOpObjectID)")
         }
         return postUploadOp
     }
@@ -151,7 +151,7 @@ extension SharedCoreDataStack {
         let request = NSFetchRequest<NSFetchRequestResult>(entityName: "MediaUploadOperation")
         request.predicate = NSPredicate(format: "(groupID == %@)", groupID)
         guard let results = (try? managedContext.fetch(request)) as? [MediaUploadOperation] else {
-            // DDLogError("Failed to fetch MediaUploadOperation for group ID: \(groupID)")
+            DDLogError("Failed to fetch MediaUploadOperation for group ID: \(groupID)")
             return nil
         }
         return results
@@ -195,7 +195,7 @@ extension SharedCoreDataStack {
         do {
             uploadOps = try managedContext.fetch(request) as! [MediaUploadOperation]
         } catch {
-            // DDLogError("Failed to fetch MediaUploadOperation: \(error)")
+            DDLogError("Failed to fetch MediaUploadOperation: \(error)")
         }
 
         return uploadOps
@@ -217,7 +217,7 @@ extension SharedCoreDataStack {
         do {
             uploadOp = try managedContext.existingObject(with: uploadOpObjectID) as? UploadOperation
         } catch {
-            // DDLogError("Error setting \(status.stringValue) status for UploadOperation Object with ID: \(uploadOpObjectID) — could not fetch object.")
+            DDLogError("Error setting \(status.stringValue) status for UploadOperation Object with ID: \(uploadOpObjectID) — could not fetch object.")
             return
         }
         uploadOp?.currentStatus = status
@@ -260,7 +260,7 @@ extension SharedCoreDataStack {
     ///
     public func updateMediaOperation(for fileName: String, with sessionID: String, remoteMediaID: Int64?, remoteURL: String?, width: Int32?, height: Int32?) {
         guard let mediaUploadOp = fetchMediaUploadOp(for: fileName, with: sessionID) else {
-            // DDLogError("Error loading UploadOperation Object with File Name: \(fileName)")
+            DDLogError("Error loading UploadOperation Object with File Name: \(fileName)")
             return
         }
 
@@ -305,7 +305,7 @@ extension SharedCoreDataStack {
     ///
     public func updatePostOperation(with status: UploadOperation.UploadStatus, remotePostID: Int64, forPostUploadOpWithObjectID postUploadOpObjectID: NSManagedObjectID) {
         guard let postUploadOp = (try? managedContext.existingObject(with: postUploadOpObjectID)) as? PostUploadOperation else {
-            // DDLogError("Error loading PostUploadOperation Object with ID: \(postUploadOpObjectID)")
+            DDLogError("Error loading PostUploadOperation Object with ID: \(postUploadOpObjectID)")
             return
         }
         postUploadOp.currentStatus = status
@@ -324,7 +324,7 @@ extension SharedCoreDataStack {
         do {
             uploadOp = try managedContext.existingObject(with: uploadOpObjectID) as? UploadOperation
         } catch {
-            // DDLogError("Error loading UploadOperation Object with ID: \(uploadOpObjectID)")
+            DDLogError("Error loading UploadOperation Object with ID: \(uploadOpObjectID)")
             return
         }
         uploadOp?.backgroundSessionTaskID = taskID.int32Value

--- a/Modules/Sources/ShareExtensionCore/ShareMediaFileManager.swift
+++ b/Modules/Sources/ShareExtensionCore/ShareMediaFileManager.swift
@@ -1,6 +1,6 @@
 import Foundation
 import BuildSettingsKit
-// import CocoaLumberjackSwift
+import CocoaLumberjackSwift
 
 /// Encapsulates media file operations relative to the shared container's Media directory.
 ///
@@ -26,7 +26,7 @@ public final class ShareMediaFileManager: Sendable {
             do {
                 try fileManager.createDirectory(at: mediaDirectoryURL, withIntermediateDirectories: true, attributes: nil)
             } catch {
-                // DDLogError("Error creating local media directory: \(error)")
+                DDLogError("Error creating local media directory: \(error)")
             }
         }
         return mediaDirectoryURL
@@ -57,7 +57,7 @@ public final class ShareMediaFileManager: Sendable {
                                                            includingPropertiesForKeys: nil,
                                                            options: .skipsHiddenFiles)
         } catch {
-            // DDLogError("Error retrieving contents of shared container media directory: \(error)")
+            DDLogError("Error retrieving contents of shared container media directory: \(error)")
             return
         }
 
@@ -68,12 +68,12 @@ public final class ShareMediaFileManager: Sendable {
                     try fileManager.removeItem(at: url)
                     removedCount += 1
                 } catch {
-                    // DDLogError("Error while removing Media at path: \(error.localizedDescription) - \(url.path)")
+                    DDLogError("Error while removing Media at path: \(error.localizedDescription) - \(url.path)")
                 }
             }
         }
         if removedCount > 0 {
-            // DDLogInfo("Shared container media: removed \(removedCount) file(s) during cleanup.")
+            DDLogInfo("Shared container media: removed \(removedCount) file(s) during cleanup.")
         }
     }
 
@@ -91,9 +91,9 @@ public final class ShareMediaFileManager: Sendable {
         if fileManager.fileExists(atPath: fullPath.path) {
             do {
                 try fileManager.removeItem(at: fullPath)
-                // DDLogInfo("Shared container media: removed \(fullPath.path) during cleanup.")
+                DDLogInfo("Shared container media: removed \(fullPath.path) during cleanup.")
             } catch {
-                // DDLogError("Error while removing Media file at path: \(error.localizedDescription) - \(fullPath.path)")
+                DDLogError("Error while removing Media file at path: \(error.localizedDescription) - \(fullPath.path)")
             }
         }
     }


### PR DESCRIPTION
#24451 [commented out CocoaLumberjack](https://github.com/wordpress-mobile/WordPress-iOS/pull/24451/commits/1fa0c2f4b1c18d03ae20604c1e572ad15f3043f7) because of a build failure after changing the app-framework-modules dependency chain

```
Undefined symbols for architecture arm64:
  "_OBJC_CLASS_$_DDLog", referenced from:
       in SharedCoreDataStack.o
ld: symbol(s) not found for architecture arm64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

![image](https://github.com/user-attachments/assets/4f93029a-c32a-48e2-9ef3-ca422fe88ef4)

I run into a similar issue in #24378, which I [solved](https://github.com/wordpress-mobile/WordPress-iOS/pull/24378/commits/e7e25c4eb2857cfc3fd8e43ef155c1dd22748ad6) by adding CocoaLumberjack (the Objective-C dependency) to the Xcode target helper modules for the Swift only app extensions, even though one would expect them to only need CocoaLumberjackSwift. 

I replicate ported the approach (which is not yet in `trunk`) here, and the app builds and runs fine

![image](https://github.com/user-attachments/assets/091353ab-2b85-46ea-aedd-54d8d4e96714)

<img width="300" alt="Screenshot 2025-04-15 at 6 20 02 PM" src="https://github.com/user-attachments/assets/54dd8782-cc53-41c3-b2eb-852f158df600" />
