### PR TITLE
[Tooling] Skip jobs if there are no relevant code changes

### DIFF
--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type build; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type build; then
   exit 0
 fi
 

--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --build; then
+if .buildkite/commands/should-skip-job.sh --job-type build; then
   message="Skipping Build - no relevant files changed"
   echo "$message" | buildkite-agent annotate --style "info" --context "skip-build"
   echo "$message"

--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -1,9 +1,6 @@
 #!/bin/bash -eu
 
 if .buildkite/commands/should-skip-job.sh --job-type build; then
-  message="Skipping Build - no relevant files changed"
-  echo "$message" | buildkite-agent annotate --style "info" --context "skip-build"
-  echo "$message"
   exit 0
 fi
 

--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -1,4 +1,12 @@
 #!/bin/bash -eu
+
+if .buildkite/commands/should-skip-job.sh --build; then
+  message="Skipping Build - no relevant files changed"
+  echo "$message" | buildkite-agent annotate --style "info" --context "skip-build"
+  echo "$message"
+  exit 0
+fi
+
 APP=${1:-}
 
 # Run this at the start to fail early if value not available

--- a/.buildkite/commands/lint-localized-strings-format.sh
+++ b/.buildkite/commands/lint-localized-strings-format.sh
@@ -1,9 +1,6 @@
 #!/bin/bash -eu
 
 if .buildkite/commands/should-skip-job.sh --job-type localization; then
-  message="Skipping Localization Lint - no localization files changed"
-  echo "$message" | buildkite-agent annotate --style "info" --context "skip-localization-lint"
-  echo "$message"
   exit 0
 fi
 

--- a/.buildkite/commands/lint-localized-strings-format.sh
+++ b/.buildkite/commands/lint-localized-strings-format.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --localization; then
+if .buildkite/commands/should-skip-job.sh --job-type localization; then
   message="Skipping Localization Lint - no localization files changed"
   echo "$message" | buildkite-agent annotate --style "info" --context "skip-localization-lint"
   echo "$message"

--- a/.buildkite/commands/lint-localized-strings-format.sh
+++ b/.buildkite/commands/lint-localized-strings-format.sh
@@ -1,5 +1,12 @@
 #!/bin/bash -eu
 
+if .buildkite/commands/should-skip-job.sh --localization; then
+  message="Skipping Localization Lint - no localization files changed"
+  echo "$message" | buildkite-agent annotate --style "info" --context "skip-localization-lint"
+  echo "$message"
+  exit 0
+fi
+
 echo "--- :writing_hand: Copy Files"
 mkdir -pv ~/.configure/wordpress-ios/secrets
 cp -v fastlane/env/project.env-example ~/.configure/wordpress-ios/secrets/project.env

--- a/.buildkite/commands/lint-localized-strings-format.sh
+++ b/.buildkite/commands/lint-localized-strings-format.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type localization; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type localization; then
   exit 0
 fi
 

--- a/.buildkite/commands/prototype-build-jetpack.sh
+++ b/.buildkite/commands/prototype-build-jetpack.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type build; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type build; then
   exit 0
 fi
 

--- a/.buildkite/commands/prototype-build-jetpack.sh
+++ b/.buildkite/commands/prototype-build-jetpack.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --build; then
+if .buildkite/commands/should-skip-job.sh --job-type build; then
   message="Skipping Jetpack Prototype Build - no relevant files changed"
   echo "$message" | buildkite-agent annotate --style "info" --context "skip-prototype-build-jetpack"
   echo "$message"

--- a/.buildkite/commands/prototype-build-jetpack.sh
+++ b/.buildkite/commands/prototype-build-jetpack.sh
@@ -1,9 +1,6 @@
 #!/bin/bash -eu
 
 if .buildkite/commands/should-skip-job.sh --job-type build; then
-  message="Skipping Jetpack Prototype Build - no relevant files changed"
-  echo "$message" | buildkite-agent annotate --style "info" --context "skip-prototype-build-jetpack"
-  echo "$message"
   exit 0
 fi
 

--- a/.buildkite/commands/prototype-build-jetpack.sh
+++ b/.buildkite/commands/prototype-build-jetpack.sh
@@ -1,5 +1,12 @@
 #!/bin/bash -eu
 
+if .buildkite/commands/should-skip-job.sh --build; then
+  message="Skipping Jetpack Prototype Build - no relevant files changed"
+  echo "$message" | buildkite-agent annotate --style "info" --context "skip-prototype-build-jetpack"
+  echo "$message"
+  exit 0
+fi
+
 "$(dirname "${BASH_SOURCE[0]}")/shared-set-up.sh"
 "$(dirname "${BASH_SOURCE[0]}")/shared-set-up-distribution.sh"
 

--- a/.buildkite/commands/prototype-build-wordpress.sh
+++ b/.buildkite/commands/prototype-build-wordpress.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type build; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type build; then
   exit 0
 fi
 

--- a/.buildkite/commands/prototype-build-wordpress.sh
+++ b/.buildkite/commands/prototype-build-wordpress.sh
@@ -1,9 +1,6 @@
 #!/bin/bash -eu
 
 if .buildkite/commands/should-skip-job.sh --job-type build; then
-  message="Skipping WordPress Prototype Build - no relevant files changed"
-  echo "$message" | buildkite-agent annotate --style "info" --context "skip-prototype-build-wordpress"
-  echo "$message"
   exit 0
 fi
 

--- a/.buildkite/commands/prototype-build-wordpress.sh
+++ b/.buildkite/commands/prototype-build-wordpress.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --build; then
+if .buildkite/commands/should-skip-job.sh --job-type build; then
   message="Skipping WordPress Prototype Build - no relevant files changed"
   echo "$message" | buildkite-agent annotate --style "info" --context "skip-prototype-build-wordpress"
   echo "$message"

--- a/.buildkite/commands/prototype-build-wordpress.sh
+++ b/.buildkite/commands/prototype-build-wordpress.sh
@@ -1,5 +1,12 @@
 #!/bin/bash -eu
 
+if .buildkite/commands/should-skip-job.sh --build; then
+  message="Skipping WordPress Prototype Build - no relevant files changed"
+  echo "$message" | buildkite-agent annotate --style "info" --context "skip-prototype-build-wordpress"
+  echo "$message"
+  exit 0
+fi
+
 "$(dirname "${BASH_SOURCE[0]}")/shared-set-up.sh"
 "$(dirname "${BASH_SOURCE[0]}")/shared-set-up-distribution.sh"
 

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type validation; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type validation; then
   exit 0
 fi
 

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -1,9 +1,6 @@
 #!/bin/bash -eu
 
 if .buildkite/commands/should-skip-job.sh --job-type validation; then
-  message="Skipping UI Tests - no relevant files changed"
-  echo "$message" | buildkite-agent annotate --style "info" --context "skip-ui-tests"
-  echo "$message"
   exit 0
 fi
 

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -1,5 +1,12 @@
 #!/bin/bash -eu
 
+if .buildkite/commands/should-skip-job.sh --validation; then
+  message="Skipping UI Tests - no relevant files changed"
+  echo "$message" | buildkite-agent annotate --style "info" --context "skip-ui-tests"
+  echo "$message"
+  exit 0
+fi
+
 DEVICE=$1
 
 echo "Running UI tests on $DEVICE. The iOS version will be the latest available in the CI host."

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --validation; then
+if .buildkite/commands/should-skip-job.sh --job-type validation; then
   message="Skipping UI Tests - no relevant files changed"
   echo "$message" | buildkite-agent annotate --style "info" --context "skip-ui-tests"
   echo "$message"

--- a/.buildkite/commands/run-unit-tests-reader.sh
+++ b/.buildkite/commands/run-unit-tests-reader.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type validation; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type validation; then
   exit 0
 fi
 

--- a/.buildkite/commands/run-unit-tests-reader.sh
+++ b/.buildkite/commands/run-unit-tests-reader.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --validation; then
+if .buildkite/commands/should-skip-job.sh --job-type validation; then
   message="Skipping Reader Unit Tests - no relevant files changed"
   echo "$message" | buildkite-agent annotate --style "info" --context "skip-reader-unit-tests"
   echo "$message"

--- a/.buildkite/commands/run-unit-tests-reader.sh
+++ b/.buildkite/commands/run-unit-tests-reader.sh
@@ -1,5 +1,12 @@
 #!/bin/bash -eu
 
+if .buildkite/commands/should-skip-job.sh --validation; then
+  message="Skipping Reader Unit Tests - no relevant files changed"
+  echo "$message" | buildkite-agent annotate --style "info" --context "skip-reader-unit-tests"
+  echo "$message"
+  exit 0
+fi
+
 # Run this at the start to fail early if value not available
 # TODO: We'll need to create a token for Reader
 # echo '--- :test-analytics: Configuring Test Analytics'

--- a/.buildkite/commands/run-unit-tests-reader.sh
+++ b/.buildkite/commands/run-unit-tests-reader.sh
@@ -1,9 +1,6 @@
 #!/bin/bash -eu
 
 if .buildkite/commands/should-skip-job.sh --job-type validation; then
-  message="Skipping Reader Unit Tests - no relevant files changed"
-  echo "$message" | buildkite-agent annotate --style "info" --context "skip-reader-unit-tests"
-  echo "$message"
   exit 0
 fi
 

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --job-type validation; then
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type validation; then
   exit 0
 fi
 

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -1,9 +1,6 @@
 #!/bin/bash -eu
 
 if .buildkite/commands/should-skip-job.sh --job-type validation; then
-  message="Skipping Unit Tests - no relevant files changed"
-  echo "$message" | buildkite-agent annotate --style "info" --context "skip-unit-tests"
-  echo "$message"
   exit 0
 fi
 

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -1,5 +1,12 @@
 #!/bin/bash -eu
 
+if .buildkite/commands/should-skip-job.sh --validation; then
+  message="Skipping Unit Tests - no relevant files changed"
+  echo "$message" | buildkite-agent annotate --style "info" --context "skip-unit-tests"
+  echo "$message"
+  exit 0
+fi
+
 # Run this at the start to fail early if value not available
 echo '--- :test-analytics: Configuring Test Analytics'
 export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-if .buildkite/commands/should-skip-job.sh --validation; then
+if .buildkite/commands/should-skip-job.sh --job-type validation; then
   message="Skipping Unit Tests - no relevant files changed"
   echo "$message" | buildkite-agent annotate --style "info" --context "skip-unit-tests"
   echo "$message"

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -1,0 +1,40 @@
+#!/bin/bash -eu
+
+# Usage: should-skip-job.sh [--validation|--build|--localization]
+# --validation: Skip when changes are limited to documentation, tooling, non-code files, and localization files
+# --build: Skip when changes are limited to documentation, tooling, and non-code files
+# --localization: Check if any localization files have changed
+
+COMMON_PATTERNS=(
+  "*.md"
+  "*.pot"
+  "*.txt"
+  ".gitignore"
+  "config/Version.Public.xcconfig"
+  "docs/**"
+  "fastlane/**"
+  "Gemfile"
+  "Gemfile.lock"
+)
+
+LOCALIZATION_PATTERNS=(
+  "**/*.strings"
+  "**/*.stringsdict"
+)
+
+if [ "$1" = "--validation" ]; then
+  # Check if changes are limited to documentation, tooling, non-code files, and localization files
+  PATTERNS=("${COMMON_PATTERNS[@]}" "${LOCALIZATION_PATTERNS[@]}")
+  pr_changed_files --all-match "${PATTERNS[@]}"
+elif [ "$1" = "--localization" ]; then
+  # Check if any localization files have changed
+  # Return true (skip) if NO localization files have changed
+  ! pr_changed_files --any-match "${LOCALIZATION_PATTERNS[@]}"
+elif [ "$1" = "--build" ]; then
+  # Check if changes are limited to documentation, tooling, and non-code files (NOT localization files)
+  PATTERNS=("${COMMON_PATTERNS[@]}")
+  pr_changed_files --all-match "${PATTERNS[@]}"
+else
+  echo "Error: Must specify either --validation, --build, or --localization"
+  exit 1
+fi

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -31,9 +31,14 @@ LOCALIZATION_PATTERNS=(
   "**/*.stringsdict"
 )
 
+# Define constants for job types
+VALIDATION="validation"
+BUILD="build"
+LOCALIZATION="localization"
+
 # Check if arguments are valid
 if [ -z "${1:-}" ] || [ "$1" != "--job-type" ] || [ -z "${2:-}" ]; then
-  echo "Error: Must specify --job-type [validation|build|localization]"
+  echo "Error: Must specify --job-type [$VALIDATION|$BUILD|$LOCALIZATION]"
   buildkite-agent step cancel
   exit 15
 fi
@@ -41,7 +46,7 @@ fi
 # Function to display skip message and create annotation
 show_skip_message() {
   local job_type=$1
-  local message="Skipping ${BUILDKITE_LABEL:-Job} - no relevant files changed"
+  local message="Skipped ${BUILDKITE_LABEL:-Job} - no relevant files changed"
   local context="skip-$(echo "${BUILDKITE_LABEL:-$job_type}" | sed -E -e 's/[^[:alnum:]]+/-/g' | tr A-Z a-z)"
   
   echo "$message" | buildkite-agent annotate --style "info" --context "$context"
@@ -50,7 +55,7 @@ show_skip_message() {
 
 job_type="$2"
 case "$job_type" in
-  "validation")
+  $VALIDATION)
     # We should skip if changes are limited to documentation, tooling, non-code files, and localization files
     PATTERNS=("${COMMON_PATTERNS[@]}" "${LOCALIZATION_PATTERNS[@]}")
     if pr_changed_files --all-match "${PATTERNS[@]}"; then
@@ -59,7 +64,7 @@ case "$job_type" in
     fi
     exit 1
     ;;
-  "localization")
+  $LOCALIZATION)
     # Check if any localization files have changed
     # Return true (skip) if NO localization files have changed
     if ! pr_changed_files --any-match "${LOCALIZATION_PATTERNS[@]}"; then
@@ -68,7 +73,7 @@ case "$job_type" in
     fi
     exit 1
     ;;
-  "build")
+  $BUILD)
     # We should skip if changes are limited to documentation, tooling, and non-code files
     # We'll let the job run (won't skip) if PR includes changes in localization files though
     PATTERNS=("${COMMON_PATTERNS[@]}")
@@ -79,7 +84,7 @@ case "$job_type" in
     exit 1
     ;;
   *)
-    echo "Error: Job type must be either 'validation', 'build', or 'localization'"
+    echo "Error: Job type must be either '$VALIDATION', '$BUILD', or '$LOCALIZATION'"
     buildkite-agent step cancel
     exit 15
     ;;

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -1,9 +1,9 @@
 #!/bin/bash -eu
 
-# Usage: should-skip-job.sh [--validation|--build|--localization]
-# --validation: Skip when changes are limited to documentation, tooling, non-code files, and localization files
-# --build: Skip when changes are limited to documentation, tooling, and non-code files
-# --localization: Check if any localization files have changed
+# Usage: should-skip-job.sh --job-type [validation|build|localization]
+# --job-type validation: Skip when changes are limited to documentation, tooling, non-code files, and localization files
+# --job-type build: Skip when changes are limited to documentation, tooling, and non-code files
+# --job-type localization: Check if any localization files have changed
 
 COMMON_PATTERNS=(
   "*.md"
@@ -22,19 +22,33 @@ LOCALIZATION_PATTERNS=(
   "**/*.stringsdict"
 )
 
-if [ "$1" = "--validation" ]; then
-  # Check if changes are limited to documentation, tooling, non-code files, and localization files
-  PATTERNS=("${COMMON_PATTERNS[@]}" "${LOCALIZATION_PATTERNS[@]}")
-  pr_changed_files --all-match "${PATTERNS[@]}"
-elif [ "$1" = "--localization" ]; then
-  # Check if any localization files have changed
-  # Return true (skip) if NO localization files have changed
-  ! pr_changed_files --any-match "${LOCALIZATION_PATTERNS[@]}"
-elif [ "$1" = "--build" ]; then
-  # Check if changes are limited to documentation, tooling, and non-code files (NOT localization files)
-  PATTERNS=("${COMMON_PATTERNS[@]}")
-  pr_changed_files --all-match "${PATTERNS[@]}"
-else
-  echo "Error: Must specify either --validation, --build, or --localization"
-  exit 1
+# Check if arguments are valid
+if [ -z "${1:-}" ] || [ "$1" != "--job-type" ] || [ -z "${2:-}" ]; then
+  echo "Error: Must specify --job-type [validation|build|localization]"
+  buildkite-agent step cancel
+  exit 15
 fi
+
+case "$2" in
+  "validation")
+    # We should skip if changes are limited to documentation, tooling, non-code files, and localization files
+    PATTERNS=("${COMMON_PATTERNS[@]}" "${LOCALIZATION_PATTERNS[@]}")
+    pr_changed_files --all-match "${PATTERNS[@]}"
+    ;;
+  "localization")
+    # Check if any localization files have changed
+    # Return true (skip) if NO localization files have changed
+    ! pr_changed_files --any-match "${LOCALIZATION_PATTERNS[@]}"
+    ;;
+  "build")
+    # We should skip if changes are limited to documentation, tooling, and non-code files
+    # We'll let the job run (won't skip) if PR includes changes in localization files though
+    PATTERNS=("${COMMON_PATTERNS[@]}")
+    pr_changed_files --all-match "${PATTERNS[@]}"
+    ;;
+  *)
+    echo "Error: Job type must be either 'validation', 'build', or 'localization'"
+    buildkite-agent step cancel
+    exit 15
+    ;;
+esac

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -1,9 +1,17 @@
 #!/bin/bash -eu
 
 # Usage: should-skip-job.sh --job-type [validation|build|localization]
-# --job-type validation: Skip when changes are limited to documentation, tooling, non-code files, and localization files
-# --job-type build: Skip when changes are limited to documentation, tooling, and non-code files
-# --job-type localization: Check if any localization files have changed
+# --job-type validation: For jobs like unit/instrumented tests, manifest validation…
+#     Skip when changes are limited to documentation, tooling, non-code files, and localization files
+# --job-type localization: For jobs doing linting, especially ones that might include linting of localization files
+#     Check if any localization files have changed
+# --job-type build: For jobs building an apk binary, e.g. Assemble, Prototype Builds…
+#     Skip when changes are limited to documentation, tooling, and non-code files
+#
+# Return codes:
+# 0 - Job should be skipped (script also handles displaying the message and annotation)
+# 1 - Job should not be skipped
+# 15 - Error in script parameters
 
 COMMON_PATTERNS=(
   "*.md"
@@ -29,22 +37,45 @@ if [ -z "${1:-}" ] || [ "$1" != "--job-type" ] || [ -z "${2:-}" ]; then
   exit 15
 fi
 
-case "$2" in
+# Function to display skip message and create annotation
+show_skip_message() {
+  local job_type=$1
+  local message="Skipping ${BUILDKITE_LABEL:-Job} - no relevant files changed"
+  local context="skip-$(echo "${BUILDKITE_LABEL:-$job_type}" | sed -E -e 's/[^[:alnum:]]+/-/g' | tr A-Z a-z)"
+  
+  echo "$message" | buildkite-agent annotate --style "info" --context "$context"
+  echo "$message"
+}
+
+job_type="$2"
+case "$job_type" in
   "validation")
     # We should skip if changes are limited to documentation, tooling, non-code files, and localization files
     PATTERNS=("${COMMON_PATTERNS[@]}" "${LOCALIZATION_PATTERNS[@]}")
-    pr_changed_files --all-match "${PATTERNS[@]}"
+    if pr_changed_files --all-match "${PATTERNS[@]}"; then
+      show_skip_message "$job_type"
+      exit 0
+    fi
+    exit 1
     ;;
   "localization")
     # Check if any localization files have changed
     # Return true (skip) if NO localization files have changed
-    ! pr_changed_files --any-match "${LOCALIZATION_PATTERNS[@]}"
+    if ! pr_changed_files --any-match "${LOCALIZATION_PATTERNS[@]}"; then
+      show_skip_message "$job_type"
+      exit 0
+    fi
+    exit 1
     ;;
   "build")
     # We should skip if changes are limited to documentation, tooling, and non-code files
     # We'll let the job run (won't skip) if PR includes changes in localization files though
     PATTERNS=("${COMMON_PATTERNS[@]}")
-    pr_changed_files --all-match "${PATTERNS[@]}"
+    if pr_changed_files --all-match "${PATTERNS[@]}"; then
+      show_skip_message "$job_type"
+      exit 0
+    fi
+    exit 1
     ;;
   *)
     echo "Error: Job type must be either 'validation', 'build', or 'localization'"

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -15,6 +15,7 @@
 
 COMMON_PATTERNS=(
   "*.md"
+  "*.po"
   "*.pot"
   "*.txt"
   ".gitignore"

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -eu
 
-# Usage: should-skip-job.sh --job-type [validation|build|localization]
+# Usage: should-skip-job.sh --job-type [validation|localization|build]
 # --job-type validation: For jobs like unit/instrumented tests, manifest validation…
 #     Skip when changes are limited to documentation, tooling, non-code files, and localization files
 # --job-type localization: For jobs doing linting, especially ones that might include linting of localization files

--- a/.buildkite/commands/should-skip-job.sh
+++ b/.buildkite/commands/should-skip-job.sh
@@ -18,7 +18,7 @@ COMMON_PATTERNS=(
   "*.pot"
   "*.txt"
   ".gitignore"
-  "config/Version.Public.xcconfig"
+  "config/Version.public.xcconfig"
   "docs/**"
   "fastlane/**"
   "Gemfile"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,7 +10,12 @@ steps:
     steps:
       - label: ":eyeglasses: Reader ASC Demo Build"
         key: build_asc_reader
-        command: .buildkite/commands/release-build-reader.sh
+        command: |
+          if .buildkite/commands/should-skip-job.sh --job-type build; then
+            exit 0
+          fi
+
+          .buildkite/commands/release-build-reader.sh
         plugins: [$CI_TOOLKIT_PLUGIN]
         artifact_paths:
           - Artifacts/*.zip
@@ -30,7 +35,12 @@ steps:
 
       - label: ":eyeglasses: Reader one-off TestFlight Upload"
         depends_on: [build_asc_reader, testflight_triggered_reader]
-        command: .buildkite/commands/release-upload-reader.sh
+        command: |
+          if .buildkite/commands/should-skip-job.sh --job-type build; then
+            exit 0
+          fi
+
+          .buildkite/commands/release-upload-reader.sh
         plugins: [$CI_TOOLKIT_PLUGIN]
         notify:
           - github_commit_status:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -102,6 +102,10 @@ steps:
               context: "Reader Unit Tests"
       - label: "🔬 Keystone Unit Tests"
         command: |
+          if .buildkite/commands/should-skip-job.sh --job-type validation; then
+            exit 0
+          fi
+
           .buildkite/commands/shared-set-up.sh
           xcodebuild \
             -scheme Keystone \
@@ -116,6 +120,10 @@ steps:
               context: "Unit Tests Keystone"
       - label: "🔬 WordPressData Unit Tests"
         command: |
+          if .buildkite/commands/should-skip-job.sh --job-type validation; then
+            exit 0
+          fi
+
           .buildkite/commands/shared-set-up.sh
           xcodebuild \
             -scheme WordPressData \

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -5,7 +5,7 @@
 
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed -E 's/^~> ?//' .xcode-version)
-CI_TOOLKIT_PLUGIN_VERSION="3.8.0"
+CI_TOOLKIT_PLUGIN_VERSION="5.3.1"
 
 export IMAGE_ID="xcode-$XCODE_VERSION"
 export CI_TOOLKIT_PLUGIN="automattic/a8c-ci-toolkit#$CI_TOOLKIT_PLUGIN_VERSION"


### PR DESCRIPTION
Internal reference: paaHJt-7Ss-p2

The main goal of this PR is to optimize the wait time for PRs with minor, non-code related changes, specially the ones related to the release process.

There's a script to check in jobs if the changes in a PR is relevant to the said job.
The jobs are the time consuming ones running UI tests or building the app:
- `should-skip-job.sh --job-type build`: skips if the changes are limited to documentation, tooling, metadata, etc
- `should-skip-job.sh --job-type localization`: skips the job if the changes don't contain localization changes
- `should-skip-job.sh --job-type validation`: same as above, but also skip on localization changes. The idea is that it can be valuable to run things as a Prototype build when localization changes

## Testing
I've created the PR https://github.com/wordpress-mobile/WordPress-iOS/pull/24546 to test a few scenarios skipping jobs:
- App version bump: https://buildkite.com/automattic/wordpress-ios/builds/27705
- ++ Localization update: https://buildkite.com/automattic/wordpress-ios/builds/27706
- ++ Metadata update: https://buildkite.com/automattic/wordpress-ios/builds/27707