### PR TITLE
Improve Comment Details

### DIFF
--- a/Modules/Sources/UITestsFoundation/Screens/NotificationsScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/NotificationsScreen.swift
@@ -39,7 +39,7 @@ public class NotificationsScreen: ScreenObject {
 
         // If on iPhone, tap back to return to notifications list
         if XCTestCase.isPhone {
-            navigateBack()
+            navBackButton.firstMatch.tap()
         }
 
         return self

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
@@ -195,7 +195,7 @@ public class CommentDetailViewController: UIViewController, NoResultsViewHost {
             : UIImage(systemName: "square.and.arrow.up"),
             style: .plain,
             target: self,
-            action: #selector(shareCommentURL)
+            action: #selector(buttonShareCommentTapped)
         )
         button.accessibilityLabel = NSLocalizedString("Share comment", comment: "Accessibility label for button to share a comment from a notification")
         return button
@@ -452,6 +452,10 @@ private extension CommentDetailViewController {
             cell.accessoryButtonAction = { [weak self] senderView in
                 self?.presentUserInfoSheet(senderView)
             }
+        } else {
+            cell.accessoryButtonAction = { [weak self] senderView in
+                self?.shareComment(sourceItem: senderView)
+            }
         }
 
         cell.replyButtonAction = { [weak self] in
@@ -657,7 +661,11 @@ private extension CommentDetailViewController {
                                      })
     }
 
-    @objc func shareCommentURL(_ barButtonItem: UIBarButtonItem) {
+    @objc private func buttonShareCommentTapped(_ button: UIBarButtonItem) {
+        shareComment(sourceItem: button)
+    }
+
+    private func shareComment(sourceItem: (any UIPopoverPresentationControllerSourceItem)) {
         guard let commentURL = comment.commentURL() else {
             return
         }
@@ -666,7 +674,7 @@ private extension CommentDetailViewController {
         WPAnalytics.track(.siteCommentsCommentShared)
 
         let activityViewController = UIActivityViewController(activityItems: [commentURL as Any], applicationActivities: nil)
-        activityViewController.popoverPresentationController?.barButtonItem = barButtonItem
+        activityViewController.popoverPresentationController?.sourceItem = sourceItem
         present(activityViewController, animated: true, completion: nil)
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
@@ -446,10 +446,12 @@ private extension CommentDetailViewController {
             self?.openWebView(for: url)
         }
 
-        cell.accessoryButtonType = .info
-        cell.isAccessoryButtonEnabled = true
-        cell.accessoryButtonAction = { [weak self] senderView in
-            self?.presentUserInfoSheet(senderView)
+        if comment.allowsModeration() {
+            cell.accessoryButtonType = .info
+            cell.isAccessoryButtonEnabled = true
+            cell.accessoryButtonAction = { [weak self] senderView in
+                self?.presentUserInfoSheet(senderView)
+            }
         }
 
         cell.replyButtonAction = { [weak self] in

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
@@ -19,9 +19,6 @@ public class CommentDetailViewController: UIViewController, NoResultsViewHost {
 
     let tableView = UITableView(frame: .zero, style: .plain)
 
-    // Reply properties
-    private var addCommentButton: CommentLargeButton?
-
     @objc public weak var commentDelegate: CommentDetailsDelegate?
     private weak var notificationDelegate: CommentDetailsNotificationDelegate?
 
@@ -240,7 +237,6 @@ public class CommentDetailViewController: UIViewController, NoResultsViewHost {
     public override func viewDidLoad() {
         super.viewDidLoad()
 
-        configureReplyView()
         configureNavigationBar()
         configureTable()
         configureSections()
@@ -261,7 +257,6 @@ public class CommentDetailViewController: UIViewController, NoResultsViewHost {
     @objc public func displayComment(_ comment: Comment, isLastInList: Bool = true) {
         self.comment = comment
         self.isLastInList = isLastInList
-        addCommentButton?.placeholder = String(format: .replyPlaceholderFormat, comment.authorForDisplay())
         refreshData()
         refreshCommentReplyIfNeeded()
     }
@@ -703,10 +698,7 @@ private extension String {
     static let trashButtonAccessibilityId = "trash-comment-button"
     static let deleteButtonAccessibilityId = "delete-comment-button"
 
-    // MARK: Localization
-    static let replyPlaceholderFormat = NSLocalizedString("Reply to %1$@", comment: "Placeholder text for the reply text field."
-                                                          + "%1$@ is a placeholder for the comment author."
-                                                          + "Example: Reply to Pamela Nguyen")
+    // MARK: Localizatio
     static let replyIndicatorLabelText = NSLocalizedString("You replied to this comment.", comment: "Informs that the user has replied to this comment.")
     static let deleteButtonText = NSLocalizedString("Delete Permanently", comment: "Title for button on the comment details page that deletes the comment when tapped.")
     static let trashButtonText = NSLocalizedString("Move to Trash", comment: "Title for button on the comment details page that moves the comment to trash when tapped.")
@@ -989,19 +981,6 @@ extension CommentDetailViewController: UITableViewDelegate, UITableViewDataSourc
 // MARK: - Reply Handling
 
 private extension CommentDetailViewController {
-
-    func configureReplyView() {
-        let button = CommentLargeButton()
-
-        button.placeholder = String(format: .replyPlaceholderFormat, comment.authorForDisplay())
-        button.accessibilityHint = NSLocalizedString("Reply Text", comment: "Notifications Reply Accessibility Identifier")
-        button.onTap = { [weak self] in
-            self?.buttonAddCommentTapped()
-        }
-        button.isHidden = true
-//        containerStackView.addArrangedSubview(button)
-        addCommentButton = button
-    }
 
     @objc func buttonAddCommentTapped() {
         let viewModel = CommentCreateViewModel(replyingTo: comment) { [weak self] in

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
@@ -430,7 +430,10 @@ private extension CommentDetailViewController {
         let viewModel = CommentCellViewModel(comment: comment, notification: notification)
 
         cell.configure(viewModel: viewModel, helper: helper) { [weak self] _ in
-            self?.tableView.performBatchUpdates({})
+            guard let self else { return }
+            UIView.setAnimationsEnabled(false)
+            self.tableView.performBatchUpdates({})
+            UIView.setAnimationsEnabled(true)
         }
 
         cell.configureForCommentDetails()

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
@@ -443,15 +443,16 @@ private extension CommentDetailViewController {
 
         if comment.allowsModeration() {
             cell.accessoryButtonType = .info
-            cell.isAccessoryButtonEnabled = true
             cell.accessoryButtonAction = { [weak self] senderView in
                 self?.presentUserInfoSheet(senderView)
             }
         } else {
+            cell.accessoryButtonType = .ellipsis
             cell.accessoryButtonAction = { [weak self] senderView in
                 self?.shareComment(sourceItem: senderView)
             }
         }
+        cell.isAccessoryButtonEnabled = true
 
         cell.replyButtonAction = { [weak self] in
             self?.buttonAddCommentTapped()

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
@@ -341,7 +341,8 @@ private extension CommentDetailViewController {
         tableView.dataSource = self
         tableView.separatorInsetReference = .fromAutomaticInsets
 
-        // get rid of the separator line for the last cell.
+        // get rid of the separator lines
+        tableView.tableHeaderView = UIView(frame: .init(x: 0, y: 0, width: tableView.frame.size.width, height: 1))
         tableView.tableFooterView = UIView(frame: .init(x: 0, y: 0, width: tableView.frame.size.width, height: Constants.tableBottomMargin))
 
         // assign 20pt leading inset to the table view, as per the design.
@@ -356,6 +357,8 @@ private extension CommentDetailViewController {
 
         view.addSubview(tableView)
         tableView.pinEdges()
+
+        headerCell.contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 54).isActive = true
     }
 
     func configureContentRows() -> [RowType] {
@@ -423,7 +426,6 @@ private extension CommentDetailViewController {
 
         // otherwise, if this is a comment to a post, show the post title instead.
         headerCell.configure(for: .post, subtitle: comment.titleForDisplay())
-        headerCell.contentView.heightAnchor.constraint(greaterThanOrEqualToConstant: 54).isActive = true
     }
 
     func configureContentCell(_ cell: CommentContentTableViewCell, comment: Comment) {

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentDetailViewController.swift
@@ -17,8 +17,7 @@ public class CommentDetailViewController: UIViewController, NoResultsViewHost {
 
     // MARK: Properties
 
-    private let containerStackView = UIStackView()
-    private let tableView = UITableView(frame: .zero, style: .plain)
+    let tableView = UITableView(frame: .zero, style: .plain)
 
     // Reply properties
     private var addCommentButton: CommentLargeButton?
@@ -241,7 +240,6 @@ public class CommentDetailViewController: UIViewController, NoResultsViewHost {
     public override func viewDidLoad() {
         super.viewDidLoad()
 
-        configureView()
         configureReplyView()
         configureNavigationBar()
         configureTable()
@@ -325,14 +323,6 @@ private extension CommentDetailViewController {
         return .init(top: 0, left: -tableView.separatorInset.left, bottom: 0, right: tableView.frame.size.width)
     }
 
-    func configureView() {
-        containerStackView.translatesAutoresizingMaskIntoConstraints = false
-        view.addSubview(containerStackView)
-        containerStackView.axis = .vertical
-        containerStackView.addArrangedSubview(tableView)
-        view.pinSubviewToAllEdges(containerStackView)
-    }
-
     func configureNavigationBar() {
         configureNavBarButton()
     }
@@ -355,12 +345,17 @@ private extension CommentDetailViewController {
         tableView.tableFooterView = UIView(frame: .init(x: 0, y: 0, width: tableView.frame.size.width, height: Constants.tableBottomMargin))
 
         // assign 20pt leading inset to the table view, as per the design.
-        tableView.directionalLayoutMargins = .init(top: tableView.directionalLayoutMargins.top,
-                                                   leading: Constants.tableHorizontalInset,
-                                                   bottom: tableView.directionalLayoutMargins.bottom,
-                                                   trailing: Constants.tableHorizontalInset)
+        tableView.directionalLayoutMargins = .init(
+            top: tableView.directionalLayoutMargins.top,
+            leading: Constants.tableHorizontalInset,
+            bottom: tableView.directionalLayoutMargins.bottom,
+            trailing: Constants.tableHorizontalInset
+        )
 
         tableView.register(CommentContentTableViewCell.defaultNib, forCellReuseIdentifier: CommentContentTableViewCell.defaultReuseID)
+
+        view.addSubview(tableView)
+        tableView.pinEdges()
     }
 
     func configureContentRows() -> [RowType] {
@@ -989,7 +984,7 @@ private extension CommentDetailViewController {
             self?.buttonAddCommentTapped()
         }
         button.isHidden = true
-        containerStackView.addArrangedSubview(button)
+//        containerStackView.addArrangedSubview(button)
         addCommentButton = button
     }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
@@ -92,7 +92,6 @@ class NotificationCommentDetailViewController: UIViewController, NoResultsViewHo
         super.viewDidLoad()
 
         configureNavBar()
-        WPStyleGuide.disableScrollEdgeAppearance(for: self)
         view.backgroundColor = .systemBackground
         loadComment()
     }
@@ -106,7 +105,6 @@ class NotificationCommentDetailViewController: UIViewController, NoResultsViewHo
         self.notification = notification
         loadComment()
     }
-
 }
 
 private extension NotificationCommentDetailViewController {
@@ -166,9 +164,11 @@ private extension NotificationCommentDetailViewController {
                 managedObjectContext: managedObjectContext
             )
             detailsVC.willMove(toParent: self)
+            addChild(detailsVC)
             view.addSubview(detailsVC.view)
-            detailsVC.view.pinEdges(to: view.safeAreaLayoutGuide)
+            detailsVC.view.pinEdges()
             detailsVC.didMove(toParent: self)
+            setContentScrollView(detailsVC.tableView)
             self.detailsVC = detailsVC
         }
 


### PR DESCRIPTION
- Add support for scroll edge appearance
- Remove poorly looking animation when the comment is rendered
- Remove top separator
- Fix layout of `headerCell`
- Remove info button when moderation isn't available – show the standard "more" menu instead 

Before / After

<img width="320" alt="Screenshot 2025-04-21 at 1 13 38 PM" src="https://github.com/user-attachments/assets/342840f1-ef8c-43cd-87e8-88ec5f96c991" /> <img width="320" alt="Screenshot 2025-04-21 at 2 48 08 PM" src="https://github.com/user-attachments/assets/1a5b49f3-f395-4cbd-afaa-7cb7fc029d51" />


## Testing instructions

- Open a notification comment on a site that you can not moderate
- **Verify** that the details screen works correctly with scrolling edge appearance for navigation bar
- **Verify** that you can like and reply (if comments are not closed)
- Verify other steps from <description>
