### PR TITLE
Remove an invalid assertion

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/Controllers/Create/CommentCreateViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/Create/CommentCreateViewModel.swift
@@ -45,7 +45,7 @@ final class CommentCreateViewModel {
         self.replyToComment = comment
         self._save = save
 
-        self.suggestionsViewModel = SuggestionsListViewModel.make(siteID: siteID)
+        self.suggestionsViewModel = comment.blog.flatMap { SuggestionsListViewModel.make(blog: $0) }
         self.suggestionsViewModel?.enableProminentSuggestions(
             postAuthorID: comment.post?.authorID,
             commentAuthorID: comment.commentID as NSNumber

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/Create/CommentCreateViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/Create/CommentCreateViewModel.swift
@@ -40,7 +40,6 @@ final class CommentCreateViewModel {
     /// Create a reply to the given comment.
     init(replyingTo comment: Comment, save: @escaping (String) async throws -> Void) {
         let siteID = comment.associatedSiteID ?? 0
-        wpAssert(siteID != 0, "missing required parameter siteID")
 
         self.siteID = siteID
         self.replyToComment = comment

--- a/WordPress/Classes/ViewRelated/Suggestions/SuggestionsListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Suggestions/SuggestionsListViewModel.swift
@@ -69,8 +69,17 @@ import CoreData
         service: SuggestionService = SuggestionService.shared,
         context: NSManagedObjectContext = ContextManager.shared.mainContext
     ) -> SuggestionsListViewModel? {
-        guard let blog = Blog.lookup(withID: siteID, in: context),
-              service.shouldShowSuggestions(for: blog) else {
+        guard siteID.intValue != 0, let blog = Blog.lookup(withID: siteID, in: context) else {
+            return nil
+        }
+        return make(blog: blog, service: service)
+    }
+
+    static func make(
+        blog: Blog,
+        service: SuggestionService = SuggestionService.shared
+    ) -> SuggestionsListViewModel? {
+        guard service.shouldShowSuggestions(for: blog) else {
             return nil
         }
         return SuggestionsListViewModel(blog: blog)


### PR DESCRIPTION
`siteID` (WP.com site id) is nil for self-hosted sites.
