### PR TITLE
feat: Reduce editor activity indicator size

### DIFF
--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -331,7 +331,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     // MARK: - Activity Indicator
 
     private func showActivityIndicator() {
-        let indicator = UIActivityIndicatorView(style: .large)
+        let indicator = UIActivityIndicatorView()
         indicator.color = .gray
         indicator.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(indicator)


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Align with default OS patterns.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
Load the experimental editor and note the activity indicator size is smaller.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

| Before | After |
| - | - |
| ![activity-indicator-before](https://github.com/user-attachments/assets/4baf6183-f147-41e6-9943-368fd4b4bfdb) | ![activity-indicator-after](https://github.com/user-attachments/assets/8a3deb4d-9fb2-49b4-887b-8bc0a4eb2c23) |
