### PR TITLE
refactor: Catch GutenbergKit WebViewGlobal exceptions

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250411"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "a03e0dae10a404c88c215bfcee3176df951302f5"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "705036cb06e83c26d6654175d26d35c90e4f1d8c"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", from: "1.20.0"),
     ],

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250411"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "705036cb06e83c26d6654175d26d35c90e4f1d8c"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "fc369073730384c8946bee15ec8ff7c763cf69c9"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", from: "1.20.0"),
     ],

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "33ddb0aa3726e1d733791a917985ff8cb4c0e0dd7def70443bf5515669f01701",
+  "originHash" : "8c01b9c7fa2aff57b49e7b3fad3bcf3422a0304fbe8d68dba32ffbab93c89022",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,7 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "a03e0dae10a404c88c215bfcee3176df951302f5"
+        "revision" : "705036cb06e83c26d6654175d26d35c90e4f1d8c"
       }
     },
     {

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8c01b9c7fa2aff57b49e7b3fad3bcf3422a0304fbe8d68dba32ffbab93c89022",
+  "originHash" : "645dd3ef573ab8e20ff04cddccb0ffcc29b7a5f354c0eb4d8f44d125b5a8694d",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -150,7 +150,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "705036cb06e83c26d6654175d26d35c90e4f1d8c"
+        "revision" : "fc369073730384c8946bee15ec8ff7c763cf69c9"
       }
     },
     {

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -168,9 +168,14 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
         if !post.blog.isSelfHosted {
             let siteType: String = post.blog.isHostedAtWPcom ? "simple" : "atomic"
-            conf.webViewGlobals = [
-                WebViewGlobal(name: "_currentSiteType", value: .string(siteType))
-            ]
+            do {
+                conf.webViewGlobals = [
+                    try WebViewGlobal(name: "_currentSiteType", value: .string(siteType))
+                ]
+            } catch {
+                DDLogError("Failed to create WebViewGlobal: \(error)")
+                conf.webViewGlobals = []
+            }
         }
 
         self.editorViewController = GutenbergKit.EditorViewController(configuration: conf)

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -173,7 +173,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
                     try WebViewGlobal(name: "_currentSiteType", value: .string(siteType))
                 ]
             } catch {
-                DDLogError("Failed to create WebViewGlobal: \(error)")
+                wpAssertionFailure("Failed to create WebViewGlobal", userInfo: ["error": "\(error)"])
                 conf.webViewGlobals = []
             }
         }


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
GutenbergKit now throws exceptions for invalid WebView global values. Therefore,
we must catch those cases.

Related: https://github.com/wordpress-mobile/GutenbergKit/pull/119

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
N/A, no user-facing changes.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
