### PR TITLE
Remove long-unused Iterable deep links handling

### DIFF
--- a/Sources/Reader/Reader.entitlements
+++ b/Sources/Reader/Reader.entitlements
@@ -6,7 +6,6 @@
 	<array>
 		<string>webcredentials:wordpress.com</string>
 		<string>webcredentials:*.wordpress.com</string>
-		<string>applinks:links.wp.a8cmail.com</string>
 	</array>
 	<key>aps-environment</key>
 	<string>development</string>

--- a/WordPress/Classes/System/Root View/WPTabBarController+RootViewPresenter.swift
+++ b/WordPress/Classes/System/Root View/WPTabBarController+RootViewPresenter.swift
@@ -22,8 +22,13 @@ extension WPTabBarController: RootViewPresenter {
     }
 
     func showNotificationsTab(completion: ((NotificationsViewController) -> Void)?) {
-        self.selectedIndex = WPTab.notifications.rawValue
-        completion?(self.notificationsViewController!)
+        // UITabBarController.selectedIndex must be used from main thread only.
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+
+            self.selectedIndex = WPTab.notifications.rawValue
+            completion?(self.notificationsViewController!)
+        }
     }
 
     // MARK: Me

--- a/WordPress/Classes/System/Root View/WPTabBarController+RootViewPresenter.swift
+++ b/WordPress/Classes/System/Root View/WPTabBarController+RootViewPresenter.swift
@@ -1,4 +1,5 @@
 import UIKit
+import WordPressShared
 
 /// `WPTabBarController` is used as the root presenter when Jetpack features are enabled
 /// and the app's UI is normal.
@@ -23,12 +24,10 @@ extension WPTabBarController: RootViewPresenter {
 
     func showNotificationsTab(completion: ((NotificationsViewController) -> Void)?) {
         // UITabBarController.selectedIndex must be used from main thread only.
-        DispatchQueue.main.async { [weak self] in
-            guard let self else { return }
+        wpAssert(Thread.isMainThread)
 
-            self.selectedIndex = WPTab.notifications.rawValue
-            completion?(self.notificationsViewController!)
-        }
+        selectedIndex = WPTab.notifications.rawValue
+        completion?(notificationsViewController!)
     }
 
     // MARK: Me

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -473,24 +473,15 @@ extension WordPressAppDelegate {
 extension WordPressAppDelegate {
 
     private func trackDeepLink(for url: URL, completion: @escaping ((URL) -> Void)) {
-        guard isIterableDeepLink(url) else {
-            completion(url)
-            return
-        }
-
-        let task = URLSession.shared.dataTask(with: url) {(_, response, error) in
-            if let url = response?.url {
-                completion(url)
+        let task = URLSession.shared.dataTask(with: url) { _, response, error in
+            guard let url = response?.url else {
+                return
             }
+
+            completion(url)
         }
         task.resume()
     }
-
-    private func isIterableDeepLink(_ url: URL) -> Bool {
-        return url.absoluteString.contains(WordPressAppDelegate.iterableDomain)
-    }
-
-    private static let iterableDomain = "links.wp.a8cmail.com"
 }
 
 // MARK: - Helpers

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -457,7 +457,9 @@ extension WordPressAppDelegate {
         }
 
         trackDeepLink(for: url) { url in
-            UniversalLinkRouter.shared.handle(url: url)
+            DispatchQueue.main.async {
+                UniversalLinkRouter.shared.handle(url: url)
+            }
         }
     }
 

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -477,6 +477,10 @@ extension WordPressAppDelegate {
     private func trackDeepLink(for url: URL, completion: @escaping ((URL) -> Void)) {
         let task = URLSession.shared.dataTask(with: url) { _, response, error in
             guard let url = response?.url else {
+                wpAssertionFailure(
+                    "Received a deep link response without URL attached.",
+                    userInfo: ["response": response ?? "no response"]
+                )
                 return
             }
 

--- a/WordPress/Jetpack/JetpackDebug.entitlements
+++ b/WordPress/Jetpack/JetpackDebug.entitlements
@@ -17,7 +17,6 @@
 		<string>applinks:wordpress.com</string>
 		<string>applinks:*.wordpress.com</string>
 		<string>applinks:public-api.wordpress.com</string>
-		<string>applinks:links.wp.a8cmail.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/WordPress/Jetpack/JetpackRelease-Alpha.entitlements
+++ b/WordPress/Jetpack/JetpackRelease-Alpha.entitlements
@@ -13,7 +13,6 @@
 		<string>applinks:wordpress.com</string>
 		<string>applinks:*.wordpress.com</string>
 		<string>applinks:public-api.wordpress.com</string>
-		<string>applinks:links.wp.a8cmail.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/WordPress/Jetpack/JetpackRelease.entitlements
+++ b/WordPress/Jetpack/JetpackRelease.entitlements
@@ -17,7 +17,6 @@
 		<string>applinks:wordpress.com</string>
 		<string>applinks:*.wordpress.com</string>
 		<string>applinks:public-api.wordpress.com</string>
-		<string>applinks:links.wp.a8cmail.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/WordPress/WordPress-Alpha.entitlements
+++ b/WordPress/WordPress-Alpha.entitlements
@@ -6,7 +6,6 @@
 	<array>
 		<string>webcredentials:wordpress.com</string>
 		<string>webcredentials:*.wordpress.com</string>
-		<string>applinks:links.wp.a8cmail.com</string>
 	</array>
 	<key>com.apple.security.application-groups</key>
 	<array>

--- a/WordPress/WordPress.entitlements
+++ b/WordPress/WordPress.entitlements
@@ -12,7 +12,6 @@
 	<array>
 		<string>webcredentials:wordpress.com</string>
 		<string>webcredentials:*.wordpress.com</string>
-		<string>applinks:links.wp.a8cmail.com</string>
 	</array>
 	<key>com.apple.developer.icloud-container-identifiers</key>
 	<array>


### PR DESCRIPTION
See pbMoDN-fd-p2#comment-7311 , with thanks to @crazytonyli for noticing this.

I'm still waiting for confirmation from the marketing folks that the unused assumption is correct, but I'm fairly confident it is, so in the meantime I went ahead and opened this quick PR.

For reference, Iterable support was introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/14212

This PR relates to https://linear.app/a8c/issue/CMM-260/configure-reader-target 

I tested this using the same deep link URL suggested in #14212 from Jetpack. 

![image](https://github.com/user-attachments/assets/acb7aef8-eea1-44e1-b9ff-b301afe276ce)

Notice two warnings in the console that we might want to look into later:

- Presenting view controller `<UINavigationController: 0x3222d8c00>` from detached view controller `<WordPress.NotificationsViewController: 0x32383ea00>` is not supported, and may result in incorrect safe area insets and a corrupt root presentation. Make sure `<WordPress.NotificationsViewController: 0x32383ea00>` is in the view controller hierarchy before presenting from it. Will become a hard exception in a future release.
- Background Task 57 ("Called by Jetpack.debug.dylib, from `$s9WordPress0aB11AppDelegateC29applicationDidEnterBackgroundyySo13UIApplicationCFTo`"), was created over 30 seconds ago. In applications running in the background, this creates a risk of termination. Remember to call `UIApplication.endBackgroundTask(_:)` for your task in a timely manner to avoid this.
