### PR TITLE
Fix an issue with the Me tab re-adding the profile header when you sitch sites

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -740,7 +740,8 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         self.blogDashboardViewController = blogDashboardViewController
         stackView.sendSubviewToBack(blogDashboardViewController.view)
 
-        if isReaderAppModeEnabled, let account = blog.account {
+        if isReaderAppModeEnabled, let account = blog.account,
+           !stackView.subviews.contains(where: { $0 is MeHeaderView }) {
             let headerView = MeHeaderView()
             headerView.update(with: .init(account: account))
             headerView.configureReaderMode()


### PR DESCRIPTION
To test:

- Run the "Reader" app
- Open the "Me" tab
- Switch to a different site
- **Verify** that the profile header view is not re-added (there is still only one header on the screen)

## Regression Notes
1. Potential unintended areas of impact


2. What I did to test those areas of impact (or what existing automated tests I relied on)


3. What automated tests I added (or what prevented me from doing so)

PR submission checklist:

- [ ] I have completed the Regression Notes.
- [ ] I have considered adding unit tests for my changes.
- [ ] I have considered adding accessibility improvements for my changes.
- [ ] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.

Testing checklist:
- [ ] WordPress.com sites and self-hosted Jetpack sites.
- [ ] Portrait and landscape orientations.
- [ ] Light and dark modes.
- [ ] Fonts: Larger, smaller and bold text.
- [ ] High contrast.
- [ ] VoiceOver.
- [ ] Languages with large words or with letters/accents not frequently used in English.
- [ ] Right-to-left languages. (Even if translation isn’t complete, formatting should still respect the right-to-left layout)
- [ ] iPhone and iPad. 
- [ ] Multi-tasking: Split view and Slide over. (iPad)
