### PR TITLE
Implement a new CommentServiceRemote that uses .org REST API

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "202b7f16a53d3be86120a57e70060dc74ae4a74a65678186b337db383a8a816d",
+  "originHash" : "2f50dc7601f992ac0e22d0e32a759ef5d14289c7cc5f8b887c46073f7d50391b",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -380,8 +380,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/wordpress-rs",
       "state" : {
-        "branch" : "alpha-20250513",
-        "revision" : "0aff0035734bb311d1a710e123d95b9b50fba400"
+        "branch" : "alpha-20250520",
+        "revision" : "a1960ad79ecec20a8b18deda447f2f45630b14ce"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
         ),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
-        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250513"),
+        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250520"),
         .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "fdfe788530bbff864ce7147b5a68608d7025e078"),
         .package(
             url: "https://github.com/Automattic/color-studio",

--- a/Modules/Sources/WordPressCore/Extensions/Avatar.swift
+++ b/Modules/Sources/WordPressCore/Extensions/Avatar.swift
@@ -1,0 +1,15 @@
+import Foundation
+import WordPressAPI
+import WordPressAPIInternal
+
+extension Dictionary where Key == UserAvatarSize, Value == WpResponseString {
+
+    public func avatarURL() -> URL? {
+        guard let url = self[.size96] ?? self[.size48] ?? self[.size24], let url else {
+            return nil
+        }
+
+        return URL(string: url)
+    }
+
+}

--- a/Modules/Sources/WordPressCore/Users/UserService.swift
+++ b/Modules/Sources/WordPressCore/Users/UserService.swift
@@ -86,19 +86,11 @@ private extension DisplayUser {
             firstName: user.firstName,
             lastName: user.lastName,
             displayName: user.name,
-            profilePhotoUrl: Self.profilePhotoUrl(for: user),
+            profilePhotoUrl: user.avatarUrls?.avatarURL(),
             role: role,
             emailAddress: user.email,
             websiteUrl: user.link,
             biography: user.description
         )
-    }
-
-    static func profilePhotoUrl(for user: UserWithEditContext) -> URL? {
-        guard let url = user.avatarUrls?[.size96] ?? user.avatarUrls?[.size48] ?? user.avatarUrls?[.size24], let url else {
-            return nil
-        }
-
-        return URL(string: url)
     }
 }

--- a/Sources/WordPressData/Swift/Blog+SelfHosted.swift
+++ b/Sources/WordPressData/Swift/Blog+SelfHosted.swift
@@ -183,9 +183,9 @@ public enum WordPressSite {
     case selfHosted(blogId: TaggedManagedObjectID<Blog>, apiRootURL: ParsedUrl, username: String, authToken: String)
 
     public init(blog: Blog) throws {
-        if let account = blog.account {
-            let authToken = try account.authToken ?? WPAccount.token(forUsername: account.username)
-            self = .dotCom(siteId: blog.dotComID?.intValue ?? 0, authToken: authToken)
+        if let _ = blog.account {
+            // WP.com support is not ready yet.
+            throw NSError(domain: "WordPressAPI", code: 0)
         } else {
             let url = try blog.restApiRootURL ?? blog.getUrl().appending(path: "wp-json").absoluteString
             let apiRootURL = try ParsedUrl.parse(input: url)

--- a/WordPress/Classes/Services/CommentService+Swift.swift
+++ b/WordPress/Classes/Services/CommentService+Swift.swift
@@ -1,3 +1,6 @@
+import Foundation
+import WordPressData
+
 /// Encapsulates actions related to fetching reply comments.
 ///
 extension CommentService {
@@ -72,6 +75,32 @@ extension CommentService {
             }
 
             self.coreDataStack.save(context, completion: completion, on: .main)
+        }
+    }
+
+    // The app may display `RemoteComment.postTitle` on comments list. However, the comments endpoint in the .org
+    // REST API does not return post title. This function prefetchs the associated posts and saves them locally if
+    // they don't already exist.
+    @objc(fetchPostsIfNeededForComments:inBlog:)
+    func fetchPostsIfNeeded(for comments: [RemoteComment], in blog: Blog) {
+        // Find posts that do not exists locally.
+        let postIds = comments
+            .reduce(into: Set<NSNumber>()) { result, comment in
+                if let postId = comment.postID, comment.postTitle == nil {
+                    result.insert(postId)
+                }
+            }
+            .filter { postId in
+                blog.lookupPost(withID: postId, in: blog.managedObjectContext!) == nil
+            }
+
+        let blogId = TaggedManagedObjectID(blog)
+        DDLogInfo("Pre-fetching \(postIds.count) posts...")
+        Task {
+            let repository = PostRepository()
+            for postId in postIds {
+                _ = try? await repository.getPost(withID: postId, from: blogId)
+            }
         }
     }
 }

--- a/WordPress/Classes/Services/CommentService+Swift.swift
+++ b/WordPress/Classes/Services/CommentService+Swift.swift
@@ -82,7 +82,7 @@ extension CommentService {
     // REST API does not return post title. This function prefetchs the associated posts and saves them locally if
     // they don't already exist.
     @objc(fetchPostsIfNeededForComments:inBlog:)
-    func fetchPostsIfNeeded(for comments: [RemoteComment], in blog: Blog) {
+    public func fetchPostsIfNeeded(for comments: [RemoteComment], in blog: Blog) {
         // Find posts that do not exists locally.
         let postIds = comments
             .reduce(into: Set<NSNumber>()) { result, comment in

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -175,6 +175,8 @@ static NSTimeInterval const CommentsRefreshTimeoutInSeconds = 60 * 5; // 5 minut
                 fetchedComments = [self filterUnrepliedComments:comments forAuthor:author];
             }
             [self mergeComments:fetchedComments forBlog:blog purgeExisting:YES];
+            [self fetchPostsIfNeededForComments:fetchedComments inBlog:blog];
+
             blog.lastCommentsSync = [NSDate date];
         } completion:^{
             [[self class] stopSyncingCommentsForBlog:blogID];

--- a/WordPress/Classes/Services/CommentServiceRemoteCoreRESTAPI.swift
+++ b/WordPress/Classes/Services/CommentServiceRemoteCoreRESTAPI.swift
@@ -1,0 +1,323 @@
+import Foundation
+import WordPressCore
+import WordPressAPI
+import WordPressAPIInternal
+import WordPressKit
+import WordPressShared
+import WordPressData
+
+final class CommentServiceRemoteCoreRESTAPI: NSObject, CommentServiceRemote {
+    private let client: WordPressClient
+
+    init(client: WordPressClient) {
+        self.client = client
+    }
+
+    func getCommentsWithMaximumCount(_ maximumComments: Int, success: (([Any]?) -> Void)?, failure: (((any Error)?) -> Void)?) {
+        getCommentsWithMaximumCount(maximumComments, options: nil, success: success, failure: failure)
+    }
+
+    func getCommentsWithMaximumCount(_ maximumComments: Int, options: [AnyHashable: Any]? = [:], success: (([Any]?) -> Void)?, failure: (((any Error)?) -> Void)?) {
+        Task { @MainActor in
+            do {
+                let sequence = await client.api.comments.sequenceWithEditContext(params: .init(options: options))
+                var all = [RemoteComment]()
+                for try await page in sequence where maximumComments > all.count {
+                    let comments = page.prefix(maximumComments - all.count).map { RemoteComment(comment: $0) }
+                    all.append(contentsOf: comments)
+                }
+
+                success?(all)
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func getCommentWithID(_ commentID: NSNumber, success: ((RemoteComment?) -> Void)?, failure: (((any Error)?) -> Void)?) {
+        Task { @MainActor in
+            do {
+                let comment = try await client.api.comments.retrieveWithEditContext(commentId: commentID.int64Value, params: .init()).data
+                success?(RemoteComment(comment: comment))
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func createComment(_ comment: RemoteComment, success: ((RemoteComment?) -> Void)?, failure: (((any Error)?) -> Void)?) {
+        guard comment.postID != nil else {
+            wpAssertionFailure("post id missing in the comment")
+            failure?(URLError(.unknown))
+            return
+        }
+
+        Task { @MainActor in
+            do {
+                let comment = try await client.api.comments.create(params: .init(comment: comment)).data
+                success?(RemoteComment(comment: comment))
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func update(_ comment: RemoteComment, success: ((RemoteComment?) -> Void)?, failure: (((any Error)?) -> Void)?) {
+        guard let commentID = comment.commentID else {
+            wpAssertionFailure("comment id missing in the comment")
+            failure?(URLError(.unknown))
+            return
+        }
+
+        Task { @MainActor in
+            do {
+                let comment = try await client.api.comments.update(commentId: commentID.int64Value, params: .init(comment: comment)).data
+                success?(RemoteComment(comment: comment))
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func moderateComment(_ comment: RemoteComment, success: ((RemoteComment?) -> Void)?, failure: (((any Error)?) -> Void)?) {
+        guard let commentID = comment.commentID else {
+            wpAssertionFailure("comment id missing in the comment")
+            failure?(URLError(.unknown))
+            return
+        }
+
+        guard let status = comment.commentStatus else {
+            wpAssertionFailure("invalid comment status in the comment")
+            failure?(URLError(.unknown))
+            return
+        }
+
+        Task { @MainActor in
+            do {
+                let comment = try await client.api.comments.update(commentId: commentID.int64Value, params: .init(status: status)).data
+                success?(RemoteComment(comment: comment))
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func trashComment(_ comment: RemoteComment, success: (() -> Void)?, failure: (((any Error)?) -> Void)?) {
+        guard let commentID = comment.commentID else {
+            wpAssertionFailure("comment id missing in the comment")
+            failure?(URLError(.unknown))
+            return
+        }
+
+        Task { @MainActor in
+            do {
+                // The `WordPressAPI.comments.trash` moves comments to trash.
+                // The `WordPressAPI.comments.delete` deletes comments  permanently.
+                //
+                // Even though this function here is called "trash comment", it's actually used to deleted
+                // comments permanently.
+                _ = try await client.api.comments.delete(commentId: commentID.int64Value, params: .init())
+                success?()
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+}
+
+private extension RemoteComment {
+    convenience init(comment: CommentWithEditContext) {
+        self.init()
+
+        self.commentID = NSNumber(value: comment.id)
+        self.authorID = NSNumber(value: comment.author)
+        self.author = comment.authorName
+        self.authorEmail = comment.authorEmail
+        self.authorUrl = comment.authorUrl
+        self.authorAvatarURL = comment.authorAvatarUrls.avatarURL()?.absoluteString
+        self.authorIP = comment.authorIp
+        self.content = comment.content.raw
+        self.rawContent = comment.content.raw
+        self.date = comment.dateGmt
+        self.link = comment.link
+        self.parentID = NSNumber(value: comment.parent)
+        self.postID = NSNumber(value: comment.post)
+
+        self.status = comment.status.commentStatusType?.description
+        self.type = comment.commentType.type
+
+        // The following properties are not available in .org REST API.
+        self.postTitle = nil
+        self.isLiked = false
+        self.likeCount = 0
+        self.canModerate = false
+    }
+
+    /// When `RemoteComment` is created by the app to send to API, some properties are set to default values (like
+    /// empty string, 0). We should treat those values as `nil`, because wordpress-rs emits nil values in request body,
+    /// but keeps them if they are "" or 0.
+    ///
+    /// We'll treat each property case by case, but in general it's safe to treat "" or 0 as nil. For example, there is
+    /// no post whose id is 0, and there is no email address is an empty string.
+    func resetDefaultValuesToNil() {
+        if self.commentID?.intValue == 0 { self.commentID = nil }
+        if self.authorID?.intValue == 0 { self.authorID = nil }
+        if self.author?.isEmpty == true { self.author = nil }
+        if self.authorEmail?.isEmpty == true { self.authorEmail = nil }
+        if self.authorUrl?.isEmpty == true { self.authorUrl = nil }
+        if self.authorAvatarURL?.isEmpty == true { self.authorAvatarURL = nil }
+        if self.authorIP?.isEmpty == true { self.authorIP = nil }
+        if self.content?.isEmpty == true { self.content = nil }
+        if self.rawContent?.isEmpty == true { self.rawContent = nil }
+        if self.link?.isEmpty == true { self.link = nil }
+        if self.parentID?.intValue == 0 { self.parentID = nil }
+        if self.postID?.intValue == 0 { self.postID = nil }
+        if self.postTitle?.isEmpty == true { self.postTitle = nil }
+        if self.status?.isEmpty == true { self.status = nil }
+        if self.type?.isEmpty == true { self.type = nil }
+
+        // The following properties are not updated:
+        // - likeCount
+    }
+
+    /// The `status: String` property value does not match the `CommentStatus` values. This variable provides a safe
+    /// way to cast the `status` property to a `CommentStatus` instance.
+    var commentStatus: CommentStatus? {
+        if let status = CommentStatusType.typeForStatus(status) {
+            return CommentStatus(status)
+        }
+
+        return nil
+    }
+}
+
+extension CommentUpdateParams {
+    init(comment: RemoteComment) {
+        comment.resetDefaultValuesToNil()
+        self.init(
+            author: nil,
+            authorEmail: comment.authorEmail,
+            authorIp: comment.authorIP,
+            authorName: comment.author,
+            authorUrl: comment.authorUrl,
+            authorUserAgent: nil,
+            content: comment.content,
+            date: nil,
+            dateGmt: comment.date,
+            parent: comment.parentID?.int64Value,
+            post: comment.postID?.int64Value,
+            status: comment.commentStatus
+        )
+    }
+}
+
+extension CommentCreateParams {
+    init(comment: RemoteComment) {
+        comment.resetDefaultValuesToNil()
+        self.init(
+            post: comment.postID.int64Value,
+            author: nil,
+            authorEmail: comment.authorEmail,
+            authorIp: comment.authorIP,
+            authorName: comment.author,
+            authorUrl: comment.authorUrl,
+            authorUserAgent: nil,
+            content: comment.content,
+            date: nil,
+            dateGmt: comment.date,
+            parent: comment.parentID?.int64Value,
+            status: comment.commentStatus
+        )
+    }
+}
+
+private extension CommentListParams {
+    init(options: [AnyHashable: Any]?) {
+        guard var options else {
+            self = .init()
+            return
+        }
+
+        // Here are all supported options:
+        // - status: CommentStatusFilter
+        // - before: date string
+        // - order: "desc"
+        // - offset: NSUInteger
+
+        var status: CommentStatus?
+        if let value = options.removeValue(forKey: "status") as? NSNumber {
+            switch CommentStatusFilter(rawValue: value.uint32Value) {
+            case CommentStatusFilterUnapproved:
+                status = .hold
+            case CommentStatusFilterApproved:
+                status = .approved
+            case CommentStatusFilterTrash:
+                status = .trash
+            case CommentStatusFilterSpam:
+                status = .spam
+            default:
+                status = nil
+            }
+        }
+
+        var before: Date?
+        if let value = options.removeValue(forKey: "before") {
+            if let value = value as? Date {
+                before = value
+            } else if let value = value as? String {
+                before = NSDate.with(wordPressComJSONString: value)
+            }
+        }
+
+        var order: WpApiParamOrder?
+        if let value = options.removeValue(forKey: "order") as? String, value == "desc" {
+            order = .desc
+        }
+
+        var offset: UInt32?
+        if let value = options.removeValue(forKey: "offset") as? NSNumber {
+            offset = value.uint32Value
+        }
+
+        wpAssert(options.isEmpty)
+
+        self = .init(
+            before: before,
+            offset: offset,
+            order: order,
+            status: status,
+        )
+    }
+}
+
+private extension CommentStatus {
+    init?(_ commentStatusType: CommentStatusType) {
+        switch commentStatusType {
+        case .pending:
+            self = .hold
+        case .approved:
+            self = .approved
+        case .unapproved:
+            self = .trash
+        case .spam:
+            self = .spam
+        case .draft:
+            return nil
+        }
+    }
+
+    var commentStatusType: CommentStatusType? {
+        switch self {
+        case .hold:
+            return .pending
+        case .approved:
+            return .approved
+        case .spam:
+            return .spam
+        case .trash:
+            return .unapproved
+        case let .custom(other):
+            return other == "draft" ? .draft : nil
+        }
+    }
+}

--- a/WordPress/Classes/Services/CommentServiceRemoteFactory.swift
+++ b/WordPress/Classes/Services/CommentServiceRemoteFactory.swift
@@ -15,6 +15,10 @@ import WordPressKit
             return CommentServiceRemoteREST(wordPressComRestApi: api, siteID: dotComID)
         }
 
+        if let site = try? WordPressSite(blog: blog) {
+            return CommentServiceRemoteCoreRESTAPI(client: .init(site: site))
+        }
+
         if let api = blog.xmlrpcApi,
            let username = blog.username,
            let password = blog.password {


### PR DESCRIPTION
> [!Note]
> This PR is built on top of https://github.com/wordpress-mobile/WordPress-iOS/pull/24548.

## Description

Self-hosted sites that are not connected to WP.com and have authenticated with an application password now use REST API (instead of XML-RPC) to perform comments related API requests.

## Testing instructions

Verify that the post comments work as usual in the app. There is no UI change in this PR.