### PR TITLE
Fix how local Modules are added

### DIFF
--- a/WordPress.xcworkspace/contents.xcworkspacedata
+++ b/WordPress.xcworkspace/contents.xcworkspacedata
@@ -4,7 +4,4 @@
    <FileRef
       location = "group:WordPress/WordPress.xcodeproj">
    </FileRef>
-   <FileRef
-      location = "group:Modules">
-   </FileRef>
 </Workspace>

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -2687,7 +2687,7 @@
 			);
 			mainGroup = 29B97314FDCFA39411CA2CEA /* CustomTemplate */;
 			packageReferences = (
-				0C0C6BC22D8A14DD0056E696 /* XCLocalSwiftPackageReference "../Modules" */,
+				0C8095952DC2A4B9008DFC2F /* XCLocalSwiftPackageReference "../Modules" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 19C28FACFE9D520D11CA2CBB /* Products */;
@@ -7050,7 +7050,7 @@
 /* End XCConfigurationList section */
 
 /* Begin XCLocalSwiftPackageReference section */
-		0C0C6BC22D8A14DD0056E696 /* XCLocalSwiftPackageReference "../Modules" */ = {
+		0C8095952DC2A4B9008DFC2F /* XCLocalSwiftPackageReference "../Modules" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = ../Modules;
 		};


### PR DESCRIPTION
## Timeline

- When Modules were initially created, they were added to the project by drag-n-dropping them to the Xcode Project Navigator (assumption). 
- When I explored [SwiftLint Build Tool Plugin](https://github.com/wordpress-mobile/WordPress-iOS/pull/24213), I used the new workflow for adding local packages (Packages / Add / Add Local...). It was required to get Xcode to see the plugins.

As a result, Xcode now thinks there are two sets of the same local packages:

<img width="489" alt="Screenshot 2025-04-30 at 2 33 05 PM" src="https://github.com/user-attachments/assets/dc96b443-a46d-49f3-a139-ca08607f3aab" />

## Fix

In order to fix it, I removed the packages that were drag-n-dropped to the project. The local modules are now displayed automatically under "Package Dependencies". Xcode puts them at the top.

<img width="575" alt="Screenshot 2025-04-30 at 2 35 03 PM" src="https://github.com/user-attachments/assets/48a59cd0-a6b5-4f13-82fc-2a308bf30f14" />
<img width="563" alt="Screenshot 2025-04-30 at 2 35 06 PM" src="https://github.com/user-attachments/assets/1ec57fa7-5dc8-46eb-809c-d341908ae0af" />

