### PR TITLE
Add/more error logging

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -70,7 +70,8 @@ final class BlogDashboardService {
                 failure?([])
             }
 
-        }, failure: { [weak self] _ in
+        }, failure: { [weak self] error in
+            DDLogError("Failed to fetch Dashboard Cards: \(error.localizedDescription)")
             blog.dashboardState.failedToLoad = true
             let items = self?.fetchLocal(blog: blog)
             failure?(items ?? [])

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -132,7 +132,7 @@ class NotificationSettingsViewController: UIViewController {
             dispatchGroup.leave()
         }, failure: { [weak self] (error: NSError?) in
             dispatchGroup.leave()
-            self?.handleLoadError()
+            self?.handleLoadError(error: error)
         })
 
         dispatchGroup.enter()
@@ -210,12 +210,22 @@ class NotificationSettingsViewController: UIViewController {
 
     // MARK: - Error Handling
 
-    fileprivate func handleLoadError() {
+    fileprivate func handleLoadError(error: NSError?) {
         let title = NSLocalizedString("Oops!", comment: "An informal exclaimation meaning `something went wrong`.")
-        let message = NSLocalizedString("There has been a problem while loading your Notification Settings",
-                                            comment: "Displayed after Notification Settings failed to load")
         let cancelText = NSLocalizedString("Cancel", comment: "Cancel. Action.")
         let retryText = NSLocalizedString("Try Again", comment: "Try Again. Action")
+
+        var message = NSLocalizedString(
+            "There has been a problem while loading your Notification Settings",
+            comment: "Displayed after Notification Settings failed to load"
+        )
+
+        if let error {
+            message = NSLocalizedString(
+                "There has been a problem while loading your Notification Settings: \(error.localizedDescription)",
+                comment: "Displayed after Notification Settings failed to load"
+            )
+        }
 
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -211,7 +211,7 @@ class NotificationSettingsViewController: UIViewController {
     // MARK: - Error Handling
 
     fileprivate func handleLoadError(error: NSError?) {
-        let title = NSLocalizedString("Oops!", comment: "An informal exclaimation meaning `something went wrong`.")
+        let title = NSLocalizedString("Failed to load settings", comment: "An informal exclaimation meaning `something went wrong`.")
         let cancelText = NSLocalizedString("Cancel", comment: "Cancel. Action.")
         let retryText = NSLocalizedString("Try Again", comment: "Try Again. Action")
 
@@ -221,10 +221,7 @@ class NotificationSettingsViewController: UIViewController {
         )
 
         if let error {
-            message = NSLocalizedString(
-                "There has been a problem while loading your Notification Settings: \(error.localizedDescription)",
-                comment: "Displayed after Notification Settings failed to load"
-            )
+            message = error.localizedDescription
         }
 
         let alertController = UIAlertController(title: title, message: message, preferredStyle: .alert)

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -211,7 +211,10 @@ class NotificationSettingsViewController: UIViewController {
     // MARK: - Error Handling
 
     fileprivate func handleLoadError(error: NSError?) {
-        let title = NSLocalizedString("Failed to load settings", comment: "An informal exclaimation meaning `something went wrong`.")
+        let title = NSLocalizedString(
+            "Failed to load settings",
+            comment: "A message indicating that we couldn't load the user's settings."
+        )
         let cancelText = NSLocalizedString("Cancel", comment: "Cancel. Action.")
         let retryText = NSLocalizedString("Try Again", comment: "Try Again. Action")
 


### PR DESCRIPTION
## Description
Helps us get more information about user-facing issues. If an endpoint fails, we need to know what it reported.

## Testing instructions
Probably not required

