### PR TITLE
Fix "Preview Unavailable" for Unedited Pages

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -20,11 +20,6 @@ extension PostEditor {
     }
 
     private func savePostBeforePreview(completion: @escaping ((String?, Error?) -> Void)) {
-        guard !post.changes.isEmpty else {
-            completion(nil, nil)
-            return
-        }
-
         Task { @MainActor in
             let coordinator = PostCoordinator.shared
             do {


### PR DESCRIPTION
**Fixes #24051**

**Description:** Removes the check for post.changes.isEmpty to ensure new pages are saved before preview, even if untouched. This allows previews to work consistently, including for template-based drafts. Previews were failing because unedited drafts weren’t being saved, leaving them without a permalink or autosave.

**To test:**
1. Create a new page.
2. Tap the more button (three horizontal dots) in the top-right corner.
3. Tap Preview.

**Images:**

Before
![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-19 at 15 56 02](https://github.com/user-attachments/assets/e87934b1-fced-4a25-b993-daed2b9985e3)

After
![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-19 at 15 54 36](https://github.com/user-attachments/assets/c258e6b0-4046-48c1-a289-ce3641ed6955)

