### PR TITLE
feat: Allow experimental editor opt out

### DIFF
--- a/Modules/Sources/WordPressUI/Views/Settings/ExperimentalFeatures/ExperimentalFeaturesList.swift
+++ b/Modules/Sources/WordPressUI/Views/Settings/ExperimentalFeatures/ExperimentalFeaturesList.swift
@@ -10,9 +10,24 @@ public struct ExperimentalFeaturesList: View {
     }
 
     public var body: some View {
-        List(viewModel.items) { item in
-            Toggle(item.name, isOn: viewModel.binding(for: item))
+        List {
+            Section {
+                ForEach(viewModel.items) { item in
+                    Toggle(item.name, isOn: viewModel.binding(for: item))
+                }
+            } footer: {
+                if !viewModel.notes.isEmpty {
+                    VStack(alignment: .leading, spacing: 4) {
+                        ForEach(viewModel.notes, id: \.self) { note in
+                            Text(note)
+                                .font(.footnote)
+                                .foregroundColor(.secondary)
+                        }
+                    }
+                }
+            }
         }
+        .listStyle(.insetGrouped)
         .navigationTitle(Strings.pageTitle)
         .task {
             await viewModel.loadItems()

--- a/Modules/Sources/WordPressUI/Views/Settings/ExperimentalFeatures/ExperimentalFeaturesViewModel.swift
+++ b/Modules/Sources/WordPressUI/Views/Settings/ExperimentalFeatures/ExperimentalFeaturesViewModel.swift
@@ -6,6 +6,7 @@ public class ExperimentalFeaturesViewModel: ObservableObject {
         func loadItems() async throws -> [Feature]
         func value(for: Feature) -> Bool
         func didChangeValue(for feature: Feature, to newValue: Bool)
+        var notes: [String] { get }
     }
 
     package class DefaultDataProvider: DataProvider {
@@ -13,9 +14,11 @@ public class ExperimentalFeaturesViewModel: ObservableObject {
         let items: [Feature]
 
         var values = [String: Bool]()
+        package let notes: [String]
 
-        init(items: [Feature]) {
+        init(items: [Feature], notes: [String] = []) {
             self.items = items
+            self.notes = notes
         }
 
         package func loadItems() throws -> [Feature] {
@@ -45,10 +48,13 @@ public class ExperimentalFeaturesViewModel: ObservableObject {
     @Published
     public private(set) var error: Error? = nil
 
+    public private(set) var notes: [String]
+
     private var dataProvider: DataProvider
 
     public init(dataProvider: DataProvider) {
         self.dataProvider = dataProvider
+        self.notes = dataProvider.notes
     }
 
     func loadItems() async {

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -19,7 +19,6 @@ public enum FeatureFlag: Int, CaseIterable {
     case googleDomainsCard
     case voiceToContent
     case authenticateUsingApplicationPassword
-    case newGutenberg
     case newGutenbergThemeStyles
     case selfHostedSiteUserManagement
     case readerGutenbergCommentComposer
@@ -69,8 +68,6 @@ public enum FeatureFlag: Int, CaseIterable {
             return app == .jetpack && BuildConfiguration.current.isInternal
         case .authenticateUsingApplicationPassword:
             return false
-        case .newGutenberg:
-            return app == .reader
         case .newGutenbergThemeStyles:
             return false
         case .selfHostedSiteUserManagement:
@@ -118,7 +115,6 @@ extension FeatureFlag {
         case .googleDomainsCard: "Google Domains Promotional Card"
         case .voiceToContent: "Voice to Content"
         case .authenticateUsingApplicationPassword: "Application Passwords for self-hosted sites"
-        case .newGutenberg: "Experimental Block Editor"
         case .newGutenbergThemeStyles: "Experimental Block Editor Styles"
         case .selfHostedSiteUserManagement: "Self-hosted Site User Management"
         case .pluginManagementOverhaul: "Plugin Management Overhaul"

--- a/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/RemoteFeatureFlag.swift
@@ -34,6 +34,8 @@ public enum RemoteFeatureFlag: Int, CaseIterable {
     case newGutenbergPlugins
 
     var defaultValue: Bool {
+        let app = BuildSettings.current.brand
+
         switch self {
         case .jetpackMigrationPreventDuplicateNotifications:
             return true
@@ -90,7 +92,7 @@ public enum RemoteFeatureFlag: Int, CaseIterable {
         case .dotComWebLogin:
             return false
         case .newGutenberg:
-            return false
+            return app == .reader
         case .newGutenbergPlugins:
             return false
         }

--- a/WordPress/Classes/Utility/Editor/EditorFactory.swift
+++ b/WordPress/Classes/Utility/Editor/EditorFactory.swift
@@ -14,7 +14,7 @@ class EditorFactory {
 
     func instantiateEditor(for post: AbstractPost, replaceEditor: @escaping ReplaceEditorBlock) -> EditorViewController {
         if gutenbergSettings.mustUseGutenberg(for: post) {
-            if FeatureFlag.newGutenberg.enabled || RemoteFeatureFlag.newGutenberg.enabled() {
+            if RemoteFeatureFlag.newGutenberg.enabled() {
                 return NewGutenbergViewController(post: post, replaceEditor: replaceEditor)
             }
             return createGutenbergVC(with: post, replaceEditor: replaceEditor)

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -71,7 +71,7 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
 
     private let overlaysCoordinator: MySiteOverlaysCoordinator
     private lazy var editorSettingsService: RawBlockEditorSettingsService? = {
-        guard let blog, FeatureFlag.newGutenberg.enabled || RemoteFeatureFlag.newGutenberg.enabled() else { return nil }
+        guard let blog, RemoteFeatureFlag.newGutenberg.enabled() else { return nil }
         return RawBlockEditorSettingsService(blog: blog)
     }()
 
@@ -172,7 +172,7 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         subscribeToPostPublished()
         subscribeToWillEnterForeground()
 
-        if FeatureFlag.newGutenberg.enabled || RemoteFeatureFlag.newGutenberg.enabled() {
+        if RemoteFeatureFlag.newGutenberg.enabled() {
             GutenbergKit.EditorViewController.warmup()
         }
     }
@@ -386,7 +386,7 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
             showDashboard(for: blog)
         }
 
-        if FeatureFlag.newGutenberg.enabled || RemoteFeatureFlag.newGutenberg.enabled() {
+        if RemoteFeatureFlag.newGutenberg.enabled() {
             // Update editor settings service with new blog and fetch settings
             editorSettingsService = RawBlockEditorSettingsService(blog: blog)
             fetchEditorSettings()

--- a/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
@@ -6,7 +6,7 @@ class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvid
 
     let flags: [OverridableFlag] = [
         FeatureFlag.authenticateUsingApplicationPassword,
-        FeatureFlag.newGutenberg,
+        RemoteFeatureFlag.newGutenberg,
         FeatureFlag.newGutenbergThemeStyles,
     ]
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
@@ -33,7 +33,7 @@ class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvid
     func didChangeValue(for feature: WordPressUI.Feature, to newValue: Bool) {
         flagStore.override(flag(for: feature), withValue: newValue)
 
-        if feature.key == FeatureFlag.newGutenberg.key && !newValue {
+        if (feature.key == FeatureFlag.newGutenberg.key || feature.key == RemoteFeatureFlag.newGutenberg.key) && !newValue {
             let alert = UIAlertController(title: Strings.editorFeedbackTitle, message: Strings.editorFeedbackMessage, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: Strings.editorFeedbackDecline, style: .cancel, handler: nil))
             alert.addAction(UIAlertAction(title: Strings.editorFeedbackAccept, style: .default, handler: { _ in

--- a/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
@@ -33,7 +33,7 @@ class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvid
     func didChangeValue(for feature: WordPressUI.Feature, to newValue: Bool) {
         flagStore.override(flag(for: feature), withValue: newValue)
 
-        if (feature.key == FeatureFlag.newGutenberg.key || feature.key == RemoteFeatureFlag.newGutenberg.key) && !newValue {
+        if feature.key == RemoteFeatureFlag.newGutenberg.key && !newValue {
             let alert = UIAlertController(title: Strings.editorFeedbackTitle, message: Strings.editorFeedbackMessage, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: Strings.editorFeedbackDecline, style: .cancel, handler: nil))
             alert.addAction(UIAlertAction(title: Strings.editorFeedbackAccept, style: .default, handler: { _ in

--- a/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
@@ -12,9 +12,16 @@ class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvid
 
     private let flagStore = FeatureFlagOverrideStore()
 
+    var notes: [String] {
+        [Strings.editorNote]
+    }
+
     func loadItems() throws -> [WordPressUI.Feature] {
         flags.map { flag in
-            WordPressUI.Feature(name: flag.description, key: flag.key)
+            WordPressUI.Feature(
+                name: flag.description,
+                key: flag.key
+            )
         }
     }
 
@@ -60,5 +67,6 @@ class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvid
         static let editorFeedbackMessage = NSLocalizedString("experimentalFeatures.editorFeedbackMessage", value: "Are you willing to share feedback on the experimental editor?", comment: "Message for the alert asking for feedback on the experimental editor")
         static let editorFeedbackDecline = NSLocalizedString("experimentalFeatures.editorFeedbackDecline", value: "Not now", comment: "Dismiss button title for the alert asking for feedback")
         static let editorFeedbackAccept = NSLocalizedString("experimentalFeatures.editorFeedbackAccept", value: "Send feedback", comment: "Accept button title for the alert asking for feedback")
+        static let editorNote = NSLocalizedString("experimentalFeatures.editorNote", value: "Experimental Block Editor will become the default in a future release and the ability to disable it will be removed.", comment: "Communicates the future removal of the option to disable the experimental editor, displayed beneath the experimental features list")
     }
 }


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Utilize the remote feature flag to enable a phased roll out. Allow opting out of
the experimental editor for a TBD period of time.

Ref CMM-291.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
The experimental editor availability should operate much like any other remote
feature flag, where a remote value can be overridden by a local value controlled
by the user.

Users who enabled the now deprecated local-only feature flag should still see 
the experimental editor loaded. 

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

| Light | Dark |
| - | - |
| <img width="379" alt="Screenshot 2025-04-24 at 14 54 28" src="https://github.com/user-attachments/assets/75522f46-11aa-4358-89fa-727f54a52199" /> | <img width="380" alt="Screenshot 2025-04-24 at 14 54 36" src="https://github.com/user-attachments/assets/077e0398-91db-4790-aac5-93764cfe857a" /> |
