### PR TITLE
Fix an issue with Jetpack migration overlays being shown in the Reader app

### DIFF
--- a/Tests/KeystoneTests/Tests/Jetpack/JetpackFeaturesRemovalCoordinatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Jetpack/JetpackFeaturesRemovalCoordinatorTests.swift
@@ -357,7 +357,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
 
         // When
         // assume that we're requesting from the WordPress app.
-        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store, isJetpack: false)
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store, app: .wordpress)
 
         // Then
         XCTAssertEqual(phase, .staticScreens)
@@ -372,7 +372,7 @@ final class JetpackFeaturesRemovalCoordinatorTests: CoreDataTestCase {
 
         // When
         // assume that we're requesting from the Jetpack app.
-        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store, isJetpack: true)
+        let phase = JetpackFeaturesRemovalCoordinator.generalPhase(featureFlagStore: store, app: .jetpack)
 
         // Then
         XCTAssertEqual(phase, .normal)

--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -1,4 +1,5 @@
 import Foundation
+import BuildSettingsKit
 import WordPressShared
 
 /// A class containing convenience methods for the the Jetpack features removal experience
@@ -92,9 +93,9 @@ public class JetpackFeaturesRemovalCoordinator: NSObject {
     static var currentAppUIType: RootViewCoordinator.AppUIType?
 
     static func generalPhase(featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore(),
-                             isJetpack: Bool = AppConfiguration.isJetpack) -> GeneralPhase {
-        if isJetpack {
-            return .normal // Always return normal for Jetpack
+                             app: AppBrand = BuildSettings.current.brand) -> GeneralPhase {
+        guard app == .wordpress else {
+            return .normal // Show migration only for the WordPress app
         }
 
         if AccountHelper.noWordPressDotComAccount {
@@ -124,8 +125,8 @@ public class JetpackFeaturesRemovalCoordinator: NSObject {
     }
 
     static func siteCreationPhase(featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore()) -> SiteCreationPhase {
-        if AppConfiguration.isJetpack {
-            return .normal // Always return normal for Jetpack
+        guard BuildSettings.current.brand == .wordpress else {
+            return .normal // Show migration only for the WordPress app
         }
 
         if RemoteFeatureFlag.jetpackFeaturesRemovalPhaseNewUsers.enabled(using: featureFlagStore)


### PR DESCRIPTION
These are now shown only in the WordPress app.