### PR TITLE
Remove duplicated SFHFKeychainUtils dependency from WordPressUnitTests

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -312,7 +312,6 @@ enum XcodeSupport {
             .xcodeTarget("XcodeTarget_App", dependencies: keystoneDependencies),
             .xcodeTarget("XcodeTarget_Keystone", dependencies: keystoneDependencies),
             .xcodeTarget("XcodeTarget_WordPressTests", dependencies: testDependencies + [
-                "SFHFKeychainUtils",
                 "WordPressShared",
                 "WordPressUI",
                 .product(name: "Gravatar", package: "Gravatar-SDK-iOS"),


### PR DESCRIPTION
Noticed this because Xcode added a warning sign next to the Modules in the file navigator. Probably a rebase / merge conflict byproduct.

![image](https://github.com/user-attachments/assets/aaf77791-7a4a-4502-b93f-9554941df079)

![image](https://github.com/user-attachments/assets/512793d4-c6a9-4f71-a9ed-b026d7f55ecd)

