### PR TITLE
Add missing NSURL-IDN package

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -294,6 +294,7 @@ enum XcodeSupport {
             .product(name: "Lottie", package: "lottie-ios"),
             .product(name: "MediaEditor", package: "MediaEditor-iOS"),
             .product(name: "NSObject-SafeExpectations", package: "NSObject-SafeExpectations"),
+            .product(name: "NSURL+IDN", package: "NSURL-IDN"),
             .product(name: "Reachability", package: "Reachability"),
             .product(name: "Starscream", package: "Starscream"),
             .product(name: "SVProgressHUD", package: "SVProgressHUD"),


### PR DESCRIPTION
This package used to be included in a single Xcode-based framework (WordPressAuthentificator ) using static linking. With the addition of WordPressData that also depends on it, SwiftPM started using dynamic linking by default. Unfortunately, SwiftPM doesn't know anything about how Xcode targets depend on each other, so you need to manually tell it to embed NSURL+IDN binary into the app. It doesn't know where to embed the dynamic framework. 