### PR TITLE
Page created from template is now treated as unsaved content

### DIFF
--- a/WordPress/Classes/ViewRelated/Pages/Controllers/EditPageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/Controllers/EditPageViewController.swift
@@ -45,7 +45,9 @@ class EditPageViewController: UIViewController {
         if let page = self.page {
             return page
         } else {
-            let newPage = blog.createDraftPage()
+            // Leave the original Page object as an empty draft. Set the page content to the newly created revision.
+            // With this setup, the content will be treated as unsaved content.
+            let newPage = blog.createDraftPage().createRevision() as! Page
             newPage.content = self.content
             newPage.postTitle = self.postTitle
             self.page = newPage


### PR DESCRIPTION
## Description

Fix the issue found by @kean in https://github.com/wordpress-mobile/WordPress-iOS/pull/24470#discussion_r2049008186. The code changes are also from Alex.

To reproduce the issue:
1. Create a page
2. Choose a template
3. Close the editor, _without_ making any changes.

I can see two potential solutions here:
1. Once the page template is chosen, we should auto-save the page content as a draft. This is similar to Google Docs.
2. Treat the chosen template as content copied to the editor. That means the editor is presenting unsaved content and should warn users that the content is unsaved when closing the editor.

This PR went with the second solution.