### PR TITLE
Application passwords reauthentication flow

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -51,9 +51,8 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/WordPressKit-iOS", branch: "wpios-edition"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
-        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250411"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from:
-        "0.2.0"),
+        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250505"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.2.0"),
         .package(url: "https://github.com/Automattic/color-studio", branch: "trunk"),
         .package(url: "https://github.com/wordpress-mobile/AztecEditor-iOS", from: "1.20.0"),
     ],

--- a/Tests/KeystoneTests/Tests/Models/Blog+RestAPITests.swift
+++ b/Tests/KeystoneTests/Tests/Models/Blog+RestAPITests.swift
@@ -23,6 +23,7 @@ final class Blog_RestAPITests: CoreDataTestCase {
             using: testKeychain
         )
         self.blog = try XCTUnwrap(contextManager.mainContext.fetch(NSFetchRequest<Blog>(entityName: "Blog")).first)
+        try blog.setPassword(to: "account-password", using: testKeychain)
     }
 
     func testThatCreateRestApiBlogStoresUrl() throws {
@@ -33,8 +34,8 @@ final class Blog_RestAPITests: CoreDataTestCase {
         XCTAssertEqual(try blog.getUsername(), loginDetails.userLogin)
     }
 
-    func testThatCreateRestApiBlogStoresPassword() throws {
-        XCTAssertEqual(try blog.getPassword(using: testKeychain), loginDetails.password)
+    func testThatCreateRestApiBlogDoesNotStorePassword() throws {
+        XCTAssertNotEqual(try blog.getPassword(using: testKeychain), loginDetails.password)
     }
 
     func testThatCreateRestApiBlogStoresSiteIdentifier() throws {

--- a/Tests/KeystoneTests/Tests/Services/UserListViewModelTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/UserListViewModelTests.swift
@@ -16,7 +16,7 @@ class UserListViewModelTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
 
-        let client = try WordPressClient(api: .init(urlSession: .shared, apiRootUrl: .parse(input: "https://example.com/wp-json"), authenticationStategy: .none), rootUrl: .parse(input: "https://example.com"))
+        let client = try WordPressClient(api: .init(urlSession: .shared, apiRootUrl: .parse(input: "https://example.com/wp-json"), authentication: .none), rootUrl: .parse(input: "https://example.com"))
         service = UserService(client: client)
         viewModel = await UserListViewModel(userService: service, currentUserId: 0)
     }

--- a/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/WordPress.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0ed52b944e605856a7ca56314dcbfee8c4c681a2a599fd3ef8d32d3c7ba95616",
+  "originHash" : "e0e032948809f0069d23395b55645e656a14e1684585142435fb87682e5b76ef",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -383,8 +383,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/wordpress-rs",
       "state" : {
-        "branch" : "alpha-20250411",
-        "revision" : "0de58e944c075cf509d7e13a9b4625dae430d84f"
+        "branch" : "alpha-20250505",
+        "revision" : "645c8a22303e93267d4f1e645f8e01d228fd7e7c"
       }
     },
     {

--- a/WordPress/Classes/Login/ApplicationPasswordReAuthenticationView.swift
+++ b/WordPress/Classes/Login/ApplicationPasswordReAuthenticationView.swift
@@ -1,0 +1,78 @@
+import Foundation
+import UIKit
+import SwiftUI
+import DesignSystem
+
+struct ApplicationPasswordReAuthenticationView: View {
+    let blog: Blog
+    let presenter: UIViewController
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var error: String?
+
+    var body: some View {
+        NavigationView {
+            VStack(spacing: 20) {
+                Image(systemName: "key.slash")
+                    .font(.system(size: 50))
+                    .foregroundColor(.gray)
+
+                Text(Strings.title)
+                    .font(.headline)
+
+                Text(Strings.description)
+                    .font(.body)
+                    .frame(maxWidth: .infinity)
+
+                DSButton(
+                    title: Strings.signInButton,
+                    style: DSButtonStyle(emphasis: .primary, size: .large),
+                    isLoading: .constant(false)
+                ) {
+                    self.error = nil
+
+                    Task { @MainActor in
+                        do {
+                            let _ = try await SelfHostedSiteAuthenticator()
+                                .signIn(
+                                    site: blog.getUrl().absoluteString,
+                                    from: presenter,
+                                    context: .reauthentication(username: blog.getUsername())
+                                )
+
+                            // Automatically dismiss this view upon a successful re-authentication.
+                            dismiss()
+                        } catch {
+                            self.error = error.localizedDescription
+                        }
+                    }
+                }
+
+                if let error {
+                    Text(error)
+                        .font(.body)
+                        .foregroundStyle(.red)
+                        .padding(.horizontal)
+                }
+
+                Spacer()
+            }
+            .padding()
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button(Strings.cancelButton) {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+
+private enum Strings {
+    static let title: String = NSLocalizedString("login.appPasswordReAuth.title", value: "Invalid application password", comment: "Title shown when the application password is invalid")
+    static let description: String = NSLocalizedString("login.appPasswordReAuth.description", value: "The application password assigned to the app no longer exists in your profile.\nPlease sign in again to create a new application password for the app to use.", comment: "Description explaining why the user needs to re-authenticate")
+    static let signInButton: String = NSLocalizedString("login.appPasswordReAuth.signInButton", value: "Sign In", comment: "Button to start the re-authentication process")
+    static let cancelButton: String = NSLocalizedString("login.appPasswordReAuth.cancelButton", value: "Cancel", comment: "Button to dismiss the re-authentication view")
+}

--- a/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
+++ b/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
@@ -54,6 +54,9 @@ struct InstalledPluginsListView: View {
                 AddNewPluginView(service: viewModel.service)
             }
         }
+        .onApplicationPasswordUpdate {
+            Task { await viewModel.refreshItems() }
+        }
         .task {
             await viewModel.onAppear()
         }
@@ -217,6 +220,7 @@ private final class InstalledPluginsListViewModel: ObservableObject {
         isRefreshing = true
         defer { isRefreshing = false }
 
+        self.error = nil
         self.showNoPluginsView = false
 
         do {
@@ -279,5 +283,21 @@ private final class InstalledPluginsListViewModel: ObservableObject {
             DDLogError("Failed to uninstall plugin: \(error)")
         }
 
+    }
+}
+
+private struct ApplicationPasswordUpdatedViewModifier: ViewModifier {
+    var action: () -> Void
+
+    func body(content: Content) -> some View {
+        content.onReceive(NotificationCenter.default.publisher(for: SelfHostedSiteAuthenticator.applicationPasswordUpdated)) { _ in
+            action()
+        }
+    }
+}
+
+extension View {
+    func onApplicationPasswordUpdate(action: @escaping () -> Void) -> some View {
+        modifier(ApplicationPasswordUpdatedViewModifier(action: action))
     }
 }

--- a/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
+++ b/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
@@ -286,18 +286,10 @@ private final class InstalledPluginsListViewModel: ObservableObject {
     }
 }
 
-private struct ApplicationPasswordUpdatedViewModifier: ViewModifier {
-    var action: () -> Void
-
-    func body(content: Content) -> some View {
-        content.onReceive(NotificationCenter.default.publisher(for: SelfHostedSiteAuthenticator.applicationPasswordUpdated)) { _ in
-            action()
-        }
-    }
-}
-
 extension View {
     func onApplicationPasswordUpdate(action: @escaping () -> Void) -> some View {
-        modifier(ApplicationPasswordUpdatedViewModifier(action: action))
+        onReceive(NotificationCenter.default.publisher(for: SelfHostedSiteAuthenticator.applicationPasswordUpdated)) { _ in
+            action()
+        }
     }
 }

--- a/WordPress/Classes/Users/ViewModel/UserListViewModel.swift
+++ b/WordPress/Classes/Users/ViewModel/UserListViewModel.swift
@@ -113,6 +113,7 @@ class UserListViewModel: ObservableObject {
         refreshItemsTask?.cancel()
         refreshItemsTask = Task {
             isRefreshing = true
+            self.error = nil
             defer { isRefreshing = false }
             do {
                 try await userService.fetchUsers()

--- a/WordPress/Classes/Users/Views/UserListView.swift
+++ b/WordPress/Classes/Users/Views/UserListView.swift
@@ -59,6 +59,9 @@ public struct UserListView: View {
                 }
             }
         }
+        .onApplicationPasswordUpdate {
+            Task { await viewModel.refreshItems() }
+        }
         .task(id: viewModel.mode) {
             await viewModel.performQuery()
         }

--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackConnectionViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackConnectionViewModel.swift
@@ -172,7 +172,7 @@ class JetpackConnectionService {
         }
 
         guard let site = try? WordPressSite(blog: blog),
-              case let .selfHosted(apiRootURL, username, password) = site
+              case let .selfHosted(_, apiRootURL, username, password) = site
         else {
             return nil
         }


### PR DESCRIPTION
## Description

Considering users have very easy access to application passwords on wp-admin, and there is no super obvious indicator on wp-admin to show that the official WordPress/Jetpack app is currently using one application password, I _presume_ users may accidentally revoke the one used by the app. This PR introduces a reauthentication flow when the app notices that the application password becomes invalid. The flow is similar to where WP.com users disconnect the app from their "Connected Application" webpage on WP.com.

## Testing instructions

Here is a video demo:

https://github.com/user-attachments/assets/8a38c6f3-1c8a-437e-a172-1a1b79264856.mov

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
