### PR TITLE
Use the same `key` for the Reader build step across pipelines

### DIFF
--- a/.buildkite/reader-testflight.yml
+++ b/.buildkite/reader-testflight.yml
@@ -4,7 +4,7 @@
 steps:
   - label: ":eyeglasses: :xcode: Reader App Store Connect Build"
     command: .buildkite/commands/release-build-reader.sh
-    key: reader_asc_build
+    key: build_asc_reader
     plugins: [$CI_TOOLKIT_PLUGIN]
     agents:
       queue: mac
@@ -17,7 +17,7 @@ steps:
       - slack: "#build-and-ship"
 
   - label: ":eyeglasses: :testflight: Reader App Store Connect Upload"
-    depends_on: reader_asc_build
+    depends_on: build_asc_reader
     command: .buildkite/commands/release-upload-reader.sh
     plugins: [$CI_TOOLKIT_PLUGIN]
     agents:


### PR DESCRIPTION
## Description
See how
https://buildkite.com/automattic/wordpress-ios/builds/27417/steps?jid=01964b59-300d-46d2-bf40-33558caa03fa failed because the pipeline used `reader_asc_build` instead of `build_asc_reader`. Thanks @twstokes for bringing this to my attention!

I decided to consolidate to `build_asc_reader` because of the information hierarchy: build > build for ASC > build for ASC, the Reader app.

When we'll get to split build from upload for the other apps, we'll be able to have auto-complete friendly keys, su as `build_asc_wordpress` or `build_firebase_jetpack`.

Part of https://linear.app/a8c/project/automate-reader-ios-testflight-distribution-81ddc60737f0

## Testing instructions

Run https://buildkite.com/automattic/wordpress-ios/builds/27449 to test this, which shows we need to wait for https://github.com/wordpress-mobile/WordPress-iOS/pull/24478 to land first.