### PR TITLE
task: Remote feature flag gates GutenbergKit

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -30,6 +30,7 @@ public enum RemoteFeatureFlag: Int, CaseIterable {
     case inAppUpdates
     case gravatarQuickEditor
     case dotComWebLogin
+    case newGutenberg
     case newGutenbergPlugins
 
     var defaultValue: Bool {
@@ -87,6 +88,8 @@ public enum RemoteFeatureFlag: Int, CaseIterable {
         case .gravatarQuickEditor:
             return BuildConfiguration.current.isInternal
         case .dotComWebLogin:
+            return false
+        case .newGutenberg:
             return false
         case .newGutenbergPlugins:
             return false
@@ -150,6 +153,8 @@ public enum RemoteFeatureFlag: Int, CaseIterable {
             return "gravatar_quick_editor"
         case .dotComWebLogin:
             return "jp_wpcom_web_login"
+        case .newGutenberg:
+            return "gutenberg_kit"
         case .newGutenbergPlugins:
             return "gutenberg_kit_plugins"
         }
@@ -211,6 +216,8 @@ public enum RemoteFeatureFlag: Int, CaseIterable {
             return "Gravatar Quick Editor"
         case .dotComWebLogin:
             return "Log in to WordPress.com from web browser"
+        case .newGutenberg:
+            return "Experimental Block Editor"
         case .newGutenbergPlugins:
             return "Experimental Block Editor Plugins"
         }

--- a/WordPress/Classes/Utility/Editor/EditorFactory.swift
+++ b/WordPress/Classes/Utility/Editor/EditorFactory.swift
@@ -14,7 +14,7 @@ class EditorFactory {
 
     func instantiateEditor(for post: AbstractPost, replaceEditor: @escaping ReplaceEditorBlock) -> EditorViewController {
         if gutenbergSettings.mustUseGutenberg(for: post) {
-            if FeatureFlag.newGutenberg.enabled {
+            if FeatureFlag.newGutenberg.enabled || RemoteFeatureFlag.newGutenberg.enabled() {
                 return NewGutenbergViewController(post: post, replaceEditor: replaceEditor)
             }
             return createGutenbergVC(with: post, replaceEditor: replaceEditor)


### PR DESCRIPTION
Augment the existing, user-controlled experimental feature toggle with a remote feature flag that can we used for a phased roll out GutenbergKit regardless of the experimental feature toggle state. 

To test: A remote feature flag has not yet been deployed on the server, so there should be no changes to the UX.

## Regression Notes
1. Potential unintended areas of impact
    Unlikely for this addition.
2. What I did to test those areas of impact (or what existing automated tests I relied on)
    N/A.
3. What automated tests I added (or what prevented me from doing so)
    Deemed unnecessary for the experimental feature.

PR submission checklist:

- [x] I have completed the Regression Notes.
- [x] I have considered adding unit tests for my changes.
- [x] I have considered adding accessibility improvements for my changes.
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
