### PR TITLE
Implement a wordpress-rs backed MediaServiceRemote

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fe094f15c8e18dab512a2ddf88e08b4c895c60964ac1158c031ee731381eda34",
+  "originHash" : "202b7f16a53d3be86120a57e70060dc74ae4a74a65678186b337db383a8a816d",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -380,8 +380,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/wordpress-rs",
       "state" : {
-        "branch" : "alpha-20250505",
-        "revision" : "645c8a22303e93267d4f1e645f8e01d228fd7e7c"
+        "branch" : "alpha-20250513",
+        "revision" : "0aff0035734bb311d1a710e123d95b9b50fba400"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
         ),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
-        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250505"),
+        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250513"),
         .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "fdfe788530bbff864ce7147b5a68608d7025e078"),
         .package(
             url: "https://github.com/Automattic/color-studio",

--- a/Sources/WordPressData/Objective-C/Blog.m
+++ b/Sources/WordPressData/Objective-C/Blog.m
@@ -614,7 +614,7 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
             // alt is not supported via XML-RPC API
             // https://core.trac.wordpress.org/ticket/58582
             // https://github.com/wordpress-mobile/WordPress-Android/issues/18514#issuecomment-1589752274
-            return [self supportsRestApi];
+            return [self supportsRestApi] || [self supportsCoreRestApi];
         case BlogFeatureMediaDeletion:
             return [self isAdmin];
         case BlogFeatureHomepageSettings:

--- a/Sources/WordPressData/Swift/Blog+SelfHosted.swift
+++ b/Sources/WordPressData/Swift/Blog+SelfHosted.swift
@@ -170,3 +170,19 @@ public extension WpApiApplicationPasswordDetails {
             .joined()
     }
 }
+
+public enum WordPressSite {
+    case dotCom(siteId: Int, authToken: String)
+    case selfHosted(blogId: TaggedManagedObjectID<Blog>, apiRootURL: ParsedUrl, username: String, authToken: String)
+
+    public init(blog: Blog) throws {
+        if let account = blog.account {
+            let authToken = try account.authToken ?? WPAccount.token(forUsername: account.username)
+            self = .dotCom(siteId: blog.dotComID?.intValue ?? 0, authToken: authToken)
+        } else {
+            let url = try blog.restApiRootURL ?? blog.getUrl().appending(path: "wp-json").absoluteString
+            let apiRootURL = try ParsedUrl.parse(input: url)
+            self = .selfHosted(blogId: TaggedManagedObjectID(blog), apiRootURL: apiRootURL, username: try blog.getUsername(), authToken: try blog.getApplicationToken())
+        }
+    }
+}

--- a/Sources/WordPressData/Swift/Blog+SelfHosted.swift
+++ b/Sources/WordPressData/Swift/Blog+SelfHosted.swift
@@ -161,6 +161,13 @@ public extension Blog {
     @objc var isSelfHosted: Bool {
         self.account == nil
     }
+
+    @objc var supportsCoreRestApi: Bool {
+        if case .selfHosted = try? WordPressSite(blog: self) {
+            return true
+        }
+        return false
+    }
 }
 
 public extension WpApiApplicationPasswordDetails {

--- a/WordPress/Classes/Services/MediaRepository.swift
+++ b/WordPress/Classes/Services/MediaRepository.swift
@@ -94,6 +94,10 @@ private extension MediaRepository {
             return MediaServiceRemoteREST(wordPressComRestApi: api, siteID: dotComID)
         }
 
+        if let site = try? WordPressSite(blog: blog) {
+            return MediaServiceRemoteCoreREST(client: .init(site: site))
+        }
+
         if let username = blog.username, let password = blog.password, let api = blog.xmlrpcApi {
             return MediaServiceRemoteXMLRPC(api: api, username: username, password: password)
         }

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -476,16 +476,7 @@ NSErrorDomain const MediaServiceErrorDomain = @"MediaServiceErrorDomain";
 
 - (id<MediaServiceRemote>)remoteForBlog:(Blog *)blog
 {
-    id <MediaServiceRemote> remote;
-    if ([blog supports:BlogFeatureWPComRESTAPI]) {
-        if (blog.wordPressComRestApi) {
-            remote = [[MediaServiceRemoteREST alloc] initWithWordPressComRestApi:blog.wordPressComRestApi
-                                                                          siteID:blog.dotComID];
-        }
-    } else if (blog.xmlrpcApi) {
-        remote = [[MediaServiceRemoteXMLRPC alloc] initWithApi:blog.xmlrpcApi username:blog.username password:blog.password];
-    }
-    return remote;
+    return [[[MediaServiceRemoteFactory alloc] init] remoteForBlog:blog error:nil];
 }
 
 - (void)mergeMedia:(NSArray *)media

--- a/WordPress/Classes/Services/MediaServiceRemoteCoreREST.swift
+++ b/WordPress/Classes/Services/MediaServiceRemoteCoreREST.swift
@@ -31,7 +31,11 @@ class MediaServiceRemoteCoreREST: NSObject, MediaServiceRemote {
         success: ((RemoteMedia?) -> Void)?,
         failure: (((any Error)?) -> Void)?
     ) {
-        wpAssert(media.localURL != nil)
+        guard let localURL = media.localURL else {
+            wpAssertionFailure("local url missing in the media")
+            failure?(URLError(.fileDoesNotExist))
+            return
+        }
 
         // Set up a `Progress` instance that are updated from the main thread, which is a behaviour that other parts of the app rely on.
         let totalUnit: Int64 = 100
@@ -48,7 +52,7 @@ class MediaServiceRemoteCoreREST: NSObject, MediaServiceRemote {
                     .assign(to: \.completedUnitCount, on: mainThreadProgress)
                 defer { cancellable.cancel() }
 
-                let media = try await client.api.uploadMedia(params: .init(media: media), fromLocalFileURL: media.localURL!, fulfilling: progress).data
+                let media = try await client.api.uploadMedia(params: .init(media: media), fromLocalFileURL: localURL, fulfilling: progress).data
                 success?(.init(media: media))
             } catch {
                 failure?(error)
@@ -57,11 +61,15 @@ class MediaServiceRemoteCoreREST: NSObject, MediaServiceRemote {
     }
 
     func update(_ media: RemoteMedia, success: ((RemoteMedia?) -> Void)?, failure: (((any Error)?) -> Void)?) {
-        wpAssert(media.mediaID != nil)
+        guard let mediaID = media.mediaID else {
+            wpAssertionFailure("id missing in the media")
+            failure?(URLError(.unknown))
+            return
+        }
 
         Task { @MainActor in
             do {
-                let media = try await client.api.media.update(mediaId: media.mediaID!.int64Value, params: .init(media: media)).data
+                let media = try await client.api.media.update(mediaId: mediaID.int64Value, params: .init(media: media)).data
                 success?(.init(media: media))
             } catch {
                 failure?(error)
@@ -70,11 +78,15 @@ class MediaServiceRemoteCoreREST: NSObject, MediaServiceRemote {
     }
 
     func delete(_ media: RemoteMedia, success: (() -> Void)?, failure: (((any Error)?) -> Void)?) {
-        wpAssert(media.mediaID != nil)
+        guard let mediaID = media.mediaID else {
+            wpAssertionFailure("id missing in the media")
+            failure?(URLError(.unknown))
+            return
+        }
 
         Task { @MainActor in
             do {
-                let _ = try await client.api.media.delete(mediaId: media.mediaID!.int64Value)
+                let _ = try await client.api.media.delete(mediaId: mediaID.int64Value)
                 success?()
             } catch {
                 failure?(error)

--- a/WordPress/Classes/Services/MediaServiceRemoteCoreREST.swift
+++ b/WordPress/Classes/Services/MediaServiceRemoteCoreREST.swift
@@ -1,0 +1,217 @@
+import Foundation
+import Combine
+import WordPressCore
+import WordPressShared
+import WordPressAPI
+import WordPressAPIInternal
+import WordPressKit
+
+/// A `MediaServiceRemote` implementation that uses the WordPress core REST API (`/wp-json/wp/v2/media`).
+class MediaServiceRemoteCoreREST: NSObject, MediaServiceRemote {
+    let client: WordPressClient
+
+    init(client: WordPressClient) {
+        self.client = client
+    }
+
+    func getMediaWithID(_ mediaID: NSNumber, success: ((RemoteMedia?) -> Void)?, failure: (((any Error)?) -> Void)?) {
+        Task { @MainActor in
+            do {
+                let media = try await client.api.media.retrieveWithEditContext(mediaId: mediaID.int64Value).data
+                success?(RemoteMedia(media: media))
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func uploadMedia(
+        _ media: RemoteMedia,
+        progress progressPtr: AutoreleasingUnsafeMutablePointer<Progress?>?,
+        success: ((RemoteMedia?) -> Void)?,
+        failure: (((any Error)?) -> Void)?
+    ) {
+        wpAssert(media.localURL != nil)
+
+        // Set up a `Progress` instance that are updated from the main thread, which is a behaviour that other parts of the app rely on.
+        let totalUnit: Int64 = 100
+        let mainThreadProgress = Progress(totalUnitCount: totalUnit)
+        progressPtr?.pointee = mainThreadProgress
+
+        Task { @MainActor in
+            do {
+                let progress = Progress.discreteProgress(totalUnitCount: totalUnit)
+                let cancellable = progress
+                    .publisher(for: \.fractionCompleted, options: .new)
+                    .map { Int64($0 * Double(totalUnit)) }
+                    .receive(on: DispatchQueue.main)
+                    .assign(to: \.completedUnitCount, on: mainThreadProgress)
+                defer { cancellable.cancel() }
+
+                let media = try await client.api.uploadMedia(params: .init(media: media), fromLocalFileURL: media.localURL!, fulfilling: progress).data
+                success?(.init(media: media))
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func update(_ media: RemoteMedia, success: ((RemoteMedia?) -> Void)?, failure: (((any Error)?) -> Void)?) {
+        wpAssert(media.mediaID != nil)
+
+        Task { @MainActor in
+            do {
+                let media = try await client.api.media.update(mediaId: media.mediaID!.int64Value, params: .init(media: media)).data
+                success?(.init(media: media))
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func delete(_ media: RemoteMedia, success: (() -> Void)?, failure: (((any Error)?) -> Void)?) {
+        wpAssert(media.mediaID != nil)
+
+        Task { @MainActor in
+            do {
+                let _ = try await client.api.media.delete(mediaId: media.mediaID!.int64Value)
+                success?()
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func getMediaLibrary(pageLoad: (([Any]?) -> Void)!, success: (([Any]?) -> Void)?, failure: (((any Error)?) -> Void)?) {
+        Task { @MainActor in
+            do {
+                var all = [RemoteMedia]()
+                let sequence = await client.api.media.sequenceWithEditContext(params: .init())
+                for try await element in sequence {
+                    let page = element.map { RemoteMedia(media: $0) }
+                    all.append(contentsOf: page)
+                    pageLoad(page)
+                }
+                success?(all)
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func getMediaLibraryCount(forType mediaType: String?, withSuccess success: ((Int) -> Void)?, failure: (((any Error)?) -> Void)?) {
+        Task { @MainActor in
+            do {
+                let response = try await client.api.media.listWithEditContext(params: .init(mimeType: mediaType))
+                success?(Int(response.headerMap.wpTotal() ?? 0))
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func getMetadataFromVideoPressID(
+        _ videoPressID: String!,
+        isSitePrivate: Bool,
+        success: ((WordPressKit.RemoteVideoPressVideo?) -> Void)?,
+        failure: (((any Error)?) -> Void)?
+    ) {
+        // ⚠️ The endpoint is not available in WordPress core.
+        failure?(URLError(.unsupportedURL))
+    }
+
+    func getVideoPressToken(_ videoPressID: String!, success: ((String?) -> Void)?, failure: (((any Error)?) -> Void)?) {
+        // ⚠️ The endpoint is not available in WordPress core.
+        failure?(URLError(.unsupportedURL))
+    }
+}
+
+private extension RemoteMedia {
+    convenience init(media: MediaWithEditContext) {
+        self.init()
+
+        self.mediaID = NSNumber(value: media.id)
+        self.url = URL(string: media.sourceUrl)
+        self.guid = URL(string: media.guid.raw)
+        self.date = media.dateGmt
+        self.postID = media.postId.map { NSNumber(value: $0) }
+        self.mimeType = media.mimeType
+        self.extension = URL(string: media.sourceUrl)?.pathExtension
+        self.title = media.title.raw
+        self.caption = media.caption.raw
+        self.descriptionText = media.description.raw
+        self.alt = media.altText
+
+        if case let .object(mediaDetails) = media.mediaDetails {
+            if case let .int(width) = mediaDetails["width"] {
+                self.width = NSNumber(value: width)
+            }
+            if case let .int(height) = mediaDetails["height"] {
+                self.height = NSNumber(value: height)
+            }
+            if case let .string(file) = mediaDetails["file"] {
+                self.file = file
+            }
+
+            if case let .object(sizes) = mediaDetails["sizes"] {
+                if case let .object(medium) = sizes["medium"],
+                   case let .string(url) = medium["source_url"] {
+                    self.mediumURL = URL(string: url)
+                }
+                if case let .object(large) = sizes["large"],
+                   case let .string(url) = large["source_url"] {
+                    self.largeURL = URL(string: url)
+                }
+                if case let .object(thumbnail) = sizes["thumbnail"],
+                   case let .string(url) = thumbnail["source_url"] {
+                    self.remoteThumbnailURL = url
+                }
+            }
+        }
+
+        self.localURL = nil
+        self.videopressGUID = nil
+        self.length = nil
+        self.shortcode = nil
+    }
+}
+
+private extension MediaCreateParams {
+    init(media: RemoteMedia) {
+        self.init(
+            date: nil,
+            dateGmt: media.date,
+            slug: nil,
+            status: nil,
+            title: media.title,
+            author: nil,
+            commentStatus: nil,
+            pingStatus: nil,
+            template: nil,
+            altText: media.alt,
+            caption: media.caption,
+            description: media.descriptionText,
+            postId: media.postID?.int64Value
+        )
+    }
+}
+
+private extension MediaUpdateParams {
+    init(media: RemoteMedia) {
+        self.init(
+            date: nil,
+            dateGmt: media.date,
+            slug: nil,
+            status: nil,
+            title: media.title,
+            author: nil,
+            commentStatus: nil,
+            pingStatus: nil,
+            template: nil,
+            altText: media.alt,
+            caption: media.caption,
+            description: media.descriptionText,
+            postId: media.postID?.int64Value
+        )
+    }
+}


### PR DESCRIPTION
## Description

The new type uses wordpress-rs to access the media library via the .org REST API. It's only used when the current user has authenticated via application passwords.

The only UI change is "alt text" is now editable when application password is available.