### PR TITLE
Fixed the display of YouTube video embedded in comments

### DIFF
--- a/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
@@ -14,7 +14,7 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
     private let webView = WKWebView(frame: .zero, configuration: {
         let configuration = WKWebViewConfiguration()
         configuration.allowsInlineMediaPlayback = true
-        configuration.defaultWebpagePreferences.allowsContentJavaScript = false
+        configuration.defaultWebpagePreferences.allowsContentJavaScript = true
         return configuration
     }())
 


### PR DESCRIPTION
**Fixes #24427, #24448**

**Description:** This PR enables JavaScript in the WKWebViewConfiguration used by WebCommentContentRenderer. This resolves an issue where embedded YouTube videos in comment content were displaying as black boxes.

**To test:**
Issue 1
1. Make a Blog Post
2. Leave a comment with a YouTube Link
3. Navigate to published section in Posts
4. Click on the three horizontal dot on selected post
5. Select Comments from the dropdown menu

Issue 2
1. Tap on Notifications from the nav bar on the bottom
2. Click on the corresponding comment notification

**Images:**

Before
![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-19 at 18 08 27](https://github.com/user-attachments/assets/aba2a2ec-3aa5-40f1-91e5-7868bc349398)

![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-19 at 20 46 56](https://github.com/user-attachments/assets/9045bbd4-ef3d-42e0-a24f-1ac7c1ee35ac)

After
![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-19 at 20 53 25](https://github.com/user-attachments/assets/b82b5aa6-356c-4bb6-8f56-10ec057d4fc4)

![Simulator Screenshot - iPhone 16 Pro Max - 2025-04-19 at 20 15 34](https://github.com/user-attachments/assets/fbade0a9-5c28-4c70-a9f5-2134fb62ae0d)