### PR TITLE
DRY notifications stack storyboard and initial VC access

### DIFF
--- a/WordPress/Classes/Apps/Reader/ReaderTabViewController.swift
+++ b/WordPress/Classes/Apps/Reader/ReaderTabViewController.swift
@@ -108,8 +108,7 @@ final class ReaderTabViewController: UITabBarController, UITabBarControllerDeleg
     }
 
     private func makeNotificationsViewController() -> UIViewController {
-        let notificationsVC = Notifications.storyboard
-            .instantiateInitialViewController() as! NotificationsViewController
+        let notificationsVC = Notifications.instantiateInitialViewController()
         notificationsVC.tabBarItem = UITabBarItem(
             title: Strings.notifications,
             image: UIImage(named: "tab-bar-notifications"),

--- a/WordPress/Classes/Apps/Reader/ReaderTabViewController.swift
+++ b/WordPress/Classes/Apps/Reader/ReaderTabViewController.swift
@@ -108,7 +108,7 @@ final class ReaderTabViewController: UITabBarController, UITabBarControllerDeleg
     }
 
     private func makeNotificationsViewController() -> UIViewController {
-        let notificationsVC = UIStoryboard(name: "Notifications", bundle: Bundle(for: Self.self))
+        let notificationsVC = Notifications.storyboard
             .instantiateInitialViewController() as! NotificationsViewController
         notificationsVC.tabBarItem = UITabBarItem(
             title: Strings.notifications,

--- a/WordPress/Classes/System/Root View/SplitViewRootPresenter+Notifications.swift
+++ b/WordPress/Classes/System/Root View/SplitViewRootPresenter+Notifications.swift
@@ -7,7 +7,7 @@ class NotificationsSplitViewContent: SplitViewDisplayable {
     var secondary: UINavigationController
 
     init() {
-        notificationsViewController = Notifications.storyboard.instantiateInitialViewController() as! NotificationsViewController
+        notificationsViewController = Notifications.instantiateInitialViewController()
         supplementary = UINavigationController(rootViewController: notificationsViewController)
         secondary = UINavigationController()
 

--- a/WordPress/Classes/System/Root View/SplitViewRootPresenter+Notifications.swift
+++ b/WordPress/Classes/System/Root View/SplitViewRootPresenter+Notifications.swift
@@ -7,7 +7,7 @@ class NotificationsSplitViewContent: SplitViewDisplayable {
     var secondary: UINavigationController
 
     init() {
-        notificationsViewController = UIStoryboard(name: "Notifications", bundle: nil).instantiateInitialViewController() as! NotificationsViewController
+        notificationsViewController = Notifications.storyboard.instantiateInitialViewController() as! NotificationsViewController
         supplementary = UINavigationController(rootViewController: notificationsViewController)
         secondary = UINavigationController()
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -119,7 +119,7 @@ class NotificationsViewController: UIViewController, UITableViewDataSource, UITa
     // MARK: - View Lifecycle
 
     static func showInPopover(from presentingVC: UIViewController, sourceItem: UIPopoverPresentationControllerSourceItem) {
-        let notificationsVC = UIStoryboard(name: "Notifications", bundle: nil).instantiateInitialViewController() as! NotificationsViewController
+        let notificationsVC = Notifications.storyboard.instantiateInitialViewController() as! NotificationsViewController
         notificationsVC.isSidebarModeEnabled = true
 
         let navigationVC = UINavigationController(rootViewController: notificationsVC)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -119,7 +119,7 @@ class NotificationsViewController: UIViewController, UITableViewDataSource, UITa
     // MARK: - View Lifecycle
 
     static func showInPopover(from presentingVC: UIViewController, sourceItem: UIPopoverPresentationControllerSourceItem) {
-        let notificationsVC = Notifications.storyboard.instantiateInitialViewController() as! NotificationsViewController
+        let notificationsVC = Notifications.instantiateInitialViewController()
         notificationsVC.isSidebarModeEnabled = true
 
         let navigationVC = UINavigationController(rootViewController: notificationsVC)

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
@@ -1,8 +1,16 @@
 import Foundation
 import WordPressShared
 
-// This facilitates showing the CommentDetailViewController within the context of Notifications.
+enum Notifications {
+    static let storyboardName = "Notifications"
 
+    static let storyboard = UIStoryboard(
+        name: Notifications.storyboardName,
+        bundle: Bundle(for: NotificationsViewController.self)
+    )
+}
+
+/// Facilitates showing the `CommentDetailViewController` within the context of Notifications.
 protocol CommentDetailsNotificationDelegate: AnyObject {
     func previousNotificationTapped(current: Notification?)
     func nextNotificationTapped(current: Notification?)
@@ -76,10 +84,9 @@ private extension NotificationCommentDetailCoordinator {
     }
 
     func showNotificationDetails(with notification: Notification) {
-        let storyboard = UIStoryboard(name: Notifications.storyboardName, bundle: nil)
-
         guard let viewController,
-              let notificationDetailsViewController = storyboard.instantiateViewController(withIdentifier: Notifications.viewControllerName) as? NotificationDetailsViewController else {
+              let notificationDetailsViewController = Notifications.storyboard
+            .instantiateViewController(withIdentifier: NotificationDetailsViewController.classNameWithoutNamespaces()) as? NotificationDetailsViewController else {
                   DDLogError("NotificationCommentDetailCoordinator: missing view controller.")
                   return
               }
@@ -125,12 +132,6 @@ private extension NotificationCommentDetailCoordinator {
         let properties = ["notification_type": notification.type ?? "unknown"]
         WPAnalytics.track(.openedNotificationDetails, withProperties: properties)
     }
-
-    enum Notifications {
-        static let storyboardName = "Notifications"
-        static let viewControllerName = NotificationDetailsViewController.classNameWithoutNamespaces()
-    }
-
 }
 
 // MARK: - CommentDetailsNotificationDelegate

--- a/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Tools/NotificationCommentDetailCoordinator.swift
@@ -2,12 +2,16 @@ import Foundation
 import WordPressShared
 
 enum Notifications {
-    static let storyboardName = "Notifications"
+    private static let storyboardName = "Notifications"
 
     static let storyboard = UIStoryboard(
         name: Notifications.storyboardName,
         bundle: Bundle(for: NotificationsViewController.self)
     )
+
+    static func instantiateInitialViewController() -> NotificationsViewController {
+        storyboard.instantiateInitialViewController() as! NotificationsViewController
+    }
 }
 
 /// Facilitates showing the `CommentDetailViewController` within the context of Notifications.


### PR DESCRIPTION
Follow us on the change in #24463 that fixed the notifications Storyboard access from the Reader app.





<table>
<tr>
<td><img width="559" alt="Screenshot 2025-04-16 at 1 46 29 PM" src="https://github.com/user-attachments/assets/d05dc466-1b2f-4613-bf69-280b5beda5e2" /></td>
<td><img width="559" alt="Screenshot 2025-04-16 at 1 59 03 PM" src="https://github.com/user-attachments/assets/848039c5-df6a-4293-a70e-d1be8f5b4b46" /></td>
<td><img width="559" alt="Screenshot 2025-04-16 at 1 58 31 PM" src="https://github.com/user-attachments/assets/685d94b7-17aa-4fd8-b141-64eb66d05202" /></td>
</tr>
</table>

Part of https://linear.app/a8c/issue/CMM-260/configure-reader-target