### PR TITLE
Fix 25.9 localization

### DIFF
--- a/WordPress/Resources/ar.lproj/Localizable.strings
+++ b/WordPress/Resources/ar.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Translation-Revision-Date: 2025-05-12 14:54:08+0000 */
+/* Translation-Revision-Date: 2025-03-11 14:54:07+0000 */
 /* Plural-Forms: nplurals=6; plural=(n == 0) ? 0 : ((n == 1) ? 1 : ((n == 2) ? 2 : ((n % 100 >= 3 && n % 100 <= 10) ? 3 : ((n % 100 >= 11 && n % 100 <= 99) ? 4 : 5)))); */
 /* Generator: GlotPress/4.0.1 */
 /* Language: ar */
@@ -98,6 +98,9 @@
 
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "%1$@ من %2$@ على موقعك";
+
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "تم استخدام %1$@ من %2$@ على موقعك";
 
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ من الكوادرليونات";
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(بدون اسم)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(بدون عنوان)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "قام *Johann Brandt* بالردّ على مقالتك";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "يحتوي زر \"المزيد\" على قائمة منسدلة تعرض أزرار المشاركة";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "يرتبط حساب ووردبريس.كوم ببيانات اعتماد متجرك. للمواصلة، سنرسل رابط تحقُّق إلى عنوان البريد الإلكتروني الوارد أعلاه.";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "يحتوي أحد الملفات على نمط أكواد برمجية ضارة";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "عنوان قصير للموقع";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "يلزم إدخال عنوان بريد إلكتروني صحيح لإرسال رابط المصادقة. يرجى العودة إلى الشاشة السابقة وإدخال عنوان بريد إلكتروني صحيح.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "سيحتوي رمز التحقق على أرقام فقط.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "مفعّل";
@@ -334,9 +349,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* My Profile 'About me' label */
 "About Me" = "نبذة عني";
-
-/* Link to About screen for Jetpack for iOS */
-"About Reader for iOS" = "نبذة عن القارئ لنظام iOS";
 
 /* Link to About screen for WordPress for iOS */
 "About WordPress" = "نبذة عن ووردبريس";
@@ -525,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "بعد %@";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "محاذاة";
@@ -588,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "قائمة عناوين IP المسموح بها";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "تقريبًا هناك! يرجى إدخال رمز التحقق من تطبيق الموثق الخاص بك.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "النص البديل";
@@ -600,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "بدلاً من ذلك، يمكنك تمهيد المحتوى عن طريق فك تجميع المكوّن.";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "بدلاً من ذلك، قد تقوم بإدخال كلمة مرور هذا الحساب.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "بدلاً من ذلك:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "إرسال سجلات الأعطال دومًا";
@@ -621,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "هناك حاجة إلى وجود اتصال نشط بالإنترنت لعرض الأنشطة";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "يلزم تفعيل الاتصال بالإنترنت لعرض الباقات";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -671,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "إحصاءات الموقع السنوية";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "غير معروف";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "إجابة";
 
@@ -692,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "المظهر";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "فشلت مصادقة Apple.\nيرجى التأكُّد من تسجيل الدخول إلى iCloud باستخدام معرِّف Apple الذي يستخدم مصادفة من عاملين.";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "يقوم بتطبيق الإعداد";
@@ -778,6 +811,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "فشلت المصادقة";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "رمز المصادقة";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "يلزم مصادقة للمضيف: %@";
@@ -888,6 +925,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "كن أول من يعلق";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "كن أول من يضع تعليقًا.";
 
 /* Beauty site intent topic */
 "Beauty" = "الجمال";
@@ -1024,12 +1064,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button to copy post text" = "زر نسخ نص التدوينة";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "بالمتابعة، فإنك توافق على _شروط الخدمة_ الخاصة بنا.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "عن طريق تسجيل هذا النطاق، أنت توافق على <a>شروط الخدمة<\/a> التي نُقرها.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "يعني إعداد Jetpack موافقتك على\n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "يعني تسجيل الدخول موافقتك على _Terms of Service_.";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "تخصيص";
@@ -1043,6 +1089,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "يلزم الوصول إلى الكاميرا لمسح رموز تسجيل الدخول ضوئيًا";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "يتعذر طلب رابط";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "يتعذر نشر صفحة فارغة";
 
@@ -1052,6 +1101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1061,6 +1111,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1079,6 +1130,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1106,6 +1158,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "جاري الإلغاء...";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "يتعذر الوصول إلى الموقع على هذا العنوان. يرجى التحقُّق مجددًا والمحاولة مرة أخرى.";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "ألا يمكنك التحديد؟ يمكنك تغيير القالب في أي وقت.";
 
@@ -1113,7 +1168,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "كلمات توضيحية";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "كن حذرًا!";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1122,7 +1178,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "تصنيفات";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "التصنيف";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1171,6 +1228,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "راجع أفضل نصائحنا لزيادة مشاهداتك وحركة مرورك";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "تحقَّق من بريدك الإلكتروني على هذا الجهاز!";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "تحقق من بريدك الإلكتروني على هذا الجهاز، واضغط على الرابط في رسالة البريد الإلكتروني التي استلمتها من WordPress.com.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "تحقّق من بريدك الإلكتروني على هذا الجهاز، واضغط على الرابط في البريد الإلكتروني الذي تلقيته من WordPress.com.\n\nلم تعثر على البريد الإلكتروني؟ تحقّق من مجلد البريد الغير هام أو البريد العشوائي.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "التحقق من بريدك الإلكتروني!";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "تحقَّق من اتصالك بالإنترنت، واسحب للتحديث.";
@@ -1267,6 +1336,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "طالب بنطاقك المجاني";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "المدونة التقليدية";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "مسح ذاكرة التخزين المؤقت لوسائط الجهاز";
 
@@ -1294,6 +1366,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "إغلاق";
 
@@ -1335,6 +1408,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "إعدادات الأعمدة";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "كوميكات";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1386,6 +1462,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "تعليقات";
 
@@ -1453,12 +1530,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "الحسابات المتصلة";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "تم الاتصال ولكن...";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "جاري الاتصال بـ %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "سيحل الاتصال بـ %1$@ محل الاتصال الحالي بـ %2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "الاتصال بـ WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "جاري الاتصال...";
@@ -1489,8 +1572,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "اتصل بنا على %@";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "بنية المحتوى \nالمكوِّنات: %1$li، الكلمات: %2$li، الأحرف: %3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1505,6 +1592,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "متابعة القراءة";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "المتابعة باستخدام Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "المتابعة باستخدام Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "المتابعة عبر Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "مساهمة";
@@ -1633,6 +1729,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "إنشاء";
 
+/* The button title text for creating a new account. */
+"Create Account" = "إنشاء حساب";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "إنشاء صفحة فارغة";
 
@@ -1653,6 +1752,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "إنشاء مقالة";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "إنشاء موقع";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "إنشاء وسم";
@@ -1686,6 +1788,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "الحالي";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "الخطة الحالية";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "القالب الحالي";
@@ -1788,6 +1893,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "التصنيف الافتراضي";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "القائمة الافتراضية";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "التنسيق الافتراضي للمقالة";
@@ -1796,6 +1904,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "الإعدادات الافتراضية للمقالات الجديدة";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "حذف";
@@ -1853,6 +1962,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "تفاصيل";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "ألم تقصد إنشاء حساب جديد؟ العودة للخلف لإعادة إدخال عنوان بريدك الإلكتروني.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "الأبعاد";
 
@@ -1900,7 +2012,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "مناقشة";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "تجاهل";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1922,6 +2036,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "النطاقات";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "ليس لديك حساب؟ _تسجيل_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2051,6 +2168,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "التنزيلات";
 
+/* Name for the status of a draft post. */
+"Draft" = "مسودة";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "المسودات";
 
@@ -2160,7 +2280,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "البريد الإلكتروني";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "عنوان البريد الإلكتروني";
 
 /* Notification Settings Channel */
@@ -2244,8 +2367,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "أدخل كلمة المرور";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "أدخل العنوان لموقع ووردبريس الذي تودّ الاتصال به.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "أدخل كلمة مرور حساب WordPress.com الخاص بك.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "أدخل اسم المستخدم";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "أدخل معلومات حسابك لـ %@.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "أدخل عنوان بريدك الإلكتروني لتسجيل الدخول أو إنشاء حساب WordPress.com.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "أدخل رابط موقعك الحالي";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "بدلاً من ذلك، أدخل كلمة المرور.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "إدخال بيانات اعتماد الخادم الخاصة بك";
@@ -2408,6 +2551,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "خارجي";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "فشل";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "فشل وضع علامة على التنبيهات بأنها مقروءة";
 
@@ -2419,9 +2565,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Failed to insert media.\nTap for more info." = "فشل في إدراج وسائط.\nانقر للحصول على مزيد من المعلومات.";
-
-/* A message indicating that we couldn't load the user's settings. */
-"Failed to load settings" = "فشل تحميل الإعدادات";
 
 /* No comment provided by engineer. */
 "Failed to save files.\nPlease tap for options." = "فشل حفظ الملفات.\nيرجى النقر على الخيارات.";
@@ -2437,6 +2580,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "الموضة";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "بارز";
@@ -2495,6 +2641,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "اكتشاف المزيد";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "العثور على عنوان رابط الموقع";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2517,6 +2666,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "جاري معالجة التهديدات";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "تابع";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "متابعة المحادثة";
@@ -2611,6 +2763,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "إنشاء رابط جديد";
 
+/* View title for initial auth views. */
+"Get Started" = "البدء";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "الحصول على رابط تسجيل الدخول عن طريق البريد الإلكتروني";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "كن نشطًا! التعليق على المقالات من المدونات التي تتابعها.";
 
@@ -2632,8 +2790,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "الحصول على الإلهام";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "الحصول على معلومات الحساب";
+
+/* Cancel */
+"Give Up" = "توقف";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "جربه عن طريق إضافة القليل من المكوِّنات إلى مقالتك أو صفحتك!";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "الانتقال إلى القارئ";
@@ -2644,6 +2811,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "انتقال إلى إعدادات iOS";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "فشل الاشتراك في Google";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2718,6 +2888,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "أيقونة المساعدة";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "مخفي";
+
 /* Title of a button used to collapse a group */
 "Hide" = "إخفاء";
 
@@ -2786,6 +2959,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "فشل تحديث الرمز";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "إذا تعذر عليك العثور على البريد الإلكتروني، فيرجى التحقُّق من مجلد البريد الإلكتروني غير الهام والبريد الإلكتروني المزعج";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "إذا قمت بالمتابعة مع Apple أو Google وليس لديك حساب WordPress.com بالفعل، فأنت تقوم بإنشاء حساب وتوافق على _شروط الخدمة_.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "إذا قمتَ بإزالة %1$@، فلن يتمكن هذا المستخدم بعد الآن من الوصول إلى هذا الموقع، ولكن سيظل أي محتوى قام %2$@ بإنشائه على الموقع.";
@@ -2861,6 +3040,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "يتضمن wp-config.php وأي ملفات ليس لها علاقة بـ ملفات ووردبريس";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "اسم المستخدم أو كلمة المرور غير صحيحين. يُرجى محاولة إدخال بيانات تسجيل دخولك مرة أخرى.";
 
 /* Title for a threat */
 "Infected core file" = "ملف أساسي (core file) مصاب";
@@ -2962,6 +3144,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "تقديم مطالبات التدوين";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "عنوان بريد إلكتروني غير صالح";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "عنوان موقع غير صالح";
 
@@ -2979,6 +3164,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "رابط غير صالح. لم يتم العثور على ملف صوت.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "عنوان URL غير صالح. يرجى التحقُّق مجددًا والمحاولة مرة أخرى.";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "رابط غير صالح. الرجاء إدخال عنوان موقع صالح.";
@@ -3000,6 +3188,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "دعوة أشخاص";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "يبدو أن اسم المستخدم هذا \/ كلمة المرور هذه غير مقترنين بهذه الموقع.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "يبدو أنك أدخلت كلمة مرور غير صحيحة. هل ترغب في تجربته مرة أخرى؟";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "حان الوقت للتدوين في %@!";
@@ -3228,7 +3422,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "ارتفاع السطر";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "الرابط";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3290,6 +3485,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "جاري تحميل الأشخاص...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "جاري تحميل الخطة...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "جاري تحميل الخطط...";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "جاري تحميل الإضافة...";
 
@@ -3324,11 +3525,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "جاري التحميل ...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "محلي";
+
 /* Local Services site intent topic */
 "Local Services" = "الخدمات المحلية";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "التغييرات المحلية";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "الموقع";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "يجب تمكين خدمات الموقع قبل أن يستطيع ووردبريس إضافة موقعك الحالي. يُرجى تمكين خدمات الموقع من تطبيق الإعدادات.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "الموقع غير معروف";
 
 /* No comment provided by engineer. */
 "Lock icon" = "أيقونة القفل";
@@ -3336,9 +3549,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "تسجيل الملفات حسب تاريخ إنشائها";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "تسجيل الدخول";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3348,17 +3563,33 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of a button for signing in. */
 "Log in" = "تسجيل الدخول";
 
-/* LogOut confirmation text, whenever there are no local changes */
-"Log out of Jetpack?" = "هل ترغب في تسجيل الخروج من Jetpack؟";
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "فشل تسجيل الدخول. يُرجى المحاولة مرة أخرى.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "تسجيل الدخول أو إنشاء حساب على WordPress.com";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "سجّل الدخول إلى حساب WordPress.com الذي تستخدمه للاتصال بـ Jetpack.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "تسجيل الدخول إلى حسابك في WordPress.com باستخدام بريدك الإلكتروني.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "سجِّل الدخول من خلال اسم المستخدم وكلمة المرور الخاصين بحسابك على WordPress.com.";
 
 /* LogOut confirmation text, whenever there are no local changes */
-"Log out of Reader?" = "هل تريد تسجيل الخروج من القارئ؟";
+"Log out of Jetpack?" = "هل ترغب في تسجيل الخروج من Jetpack؟";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of WordPress?" = "هل ترغب في تسجيل الخروج من ووردبريس؟";
 
 /* Login Request Expired */
 "Login Request Expired" = "انتهت صلاحية طلب تسجيل الدخول";
+
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "تسجيل الدخول باستخدام كلمة مرور الحساب";
 
 /* No comment provided by engineer. */
 "Logs" = "السجلات";
@@ -3368,6 +3599,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "يبدو أنّ لديك Jetpack معدٌ على موقعك. تهانينا! قم بتسجيل الدخول باستخدام بيانات اعتماد WordPress.com لتمكين الإحصاءات والإشعارات.";
+
+/* Title of a button. */
+"Lost your password?" = "هل فقدت كلمة مرورك؟";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "البريد (افتراضي)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "التنقل الرئيسي";
@@ -3515,6 +3752,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "رسالة";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "ثغرات أمنية متنوعة";
 
@@ -3610,6 +3850,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "موقعي";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "المواقع الخاصة بي في ووردبريس";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "أفضل عشرة مقاهي";
 
@@ -3649,8 +3892,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "هل تحتاج إلى المساعدة؟";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "هل تحتاج إلى المساعدة في العثور على عنوان رابط موقعك؟";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "هل تحتاج إلى مساعدة؟";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "بحاجة إلى مزيد من المساعدة؟";
 
 /* Describes a status of a plugin */
 "Needs Update" = "بحاجة إلى تحديث";
@@ -3679,6 +3929,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "مقالة جديدة";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "عنصر جديد";
+
 /* Placeholder text for password field */
 "New password" = "كلمة مرور جديدة";
 
@@ -3696,7 +3949,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "الأخبار";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "التالي";
 
 /* Accessibility label for the next notification button */
@@ -3732,6 +3987,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "لا يتوفر عنوان URL للمعاينة";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "بلا عنوان";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "لا توجد أنشطة متاحة";
 
@@ -3764,7 +4022,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "لا توجد تعليقات حتى الآن";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "لا يوجد اتصال";
 
@@ -3913,6 +4172,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "ليس الآن";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "لم تشاهد البريد الإلكتروني؟ تحقّق من مجلد البريد المزعج أو البريد العشوائي.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "ملاحظة:";
 
@@ -3976,7 +4238,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "قائمة مرقّمة";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "موافق";
@@ -4033,7 +4300,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "عذرًا";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "عفوًا!";
 
 /* No comment provided by engineer. */
@@ -4048,7 +4316,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "فتح إعدادات أمان Jetpack";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "فتح البريد";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "فتح الإعدادات";
 
 /* No comment provided by engineer. */
@@ -4066,6 +4339,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "فتح الرابط في نافذة\/علامة تبويب جديدة";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "فتح إعدادات الاشتراك الخاصة بالمقالة";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "فتح قسم \"أنا\"";
 
@@ -4080,6 +4356,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "اختياري: أدخل رسالة مخصصة تصل إلى ⁦%1$d⁩ من الأحرف ليتم إرسالها مع دعوتك.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "أو";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "أو اختر نموذج مصادقة آخر.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "أو تسجيل الدخول عن طريق _إدخال عنوان رابط موقعك_.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "أو تسجيل الدخول باستخدام رابط سحري";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "قائمة مرتبة";
@@ -4128,7 +4416,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "الهوامش الداخلية";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "الصفحة";
 
@@ -4161,8 +4450,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "الأبوة والأمومة";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "كلمة المرور";
 
@@ -4179,8 +4471,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "لصق المكوِّن بعد";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "انتظار";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "في انتظار المراجعة";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4211,6 +4507,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "اختيار اسم مستخدم";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "الخطط";
+
 /* User action to play a video on the editor. */
 "Play video" = "تشغيل الفيديو";
 
@@ -4240,6 +4540,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "يرجى التأكُّد من أنه تم تمكين محرِّر المكوِّن على موقعك. إذا لم يتم تمكينه، فلن يقوم بالتحميل.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "يرجى إدخال عنوانًا كاملاً لعنوان موقع الويب، مثل example.com.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "يُرجى إدخال عنوان موقع.";
@@ -4274,11 +4577,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "الرجاء إدخال عنوان بريد إلكتروني صحيح";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "يرجى إدخال عنوان بريد إلكتروني صالح لحساب ووردبريس.كوم.";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "الرجاء إدخال عنوان بريد إلكتروني صالح.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "يُرجى إدخال رقم هاتف صالح";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "يرجى إدخال كلمة المرور لحساب WordPress.com الخاص بك لتسجيل الدخول باستخدام مُعرّف Apple الخاص بك.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "يُرجى إدخال بيانات اعتمادك";
@@ -4286,8 +4595,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "يُرجى إدخال عنوان البريد الإلكتروني.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "يُرجى تعبئة جميع الحقول";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "يُرجى تشغيل تطبيق ووردبريس وتسجيل الدخول إلى WordPress.com والتأكد من أن لديك موقعًا واحدًا على الأقل والمحاولة مرة أخرى.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "يرجى تسجيل الخروج قبل الاتصال بموقع wordpress.com مختلف";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "يرجى المحاولة مجددًا في وقت لاحق";
@@ -4355,7 +4670,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "اللغات الشائعة";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "مقالة";
 
@@ -4476,6 +4792,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "إشعار الخصوصية الخاص بالمستخدمين في كاليفورنيا";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "خاص";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "ثمَّة مشكلة في أثناء عرض المكوِّن. \nانقر لمحاولة استعادة المكوِّن.";
 
@@ -4490,6 +4809,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "حدثت مشكلة أثناء شراء نطاقك. يرجى المحاولة مرة أخرى.";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "ستؤدي المتابعة إلى حذف جميع بيانات WordPress.com من هذا الجهاز، وحذف أي مسودات محفوظة محليًا. لن تفقد أي شيء محفوظ بالفعل على مدونة (مدونات) WordPress.com.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "مشاريع";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "تم تخطي المطالبة";
@@ -4507,13 +4832,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "تاريخ النشر";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "النشر في الحال";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "انشر الصفحة في:";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "نشر مقالة على:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "منشور";
 
@@ -4715,7 +5044,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "رد";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "نص الرد";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "الرد على %1$@";
 
 /* An explaination of a setting. */
@@ -4744,6 +5078,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "إعادة تعيين عامل تصفية نطاق التاريخ";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "إعادة تعيين كلمة المرور الخاصة بك";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "تغيير الحجم والقص";
@@ -4801,6 +5138,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "محاولة الجميع مرة أخرى";
 
+/* No comment provided by engineer. */
+"Retry?" = "هل تريد إعادة المحاولة؟";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "العودة إلى المقالة";
 
@@ -4830,6 +5170,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "الدور";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "تم إرسال SMS";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "الحالة";
 
@@ -4841,6 +5184,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4907,7 +5251,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "ملفات الفحص";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "مجدول";
 
 /* No comment provided by engineer. */
@@ -5047,6 +5392,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "يُحدِّد هذا الموضوع بوصفه هدف موقعك.";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "إرسال رابط";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "إرسال الرابط عبر البريد الإلكتروني";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "إرسال رسالة السجل";
 
@@ -5055,6 +5406,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "إرسال اختبار الأعطال";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "إرسال رابط التحقُّق عبر البريد الإلكتروني";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "إرسال تنبيهات عبر البريد الإلكتروني";
@@ -5101,11 +5455,11 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Message to show when setting save failed */
 "Settings update failed" = "فشل تحديث الإعدادات";
 
-/* Title for a button that recommends the app to others */
-"Share Jetpack with a friend" = "مشاركة Jetpack مع صديق";
+/* Spoken accessibility label */
+"Share" = "مشاركة";
 
 /* Title for a button that recommends the app to others */
-"Share Reader with a friend" = "مشاركة القارئ مع صديق";
+"Share Jetpack with a friend" = "مشاركة Jetpack مع صديق";
 
 /* Title for a button that recommends the app to others */
 "Share WordPress with a friend" = "مشاركة ووردبريس مع صديق";
@@ -5156,6 +5510,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "عرض رز \"إعادة تدوين\"";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "عرض كلمة المرور";
+
 /* No comment provided by engineer. */
 "Show post content" = "إظهار محتوى المقالة";
 
@@ -5167,6 +5525,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "عرض الإحصائيات لـ:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "معروض";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "يظهر للعامة عندما تعلِّق على المدونات.";
@@ -5182,6 +5543,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "يعرض المقالة";
+
+/* View title during the sign up process. */
+"Sign Up" = "تسجيل";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "تسجيل الدخول باستخدام بيانات اعتماد الموقع";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "تسجيل";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "الاشتراك في WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "تسجيل الدخول باستخدام البريد الإلكتروني";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "نظرًا لأنك مشترك في الخطة المجانية، سترى أحداثًا محدودة في سجل نشاطك.";
@@ -5220,6 +5596,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "إنجازات الموقع";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "رابط الموقع";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "يجب أن يحتوي عنوان الموقع على 4 حروف على الأقل.";
@@ -5304,7 +5683,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "عذرًا، يجب أن تحتوي عناوين المواقع على حروف أبجدية أيضًا!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "عذرًا، يتم بالفعل استخدام عنوان البريد الإلكتروني هذا!";
 
 /* No comment provided by engineer. */
@@ -5364,6 +5743,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "مزعج";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "زيادة سرعة موقعك";
@@ -5389,6 +5771,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "الحالة";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "صفحة رئيسية ثابتة";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5419,6 +5804,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "يتوسطه خط";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Stub";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "إرسال للمراجعة";
@@ -5509,7 +5897,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "الجهاز اللوحي";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "العلامة";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5644,6 +6033,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "شروط الخدمة";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "الشهادات";
+
 /* Title of a button style */
 "Text Only" = "نص فقط";
 
@@ -5653,8 +6045,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "توجد عناصر التحكم في تنسيق النص ضمن شريط الأدوات الذي يوجد فوق لوحة المفاتيح في أثناء تحرير مكوِّن نص";
 
+/* Button title */
+"Text me a code instead" = "اكتب رمزًا لي بدلاً من ذلك";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "إرسال الكود إليَّ عبر رسالة نصية قصيرة";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "شكرًا لاختيارك %1$@ من %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "لا يبدو هذا رمز تحقيق صالحًا.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "لا يبدو ذلك كـ موقع ووردبريس.";
@@ -5676,6 +6077,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "يتعذر الاتصال بـ Facebook العثور على أي صفحات. لا يمكن لآلية النشر الاتصال بملفات تعريف Facebook الشخصية، فقط للصفحات المنشورة.";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "لا يتطابق حساب جوجل \"‎%@\" مع أي حساب موجود على WordPress.com.";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "يبدو أن الاتصال بالإنترنت في وضع دون اتصال.";
@@ -5715,6 +6119,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "تعذرت إضافة الصورة إلى مكتبة الوسائط.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "يبدو أن الاتصال بالإنترنت في وضع دون اتصال.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "أنواع المواقع التي يمكن إنشاؤها";
@@ -5758,6 +6165,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "يستخدم الموقع في %1$@ ووردبريس %2$@. نوصي بالتحديث إلى أحدث إصدار أو الإصدار %3$@ على الأقل";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "الموقع الموجود على هذا العنوان ليس موقع ووردبريس. لكي نتصل بالموقع، يجب أن يستخدم الموقع ووردبريس.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "تعذر حذف الموقع.";
 
@@ -5799,6 +6210,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "حدث خطأ غير متوقع أثناء تحرير تعليقك";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "حدث خطأ غير متوقع أثناء تحميل التعليقات.";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "حدث خطأ غير متوقع أثناء تسجيل نطاقك";
 
@@ -5807,6 +6221,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "حدث خطأ غير متوقع أثناء تحديث إعدادات التنبيهات";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "حدث خطأ غير متوقع أثناء تحديث تعليقك";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "حدث خطأ غير متوقع.";
@@ -5828,6 +6245,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "حدثت مشكلة في أثناء الاتصال بالموقع.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "حدثت مشكلة أثناء الاتصال بـ WordPress.com. يُرجى تسجيل الدخول مرة أخرى.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "حدثت مشكلة أثناء عرض هذه المقالة.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "حدثت مشكلة أثناء تحميل بياناتك، يمكنك تحديث صفحتك للمحاولة مجددًا.";
 
@@ -5837,12 +6260,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "حدثت مشكلة أثناء حفظ التغييرات إلى إدارة المشاركة.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "حدثت مشكلة عند محاولة الوصول إلى موقعك. يُرجى المحاولة مرة أخرى لاحقاً.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "حدث خطأ أثناء تغيير كلمة المرور";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "حدث خطأ أثناء تحميل الأنشطة";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "حدث خطأ أثناء تحميل الخطط";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "حدث خطأ عند تحميل الإضافات";
@@ -5855,6 +6284,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "حدث خطأ أثناء تحميل السجلّ";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "حدث خطأ أثناء رفع الخطة";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "حدث خطأ أثناء تحميل سجلّ الفحص";
@@ -5903,6 +6335,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "هذا النطاق غير متاح.";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "عنوان البريد الإلكتروني هذا غير مسجَّل على WordPress.com.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "هذا الملف كبير لدرجة يتعذر معها رفعه إلى موقعك أو لا يدعم تنسيق الوسائط هذا.";
@@ -5983,6 +6418,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "المنطقة الزمنيّة";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "انتهى الوقت، لكن لا داعي للقلق، فأمانك هو أولويتنا. يرجى المحاولة مرة أخرى!";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "نصائح للحصول على أكبر استفادة من WordPress.com.";
 
@@ -5996,6 +6434,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "للمتابعة، يرجى إدخال عنوان بريدك الإلكتروني واسمك.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "لإنشاء حسابك الجديد على WordPress.com، يرجى إدخال عنوان بريدك الإلكتروني.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "للحصول على إشعارات مساعدة على هاتفك من موقع ووردبريس الخاص بك، سيتعين عليك تنصيب إضافة Jetpack.";
 
@@ -6004,6 +6445,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "لتنصيب الإضافات، لا بد من أن يكون لديك نطاق مخصص مرتبط بموقعك.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "لمتابعة استخدام معرِّف Apple هذا، يُرجى تسجيل الدخول أولاً باستخدام كلمة مرورك على WordPress.com. سيُطلب منك هذا مرة واحدة فقط.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "للاستمرار باستخدام حساب Google هذا، يُرجى تسجيل الدخول أولاً باستخدام كلمة مرور حساب WordPress.com الخاص بك. سيُطلب منك هذا مرة واحدة فقط.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "لإزالة مكوِّن، حدِّد المكوِّن وانقر على النقاط الثلاث الموجودة في أسفل يمين المكوِّن لعرض الإعدادات. من هناك، اختر خيار إزالة المكوِّن.";
@@ -6078,7 +6525,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "سلة المهملات";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "محذوف";
 
@@ -6092,6 +6540,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "محاولة وتخصيص";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "حاول مرّة اخرى";
@@ -6117,6 +6566,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "تجربة محرر المكوِّنات الجديد";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "حاول ببريد إلكتروني آخر";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "حاول بعنوان رابط الموقع";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "إيقاف تشغيل المطالبات";
@@ -6159,6 +6614,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "استخدامات";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "يتعذر الاتصال";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "يتعذر تحميل المقالات";
@@ -6208,6 +6666,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "يتعذر تشغيل الفيديو";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "تعذر قراءة موقع ووردبريس على الرابط URL هذا. أنقر على \"بحاجة إلى مزيد من المساعدة؟\" لمشاهدة الأسئلة الشائعة.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "غير قادر على استعادة موقعك";
 
@@ -6234,6 +6695,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "تعذر رفع مقالة واحدة، ملف واحد";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "تعذر التحقق من عنوان البريد الإلكتروني. يُرجى إعادة المحاولة لاحقًا.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "غير قادر على زيارة إعدادات Jetpack للموقع";
@@ -6378,7 +6842,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "فشل الرفع";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "تم الرفع";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6396,7 +6861,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "القوالب التي تم رفعها";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "جاري الرفع";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6411,18 +6877,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "استخدم";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "استخدام مفتاح الأمان";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "استخدام مُحرر المكوّنات";
 
 /* No comment provided by engineer. */
 "Use icon button" = "استخدام زر الأيقونة";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "استخدام كلمة المرور لتسجيل الدخول";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "اسم المستخدم";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6437,6 +6912,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "المستخدمون";
+
+/* two factor code placeholder */
+"Verification code" = "رمز التحقق";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "تم إرسال رسالة البريد الإلكتروني الخاصة بالتحقق، افحص علبة الوارد لديك.";
@@ -6569,8 +7047,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "دليل WP-content";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "بانتظار اكتمال Google…";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "انتظار الاتصال";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "انتظار مفتاح الأمان";
+
+/* View title during the Google auth process. */
+"Waiting..." = "جاري الانتظار...";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6610,6 +7098,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "واجهنا مشكلة في تحميل البيانات";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "أرسلنا للتو رسالة عبر البريد الإلكتروني إلى %@ تتضمن رابطًا. يرجى التحقق من تطبيق البريد الخاص بك والنقر على الرابط لتسجيل الدخول.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "أرسلنا رابطًا سحريًا للتو إلى";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "لقد نجحنا في إنشاء نسخة احتياطية لموقعك اعتبارًا من %@";
 
@@ -6619,14 +7113,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "نستخدم أدوات تتبع أخرى، بما في ذلك بعض الأدوات التي تنتمي إلى أطراف ثالثة. اقرأ عن هذه الأدوات وكيفية التحكم فيها.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "يتعذر علينا إرسال بريد إلكتروني في هذا الوقت. يُرجى المحاولة مرة أخرى لاحقًا.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "سنرسل لك بريدًا إلكترونيًا إذا تم العثور على تهديدات أمنية. في هذه الأثناء لا تتردد في الاستمرار في استخدام موقعك كالمعتاد، ويمكنك التحقُّق مجددًا من التقدُّم في أي وقت.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "سنرسل إليك رسالة على البريد الإلكتروني تحتوي على ارتباط سحري يمكنك من تسجيل الدخول على الفور، دون الحاجة إلى كلمة مرور. لا توجد حاجة إلى تحديد المزيد أو النقر عليه!";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "سنرسل إليك رسالة عبر البريد الإلكتروني تتضمن رابطًا لإنشاء حسابك الجديد على WordPress.com.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "سنُخطرك عندما تحصل على متابعين وتعليقات وإعجابات.";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "سنُخطرك عندما تحصل على متابعين وتعليقات وإعجابات جديدة. هل ترغب في السماح بتنبيهات الدفع؟";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "سنستخدم عنوان البريد الإلكتروني هذا لإنشاء حسابك الجديد على WordPress.com.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "سنُنشئ نسخة احتياطية قابلة للتنزيل من موقعك من %1$@.";
@@ -6637,6 +7143,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "نعمل بجد على إصلاح هذه التهديدات الموجودة في الخلفية. في هذه الأثناء لا تتردد في الاستمرار في استخدام موقعك كالمعتاد، ويمكنك التحقُّق مجددًا من التقدُّم في أي وقت.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "لا يمكننا الاتصال بموقع Jetpack على عنوان URL هذا. اتصل بنا لطلب المساعدة.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "نحن بصدد استعادة موقعك إلى %1$@.";
 
@@ -6645,6 +7154,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "أرسلنا إليك أيضًا رابطًا إلى ملفك عبر البريد الإلكتروني.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "أرسلنا إليك رسالة عبر البريد الإلكتروني تتضمن رابط التسجيل لإنشاء حسابك الجديد على WordPress.com. تحقَّق من بريدك الإلكتروني على هذا الجهاز، وانقر على الرابط الموجود في الرسالة التي تم تلقيها عبر البريد الإلكتروني من WordPress.com.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6671,6 +7183,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "الموجز الأسبوعي: %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "مرحبًا بك في Jetpack";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "مرحبًا بك في ووردبريس.";
 
 /* A message title */
 "Welcome to the Reader" = "أهلاً بك في القارئ";
@@ -6715,6 +7233,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "ما المقصود بخدمة جرافتار؟";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "ما هو ووردبريس.كوم؟";
+
 /* No comment provided by engineer. */
 "What is a block?" = "ماذا يُقصد بالمكوِّن؟";
 
@@ -6731,10 +7252,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "What's New in Jetpack" = "ما الجديد في Jetpack";
 
 /* Opens the What's New / Feature Announcement modal */
-"What's New in Reader" = "ما الجديد في القارئ";
-
-/* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "ما الجديد في ووردبريس";
+
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "ما هو عنوان رابط الموقع الخاص بي؟";
 
 /* Select the site's intent. Title */
 "What's your website about?" = "ما الذي يدور موقعك حوله؟";
@@ -6748,6 +7269,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "عندما تُجري تغييرات على موقعك، ستتمكن من رؤية تاريخ النشاط الخاص بك هنا.";
 
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "عذرًا، حدث خطأ ما وتعذر عليك تسجيل الدخول. يرجى المحاولة مرة أخرى!";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "عذرًا، حدث خطأ ما. يرجى المحاولة مرة أخرى!";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "عذرًا، لا يبدو مفتاح الأمان ذلك صالحًا. يرجى المحاولة مجددًا باستخدام واحد آخر";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "عذرًا، هذا رمز تحقق من عاملين غير صالح. تحقق مجددًا من رمزك وحاول مجددًا!";
+
 /* No comment provided by engineer. */
 "Width Settings" = "إعدادات العرض";
 
@@ -6760,17 +7293,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "ووردبريس";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "إعدادات تطبيق ووردبريس";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "تطبيقات ووردبريس - تطبيقات لأي شاشة";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "مدونة ووردبريس";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "مساعدة ووردبريس";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "مكتبة وسائط ووردبريس";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "إعدادات إشعارات ووردبريس";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "إشعارات ووردبريس";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "إضافات ووردبريس";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "ملف ووردبريس الشخصي";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "قارئ ووردبريس";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "تفاصيل موقع ووردبريس";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "قوالب ووردبريس";
@@ -6781,17 +7335,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "مواقع ووردبريس المتعددة غير مدعومة";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "يحتاج ووردبريس إلى صلاحية للوصول إلى الموقع الحالي لجهازك لإضافته إلى مقالتك. يُرجى تحديث إعدادات الخصوصية لديك.";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "جذر ووردبريس";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "إصدار ووردبريس قديم جدًا";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "إصدار WordPress قديم جدًا. يستخدم الموقع في %1$@ WordPress %2$@. نوصي بالتحديث إلى أحدث إصدار أو الإصدار %3$@ على الأقل";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "حساب WordPress.com";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "خطط WordPress.com";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "قوالب WordPress.com";
@@ -6822,6 +7385,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "كتابة مقالة";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "كتابة رد";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "اكتب ردًا…";
 
 /* Title for the writing section in site settings screen */
@@ -6835,6 +7401,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "موضع المحور الصادي";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "عام";
@@ -6919,6 +7488,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Displayed when the user views trashed in the posts list and there are no posts */
 "You don't have any trashed posts" = "ليس لديك أي مقالات تم وضعها في سلة المهملات";
 
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"You don't have permission to view this private blog." = "ليست لديك صلاحيات عرض هذه المدونة الخاصة.";
+
 /* Description for the first domain purchased with a paid plan. */
 "You have a free one-year domain registration with your plan." = "لديك تسجيل نطاق مجاني مدته عام واحد ضمن خطتك.";
 
@@ -6934,7 +7506,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "ليست لديك أي تذكيرات معينة.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "لديك تغييرات لم تحفظ.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -7021,9 +7594,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Help text that describes how the password should be. It appears while editing the password */
 "Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ & )." = "ينبغي ألا يقل طول كلمة المرور الخاصة بك عن ستة أحرف. ولجعل كلمة المرور أقوى، استخدم أحرفًا كبيرة وصغيرة وأرقامًا ورموزًا مثل ! \" ؟ $ % ^ & ).";
 
-/* Message of Export Content confirmation alert */
-"Your posts, pages, and settings will be mailed to the account's email address." = "سيتم إرسال تدويناتك، وصفحاتك، وإعداداتك إلى عنوان البريد الإلكتروني الخاص بالحساب.";
-
 /* Message of Export Content confirmation alert; substitution is user's email address */
 "Your posts, pages, and settings will be mailed to you at %@." = "سيتم إرسال المقالات والصفحات والإعدادات الخاصة بك لك عبر %@.";
 
@@ -7032,6 +7602,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "يتضمن بحثك أحرف غير مدعومة في نطاقات ووردبريس.كوم. يُسمح بالأحرف الآتية: من A إلى Z، ومن a إلى z، ومن 0 إلى 9.";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "يظهر عنوان رابط موقعك في الشريط الموجود أعلى الشاشة عندما تزور موقعك من متصفح Safari.";
 
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "أنت محمي بالفعل بواسطة VaultPress. يمكنك العثور على رابط إلى لوحة تحكم VaultPress الخاصة بك أدناه.";
@@ -7111,17 +7684,23 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility identifier for an 'Add Comment' button */
 "addCommentButton.accessibilityIdentifity" = "إضافة تعليق";
 
-/* Error message when user cancels login */
-"addSite.selfHosted.cancelled" = "تم إلغاء تسجيل الدخول";
+/* Error message shown a URL does not point to an existing site. */
+"addSite.restApiNotAvailable" = "الموقع الموجود على هذا العنوان ليس موقع ووردبريس. لكي نتصل بالموقع، يجب أن يستخدم ووردبريس.";
+
+/* Error message shown when an receiving an invalid application-password authentication result from a self-hosted WordPress site */
+"addSite.selfHosted.authenticationFailed" = "يتعذر تسجيل الدخول باستخدام مصادقة كلمة مرور التطبيق.";
 
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "أدخل عنوان موقع ووردبريس الذي ترغب في الاتصال به.";
 
+/* Error message when user input is not a WordPress site */
+"addSite.selfHosted.invalidUrl" = "عنوان الموقع غير صالح.";
+
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "يتعذر تحميل تفاصيل موقع ووردبريس";
 
-/* Error message when user signs in with an unexpected usern. The first argument is the expected username */
-"addSite.selfHosted.mismatchUser" = "يرجى تسجيل الدخول باستخدام المستخدم الحالي. اسم المستخدم: %@";
+/* Error message shown when application-password authentication is disabled on a self-hosted WordPress site */
+"addSite.selfHosted.noLoginUrlFound" = "يتعين تمكين مصادقة كلمة مرور للتطبيق على موقع ووردبريس.كوم.";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "يتعذر حفظ موقع على ووردبريس، يرجى المحاولة لاحقًا مجددًا.";
@@ -7129,17 +7708,14 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "إضافة موقع مستضاف ذاتيًا";
 
-/* Error message when XML-RPC is disabled on the WordPress site. The first argument is detailed error message */
-"addSite.selfHosted.xmlrpcDisabled" = "تعذر الاتصال بموقع ووردبريس. ربما تم تعطيل XML-RPC للخادم. يرجى الاتصال بمزوِّد الخدمة لديك لحل هذه المشكلة.";
+/* Error message when an unknown error occurred when adding a self-hosted site */
+"addSite.selfHosted.unknownError" = "حدث خطأ. ترجى المحاولة مجددًا.";
 
 /* Age between dates equaling one hour. */
 "an hour" = "ساعة";
 
 /* This is the string we display when prompting the user to review the Jetpack app */
 "appRatings.jetpack.prompt" = "ما رأيك في Jetpack؟";
-
-/* This is the string we display when prompting the user to review the Reader app */
-"appRatings.reader.prompt" = "ما رأيك في القارئ؟";
 
 /* This is the string we display when prompting the user to review the WordPress app */
 "appRatings.wordpress.prompt" = "ما هو رأيك في ووردبريس؟";
@@ -7834,6 +8410,10 @@ Example: Reply to Pamela Nguyen */
 /* Shared empty state view */
 "emptyStateView.noSearchResult.title" = "لا توجد نتائج";
 
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "example.com";
+
 /* Accept button title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackAccept" = "إرسال الملاحظات";
 
@@ -7845,9 +8425,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackTitle" = "مشاركة الملاحظات";
-
-/* Communicates the future removal of the option to disable the experimental editor, displayed beneath the experimental features list */
-"experimentalFeatures.editorNote" = "سيصبح محرر المكوّنات التجريبي هو المحرر الافتراضي في الإصدارات المستقبلية وستتم إزالة إمكانية تعطيله.";
 
 /* The title for the experimental features list */
 "experimentalFeaturesList.heading" = "الميزات التجريبية";
@@ -7894,8 +8471,14 @@ Example: Reply to Pamela Nguyen */
 /* A footer retry button */
 "general.pagingFooterView.retry" = "إعادة المحاولة";
 
+/* Error message format when REST API returns an error response. The first argument is error message. */
+"generic.error.rest-api-error" = "أرسل موقعك استجابة للخطأ: %@";
+
 /* A generic title for an error */
 "generic.error.title" = "خطأ";
+
+/* Error message when failing to parse API responses */
+"generic.error.unparsableResponse" = "أرسل موقعك استجابة تعذر على التطبيق تحليلها";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "تعيين تذكيرات التدوين";
@@ -8067,39 +8650,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title of the Jetpack powered overlay. */
 "jetpack.branding.overlay.title" = "ووردبريس أفضل مع Jetpack";
-
-/* Title for the button that starts the Jetpack connection process */
-"jetpack.connection.connect.button" = "الاتصال بموقعك";
-
-/* Error message shown when WordPress.com authentication fails */
-"jetpack.connection.error.authentication" = "حساب ووردبريس.كوم غير صالح";
-
-/* Error message shown when a connection step is attempted in an invalid order */
-"jetpack.connection.error.context" = "هذه الخطوة ليست جاهزة بعد";
-
-/* Title for the retry button shown when a connection step fails */
-"jetpack.connection.retry.button" = "إعادة المحاولة";
-
-/* Status message when a connection step is pending */
-"jetpack.connection.stage.pending" = "في انتظار البدء";
-
-/* Status message when a connection step is in progress */
-"jetpack.connection.stage.processing" = "قيد التقدم...";
-
-/* Status message when a connection step is completed successfully */
-"jetpack.connection.stage.success" = "مكتمل";
-
-/* Title for the finalization step in Jetpack connection flow */
-"jetpack.connection.step.finalize.title" = "إنهاء الاتصال";
-
-/* Title for the login step in Jetpack connection flow */
-"jetpack.connection.step.login.title" = "تسجيل الدخول إلى ووردبريس.كوم";
-
-/* Title for the site connection step in Jetpack connection flow */
-"jetpack.connection.step.site.title" = "الاتصال بموقعك";
-
-/* Title for the user connection step in Jetpack connection flow */
-"jetpack.connection.step.user.title" = "الاتصال بحسابك على ووردبريس.كوم";
 
 /* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
 "jetpack.fullscreen.overlay.early.switch.title" = "التبديل إلى تطبيق Jetpack الجديد";
@@ -8320,41 +8870,11 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "ليست لديك صلاحيات عرض هذه المدونة الخاصة.";
 
-/* Button to dismiss the re-authentication view */
-"login.appPasswordReAuth.cancelButton" = "إلغاء";
-
-/* Description explaining why the user needs to re-authenticate */
-"login.appPasswordReAuth.description" = "لم تعد كلمة مرور التطبيق المخصصة لهذا التطبيق موجودة في ملفك الشخصي.\nيُرجى تسجيل الدخول مرة أخرى لإنشاء كلمة مرور جديدة للتطبيق لاستخدامها مع التطبيق.";
-
-/* Button to start the re-authentication process */
-"login.appPasswordReAuth.signInButton" = "تسجيل الدخول";
-
-/* Title shown when the application password is invalid */
-"login.appPasswordReAuth.title" = "كلمة مرور التطبيق غير صالحة";
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "يرجى إدخال كود التحقق من تطبيق المصادقة الخاص بك بالنسبة إلى حسابك على ووردبريس.كوم.";
 
 /* Indicating that referrer was marked as spam */
 "marked as spam" = "تم وضع علامة على أنه بريد مزعج";
-
-/* Button title when verification link sending failed */
-"me.verifyEmail.button.retry" = "المحاولة مجددًا";
-
-/* Button title to send verification link */
-"me.verifyEmail.button.send" = "إعادة إرسال البريد الإلكتروني";
-
-/* Button title while verification link is being sent */
-"me.verifyEmail.button.sending" = "جارِ الإرسال...";
-
-/* Button title after verification link is sent */
-"me.verifyEmail.button.sent" = "تم إرسال رسالة عبر البريد الإلكتروني";
-
-/* Message for email verification card */
-"me.verifyEmail.message.noEmail" = "تحقق من بريدك الإلكتروني لتأمين حسابك والوصول إلى مزيد من الميزات.\nتحقق من صندوق الوارد لديك للاطلاع على رسالة التأكيد عبر البريد الإلكتروني، أو انقر على \"%@\" للحصول على رسالة تأكيد جديدة.";
-
-/* Message for email verification card with email address */
-"me.verifyEmail.message.withEmail" = "تحقق من بريدك الإلكتروني لتأمين حسابك والوصول إلى مزيد من الميزات.\nتحقق من صندوق الوارد لديك في %1$@ للحصول على رسالة التأكيد عبر البريد الإلكتروني، أو انقر على \"%2$@\" للحصول على رسالة تأكيد جديدة.";
-
-/* Title for email verification card */
-"me.verifyEmail.title" = "التحقُّق من بريدك الإلكتروني";
 
 /* Me tab menu items */
 "meMenu.submitFeedback" = "إرسال الملاحظات";
@@ -8797,6 +9317,9 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "الصفحة الأصل";
 
+/* No comment provided by engineer. */
+"password" = "كلمة المرور";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "قد تعرض البطاقات محتوى مختلفًا استنادًا إلى ما يحدث على موقعك. إننا نعمل على مزيد من البطاقات وضوابط التحكم.";
 
@@ -8901,9 +9424,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Message shown while loading plugin details */
 "pluginDetails.loading" = "جارٍ تحميل معلومات الإضافة…";
-
-/* Placeholder message shown when a plugin has no description */
-"pluginDetails.noDescription" = "لم تقدم هذه الإضافة أي وصف.";
 
 /* Title of the changelog section in plugin details */
 "pluginDetails.section.changelog" = "سجّل التغييرات";
@@ -9190,6 +9710,30 @@ Example: Reply to Pamela Nguyen */
 /* An alert message explaning that by changing the visibility to private, the post will be published immediately to your site */
 "postSettings.warningPostWillBePublishedAlertMessage" = "يعني تغيير إمكانية الرؤية إلى \"خاص\" أن التدوينة ستُنشر فورًا";
 
+/* Localized post type: `Page` */
+"postType.page" = "صفحة";
+
+/* Localized post type: `Post` */
+"postType.post" = "تدوينة";
+
+/* Details for a 'Private' privacy setting */
+"postVisibility.private.details" = "غير مرئية إلا لمسؤولي المواقع والمحررين";
+
+/* Title for a 'Private' privacy setting */
+"postVisibility.private.title" = "خاص";
+
+/* Details for a 'Password Protected' privacy setting */
+"postVisibility.protected.details" = "مرئية للجميع لكن يلزم كلمة مرور";
+
+/* Title for a 'Password Protected' privacy setting */
+"postVisibility.protected.title" = "محمية بكلمة مرور";
+
+/* Details for a 'Public' (default) privacy setting */
+"postVisibility.public.details" = "مرئية للجميع.";
+
+/* Title for a 'Public' (default) privacy setting */
+"postVisibility.public.title" = "عام";
+
 /* Button cancel */
 "postVisibilityPicker.cancel" = "إلغاء";
 
@@ -9410,18 +9954,6 @@ Tapping on this row allows the user to edit the sharing message. */
 /* Title for the success view when the user has successfully logged in */
 "qrLoginVerifyAuthorization.completedInstructions.title" = "لقد قمت بتسجيل الدخول!";
 
-/* No comment provided by engineer. */
-"reachability-utils.alert.cancel" = "موافق";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.retry" = "هل تريد إعادة المحاولة؟";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.title" = "لا يوجد اتصال";
-
-/* Message of error prompt shown when no internet connection is available */
-"reachability-utils.alert.utils" = "يبدو أن الاتصال بالإنترنت غير متوفر حاليًا.";
-
 /* Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog. */
 "reader.blocked.blog.message" = "لن تظهر %@ المدونة في القارئ الخاص بك انقر للتراجع.";
 
@@ -9458,26 +9990,8 @@ Tapping on this row allows the user to edit the sharing message. */
 /* A shared button title for Reader */
 "reader.button.unsubscribe" = "إلغاء الاشتراك";
 
-/* Button title. Follow the comments on a post. */
-"reader.comments.buttonFollow" = "متابعة";
-
 /* Informational message, should be short. */
 "reader.comments.commentsClosed" = "تم إغلاق التعليقات";
-
-/* Empty state view title */
-"reader.comments.emptyStateTitle" = "كن أول من يضع تعليقًا.";
-
-/* Empty state view title */
-"reader.comments.errorLoadingComments" = "حدث خطأ غير متوقع أثناء تحميل التعليقات.";
-
-/* VoiceOver hint */
-"reader.comments.followingSettingAccessibilityIdentifier" = "فتح إعدادات التنبيه للتدوينة";
-
-/* Error message that informs reader comments from a private blog cannot be fetched. */
-"reader.comments.noPermissionToViewPrivateBlog" = "ليست لديك صلاحية لعرض هذه المدونة الخاصة.";
-
-/* Navigation title */
-"reader.comments.title" = "تعليقات";
 
 /* Accessibility hint to inform that the author section can be tapped to see posts from the site. */
 "reader.detail.header.authorInfo.a11y.hint" = "لعرض التدوينات الواردة من الموقع";
@@ -9555,23 +10069,8 @@ but tapping on this button will remove their like from the post. */
 /* Screen header details */
 "reader.following.header.details" = "ابقَ على اطّلاع بأحدث المدوّنات التي شاركت فيها.";
 
-/* Empty state view */
-"reader.following.lists.emptyTitle" = "القوائم فارغة";
-
-/* Screen header details */
-"reader.home.header.details" = "ابقَ على اطّلاع دائم بالمدوّنات التي شاركت فيها.";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.home.title" = "الصفحة الرئيسية";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.library.title" = "المكتبة";
-
 /* Used in multiple contexts, usually as a screen title */
 "reader.likes.title" = "إعجابات";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.lists.title" = "القوائم";
 
 /* Reader logged-out screen details */
 "reader.loggedOut.details" = "تسجيل الدخول باستخدام حساب ووردبريس.كوم لمتابعة المدونات التي تفضلها.";
@@ -9814,8 +10313,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title of a Reader tab showing Posts matching a user's search query */
 "reader.search.tab.posts" = "التدوينات";
 
-/* Title of the Reader's search feature
-   Used in multiple contexts, usually as a screen title */
+/* Title of the Reader's search feature */
 "reader.search.title" = "البحث";
 
 /* Screen title. Reader select interests title label text. */
@@ -9841,6 +10339,21 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Reader select interests title label text */
 "reader.select.tags.title" = "اكتشاف المدونات التي تحبها ومتابعتها";
+
+/* Reader sidebar menu item */
+"reader.sidebar.discover" = "اكتشاف";
+
+/* Reader sidebar menu item */
+"reader.sidebar.likes" = "إعجابات";
+
+/* Reader sidebar menu item */
+"reader.sidebar.recent" = "حديثة";
+
+/* Reader sidebar menu item */
+"reader.sidebar.saved" = "تم الحفظ";
+
+/* Reader sidebar menu item */
+"reader.sidebar.search" = "البحث";
 
 /* Reader sidebar section title */
 "reader.sidebar.section.favorites.title" = "المفضلات";
@@ -9887,7 +10400,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Number of subscriptions on a site (singular) */
 "reader.subscriptions.subscriptionsSingular" = "%@ من المشتركين";
 
-/* Used in multiple contexts, usually as a screen title */
+/* Navigation bar title */
 "reader.subscriptions.title" = "الاشتراكات";
 
 /* A suggestion of topics the user might want to subscribe to */
@@ -9929,29 +10442,11 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Verb. Button title. The user is following a tag. */
 "reader.tags.following.button.title" = "متابعة";
 
-/* Used in multiple contexts, usually as a screen title */
-"reader.tags.title" = "الوسوم";
-
 /* Accessibility label for unsubscribing from a tag */
 "reader.tags.unfollow.accessibility.label" = "إلغاء متابعة %@";
 
 /* Field title */
 "reader.userProfile.site" = "الموقع";
-
-/* Reader Welcome screen login button */
-"reader.welcome.continueText" = "المتابعة باستخدام ووردبريس.كوم";
-
-/* Reader Welcome screen */
-"reader.welcome.subtitle" = "انضم إلى أكبر مجتمع للتدوين";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.discover" = "استكشف";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.me" = "أنا";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.notifications" = "التنبيهات";
 
 /* Spoken accessibility label */
 "readerDetail.backButton.accessibilityLabel" = "رجوع";
@@ -10226,14 +10721,10 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Message shown when there are no inactive plugins on the site */
 "site.plugins.empty.inactive" = "لا توجد إضافات غير نشطة";
 
-/* The plugin fillter option for displaying active plugins */
-"site.plugins.filter.option.active" = "نشط";
-
-/* The plugin fillter option for displaying all plugins */
+/* The plugin fillter option for displaying active plugins
+   The plugin fillter option for displaying all plugins
+   The plugin fillter option for displaying inactive plugins */
 "site.plugins.filter.option.all" = "الكل";
-
-/* The plugin fillter option for displaying inactive plugins */
-"site.plugins.filter.option.inactive" = "غير نشط";
 
 /* Title of the plugin filter picker */
 "site.plugins.filter.title" = "التصفية";
@@ -10785,9 +11276,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* View title for Help & Support page. */
 "support.title" = "مساعدة";
 
-/* Subject of new Zendesk ticket. */
-"support.zendesk.readerAppTicketSubject" = "قارئ لدعم نظام iOS";
-
 /* Title for placeholder in Tenor picker */
 "tenor.welcomeMessage" = "ابحث للعثور على صور بتنسيق GIF لإضافتها إلى مكتبة الوسائط الخاصة بك!";
 
@@ -10936,8 +11424,119 @@ Feel free to replace it with other bracket types that you think looks better for
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "الحالة";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "التدوينات في كل الأوقات ومعظم المشاهدات";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "المشاهدات في كل الأوقات";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "المشاهدات والزائرون في كل الأوقات";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "أفضل المشاهدات على الإطلاق";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "معظم المشاهدات";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "يتعذر تحميل إحصاءات كل الأوقات.";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "أنشئ موقعًا أو أضفه لرؤية إحصاءات كل الأوقات.";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "مقالات";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "أبق على اطلاع بنشاط كل الأوقات على موقع ووردبريس الخاص بك.";
+
+/* Title of all time widget */
+"widget.alltime.title" = "كل الأوقات";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "قم بتسجيل الدخول إلى ووردبريس للاطلاع على إحصاءات كل الأوقات.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "سجّل الدخول إلى Jetpack لرؤية إحصاءات كل الأوقات.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "سجّل الدخول إلى Jetpack لرؤية إحصاءات هذا الأسبوع.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "سجّل الدخول إلى Jetpack لرؤية إحصاءات اليوم.";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "المشاهدات في كل الأوقات";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "المشاهدات في الوقت الحاضر";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "يتعذر تحميل إحصاءات هذا الأسبوع.";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "أنشئ موقعًا أو أضفه لرؤية إحصاءات هذا الأسبوع.";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "أبق على اطلاع بنشاط هذا الأسبوع على موقع ووردبريس الخاص بك.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "هذا الأسبوع";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "قم بتسجيل الدخول إلى ووردبريس للاطلاع على إحصاءات هذا الأسبوع.";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "تعليقات";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "لقد انتقلت الإحصاءات إلى تطبيق Switching، وأصبح التبديل مجانيًا ولا يستغرق سوى لحظات.";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "إعجابات";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "يتعذر تحميل إحصاءات الموقع.";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "يتعذر تحميل إحصاءات اليوم.";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "أنشئ موقعًا أو أضفه لرؤية إحصاءات اليوم.";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "أبق على اطلاع بنشاط اليوم على موقع ووردبريس الخاص بك.";
+
+/* Title of today widget */
+"widget.today.title" = "اليوم";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "قم بتسجيل الدخول إلى ووردبريس للاطلاع على إحصاءات اليوم.";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "العرض غير متاح";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "مشاهدات";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "الزوار";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "الإعجابات والتعليقات في الوقت الحاضر";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "المشاهدات في الوقت الحاضر";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "المشاهدات والزائرون في الوقت الحاضر";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "لن يكون متوفرًا في المستقبل.";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "هل تريد بدء موقع جديد؟";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "ووردبريس، المساعدة، الدعم، الأسئلة المتداولة، الأسئلة، كشف وتصحيح الأخطاء، السجلات، مركز التعليمات، الاتصال";
@@ -10962,6 +11561,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Error message that describes an unknown error had occured */
 "wordpress-api.error.unknown" = "حدث خطأ ما، ترجى المحاولة مجددًا في وقت لاحق.";
+
+/* Error message when failing to find selected media file on the user's device. */
+"wordpress.api.upload.media.fileNotFound" = "يتعذر تحديد موقع ملف الوسائط على الجهاز";
 
 /* Jetpack Plugin Modal on WordPress primary button title */
 "wordpress.jetpack.plugin.modal.primary.button.title" = "التبديل إلى تطبيق Jetpack";
@@ -11008,21 +11610,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Error message when user signs in with an unexpected email address. The first argument is the expected email address */
 "wpComLogin.error.mismatchedEmail" = "يرجى تسجيل الدخول باستخدام عنوان البريد الإلكتروني %@";
 
-/* Message shown when user denies WordPress.com login, offering option to try with different account */
-"wpComLogin.loginDenied.message" = "يمكنك تسجيل الدخول باستخدام حساب مختلف إذا كنت بحاجة إلى حساب مختلف. انقر على \"%@\" للبدء.";
-
-/* Title of alert shown when user cancels WordPress.com login */
-"wpComLogin.loginDenied.title" = "تم إلغاء تسجيل الدخول";
-
-/* Button title for signing in with a different WordPress.com account */
-"wpComLogin.loginDenied.useDifferentAccount" = "استخدام حساب مختلف";
-
-/* Button title to log out the current WordPress.com account */
-"wpcom.token.alert.button.logout" = "تسجيل الخروج";
-
-/* Button title to Sign In to WordPress.com */
-"wpcom.token.alert.button.signin" = "تسجيل الدخول";
-
 /* Message title to be displayed when the user needs to re-authenticate their WordPress.com account. */
 "wpcom.token.fix.signin" = "تسجيل الدخول إلى ووردبريس.كوم";
 
@@ -11037,6 +11624,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "مرفق غير مدعوم";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} تسجيل الدخول باستخدام Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• نطاقات";

--- a/WordPress/Resources/bg.lproj/Localizable.strings
+++ b/WordPress/Resources/bg.lproj/Localizable.strings
@@ -59,6 +59,9 @@
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Без заглавие)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(без заглавие)";
+
 /* Menus button text for adding a new menu to a site. */
 "+ Add new menu" = "+ Добавяне на ново меню";
 
@@ -79,6 +82,9 @@
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "Заглавие на сайта";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "Изисква се валиден имейл адрес, за да изпратим връзка за автентикация. Върнете се на предишния екран и задайте валиден имейл адрес.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "АКТИВНИ";
@@ -167,6 +173,9 @@
    Label for the alt for a media asset (image) */
 "Alt Text" = "Описателен текст";
 
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "Изисква се активна връзка с интернет, за да разглеждате плановете.";
+
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
 "An active internet connection is required to view plugins" = "За преглеждането на разширения е нужна връзка с интернет";
@@ -194,6 +203,9 @@
 
 /* Error recorded when all of the media associated with a post fail to be attached to the post on the server. */
 "An error occurred when attempting to attach uploaded media to the post." = "Възникна грешка при закачането на отдалечен медиен файл към публикацията.";
+
+/* the comment has an anonymous author. */
+"Anonymous" = "Анонимен";
 
 /* App Settings Title
    Link to App Settings section
@@ -263,6 +275,9 @@
    Previous web page */
 "Back" = "Обратно";
 
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Коментирайте първи.";
+
 /* Accessibility label for block quote button on formatting toolbar.
    Discoverability title for block quote keyboard shortcut. */
 "Block Quote" = "Цитат";
@@ -295,9 +310,13 @@
 /* Accessibility label for taking an image or video with the camera on formatting toolbar. */
 "Camera" = "Камера";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Неуспешно изискване на връзка";
+
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -307,6 +326,7 @@
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -325,6 +345,7 @@
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -347,13 +368,15 @@
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Надпис";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Внимание!";
 
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Категории";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Категория";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -386,6 +409,7 @@
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Затваряне";
 
@@ -397,6 +421,9 @@
 
 /* Close Comments Title */
 "Close commenting" = "Затваряне на дискусията";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Комикси";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -420,6 +447,7 @@
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Коментари";
 
@@ -476,6 +504,9 @@
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Свързването на %1$@ ще замести сегашната връзка с %2$@.";
 
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Свързване с WordPress.com";
+
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Свързване...";
 
@@ -500,6 +531,7 @@
 
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -537,6 +569,9 @@
    Register Domain - Domain contact information field Country */
 "Country" = "Страна";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Създаване на профил";
+
 /* Button to progress to the next step
    Site creation. Step 1. Screen title
    Title for the button to progress with creating the site with the selected design. */
@@ -547,6 +582,9 @@
 
 /* No comment provided by engineer. */
 "Current" = "В момента";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Текущ план";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Настояща тема";
@@ -569,6 +607,9 @@
    Title for selecting a default category for a post */
 "Default Category" = "Категория по подразбиране";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Меню по подразбиране";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Формат по подразбиране";
@@ -577,6 +618,7 @@
 "Defaults for New Posts" = "По подразбиране за нови публикации";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Изтриване";
@@ -653,7 +695,9 @@
    Title for the Discussion Settings Screen */
 "Discussion" = "Дискусия";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Премахване";
 
 /* Display Name label text.
@@ -676,6 +720,9 @@
    Title for button that will dismiss this view
    Title for the button that will dismiss this view. */
 "Done" = "Готово";
+
+/* Name for the status of a draft post. */
+"Draft" = "Чернова";
 
 /* Editing GIF alert default action button.
    Edits a Comment
@@ -776,6 +823,9 @@
 /* Overlay message displayed while starting content export */
 "Exporting content…" = "Експортиране на съдържанието...";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Неуспешно";
+
 /* Error message to show when wrong URL format is used to access the REST API */
 "Failed to serialize request to the REST API." = "Грешка при сериализацията на данните към REST API.";
 
@@ -808,6 +858,9 @@
    User's First Name */
 "First Name" = "Собствено име";
 
+/* Button title. Follow the comments on a post. */
+"Follow" = "Следване";
+
 /* User role badge */
 "Follower" = "Последовател";
 
@@ -825,6 +878,12 @@
 
 /* Title for the general section in site settings screen */
 "General" = "Основни";
+
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Генериране на информацията за профила";
+
+/* Cancel */
+"Give Up" = "Отмяна";
 
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
@@ -884,6 +943,9 @@
    Title of the 'Help & Support' screen within the 'Me' tab - used for spotlight indexing on iOS. */
 "Help & Support" = "Помощ";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Скрит";
+
 /* Title of a button used to collapse a group */
 "Hide" = "Скриване";
 
@@ -932,6 +994,9 @@
 
 /* Describes a standard *.wordpress.com site domain */
 "Included with Site" = "Включен по подразбиране";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Невалидно потребителско име или парола. Опитайте отново.";
 
 /* WordPress.com Community Footer Text */
 "Information on WordPress.com courses and events (online & in-person)." = "Информация за WordPress.com курсове и събития (онлайн и лично).";
@@ -1056,7 +1121,8 @@
 /* Setting: indicates if Replies to your comments will be notified */
 "Likes on my posts" = "Харесвания на моите публикации";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Връзка";
 
 /* Menus title label when editing a menu item as a link. */
@@ -1079,6 +1145,12 @@
 /* Menus label text displayed while menus are loading */
 "Loading Menus..." = "Зареждане на менютата...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Зареждане на план...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Зареждане на планове...";
+
 /* Text displayed while loading plugins for a site */
 "Loading Plugins..." = "Зареждане на разширенията...";
 
@@ -1092,23 +1164,43 @@
    Text displayed while loading time zones */
 "Loading..." = "Зареждане...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Локално";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Местоположение";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Услугата за местоположение трябва да бъде включена, за да може WordPress да добави вашето текущо местоположение. Моля, включете го от настройките на устройството.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Неизвестно местоположение";
+
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Логове по дата на създаване";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Вход";
 
 /* Button for confirming logging out from WordPress.com account
    Label for logging out from WordPress.com account */
 "Log Out" = "Изход";
 
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Неуспешно влизане - опитайте отново.";
+
 /* Login Request Expired */
 "Login Request Expired" = "Заявката за влизане е изтекла";
 
 /* No comment provided by engineer. */
 "Logs" = "Логове";
+
+/* Title of a button. */
+"Lost your password?" = "Изгубена парола?";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Основна навигация";
@@ -1197,6 +1289,9 @@
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Помощ?";
 
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Имате нужда от допълнителна помощ?";
+
 /* IP Address or Range Insertion Title */
 "New IP or IP Range" = "Нов IP адрес или обхват от IP адреси";
 
@@ -1206,6 +1301,9 @@
 /* New Post 3D Touch Shortcut */
 "New Post" = "Нова публикация";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Нов елемент";
+
 /* Screen title, where users can see the newest plugins */
 "Newest" = "Най-нов";
 
@@ -1213,7 +1311,9 @@
 "Newest first" = "Първо най-новите";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Следваща";
 
 /* Accessibility label for the next notification button */
@@ -1245,7 +1345,8 @@
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "Няма коментари";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "Няма връзка";
 
@@ -1313,7 +1414,12 @@
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Номериран списък";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "ОК";
@@ -1349,10 +1455,16 @@
    Title for the view when there's an error loading time zones */
 "Oops" = "Опа";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Упс!";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Към електронна поща";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Отваряне на настройките";
 
 /* No comment provided by engineer. */
@@ -1393,7 +1505,8 @@
    Other Sites Notification Settings Title */
 "Other Sites" = "Други сайтове";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Страница";
 
@@ -1410,14 +1523,21 @@
 /* Title for selecting parent category of a category */
 "Parent Category" = "Категория родител";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Парола";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "На изчакване";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Очаква отзив";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -1429,6 +1549,10 @@
 
 /* Section title for the personalize table section in the blog details screen. */
 "Personalize" = "Персонализиране";
+
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Планове";
 
 /* Politely asks the user to check their internet connection before trying again. */
 "Please check your internet connection and try again." = "Проверете интернет връзката си и опитайте пак.";
@@ -1442,11 +1566,14 @@
 /* No comment provided by engineer. */
 "Please enter a username." = "Моля, въведете потребителско име.";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Моля, въвете валиден имейл адрес.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Въведете вашите потребителски данни";
+
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Моля, попълнете всички полета";
 
 /* No comment provided by engineer. */
 "Please try entering your login details again." = "Опитайте да въведете данните си за вход отново.";
@@ -1465,7 +1592,8 @@
 /* Section title for Popular Languages */
 "Popular languages" = "Популярни езици";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Публикация";
 
@@ -1514,12 +1642,25 @@
 /* Title of button that displays the App's privacy policy */
 "Privacy Policy" = "Поверителност";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Лична";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Ако продължите, ще премахнете всички данни на WordPress.com от това устройство, и ще изтриете всички съхранени чернови. Няма да загубите нищо, което вече е запазено на вашите WordPress.com блогове.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Проекти";
+
 /* Label for the publish (verb) button. Tapping publishes a draft post.
    Publish post action on share extension site picker screen.
    Section title for the publish table section in the blog details screen */
 "Publish" = "Публикуване";
 
-/* Period Stats 'Published' header
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Публикуване веднага";
+
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Публикувано";
 
@@ -1598,6 +1739,9 @@
    Verb. Button title. Reply to a comment. */
 "Reply" = "Отговор";
 
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Текст на отговора";
+
 /* An explaination of a setting. */
 "Require manual approval for comments that include more than this number of links." = "Ръчно одобряване на коментари които включват повече от зададения брой връзки.";
 
@@ -1641,6 +1785,9 @@
    User action to retry media upload. */
 "Retry" = "Отново";
 
+/* No comment provided by engineer. */
+"Retry?" = "Отново?";
+
 /* Cancels a pending Email Change */
 "Revert Pending Change" = "Отмяна на изчакващата промяна";
 
@@ -1655,8 +1802,12 @@
    User's Role */
 "Role" = "Роля";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS изпратен";
+
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -1666,7 +1817,8 @@
 /* Menus save button title while it is saving a Menu. */
 "Saving..." = "Запазване...";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Насрочена";
 
 /* Title of Stats section that shows search engine referrer traffic. */
@@ -1689,6 +1841,9 @@
 
 /* Menus alert message for alerting the user to unsaved changes while trying to select a different menu. */
 "Selecting a different menu will discard changes you've made to the current menu. Are you sure you want to continue?" = "Избирането на друго меню ще отхвърли промените, които сте направили към текущото. Сигурни ли сте, че искате да продължите?";
+
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Изпращане на връзка";
 
 /* Settings: Sending Pingbacks */
 "Send Pingbacks" = "Изпращане на pingbacks";
@@ -1713,6 +1868,9 @@
 
 /* Message to show when setting save failed */
 "Settings update failed" = "Проблем при обновяване на настройките";
+
+/* Spoken accessibility label */
+"Share" = "Споделяне";
 
 /* Aztec's Text Placeholder
    Share Extension Content Body Text Placeholder */
@@ -1785,7 +1943,7 @@
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Адресът на сайта трябва да има и букви.";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Този имейл адрес вече се използва!";
 
 /* No comment provided by engineer. */
@@ -1884,7 +2042,8 @@
 /* Accessibility Identifier for the Default Font Aztec Style. */
 "Switches to the default Font Size" = "Превключва размера на шрифта на този по подразбиране";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Етикет";
 
 /* Label for tagline blog setting
@@ -1910,8 +2069,14 @@
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Условия за ползване";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Препоръки";
+
 /* Title of a button style */
 "Text Only" = "Само текст";
+
+/* Button title */
+"Text me a code instead" = "Изпращане на код чрез SMS";
 
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Благодарим ви, че избрахте %1$@ от %2$@";
@@ -1945,6 +2110,9 @@
 
 /* Message for when the certificate for the server is invalid. The %@ placeholder will be replaced the a host name, received from the API. */
 "The certificate for this server is invalid. You might be connecting to a server that is pretending to be “%@” which could put your confidential information at risk.\n\nWould you like to trust the certificate anyway?" = "Сертификатът на този сървър е невалиден. Възможно е да се свързвате със сървър който се преструва че е \"%@\", което да изложи ваша конфиденциална информация на риск.\n\nСигурни ли сте, че искате да се доверите на този сертификат?";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "Няма връзка с интернет";
 
 /* Footer Text displayed in Blog Language Settings View */
 "The language in which this site is primarily written." = "Основния език, който се използва за съдържанието на сайта.";
@@ -1987,11 +2155,17 @@
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "Възникна неизвестна грешка при редактиране на коментара";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "Възникна неочаквана грешка при зареждане на коментарите.";
+
 /* Invite Failed Message */
 "There has been an unexpected error while sending your Invitation" = "Възникна грешка при изпращане на вашата покана";
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "Възникна неочаквана грешка докато се обновяваха вашите настройки за известявания";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "Възникна неочаквана грешка при обновяване на коментара";
 
 /* Informs the user about an issue connecting to the third-party sharing service. The `%@` is a placeholder for the service name. */
 "There is an issue connecting to %@. Reconnect to continue publicizing." = "Възникна грешка при свързването с %@. Свържете се отново, за да продължите да споделяте.";
@@ -1999,14 +2173,29 @@
 /* Error message informing the user that there was a problem blocking posts from a site from their reader. */
 "There was a problem blocking posts from the specified site." = "Възникна проблем при блокирането на публикациите от сайта.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "Възникна проблем при свързването с WordPress.com. Моля, влезте отново.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "Възникна проблем при показването на тази публикация.";
+
 /* Error message informing the user that there was a problem clearing the block on site preventing its posts from displaying in the reader. */
 "There was a problem removing the block for specified site." = "Възникна проблем при премахването на блока от този сайт.";
 
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "Възникна проблем при запазването на промените в управлението на споделянето.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "Възникна проблем докато се опитвахме да получим вашето местоположение. Моля опитайте по-късно.";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "Възникна грешка при зареждане на плановете";
+
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "Възникна проблем със зареждането на разширенията";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "Възникна грешка при зареждане на плана";
 
 /* An error message display if the users device does not have a camera input available */
 "This app needs permission to access the Camera to capture new media, please change the privacy settings if you wish to allow this." = "Това приложение се нуждае от разрешение да използва камерата, за да може да заснема. Моля, променете вашите настройки за поверителност ако искате да разрешите това.";
@@ -2051,7 +2240,8 @@
    Trashes the comment */
 "Trash" = "Кошче";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "Изхвърлени";
 
@@ -2062,6 +2252,7 @@
 "Try & Customize" = "Опитайте и настройте";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Опитайте отново";
@@ -2148,13 +2339,15 @@
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Неуспешно качване";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Качено";
 
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Качени теми";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Качване";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -2164,11 +2357,14 @@
 "Use" = "Използване";
 
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Потребителско име";
 
 /* Setting: indicates if Mentions will be notified */
@@ -2180,6 +2376,9 @@
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Потребители";
+
+/* two factor code placeholder */
+"Verification code" = "Код за потвърждение";
 
 /* Push Authentication Alert Title */
 "Verify Log In" = "Потвърждение на влизането";
@@ -2255,6 +2454,9 @@
 /* Title displayed in the Notification Settings for WordPress.com */
 "We’ll always send important emails regarding your account, but you can get some helpful extras, too." = "Ще ви изпращаме важни имейли относно профила ви, също можете да получите и някои полезни екстри.";
 
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "Какъв е адресът на моя сайт?";
+
 /* Text rendered at the bottom of the Discussion Moderation Keys editor */
 "When a comment contains any of these words in its content, name, URL, e-mail or IP, it will be held in the moderation queue. You can enter partial words, so \"press\" will match \"WordPress\"." = "Когато коментар съдържа някоя от тези думи в съдържанието, името, адреса, имейла или IP адреса, този коментар ще бъде задържан за модерация. Можете да добавяте частични думи - например \"press\" ще хване и \"WordPress\".";
 
@@ -2273,14 +2475,23 @@
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "Медийна библиотека на WordPress";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress се нуждае от разрешение да достъпва текущото ви местоположение, за да го добави към публикацията. За целта трябва да промените вашите настройки за поверителност.";
+
 /* No comment provided by engineer. */
 "WordPress version too old" = "Версията на WordPress е прекалено стара";
+
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Версията на WordPress e много стара. Сайтът на %1$@ използва WordPress %2$@. Ние препоръчваме да преминете към последната версия или най-малко на %3$@";
 
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "Профил в WordPress.com";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "Планове в WordPress.com";
 
 /* WordPress.com Notification Settings Title */
 "WordPress.com Updates" = "Известия от WordPress.com";
@@ -2314,7 +2525,8 @@
 /* Message alert when attempting to delete site with purchases */
 "You have active premium upgrades on your site. Please cancel your upgrades prior to deleting your site." = "Имате активни платени услуги на сайта. Моля, отменете ги преди да изтриете сайта си.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Имате незапазени промени.";
 
 /* Error message informing the user that being logged into a WordPress.com account is required. */
@@ -2355,6 +2567,24 @@
 
 /* Later today */
 "later today" = "по-късно днес";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Публикации";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Коментари";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Харесвания";
+
+/* Title of today widget */
+"widget.today.title" = "Днес";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Преглеждания";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Посетители";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Домейни";

--- a/WordPress/Resources/cs.lproj/Localizable.strings
+++ b/WordPress/Resources/cs.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "%1$@ z %2$@ na vašem webu";
 
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "%1$@ z %2$@ použité na vašem webu";
+
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ kvadrilion";
 
@@ -230,6 +233,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Bez názvu)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(žádný název)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*Johan Brandt* odpověděl na váš příspěvek";
 
@@ -302,6 +308,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "Tlačítko \"více\" obsahuje rozbalovací seznam, který zobrazuje tlačítka sdílení";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "Účet WordPress.com je připojen k přihlašovacím údajům vašeho obchodu. Chcete-li pokračovat, zašleme ověřovací odkaz na výše uvedenou e-mailovou adresu.";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "Soubor obsahuje vzor škodlivého kódu";
 
@@ -310,6 +319,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "Přidat název pro tento web";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "Platná e-mailová adresa se důležitá pro ověření a propojení. Vraťte se na předchozí obrazovku a zadejte platný e-mail.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "Ověřovací kód bude obsahovat pouze čísla.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "AKTIVNÍ";
@@ -504,6 +519,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "Po %@";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Letecká pošta";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "Zarovnání";
@@ -564,9 +582,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "IP adresy na seznamu povolených";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "Téměř hotovo! Zadejte ověřovací kód z aplikace Authenticator.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Alternativní text";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "Případně můžete zadat heslo pro tento účet.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "Alternativní způsoby přihlášení:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "Vždy odesílat protokoly o selhání";
@@ -588,6 +615,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "K prohlížení aktivit je vyžadováno aktivní připojení k internetu";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "Aktivní připojení k internetu je vyžadován pro zobrazení plánů";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -638,6 +668,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "Roční statistiky stránek";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "Anonym";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "Odpověď";
 
@@ -659,6 +692,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "Vzhled";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "Ověření Apple se nezdařilo.\nUjistěte se, že jste přihlášeni k iCloudu pomocí Apple ID, které používá dvoufaktorové ověřování.";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "Použije nastavení";
@@ -745,6 +781,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "Autentikace se nezdařila";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "Ověřovací kód";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "Ověření potřebné pro hostitele: %@";
@@ -852,6 +892,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "Buďte první! Přidejte komentář";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Buďte první, kdo napíše komentář.";
 
 /* Beauty site intent topic */
 "Beauty" = "Krása";
@@ -961,12 +1004,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button position" = "Poloha tlačítka";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "Pokračováním vyjadřujete souhlas s našimi _podmínkami služby_.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "Registrací této domény souhlasíte s našimi <a>podmínkami <\/a>.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "Nastavením Jetpacku souhlasíte s našimi\n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "Registrací vyjadřujete souhlas s našimi _podmínkami služby_.";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "PŘIZPŮSOBIT";
@@ -980,6 +1029,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "Ke skenování přihlašovacích kódů je nutný přístup k fotoaparátu";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Nelze načíst adresu";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "Prázdnou stránku nelze publikovat";
 
@@ -989,6 +1041,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -998,6 +1051,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1016,6 +1070,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1043,6 +1098,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "Rušení...";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "Na tuto adresu nelze získat přístup k webu. Zkontrolujte prosím a zkuste to znovu.";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Nemůžete se rozhodnout? Šablonu můžete kdykoli změnit.";
 
@@ -1050,7 +1108,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Titulek";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Opatrně!";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1059,7 +1118,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Rubriky";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Rubrika";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1108,6 +1168,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "Podívejte se na naše nejlepší tipy ke zvýšení počtu zhlédnutí a návštěvnosti";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "Zkontrolujte svůj e-mail na tomto zařízení!";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Zkontrolujte svůj e-mail v tomto zařízení a klepněte na odkaz v e-mailu, který obdržíte z WordPress.com.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "Zkontrolujte svůj e-mail na tomto zařízení a klepněte na odkaz v e-mailu, který jste obdrželi z WordPress.com.\n\nNevidíte e-mail? Zkontrolujte složku spamu nebo nevyžádané pošty.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "Zkontrolujte si email!";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "Zkontrolujte připojení k internetu a zatažením obnovte.";
@@ -1204,6 +1276,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "Získat doménu zdarma";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "Klasický blog";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "Vymažte mezipaměť médií zařízení";
 
@@ -1228,6 +1303,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Zavřít";
 
@@ -1269,6 +1345,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "Nastavení sloupců";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Komiks";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1320,6 +1399,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Komentáře";
 
@@ -1387,12 +1467,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Propojen účet";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Připojeno ale…";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "Připojování %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Připojování k %1$@ nahradí stávající spojení k %2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Připojuji se k WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Připojování...";
@@ -1423,8 +1509,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "Kontaktujte nás na adrese %@";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "Struktura obsahu\nBloky: %1$li, Slova: %2$li, Znaky: %3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1439,6 +1529,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Čtěte více";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Pokračujte s Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Pokračujte pomocí Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Pokračování s Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "Přispět";
@@ -1558,6 +1657,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "Vytvořit";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Vytvořit účet";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "Vytvořit prázdnou stránku";
 
@@ -1578,6 +1680,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "Vytvořit příspěvek";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "Vytvořit web";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "Vytvořit štítek";
@@ -1611,6 +1716,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "Aktuální";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Současný plán";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Aktuální šablona";
@@ -1710,6 +1818,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "Výchozí rubrika";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Základní menu";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Výchozí formát příspěvků";
@@ -1718,6 +1829,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "Výchozí pro nové příspěvky";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Smazat";
@@ -1769,6 +1881,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "Detaily";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "Nechtěli jste vytvořit nový účet? Vraťte se zpět a znovu zadejte svou emailovou adresu.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "Rozměry";
 
@@ -1816,7 +1931,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "Diskuse";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Skrýt";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1838,6 +1955,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "Domény";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "Nemáte účet? _Přihlásit se_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -1967,6 +2087,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "Stahování";
 
+/* Name for the status of a draft post. */
+"Draft" = "Koncept";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Koncepty";
 
@@ -2067,7 +2190,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "Emailová adresa";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "E-mailová adresa";
 
 /* Notification Settings Channel */
@@ -2151,8 +2277,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Zadejte heslo";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "Zadejte adresu webu WordPress, ke kterému se chcete připojit.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Zadejte heslo pro svůj účet WordPress.com.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Zadejte uživatelské jméno";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "Zadejte informace o svém účtu pro %@.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "Zadejte svou e-mailovou adresu pro přihlášení nebo vytvořte účet WordPress.com.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "Zadejte svou stávající adresu";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "Místo toho zadejte své heslo.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "Zadejte přihlašovací údaje k serveru";
@@ -2312,6 +2458,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "Externí";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Selhalo";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "Oznámení se nepodařilo označit jako přečtené";
 
@@ -2338,6 +2487,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "Móda";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "Doporučené";
@@ -2393,6 +2545,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "Zjistit více";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Najděte adresu svého webu";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2415,6 +2570,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "Oprava hrozby";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "Sledovat";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "Sledovat konverzaci";
@@ -2500,6 +2658,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "Generovat nový odkaz";
 
+/* View title for initial auth views. */
+"Get Started" = "Začínáme";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "Získejte odkaz pro přihlášení e-mailem";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "Buď aktivní! Komentuj příspěvky z blogů, které sledujete.";
 
@@ -2521,8 +2685,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "Inspirovat se";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Získávám informace o účtu";
+
+/* Cancel */
+"Give Up" = "Vzdát se";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "Vyzkoušejte to přidáním několika bloků do svého příspěvku nebo stránky!";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "Zobrazit čtečku";
@@ -2533,6 +2706,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "Otevřít iOS nastavení";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Google registrace se nezdařila.";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2607,6 +2783,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "Ikona nápovědy";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Skrytý";
+
 /* Title of a button used to collapse a group */
 "Hide" = "Skrýt";
 
@@ -2675,6 +2854,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "Aktualizace ikony se nezdařila";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "Pokud e-mail nemůžete najít, zkontrolujte složku nevyžádané pošty nebo spamu";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "Pokud budete pokračovat se společností Apple nebo Google a ještě nemáte účet WordPress.com, vytváříte si účet a souhlasíte s našimi _Smluvními podmínkami_.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "Pokud odstraníte uživatele %1$@, nebude mít přístup k tomuto webu. Ale všechen obsah který vytvořil %2$@, zůstane na webu.";
@@ -2747,6 +2932,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "Zahrnuje wp-config.php a jakékoli jiné soubory než WordPress";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Nesprávné uživatelské jméno nebo heslo. Zkuste to znovu a zadejte vaše přihlašovací údaje.";
 
 /* Title for a threat */
 "Infected core file" = "Infikovaný soubor v jádru";
@@ -2833,6 +3021,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Interior Design site intent topic */
 "Interior Design" = "Vzhled interiéru";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "Špatná e-mailová adresa";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "Neplatná adresa webu";
 
@@ -2850,6 +3041,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "Neplatná URL. Audio soubor se nepodařilo nalézt.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "Neplatná URL. Zkontrolujte a zkuste to znovu.";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "Neplatná URL. Zadejte platnou adresu URL.";
@@ -2871,6 +3065,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "Pozvat lidi";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "Vypadá to, že toto uživatelské jméno \/ heslo není spojeno s tímto webem.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "Zdá se, že jste zadali nesprávné heslo. Chcete to zkusit znovu?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "Je čas napsat blog na %@!";
@@ -3099,7 +3299,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "Výška řádku";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Odkaz";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3161,6 +3362,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "Načítání lidí ...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Nahrávám plán...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Načítám plány...";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "Plugin se načítá...";
 
@@ -3195,11 +3402,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "Načítání…";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Místní";
+
 /* Local Services site intent topic */
 "Local Services" = "Místní služby";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "Místní změny";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Poloha";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Služba umístění musí být povolen předtím, než WordPress může přidat svou aktuální polohu. Povolte Location Services z aplikace nastavení.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Neznámá poloha";
 
 /* No comment provided by engineer. */
 "Lock icon" = "Ikona zámku";
@@ -3207,9 +3426,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Zaznamenávat soubory dle data vytvoření";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Přihlásit se";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3218,6 +3439,22 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title of a button for signing in. */
 "Log in" = "Přihlásit se";
+
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Přihlášení selhalo. Zkuste to prosím znovu.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "Přihlaste se nebo se zaregistrujte pomocí WordPress.com ";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Přihlaste se k účtu WordPress.com, který jste použili k připojení Jetpack.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "Přihlaste se ke svému účtu WordPress.com pomocí své e-mailové adresy.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "Přihlaste se pomocí svého uživatelského jména a hesla WordPress.com.";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of Jetpack?" = "Odhlásit se z Jetpacku?";
@@ -3228,6 +3465,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Login Request Expired */
 "Login Request Expired" = "Žádost o přihlášení vypršela";
 
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "Přihlaste se heslem účtu";
+
 /* No comment provided by engineer. */
 "Logs" = "Protokoly";
 
@@ -3236,6 +3476,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Na svém webu máte nastavený plugin Jetpack. Gratulujeme!\nPro zpřístupnění statistik a oznámení, se prosím níže přihlaste pomocí účtu WordPress.com";
+
+/* Title of a button. */
+"Lost your password?" = "Zapomněli jste heslo?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "Mail (výchozí)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Hlavní navigace";
@@ -3380,6 +3626,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "Zpráva";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "Různé zranitelnosti";
 
@@ -3475,6 +3724,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "Moje weby";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "Moje stránky na WordPressu";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "Moje top desítka kaváren";
 
@@ -3514,8 +3766,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Potřebujete pomoc?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "Potřebujete najít adresu webu?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "Potřebujete pomoc?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Potřebujete poradit?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "Vyžaduje aktualizaci";
@@ -3538,6 +3797,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "Vytvořit příspěvek";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Nová položka";
+
 /* Placeholder text for password field */
 "New password" = "Nové heslo";
 
@@ -3555,7 +3817,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "Novinky";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Další";
 
 /* Accessibility label for the next notification button */
@@ -3591,6 +3855,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "Není k dispozici žádná adresa URL náhledu";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "Žádný název";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "Nejsou k dispozici žádné aktivity";
 
@@ -3623,7 +3890,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "Zatím nemáte žádné komentáře";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "Žádné spojení ";
 
@@ -3766,6 +4034,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "Teď ne";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "Nevidíte e-mail? Zkontrolujte složku spamu nebo nevyžádané pošty.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "Poznámka:";
 
@@ -3829,7 +4100,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Číslovaný seznam";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -3886,7 +4162,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "Jejda";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Jejda!";
 
 /* No comment provided by engineer. */
@@ -3901,7 +4178,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "Otevřete nastavení Jetpack zabezpečení";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Otevřít e-mail";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Otevřít nastavení";
 
 /* No comment provided by engineer. */
@@ -3919,6 +4201,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "Otevřít odkaz v novém okně\/tabu";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "Otevřete nastavení odběru příspěvku";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "Otevřít mou sekci";
 
@@ -3933,6 +4218,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "Volitelné: Zadejte vlastní zprávu o délce až %1$d znaků, která bude odeslána s vaší pozvánkou.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "Nebo";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "Nebo se přihlaste _zadáním adresy vašeho webu_.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "Nebo se přihlaste pomocí magického odkazu";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Uspořádaný seznam";
@@ -3981,7 +4275,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "Odsazení";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Stránka";
 
@@ -4014,8 +4309,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "Rodičovství";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Heslo";
 
@@ -4032,8 +4330,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "Vložte blok za";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Čekající na schválení";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Čeká na schválení";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4064,6 +4366,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "Vyberte uživatelské jméno";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Plány";
+
 /* User action to play a video on the editor. */
 "Play video" = "Pustit video";
 
@@ -4087,6 +4393,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "Ujistěte se, že je na vašem webu povolen editor bloků. Pokud není povoleno, nenačte se.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "Zadejte úplnou adresu webu, například example.com.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "Zadejte prosímwebovou adresu.";
@@ -4121,11 +4430,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "Zadejte platnou e-mailovou adresu";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "Zadejte platnou e-mailovou adresu pro účet WordPress.com.";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Zadejte prosím platnou e-mailovou adresu.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "Zadejte telefonní číslo";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Chcete-li se přihlásit pomocí svého Apple ID, zadejte heslo ke svému účtu WordPress.com.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Zadejte prosím své přihlašovací údaje";
@@ -4133,8 +4448,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Prosím uveďte svůj e-mail.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Vyplňte prosím veškerá pole";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Spusťte aplikaci WordPress, přihlaste se na WordPress.com a ujistěte se, že máte alespoň jeden web, potom to zkuste znovu.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "Před připojením k jiné stránce wordpress.com se odhlaste";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "Prosím zkuste to znovu později";
@@ -4199,7 +4520,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "Oblíbené jazyky";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Příspěvek";
 
@@ -4317,6 +4639,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "Oznámení o ochraně osobních údajů pro uživatele Kalifornie";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Soukromé";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "Problém se zobrazením bloku.\nKlepnutím se pokusíte o obnovení blokování.";
 
@@ -4331,6 +4656,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "Problém s nákupem domény. Zkuste to znovu.";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Tento proces odstraní veškerá data WordPress.com z tohoto zařízení, a odstranit všechny lokálně uložené koncepty. Neztratíte nic uložili do svého blogu WordPress.com.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Projekty";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "Výzva přeskočena";
@@ -4348,13 +4679,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "Datum publikování";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Publikovat okamžitě";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "Publikovat stránku na:";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "Publikovat příspěvek na:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Publikováno";
 
@@ -4550,7 +4885,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "Odpovědět";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Text odpovědi";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "Odpovědět na %1$@";
 
 /* An explaination of a setting. */
@@ -4579,6 +4919,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "Obnovit filtr časového období";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Resetovat vaše heslo";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Změnit velikost a oříznutí";
@@ -4636,6 +4979,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "Zopakujte všechno";
 
+/* No comment provided by engineer. */
+"Retry?" = "Opakovat?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "Vrátit se k příspěvku";
 
@@ -4665,6 +5011,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "Role";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS byla odeslána";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "STAV";
 
@@ -4673,6 +5022,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4739,7 +5089,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "Skenování souborů";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Načasováno";
 
 /* No comment provided by engineer. */
@@ -4876,6 +5227,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "Vybere toto téma jako záměr vašeho webu.";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Poslat odkaz";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "Odeslat odkaz e-mailem";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "Odeslat zprávu protokolu";
 
@@ -4884,6 +5241,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "Odešlete testovací chybu";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "Odeslat odkaz na ověření e-mailu";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "Posílat oznámení e-mailem";
@@ -4929,6 +5289,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message to show when setting save failed */
 "Settings update failed" = "Aktualizace nastavení selhala";
+
+/* Spoken accessibility label */
+"Share" = "Sdílet";
 
 /* Title for a button that recommends the app to others */
 "Share Jetpack with a friend" = "Sdílejte Jetpack s přítelem";
@@ -4982,6 +5345,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "Ukázat reblog tlačítko";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "Zobrazit heslo";
+
 /* No comment provided by engineer. */
 "Show post content" = "Zobrazit obsah příspěvku";
 
@@ -4993,6 +5360,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "Zobrazeny statistiky pro:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "Zobrazeno";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Zobrazit publikované komentáře na vašem blogu.";
@@ -5008,6 +5378,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "Zobrazuje příspěvek";
+
+/* View title during the sign up process. */
+"Sign Up" = "Zaregistrovat se";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "Přihlaste se pomocí přihlašovacích údajů k webu";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Přihlásit se";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Přihlásit se k WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Zaregistrujte se pomocí e-mailu";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "Jelikož máte bezplatný plán, uvidíte v protokolu aktivit omezené události.";
@@ -5046,6 +5431,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Úspěchy webu";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Adresa webu";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "Adresa webu musí obsahovat alespoň 4 znaky";
@@ -5130,7 +5518,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Adresa webu musí obsahovat také nějaké písmeno!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Tato e-mailová adresa je již používána";
 
 /* No comment provided by engineer. */
@@ -5190,6 +5578,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "Spam";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "Zrychlete svůj web";
@@ -5215,6 +5606,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "Země";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "Statická domovská stránka";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5245,6 +5639,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "Přeškrtnutí";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Pahýl";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "Odeslat ke kontrole";
@@ -5332,7 +5729,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "Tablet";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Štítek";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5455,6 +5853,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Podmínky služby";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Ohlasy";
+
 /* Title of a button style */
 "Text Only" = "Pouze text";
 
@@ -5464,8 +5865,14 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "Ovládací prvky formátování textu se při úpravě textového bloku nacházejí na panelu nástrojů nad klávesnicí";
 
+/* Button title */
+"Text me a code instead" = "Pošlete mi raději kód.";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Děkujeme, že používáte %1$@ od autora %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "Zdá se, že to není platný ověřovací kód.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "Vypadá to, že toto není WordPress web.";
@@ -5487,6 +5894,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "Připojení k Facebooku nemůže najít žádné stránky. Publicita se nemůže připojit k profilům Facebooku, pouze k publikovaným stránkám.";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "Účet Google \"%@\" neodpovídá žádnému účtu na WordPress.com";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "Vypadá to, že jste offline.";
@@ -5523,6 +5933,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "Obrázek nelze přidat do knihovny médií.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "Zdá se, že nejste připojeni k internetu.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "Druhy webů, které lze vytvořit";
@@ -5566,6 +5979,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Webová stránka %1$@ používá WordPress %2$@. Neprodleně aktualizujte na poslední verzi WordPress %3$@";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "Web na této adrese není web WordPress. Abychom se k němu mohli připojit, musí web používat WordPress.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "Webová stránka nemůže být odstraněna.";
 
@@ -5607,6 +6024,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "Došlo k neočekávané chybě při úpravě vašeho komentáře";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "Při načítání komentářů došlo k neočekávané chybě.";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "Během registrace domény došlo k neočekávané chybě";
 
@@ -5615,6 +6035,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "Došlo k neočekávané chybě při aktualizaci nastavení oznámení";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "Během aktualizace komentáře se vyskytla neočekávaná chyba";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "Došlo k neočekávané chybě.";
@@ -5636,6 +6059,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "Při komunikaci se stránkou došlo k problému.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "Došlo k potížím s připojením k serveru WordPress.com. Přihlaste se znovu.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "Došlo k potížím při zobrazování tohoto příspěvku.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "Při načítání dat došlo k potížím. Obnovte stránku a zkuste to znovu.";
 
@@ -5645,12 +6074,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "Došlo k chybě při ukládání změn v nastavení sdílení.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "Došlo k chybě při pokusu načíst vaší polohu. Zkuste to později znovu.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "Při změně hesla došlo k chybě.";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "Při načítání aktivit došlo k chybě";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "Došlo k chybě při načítání plánů";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "Při načítání pluginů došlo k chybě";
@@ -5663,6 +6098,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "Při načítání historie došlo k chybě.";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "Došlo k chybě při načítání plánu";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "Při načítání historie skenování došlo k chybě";
@@ -5711,6 +6149,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "Tato doména není k dispozici";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "Tato e-mailová adresa není zaregistrována na WordPress.com.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "Tento soubor je příliš velký na nahrání na váš web nebo nepodporuje tento formát média.";
@@ -5804,6 +6245,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "Pro pokračování prosím uveďte svůj e-mail a jméno.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "Chcete-li vytvořit svůj nový účet WordPress.com, zadejte svou emailovou adresu.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "Chcete-li ze svého webu WordPress dostávat do telefonu užitečná upozornění, musíte si nainstalovat plugin Jetpack.";
 
@@ -5812,6 +6256,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "Chcete-li nainstalovat pluginy, musíte mít k vašemu webu přidruženou vlastní doménu.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "Chcete-li pokračovat s tímto Apple ID, nejprve se přihlaste pomocí svého hesla WordPress.com. Toto bude požádáno pouze jednou.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "Chcete-li pokračovat v tomto účtu Google, nejprve se přihlaste pomocí svého hesla WordPress.com. Toto bude požádáno pouze jednou.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "Chcete-li odstranit blok, vyberte blok a kliknutím na tři tečky v pravé dolní části bloku zobrazte nastavení. Odtud vyberte možnost odstranění bloku.";
@@ -5883,7 +6333,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "Odstranit";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "Koš";
 
@@ -5897,6 +6348,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "Vyzkoušet a upravit";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Opakovat";
@@ -5922,6 +6374,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "Vyzkoušet nový blokový editor";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Zkusit s jiným e-mailem";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Zkuste adresu webu";
 
 /* Title for a button which takes the user to the WordPress app's settings in the system Settings app. */
 "Turn on notifications" = "Zapnout notifikace";
@@ -5961,6 +6419,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "USES";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "Připojení se nezdařilo";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "Nedaří se načíst příspěvky";
@@ -6010,6 +6471,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Nelze přehrát video";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Nelze číst WordPress web na této adrese URL. Klepněte na 'Potřebujete další pomoc?' pro zobrazení FAQ.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Web nelze obnovit";
 
@@ -6036,6 +6500,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "Nelze nahrát 1 příspěvek, 1 soubor";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "E-mailovou adresu nelze ověřit. Prosím zkuste to znovu později.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "Nelze zobrazit nastavení Jetpack pro web";
@@ -6168,7 +6635,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Nahrávání selhalo";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Nahráno";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6186,7 +6654,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Nahrané šablony";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Nahrávám";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6207,12 +6676,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Use icon button" = "Použijte ikonu tlačítka";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "Pro přihlášení použijte heslo";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Uživatelské jméno";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6227,6 +6702,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Uživatelé";
+
+/* two factor code placeholder */
+"Verification code" = "Ověřovací kód";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "Byl odeslán ověřovací e-mail, zkontrolujte doručenou poštu.";
@@ -6359,6 +6837,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "WP-content adresář";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Čekání na dokončení Google…";
+
+/* View title during the Google auth process. */
+"Waiting..." = "Čekejte, prosím...";
+
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
    Title for Jetpack Restore Warning screen */
@@ -6397,6 +6881,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "Měli jsme potíže s načtením dat";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "Právě jsme zaslali e-mailem odkaz na %@. Zkontrolujte svůj e-mail a přihlaste se klepnutím na odkaz.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "Právě jsme poslali kouzelný odkaz";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "Úspěšně jsme vytvořili zálohu vašeho webu od %@";
 
@@ -6406,14 +6896,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "Používáme další nástroje pro měření, včetně některých nástrojů od třetích stran. Přečtěte si více o těchto nástrojích a jak je ovládat.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "V tuto chvíli jsme vám nemohli poslat e-mail. Prosím zkuste to znovu později.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Pokud budou nalezeny bezpečnostní hrozby, zašleme vám e-mail. Mezitím můžete svůj web nadále používat jako obvykle, pokrok můžete kdykoli zkontrolovat.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "Zašleme vám email, který vás okamžitě přihlásí, bez hesla.";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "Zašleme vám e-mail s odkazem k vytvoření nového účtu WordPress.com.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "Dáme vám vědět, pokud získáte sledující, komentáře a lajky.";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "Budeme vás informovat, když získáte nové sledující, komentáře a lajky. Chcete povolit push oznámení?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "Tuto e-mailovou adresu použijeme k vytvoření vašeho nového účtu WordPress.com.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "Vytváříme zálohu vašeho webu ke stažení z %1$@.";
@@ -6424,6 +6926,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Tvrdě pracujeme na opravování těchto hrozeb na pozadí. Mezitím můžete svůj web nadále používat jako obvykle, pokrok můžete kdykoli zkontrolovat.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "Na dané adrese URL se nemůžeme připojit k webu Jetpack. Požádejte nás o pomoc.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "Obnovujeme váš web zpět na %1$@.";
 
@@ -6432,6 +6937,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "Také jsme vám zaslali e-mailem odkaz na váš soubor.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Poslali jsme vám e-mailem odkaz na přihlášení k vytvoření nového účtu WordPress.com. Zkontrolujte svůj e-mail v tomto zařízení a klepněte na odkaz v e-mailu, který obdržíte z WordPress.com.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6458,6 +6966,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "Týdenní shrnutí: %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "Vítejte v Jetpacku";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Vítejte ve WordPressu!";
 
 /* A message title */
 "Welcome to the Reader" = "Vítejte ve čtečce";
@@ -6499,6 +7013,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title displayed via UIAlertController when a user inserts a document into a post. */
 "What do you want to do with this file: upload it and add a link to the file into your post, or add the contents of the file directly to the post?" = "Co chcete s tímto souborem udělat: nahrát jej a přidat odkaz na soubor do vašeho příspěvku, nebo přidat obsah souboru přímo do příspěvku?";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "Co je nového na WordPress.com?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "Co je to blok?";
 
@@ -6517,6 +7034,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "Co je nového na WordPressu";
 
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "Jaká je adresa mého webu?";
+
 /* Select the site's intent. Title */
 "What's your website about?" = "O čem je váš web?";
 
@@ -6528,6 +7048,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "Když na svém webu provedete změny, uvidíte zde svoji historii aktivit.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Jejda, něco se pokazilo a nemohli jsme vás přihlásit. Zkuste to prosím znovu!";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Jejda, nejde o platný dvoufaktorový ověřovací kód. Zkontrolujte svůj kód a zkuste to znovu!";
 
 /* No comment provided by engineer. */
 "Width Settings" = "Nastavení šířky";
@@ -6541,17 +7067,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "Nastavení aplikace WordPress";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "WordPress Apps – Aplikace pro jakoukoli obrazovku";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "Web vývojářů WordPressu";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "Nápověda WordPress";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "WordPress knihovna médií";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "Nastavení oznámení WordPress";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "Oznámení WordPress";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "WordPress pluginy";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "Profil WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "WordPress Reader";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "Podrobnosti o webu WordPress";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "WordPress šablony ";
@@ -6562,17 +7109,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "WordPress síť webů není podporována";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress potřebuje oprávnění pro přístup k aktuální polohy zařízení, aby ji přidat do příspěvku. Aktualizujte nastavení ochrany osobních údajů.";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "WordPress root";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "Příliš stará verze WordPress";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Verze WordPress je příliš stará. Na webu %1$@ používáte WordPress ve verzi %2$@. Doporučujeme aktualizaci na nejnovější verzi, nebo alespoň %3$@";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "WordPress.com Účet";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "WordPress.com plány";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "WordPress.com šablony";
@@ -6600,6 +7156,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "Napsat příspěvek";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "Napsat odpověď";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "Odpovědět...";
 
 /* Title for the writing section in site settings screen */
@@ -6613,6 +7172,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Pozice na ose Y";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "Rok";
@@ -6703,7 +7265,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "Nemáte nastavena žádná připomenutí.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Máte neuložené změny.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -6795,6 +7358,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "Vaše vyhledávání obsahuje znaky, které nejsou podporovány v doménách WordPress.com. Jsou povoleny pouze alfanumerické znaky: A–Z, a–z, 0–9.";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "Při návštěvě webu v Safari se na liště v horní části obrazovky zobrazí vaše adresa.";
 
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "Vaše stránky jsou již chráněny VaultPress. Níže naleznete odkaz na svůj řídicí panel VaultPress.";
@@ -6927,6 +7493,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for more button in dashboard quick start card. */
 "ellipsisButton.AccessibilityLabel" = "Více";
+
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "example.com";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "Nastavte si připomenutí blogů";
@@ -7309,6 +7879,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is one of the buttons we display when prompting the user for a review */
 "notifications.appRatings.sendFeedback.yes.buttonTitle" = "Odeslat zpětnou vazbu";
 
+/* No comment provided by engineer. */
+"password" = "heslo";
+
 /* Card title for the pesonalization menu */
 "personalizeHome.dashboardCard.blaze" = "Zvýraznění";
 
@@ -7501,6 +8074,69 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Verb. Dismiss the web view screen. */
 "webKit.button.dismiss" = "Odmítnout";
 
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "Nejlepší pohledy ze všech";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Příspěvky";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "Zůstaňte v obraze o všech aktivitách na vašem WordPress webu.";
+
+/* Title of all time widget */
+"widget.alltime.title" = "Za celou dobu";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "Přihlaste se do WordPressu, abyste viděli všechny časové statistiky.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "Pro zobrazení všech statistik se přihlaste do Jetpacku.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "Pro zobrazení statistik z tohoto týdne se přihlaste do Jetpacku.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "Pro zobrazení dnešních statistik se přihlaste do Jetpacku.";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "Zůstaňte v obraze o aktivitě tohoto týdne na vašem WordPress webu.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "Tento týden";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "Přihlaste se do WordPressu a podívejte se na statistiky tohoto týdne.";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Komentáře";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "To se mi líbí";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "Nelze načíst statistiky webu.";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "Nelze načíst statistiky webu.";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "Zůstaňte v obraze o dnešních aktivitách na vašem WordPress webu.";
+
+/* Title of today widget */
+"widget.today.title" = "Dnes";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "Chcete-li zobrazit dnešní statistiky, přihlaste se do WordPressu.";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "Zobrazení není k dispozici";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Zobrazení";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Návštěvníci";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "nebude v budoucnu k dispozici.";
 
@@ -7542,6 +8178,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Jetpack Plugin Modal title in WordPress */
 "wordpress.jetpack.plugin.modal.title" = "Tento web není aplikací WordPress podporován";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Přihlaste se pomocí Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Darování";

--- a/WordPress/Resources/cy.lproj/Localizable.strings
+++ b/WordPress/Resources/cy.lproj/Localizable.strings
@@ -59,6 +59,9 @@
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Dideitl)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(dim teitl)";
+
 /* Menus button text for adding a new menu to a site. */
 "+ Add new menu" = "+ Ychwanegu dewislen newydd";
 
@@ -67,6 +70,9 @@
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "Teitl y wefan";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "Mae angen cyfeiriad e-bost dilys er mwyn anfon dolen dilysu. Ewch nôl i'r sgrin flaenorol a darparu cyfeiriad e-bost dilys.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "GWEITHREDOL";
@@ -141,6 +147,9 @@
    Label for the alt for a media asset (image) */
 "Alt Text" = "Testun Amgen";
 
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "Mae angen cysylltiad rhyngrwyd gweithredol i weld y cynlluniau";
+
 /* An error description explaining that a Menu could not be created. */
 "An error occurred creating the Menu." = "Digwyddodd gwall wrth greu'r Ddewislen.";
 
@@ -164,6 +173,9 @@
 
 /* Error recorded when all of the media associated with a post fail to be attached to the post on the server. */
 "An error occurred when attempting to attach uploaded media to the post." = "Digwyddodd gwall wrth geisio atodi cyfrwng wedi ei lwytho i fyny i'r cofnod...";
+
+/* the comment has an anonymous author. */
+"Anonymous" = "Dienw";
 
 /* App Settings Title
    Link to App Settings section
@@ -233,6 +245,9 @@
    Previous web page */
 "Back" = "Nôl";
 
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Byddwch y cyntaf i adael sylwadau.";
+
 /* Accessibility label for block quote button on formatting toolbar.
    Discoverability title for block quote keyboard shortcut. */
 "Block Quote" = "Dyfyniad Bloc";
@@ -262,9 +277,13 @@
 /* Accessibility label for taking an image or video with the camera on formatting toolbar. */
 "Camera" = "Camera";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Methu gwneud Cais am Ddnolen";
+
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -274,6 +293,7 @@
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -292,6 +312,7 @@
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -314,13 +335,15 @@
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Egluryn";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Gofal!";
 
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Categorïau";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Categori";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -350,6 +373,7 @@
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Cau";
 
@@ -361,6 +385,9 @@
 
 /* Close Comments Title */
 "Close commenting" = "Cau sylwadau";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Comics";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -384,6 +411,7 @@
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Nodiadau";
 
@@ -440,6 +468,9 @@
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Bydd cysylltu â %1$@ yn disodli'r cysylltiad presennol â %2$@.";
 
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Cysylltu â WordPress.com";
+
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Cysylltu...";
 
@@ -493,6 +524,9 @@
    Register Domain - Domain contact information field Country */
 "Country" = "Gwlad";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Creu Cyfrif";
+
 /* Button to progress to the next step
    Site creation. Step 1. Screen title
    Title for the button to progress with creating the site with the selected design. */
@@ -503,6 +537,9 @@
 
 /* No comment provided by engineer. */
 "Current" = "Cyfredol";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Y Cynllun Cyfredol";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Y Thema Bresennol";
@@ -521,6 +558,9 @@
    Title for selecting a default category for a post */
 "Default Category" = "Categori Rhagosodedig";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Dewislen Ragosodedig";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Fformat Cofnod Rhagosodedig";
@@ -529,6 +569,7 @@
 "Defaults for New Posts" = "Rhagosodiadau Gwefannau Newydd";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Dileu";
@@ -591,7 +632,9 @@
    Title for the Discussion Settings Screen */
 "Discussion" = "Trafodaeth";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Cau";
 
 /* Display Name label text.
@@ -614,6 +657,9 @@
    Title for button that will dismiss this view
    Title for the button that will dismiss this view. */
 "Done" = "Gorffen";
+
+/* Name for the status of a draft post. */
+"Draft" = "Drafft";
 
 /* Editing GIF alert default action button.
    Edits a Comment
@@ -699,6 +745,9 @@
 /* Overlay message displayed while starting content export */
 "Exporting content…" = "Allforio cynnwys...";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Methwyd";
+
 /* Error message to show when wrong URL format is used to access the REST API */
 "Failed to serialize request to the REST API." = "Methwyd cyfresu cais i'r API REST.";
 
@@ -725,6 +774,9 @@
    User's First Name */
 "First Name" = "Enw Cyntaf";
 
+/* Button title. Follow the comments on a post. */
+"Follow" = "Dilyn";
+
 /* User role badge */
 "Follower" = "Dilynwr";
 
@@ -742,6 +794,12 @@
 
 /* Title for the general section in site settings screen */
 "General" = "Cyffredinol";
+
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Estyn manylion cyfrif";
+
+/* Cancel */
+"Give Up" = "Rhoi'r Gorau";
 
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
@@ -761,6 +819,9 @@
    Open editor help options
    Title of the 'Help & Support' screen within the 'Me' tab - used for spotlight indexing on iOS. */
 "Help & Support" = "Cymorth a Chefnogaeth";
+
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Cudd";
 
 /* No comment provided by engineer. */
 "Hide keyboard" = "Cuddio bysellfwrdd";
@@ -792,6 +853,9 @@
 
 /* Describes a standard *.wordpress.com site domain */
 "Included with Site" = "Wedi ei Gynnwys gyda'r Wefan";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Enw defnyddiwr neu gyfrinair anghywir. Ceisiwch fewngofnodi eto.";
 
 /* WordPress.com Community Footer Text */
 "Information on WordPress.com courses and events (online & in-person)." = "Gwybodaeth am gyrsiau a digwyddiadau WordPress.com (ar-lein a byw).";
@@ -898,7 +962,8 @@
 /* Setting: indicates if Replies to your comments will be notified */
 "Likes on my posts" = "Hoffi ar fy nghofnodion";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Cyswllt i";
 
 /* Menus title label when editing a menu item as a link. */
@@ -921,6 +986,12 @@
 /* Menus label text displayed while menus are loading */
 "Loading Menus..." = "Llwytho Dewislenni ...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Wrthi'n Llwytho Cynllun...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Wrthi'n Llwytho Cynlluniau...";
+
 /* Menus label text displayed when a menu is loading. */
 "Loading menu..." = "Llwytho dewislen...";
 
@@ -931,19 +1002,39 @@
    Text displayed while loading time zones */
 "Loading..." = "Llwytho...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Lleol";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Lleoliad";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Rhaid galluogi Gwasanaethau Lleoliad cyn y gall WordPress ychwanegu eich lleoliad cyfredol. Galluogwch Wasanaethau Lleoliad o'r ap Gosodiadau.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Lleoliad anhysbys";
+
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Ffeiliau Cofnod yn ôl Dyddiad Creu";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Mewngofnodi";
+
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Mewngofnodi wedi methu. Ceisiwch eto.";
 
 /* Login Request Expired */
 "Login Request Expired" = "Daeth y Cais Mewngofnodi i Ben";
 
 /* No comment provided by engineer. */
 "Logs" = "Cofnodion";
+
+/* Title of a button. */
+"Lost your password?" = "Wedi colli eich cyfrinair?";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Llywio";
@@ -1022,6 +1113,9 @@
 /* New Post 3D Touch Shortcut */
 "New Post" = "Cofnod Newydd";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Eitem newydd";
+
 /* Screen title, where users can see the newest plugins */
 "Newest" = "Diweddaraf";
 
@@ -1029,7 +1123,9 @@
 "Newest first" = "Diweddaraf yn gyntaf";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Nesaf";
 
 /* Label for a cancel button */
@@ -1058,7 +1154,8 @@
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "Dim sylwadau eto";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "Dim cysylltiad";
 
@@ -1126,7 +1223,12 @@
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Rhestr wedi'i Rhifo";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "Iawn";
@@ -1162,10 +1264,16 @@
    Title for the view when there's an error loading time zones */
 "Oops" = "Wps";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Wps!";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Agor E-bost";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Agor y Gosodiadau";
 
 /* No comment provided by engineer. */
@@ -1202,7 +1310,8 @@
    Other Sites Notification Settings Title */
 "Other Sites" = "Gwefannau Eraill";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Tudalen";
 
@@ -1219,14 +1328,21 @@
 /* Title for selecting parent category of a category */
 "Parent Category" = "Categori Rhiant";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Cyfrinair";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Dan Ystyriaeth";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Disgwyl adolygiad";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -1239,6 +1355,10 @@
 /* Section title for the personalize table section in the blog details screen. */
 "Personalize" = "Personoli";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Cynlluniau";
+
 /* Politely asks the user to check their internet connection before trying again. */
 "Please check your internet connection and try again." = "Gwiriwch eich cysylltiad rhyngrwyd a cheisiwch eto.";
 
@@ -1248,11 +1368,14 @@
 /* No comment provided by engineer. */
 "Please enter a username." = "Rhowch enw defnyddiwr.";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Rhowch gyfeiriad e-bost dilys.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Rhowch eich manylion";
+
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Llenwch pob maes";
 
 /* No comment provided by engineer. */
 "Please try entering your login details again." = "Ceisiwch fewngofnodi eto.";
@@ -1264,7 +1387,8 @@
 /* Section title for Popular Languages */
 "Popular languages" = "Ieithoedd poblogaidd";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Cofnod";
 
@@ -1313,12 +1437,25 @@
 /* Title of button that displays the App's privacy policy */
 "Privacy Policy" = "Polisi Preifatrwydd";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Preifat";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Bydd parhau'n golygu tynnu data WordPress.com i gyd o'r ddyfais hon a dileu'r drafftiau lleol rydych wedi'u cadw. Byddwch chi ddim yn colli dim wedi ei gadw i'ch blog(iau) WordPress.com.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Projectau";
+
 /* Label for the publish (verb) button. Tapping publishes a draft post.
    Publish post action on share extension site picker screen.
    Section title for the publish table section in the blog details screen */
 "Publish" = "Cyhoeddi";
 
-/* Period Stats 'Published' header
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Cyhoeddi'n Syth";
+
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Cyhoeddwyd";
 
@@ -1394,6 +1531,9 @@
    Verb. Button title. Reply to a comment. */
 "Reply" = "Ateb";
 
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Testun Ateb";
+
 /* An explaination of a setting. */
 "Require manual approval for comments that include more than this number of links." = "Bydd angen cymeradwyaeth â llaw ar gyfer sylwadau sy'n cynnwys mwy na'r nifer yma o ddolenni.";
 
@@ -1434,6 +1574,9 @@
    User action to retry media upload. */
 "Retry" = "Ceisiwch eto";
 
+/* No comment provided by engineer. */
+"Retry?" = "Ceisio eto?";
+
 /* Cancels a pending Email Change */
 "Revert Pending Change" = "Dychwelyd y Newid sydd o dan Ystyriaeth";
 
@@ -1448,8 +1591,12 @@
    User's Role */
 "Role" = "Rôl";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS wedi ei anfon";
+
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -1459,7 +1606,8 @@
 /* Menus save button title while it is saving a Menu. */
 "Saving..." = "Wrthi'n Cadw...";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Amserlenwyd";
 
 /* Title of Stats section that shows search engine referrer traffic. */
@@ -1479,6 +1627,9 @@
 
 /* Menus alert message for alerting the user to unsaved changes while trying to select a different menu. */
 "Selecting a different menu will discard changes you've made to the current menu. Are you sure you want to continue?" = "Bydd dewis dewislen gwahanol yn gwaredu'r newidiadau rydych wedi eu gwneud i'r ddewislen ar hyn o bryd. A ydych yn siŵr eich bod am barhau?";
+
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Anfon Dolen";
 
 /* Settings: Sending Pingbacks */
 "Send Pingbacks" = "Anfon Hysbysiadau Cyfeirio";
@@ -1503,6 +1654,9 @@
 
 /* Message to show when setting save failed */
 "Settings update failed" = "Methodd diweddaru'r gosodiadau";
+
+/* Spoken accessibility label */
+"Share" = "Rhannu";
 
 /* Aztec's Text Placeholder
    Share Extension Content Body Text Placeholder */
@@ -1578,7 +1732,7 @@
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Ymddiheuriadau, rhaid i enw gwefan gynnwys llythrennau hefyd!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Mae'r cyfeiriad e-bost yna eisoes yn cael ei ddefnyddio!";
 
 /* No comment provided by engineer. */
@@ -1653,7 +1807,8 @@
    Theme Support action title */
 "Support" = "Cefnogaeth";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Tag";
 
 /* Label for tagline blog setting
@@ -1678,6 +1833,9 @@
 
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Amodau Gwasanaeth";
+
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Tystebau";
 
 /* Title of a button style */
 "Text Only" = "Testun yn Unig";
@@ -1714,6 +1872,9 @@
 
 /* Message for when the certificate for the server is invalid. The %@ placeholder will be replaced the a host name, received from the API. */
 "The certificate for this server is invalid. You might be connecting to a server that is pretending to be “%@” which could put your confidential information at risk.\n\nWould you like to trust the certificate anyway?" = "Mae'r dystysgrif ar gyfer y gweinydd hwn yn annilys. Gall eich bod yn cysylltu â gweinydd sy'n esgus bod yn “%@” sy'n gallu peryglu eich gwybodaeth gyfrinachol.\n\nHoffech chi ymddiried yn y dystysgrif beth bynnag?";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "Mae'n ymddangos bod y cysylltiad rhyngrwyd all-lein.";
 
 /* Footer Text displayed in Blog Language Settings View */
 "The language in which this site is primarily written." = "Yr iaith mae'r blog yn cael ei ysgrifennu ynddi yn bennaf.";
@@ -1765,17 +1926,32 @@
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "Bu gwall annisgwyl tra'n diweddaru eich Gosodiadau Hysbysu";
 
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "Bu gwall annisgwyl wrth ddiweddaru eich sylw";
+
 /* Informs the user about an issue connecting to the third-party sharing service. The `%@` is a placeholder for the service name. */
 "There is an issue connecting to %@. Reconnect to continue publicizing." = "Bu anhawster cysylltu â %@. Ailgysylltwch i barhau'r cyhoeddusrwydd.";
 
 /* Error message informing the user that there was a problem blocking posts from a site from their reader. */
 "There was a problem blocking posts from the specified site." = "Bu anhawster wrth rwystro cofnodion o'r wefan honno.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "Bu anhawster wrth gysylltu â WordPress.com. Mewngofnodwch eto.";
+
 /* Error message informing the user that there was a problem clearing the block on site preventing its posts from displaying in the reader. */
 "There was a problem removing the block for specified site." = "Bu anhawster wrth gael gwared ar y bloc ar gyfer gwefan benodol.";
 
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "Bu anhawster cadw newidiadau i'r rheolaeth rhannu.";
+
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "Bu anhawster wrth geisio cael mynediad i'ch lleoliad. Ceisiwch eto.";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "Bu gwall wrth lwytho'r cynlluniau";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "Bu gwall wrth lwytho'r cynllun";
 
 /* An error message display if the users device does not have a camera input available */
 "This app needs permission to access the Camera to capture new media, please change the privacy settings if you wish to allow this." = "Mae'r ap angen caniatâd i gael mynediad at y Camera i gipio cyfryngau newydd, newidiwch y gosodiadau preifatrwydd os ydych yn dymuno caniatáu hyn.";
@@ -1823,7 +1999,8 @@
    Trashes the comment */
 "Trash" = "Dileu";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "Wedi eu rhoi yn y sbwriel";
 
@@ -1834,6 +2011,7 @@
 "Try & Customize" = "Defnyddio a chyfaddasu";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Ceisiwch Eto";
@@ -1920,10 +2098,12 @@
 /* Label action for updating a link on the editor */
 "Update Link" = "Diweddaru Dolen";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Wedi ei lwytho";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Llwytho i fyny";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -1933,11 +2113,14 @@
 "Use" = "Defnydd";
 
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Enw defnyddiwr";
 
 /* Setting: indicates if Mentions will be notified */
@@ -1949,6 +2132,9 @@
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Defnyddwyr";
+
+/* two factor code placeholder */
+"Verification code" = "Cod dilysu";
 
 /* Push Authentication Alert Title */
 "Verify Log In" = "Dilysu Mewngofnodi";
@@ -2039,14 +2225,23 @@
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "Blog WordPress";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "Mae angen WordPress caniatâd i gael lleoliad cyfredol eich dyfais er mwyn ei ychwanegu at eich cofnod. Diweddarwch eich gosodiadau preifatrwydd.";
+
 /* No comment provided by engineer. */
 "WordPress version too old" = "Mae'r fersiwn yma o WordPress yn rhy hen";
+
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Mae eich fersiwn o WordPress yn rhy hen. Mae'r wefan %1$@ yn defnyddio WordPress %2$@. Rydym yn argymell ei diweddaru i'r fersiwn diweddaraf, neu o leiaf %3$@";
 
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "Cyfrif WordPress.com";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "WordPress.com Plans";
 
 /* WordPress.com Notification Settings Title */
 "WordPress.com Updates" = "Diweddariadau WordPress.com";
@@ -2080,7 +2275,8 @@
 /* Message alert when attempting to delete site with purchases */
 "You have active premium upgrades on your site. Please cancel your upgrades prior to deleting your site." = "Mae gennych uwchraddiadau premiwm gweithredol ar eich gwefan. Diddymwch eich uwchraddiadau cyn dileu eich gwefan.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Mae gennych newidiadau heb eu cadw.";
 
 /* Error message informing the user that being logged into a WordPress.com account is required. */
@@ -2121,4 +2317,22 @@
 
 /* Later today */
 "later today" = "yn hwyrach heddiw";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Cofnodion";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Nodiadau";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Hoffi";
+
+/* Title of today widget */
+"widget.today.title" = "Heddiw";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Golwg";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Ymwelwyr";
 

--- a/WordPress/Resources/da.lproj/Localizable.strings
+++ b/WordPress/Resources/da.lproj/Localizable.strings
@@ -19,6 +19,9 @@
 /* Empty Post Title */
 "(No Title)" = "(Ingen titel)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(ingen titel)";
+
 /* Account Settings Title
    Link to Account Settings section */
 "Account Settings" = "Kontoindstillinger";
@@ -45,6 +48,9 @@
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Alternativ tekst";
+
+/* the comment has an anonymous author. */
+"Anonymous" = "Anonym";
 
 /* Approve action. Verb
    Approve comment (verb)
@@ -91,6 +97,7 @@
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -100,6 +107,7 @@
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -118,6 +126,7 @@
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -159,6 +168,7 @@
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Luk";
 
@@ -175,6 +185,7 @@
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Kommentarer";
 
@@ -186,6 +197,9 @@
 
 /* Verb. Title for Jetpack Restore confirm button. */
 "Confirm" = "Bekræft";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Forbinder til WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Forbinder...";
@@ -209,6 +223,9 @@
 /* Label for list of countries.
    Register Domain - Domain contact information field Country */
 "Country" = "Land";
+
+/* The button title text for creating a new account. */
+"Create Account" = "Opret konto";
 
 /* Button for selecting the current page template.
    Title for button to make a page with the contents of the selected layout */
@@ -242,6 +259,7 @@
 "Default Post Format" = "Standard indlægsformat";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Slet";
@@ -285,7 +303,9 @@
 /* Disconnect from WordPress.com button */
 "Disconnect from WordPress.com" = "Afbryd forbindelse til WordPress.com";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Afvis";
 
 /* A done button
@@ -300,6 +320,9 @@
    Title for button that will dismiss this view
    Title for the button that will dismiss this view. */
 "Done" = "Færdig";
+
+/* Name for the status of a draft post. */
+"Draft" = "Kladde";
 
 /* Editing GIF alert default action button.
    Edits a Comment
@@ -335,7 +358,10 @@
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "E-mail-adresse";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "E-mailadresse";
 
 /* Message to show to user when he tries to add a self-hosted site that is an empty URL. */
@@ -360,6 +386,9 @@
 /* Label for the excerpt field. Should be the same as WP core. */
 "Excerpt" = "Uddrag";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Mislykkedes";
+
 /* Label for the Featured Image area in post settings. */
 "Featured Image" = "Fremhævet billede";
 
@@ -378,6 +407,9 @@
 /* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
 "File type" = "Filtype";
 
+/* Button title. Follow the comments on a post. */
+"Follow" = "Følg";
+
 /* User role badge */
 "Follower" = "Følger";
 
@@ -390,6 +422,12 @@
 /* Full size image. (default). Should be the same as in core WP. */
 "Full Size" = "Fuld størrelse";
 
+/* View title for initial auth views. */
+"Get Started" = "Kom i gang!";
+
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Henter kontooplysninger";
+
 /* Accessibility label for HTML button on formatting toolbar. */
 "HTML" = "HTML";
 
@@ -401,6 +439,9 @@
    Open editor help options
    Title of the 'Help & Support' screen within the 'Me' tab - used for spotlight indexing on iOS. */
 "Help & Support" = "Hjælp & support";
+
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Skjult";
 
 /* No comment provided by engineer. */
 "Hide keyboard" = "Skjul tastatur";
@@ -485,7 +526,8 @@
 /* Setting: indicates if Replies to your comments will be notified */
 "Likes on my posts" = "Likes på mine indlæg";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Link";
 
 /* Link name field placeholder */
@@ -493,6 +535,9 @@
 
 /* Image link option title. */
 "Link To" = "Link til";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Henter planer...";
 
 /* Text displayed while loading the scan section for a site */
 "Loading Scan..." = "Indlæser scan...";
@@ -504,16 +549,33 @@
    Text displayed while loading time zones */
 "Loading..." = "Henter...";
 
-/* Label for logging in to WordPress.com account
+/* Status for Media object that is only exists locally. */
+"Local" = "Lokal";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Placering";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Placering ukendt";
+
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Log ind";
 
 /* Title of a button for signing in. */
 "Log in" = "Log ind";
 
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Log ind fejlede. Prøv venligst igen.";
+
 /* No comment provided by engineer. */
 "Logs" = "Logfiler";
+
+/* Title of a button. */
+"Lost your password?" = "Mistet din adgangskode?";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Hovednavigation";
@@ -576,7 +638,9 @@
 "Newest" = "Nyeste";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Næste";
 
 /* Label for a cancel button */
@@ -632,7 +696,12 @@
    Title of the 'Notifications' tab - used for spotlight indexing on iOS. */
 "Notifications" = "Notifikationer";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -661,7 +730,8 @@
    Title for the view when there's an error loading time zones */
 "Oops" = "Ups";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Åbn Indstillinger";
 
 /* No comment provided by engineer. */
@@ -691,14 +761,21 @@
 /* Title for selecting parent category of a category */
 "Parent Category" = "Forælderkategori";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Kodeord";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Afventer godkendelse";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Afventer godkendelse";
 
 /* Label for date periods. */
 "Period" = "Periode";
@@ -709,11 +786,14 @@
 /* No comment provided by engineer. */
 "Please enter a username." = "Indtast venligst et brugernavn.";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Indtast venligst en gyldig e-mail-adresse.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Indtast venligst dine legitimationsoplysninger";
+
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Udfyld venligts alle felter";
 
 /* No comment provided by engineer. */
 "Please try entering your login details again." = "Prøv at taste dine login oplysninger igen.";
@@ -725,7 +805,8 @@
 /* Section title for Popular Languages */
 "Popular languages" = "Populære sprog";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Indlæg";
 
@@ -757,12 +838,19 @@
 /* Title of button that displays the App's privacy policy */
 "Privacy Policy" = "Privatlivspolitik";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Privat";
+
 /* Label for the publish (verb) button. Tapping publishes a draft post.
    Publish post action on share extension site picker screen.
    Section title for the publish table section in the blog details screen */
 "Publish" = "Udgiv";
 
-/* Period Stats 'Published' header
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Udgiv med det samme";
+
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Udgivet";
 
@@ -837,11 +925,18 @@
    User action to retry media upload. */
 "Retry" = "Prøv igen";
 
+/* No comment provided by engineer. */
+"Retry?" = "Prøv igen?";
+
 /* Right alignment for an image. Should be the same as in core WP. */
 "Right" = "Højre";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS sendt";
+
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -851,7 +946,8 @@
 /* Menus save button title while it is saving a Menu. */
 "Saving..." = "Gemmer...";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Planlagt";
 
 /* Title of Stats section that shows search engine referrer traffic. */
@@ -868,6 +964,15 @@
    Title for screen that allows configuration of your blog/site settings.
    Title for the Jetpack Security Settings Screen */
 "Settings" = "Indstillinger";
+
+/* Spoken accessibility label */
+"Share" = "Del";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Tilmeld dig";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Registrer dig på WordPress.com";
 
 /* Title for the Language Picker View */
 "Site Language" = "Webstedets sprog";
@@ -902,7 +1007,7 @@
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Beklager, webstedsadresser skal også have bogstaver!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Beklager, den e-mail-adresse er allerede i brug!";
 
 /* No comment provided by engineer. */
@@ -990,6 +1095,9 @@
 /* Example post title used in the login prologue screens. This is a post about football fans. */
 "The World's Best Fans" = "Verdens bedste fans";
 
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "Internetforbindelsen ser ud til at være nede.";
+
 /* No comment provided by engineer. */
 "The site address must be shorter than 64 characters." = "Adressen på webstedet skal være kortere end 64 tegn.";
 
@@ -1003,6 +1111,9 @@
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "Der er sket en uventet fejl under opdateringen af notifikationsindstillingerne";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "Der opstod en fejl under indlæsningen af planen.";
 
 /* Thumbnail image size. Should be the same as in core WP. */
 "Thumbnail" = "Miniaturebillede";
@@ -1031,6 +1142,7 @@
 "Trust" = "Tillid";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Prøv igen";
@@ -1071,21 +1183,26 @@
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Upload fejlede";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Uploadet";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Uploader";
 
 /* No comment provided by engineer. */
 "Uploading…" = "Overfører...";
 
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Brugernavn";
 
 /* No comment provided by engineer. */
@@ -1131,6 +1248,9 @@
    Today's Stats 'Visitors' label */
 "Visitors" = "Besøgende";
 
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Velkommen til WordPress";
+
 /* Title displayed in the Notification Settings for WordPress.com */
 "We’ll always send important emails regarding your account, but you can get some helpful extras, too." = "Vi vil altid sende vigtige e-mails vedrørende din konto, men kan også modtage nyttig ekstramateriale.";
 
@@ -1159,7 +1279,8 @@
 /* No comment provided by engineer. */
 "You cannot use that email address to signup. We are having problems with them blocking some of our email. Please use another email provider." = "Du kan ikke bruge den e-mail-adresse ved tilmelding. Vi har problemer med, at de blokerer nogle af vores e-mails. Benyt venligst en anden e-mail-udbyder.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Du har ikke gemt dine ændringer";
 
 /* Title for a view milestone push notification */
@@ -1191,4 +1312,22 @@
 
 /* Later today */
 "later today" = "senere i dag";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Indlæg";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Kommentarer";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Likes";
+
+/* Title of today widget */
+"widget.today.title" = "I dag";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Visninger";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Besøgende";
 

--- a/WordPress/Resources/de.lproj/Localizable.strings
+++ b/WordPress/Resources/de.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Translation-Revision-Date: 2025-05-13 11:54:08+0000 */
+/* Translation-Revision-Date: 2025-03-22 22:41:00+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
 /* Generator: GlotPress/4.0.1 */
 /* Language: de */
@@ -99,6 +99,9 @@
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "%1$@ von %2$@ auf deiner Website";
 
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "%1$@ von %2$@, die auf deiner Seite verwendet wird";
+
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ Billiarden";
 
@@ -189,7 +192,7 @@
 
 /* translators: Block name. %s: The localized block name
 translators: %s: Block name e.g. \"Image block\" */
-"%s block" = "Block %s";
+"%s block" = "%s blockieren";
 
 /* translators: %s: block title e.g: \"Paragraph\". */
 "%s block options" = "%s Blockoptionen";
@@ -235,6 +238,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Ohne Titel)";
+
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(kein Titel)";
 
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*Johan Brandt* hat auf deinen Beitrag geantwortet";
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "Der Button „Mehr“ enthält ein Aufklappmenü mit Teilen-Buttons.";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "Ein WordPress.com-Konto ist mit deinen Shop-Anmeldedaten verknüpft. Um fortzufahren, senden wir einen Bestätigungslink an die oben angegebene E-Mail-Adresse.";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "Eine Datei enthält ein bösartiges Codemuster";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "Website-Titel";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "Für die Zusendung des Authentifizierungs-Links wird eine gültige E-Mail-Adresse benötigt. Bitte kehre zum vorherigen Bildschirm zurück und gib eine gültige E-Mail-Adresse an.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "Der Verifizierungscode besteht ausschließlich aus Zahlen.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "AKTIV";
@@ -334,9 +349,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* My Profile 'About me' label */
 "About Me" = "Über mich";
-
-/* Link to About screen for Jetpack for iOS */
-"About Reader for iOS" = "Über den Reader für iOS";
 
 /* Link to About screen for WordPress for iOS */
 "About WordPress" = "Über WordPress";
@@ -525,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "Nach %@";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "Ausrichtung";
@@ -588,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "IP-Adressen als zulässig gespeichert";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "Fast geschafft! Gib bitte den Verifizierungscode aus deiner Authenticator-App ein.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Alt-Text";
@@ -600,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "Alternativ kannst du die Tiefe des Inhalts reduzieren, indem du die Gruppierung des Blocks aufhebst.";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "Alternativ kannst du das Passwort für dieses Konto eingeben.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "Alternativ:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "Crash-Logs immer senden";
@@ -621,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "Für die Anzeige der Aktivitäten ist eine aktive Internetverbindung erforderlich";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "Eine aktive Internetverbindung ist erforderlich, um Tarife anzuzeigen";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -671,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "Jährliche Website-Statistiken";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "Anonym";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "Antwort";
 
@@ -692,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "Design";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "Apple-Authentifizierung fehlgeschlagen.\nStelle sicher, dass du bei iCloud mit einer Apple-ID angemeldet bist, welche die zweistufige Authentifizierung unterstützt.";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "Wendet die Einstellungen an";
@@ -778,6 +811,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "Authentifizierung fehlgeschlagen";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "Authentifizierungscode";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "Autorisierung erforderlich für Host: %@ ";
@@ -888,6 +925,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "Als Erster kommentieren";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Schreibe den ersten Kommentar.";
 
 /* Beauty site intent topic */
 "Beauty" = "Beauty";
@@ -1024,12 +1064,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button to copy post text" = "Button zum Kopieren des Beitragstexts";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "Wenn du fortfährst, stimmst du unseren _Geschäftsbedingungen_ zu.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "Wenn du diese Domain registrierst, stimmst du unseren <a>Geschäftsbedingungen<\/a> zu.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "Mit der Einrichtung von Jetpack erklärst du dich einverstanden, mit unseren\n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "Durch die Registrierung stimmst du unseren Geschäftsbedingungen zu.";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "ANPASSEN";
@@ -1043,6 +1089,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "Zugriff auf Kamera für das Scannen von Anmeldecodes benötigt";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Kann den Link nicht anfordern.";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "Eine leere Seite kann nicht veröffentlicht werden";
 
@@ -1052,6 +1101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1061,6 +1111,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1079,6 +1130,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1106,6 +1158,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "Abbrechen ...";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "Zugriff auf Website unter dieser Adresse nicht möglich. Bitte überprüfen und erneut versuchen.";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Unentschlossen? Du kannst das Theme jederzeit ändern.";
 
@@ -1113,7 +1168,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Bildunterschrift";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Vorsicht!";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1122,7 +1178,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Kategorien";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Kategorie";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1171,6 +1228,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "Schau dir unsere Top-Tipps für mehr Aufrufe und höheren Traffic an";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "Überprüfe dein Postfach auf diesem Gerät!";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Überprüfe deine E-Mails auf diesem Gerät und tippe auf den Link in der E-Mail, die du von WordPress.com erhalten hast.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "Überprüfe dein E-Mail-Postfach auf diesem Gerät, und tippe auf den Link in der E-Mail, die du von WordPress.com erhalten hast.\n\nDu siehst keine E-Mail? Überprüfe deinen Spam- oder Junk-E-Mail-Ordner.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "Überprüfe dein E-Mail-Postfach!";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "Prüfe deine Internetverbindung und ziehe nach unten, um zu aktualisieren.";
@@ -1267,6 +1336,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "Kostenlose Domain in Anspruch nehmen";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "Klassischer Blog";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "Medien-Cache des Geräts leeren";
 
@@ -1294,6 +1366,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Schließen";
 
@@ -1335,6 +1408,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "Spalteneinstellungen";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Comics";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1386,6 +1462,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Kommentare";
 
@@ -1453,12 +1530,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Verbundene Konten";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Verbunden, aber …";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "Mit %@ verbinden";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Durch die Verbindung mit %1$@ wird die vorhandene Verbindung mit %2$@ ersetzt.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Verbinde mit WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Verbindung wird hergestellt …";
@@ -1489,8 +1572,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "Kontaktiere uns unter %@";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "Inhaltliche Struktur\nBlöcke: %1$li, Wörter: %2$li, Zeichen: %3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1505,6 +1592,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Weiterlesen";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Mit Apple fortfahren";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Mit Google fortfahren";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Weiter mit Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "Beitragen";
@@ -1633,6 +1729,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "Erstellen";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Konto erstellen";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "Leere Seite erstellen";
 
@@ -1653,6 +1752,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "Einen Beitrag erstellen";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "Website erstellen";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "Ein Schlagwort erstellen";
@@ -1686,6 +1788,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "Aktuell";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Aktueller Tarif";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Aktuelles Theme";
@@ -1788,6 +1893,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "Standardkategorie";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Standard-Menu";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Standard-Beitragsformat";
@@ -1796,6 +1904,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "Standardeinstellungen für neue Beiträge";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Löschen";
@@ -1853,6 +1962,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "Details";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "Du wolltest kein neues Konto erstellen? Gehe zurück und gib deine E-Mail-Adresse noch einmal ein.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "Abmessungen";
 
@@ -1900,7 +2012,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "Diskussion";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Verwerfen";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1922,6 +2036,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "Domains";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "Du hast noch kein Konto? _Registrieren_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2051,6 +2168,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "Downloads";
 
+/* Name for the status of a draft post. */
+"Draft" = "Entwurf";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Entwürfe";
 
@@ -2160,7 +2280,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "E-Mail-Adresse";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "E-Mail-Adresse";
 
 /* Notification Settings Channel */
@@ -2244,8 +2367,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Passwort eingeben";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "Gib die Adresse der WordPress-Website ein, die du verbinden möchtest.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Gib das Passwort für dein WordPress.com-Konto ein.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Benutzernamen eingeben";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "Gib deine Kontodetails für %@ ein.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "Gib deine E-Mail-Adresse ein, um dich anzumelden, oder erstelle ein WordPress.com-Konto.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "Gib deine bestehende Website-Adresse ein";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "Gib stattdessen dein Passwort ein.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "Gib deine Server-Anmeldedaten ein";
@@ -2408,6 +2551,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "Extern";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Fehlgeschlagen";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "Benachrichtigungen konnten nicht als gelesen markiert werden";
 
@@ -2434,6 +2580,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "Mode";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "Vorgestellt";
@@ -2492,6 +2641,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "Mehr erfahren";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Finde deine Website-Adresse";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2514,6 +2666,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "Bedrohungen werden behoben";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "Folgen";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "Unterhaltung folgen";
@@ -2608,6 +2763,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "Neuen Link generieren";
 
+/* View title for initial auth views. */
+"Get Started" = "Los geht's";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "Anmelde-Link per E-Mail erhalten";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "Leg los! Kommentiere Beiträge aus Blogs, denen du folgst.";
 
@@ -2629,8 +2790,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "Inspiration";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Hole Konto-Informationen";
+
+/* Cancel */
+"Give Up" = "Aufgeben";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "Probier es aus, indem du deinem Beitrag oder deiner Seite ein paar Blocks hinzufügst!";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "Reader aufrufen";
@@ -2641,6 +2811,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "iOS-Einstellungen öffnen";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Anmeldung mit Google fehlgeschlagen.";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2715,6 +2888,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "Hilfe-Icon";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Versteckt";
+
 /* Title of a button used to collapse a group */
 "Hide" = "Ausblenden";
 
@@ -2783,6 +2959,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "Icon-Aktualisierung fehlgeschlagen";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "Wenn du die E-Mail nicht findest, schau in deinem Spam-E-Mail-Ordner nach.";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "Wenn du mit Apple oder Google fortfährst und noch kein WordPress.com-Konto hast, erstellst du damit ein Konto und stimmst unseren _Geschäftsbedingungen_ zu.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "Wenn du %1$@ entfernst, kann dieser Benutzer nicht mehr auf diese Website zugreifen, aber alle von %2$@ erstellten Inhalte bleiben weiterhin auf der Website.";
@@ -2858,6 +3040,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "Beinhaltet wp-config.php und alle Nicht-WordPress-Dateien";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Falsche Benutzername oder Passwort. Bitte gib deine Zugangsdaten erneut ein.";
 
 /* Title for a threat */
 "Infected core file" = "Infizierte Core-Datei";
@@ -2959,6 +3144,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "Neu: Blog-Schreibanregungen";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "Ungültige E-Mail-Adresse";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "Ungültige Website-Adresse";
 
@@ -2976,6 +3164,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "Ungültige URL. Audiodatei nicht gefunden.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "Ungültige URL. Bitte überprüfen und erneut versuchen.";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "Ungültige URL. Bitte gib eine gültige URL ein.";
@@ -2997,6 +3188,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "Personen einladen";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "Dieser Benutzername\/dieses Passwort ist anscheinend nicht mit dieser Website verknüpft.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "Scheinbar hast du ein falsches Passwort eingegeben. Möchtest du es noch einmal versuchen?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "Am %@ ist es Zeit, einen Beitrag zu veröffentlichen!";
@@ -3225,7 +3422,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "Zeilenhöhe";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Link";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3253,7 +3451,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Link inserted" = "Link eingefügt";
 
 /* No comment provided by engineer. */
-"Link label" = "Link-Beschriftung";
+"Link label" = "Link-Label";
 
 /* No comment provided by engineer. */
 "Link text" = "Link-Text";
@@ -3286,6 +3484,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Text displayed while loading site People. */
 "Loading People..." = "Personen werden geladen ...";
+
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Lade Tarif ...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Lade Tarife ...";
 
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "Plugin wird geladen …";
@@ -3321,11 +3525,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "Wird geladen …";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Lokal";
+
 /* Local Services site intent topic */
 "Local Services" = "Lokale Dienstleistungen";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "Lokale Änderungen";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Ort";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Damit dein aktueller Standort in WordPress hinzugefügt werden kann, müssen die Ortungsdienste aktiviert werden. Aktiviere in der App „Einstellungen“ die Ortungsdienste.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Standort unbekannt";
 
 /* No comment provided by engineer. */
 "Lock icon" = "Schloss-Icon";
@@ -3333,9 +3549,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Protokolldateien nach Erstellungsdatum";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Anmelden";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3345,17 +3563,33 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of a button for signing in. */
 "Log in" = "Anmelden";
 
-/* LogOut confirmation text, whenever there are no local changes */
-"Log out of Jetpack?" = "Von Jetpack abmelden?";
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Anmeldung fehlgeschlagen. Bitte erneut versuchen.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "Mit WordPress.com anmelden oder registrieren";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Melde dich bei deinem WordPress.com-Konto an, das du für die Jetpack-Verbindung verwendet hast.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "Melde dich mit deiner E-Mail-Adresse bei deinem WordPress.com-Konto an.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "Melde dich mit deinem WordPress.com-Benutzernamen und -Passwort an.";
 
 /* LogOut confirmation text, whenever there are no local changes */
-"Log out of Reader?" = "Vom Reader abmelden?";
+"Log out of Jetpack?" = "Von Jetpack abmelden?";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of WordPress?" = "Von WordPress abmelden?";
 
 /* Login Request Expired */
 "Login Request Expired" = "Anmeldungsanforderung abgelaufen";
+
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "Mit Konto-Passwort anmelden";
 
 /* No comment provided by engineer. */
 "Logs" = "Protokolle";
@@ -3365,6 +3599,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Es sieht so aus, als wäre Jetpack auf deiner Website aktiviert. Glückwunsch!\nBitte melde dich mit deinen WordPress.com-Anmeldedaten an, um Website-Statistiken und Benachrichtigungen zu aktivieren.";
+
+/* Title of a button. */
+"Lost your password?" = "Passwort vergessen?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "Mail (Standard)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Hauptnavigation";
@@ -3512,6 +3752,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "Nachricht";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "Verschiedene Schwachstellen";
 
@@ -3607,6 +3850,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "Meine Webseite";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "Meine Websites in WordPress";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "Meine Top 10 Cafés";
 
@@ -3646,8 +3892,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Brauchst du Hilfe?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "Brauchst du Hilfe, um deine Website-Adresse zu finden?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "Brauchst du Hilfe?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Brauchst du weitere Hilfe?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "Benötigt Update";
@@ -3676,6 +3929,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "Neuer Beitrag";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Neuer Menupunkt";
+
 /* Placeholder text for password field */
 "New password" = "Neues Passwort";
 
@@ -3693,7 +3949,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "Nachrichten";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Weiter";
 
 /* Accessibility label for the next notification button */
@@ -3729,6 +3987,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "Keine Vorschau-URL verfügbar";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "Kein Titel";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "Keine Aktivitäten verfügbar";
 
@@ -3761,7 +4022,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "Keine Kommentare bisher";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "Keine Verbindung";
 
@@ -3910,6 +4172,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "Später";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "Du siehst die E-Mail nicht? Überprüfe deinen Spam- oder Junk-E-Mail-Ordner.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "Hinweis:";
 
@@ -3973,7 +4238,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Nummerierte Liste";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -4030,7 +4300,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "Hoppala";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Hoppala!";
 
 /* No comment provided by engineer. */
@@ -4045,7 +4316,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "Jetpack-Security-Einstellungen öffnen";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Mail öffnen";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Einstellungen öffnen";
 
 /* No comment provided by engineer. */
@@ -4063,6 +4339,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "Link in neuem Fenster\/Tab öffnen";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "Abonnement-Einstellungen für diesen Beitrag öffnen";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "Öffne den „Ich“-Abschnitt";
 
@@ -4077,6 +4356,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "Optional: Gib eine individuelle Nachricht mit bis zu %1$d Zeichen ein, die zusammen mit deiner Einladung gesendet wird.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "Oder";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "Oder wähle eine andere Authentifizierungsmethode aus.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "Oder melde dich an, indem du _deine Website-Adresse eingibst_.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "Oder mit magischem Link anmelden";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Geordnete Liste";
@@ -4125,7 +4416,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "Innenabstand";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Seite";
 
@@ -4158,8 +4450,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "Kindererziehung";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Passwort";
 
@@ -4176,8 +4471,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "Einfügen von Block nach";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Ausstehend";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Ausstehende Überprüfung";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4208,6 +4507,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "Wähle einen Benutzernamen aus";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Tarife";
+
 /* User action to play a video on the editor. */
 "Play video" = "Video abspielen";
 
@@ -4237,6 +4540,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "Stelle sicher, dass der Block-Editor auf deiner Website aktiviert ist. Falls er nicht aktiviert ist, wird er nicht geladen.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "Bitte gib eine vollständige Website-Adresse ein, wie zum Beispiel example.com.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "Bitte gib eine Website-Adresse ein.";
@@ -4271,11 +4577,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "Bitte gib eine gültige Adresse ein.";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "Bitte gib eine gültige E-Mail-Adresse für ein WordPress.com-Konto an.";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Bitte gib eine gültige E-Mail-Adresse ein.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "Bitte gib eine gültige Telefonnummer an.";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Bitte gib das Passwort für dein WordPress.com-Konto ein, um dich mit deiner Apple-ID anzumelden.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Bitte Zugangsdaten eingeben";
@@ -4283,8 +4595,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Bitte gib deine E-Mail-Adresse ein.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Bitte fülle alle Felder aus";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Starte die WordPress-App, melde dich bei WordPress.com an und stelle sicher, dass du über mindestens eine Website verfügst. Versuche es nun erneut.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "Bitte melde dich ab, bevor du dich mit einer anderen wordpress.com-Seite verbindest.";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "Bitte versuche es später erneut";
@@ -4352,7 +4670,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "Beliebte Sprachen";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Veröffentlichen";
 
@@ -4473,6 +4792,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "Datenschutzhinweis für Benutzer in Kalifornien";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Privat";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "Bei der Anzeige des Blocks ist ein Problem aufgetreten. \nTippe, um die Wiederherstellung des Blocks zu versuchen.";
 
@@ -4487,6 +4809,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "Beim Kauf deiner Domain ist ein Problem aufgetreten. Bitte versuche es erneut.";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Fortfahren wird sämtliche Daten von WordPress.com von diesem Gerät entfernen und jeden lokal gespeicherten Entwurf löschen. Es geht nichts verloren, was bereits auf einem der WordPress.com-Blogs gespeichert wurde.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Projekte";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "Aufforderung übersprungen";
@@ -4504,13 +4832,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "Veröffentlichungsdatum";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Sofort veröffentlichen";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "Seite veröffentlichen auf:";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "Beitrag veröffentlichen auf:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Veröffentlicht";
 
@@ -4712,7 +5044,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "Antwort";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Antworttext";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "%1$@ antworten";
 
 /* An explaination of a setting. */
@@ -4741,6 +5078,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "Datumsbereich-Filter zurücksetzen";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Dein Passwort zurücksetzen";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Größe ändern & Zuschneiden";
@@ -4798,6 +5138,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "Alles erneut versuchen";
 
+/* No comment provided by engineer. */
+"Retry?" = "Erneut versuchen?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "Zum Beitrag zurückkehren";
 
@@ -4827,6 +5170,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "Rolle";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS gesendet";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "STATUS";
 
@@ -4838,6 +5184,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4904,7 +5251,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "Dateien werden gescannt";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Geplant";
 
 /* No comment provided by engineer. */
@@ -5044,6 +5392,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "Dieses Thema wird als Intent für deine Website ausgewählt.";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Link senden";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "Link per E-Mail senden";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "Log-Nachricht senden";
 
@@ -5052,6 +5406,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "Testabsturz senden";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "Bestätigungslink per E-Mail senden";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "Benachrichtigungen per E-Mail senden";
@@ -5097,6 +5454,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message to show when setting save failed */
 "Settings update failed" = "Aktualisierung der Einstellungen fehlgeschlagen";
+
+/* Spoken accessibility label */
+"Share" = "Teilen";
 
 /* Title for a button that recommends the app to others */
 "Share Jetpack with a friend" = "Jetpack mit einem Freund teilen";
@@ -5150,6 +5510,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "Reblog-Button anzeigen";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "Passwort anzeigen";
+
 /* No comment provided by engineer. */
 "Show post content" = "Beitragsinhalt anzeigen";
 
@@ -5161,6 +5525,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "Statistiken anzeigen für:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "Wird angezeigt";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Wird öffentlich angezeigt, wenn du auf Blogs kommentierst.";
@@ -5176,6 +5543,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "Zeigt den Beitrag an";
+
+/* View title during the sign up process. */
+"Sign Up" = "Registrieren";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "Mit den Website-Anmeldedaten anmelden";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Registrieren";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Bei WordPress.com registrieren";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Mit E-Mail-Adresse registrieren";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "Da du einen Free-Tarif hast, siehst du nur begrenzte Ereignisse in deinem Aktivitätsprotokoll.";
@@ -5214,6 +5596,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Website-Auszeichnungen";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Website-Adresse";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "Website-Adresse muss mindestens 4 Zeichen lang sein.";
@@ -5298,7 +5683,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Website-Adressen müssen auch Buchstaben enthalten!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Diese E-Mail-Adresse wird leider bereits genutzt!";
 
 /* No comment provided by engineer. */
@@ -5358,6 +5743,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "Spam";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "Verkürze die Ladezeit deiner Website";
@@ -5383,6 +5771,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "Bundesland";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "Statische Seite";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5413,6 +5804,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "Durchstreichen";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Stub";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "Zur Überprüfung vorlegen";
@@ -5503,7 +5897,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "Tablet";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Schlagwort";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5638,6 +6033,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Allgemeine Geschäftsbedingungen";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Testimonials";
+
 /* Title of a button style */
 "Text Only" = "Nur-Text";
 
@@ -5647,8 +6045,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "Die Textformatierungskontrollen findest du beim Bearbeiten eines Textblocks in der Toolbar über der Tastatur.";
 
+/* Button title */
+"Text me a code instead" = "Code per SMS senden";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "Code per SMS zusenden";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Danke, dass du dich für %1$@ von %2$@ entschieden hast.";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "Der Verifizierungscode scheint ungültig zu sein.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "Das sieht nicht nach einer WordPress-Website aus.";
@@ -5670,6 +6077,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "Die Facebook-Verbindung findet keine Seiten. Publicize kann keine Verbindung zu Facebook-Profilen herstellen, sondern nur zu öffentlichen Seiten.";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "Das Google-Konto „%@“ stimmt mit keinem WordPress.com-Konto überein.";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "Die Internetverbindung scheint offline zu sein.";
@@ -5709,6 +6119,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "Das Bild konnte nicht zur Mediathek hinzugefügt werden.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "Die Internetverbindung scheint gerade offline zu sein.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "Die Arten von Websites, die erstellt werden können.";
@@ -5752,6 +6165,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Die Website unter %1$@ nutzt WordPress %2$@. Wir empfehlen ein Update auf die aktuellste Version oder mindestens auf %3$@";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "Die Website mit dieser Adresse ist keine WordPress-Website. Damit wir uns mit ihr verbinden können, muss die Website WordPress verwenden.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "Die Website konnte nicht gelöscht werden.";
 
@@ -5793,6 +6210,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "Beim Bearbeiten deines Kommentars ist ein unerwarteter Fehler aufgetreten";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "Beim Laden der Kommentare ist ein unerwarteter Fehler aufgetreten";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "Beim Registrieren deiner Domain ist ein unerwarteter Fehler aufgetreten";
 
@@ -5801,6 +6221,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "Ein unerwarteter Fehler ist aufgetreten beim Aktualisieren der Benachrichtigungseinstellungen";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "Bei der Aktualisierung deines Kommentars ist ein unerwarteter Fehler aufgetreten";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "Es ist ein unerwarteter Fehler aufgetreten.";
@@ -5822,6 +6245,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "Bei dem Versuch, mit der Website zu kommunizieren, ist ein Problem aufgetreten.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "Es gab ein Problem beim Verbinden mit WordPress.com. Bitte noch einmal anmelden.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "Beim Anzeigen dieses Beitrags ist ein Fehler aufgetreten.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "Beim Laden deiner Daten ist ein Fehler aufgetreten. Aktualisiere deine Seite und versuche es erneut.";
 
@@ -5831,12 +6260,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "Es gab ein Problem beim Speichern der Änderungen an den Teilen-Buttons.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "Es gab ein Problem beim Versuch, auf deinen Standort zuzugreifen. Versuche es später erneut.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "Beim Ändern des Passworts ist ein Fehler aufgetreten";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "Beim Laden der Aktivitäten ist ein Fehler aufgetreten";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "Beim Laden der Tarife ist ein Fehler aufgetreten";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "Beim Laden der Plugins ist ein Fehler aufgetreten";
@@ -5849,6 +6284,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "Beim Laden des Verlaufs ist ein Fehler aufgetreten";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "Beim Laden des Tarifs ist ein Fehler aufgetreten";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "Beim Laden des Scan-Verlaufs ist ein Fehler aufgetreten";
@@ -5897,6 +6335,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "Diese Domain ist nicht verfügbar";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "Diese E-Mail-Adresse ist auf WordPress.com nicht registriert.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "Diese Datei ist zu groß, um auf deine Website hochgeladen zu werden, oder sie unterstützt dieses Medienformat nicht.";
@@ -5977,6 +6418,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "Zeitzone";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "Die Zeit ist abgelaufen, aber mach dir keine Sorgen, deine Sicherheit steht bei uns an erster Stelle. Versuche es bitte noch einmal!";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "Tipps, um das Meiste aus WordPress.com herauszukriegen.";
 
@@ -5990,6 +6434,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "Bitte gib deine E-Mail-Adresse und deinen Namen ein, um fortfahren zu können.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "Um dein neues WordPress.com-Konto zu erstellen, gib deine E-Mail-Adresse ein.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "Um hilfreiche Benachrichtigungen auf deinem Mobiltelefon von deiner WordPress-Website zu erhalten, musst du das Jetpack-Plugin installieren.";
 
@@ -5998,6 +6445,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "Um Plugins zu installieren, benötigst du eine individuelle Domain, die mit deiner Website verknüpft ist.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "Bitte melde dich zuerst mit deinem WordPress.com-Passwort an, um mit dieser Apple-ID fortzufahren. Es wird nur einmal benötigt.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "Um mit diesem Google-Konto fortzufahren, melde dich bitte zuerst mit deinem WordPress.com-Passwort an. Dies wird nur einmal nachgefragt.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "Wenn du einen Block entfernen möchtest, wähle ihn aus und klicke auf die drei Punkte unten rechts im Block, um die Einstellungen anzuzeigen. Hier kannst du die Option zum Entfernen des Blocks auswählen.";
@@ -6072,7 +6525,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "Entfernen";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "In den Papierkorb verschoben.";
 
@@ -6086,6 +6540,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "Ausprobieren und Anpassen";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Erneut versuchen";
@@ -6111,6 +6566,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "Probiere den neuen Block-Editor aus";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Mit einer anderen E-Mail-Adresse versuchen";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Mit der Website-Adresse versuchen";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "Schreibanregungen ausschalten";
@@ -6153,6 +6614,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "VERWENDUNGEN";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "Verbindung kann nicht hergestellt werden";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "Beiträge können nicht geladen werden";
@@ -6202,6 +6666,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Video konnte nicht abgespielt werden";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Es konnte keine WordPress-Website unter dieser URL gefunden werden. Bitte tippe „Brauchst du Hilfe?“ an, um die FAQ anzuzeigen.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Deine Website kann nicht wiederhergestellt werden";
 
@@ -6228,6 +6695,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "1 Beitrag, 1 Datei konnten nicht hochgeladen werden";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "Die E-Mail-Adresse konnte nicht überprüft werden. Versuche es später erneut.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "Jetpack-Einstellungen der Website können nicht aufgerufen werden";
@@ -6372,7 +6842,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Hochladen fehlgeschlagen";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Hochgeladen";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6390,7 +6861,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Themes hochladen";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Lade hoch";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6405,18 +6877,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "Benutzen";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "Sicherheitsschlüssel verwenden";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "Block-Editor benutzen";
 
 /* No comment provided by engineer. */
 "Use icon button" = "Icon-Button verwenden";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "Mit Passwort anmelden";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Benutzername";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6431,6 +6912,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Benutzer";
+
+/* two factor code placeholder */
+"Verification code" = "Verifizierungscode";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "Es wurde eine Verifizierungs-E-Mail gesendet. Überprüfe deinen Posteingang.";
@@ -6563,8 +7047,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "WP-content-Verzeichnis";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Registrierung wird von Google abgeschlossen …";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "Warten auf Verbindung";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "Warten auf Sicherheitsschlüssel";
+
+/* View title during the Google auth process. */
+"Waiting..." = "Warten …";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6604,6 +7098,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "Wir konnten die Daten nicht laden";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "Wir haben gerade per E-Mail einen Link an %@ geschickt. Bitte überprüfe deine E-Mail-App und tippe auf den Link, um dich anzumelden.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "Wir haben einen magischen Link an folgende Adresse geschickt:";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "Wir haben erfolgreich ein Backup deiner Website mit Stand %@ erstellt";
 
@@ -6613,14 +7113,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "Wir verwenden andere Werkzeuge zum Tracking, darunter auch welche von Drittanbietern. Hier erhältst du weitere Informationen und Tipps, wie du sie kontrollierst.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "Leider können wir dir zu diesem Zeitpunkt keine E-Mail senden. Bitte versuche es später erneut.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Wir senden dir eine E-Mail, falls Sicherheitsbedrohungen gefunden werden. In der Zwischenzeit kannst du deine Website ganz normal verwenden und jederzeit nachsehen, wie weit der Scan schon ist.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "Wir senden dir per E-Mail einen magischen Link, mit dem du sofort angemeldet wirst, ohne dass du ein Passwort eingeben musst.";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "Wir haben dir einen Anmeldelink per E-Mail gesendet, um dein neues WordPress.com-Konto zu erstellen.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "Wir werden dich benachrichtigen, wenn du Follower, Kommentare und Likes erhältst.";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "Wir werden dich benachrichtigen, wenn du neue Follower, Kommentare und Likes erhältst. Möchtest du Push-Benachrichtigungen erlauben?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "Wir werden diese E-Mail-Adresse verwenden, um dein neues WordPress.com-Konto zu erstellen.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "Wir erstellen ein herunterladbares Backup deiner Website vom %1$@.";
@@ -6631,6 +7143,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Wir arbeiten im Hintergrund daran, diese Bedrohungen zu beheben. In der Zwischenzeit kannst du deine Website ganz normal verwenden und jederzeit nachsehen, wie weit der Scan schon ist.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "Wir können zur Jetpack-Website unter dieser URL keine Verbindung herstellen. Wende dich an uns, um Unterstützung zu erhalten.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "Wir stellen deine Website auf %1$@ wieder her.";
 
@@ -6639,6 +7154,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "Wir haben dir auch einen Link zu deiner Datei per E-Mail geschickt.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Wir haben dir einen Anmeldelink per E-Mail gesendet, um dein neues WordPress.com-Konto zu erstellen. Überprüfe deine E-Mails auf diesem Gerät und tippe auf den Link in der E-Mail, die du von WordPress.com erhalten hast.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6665,6 +7183,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "Wöchentliche Zusammenfassung: %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "Willkommen bei Jetpack";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Willkommen bei WordPress";
 
 /* A message title */
 "Welcome to the Reader" = "Willkommen zum Reader";
@@ -6709,6 +7233,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "Was ist Gravatar?";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "Was ist WordPress.com?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "Was ist ein Block?";
 
@@ -6725,10 +7252,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "What's New in Jetpack" = "Neu in Jetpack";
 
 /* Opens the What's New / Feature Announcement modal */
-"What's New in Reader" = "Neues im Reader";
-
-/* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "Neues in WordPress";
+
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "Wie lautet meine Website-Adresse?";
 
 /* Select the site's intent. Title */
 "What's your website about?" = "Worum geht es auf deiner Website?";
@@ -6742,6 +7269,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "Wenn du Änderungen an deiner Website vornimmst, kann du hier deinen Aktivitätsverlauf sehen.";
 
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Ups, aufgrund eines Fehlers konnten wir dich nicht anmelden. Versuche es bitte noch einmal!";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "Ups, etwas ist schiefgelaufen. Versuche es bitte noch einmal!";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "Ups, dieser Sicherheitsschlüssel ist anscheinend nicht gültig. Versuche es bitte noch einmal mit einem anderen";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Ups, das ist kein gültiger zweistufiger Verifizierungscode. Überprüfe deinen Code und versuche es noch einmal!";
+
 /* No comment provided by engineer. */
 "Width Settings" = "Breite-Einstellungen";
 
@@ -6754,17 +7293,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "WordPress-App-Einstellungen";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "WordPress-Apps – Apps für jeden Bildschirm";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "WordPress-Blog";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "WordPress-Hilfe";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "WordPress-Mediathek";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "WordPress-Benachrichtigungseinstellungen";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "WordPress-Benachrichtigungen";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "WordPress-Plugins";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "WordPress-Profil";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "WordPress Reader";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "WordPress-Websitedetails";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "WordPress-Themes";
@@ -6775,17 +7335,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "WordPress-Netzwerke werden nicht unterstützt";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress benötigt deine Genehmigung, um auf den aktuellen Standort deines Geräts zuzugreifen, sodass dieser deinem Beitrag hinzugefügt werden kann. Aktualisiere deine Datenschutzeinstellungen.";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "WordPress-Root";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "WordPress-Version zu alt";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Zu alte WordPress-Version. Die Website unter %1$@ benutzt WordPress %2$@. Wir empfehlen ein Update auf die aktuellste Version oder zumindest auf %3$@";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "WordPress.com-Konto";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "WordPress.com-Tarife";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "WordPress.com Kostenlos";
@@ -6816,6 +7385,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "Beitrag verfassen";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "Antwort schreiben";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "Schreib eine Antwort …";
 
 /* Title for the writing section in site settings screen */
@@ -6829,6 +7401,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Position auf der y-Achse";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "Jahr";
@@ -6913,6 +7488,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Displayed when the user views trashed in the posts list and there are no posts */
 "You don't have any trashed posts" = "Du hast keine Beiträge im Papierkorb";
 
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"You don't have permission to view this private blog." = "Du hast keine Berechtigung, diesen privaten Blog anzuzeigen.";
+
 /* Description for the first domain purchased with a paid plan. */
 "You have a free one-year domain registration with your plan." = "In deinem Tarif ist eine kostenlose Domain-Registrierung für ein Jahr enthalten.";
 
@@ -6928,7 +7506,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "Du hast keine Erinnerungen festgelegt.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Es gibt nicht gespeicherte Änderungen.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -7015,9 +7594,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Help text that describes how the password should be. It appears while editing the password */
 "Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ & )." = "Dein Passwort muss aus mindestens sechs Zeichen bestehen. Verwende zur Erhöhung der Sicherheit Groß- und Kleinbuchstaben, Zahlen und Sonderzeichen wie ! \" ? $ % ^ & ).";
 
-/* Message of Export Content confirmation alert */
-"Your posts, pages, and settings will be mailed to the account's email address." = "Deine Beiträge, Seiten und Einstellungen werden an die E-Mail-Adresse des Kontos gesendet.";
-
 /* Message of Export Content confirmation alert; substitution is user's email address */
 "Your posts, pages, and settings will be mailed to you at %@." = "Deine Beiträge, Seiten und Einstellungen werden dir per E-Mail an %@ geschickt.";
 
@@ -7026,6 +7602,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "Deine Suche enthält Zeichen, die in WordPress.com-Domains nicht unterstützt werden. Diese Zeichen sind zulässig: A–Z, a–z, 0–9.";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "Wenn du deine Website im Safari aufrufst, wird die Adresse deiner Website oben in der Leiste angezeigt.";
 
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "Deine Website ist bereits durch VaultPress geschützt. Klicke auf den nachfolgenden Link, um zu deinem VaultPress-Dashboard zu gelangen.";
@@ -7105,17 +7684,23 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility identifier for an 'Add Comment' button */
 "addCommentButton.accessibilityIdentifity" = "Kommentar hinzufügen";
 
-/* Error message when user cancels login */
-"addSite.selfHosted.cancelled" = "Die Anmeldung wurde abgebrochen";
+/* Error message shown a URL does not point to an existing site. */
+"addSite.restApiNotAvailable" = "Die Website mit dieser Adresse ist keine WordPress-Website. Damit wir uns mit ihr verbinden können, muss die Website WordPress verwenden.";
+
+/* Error message shown when an receiving an invalid application-password authentication result from a self-hosted WordPress site */
+"addSite.selfHosted.authenticationFailed" = "Anmeldung mit Anwendungspasswort-Authentifizierung nicht möglich";
 
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "Gib die Adresse der WordPress-Website ein, die du verbinden möchtest.";
 
+/* Error message when user input is not a WordPress site */
+"addSite.selfHosted.invalidUrl" = "Die Website-Adresse ist ungültig.";
+
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "Die Details der WordPress-Website konnten nicht geladen werden";
 
-/* Error message when user signs in with an unexpected usern. The first argument is the expected username */
-"addSite.selfHosted.mismatchUser" = "Bitte melde dich mit dem angemeldeten Benutzer an. Benutzername: %@";
+/* Error message shown when application-password authentication is disabled on a self-hosted WordPress site */
+"addSite.selfHosted.noLoginUrlFound" = "Auf der WordPress-Website muss die Anwendungspasswort-Authentifizierung aktiviert werden.";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "Die WordPress-Website kann nicht gespeichert werden. Versuche es später noch einmal.";
@@ -7123,17 +7708,14 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "Selbstgehostete Website hinzufügen";
 
-/* Error message when XML-RPC is disabled on the WordPress site. The first argument is detailed error message */
-"addSite.selfHosted.xmlrpcDisabled" = "Es konnte keine Verbindung zur WordPress-Website hergestellt werden. XML-RPC wurde möglicherweise auf dem Server deaktiviert. Bitte wende dich an deinen Hosting-Anbieter, um dieses Problem zu beheben.";
+/* Error message when an unknown error occurred when adding a self-hosted site */
+"addSite.selfHosted.unknownError" = "Es ist ein Fehler aufgetreten. Bitte versuche es erneut.";
 
 /* Age between dates equaling one hour. */
 "an hour" = "eine Stunde";
 
 /* This is the string we display when prompting the user to review the Jetpack app */
 "appRatings.jetpack.prompt" = "Was ist deine Meinung zu Jetpack?";
-
-/* This is the string we display when prompting the user to review the Reader app */
-"appRatings.reader.prompt" = "Was hältst du vom Reader?";
 
 /* This is the string we display when prompting the user to review the WordPress app */
 "appRatings.wordpress.prompt" = "Was ist deine Meinung zu WordPress?";
@@ -7837,6 +8419,10 @@ Example: Reply to Pamela Nguyen */
 /* A name of the ID field (it's a technical field, has to be short, displayed below everything else) */
 "entityMetadataFooterView.id" = "ID";
 
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "example.com";
+
 /* Accept button title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackAccept" = "Feedback senden";
 
@@ -7848,9 +8434,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackTitle" = "Feedback teilen";
-
-/* Communicates the future removal of the option to disable the experimental editor, displayed beneath the experimental features list */
-"experimentalFeatures.editorNote" = "Der experimentelle Block-Editor wird in einer zukünftigen Version zum Standard und die Möglichkeit, ihn zu deaktivieren, wird entfernt.";
 
 /* The title for the experimental features list */
 "experimentalFeaturesList.heading" = "Experimentelle Funktionen";
@@ -7897,8 +8480,14 @@ Example: Reply to Pamela Nguyen */
 /* A footer retry button */
 "general.pagingFooterView.retry" = "Erneut versuchen";
 
+/* Error message format when REST API returns an error response. The first argument is error message. */
+"generic.error.rest-api-error" = "Deine Website hat eine Fehlerantwort gesendet: %@";
+
 /* A generic title for an error */
 "generic.error.title" = "Fehler";
+
+/* Error message when failing to parse API responses */
+"generic.error.unparsableResponse" = "Deine Website hat eine Antwort gesendet, die die App nicht analysieren konnte";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "Blog-Erinnerungen einrichten";
@@ -8070,33 +8659,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title of the Jetpack powered overlay. */
 "jetpack.branding.overlay.title" = "WordPress ist mit Jetpack noch besser";
-
-/* Title for the button that starts the Jetpack connection process */
-"jetpack.connection.connect.button" = "Website verbinden";
-
-/* Error message shown when WordPress.com authentication fails */
-"jetpack.connection.error.authentication" = "Ungültiges WordPress.com-Konto";
-
-/* Error message shown when a connection step is attempted in an invalid order */
-"jetpack.connection.error.context" = "Dieser Schritt ist noch nicht fertig";
-
-/* Status message when a connection step is pending */
-"jetpack.connection.stage.pending" = "Warten auf Start";
-
-/* Status message when a connection step is in progress */
-"jetpack.connection.stage.processing" = "In Bearbeitung …";
-
-/* Status message when a connection step is completed successfully */
-"jetpack.connection.stage.success" = "Abgeschlossen";
-
-/* Title for the finalization step in Jetpack connection flow */
-"jetpack.connection.step.finalize.title" = "Verbindung abschließen";
-
-/* Title for the site connection step in Jetpack connection flow */
-"jetpack.connection.step.site.title" = "Mit deiner Website verbinden";
-
-/* Title for the user connection step in Jetpack connection flow */
-"jetpack.connection.step.user.title" = "Mit deinem WordPress.com-Konto verbinden";
 
 /* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
 "jetpack.fullscreen.overlay.early.switch.title" = "Zur neuen Jetpack-App wechseln";
@@ -8317,23 +8879,11 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "Du hast keine Berechtigung, diesen privaten Blog anzuzeigen.";
 
-/* Description explaining why the user needs to re-authenticate */
-"login.appPasswordReAuth.description" = "Das der App zugewiesene Anwendungspasswort ist in deinem Profil nicht mehr vorhanden.\nBitte melde dich erneut an, um ein neues Anwendungspasswort für die App zu erstellen.";
-
-/* Title shown when the application password is invalid */
-"login.appPasswordReAuth.title" = "Ungültiges Anwendungspasswort";
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "Bitte gib den Verifizierungscode für dein WordPress.com-Konto aus deiner Authenticator-App ein.";
 
 /* Indicating that referrer was marked as spam */
 "marked as spam" = "als Spam markiert";
-
-/* Button title after verification link is sent */
-"me.verifyEmail.button.sent" = "E-Mail gesendet";
-
-/* Message for email verification card */
-"me.verifyEmail.message.noEmail" = "Verifiziere deine E-Mail-Adresse, um dein Konto zu sichern und auf weitere Funktionen zuzugreifen.\nSuche in deinem Posteingang nach der Bestätigungs-E-Mail oder klicke auf „%@“, um eine neue E-Mail zu erhalten.";
-
-/* Message for email verification card with email address */
-"me.verifyEmail.message.withEmail" = "Verifiziere deine E-Mail-Adresse, um dein Konto zu sichern und auf weitere Funktionen zuzugreifen.\nSuche in deinem Posteingang unter %1$@ nach der Bestätigungs-E-Mail oder klicke auf „%2$@“, um eine neue E-Mail zu erhalten.";
 
 /* Me tab menu items */
 "meMenu.submitFeedback" = "Feedback senden";
@@ -8776,6 +9326,9 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "Übergeordnete Seite";
 
+/* No comment provided by engineer. */
+"password" = "Passwort";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "Je nachdem was auf deiner Website los ist, zeigen Karten möglicherweise unterschiedliche Inhalte an. Wir arbeiten daran, mehr Karten und Bedienelemente zu ermöglichen.";
 
@@ -8880,9 +9433,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Message shown while loading plugin details */
 "pluginDetails.loading" = "Plugininformationen werden geladen …";
-
-/* Placeholder message shown when a plugin has no description */
-"pluginDetails.noDescription" = "Dieses Plugin hat keine Beschreibung angegeben.";
 
 /* Title of the changelog section in plugin details */
 "pluginDetails.section.changelog" = "Änderungsprotokoll";
@@ -9172,6 +9722,30 @@ Example: Reply to Pamela Nguyen */
 /* An alert message explaning that by changing the visibility to private, the post will be published immediately to your site */
 "postSettings.warningPostWillBePublishedAlertMessage" = "Wenn du die Sichtbarkeit in „Privat“ änderst, wird der Beitrag sofort veröffentlicht";
 
+/* Localized post type: `Page` */
+"postType.page" = "Seite";
+
+/* Localized post type: `Post` */
+"postType.post" = "Beitrag";
+
+/* Details for a 'Private' privacy setting */
+"postVisibility.private.details" = "Nur für Website-Administratoren und Redakteure sichtbar";
+
+/* Title for a 'Private' privacy setting */
+"postVisibility.private.title" = "Privat";
+
+/* Details for a 'Password Protected' privacy setting */
+"postVisibility.protected.details" = "Sichtbar für jeden, erfordert aber ein Passwort";
+
+/* Title for a 'Password Protected' privacy setting */
+"postVisibility.protected.title" = "Passwortgeschützt";
+
+/* Details for a 'Public' (default) privacy setting */
+"postVisibility.public.details" = "Sichtbar für jeden";
+
+/* Title for a 'Public' (default) privacy setting */
+"postVisibility.public.title" = "Öffentlich";
+
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Abbrechen";
 
@@ -9392,9 +9966,6 @@ Tapping on this row allows the user to edit the sharing message. */
 /* Title for the success view when the user has successfully logged in */
 "qrLoginVerifyAuthorization.completedInstructions.title" = "Du bist angemeldet!";
 
-/* Message of error prompt shown when no internet connection is available */
-"reachability-utils.alert.utils" = "Die Internetverbindung wurde anscheinend unterbrochen.";
-
 /* Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog. */
 "reader.blocked.blog.message" = "Der Blog %@ wird nicht mehr in deinem Reader erscheinen. Tippe, um es rückgängig zu machen.";
 
@@ -9431,20 +10002,8 @@ Tapping on this row allows the user to edit the sharing message. */
 /* A shared button title for Reader */
 "reader.button.unsubscribe" = "Deabonnieren";
 
-/* Button title. Follow the comments on a post. */
-"reader.comments.buttonFollow" = "Abonnieren";
-
 /* Informational message, should be short. */
 "reader.comments.commentsClosed" = "Kommentare geschlossen";
-
-/* Empty state view title */
-"reader.comments.errorLoadingComments" = "Beim Laden der Kommentare ist ein unerwarteter Fehler aufgetreten.";
-
-/* VoiceOver hint */
-"reader.comments.followingSettingAccessibilityIdentifier" = "Benachrichtigungseinstellungen für diesen Beitrag öffnen";
-
-/* Error message that informs reader comments from a private blog cannot be fetched. */
-"reader.comments.noPermissionToViewPrivateBlog" = "Du bist nicht berechtigt, dieses private Blog anzuzeigen.";
 
 /* Accessibility hint to inform that the author section can be tapped to see posts from the site. */
 "reader.detail.header.authorInfo.a11y.hint" = "Zeigt Beiträge von der Website an";
@@ -9521,18 +10080,6 @@ but tapping on this button will remove their like from the post. */
 
 /* Screen header details */
 "reader.following.header.details" = "Bleib auf dem Laufenden mit deinen abonnierten Blogs.";
-
-/* Empty state view */
-"reader.following.lists.emptyTitle" = "Listen leer";
-
-/* Screen header details */
-"reader.home.header.details" = "Bleib auf dem Laufenden mit deinen abonnierten Blogs.";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.home.title" = "Startseite";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.library.title" = "Bibliothek";
 
 /* Used in multiple contexts, usually as a screen title */
 "reader.likes.title" = "Likes";
@@ -9778,8 +10325,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title of a Reader tab showing Posts matching a user's search query */
 "reader.search.tab.posts" = "Beiträge";
 
-/* Title of the Reader's search feature
-   Used in multiple contexts, usually as a screen title */
+/* Title of the Reader's search feature */
 "reader.search.title" = "Suche";
 
 /* Screen title. Reader select interests title label text. */
@@ -9805,6 +10351,21 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Reader select interests title label text */
 "reader.select.tags.title" = "Entdecke Blogs, die dir gefallen, und folge ihnen";
+
+/* Reader sidebar menu item */
+"reader.sidebar.discover" = "Entdecken";
+
+/* Reader sidebar menu item */
+"reader.sidebar.likes" = "Likes";
+
+/* Reader sidebar menu item */
+"reader.sidebar.recent" = "Neueste";
+
+/* Reader sidebar menu item */
+"reader.sidebar.saved" = "Gespeichert";
+
+/* Reader sidebar menu item */
+"reader.sidebar.search" = "Suche";
 
 /* Reader sidebar section title */
 "reader.sidebar.section.favorites.title" = "Favoriten";
@@ -9854,7 +10415,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Number of subscriptions on a site (singular) */
 "reader.subscriptions.subscriptionsSingular" = "%@ Abonnent";
 
-/* Used in multiple contexts, usually as a screen title */
+/* Navigation bar title */
 "reader.subscriptions.title" = "Abonnements";
 
 /* A suggestion of topics the user might want to subscribe to */
@@ -9901,12 +10462,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Field title */
 "reader.userProfile.site" = "Website";
-
-/* Reader Welcome screen */
-"reader.welcome.subtitle" = "Werde Teil der größten Blogging-Community";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.me" = "Ich";
 
 /* Spoken accessibility label */
 "readerDetail.backButton.accessibilityLabel" = "Zurück";
@@ -10184,7 +10739,9 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Message shown when there are no inactive plugins on the site */
 "site.plugins.empty.inactive" = "Keine inaktiven Plugins";
 
-/* The plugin fillter option for displaying all plugins */
+/* The plugin fillter option for displaying active plugins
+   The plugin fillter option for displaying all plugins
+   The plugin fillter option for displaying inactive plugins */
 "site.plugins.filter.option.all" = "Alle";
 
 /* Title of the plugin filter picker */
@@ -10737,9 +11294,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* View title for Help & Support page. */
 "support.title" = "Hilfe";
 
-/* Subject of new Zendesk ticket. */
-"support.zendesk.readerAppTicketSubject" = "Reader für iOS-Support";
-
 /* Title for placeholder in Tenor picker */
 "tenor.welcomeMessage" = "Suche nach kostenlosen GIFs, die du deiner Mediathek hinzufügen kannst!";
 
@@ -10888,8 +11442,119 @@ Feel free to replace it with other bracket types that you think looks better for
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "Status";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "Beiträge im gesamten Zeitraum und häufigste Aufrufe";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "Aufrufe im gesamten Zeitraum";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "Aufrufe und Besucher im gesamten Zeitraum";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "Bisher bestes Aufrufergebnis";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "Häufigste Aufrufe";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "Die Gesamtstatistiken konnten nicht geladen werden.";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "Erstelle oder füge eine Website hinzu, um die Gesamtstatistiken anzuzeigen.";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Beiträge";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "Bleibe auf dem Laufenden über die Aktivitäten des Gesamtzeitraums auf deiner WordPress-Website.";
+
+/* Title of all time widget */
+"widget.alltime.title" = "Gesamtzeitraum";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "Melde dich in WordPress an, um dir alle Statistiken des Gesamtzeitraums anzusehen.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "Melde dich bei Jetpack an, um dir die Statistiken des Gesamtzeitraums anzusehen.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "Melde dich bei Jetpack an, um dir die Statistiken dieser Woche anzusehen.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "Melde dich bei Jetpack an, um dir die Statistiken von heute anzusehen.";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "Aufrufe im gesamten Zeitraum";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "Aufrufe heute";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "Die Statistiken dieser Woche konnten nicht geladen werden.";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "Erstelle oder füge eine Website hinzu, um die Statistiken dieser Woche anzuzeigen.";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "Bleibe auf dem Laufenden über die Aktivitäten dieser Woche auf deiner WordPress-Website.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "Diese Woche";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "Melde dich in WordPress an, um dir die Statistiken dieser Woche anzusehen.";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Kommentare";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "Die Statistiken wurden in die Jetpack-App verschoben. Der Wechsel ist kostenlos und dauert nur eine Minute.";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Likes";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "Website-Statistiken konnten nicht geladen werden.";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "Die heutigen Statistiken konnten nicht geladen werden.";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "Erstelle oder füge eine Website hinzu, um die heutigen Statistiken anzuzeigen.";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "Bleibe auf dem Laufenden über die heutigen Aktivitäten auf deiner WordPress-Website.";
+
+/* Title of today widget */
+"widget.today.title" = "Heute";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "Melde dich in WordPress an, um dir die heutigen Statistiken anzusehen.";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "Ansicht ist nicht verfügbar";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Aufrufe";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Besucher";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "Heutige Likes und Kommentare";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "Heutige Aufrufe";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "Heutige Aufrufe und Besucher";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "wird zukünftig deaktiviert sein";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "Du willst eine neue Website aufbauen?";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "wordpress, hilfe, support, faq, fragen, debuggen, protokolle, hilfe-center, kontakt";
@@ -10914,6 +11579,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Error message that describes an unknown error had occured */
 "wordpress-api.error.unknown" = "Etwas ist schiefgelaufen. Bitte versuche es später erneut.";
+
+/* Error message when failing to find selected media file on the user's device. */
+"wordpress.api.upload.media.fileNotFound" = "Die Mediendatei kann auf dem Gerät nicht gefunden werden";
 
 /* Jetpack Plugin Modal on WordPress primary button title */
 "wordpress.jetpack.plugin.modal.primary.button.title" = "Zur Jetpack-App wechseln";
@@ -10960,15 +11628,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Error message when user signs in with an unexpected email address. The first argument is the expected email address */
 "wpComLogin.error.mismatchedEmail" = "Bitte melde dich mit der E-Mail-Adresse %@ an";
 
-/* Message shown when user denies WordPress.com login, offering option to try with different account */
-"wpComLogin.loginDenied.message" = "Du kannst dich mit einem anderen Konto anmelden, wenn nötig. Tippe auf „%@“, um zu beginnen.";
-
-/* Title of alert shown when user cancels WordPress.com login */
-"wpComLogin.loginDenied.title" = "Anmeldung abgebrochen";
-
-/* Button title for signing in with a different WordPress.com account */
-"wpComLogin.loginDenied.useDifferentAccount" = "Anderes Konto verwenden";
-
 /* Message title to be displayed when the user needs to re-authenticate their WordPress.com account. */
 "wpcom.token.fix.signin" = "Bei WordPress.com anmelden";
 
@@ -10983,6 +11642,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "Nicht unterstützter Anhang";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Mit Google anmelden.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Domains";

--- a/WordPress/Resources/en-AU.lproj/Localizable.strings
+++ b/WordPress/Resources/en-AU.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "%1$@ of %2$@ on your site";
 
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "%1$@ of %2$@ used on your site";
+
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ quadrillion";
 
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Untitled)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(no title)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*Johann Brandt* responded to your post";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "A \"more\" button contains a dropdown which displays sharing buttons";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above.";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "A file contains a malicious code pattern";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "A title for the site";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "A verification code will only contain numbers.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "ACTIVE";
@@ -522,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "After %@";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "Alignment";
@@ -585,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "Allowlisted IP addresses";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "Almost there! Please enter the verification code from your authenticator app.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Alt Text";
@@ -597,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "Alternatively, you can flatten the content by ungrouping the block.";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "Alternatively, you may enter the password for this account.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "Alternatively:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "Always Send Crash Logs";
@@ -618,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "An active internet connection is required to view activities";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "An active internet connection is required to view plans";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -668,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "Annual Site Stats";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "Anonymous";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "Answer";
 
@@ -689,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "Appearance";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication.";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "Applies the setting";
@@ -775,6 +811,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "Authentication Failed";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "Authentication code";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "Authentication required for host: %@";
@@ -882,6 +922,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "Be the first to comment";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Be the first to leave a comment.";
 
 /* Beauty site intent topic */
 "Beauty" = "Beauty";
@@ -1012,12 +1055,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button position" = "Button position";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "By continuing, you agree to our _Terms of Service_.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "By setting up Jetpack you agree to our\n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "By signing up, you agree to our _Terms of Service_.";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "CUSTOMISE";
@@ -1031,6 +1080,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "Camera access needed to scan login codes";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Can Not Request Link";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "Can't publish an empty page";
 
@@ -1040,6 +1092,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1049,6 +1102,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1067,6 +1121,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1094,6 +1149,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "Cancelling...";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "Cannot access the site at this address. Please double-check and try again.";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Can’t decide? You can change the theme at any time.";
 
@@ -1101,7 +1159,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Caption";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Careful!";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1110,7 +1169,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Categories";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Category";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1159,6 +1219,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "Check out our top tips to increase your views and traffic";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "Check your email on this device!";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Check your email on this device, and tap the link in the email you receive from WordPress.com.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "Check your email!";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "Check your internet connection and pull to refresh.";
@@ -1255,6 +1327,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "Claim your free domain";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "Classic Blog";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "Clear Device Media Cache";
 
@@ -1279,6 +1354,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Close";
 
@@ -1320,6 +1396,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "Columns Settings";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Comics";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1371,6 +1450,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Comments";
 
@@ -1438,12 +1518,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Connected Accounts";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Connected But…";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "Connecting %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Connecting %1$@ will replace the existing connection to %2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Connecting to WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Connecting...";
@@ -1474,8 +1560,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "Contact us at %@";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "Content Structure\nBlocks: %1$li, Words: %2$li, Characters: %3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1490,6 +1580,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Continue reading";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Continue with Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Continue with Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Continuing with Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "Contribute";
@@ -1612,6 +1711,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "Create";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Create Account";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "Create Blank Page";
 
@@ -1632,6 +1734,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "Create a Post";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "Create a Site";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "Create a Tag";
@@ -1665,6 +1770,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "Current";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Current Plan";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Current Theme";
@@ -1767,6 +1875,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "Default Category";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Default Menu";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Default Post Format";
@@ -1775,6 +1886,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "Defaults for New Posts";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Delete";
@@ -1832,6 +1944,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "Details";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "Didn't mean to create a new account? Go back to re-enter your email address.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "Dimensions";
 
@@ -1879,7 +1994,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "Discussion";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Dismiss";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1901,6 +2018,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "Domains";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "Don't have an account? _Sign up_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2030,6 +2150,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "Downloads";
 
+/* Name for the status of a draft post. */
+"Draft" = "Draft";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Drafts";
 
@@ -2139,7 +2262,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "Email Address";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "Email address";
 
 /* Notification Settings Channel */
@@ -2223,8 +2349,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Enter password";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "Enter the address of the WordPress site you'd like to connect.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Enter the password for your WordPress.com account.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Enter username";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "Enter your account information for %@.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "Enter your email address to log in or create a WordPress.com account.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "Enter your existing site address";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "Enter your password instead.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "Enter your server credentials";
@@ -2384,6 +2530,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "External";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Failed";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "Failed marking Notifications as read";
 
@@ -2410,6 +2559,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "Fashion";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "Featured";
@@ -2468,6 +2620,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "Find out more";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Find your site address";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2490,6 +2645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "Fixing Threats";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "Follow";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "Follow Conversation";
@@ -2584,6 +2742,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "Generate new link";
 
+/* View title for initial auth views. */
+"Get Started" = "Get Started";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "Get a login link by email";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "Get active! Comment on posts from blogs you follow.";
 
@@ -2605,8 +2769,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "Getting Inspired";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Getting account information";
+
+/* Cancel */
+"Give Up" = "Give Up";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "Give it a try by adding a few blocks to your post or page!";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "Go to Reader";
@@ -2617,6 +2790,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "Go to iOS Settings";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Google sign up failed.";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2691,6 +2867,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "Help icon";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Hidden";
+
 /* Title of a button used to collapse a group */
 "Hide" = "Hide";
 
@@ -2759,6 +2938,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "Icon update failed";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "If you can’t find the email, please check your junk or spam email folder";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "If you remove %1$@, that user will no longer be able to access this site, but any content that was created by %2$@ will remain on the site.";
@@ -2834,6 +3019,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "Includes wp-config.php and any non WordPress files";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Incorrect username or password. Please try entering your login details again.";
 
 /* Title for a threat */
 "Infected core file" = "Infected core file";
@@ -2935,6 +3123,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "Introducing Blogging Prompts";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "Invalid Email Address";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "Invalid Site Address";
 
@@ -2952,6 +3143,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "Invalid URL. Audio file not found.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "Invalid URL. Please double-check and try again.";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "Invalid URL. Please enter a valid URL.";
@@ -2973,6 +3167,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "Invite People";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "It looks like this username\/password isn't associated with this site.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "It seems like you've entered an incorrect password. Want to give it another try?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "It's time to blog on %@!";
@@ -3201,7 +3401,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "Line Height";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Link";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3260,6 +3461,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "Loading People...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Loading Plan...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Loading Plans...";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "Loading Plugin...";
 
@@ -3294,11 +3501,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "Loading...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Local";
+
 /* Local Services site intent topic */
 "Local Services" = "Local Services";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "Local changes";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Location";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Location unknown";
 
 /* No comment provided by engineer. */
 "Lock icon" = "Lock icon";
@@ -3306,9 +3525,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Log Files By Created Date";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Log In";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3317,6 +3538,22 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title of a button for signing in. */
 "Log in" = "Log in";
+
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Log in failed. Please try again.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "Log in or sign up with WordPress.com";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Log in to the WordPress.com account you used to connect Jetpack.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "Log in to your WordPress.com account with your email address.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "Log in with your WordPress.com username and password.";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of Jetpack?" = "Log out of Jetpack?";
@@ -3327,6 +3564,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Login Request Expired */
 "Login Request Expired" = "Login Request Expired";
 
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "Log in with account password";
+
 /* No comment provided by engineer. */
 "Logs" = "Logs";
 
@@ -3335,6 +3575,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications.";
+
+/* Title of a button. */
+"Lost your password?" = "Lost your password?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "Mail (Default)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Main Navigation";
@@ -3482,6 +3728,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "Message";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "Miscellaneous vulnerability";
 
@@ -3577,6 +3826,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "My Site";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "My Sites in WordPress";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "My Top Ten Cafes";
 
@@ -3616,8 +3868,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Need Help?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "Need help finding your site address?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "Need help?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Need more help?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "Needs Update";
@@ -3646,6 +3905,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "New Post";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "New item";
+
 /* Placeholder text for password field */
 "New password" = "New password";
 
@@ -3663,7 +3925,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "News";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Next";
 
 /* Accessibility label for the next notification button */
@@ -3699,6 +3963,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "No Preview URL available";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "No Title";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "No activities available";
 
@@ -3731,7 +3998,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "No comments yet";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "No connection";
 
@@ -3880,6 +4148,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "Not now";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "Not seeing the email? Check your Spam or Junk Mail folder.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "Note:";
 
@@ -3943,7 +4214,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Numbered List";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -4000,7 +4276,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "Oops";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Oops!";
 
 /* No comment provided by engineer. */
@@ -4015,7 +4292,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "Open Jetpack Security settings";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Open Mail";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Open Settings";
 
 /* No comment provided by engineer. */
@@ -4033,6 +4315,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "Open link in new window\/tab";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "Open subscription settings for the post";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "Open the Me Section";
 
@@ -4047,6 +4332,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "Optional: enter a custom message of up to %1$d characters to be sent with your invitation.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "Or";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "Or choose another form of authentication.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "Or log in by _entering your site address_.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "Or log in with magic link";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Ordered List";
@@ -4095,7 +4392,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "Padding";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Page";
 
@@ -4128,8 +4426,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "Parenting";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Password";
 
@@ -4146,8 +4447,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "Paste block after";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Pending";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Pending review";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4178,6 +4483,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "Pick username";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Plans";
+
 /* User action to play a video on the editor. */
 "Play video" = "Play video";
 
@@ -4207,6 +4516,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "Please enter a complete website address, like example.com.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "Please enter a site address.";
@@ -4241,11 +4553,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "Please enter a valid address";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "Please enter a valid email address for a WordPress.com account.";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Please enter a valid email address.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "Please enter a valid phone number";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Please enter the password for your WordPress.com account to log in with your Apple ID.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Please enter your credentials";
@@ -4253,8 +4571,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Please enter your email address.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Please fill out all the fields";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "Please log out before connecting to a different wordpress.com site";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "Please try again later";
@@ -4319,7 +4643,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "Popular languages";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Post";
 
@@ -4440,6 +4765,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "Privacy notice for California users";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Private";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "Problem displaying block. \nTap to attempt block recovery.";
 
@@ -4454,6 +4782,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "Problem purchasing your domain. Please try again.";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s).";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Projects";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "Prompt skipped";
@@ -4471,13 +4805,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "Publish Date";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Publish Immediately";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "Publish page on:";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "Publish post on:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Published";
 
@@ -4676,7 +5014,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "Reply";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Reply Text";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "Reply to %1$@";
 
 /* An explaination of a setting. */
@@ -4705,6 +5048,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "Reset Date Range filter";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Reset your password";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Resize & Crop";
@@ -4762,6 +5108,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "Retry all";
 
+/* No comment provided by engineer. */
+"Retry?" = "Retry?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "Return to post";
 
@@ -4791,6 +5140,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "Role";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS Sent";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "STATUS";
 
@@ -4802,6 +5154,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4868,7 +5221,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "Scanning files";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Scheduled";
 
 /* No comment provided by engineer. */
@@ -5008,6 +5362,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "Selects this topic as the intent for your site.";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Send Link";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "Send Link by Email";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "Send Log Message";
 
@@ -5016,6 +5376,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "Send Test Crash";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "Send email verification link";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "Send notifications by email";
@@ -5061,6 +5424,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message to show when setting save failed */
 "Settings update failed" = "Settings update failed";
+
+/* Spoken accessibility label */
+"Share" = "Share";
 
 /* Title for a button that recommends the app to others */
 "Share Jetpack with a friend" = "Share Jetpack with a friend";
@@ -5114,6 +5480,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "Show Reblog button";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "Show password";
+
 /* No comment provided by engineer. */
 "Show post content" = "Show post content";
 
@@ -5125,6 +5495,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "Showing stats for:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "Shown";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Shown publicly when you comment on blogs.";
@@ -5140,6 +5513,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "Shows the post";
+
+/* View title during the sign up process. */
+"Sign Up" = "Sign Up";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "Sign in with site credentials";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Sign up";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Sign up for WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Sign up with Email";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "Since you're on a free plan, you'll see limited events in your Activity Log.";
@@ -5178,6 +5566,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Site achievements";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Site Address";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "Site address must be at least 4 characters.";
@@ -5262,7 +5653,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Sorry, site addresses must have letters too!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Sorry, that email address is already being used!";
 
 /* No comment provided by engineer. */
@@ -5322,6 +5713,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "Spam";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "Speed up your site";
@@ -5347,6 +5741,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "State";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "Static Home page";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5377,6 +5774,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "Strikethrough";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Stub";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "Submit for Review";
@@ -5467,7 +5867,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "Tablet";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Tag";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5593,6 +5994,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Terms of Service";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Testimonials";
+
 /* Title of a button style */
 "Text Only" = "Text Only";
 
@@ -5602,8 +6006,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block";
 
+/* Button title */
+"Text me a code instead" = "Text me a code instead";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "Text me a code via SMS";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Thanks for choosing %1$@ by %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "That doesn't appear to be a valid verification code.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "That doesn't look like a WordPress site.";
@@ -5625,6 +6038,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages.";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "The Google account \"%@\" doesn't match any account on WordPress.com";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "The Internet connection appears to be offline.";
@@ -5661,6 +6077,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "The image could not be added to the Media Library.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "The internet connection appears to be offline.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "The kinds of sites that can be created";
@@ -5704,6 +6123,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "The site at %1$@ uses WordPress %2$@. We recommend to update to the latest version, or at least %3$@";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "The site could not be deleted.";
 
@@ -5745,6 +6168,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "There has been an unexpected error while editing your comment";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "There has been an unexpected error while loading the comments.";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "There has been an unexpected error while registering your domain";
 
@@ -5753,6 +6179,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "There has been an unexpected error while updating your Notification Settings";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "There has been an unexpected error while updating your comment";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "There has been an unexpected error.";
@@ -5774,6 +6203,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "There was a problem communicating with the site.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "There was a problem connecting to WordPress.com. Please log in again.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "There was a problem displaying this post.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "There was a problem loading your data, refresh your page to try again.";
 
@@ -5783,12 +6218,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "There was a problem saving changes to sharing management.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "There was a problem when trying to access your location. Please try again later.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "There was an error changing the password";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "There was an error loading activities";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "There was an error loading plans";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "There was an error loading plugins";
@@ -5801,6 +6242,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "There was an error loading the history";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "There was an error loading the plan";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "There was an error loading the scan history";
@@ -5849,6 +6293,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "This domain is unavailable";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "This email address is not registered on WordPress.com.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "This file is too large to upload to your site or it does not support this media format.";
@@ -5929,6 +6376,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "Time Zone";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "Time's up, but don't worry, your security is our priority. Please try again!";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "Tips for getting the most out of WordPress.com.";
 
@@ -5942,6 +6392,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "To continue please enter your email address and name.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "To create your new WordPress.com account, please enter your email address.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin.";
 
@@ -5950,6 +6403,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "To install plugins, you need to have a custom domain associated with your site.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block.";
@@ -6024,7 +6483,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "Trash";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "Trashed";
 
@@ -6038,6 +6498,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "Try & Customise";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Try Again";
@@ -6063,6 +6524,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "Try the new Block Editor";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Try with another email";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Try with the site address";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "Turn off prompts";
@@ -6105,6 +6572,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "USES";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "Unable To Connect";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "Unable to Load Posts";
@@ -6154,6 +6624,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Unable to play video";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Unable to restore your site";
 
@@ -6180,6 +6653,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "Unable to upload 1 post, 1 file";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "Unable to verify the email address. Please try again later.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "Unable to visit Jetpack settings for site";
@@ -6318,7 +6794,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Upload failed";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Uploaded";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6336,7 +6813,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Uploaded themes";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Uploading";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6351,18 +6829,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "Use";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "Use a security key";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "Use block editor";
 
 /* No comment provided by engineer. */
 "Use icon button" = "Use icon button";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "Use password to sign in";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Username";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6377,6 +6864,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Users";
+
+/* two factor code placeholder */
+"Verification code" = "Verification code";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "Verification email sent, check your inbox.";
@@ -6509,8 +6999,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "WP-content directory";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Waiting for Google to complete…";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "Waiting for connection";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "Waiting for security key";
+
+/* View title during the Google auth process. */
+"Waiting..." = "Waiting...";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6550,6 +7050,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "We had trouble loading data";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "We just emailed a link to %@. Please check your mail app and tap the link to log in.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "We just sent a magic link to";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "We successfully created a backup of your site as of %@";
 
@@ -6559,14 +7065,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "We use other tracking tools, including some from third parties. Read about these and how to control them.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "We were unable to send you an email at this time. Please try again later.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "We will send you an email if security threats are found. In the meantime, feel free to continue to use your site as normal, you can check back on progress at any time.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "We'll email you a magic link to create your new WordPress.com account.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "We'll notify you when you get followers, comments, and likes.";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "We’ll notify you when you get followers, comments and likes. Would you like to allow push notifications?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "We'll use this email address to create your new WordPress.com account.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "We're creating a downloadable backup of your site from %1$@.";
@@ -6577,6 +7095,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "We're not able to connect to the Jetpack site at that URL.  Contact us for assistance.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "We're restoring your site back to %1$@.";
 
@@ -6585,6 +7106,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "We've also emailed you a link to your file.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "We’ve emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6611,6 +7135,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "Weekly Roundup: %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "Welcome to Jetpack";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Welcome to WordPress";
 
 /* A message title */
 "Welcome to the Reader" = "Welcome to the Reader";
@@ -6652,6 +7182,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title displayed via UIAlertController when a user inserts a document into a post. */
 "What do you want to do with this file: upload it and add a link to the file into your post, or add the contents of the file directly to the post?" = "What do you want to do with this file: upload it and add a link to the file into your post, or add the contents of the file directly to the post?";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "What is WordPress.com?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "What is a block?";
 
@@ -6670,6 +7203,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "What's New in WordPress";
 
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "What's my site address?";
+
 /* Select the site's intent. Title */
 "What's your website about?" = "What's your website about?";
 
@@ -6681,6 +7217,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "When you make changes to your site you'll be able to see your activity history here.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Whoops, something went wrong and we couldn't log you in. Please try again!";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "Whoops, something went wrong. Please try again!";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "Whoops, that security key does not seem valid. Please try again with another one";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Whoops, that's not a valid two-factor verification code. Double-check your code and try again!";
 
 /* No comment provided by engineer. */
 "Width Settings" = "Width Settings";
@@ -6694,17 +7242,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "WordPress App Settings";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "WordPress Apps - Apps for any screen";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "WordPress Blog";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "WordPress Help";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "WordPress Media Library";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "WordPress Notification Settings";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "WordPress Notifications";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "WordPress Plugins";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "WordPress Profile";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "WordPress Reader";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "WordPress Site Details";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "WordPress Themes";
@@ -6715,17 +7284,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "WordPress multisites are not supported";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings.";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "WordPress root";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "WordPress version too old";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "WordPress version too old. The site at %1$@ uses WordPress %2$@. We recommend to update to the latest version, or at least %3$@";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "WordPress.com Account";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "WordPress.com Plans";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "WordPress.com Themes";
@@ -6756,6 +7334,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "Write Post";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "Write a reply";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "Write a reply…";
 
 /* Title for the writing section in site settings screen */
@@ -6769,6 +7350,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Y-Axis Position";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "Year";
@@ -6865,7 +7449,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "You have no reminders set.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "You have unsaved changes.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -6957,6 +7542,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9.";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "Your site address appears in the bar at the top of the screen when you visit your site in Safari.";
 
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below.";
@@ -7538,6 +8126,10 @@ Example: Reply to Pamela Nguyen */
 
 /* Accessibility label for more button in dashboard quick start card. */
 "ellipsisButton.AccessibilityLabel" = "More";
+
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "example.com";
 
 /* Title for confirmation navigation bar button item */
 "externalMediaPicker.add" = "Add";
@@ -8301,6 +8893,9 @@ Example: Reply to Pamela Nguyen */
 /* Menu option for filtering posts by me */
 "pagesList.pagesByMe" = "Pages by me";
 
+/* No comment provided by engineer. */
+"password" = "password";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "Cards may show different content depending on what's happening on your site. We're working on more cards and controls.";
 
@@ -9041,6 +9636,114 @@ but tapping on this button will remove their like from the post. */
 /* Verb. Dismiss the web view screen. */
 "webKit.button.dismiss" = "Dismiss";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "All-Time Posts & Most Views";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "All-Time Views";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "All-Time Views & Visitors";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "Best views ever";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "Most Views";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "Unable to load all time stats.";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "Create or add a site to see all time stats.";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Posts";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "Stay up to date with all time activity on your WordPress site.";
+
+/* Title of all time widget */
+"widget.alltime.title" = "All Time";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "Log in to WordPress to see all time stats.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "Log in to Jetpack to see all time stats.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "Log in to Jetpack to see this week's stats.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "Log in to Jetpack to see today's stats.";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "All-Time Views";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "Views Today";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "Unable to load this week's stats.";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "Create or add a site to see this week's stats.";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "Stay up to date with this week activity on your WordPress site.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "This Week";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "Log in to WordPress to see this week's stats.";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Comments";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "Stats have moved to the Jetpack app. Switching is free and only takes a minute.";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Likes";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "Unable to load site stats.";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "Unable to load today's stats.";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "Create or add a site to see today's stats.";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "Stay up to date with today's activity on your WordPress site.";
+
+/* Title of today widget */
+"widget.today.title" = "Today";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "Log in to WordPress to see today's stats.";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "View is unavailable";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Views";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Visitors";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "Today's Likes & Comments";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "Today's Views";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "Today's Views & Visitors";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "will be unavailable in the future.";
 
@@ -9091,6 +9794,9 @@ but tapping on this button will remove their like from the post. */
 
 /* Title of a button that displays a blog post in a web view. */
 "wp.migration.successCard.learnMore" = "Learn more";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Log in with Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Domains";

--- a/WordPress/Resources/en-CA.lproj/Localizable.strings
+++ b/WordPress/Resources/en-CA.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "%1$@ of %2$@ on your site";
 
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "%1$@ of %2$@ used on your site";
+
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ quadrillion";
 
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Untitled)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(no title)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*Johann Brandt* responded to your post";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "A \"more\" button contains a dropdown which displays sharing buttons";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above.";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "A file contains a malicious code pattern";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "A title for the site";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "A verification code will only contain numbers.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "ACTIVE";
@@ -522,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "After %@";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "Alignment";
@@ -585,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "Allowlisted IP addresses";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "Almost there! Please enter the verification code from your authenticator app.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Alt Text";
@@ -597,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "Alternatively, you can flatten the content by ungrouping the block.";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "Alternatively, you may enter the password for this account.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "Alternatively:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "Always Send Crash Logs";
@@ -618,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "An active internet connection is required to view activities";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "An active internet connection is required to view plans";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -668,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "Annual Site Stats";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "Anonymous";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "Answer";
 
@@ -689,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "Appearance";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication.";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "Applies the setting";
@@ -775,6 +811,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "Authentication Failed";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "Authentication code";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "Authentication required for host: %@";
@@ -885,6 +925,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "Be the first to comment";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Be the first to leave a comment.";
 
 /* Beauty site intent topic */
 "Beauty" = "Beauty";
@@ -1015,12 +1058,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button position" = "Button position";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "By continuing, you agree to our _Terms of Service_.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "By setting up Jetpack you agree to our\n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "By signing up, you agree to our _Terms of Service_.";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "CUSTOMIZE";
@@ -1034,6 +1083,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "Camera access needed to scan login codes";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Can Not Request Link";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "Can't publish an empty page";
 
@@ -1043,6 +1095,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1052,6 +1105,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1070,6 +1124,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1097,6 +1152,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "Cancelling...";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "Cannot access the site at this address. Please double-check and try again.";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Can’t decide? You can change the theme at any time.";
 
@@ -1104,7 +1162,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Caption";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Careful!";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1113,7 +1172,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Categories";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Category";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1162,6 +1222,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "Check out our top tips to increase your views and traffic";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "Check your email on this device!";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Check your email on this device, and tap the link in the email you receive from WordPress.com.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "Check your email!";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "Check your internet connection and pull to refresh.";
@@ -1258,6 +1330,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "Claim your free domain";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "Classic Blog";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "Clear Device Media Cache";
 
@@ -1282,6 +1357,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Close";
 
@@ -1323,6 +1399,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "Columns settings";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Comics";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1374,6 +1453,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Comments";
 
@@ -1441,12 +1521,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Connected Accounts";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Connected But…";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "Connecting %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Connecting %1$@ will replace the existing connection to %2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Connecting to WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Connecting…";
@@ -1477,8 +1563,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "Contact us at %@";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "Content Structure\nBlocks: %1$li, Words: %2$li, Characters: %3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1493,6 +1583,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Continue reading";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Continue with Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Continue with Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Continuing with Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "Contribute";
@@ -1615,6 +1714,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "Create";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Create Account";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "Create Blank Page";
 
@@ -1635,6 +1737,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "Create a Post";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "Create a Site";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "Create a Tag";
@@ -1668,6 +1773,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "Current";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Current Plan";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Current Theme";
@@ -1770,6 +1878,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "Default Category";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Default Menu";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Default Post Format";
@@ -1778,6 +1889,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "Defaults for New Posts";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Delete";
@@ -1835,6 +1947,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "Details";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "Didn't mean to create a new account? Go back to re-enter your email address.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "Dimensions";
 
@@ -1882,7 +1997,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "Discussion";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Dismiss";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1904,6 +2021,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "Domains";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "Don't have an account? _Sign up_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2033,6 +2153,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "Downloads";
 
+/* Name for the status of a draft post. */
+"Draft" = "Draft";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Drafts";
 
@@ -2142,7 +2265,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "Email Address";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "Email address";
 
 /* Notification Settings Channel */
@@ -2226,8 +2352,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Enter password";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "Enter the address of the WordPress site you'd like to connect.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Enter the password for your WordPress.com account.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Enter username";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "Enter your account information for %@.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "Enter your email address to log in or create a WordPress.com account.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "Enter your existing site address";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "Enter your password instead.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "Enter your server credentials";
@@ -2387,6 +2533,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "External";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Failed";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "Failed marking Notifications as read";
 
@@ -2413,6 +2562,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "Fashion";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "Featured";
@@ -2471,6 +2623,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "Find out more";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Find your site address";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2493,6 +2648,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "Fixing Threats";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "Follow";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "Follow Conversation";
@@ -2587,6 +2745,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "Generate new link";
 
+/* View title for initial auth views. */
+"Get Started" = "Get Started";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "Get a login link by email";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "Get active! Comment on posts from blogs you follow.";
 
@@ -2608,8 +2772,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "Getting Inspired";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Getting account information";
+
+/* Cancel */
+"Give Up" = "Give Up";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "Give it a try by adding a few blocks to your post or page!";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "Go to Reader";
@@ -2620,6 +2793,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "Go to iOS Settings";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Google sign up failed.";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2694,6 +2870,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "Help icon";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Hidden";
+
 /* Title of a button used to collapse a group */
 "Hide" = "Hide";
 
@@ -2762,6 +2941,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "Icon update failed";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "If you can’t find the email, please check your junk or spam email folder";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "If you remove %1$@, that user will no longer be able to access this site, but any content that was created by %2$@ will remain on the site.";
@@ -2837,6 +3022,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "Includes wp-config.php and any non-WordPress files";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Incorrect username or password. Please try entering your login details again.";
 
 /* Title for a threat */
 "Infected core file" = "Infected core file";
@@ -2938,6 +3126,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "Introducing Blogging Prompts";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "Invalid Email Address";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "Invalid Site Address";
 
@@ -2955,6 +3146,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "Invalid URL. Audio file not found.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "Invalid URL. Please double-check and try again.";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "Invalid URL. Please enter a valid URL.";
@@ -2976,6 +3170,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "Invite People";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "It looks like this username\/password isn't associated with this site.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "It seems like you've entered an incorrect password. Want to give it another try?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "It's time to blog on %@!";
@@ -3204,7 +3404,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "Line Height";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Link";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3263,6 +3464,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "Loading People…";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Loading Plan…";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Loading Plans…";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "Loading Plugin…";
 
@@ -3297,11 +3504,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "Loading…";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Local";
+
 /* Local Services site intent topic */
 "Local Services" = "Local Services";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "Local changes";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Location";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Location unknown";
 
 /* No comment provided by engineer. */
 "Lock icon" = "Lock icon";
@@ -3309,9 +3528,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Log Files By Created Date";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Log In";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3320,6 +3541,22 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title of a button for signing in. */
 "Log in" = "Log in";
+
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Login failed. Please try again.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "Log in or sign up with WordPress.com";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Log in to the WordPress.com account you used to connect Jetpack.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "Log in to your WordPress.com account with your email address.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "Log in with your WordPress.com username and password.";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of Jetpack?" = "Log out of Jetpack?";
@@ -3330,6 +3567,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Login Request Expired */
 "Login Request Expired" = "Login Request Expired";
 
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "Login with account password";
+
 /* No comment provided by engineer. */
 "Logs" = "Logs";
 
@@ -3338,6 +3578,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications.";
+
+/* Title of a button. */
+"Lost your password?" = "Lost your password?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "Mail (Default)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Main Navigation";
@@ -3485,6 +3731,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "Message";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "Miscellaneous vulnerability";
 
@@ -3580,6 +3829,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "My Site";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "My Sites in WordPress";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "My Top Ten Cafes";
 
@@ -3619,8 +3871,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Need Help?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "Need help finding your site address?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "Need help?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Need more help?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "Needs Update";
@@ -3649,6 +3908,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "New Post";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "New item";
+
 /* Placeholder text for password field */
 "New password" = "New password";
 
@@ -3666,7 +3928,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "News";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Next";
 
 /* Accessibility label for the next notification button */
@@ -3702,6 +3966,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "No Preview URL available";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "No Title";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "No activities available";
 
@@ -3734,7 +4001,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "No comments yet";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "No connection";
 
@@ -3883,6 +4151,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "Not now";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "Not seeing the email? Check your Spam or Junk Mail folder.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "Note:";
 
@@ -3946,7 +4217,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Numbered List";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -4003,7 +4279,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "Oops";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Oops!";
 
 /* No comment provided by engineer. */
@@ -4018,7 +4295,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "Open Jetpack Security settings";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Open Mail";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Open Settings";
 
 /* No comment provided by engineer. */
@@ -4036,6 +4318,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "Open link in new window\/tab";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "Open subscription settings for the post";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "Open the Me Section";
 
@@ -4050,6 +4335,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "Optional: enter a custom message of up to %1$d characters to be sent with your invitation.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "Or";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "Or choose another form of authentication.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "Or log in by _entering your site address_.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "Or log in with magic link";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Ordered List";
@@ -4098,7 +4395,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "Padding";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Page";
 
@@ -4131,8 +4429,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "Parenting";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Password";
 
@@ -4149,8 +4450,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "Paste block after";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Pending";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Pending review";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4181,6 +4486,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "Pick username";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Plans";
+
 /* User action to play a video on the editor. */
 "Play video" = "Play video";
 
@@ -4210,6 +4519,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "Please enter a complete website address, like example.com.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "Please enter a site address.";
@@ -4244,11 +4556,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "Please enter a valid address";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "Please enter a valid email address for a WordPress.com account.";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Please enter a valid email address.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "Please enter a valid phone number";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Please enter the password for your WordPress.com account to log in with your Apple ID.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Please enter your credentials";
@@ -4256,8 +4574,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Please enter your email address.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Please fill out all the fields";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "Please log out before connecting to a different WordPress.com site";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "Please try again later";
@@ -4322,7 +4646,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "Popular languages";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Post";
 
@@ -4443,6 +4768,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "Privacy notice for California users";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Private";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "Problem displaying block. \nTap to attempt block recovery.";
 
@@ -4457,6 +4785,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "Problem purchasing your domain. Please try again.";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s).";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Projects";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "Prompt skipped";
@@ -4474,13 +4808,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "Publish Date";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Publish Immediately";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "Publish page on:";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "Publish post on:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Published";
 
@@ -4682,7 +5020,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "Reply";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Reply Text";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "Reply to %1$@";
 
 /* An explaination of a setting. */
@@ -4711,6 +5054,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "Reset Date Range filter";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Reset your password";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Resize & Crop";
@@ -4768,6 +5114,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "Retry all";
 
+/* No comment provided by engineer. */
+"Retry?" = "Retry?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "Return to post";
 
@@ -4797,6 +5146,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "Role";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS Sent";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "STATUS";
 
@@ -4808,6 +5160,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4874,7 +5227,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "Scanning files";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Scheduled";
 
 /* No comment provided by engineer. */
@@ -5014,6 +5368,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "Selects this topic as the intent for your site.";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Send Link";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "Send Link by Email";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "Send Log Message";
 
@@ -5022,6 +5382,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "Send Test Crash";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "Send email verification link";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "Send notifications by email";
@@ -5067,6 +5430,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message to show when setting save failed */
 "Settings update failed" = "Settings update failed";
+
+/* Spoken accessibility label */
+"Share" = "Share";
 
 /* Title for a button that recommends the app to others */
 "Share Jetpack with a friend" = "Share Jetpack with a friend";
@@ -5120,6 +5486,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "Show Reblog button";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "Show password";
+
 /* No comment provided by engineer. */
 "Show post content" = "Show post content";
 
@@ -5131,6 +5501,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "Showing stats for:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "Shown";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Shown publicly when you comment on blogs.";
@@ -5146,6 +5519,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "Shows the post";
+
+/* View title during the sign up process. */
+"Sign Up" = "Sign Up";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "Sign in with site credentials";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Sign up";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Sign up for WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Sign up with Email";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "Since you're on a free plan, you'll see limited events in your Activity Log.";
@@ -5184,6 +5572,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Site achievements";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Site address";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "Site address must be at least 4 characters.";
@@ -5268,7 +5659,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Sorry, site addresses must have letters too!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Sorry, that email address is already being used!";
 
 /* No comment provided by engineer. */
@@ -5328,6 +5719,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "Spam";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "Speed up your site";
@@ -5353,6 +5747,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "Province";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "Static Homepage";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5383,6 +5780,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "Strikethrough";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Stub";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "Submit for Review";
@@ -5473,7 +5873,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "Tablet";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Tag";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5602,6 +6003,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Terms of Service";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Testimonials";
+
 /* Title of a button style */
 "Text Only" = "Text Only";
 
@@ -5611,8 +6015,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block";
 
+/* Button title */
+"Text me a code instead" = "Text me a code instead";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "Text me a code via SMS";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Thanks for choosing %1$@ by %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "That doesn't appear to be a valid verification code.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "That doesn't look like a WordPress site.";
@@ -5634,6 +6047,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages.";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "The Google account \"%@\" doesn't match any account on WordPress.com";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "The Internet connection appears to be offline.";
@@ -5670,6 +6086,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "The image could not be added to the Media Library.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "The internet connection appears to be offline.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "The kinds of sites that can be created";
@@ -5713,6 +6132,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "The site at %1$@ uses WordPress %2$@. We recommend to update to the latest version, or at least %3$@";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "The site could not be deleted.";
 
@@ -5754,6 +6177,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "There has been an unexpected error while editing your comment";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "There has been an unexpected error while loading the comments.";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "There has been an unexpected error while registering your domain";
 
@@ -5762,6 +6188,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "There has been an unexpected error while updating your Notification Settings";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "There has been an unexpected error while updating your comment";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "There has been an unexpected error.";
@@ -5783,6 +6212,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "There was a problem communicating with the site.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "There was a problem connecting to WordPress.com. Please login again.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "There was a problem displaying this post.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "There was a problem loading your data, refresh your page to try again.";
 
@@ -5792,12 +6227,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "There was a problem saving changes to sharing management.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "There was a problem when trying to access your location. Please try again later.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "There was an error changing the password";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "There was an error loading activities";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "There was an error loading plans";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "There was an error loading plugins";
@@ -5810,6 +6251,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "There was an error loading the history";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "There was an error loading the plan";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "There was an error loading the scan history";
@@ -5858,6 +6302,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "This domain is unavailable";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "This email address is not registered on WordPress.com.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "This file is too large to upload to your site or it does not support this media format.";
@@ -5938,6 +6385,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "Time Zone";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "Time's up, but don't worry, your security is our priority. Please try again!";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "Tips for getting the most out of WordPress.com.";
 
@@ -5951,6 +6401,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "To continue please enter your email address and name.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "To create your new WordPress.com account, please enter your email address.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin.";
 
@@ -5959,6 +6412,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "To install plugins, you need to have a custom domain associated with your site.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block.";
@@ -6033,7 +6492,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "Trash";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "Trashed";
 
@@ -6047,6 +6507,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "Try & Customize";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Try Again";
@@ -6072,6 +6533,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "Try the new Block Editor";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Try with another email";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Try with the site address";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "Turn off prompts";
@@ -6114,6 +6581,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "USES";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "Unable To Connect";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "Unable to Load Posts";
@@ -6163,6 +6633,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Unable to play video";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Unable to restore your site";
 
@@ -6189,6 +6662,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "Unable to upload 1 post, 1 file";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "Unable to verify the email address. Please try again later.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "Unable to visit Jetpack settings for site";
@@ -6333,7 +6809,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Upload failed";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Uploaded";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6351,7 +6828,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Uploaded themes";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Uploading";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6366,18 +6844,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "Use";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "Use a security key";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "Use block editor";
 
 /* No comment provided by engineer. */
 "Use icon button" = "Use icon button";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "Use password to sign in";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Username";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6392,6 +6879,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Users";
+
+/* two factor code placeholder */
+"Verification code" = "Verification code";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "Verification email sent, check your inbox.";
@@ -6524,8 +7014,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "WP-content directory";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Waiting for Google to complete…";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "Waiting for connection";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "Waiting for security key";
+
+/* View title during the Google auth process. */
+"Waiting..." = "Waiting…";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6565,6 +7065,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "We had trouble loading data";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "We just emailed a link to %@. Please check your mail app and tap the link to log in.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "We just sent a magic link to";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "We successfully created a backup of your site as of %@";
 
@@ -6574,14 +7080,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "We use other tracking tools, including some from third parties. Read about these and how to control them.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "We were unable to send you an email at this time. Please try again later.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "We will send you an email if security threats are found. In the meantime, feel free to continue to use your site as normal, you can check back on progress at any time.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "We'll email you a signup link to create your new WordPress.com account.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "We'll notify you when you get followers, comments, and likes.";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "We'll use this email address to create your new WordPress.com account.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "We're creating a downloadable backup of your site from %1$@.";
@@ -6592,6 +7110,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "We're not able to connect to the Jetpack site at that URL.  Contact us for assistance.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "We're restoring your site back to %1$@.";
 
@@ -6600,6 +7121,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "We've also emailed you a link to your file.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "We’ve emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6626,6 +7150,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "Weekly Roundup: %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "Welcome to Jetpack";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Welcome to WordPress";
 
 /* A message title */
 "Welcome to the Reader" = "Welcome to the Reader";
@@ -6670,6 +7200,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "What is Gravatar?";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "What is WordPress.com?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "What is a block?";
 
@@ -6688,6 +7221,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "What's New in WordPress";
 
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "What's my site address?";
+
 /* Select the site's intent. Title */
 "What's your website about?" = "What's your website about?";
 
@@ -6699,6 +7235,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "When you make changes to your site you'll be able to see your activity history here.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Whoops, something went wrong and we couldn't log you in. Please try again!";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "Whoops, something went wrong. Please try again!";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "Whoops, that security key does not seem valid. Please try again with another one";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Whoops, that's not a valid two-factor verification code. Double-check your code and try again!";
 
 /* No comment provided by engineer. */
 "Width Settings" = "Width settings";
@@ -6712,17 +7260,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "WordPress App Settings";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "WordPress Apps – Apps for any screen";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "WordPress Blog";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "WordPress Help";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "WordPress Media Library";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "WordPress Notification Settings";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "WordPress Notifications";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "WordPress Plugins";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "WordPress Profile";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "WordPress Reader";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "WordPress Site Details";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "WordPress Themes";
@@ -6733,17 +7302,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "WordPress multisites are not supported";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings.";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "WordPress root";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "WordPress version too old";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "WordPress version too old. The site at %1$@ uses WordPress %2$@. We recommend to update to the latest version, or at least %3$@";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "WordPress.com Account";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "WordPress.com Plans";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "WordPress.com Themes";
@@ -6774,6 +7352,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "Write Post";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "Write a reply";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "Write a reply…";
 
 /* Title for the writing section in site settings screen */
@@ -6787,6 +7368,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Y-axis position";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "Year";
@@ -6883,7 +7467,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "You have no reminders set.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "You have unsaved changes.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -6978,6 +7563,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9.";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "Your site address appears in the bar at the top of the screen when you visit your site in Safari.";
 
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below.";
@@ -7565,6 +8153,10 @@ Example: Reply to Pamela Nguyen */
 
 /* Accessibility label for more button in dashboard quick start card. */
 "ellipsisButton.AccessibilityLabel" = "More";
+
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "example.com";
 
 /* Title for confirmation navigation bar button item */
 "externalMediaPicker.add" = "Add";
@@ -8342,6 +8934,9 @@ Example: Reply to Pamela Nguyen */
 
 /* Menu option for filtering posts by me */
 "pagesList.pagesByMe" = "Pages by me";
+
+/* No comment provided by engineer. */
+"password" = "password";
 
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "Cards may show different content depending on what's happening on your site. We're working on more cards and controls.";
@@ -9312,6 +9907,114 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "Status";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "All-Time Posts & Most Views";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "All-Time Views";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "All-Time Views & Visitors";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "Best views ever";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "Most Views";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "Unable to load all time stats.";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "Create or add a site to see all time stats.";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Posts";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "Stay up to date with all time activity on your WordPress site.";
+
+/* Title of all time widget */
+"widget.alltime.title" = "All Time";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "Log in to WordPress to see all time stats.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "Log in to Jetpack to see all time stats.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "Log in to Jetpack to see this week's stats.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "Log in to Jetpack to see today's stats.";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "All-Time Views";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "Views Today";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "Unable to load this week's stats.";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "Create or add a site to see this week's stats.";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "Stay up to date with this week activity on your WordPress site.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "This Week";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "Log in to WordPress to see this week's stats.";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Comments";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "Stats have moved to the Jetpack app. Switching is free and only takes a minute.";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Likes";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "Unable to load site stats.";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "Unable to load today's stats.";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "Create or add a site to see today's stats.";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "Stay up to date with today's activity on your WordPress site.";
+
+/* Title of today widget */
+"widget.today.title" = "Today";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "Log in to WordPress to see today's stats.";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "View is unavailable";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Views";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Visitors";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "Today's Likes & Comments";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "Today's Views";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "Today's Views & Visitors";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "will be unavailable in the future.";
 
@@ -9368,6 +10071,9 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Title of a button that displays a blog post in a web view. */
 "wp.migration.successCard.learnMore" = "Learn more";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Log in with Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Domains";

--- a/WordPress/Resources/en-GB.lproj/Localizable.strings
+++ b/WordPress/Resources/en-GB.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Translation-Revision-Date: 2025-04-06 13:17:13+0000 */
+/* Translation-Revision-Date: 2024-10-08 11:02:03+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
 /* Generator: GlotPress/4.0.1 */
 /* Language: en_GB */
@@ -98,6 +98,9 @@
 
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "%1$@ of %2$@ on your site";
+
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "%1$@ of %2$@ used on your site";
 
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ quadrillion";
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Untitled)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(no title)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*Johann Brandt* responded to your post";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "A \"more\" button contains a dropdown which displays sharing buttons";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above.";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "A file contains a malicious code pattern";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "A title for the site";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "A verification code will only contain numbers.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "ACTIVE";
@@ -522,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "After %@";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "Alignment";
@@ -585,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "Allowlisted IP addresses";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "Almost there! Please enter the verification code from your authenticator app.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Alt Text";
@@ -597,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "Alternatively, you can flatten the content by ungrouping the block.";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "Alternatively, you may enter the password for this account.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "Alternatively:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "Always Send Crash Logs";
@@ -618,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "An active internet connection is required to view activities";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "An active internet connection is required to view plans";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -668,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "Annual Site Stats";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "Anonymous";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "Answer";
 
@@ -689,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "Appearance";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication.";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "Applies the setting";
@@ -775,6 +811,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "Authentication Failed";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "Authentication code";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "Authentication required for host: %@";
@@ -885,6 +925,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "Be the first to comment";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Be the first to leave a comment.";
 
 /* Beauty site intent topic */
 "Beauty" = "Beauty";
@@ -1021,12 +1064,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button to copy post text" = "Button to copy post text";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "By continuing, you agree to our _Terms of Service_.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "By setting up Jetpack you agree to our\n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "By signing up, you agree to our _Terms of Service_.";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "CUSTOMISE";
@@ -1040,6 +1089,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "Camera access needed to scan log-in codes";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Can Not Request Link";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "Can't publish an empty page";
 
@@ -1049,6 +1101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1058,6 +1111,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1076,6 +1130,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1103,6 +1158,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "Cancelling...";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "Cannot access the site at this address. Please double-check and try again.";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Can’t decide? You can change the theme at any time.";
 
@@ -1110,7 +1168,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Caption";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Careful!";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1119,7 +1178,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Categories";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Category";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1168,6 +1228,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "Check out our top tips to increase your views and traffic";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "Check your email on this device!";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Check your email on this device, and tap the link in the email you receive from WordPress.com.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "Check your email!";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "Check your internet connection and pull to refresh.";
@@ -1264,6 +1336,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "Claim your free domain";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "Classic Blog";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "Clear Device Media Cache";
 
@@ -1291,6 +1366,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Close";
 
@@ -1332,6 +1408,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "Columns settings";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Comics";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1383,6 +1462,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Comments";
 
@@ -1450,12 +1530,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Connected Accounts";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Connected But…";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "Connecting %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Connecting %1$@ will replace the existing connection to %2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Connecting to WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Connecting...";
@@ -1486,8 +1572,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "Contact us at %@";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "Content Structure\nBlocks: %1$li, Words: %2$li, Characters: %3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1502,6 +1592,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Continue reading";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Continue with Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Continue with Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Continuing with Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "Contribute";
@@ -1630,6 +1729,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "Create";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Create Account";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "Create Blank Page";
 
@@ -1650,6 +1752,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "Create a Post";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "Create a Site";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "Create a Tag";
@@ -1683,6 +1788,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "Current";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Current Plan";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Current Theme";
@@ -1785,6 +1893,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "Default Category";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Default Menu";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Default Post Format";
@@ -1793,6 +1904,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "Defaults for New Posts";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Delete";
@@ -1850,6 +1962,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "Details";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "Didn't mean to create a new account? Go back to re-enter your email address.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "Dimensions";
 
@@ -1897,7 +2012,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "Discussion";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Dismiss";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1919,6 +2036,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "Domains";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "Don't have an account? _Sign up_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2048,6 +2168,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "Downloads";
 
+/* Name for the status of a draft post. */
+"Draft" = "Draft";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Drafts";
 
@@ -2157,7 +2280,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "Email Address";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "Email address";
 
 /* Notification Settings Channel */
@@ -2241,8 +2367,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Enter password";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "Enter the address of the WordPress site you'd like to connect.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Enter the password for your WordPress.com account.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Enter username";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "Enter your account information for %@.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "Enter your email address to log in or create a WordPress.com account.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "Enter your existing site address";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "Enter your password instead.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "Enter your server credentials";
@@ -2405,6 +2551,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "External";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Failed";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "Failed marking Notifications as read";
 
@@ -2431,6 +2580,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "Fashion";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "Featured";
@@ -2489,6 +2641,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "Find out more";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Find your site address";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2511,6 +2666,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "Fixing Threats";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "Follow";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "Follow conversation";
@@ -2605,6 +2763,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "Generate new link";
 
+/* View title for initial auth views. */
+"Get Started" = "Get Started";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "Get a login link by email";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "Get active! Comment on posts from blogs you follow.";
 
@@ -2626,8 +2790,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "Getting Inspired";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Getting account information";
+
+/* Cancel */
+"Give Up" = "Give Up";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "Give it a try by adding a few blocks to your post or page!";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "Go to Reader";
@@ -2638,6 +2811,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "Go to iOS Settings";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Google sign up failed.";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2712,6 +2888,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "Help icon";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Hidden";
+
 /* Title of a button used to collapse a group */
 "Hide" = "Hide";
 
@@ -2780,6 +2959,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "Icon update failed";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "If you can’t find the email, please check your junk or spam email folder";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "If you remove %1$@, that user will no longer be able to access this site, but any content that was created by %2$@ will remain on the site.";
@@ -2855,6 +3040,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "Includes wp-config.php and any non-WordPress files";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Incorrect username or password. Please try entering your login details again.";
 
 /* Title for a threat */
 "Infected core file" = "Infected core file";
@@ -2956,6 +3144,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "Introducing Blogging Prompts";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "Invalid email address";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "Invalid Site Address";
 
@@ -2973,6 +3164,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "Invalid URL. Audio file not found.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "Invalid URL. Please double-check and try again.";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "Invalid URL. Please enter a valid URL.";
@@ -2994,6 +3188,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "Invite People";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "It looks like this username\/password isn't associated with this site.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "It seems like you've entered an incorrect password. Want to give it another try?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "It's time to blog on %@!";
@@ -3222,7 +3422,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "Line Height";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Link";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3284,6 +3485,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "Loading People...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Loading Plan...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Loading Plans...";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "Loading Plugin...";
 
@@ -3318,11 +3525,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "Loading...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Local";
+
 /* Local Services site intent topic */
 "Local Services" = "Local Services";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "Local changes";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Location";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Location unknown";
 
 /* No comment provided by engineer. */
 "Lock icon" = "Lock icon";
@@ -3330,9 +3549,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Log Files By Created Date";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Log In";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3341,6 +3562,22 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title of a button for signing in. */
 "Log in" = "Log in";
+
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Log in failed. Please try again.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "Log in or sign up with WordPress.com";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Log in to the WordPress.com account you used to connect Jetpack.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "Log in to your WordPress.com account with your email address.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "Log in with your WordPress.com username and password.";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of Jetpack?" = "Log out of Jetpack?";
@@ -3351,6 +3588,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Login Request Expired */
 "Login Request Expired" = "Login Request Expired";
 
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "Log in with account password";
+
 /* No comment provided by engineer. */
 "Logs" = "Logs";
 
@@ -3359,6 +3599,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications.";
+
+/* Title of a button. */
+"Lost your password?" = "Lost your password?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "Mail (Default)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Main Navigation";
@@ -3506,6 +3752,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "Message";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "Miscellaneous vulnerability";
 
@@ -3601,6 +3850,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "My Site";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "My Sites in WordPress";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "My Top Ten Cafés";
 
@@ -3640,8 +3892,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Need Help?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "Need help finding your site address?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "Need help?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Need more help?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "Needs Update";
@@ -3670,6 +3929,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "New Post";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "New item";
+
 /* Placeholder text for password field */
 "New password" = "New password";
 
@@ -3687,7 +3949,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "News";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Next";
 
 /* Accessibility label for the next notification button */
@@ -3723,6 +3987,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "No Preview URL available";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "No Title";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "No activities available";
 
@@ -3755,7 +4022,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "No comments yet";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "No connection";
 
@@ -3904,6 +4172,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "Not now";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "Not seeing the email? Check your Spam or Junk Mail folder.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "Note:";
 
@@ -3967,7 +4238,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Numbered List";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -4024,7 +4300,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "Oops";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Oops!";
 
 /* No comment provided by engineer. */
@@ -4039,7 +4316,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "Open Jetpack security settings";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Open Mail";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Open Settings";
 
 /* No comment provided by engineer. */
@@ -4057,6 +4339,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "Open link in new window\/tab";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "Open subscription settings for the post";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "Open the Me Section";
 
@@ -4071,6 +4356,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "Optional: enter a custom message of up to %1$d characters to be sent with your invitation.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "Or";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "Or choose another form of authentication.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "Or log in by _entering your site address_.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "Or log in with magic link";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Ordered List";
@@ -4119,7 +4416,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "Padding";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Page";
 
@@ -4152,8 +4450,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "Parenting";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Password";
 
@@ -4170,8 +4471,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "Paste block after";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Pending";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Pending review";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4202,6 +4507,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "Pick username";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Plans";
+
 /* User action to play a video on the editor. */
 "Play video" = "Play video";
 
@@ -4231,6 +4540,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "Please enter a complete website address, like example.com.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "Please enter a site address.";
@@ -4265,11 +4577,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "Please enter a valid address";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "Please enter a valid email address for a WordPress.com account.";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Please enter a valid email address.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "Please enter a valid phone number";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Please enter the password for your WordPress.com account to log in with your Apple ID.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Please enter your credentials";
@@ -4277,8 +4595,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Please enter your email address.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Please fill out all the fields";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "Please log out before connecting to a different WordPress.com site";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "Please try again later";
@@ -4346,7 +4670,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "Popular languages";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Post";
 
@@ -4467,6 +4792,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "Privacy notice for California users";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Private";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "Problem displaying block. \nTap to attempt block recovery.";
 
@@ -4481,6 +4809,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "Problem purchasing your domain. Please try again.";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s).";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Projects";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "Prompt skipped";
@@ -4498,13 +4832,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "Publish Date";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Publish Immediately";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "Publish page on:";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "Publish post on:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Published";
 
@@ -4706,7 +5044,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "Reply";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Reply Text";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "Reply to %1$@";
 
 /* An explaination of a setting. */
@@ -4735,6 +5078,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "Reset Date Range filter";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Reset your password";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Resize & Crop";
@@ -4792,6 +5138,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "Retry all";
 
+/* No comment provided by engineer. */
+"Retry?" = "Retry?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "Return to post";
 
@@ -4821,6 +5170,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "Role";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS Sent";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "STATUS";
 
@@ -4832,6 +5184,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4898,7 +5251,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "Scanning files";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Scheduled";
 
 /* No comment provided by engineer. */
@@ -5038,6 +5392,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "Selects this topic as the intent for your site.";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Send Link";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "Send Link by Email";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "Send Log Message";
 
@@ -5046,6 +5406,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "Send Test Crash";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "Send email verification link";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "Send notifications by email";
@@ -5091,6 +5454,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message to show when setting save failed */
 "Settings update failed" = "Settings update failed";
+
+/* Spoken accessibility label */
+"Share" = "Share";
 
 /* Title for a button that recommends the app to others */
 "Share Jetpack with a friend" = "Share Jetpack with a friend";
@@ -5144,6 +5510,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "Show Reblog button";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "Show password";
+
 /* No comment provided by engineer. */
 "Show post content" = "Show post content";
 
@@ -5155,6 +5525,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "Showing stats for:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "Shown";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Shown publicly when you comment on blogs.";
@@ -5170,6 +5543,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "Shows the post";
+
+/* View title during the sign up process. */
+"Sign Up" = "Sign Up";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "Sign in with site credentials";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Sign up";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Sign up for WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Sign up with Email";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "Since you're on a free plan, you'll see limited events in your Activity Log.";
@@ -5208,6 +5596,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Site achievements";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Site address";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "Site address must be at least 4 characters.";
@@ -5292,7 +5683,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Sorry, site addresses must have letters too!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Sorry, that email address is already being used!";
 
 /* No comment provided by engineer. */
@@ -5352,6 +5743,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "Spam";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "Speed up your site";
@@ -5377,6 +5771,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "State";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "Static Homepage";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5407,6 +5804,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "Strikethrough";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Stub";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "Submit for Review";
@@ -5497,7 +5897,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "Tablet";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Tag";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5632,6 +6033,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Terms of Service";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Testimonials";
+
 /* Title of a button style */
 "Text Only" = "Text Only";
 
@@ -5641,8 +6045,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block";
 
+/* Button title */
+"Text me a code instead" = "Text me a code instead";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "Text me a code via SMS";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Thanks for choosing %1$@ by %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "That doesn't appear to be a valid verification code.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "That doesn't look like a WordPress site.";
@@ -5664,6 +6077,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "The Facebook connection cannot find any Pages. Publicise cannot connect to Facebook Profiles, only published Pages.";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "The Google account \"%@\" doesn't match any account on WordPress.com";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "The Internet connection appears to be offline.";
@@ -5703,6 +6119,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "The image could not be added to the Media Library.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "The internet connection appears to be offline.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "The kinds of sites that can be created";
@@ -5746,6 +6165,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "The site at %1$@ uses WordPress %2$@. We recommend to update to the latest version, or at least %3$@";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "The site could not be deleted.";
 
@@ -5787,6 +6210,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "There has been an unexpected error while editing your comment";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "There has been an unexpected error while loading the comments.";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "There has been an unexpected error while registering your domain";
 
@@ -5795,6 +6221,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "There has been an unexpected error while updating your Notification Settings";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "There has been an unexpected error while updating your comment";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "There has been an unexpected error.";
@@ -5816,6 +6245,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "There was a problem communicating with the site.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "There was a problem connecting to WordPress.com. Please log in again.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "There was a problem displaying this post.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "There was a problem loading your data, refresh your page to try again.";
 
@@ -5825,12 +6260,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "There was a problem saving changes to sharing management.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "There was a problem when trying to access your location. Please try again later.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "There was an error changing the password";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "There was an error loading activities";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "There was an error loading plans";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "There was an error loading plugins";
@@ -5843,6 +6284,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "There was an error loading the history";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "There was an error loading the plan";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "There was an error loading the scan history";
@@ -5891,6 +6335,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "This domain is unavailable";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "This email address is not registered on WordPress.com.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "This file is too large to upload to your site or it does not support this media format.";
@@ -5971,6 +6418,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "Time Zone";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "Time's up, but don't worry, your security is our priority. Please try again!";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "Tips for getting the most out of WordPress.com.";
 
@@ -5984,6 +6434,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "To continue please enter your email address and name.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "To create your new WordPress.com account, please enter your email address.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin.";
 
@@ -5992,6 +6445,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "To install plugins, you need to have a custom domain associated with your site.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block.";
@@ -6066,7 +6525,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "Bin";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "Binned";
 
@@ -6080,6 +6540,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "Try & Customise";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Try Again";
@@ -6105,6 +6566,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "Try the new Block Editor";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Try with another email";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Try with the site address";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "Turn off prompts";
@@ -6147,6 +6614,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "USES";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "Unable To Connect";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "Unable to Load Posts";
@@ -6196,6 +6666,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Unable to play video";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Unable to restore your site";
 
@@ -6222,6 +6695,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "Unable to upload 1 post, 1 file";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "Unable to verify the email address. Please try again later.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "Unable to visit Jetpack settings for site";
@@ -6366,7 +6842,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Upload failed";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Uploaded";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6384,7 +6861,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Uploaded themes";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Uploading";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6399,18 +6877,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "Use";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "Use a security key";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "Use block editor";
 
 /* No comment provided by engineer. */
 "Use icon button" = "Use icon button";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "Use password to sign in";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Username";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6425,6 +6912,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Users";
+
+/* two factor code placeholder */
+"Verification code" = "Verification code";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "Verification email sent, check your inbox.";
@@ -6557,8 +7047,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "WP-content directory";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Waiting for Google to complete…";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "Waiting for connection";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "Waiting for security key";
+
+/* View title during the Google auth process. */
+"Waiting..." = "Waiting...";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6598,6 +7098,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "We had trouble loading data";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "We just emailed a link to %@. Please check your mail app and tap the link to log in.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "We just sent a magic link to";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "We successfully created a backup of your site as of %@";
 
@@ -6607,14 +7113,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "We use other tracking tools, including some from third parties. Read about these and how to control them.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "We were unable to send you an email at this time. Please try again later.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "We will send you an email if security threats are found. In the meantime, feel free to continue to use your site as normal, you can check back on progress at any time.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "We'll email you a signup link to create your new WordPress.com account.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "We'll notify you when you get followers, comments, and likes.";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "We'll use this email address to create your new WordPress.com account.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "We're creating a downloadable backup of your site from %1$@.";
@@ -6625,6 +7143,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "We're hard at work fixing these threats in the background. In the meantime, feel free to continue to use your site as normal, you can check back on progress at any time.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "We're not able to connect to the Jetpack site at that URL.  Contact us for assistance.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "We're restoring your site back to %1$@.";
 
@@ -6633,6 +7154,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "We've also emailed you a link to your file.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "We’ve emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6659,6 +7183,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "Weekly Roundup: %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "Welcome to Jetpack";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Welcome to WordPress";
 
 /* A message title */
 "Welcome to the Reader" = "Welcome to the Reader";
@@ -6703,6 +7233,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "What is Gravatar?";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "What is WordPress.com?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "What is a block?";
 
@@ -6721,6 +7254,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "What's New in WordPress";
 
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "What's my site address?";
+
 /* Select the site's intent. Title */
 "What's your website about?" = "What's your website about?";
 
@@ -6732,6 +7268,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "When you make changes to your site you'll be able to see your activity history here.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Whoops, something went wrong and we couldn't log you in. Please try again!";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "Whoops, something went wrong. Please try again!";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "Whoops, that security key does not seem valid. Please try again with another one";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Whoops, that's not a valid two-factor verification code. Double-check your code and try again!";
 
 /* No comment provided by engineer. */
 "Width Settings" = "Width settings";
@@ -6745,17 +7293,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "WordPress App Settings";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "WordPress Apps – Apps for any screen";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "WordPress Blog";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "WordPress Help";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "WordPress Media Library";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "WordPress Notification Settings";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "WordPress Notifications";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "WordPress Plugins";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "WordPress Profile";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "WordPress Reader";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "WordPress Site Details";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "WordPress Themes";
@@ -6766,17 +7335,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "WordPress multisites are not supported";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings.";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "WordPress root";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "WordPress version too old";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "WordPress version too old. The site at %1$@ uses WordPress %2$@. We recommend to update to the latest version, or at least %3$@";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "WordPress.com Account";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "WordPress.com Plans";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "WordPress.com Themes";
@@ -6807,6 +7385,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "Write Post";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "Write a reply";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "Write a reply…";
 
 /* Title for the writing section in site settings screen */
@@ -6820,6 +7401,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Y-axis position";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "Year";
@@ -6904,6 +7488,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Displayed when the user views trashed in the posts list and there are no posts */
 "You don't have any trashed posts" = "You don't have any binned posts";
 
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"You don't have permission to view this private blog." = "You don't have permission to view this private blog.";
+
 /* Description for the first domain purchased with a paid plan. */
 "You have a free one-year domain registration with your plan." = "You have a free one-year domain registration with your plan.";
 
@@ -6919,7 +7506,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "You have no reminders set.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "You have unsaved changes.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -7015,6 +7603,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9.";
 
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "Your site address appears in the bar at the top of the screen when you visit your site in Safari.";
+
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below.";
 
@@ -7090,20 +7681,32 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Cell placeholder */
 "addCategory.titlePlaceholder" = "Title";
 
-/* Accessibility identifier for an 'Add Comment' button */
-"addCommentButton.accessibilityIdentifity" = "Add Comment";
+/* Error message shown a URL does not point to an existing site. */
+"addSite.restApiNotAvailable" = "The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.";
+
+/* Error message shown when an receiving an invalid application-password authentication result from a self-hosted WordPress site */
+"addSite.selfHosted.authenticationFailed" = "Cannot log in using application password authentication.";
 
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "Enter the address of the WordPress site you'd like to connect.";
 
+/* Error message when user input is not a WordPress site */
+"addSite.selfHosted.invalidUrl" = "The site address is not valid.";
+
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "Cannot load the WordPress site details";
+
+/* Error message shown when application-password authentication is disabled on a self-hosted WordPress site */
+"addSite.selfHosted.noLoginUrlFound" = "Application password authentication needs to be enabled on the WordPress site.";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "Cannot save the WordPress site, please try again later.";
 
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "Add Self-Hosted Site";
+
+/* Error message when an unknown error occurred when adding a self-hosted site */
+"addSite.selfHosted.unknownError" = "Something went wrong. Please try again.";
 
 /* Age between dates equaling one hour. */
 "an hour" = "an hour";
@@ -7181,27 +7784,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of application passwords list */
 "applicationPassword.list.title" = "Application Passwords";
 
-/* Error message when the current site's url cannot be found */
-"applicationPasswordMigration.error.siteUrlNotFound" = "Cannot find the current site's URL";
-
-/* Error message when the username does not match the signed-in user. The first argument is the currently signed in user's user login name */
-"applicationPasswordMigration.error.usernameMismatch" = "You need to sign in with user \"%@\"";
-
-/* Description for the prompt to upgrade to Application Passwords. The first argument is the name of the feature that requires Application Passwords. */
-"applicationPasswordRequired.description" = "Application passwords are a more secure way to connect to your self-hosted site, and enable support for features like %@.";
-
-/* Feature name for managing plugins in the app */
-"applicationPasswordRequired.feature.plugins" = "Plugin Management";
-
-/* Feature name for managing users in the app */
-"applicationPasswordRequired.feature.users" = "User Management";
-
-/* Title for the button to authenticate with Application Passwords */
-"applicationPasswordRequired.getStartedButton" = "Get Started";
-
-/* Title for the prompt to upgrade to Application Passwords */
-"applicationPasswordRequired.title" = "Application Password Required";
-
 /* translators: displays audio file extension. e.g. MP3 audio file */
 "audio file" = "audio file";
 
@@ -7216,9 +7798,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* An alert suggesting to load autosaved revision for a published post */
 "autosaveAlert.viewChanges" = "View changes";
-
-/* An error message displayed when attempting to update an avatar while the user's email address is not verified. */
-"avatar.update.email.verification.required" = "To update your avatar, you need to verify your email address first.";
 
 /* Alert message when something goes wrong with the selected image. */
 "avatarMenu.failedToSetAvatarAlertMessage" = "Unable to load the image. Please choose a different one or try again later.";
@@ -7325,9 +7904,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Action shown in a bottom notice to dismiss it. */
 "blogDashboard.dismiss" = "Dismiss";
 
-/* Context menu button title */
-"blogHeader.actionVisitSite" = "Visit Site";
-
 /* Badge title in site list */
 "blogList.siteBadge.staging" = "Staging";
 
@@ -7371,15 +7947,6 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 /* Verb. Dismisses the blogging prompt notification. */
 "bloggingPrompt.pushNotification.customActionDescription.dismiss" = "Dismiss";
 
-/* Title of the set goals button in the Blogging Reminders Settings flow. */
-"bloggingRemindersPrompt.intro.continueButton" = "Set Reminders";
-
-/* Description on the first screen of the Blogging Reminders Settings flow called aftet post publishing. */
-"bloggingRemindersPrompt.intro.details" = "Set up your blogging reminders on days you want to post.";
-
-/* Title of the Blogging Reminders Settings screen. */
-"bloggingRemindersPrompt.intro.title" = "Blogging Reminders";
-
 /* Add self-hosted site button */
 "button.addSelfHostedSite" = "Add self-hosted site";
 
@@ -7415,48 +7982,6 @@ Example: Comment on
 %1$@ is a placeholder for the comment author's name that's been replied to.
 Example: Reply to Pamela Nguyen */
 "comment.header.subText.reply" = "Reply to %1$@";
-
-/* Button in an alert confirming discaring a new draft */
-"commentCreate.closeConfirmationAlert.deleteDraft" = "Delete Draft";
-
-/* Button to keep the changes in an alert confirming discaring changes */
-"commentCreate.closeConfirmationAlert.keepEditing" = "Keep Editing";
-
-/* Button in an alert confirming saving a new draft */
-"commentCreate.closeConfirmationAlert.saveDraft" = "Save Draft";
-
-/* Error title */
-"commentCreate.failedToSentComment" = "Failed to send comment";
-
-/* Navigation bar title when leaving a reply to a comment */
-"commentCreate.navigationTitleComment" = "Comment";
-
-/* Navigation bar title when leaving a reply to a comment */
-"commentCreate.navigationTitleReply" = "Reply";
-
-/* Navigation bar title when leaving a reply to a comment */
-"commentCreate.placeholderLeaveComment" = "Leave a comment…";
-
-/* Navigation bar title when leaving a reply to a comment */
-"commentCreate.placeholderLeaveReply" = "Leave a reply…";
-
-/* Navigation bar button title */
-"commentCreate.send" = "Send";
-
-/* Button in an alert confirming discaring a new draft */
-"commentEdit.closeConfirmationAlert.deleteDraft" = "Discard Changes";
-
-/* Button to keep the changes in an alert confirming discaring changes */
-"commentEdit.closeConfirmationAlert.keepEditing" = "Keep Editing";
-
-/* Error title */
-"commentEdit.failedToSaveComment" = "Failed to save comment";
-
-/* Navigation bar title when leaving a editing an existing comment */
-"commentEdit.navigationTitle" = "Edit Comment";
-
-/* Error title */
-"comments.failedToLike" = "Failed to like comment";
 
 /* Error message informing a user about an invalid password. */
 "common.reEnterPasswordMessage" = "The username or password stored in the app may be out of date. Please re-enter your password in the settings and try again.";
@@ -7511,9 +8036,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for an empty state view when no cards are displayed */
 "dasboard.emptyView.title" = "No cards to display";
-
-/* Personialize home screen button title */
-"dasboard.personalizeHomeButton" = "Personalise your home screen";
 
 /* Title for a menu action in the context menu on the Jetpack Social dashboard card. */
 "dashboard.card.social.menu.hide" = "Hide this";
@@ -7656,9 +8178,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Weekly Roundup debug menu item */
 "debugMenu.weeklyRoundup" = "Weekly Roundup";
-
-/* Error tilte */
-"discussionSettings.saveErrorTitle" = "Failed to save settings";
 
 /* Title for a menu action in the context menu on the Jetpack install card. */
 "domain.dashboard.card.menu.hide" = "Hide this";
@@ -7810,20 +8329,9 @@ Example: Reply to Pamela Nguyen */
 /* Shared empty state view */
 "emptyStateView.noSearchResult.title" = "No Results";
 
-/* A name of the ID field (it's a technical field, has to be short, displayed below everything else) */
-"entityMetadataFooterView.id" = "ID";
-
-/* Accept button title for the alert asking for feedback */
-"experimentalFeatures.editorFeedbackAccept" = "Send feedback";
-
-/* Dismiss button title for the alert asking for feedback */
-"experimentalFeatures.editorFeedbackDecline" = "Not now";
-
-/* Message for the alert asking for feedback on the experimental editor */
-"experimentalFeatures.editorFeedbackMessage" = "Are you willing to share feedback on the experimental editor?";
-
-/* Title for the alert asking for feedback */
-"experimentalFeatures.editorFeedbackTitle" = "Share Feedback";
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "example.com";
 
 /* The title for the experimental features list */
 "experimentalFeaturesList.heading" = "Experimental Features";
@@ -7870,8 +8378,14 @@ Example: Reply to Pamela Nguyen */
 /* A footer retry button */
 "general.pagingFooterView.retry" = "Retry";
 
+/* Error message format when REST API returns an error response. The first argument is error message. */
+"generic.error.rest-api-error" = "Your site sent an error response: %@";
+
 /* A generic title for an error */
 "generic.error.title" = "Error";
+
+/* Error message when failing to parse API responses */
+"generic.error.unparsableResponse" = "Your site sent a response that the app could not parse";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "Set up blogging reminders";
@@ -7941,9 +8455,6 @@ Example: Reply to Pamela Nguyen */
 
 /* The 'no' button title for the first feedback alert */
 "in-app.feedback.alert.no" = "Not really";
-
-/* The 'Not Now' button title for the first feedback alert */
-"in-app.feedback.alert.notNow" = "Not Now";
 
 /* The title for the first feedback alert */
 "in-app.feedback.alert.title" = "Your feedback matters";
@@ -8239,9 +8750,6 @@ Example: Reply to Pamela Nguyen */
 /* Write a blog prompt for the jetpack prologue */
 "jetpack.prologue.prompt.writeBlog" = "Write a blog";
 
-/* Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account */
-"jetpackSite.connectToDefaultAccount" = "You need to sign in with %@ to use Stats and Notifications.";
-
 /* Title for a call-to-action button on the Jetpack install card. */
 "jetpackinstallcard.button.learn" = "Learn more";
 
@@ -8367,9 +8875,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Bottom toolbar title in the selection mode */
 "mediaLibrary.toolbarSelectItemsPrompt" = "Select Items";
-
-/* A name of the action in the context menu */
-"mediaPicker.imagePlayground" = "Image Playground";
 
 /* Message for alert when access to camera is not granted */
 "mediaPicker.noCameraAccessMessage" = "This app needs permission to access the Camera to capture new media, please change the privacy settings if you wish to allow this.";
@@ -8707,6 +9212,9 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "Parent Page";
 
+/* No comment provided by engineer. */
+"password" = "password";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "Cards may show different content depending on what's happening on your site. We're working on more cards and controls.";
 
@@ -8733,9 +9241,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Card title for the pesonalization menu */
 "personalizeHome.dashboardCard.todaysStats" = "Today's stats";
-
-/* Page title */
-"personalizeHome.navigationTitle" = "Personalise Home Screen";
 
 /* Section header for shortcuts */
 "personalizeHome.shortcutsSectionHeader" = "Show or hide shortcuts";
@@ -8766,90 +9271,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the plan selection view */
 "planSelection.title" = "Plans";
-
-/* Button label to activate a plugin */
-"pluginDetails.activate.button" = "Activate";
-
-/* Button label showing plugin is activated */
-"pluginDetails.activated.button" = "Activated";
-
-/* Message shown while a plugin is being activated */
-"pluginDetails.activating.message" = "Please wait while the plugin is being activated...";
-
-/* Title shown while a plugin is being activated */
-"pluginDetails.activating.title" = "Activating Plugin";
-
-/* Plugin author information. The placeholder is the author name */
-"pluginDetails.author" = "By %@";
-
-/* Button label to deactivate a plugin */
-"pluginDetails.deactivate.button" = "Deactivate";
-
-/* Message shown while a plugin is being deactivated */
-"pluginDetails.deactivating.message" = "Please wait while the plugin is being deactivated...";
-
-/* Title shown while a plugin is being deactivated */
-"pluginDetails.deactivating.title" = "Deactivating Plugin";
-
-/* Button label to delete a plugin */
-"pluginDetails.delete.button" = "Delete";
-
-/* Message of the confirmation alert when deleting a plugin. The placeholder is the plugin name */
-"pluginDetails.delete.confirmationMessage" = "Are you sure you want to delete %@?";
-
-/* Title of the confirmation alert when deleting a plugin */
-"pluginDetails.delete.confirmationTitle" = "Delete Plugin?";
-
-/* Button label to install a plugin */
-"pluginDetails.install.button" = "Install";
-
-/* Message shown while a plugin is being installed */
-"pluginDetails.install.message" = "Please wait while the plugin is being installed...";
-
-/* Title shown while a plugin is being installed */
-"pluginDetails.install.title" = "Install Plugin";
-
-/* Message shown while loading plugin details */
-"pluginDetails.loading" = "Loading plugin information...";
-
-/* Title of the changelog section in plugin details */
-"pluginDetails.section.changelog" = "Change Log";
-
-/* Title of the description section in plugin details */
-"pluginDetails.section.description" = "Description";
-
-/* Title of the details section in plugin details */
-"pluginDetails.section.details" = "Details";
-
-/* Title of the FAQ section in plugin details */
-"pluginDetails.section.faq" = "FAQ";
-
-/* Title of the installation section in plugin details */
-"pluginDetails.section.installation" = "Installation";
-
-/* Title of the reviews section in plugin details */
-"pluginDetails.section.reviews" = "Reviews";
-
-/* Title of the screenshots section in plugin details */
-"pluginDetails.section.screenshots" = "Screenshots";
-
-/* Message shown while a plugin is being uninstalled */
-"pluginDetails.uninstalling.message" = "Please wait while the plugin is being removed...";
-
-/* Title shown while a plugin is being uninstalled */
-"pluginDetails.uninstalling.title" = "Uninstalling Plugin";
-
-/* Button title to update a plugin */
-"pluginDetails.update.action" = "Update Now";
-
-/* Title shown when a plugin update is available */
-"pluginDetails.update.title" = "Update Available";
-
-/* Message shown when a plugin update is available. The placeholder is the new version number */
-"pluginDetails.update.versionAvailable" = "Version %@ is available. Please update it from your WordPress site dashboard.";
-
-/* Button label to view plugin on WordPress.org */
-"pluginDetails.viewOnWordPressOrg.button" = "View on WordPress.org";
 
 /* Button in an alert confirming discaring changes */
 "postEditor.closeConfirmationAlert.discardChanges" = "Discard changes";
@@ -8892,9 +9313,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Post Editor / Button in the 'More' menu */
 "postEditor.moreMenu.saveDraft" = "Save draft";
-
-/* Post Editor / Button in the 'More' menu */
-"postEditor.moreMenu.sendFeedback" = "Send Feedback";
 
 /* Post Editor / Button in the 'More' menu */
 "postEditor.moreMenu.visualEditor" = "Visual editor";
@@ -9070,21 +9488,6 @@ Example: Reply to Pamela Nguyen */
 /* A default value for an post without a title */
 "postSaveErrorMessage.postUntitled" = "Untitled";
 
-/* Cancel upload button in Post Settings / Featured Image cell */
-"postSettings.featuredImage.cancelUpload" = "Cancel Upload";
-
-/* Replace image upload button in Post Settings / Featured Image cell */
-"postSettings.featuredImage.replaceImage" = "Replace";
-
-/* Button in Post Settings */
-"postSettings.featuredImage.setFeaturedImageButton" = "Set Featured Image";
-
-/* Snackbar title */
-"postSettings.featuredImage.uploadFailed" = "Failed to upload new featured image";
-
-/* Post Settings */
-"postSettings.featuredImage.uploading" = "Uploading…";
-
 /* The 'Parent Page' setting of the post */
 "postSettings.parentPage" = "Parent page";
 
@@ -9099,6 +9502,30 @@ Example: Reply to Pamela Nguyen */
 
 /* An alert message explaning that by changing the visibility to private, the post will be published immediately to your site */
 "postSettings.warningPostWillBePublishedAlertMessage" = "By changing the visibility to 'Private', the post will be published immediately";
+
+/* Localized post type: `Page` */
+"postType.page" = "page";
+
+/* Localized post type: `Post` */
+"postType.post" = "post";
+
+/* Details for a 'Private' privacy setting */
+"postVisibility.private.details" = "Only visible to site admins and editors";
+
+/* Title for a 'Private' privacy setting */
+"postVisibility.private.title" = "Private";
+
+/* Details for a 'Password Protected' privacy setting */
+"postVisibility.protected.details" = "Visibile to everyone but requires a password";
+
+/* Title for a 'Password Protected' privacy setting */
+"postVisibility.protected.title" = "Password protected";
+
+/* Details for a 'Public' (default) privacy setting */
+"postVisibility.public.details" = "Visible to everyone";
+
+/* Title for a 'Public' (default) privacy setting */
+"postVisibility.public.title" = "Public";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Cancel";
@@ -9308,9 +9735,6 @@ Tapping on this row allows the user to edit the sharing message. */
 /* Post publish success view: button 'View post' */
 "publishSuccessView.view" = "View post";
 
-/* Informational notice title. Showed when you scan a code using a camera app outside of the app, which is not allowed. */
-"qrLogin.codeHasToBeScannedFromTheAppNotice.title" = "Please scan the code using the app";
-
 /* Button label that dismisses the qr log in flow and returns the user back to the previous screen */
 "qrLoginVerifyAuthorization.completedInstructions.dismiss" = "Dismiss";
 
@@ -9338,26 +9762,8 @@ Tapping on this row allows the user to edit the sharing message. */
 /* A message title */
 "reader.blog.search.no.results.title" = "No blogs found";
 
-/* A shared button title for Reader */
-"reader.button.addToFavorites" = "Add to Favourites";
-
-/* A shared button title for Reader */
-"reader.button.notificationSettings" = "Notification Settings";
-
-/* A shared button title for Reader */
-"reader.button.removeFromFavorites" = "Remove from Favourites";
-
-/* A shared button title for Reader */
-"reader.button.subscribe" = "Subscribe";
-
 /* Reader sidebar button title */
 "reader.button.unfollow" = "Unfollow";
-
-/* A shared button title for Reader */
-"reader.button.unsubscribe" = "Unsubscribe";
-
-/* Informational message, should be short. */
-"reader.comments.commentsClosed" = "Comments Closed";
 
 /* Accessibility hint to inform that the author section can be tapped to see posts from the site. */
 "reader.detail.header.authorInfo.a11y.hint" = "Views posts from the site";
@@ -9402,50 +9808,11 @@ but tapping on this button will remove their like from the post. */
 /* Accessibility label for the 'Save Post' button when a post has been saved. */
 "reader.detail.toolbar.saved.button.a11y.label" = "Saved Post";
 
-/* Header view channel (filter) */
-"reader.discover.channel.dailyPrompts" = "Daily Prompts";
-
-/* Header view channel (filter) */
-"reader.discover.channel.firstPost" = "First Posts";
-
-/* Header view channel (filter) */
-"reader.discover.channel.latest" = "Latest";
-
-/* Header view channel (filter) */
-"reader.discover.channel.recommended" = "Recommended";
-
-/* Reader Discover header view details label. The text has a Markdown URL: [interests](/interests). Only the text in the square brackets needs to be translated: [<translate_this>](/interests). */
-"reader.discover.header.title" = "Explore popular blogs that inspire, educate, and entertain based on your [interests](\/interests).";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.discover.title" = "Discover";
-
-/* Screen title */
-"reader.editInterests.title" = "Edit Interests";
-
 /* Error message informing the user that they are already following a blog in their reader. */
 "reader.error.already.subscribed.message" = "You are already subscribed to this blog.";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to follow a tag. */
 "reader.follow.button.accessibility.hint" = "Follows the tag.";
-
-/* Reader screen title for follow conversation settings */
-"reader.followConversationSettings.title" = "Conversation Settings";
-
-/* Screen header details */
-"reader.following.header.details" = "Stay current with the blogs you've subscribed to.";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.likes.title" = "Likes";
-
-/* Reader logged-out screen details */
-"reader.loggedOut.details" = "Sign in with a WordPress.com account to follow your favourite blogs";
-
-/* Reader logged-out screen sign in button */
-"reader.loggedOut.signIn" = "Sign In";
-
-/* Reader logged-out screen title */
-"reader.loggedOut.title" = "Join the conversation";
 
 /* Title for button on the no followed blogs result screen */
 "reader.no.blogs.button" = "Discover Blogs";
@@ -9507,78 +9874,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Notice title when blocking a user fails. */
 "reader.notice.user.blocked" = "reader.notice.user.block.failed";
-
-/* Button accessibility label */
-"reader.post.buttonBookmark.accessibilityLabel" = "Bookmark";
-
-/* Button accessibility label */
-"reader.post.buttonComment.accessibilityLabel" = "Show comments";
-
-/* Button accessibility label */
-"reader.post.buttonLike.accessibilityLabel" = "Like";
-
-/* Button accessibility label */
-"reader.post.buttonReblog.accessibilityLabel" = "Reblog";
-
-/* Button accessibility label */
-"reader.post.buttonRemoveBookmark.accessibilityLint" = "Remove bookmark";
-
-/* Button accessibility label */
-"reader.post.buttonRemoveLike.accessibilityLabel" = "Remove like";
-
-/* Accessibility hint for the site header */
-"reader.post.buttonSite.accessibilityHint" = "Opens the site details";
-
-/* Button accessibility label */
-"reader.post.moreMenu.accessibilityLabel" = "More actions";
-
-/* Accessibility label showing total number of comments */
-"reader.post.numberOfComments.accessibilityLabel" = "%@ comments";
-
-/* Accessibility label showing total number of likes */
-"reader.post.numberOfLikes.accessibilityLabel" = "%@ likes";
-
-/* Context menu action */
-"reader.postContextMenu.blockOrReportMenu" = "Block or Report";
-
-/* Context menu action */
-"reader.postContextMenu.blockSite" = "Block Site";
-
-/* Context menu action */
-"reader.postContextMenu.blockUser" = "Block User";
-
-/* Context menu action (placeholder value when blog name not available – should never happen) */
-"reader.postContextMenu.blogDetails" = "Blog Details";
-
-/* Context menu action */
-"reader.postContextMenu.manageNotifications" = "Manage Notifications";
-
-/* Context menu action */
-"reader.postContextMenu.markRead" = "Mark as Read";
-
-/* Context menu action */
-"reader.postContextMenu.markUnread" = "Mark as Unread";
-
-/* Context menu action */
-"reader.postContextMenu.reportPost" = "Report Post";
-
-/* Context menu action */
-"reader.postContextMenu.reportUser" = "Report User";
-
-/* Context menu action */
-"reader.postContextMenu.showBlog" = "Go to Blog";
-
-/* Context menu action */
-"reader.postContextMenu.viewInBrowser" = "View in Browser";
-
-/* Reader post details view placeholder when blog name not avail */
-"reader.postDetails.blog" = "blog";
-
-/* Button title */
-"reader.postDetails.viewFullPost" = "View full post";
-
-/* Reader post details view */
-"reader.postDetails.viewModeDescription" = "The owner of this site only allows us to show a brief summary of their content. To view the full post, you'll have to visit their site.";
 
 /* Name for the Candy color theme, used in the Reader's reading preferences. */
 "reader.preferences.color.candy" = "Candy";
@@ -9661,27 +9956,11 @@ Feel free to replace it with other bracket types that you think looks better for
 /* A short message that informs the user no WordPress.com blogs could be found. */
 "reader.reblog.no.blogs.title" = "No available WordPress.com blogs";
 
-/* Used in multiple contexts, usually as a screen title */
-"reader.recent.title" = "Recent";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.saved.title" = "Saved";
-
 /* Notification title for when saved post is removed */
 "reader.savedPostRemovedNotificationTitle" = "Saved post removed";
 
-/* Reader Search */
-"reader.search.clearHistory" = "Clear History";
-
 /* Title of a Reader tab showing Sites matching a user's search query */
 "reader.search.tab.blogs" = "Blogs";
-
-/* Title of a Reader tab showing Posts matching a user's search query */
-"reader.search.tab.posts" = "Posts";
-
-/* Title of the Reader's search feature
-   Used in multiple contexts, usually as a screen title */
-"reader.search.title" = "Search";
 
 /* Screen title. Reader select interests title label text. */
 "reader.select.interests.follow.title" = "Follow tags";
@@ -9707,17 +9986,26 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Reader select interests title label text */
 "reader.select.tags.title" = "Discover and follow blogs you love";
 
-/* Reader sidebar section title */
-"reader.sidebar.section.favorites.title" = "Favourites";
+/* Reader sidebar menu item */
+"reader.sidebar.discover" = "Discover";
+
+/* Reader sidebar menu item */
+"reader.sidebar.likes" = "Likes";
+
+/* Reader sidebar menu item */
+"reader.sidebar.recent" = "Recent";
+
+/* Reader sidebar menu item */
+"reader.sidebar.saved" = "Saved";
+
+/* Reader sidebar menu item */
+"reader.sidebar.search" = "Search";
 
 /* Reader sidebar section title */
 "reader.sidebar.section.lists.title" = "Lists";
 
 /* Reader sidebar section title */
 "reader.sidebar.section.organization.title" = "Organisation";
-
-/* Reader sidebar section title */
-"reader.sidebar.section.subscriptions.title" = "Subscriptions";
 
 /* Reader sidebar button */
 "reader.sidebar.section.tags.addTag" = "Add tag";
@@ -9755,14 +10043,11 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Number of subscriptions on a site (singular) */
 "reader.subscriptions.subscriptionsSingular" = "%@ subscriber";
 
-/* Used in multiple contexts, usually as a screen title */
+/* Navigation bar title */
 "reader.subscriptions.title" = "Subscriptions";
 
 /* A suggestion of topics the user might want to subscribe to */
 "reader.suggested.blogs.title" = "Blogs to which to subscribe";
-
-/* A suggestion of topics (tags) the user might like */
-"reader.suggested.tags.title" = "You might like";
 
 /* Title of a feature to add a new tag to the tags subscribed by the user. */
 "reader.tags.add.tag" = "Add a Tag";
@@ -9800,17 +10085,11 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Accessibility label for unsubscribing from a tag */
 "reader.tags.unfollow.accessibility.label" = "Unfollow %@";
 
-/* Field title */
-"reader.userProfile.site" = "Site";
-
 /* Spoken accessibility label */
 "readerDetail.backButton.accessibilityLabel" = "Back";
 
 /* Spoken accessibility label */
 "readerDetail.dismissButton.accessibilityLabel" = "Dismiss";
-
-/* Spoken accessibility label for the Reading Preferences menu. */
-"readerDetail.displaySettingButton.displaySettingsLabel" = "Reading Preferences";
 
 /* Section title for global related posts. */
 "readerDetail.globalPostsSection.accessibilityLabel" = "More on WordPress.com";
@@ -9974,9 +10253,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* A shared button title used in different contexts */
 "shared.button.view" = "View";
 
-/* A generic error title indicating that a screen failed to fetch the latest data */
-"shared.error.failiedToReloadData" = "Failed to update data";
-
 /* A generic error message */
 "shared.error.geneirc" = "Something went wrong";
 
@@ -10043,57 +10319,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title for a button that opens plan and domain purchasing flow. */
 "site.domains.purchaseWithPlan.buttons.title" = "Upgrade to a plan";
 
-/* Title for the featured plugins section */
-"site.plugins.add.category.featured" = "Featured";
-
-/* Title for the popular plugins section */
-"site.plugins.add.category.popular" = "Popular";
-
-/* Title for the recommended plugins section */
-"site.plugins.add.category.recommended" = "Recommended";
-
-/* Title for the search results section */
-"site.plugins.add.category.searchResults" = "Search Results";
-
-/* Message shown when no plugins are found in the list */
-"site.plugins.add.empty" = "No plugins found";
-
-/* Tag shown next to plugins that are already installed */
-"site.plugins.add.installed.tag" = "Installed";
-
-/* Error message shown when plugins failed to load, with retry option */
-"site.plugins.add.loadError" = "Failed to load plugins. Tap here to retry";
-
-/* Message shown while loading plugins in the list */
-"site.plugins.add.loading" = "Loading plugins...";
-
-/* Navigation title for the add new plugin screen */
-"site.plugins.add.title" = "Add New Plugin";
-
-/* Message shown when there are no active plugins on the site */
-"site.plugins.empty.active" = "No active plugins";
-
-/* Button label to add a new plugin when no plugins are installed */
-"site.plugins.empty.addButton" = "Add Plugin";
-
-/* Message shown when there are no inactive plugins on the site */
-"site.plugins.empty.inactive" = "No inactive plugins";
-
-/* The plugin fillter option for displaying all plugins */
-"site.plugins.filter.option.all" = "All";
-
-/* Title of the plugin filter picker */
-"site.plugins.filter.title" = "Filter";
-
-/* Message displayed when fetching installed plugins from the site */
-"site.plugins.loading" = "Loading installed plugins…";
-
-/* No installed plugins message */
-"site.plugins.noInstalledPlugins" = "You haven't installed any plugins yet";
-
-/* Installed plugins list title */
-"site.plugins.title" = "Plugins";
-
 /* Back button title shown in Site Creation flow to come back from Plan selection to Domain selection */
 "siteCreation.domain.backButton.title" = "Domains";
 
@@ -10117,9 +10342,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Accessibility hint for actions when displaying media items. */
 "siteMedia.cellAccessibilityHint" = "Select media.";
-
-/* Title for the URL field */
-"siteMedia.details.url" = "URL";
 
 /* Accessibility hint for media item preview for user's viewing an item in their media library */
 "siteMediaItem.contentViewAccessibilityHint" = "Tap to view media in full screen";
@@ -10196,25 +10418,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title for site switcher screen */
 "sitePicker.title" = "My Sites";
 
-/* The plugin author displayed in the plugins list. The first argument is plugin author name
-   The plugin version displayed in the plugins list. The first argument is plugin version */
-"sitePluginsList.item.author" = "By %@";
-
-/* The message displayed when a plugin has no description */
-"sitePluginsList.item.noDescriptionAvailable" = "The plugin author did not provide a description for this plugin.";
-
-/* Button to activate a plugin */
-"sitePluginsList.itemAction.activate" = "Activate";
-
-/* Button to deactivate a plugin */
-"sitePluginsList.itemAction.deactivate" = "Deactivate";
-
-/* Button to delete a plugin */
-"sitePluginsList.itemAction.delete" = "Delete";
-
-/* Button to view the plugin on WordPress.org website */
-"sitePluginsList.itemAction.viewOnWordPressOrg" = "View on WordPress.org";
-
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Privacy";
 
@@ -10277,9 +10480,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* A smallprint that hints the reason behind why Twitter is deprecated. */
 "social.twitterDeprecation.text" = "Twitter auto-sharing is no longer available due to Twitter's changes in terms and pricing.";
-
-/* The number of connected accounts on a third party sharing service connected to the user's blog. The '%d' is a placeholder for the number of accounts. */
-"socialSharing.connectionDetails.nAccount" = "%d accounts";
 
 /* Title of Subscribers stats tab. */
 "stats.dashboard.tab.subscribers" = "Subscribers";
@@ -10457,9 +10657,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* The section title and or placeholder */
 "submit.feedback.detailsPlaceholder" = "Details";
-
-/* The footer in the Submit Feedback screen to clarify that it's not support */
-"submit.feedback.footer" = "If you need support, please get in touch using the \"Help & Support\" screen";
 
 /* The button title for the Submit button in the In-App Feedback screen */
 "submit.feedback.submit.button" = "Submit";
@@ -10677,85 +10874,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Site's Viewers Profile. Displayed when the name is empty! */
 "user.details.title.viewer" = "Site's Viewer";
 
-/* The 'Account Management' section of the user profile – matches what's in /wp-admin/profile.php */
-"userDetails.accountManagementSectionTitle" = "Account Management";
-
-/* The help message for reassigning content to a user after deletion. */
-"userDetails.alert.attributeContentToUserHelpMessage" = "Pages and posts belonging to the deleted user will have their author changed to the user you select in the provided dropdown.";
-
-/* The label that appears in the alert that appears when deleting a user */
-"userDetails.alert.attributeContentToUserLabel" = "Selected user";
-
-/* The message that appears when deleting a user. */
-"userDetails.alert.deleteUserAttributionMessage" = "Select another user to attribute this content to.";
-
-/* The title of the confirmation button in the alert that appears when deleting a user */
-"userDetails.alert.deleteUserConfirmButtonTitle" = "Yes, delete user";
-
-/* The title of the cancel button in the confirmation alert that appears when deleting a user */
-"userDetails.alert.deleteUserConfirmationCancelButton" = "Cancel";
-
-/* The title of the delete button in the confirmation alert that appears when deleting a user */
-"userDetails.alert.deleteUserConfirmationDeleteButton" = "Delete";
-
-/* The message in the alert that appears when deleting a user. The first argument is the display name of the user to which content will be attributed */
-"userDetails.alert.deleteUserConfirmationMessage" = "Are you sure you want to delete this user and attribute all content to %@?";
-
-/* The title of the alert that appears when deleting a user
-   The title of the confirmation alert that appears when deleting a user */
-"userDetails.alert.deleteUserConfirmationTitle" = "Delete Confirmation";
-
-/* The message in the alert that appears when deleting a user */
-"userDetails.alert.deleteUserErrorAlertMessage" = "There was an error deleting the user.";
-
-/* The title of the alert that appears when deleting a user */
-"userDetails.alert.deleteUserErrorAlertTitle" = "Error";
-
-/* The 'Biographical Info' field of the user profile – matches what's in /wp-admin/profile.php */
-"userDetails.bioFieldTitle" = "Biographical Info";
-
-/* The 'Update' button to set a new password on the user profile */
-"userDetails.button.updatePassword" = "Update";
-
-/* The 'Delete User' button on the user profile – matches what's in /wp-admin/profile.php */
-"userDetails.deleteUserActionTitle" = "Delete User";
-
-/* The 'Deleting User…' button on the user profile */
-"userDetails.deletingUserActionTitle" = "Deleting User…";
-
-/* The 'Email' field of the user profile – matches what's in /wp-admin/profile.php */
-"userDetails.emailAddressFieldTitle" = "Email Address";
-
-/* The message in the alert that appears when setting a new password on the user profile */
-"userDetails.newPasswordAlertMessage" = "Enter a new password for this user";
-
-/* The 'Role' field of the user profile – matches what's in /wp-admin/profile.php */
-"userDetails.roleFieldTitle" = "Role";
-
-/* The 'Set New Password' button on the user profile – matches what's in /wp-admin/profile.php */
-"userDetails.setNewPasswordActionTitle" = "Set New Password";
-
-/* The placeholder text for the 'New Password' field on the user profile */
-"userDetails.textField.placeholder.newPassword" = "New password";
-
-/* The placeholder text for the 'Confirm New Password' field on the user profile */
-"userDetails.textField.placeholder.newPasswordConfirmation" = "Confirm new password";
-
-/* The 'Website' field of the user profile – matches what's in /wp-admin/profile.php */
-"userDetails.websiteFieldTitle" = "Website";
-
-/* Header text fo the search results section in the users list */
-"userList.searchResults.header" = "Search Results";
-
-/* Shown when the user list is empty */
-"userlist.nousersfound" = "No users found";
-
-/* An instruction for the user to tap to start searching */
-"userlist.searchprompt" = "Search";
-
-/* The heading at the top of the user list */
-"userlist.title" = "Users";
-
 /* Site Subscribers */
 "users.list.title.subscribers" = "Subscribers";
 
@@ -10764,9 +10882,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Verb. Dismiss the web view screen. */
 "webKit.button.dismiss" = "Dismiss";
-
-/* Button label to share a web page */
-"webKit.button.share" = "Share";
 
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterEndDate" = "End Date";
@@ -10780,8 +10895,119 @@ Feel free to replace it with other bracket types that you think looks better for
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "Status";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "All-Time Posts & Most Views";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "All-Time Views";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "All-Time Views & Visitors";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "Best views ever";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "Most Views";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "Unable to load all time stats.";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "Create or add a site to see all time stats.";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Posts";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "Stay up to date with all time activity on your WordPress site.";
+
+/* Title of all time widget */
+"widget.alltime.title" = "All time";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "Log in to WordPress to see all time stats.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "Log in to Jetpack to see all time stats.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "Log in to Jetpack to see this week's stats.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "Log in to Jetpack to see today's stats.";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "All-Time Views";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "Views Today";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "Unable to load this week's stats.";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "Create or add a site to see this week's stats.";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "Stay up to date with this week activity on your WordPress site.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "This week";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "Log in to WordPress to see this week's stats.";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Comments";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "Stats have moved to the Jetpack app. Switching is free and only takes a minute.";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Likes";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "Unable to load site stats.";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "Unable to load today's stats.";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "Create or add a site to see today's stats.";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "Stay up to date with today's activity on your WordPress site.";
+
+/* Title of today widget */
+"widget.today.title" = "Today";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "Log in to WordPress to see today's stats.";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "View is unavailable";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Views";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Visitors";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "Today's Likes & Comments";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "Today's Views";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "Today's Views & Visitors";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "will be unavailable in the future.";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "Starting a new site?";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "wordpress, help, support, faq, questions, debug, logs, help centre, contact";
@@ -10837,27 +11063,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title of a button that displays a blog post in a web view. */
 "wp.migration.successCard.learnMore" = "Learn more";
 
-/* Error message when user denies access to WordPress.com */
-"wpComLogin.error.accessDenied" = "Access denied. You need to approve to log in to WordPress.com";
-
-/* Error message when user signs in with an different account than the account that's alredy signed in. The first argument is the current signed-in account email address */
-"wpComLogin.error.alreadySignedIn" = "You have already signed in with email address %@. Please sign out try again.";
-
-/* Error message when failing to load user details during WordPress.com login */
-"wpComLogin.error.fetchUser" = "Failed to load user details";
-
-/* Error message when failing to load account's site after signing in */
-"wpComLogin.error.loadingSites" = "Your account's sites cannot be loaded. Please try again later.";
-
-/* Error message when user signs in with an unexpected email address. The first argument is the expected email address */
-"wpComLogin.error.mismatchedEmail" = "Please sign in with email address %@";
-
-/* Message title to be displayed when the user needs to re-authenticate their WordPress.com account. */
-"wpcom.token.fix.signin" = "Sign in to WordPress.com";
-
-/* Detailed message to be displayed when the user needs to re-authenticate their WordPress.com account. */
-"wpcom.token.fix.signin.message" = "You need to sign in to WordPress.com to access your account.";
-
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.addAttachment" = "Add attachments";
 
@@ -10866,6 +11071,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "Unsupported attachment";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Log in with Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Domains";

--- a/WordPress/Resources/en.lproj/Localizable.strings
+++ b/WordPress/Resources/en.lproj/Localizable.strings
@@ -321,6 +321,15 @@
 /* Placeholder text for the title of a site */
 "A title for the site" = "A title for the site";
 
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "A verification code will only contain numbers.";
+
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above.";
+
 /* Age between dates equaling one year. */
 "a year" = "a year";
 
@@ -577,6 +586,9 @@
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "After %@";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "Alignment";
@@ -640,6 +652,9 @@
 /* Allowlisted IP Addresses Title */
 "Allowlisted IP Addresses" = "Allowlisted IP Addresses";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "Almost there! Please enter the verification code from your authenticator app.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Alt Text";
@@ -652,6 +667,12 @@
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "Alternatively, you can flatten the content by ungrouping the block.";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "Alternatively, you may enter the password for this account.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "Alternatively:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "Always Send Crash Logs";
@@ -747,6 +768,9 @@
 
 /* The title of the app appearance settings screen */
 "Appearance" = "Appearance";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication.";
 
 /* The list item of experimental features that users can choose to enable */
 "application-settings.experimental-features" = "Experimental Features";
@@ -930,6 +954,10 @@
 
 /* No comment provided by engineer. */
 "Authenticating" = "Authenticating";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "Authentication code";
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "Authentication Failed";
@@ -1363,11 +1391,17 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 /* Used when displaying author of a plugin. */
 "by %@" = "by %@";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "By continuing, you agree to our _Terms of Service_.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions</a>." = "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions</a>.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break \n. Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "By setting up Jetpack you agree to our\n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "By signing up, you agree to our _Terms of Service_.";
 
 /* Label for size of media while it's being calculated. */
 "Calculating..." = "Calculating...";
@@ -1378,6 +1412,9 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "Camera access needed to scan login codes";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Can Not Request Link";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "Can't publish an empty page";
 
@@ -1387,6 +1424,7 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1414,6 +1452,7 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1440,6 +1479,9 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "Canceling...";
+
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "Cannot access the site at this address. Please double-check and try again.";
 
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Can’t decide? You can change the theme at any time.";
@@ -1509,6 +1551,18 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 
 /* Title of alert when getting purchases fails */
 "Check Purchases Error" = "Check Purchases Error";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "Check your email on this device!";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Check your email on this device, and tap the link in the email you receive from WordPress.com.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "Check your email!";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "Check your internet connection and pull to refresh.";
@@ -1879,12 +1933,18 @@ Example: Reply to Pamela Nguyen */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Connected Accounts";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Connected But…";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "Connecting %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Connecting %1$@ will replace the existing connection to %2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Connecting to WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Connecting...";
@@ -1917,6 +1977,7 @@ Example: Reply to Pamela Nguyen */
 
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1926,11 +1987,20 @@ Example: Reply to Pamela Nguyen */
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Continue reading";
 
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Continue with Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Continue with Google";
+
 /* Button title. Takes the user to the login with WordPress.com flow. */
 "Continue With WordPress.com" = "Continue With WordPress.com";
 
 /* Menus alert button title to continue making changes. */
 "Continue Working" = "Continue Working";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Continuing with Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "Contribute";
@@ -2062,11 +2132,17 @@ Example: Reply to Pamela Nguyen */
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "Create a Post";
 
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "Create a Site";
+
 /* Title for the Site Icon Picker */
 "Create a site icon" = "Create a site icon";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "Create a Tag";
+
+/* The button title text for creating a new account. */
+"Create Account" = "Create Account";
 
 /* Title for button to make a blank page */
 "Create Blank Page" = "Create Blank Page";
@@ -2454,6 +2530,9 @@ Example: Reply to Pamela Nguyen */
    Theme Details action title */
 "Details" = "Details";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "Didn't mean to create a new account? Go back to re-enter your email address.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "Dimensions";
 
@@ -2504,7 +2583,8 @@ Example: Reply to Pamela Nguyen */
 /* Error tilte */
 "discussionSettings.saveErrorTitle" = "Failed to save settings";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog. */
 "Dismiss" = "Dismiss";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -2661,6 +2741,9 @@ Example: Reply to Pamela Nguyen */
 
 /* Search domain - Title for the Suggested domains screen */
 "domainSelection.search.title" = "Search domains";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "Don't have an account? _Sign up_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2908,7 +2991,10 @@ Example: Reply to Pamela Nguyen */
    Title of Stats section that shows email followers. */
 "Email" = "Email";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "Email address";
 
 /* Header for a comment author's email address, shown when editing a comment. */
@@ -3001,8 +3087,28 @@ Example: Reply to Pamela Nguyen */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Enter password";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "Enter the address of the WordPress site you'd like to connect.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Enter the password for your WordPress.com account.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Enter username";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "Enter your account information for %@.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "Enter your email address to log in or create a WordPress.com account.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "Enter your existing site address";
+
+/* Title of a button on the magic link screen.
+   Title of a button.  */
+"Enter your password instead." = "Enter your password instead.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "Enter your server credentials";
@@ -3119,6 +3225,10 @@ Example: Reply to Pamela Nguyen */
 /* Short title telling the user they will receive a blogging reminder every day of the week. */
 "Every day at %@" = "Every day at %@";
 
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "example.com";
+
 /* Label for the excerpt field. Should be the same as WP core. */
 "Excerpt" = "Excerpt";
 
@@ -3225,6 +3335,9 @@ Example: Reply to Pamela Nguyen */
 /* Fashion site intent topic */
 "Fashion" = "Fashion";
 
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
+
 /* Title of screen the displays the details of an advertisement campaign. */
 "feature.blaze.campaignDetails.title" = "Campaign Details";
 
@@ -3287,6 +3400,9 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "Find out more";
+
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Find your site address";
 
 /* My Profile first name label
    Register Domain - Domain contact information field First name
@@ -3431,6 +3547,9 @@ Example: Reply to Pamela Nguyen */
 /* A generic title for an error */
 "generic.error.title" = "Error";
 
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "Get a login link by email";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "Get active! Comment on posts from blogs you follow.";
 
@@ -3439,6 +3558,9 @@ Example: Reply to Pamela Nguyen */
 
 /* Displayed in the Notifications Tab as a message, when the Follow Filter shows no notifications */
 "Get noticed: comment on posts you've read." = "Get noticed: comment on posts you've read.";
+
+/* View title for initial auth views. */
+"Get Started" = "Get Started";
 
 /* Prompt for the screen to pick a template for a page */
 "Get started by choosing from a wide variety of pre-made page layouts. Or just start with a blank page." = "Get started by choosing from a wide variety of pre-made page layouts. Or just start with a blank page.";
@@ -3449,6 +3571,9 @@ Example: Reply to Pamela Nguyen */
 /* Title of the second alert preparing users to grant permission for us to send them push notifications. */
 "Get your notifications faster" = "Get your notifications faster";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Getting account information";
+
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "Getting Inspired";
 
@@ -3457,6 +3582,9 @@ Example: Reply to Pamela Nguyen */
 
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "Give it a try by adding a few blocks to your post or page!";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
@@ -3467,6 +3595,9 @@ Example: Reply to Pamela Nguyen */
 
 /* Instruction telling the user how to enable notifications in their device's system Settings app. The section names here should match those in Settings. */
 "Go to Settings → Notifications → WordPress, and toggle Allow Notifications." = "Go to Settings → Notifications → WordPress, and toggle Allow Notifications.";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Google sign up failed.";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -3595,6 +3726,9 @@ Example: Reply to Pamela Nguyen */
 /* No comment provided by engineer. */
 "Help icon" = "Help icon";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Hidden";
+
 /* Title of a button used to collapse a group */
 "Hide" = "Hide";
 
@@ -3669,6 +3803,12 @@ Example: Reply to Pamela Nguyen */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "Icon update failed";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "If you can’t find the email, please check your junk or spam email folder";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "If you remove %1$@, that user will no longer be able to access this site, but any content that was created by %2$@ will remain on the site.";
@@ -3771,6 +3911,9 @@ Example: Reply to Pamela Nguyen */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "Includes wp-config.php and any non WordPress files";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Incorrect username or password. Please try entering your login details again.";
 
 /* Title for a threat */
 "Infected core file" = "Infected core file";
@@ -3878,6 +4021,9 @@ Example: Reply to Pamela Nguyen */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "Introducing Blogging Prompts";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "Invalid Email Address";
+
 /* Error message generated when announcement service is unable to return a valid endpoint. */
 "Invalid endpoint" = "Invalid endpoint";
 
@@ -3898,6 +4044,9 @@ Example: Reply to Pamela Nguyen */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "Invalid URL. Audio file not found.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "Invalid URL. Please double-check and try again.";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "Invalid URL. Please enter a valid URL.";
@@ -3922,6 +4071,12 @@ Example: Reply to Pamela Nguyen */
 
 /* Describes the IP address section in the comment detail screen. */
 "IP address" = "IP address";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username/password isn't associated with this site." = "It looks like this username/password isn't associated with this site.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "It seems like you've entered an incorrect password. Want to give it another try?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "It's time to blog on %@!";
@@ -4553,13 +4708,31 @@ Please install the %3$@ to use the app with this site.";
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Log Files By Created Date";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Log In";
 
 /* Title of a button for signing in. */
 "Log in" = "Log in";
+
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Log in failed. Please try again.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "Log in or sign up with WordPress.com";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Log in to the WordPress.com account you used to connect Jetpack.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "Log in to your WordPress.com account with your email address.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "Log in with your WordPress.com username and password.";
 
 /* Button for confirming logging out from WordPress.com account
    Label for logging out from WordPress.com account */
@@ -4577,6 +4750,9 @@ Please install the %3$@ to use the app with this site.";
 /* Login Request Expired */
 "Login Request Expired" = "Login Request Expired";
 
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "Login with account password";
+
 /* Button to dismiss the re-authentication view */
 "login.appPasswordReAuth.cancelButton" = "Cancel";
 
@@ -4589,6 +4765,9 @@ Please install the %3$@ to use the app with this site.";
 /* Title shown when the application password is invalid */
 "login.appPasswordReAuth.title" = "Invalid application password";
 
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "Please enter the verification code from your authentication app for your WordPress.com account.";
+
 /* No comment provided by engineer. */
 "Logs" = "Logs";
 
@@ -4597,6 +4776,12 @@ Please install the %3$@ to use the app with this site.";
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications.";
+
+/* Title of a button.  */
+"Lost your password?" = "Lost your password?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "Mail (Default)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Main Navigation";
@@ -4912,6 +5097,9 @@ Please install the %3$@ to use the app with this site.";
    Label for the share message field on the post settings. */
 "Message" = "Message";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* The description in the Delete WordPress screen */
 "migration.deleteWordpress.description" = "It looks like you still have the WordPress app installed.";
 
@@ -5198,11 +5386,18 @@ Please install the %3$@ to use the app with this site.";
 /* No comment provided by engineer. */
 "Navigates to the previous content sheet" = "Navigates to the previous content sheet";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "Need help finding your site address?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "Need help?";
 
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Need Help?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Need more help?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "Needs Update";
@@ -5254,7 +5449,9 @@ Please install the %3$@ to use the app with this site.";
 "News" = "News";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Next";
 
 /* Accessibility label for the next notification button */
@@ -5483,6 +5680,9 @@ Please install the %3$@ to use the app with this site.";
    Title of a button that cancels enabling notifications when tapped */
 "Not Now" = "Not Now";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "Not seeing the email? Check your Spam or Junk Mail folder.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "Note:";
 
@@ -5645,7 +5845,11 @@ Please install the %3$@ to use the app with this site.";
 /* Title of a button style */
 "Official Buttons" = "Official Buttons";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -5726,6 +5930,10 @@ Please install the %3$@ to use the app with this site.";
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window/tab" = "Open link in new window/tab";
 
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Open Mail";
+
 /* Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Open Settings";
 
@@ -5743,6 +5951,18 @@ Please install the %3$@ to use the app with this site.";
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "Optional: Enter a custom message up to %1$d characters to be sent with your invitation.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "Or";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "Or choose another form of authentication.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "Or log in by _entering your site address_.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "Or log in with magic link";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Ordered List";
@@ -5848,8 +6068,14 @@ Please install the %3$@ to use the app with this site.";
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "Parent Page";
 
-/* Label for entering password in password field
+/* No comment provided by engineer. */
+"password" = "password";
+
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Password";
 
@@ -5994,6 +6220,9 @@ Please install the %3$@ to use the app with this site.";
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load.";
 
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "Please enter a complete website address, like example.com.";
+
 /* No comment provided by engineer. */
 "Please enter a site address." = "Please enter a site address.";
 
@@ -6012,7 +6241,10 @@ Please install the %3$@ to use the app with this site.";
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid Email" = "Please enter a valid Email";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "Please enter a valid email address for a WordPress.com account.";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Please enter a valid email address.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
@@ -6033,14 +6265,23 @@ Please install the %3$@ to use the app with this site.";
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid State" = "Please enter a valid State";
 
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Please enter the password for your WordPress.com account to log in with your Apple ID.";
+
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Please enter your credentials";
 
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Please enter your email address.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Please fill out all the fields";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "Please log out before connecting to a different wordpress.com site";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "Please try again later";
@@ -7676,6 +7917,9 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "Reset Date Range filter";
 
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Reset your password";
+
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Resize & Crop";
 
@@ -8004,6 +8248,15 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "Selects this topic as the intent for your site.";
 
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "Send email verification link";
+
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Send Link";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "Send Link by Email";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "Send Log Message";
 
@@ -8182,6 +8435,10 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title for the `show like button` setting */
 "Show Like button" = "Show Like button";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "Show password";
+
 /* No comment provided by engineer. */
 "Show post content" = "Show post content";
 
@@ -8199,6 +8456,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "Showing stats for:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "Shown";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Shown publicly when you comment on blogs.";
@@ -8242,6 +8502,21 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Sidebar item on iPad */
 "sidebar.notifications" = "Notifications";
 
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "Sign in with site credentials";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Sign up";
+
+/* View title during the sign up process. */
+"Sign Up" = "Sign Up";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Sign up for WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Sign up with Email";
+
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "Since you're on a free plan, you'll see limited events in your Activity Log.";
 
@@ -8256,6 +8531,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Site achievements";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Site address";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "Site address must be at least 4 characters.";
@@ -8561,6 +8839,9 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Label for the slug field. Should be the same as WP core. */
 "Slug" = "Slug";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS Sent";
+
 /* Text display in the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "So far, there are no fixed threats on your site." = "So far, there are no fixed threats on your site.";
 
@@ -8643,7 +8924,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Sorry, site addresses must have letters too!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Sorry, that email address is already being used!";
 
 /* No comment provided by engineer. */
@@ -8702,6 +8983,9 @@ Feel free to replace it with other bracket types that you think looks better for
    Marks comment as spam.
    Title of spam Comments filter. */
 "Spam" = "Spam";
+
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
 
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
@@ -9349,11 +9633,20 @@ Feel free to replace it with other bracket types that you think looks better for
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block";
 
+/* Button title */
+"Text me a code instead" = "Text me a code instead";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "Text me a code via SMS";
+
 /* Title of a button style */
 "Text Only" = "Text Only";
 
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Thanks for choosing %1$@ by %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "That doesn't appear to be a valid verification code.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "That doesn't look like a WordPress site.";
@@ -9396,6 +9689,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Title for a threat that includes the file name of the file */
 "The file %1$@ contains a malicious code pattern" = "The file %1$@ contains a malicious code pattern";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "The Google account \"%@\" doesn't match any account on WordPress.com";
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "The image could not be added to the Media Library.";
@@ -9444,6 +9740,10 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "The site at %1$@ uses WordPress %2$@. We recommend to update to the latest version, or at least %3$@";
+
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress.";
 
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "The site could not be deleted.";
@@ -9603,6 +9903,9 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "This domain is unavailable";
 
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "This email address is not registered on WordPress.com.";
+
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "This file is too large to upload to your site or it does not support this media format.";
 
@@ -9685,6 +9988,9 @@ Feel free to replace it with other bracket types that you think looks better for
    Title for the time zone selector */
 "Time Zone" = "Time Zone";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "Time's up, but don't worry, your security is our priority. Please try again!";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "Tips for getting the most out of WordPress.com.";
 
@@ -9710,6 +10016,9 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "To continue please enter your email address and name.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "To create your new WordPress.com account, please enter your email address.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin.";
 
@@ -9718,6 +10027,12 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "To install plugins, you need to have a custom domain associated with your site.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block.";
@@ -9835,6 +10150,12 @@ Feel free to replace it with other bracket types that you think looks better for
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "Try the new Block Editor";
 
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Try with another email";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Try with the site address";
+
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "Turn off prompts";
 
@@ -9870,6 +10191,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* No comment provided by engineer. */
 "Type a URL" = "Type a URL";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "Unable To Connect";
 
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "Unable to create new invite links.";
@@ -9916,6 +10240,9 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Unable to play video";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Unable to restore your site";
 
@@ -9945,6 +10272,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "Unable to upload 1 post, 1 file";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "Unable to verify the email address. Please try again later.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "Unable to visit Jetpack settings for site";
@@ -10140,11 +10470,17 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Use the current image */
 "Use" = "Use";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "Use a security key";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "Use block editor";
 
 /* No comment provided by engineer. */
 "Use icon button" = "Use icon button";
+
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "Use password to sign in";
 
 /* Site's Subscriber Profile. Displayed when the name is empty! */
 "user.details.title.subscriber" = "Site's Subscriber";
@@ -10235,11 +10571,14 @@ Feel free to replace it with other bracket types that you think looks better for
 "userlist.title" = "Users";
 
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Username";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -10260,6 +10599,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "USES";
+
+/* two factor code placeholder */
+"Verification code" = "Verification code";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "Verification email sent, check your inbox.";
@@ -10392,6 +10734,16 @@ Feel free to replace it with other bracket types that you think looks better for
 /* No comment provided by engineer. */
 "Waiting for connection" = "Waiting for connection";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Waiting for Google to complete…";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "Waiting for security key";
+
+/* View title during the Google auth process. */
+"Waiting..." = "Waiting...";
+
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
    Title for Jetpack Restore Warning screen */
@@ -10430,6 +10782,12 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "We had trouble loading data";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "We just emailed a link to %@. Please check your mail app and tap the link to log in.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "We just sent a magic link to";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "We successfully created a backup of your site as of %@";
 
@@ -10439,14 +10797,26 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "We use other tracking tools, including some from third parties. Read about these and how to control them.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "We were unable to send you an email at this time. Please try again later.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "We'll email you a signup link to create your new WordPress.com account.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "We'll notify you when you get followers, comments, and likes.";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "We'll use this email address to create your new WordPress.com account.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "We're creating a downloadable backup of your site from %1$@.";
@@ -10457,6 +10827,9 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "We're not able to connect to the Jetpack site at that URL.  Contact us for assistance.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "We're restoring your site back to %1$@.";
 
@@ -10465,6 +10838,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "We've also emailed you a link to your file.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -10559,8 +10935,14 @@ Feel free to replace it with other bracket types that you think looks better for
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "What is Gravatar?";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "What is WordPress.com?";
+
 /* Title for the problem section in the Threat Details */
 "What was the problem?" = "What was the problem?";
+
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "What's my site address?";
 
 /* Title of section that contains plugins' change log */
 "What's New" = "What's New";
@@ -10585,6 +10967,18 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "When you make changes to your site you'll be able to see your activity history here.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Whoops, something went wrong and we couldn't log you in. Please try again!";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "Whoops, something went wrong. Please try again!";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "Whoops, that security key does not seem valid. Please try again with another one";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Whoops, that's not a valid two-factor verification code. Double-check your code and try again!";
 
 /* No comment provided by engineer. */
 "Width Settings" = "Width Settings";
@@ -10627,6 +11021,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "WordPress version too old";
+
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "WordPress version too old. The site at %1$@ uses WordPress %2$@. We recommend to update to the latest version, or at least %3$@";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "wordpress, help, support, faq, questions, debug, logs, help center, contact";
@@ -10691,6 +11088,9 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Caption displayed during the login flow. */
 "wordpress.prologue.splash.caption" = "Write, edit, and publish
 from anywhere.";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "Starting a new site?";
 
 /* Message to show when a request for a WP.com API endpoint is throttled */
 "wordpresskit.api.message.endpoint_throttled" = "Limit reached. You can try again in 1 minute. Trying again before that will only increase the time you have to wait before the ban is lifted. If you think this is in error, contact support.";
@@ -10776,6 +11176,9 @@ from anywhere.";
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Y-Axis Position";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "Year";
@@ -10965,6 +11368,9 @@ from anywhere.";
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9.";
 
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "Your site address appears in the bar at the top of the screen when you visit your site in Safari.";
+
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below.";
 
@@ -11027,6 +11433,9 @@ from anywhere.";
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "Unsupported attachment";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Log in with Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Domains";

--- a/WordPress/Resources/es.lproj/Localizable.strings
+++ b/WordPress/Resources/es.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Translation-Revision-Date: 2025-05-13 13:54:07+0000 */
+/* Translation-Revision-Date: 2025-03-10 13:21:07+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
 /* Generator: GlotPress/4.0.1 */
 /* Language: es */
@@ -98,6 +98,9 @@
 
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "%1$@ de %2$@ en tu sitio";
+
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "%1$@ de %2$@ utilizados en tu sitio";
 
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ cuatrillón";
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Sin título)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(sin título)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*Juan López* respondió a tu entrada";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "El botón «Más» contiene un desplegable que muestra los botones para compartir.";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "Una cuenta WordPress.com está conectada a tus credenciales de tienda. Para continuar, te enviaremos un enlace de verificación a la dirección de correo electrónico de arriba.";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "Un archivo contiene un patrón de código malicioso";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "Título del sitio";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "Se requiere una dirección de correo electrónico válida a la cual enviar un enlace de verificación. Vuelve a la pantalla anterior y proporciona una dirección de correo electrónico válida.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "Un código de verificación solo contendrá números.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "ACTIVO";
@@ -334,9 +349,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* My Profile 'About me' label */
 "About Me" = "Sobre mí";
-
-/* Link to About screen for Jetpack for iOS */
-"About Reader for iOS" = "Acerca del Lector para iOS";
 
 /* Link to About screen for WordPress for iOS */
 "About WordPress" = "Acerca de WordPress";
@@ -525,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "Después %@";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "Alineación";
@@ -588,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "Lista de direcciones IP permitidas";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "¡Ya falta poco! Por favor, introduce el código de verificación de tu aplicación authenticator.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Texto Alt";
@@ -600,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "También puedes aplanar el contenido desagrupando el bloque.";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "También puedes introducir la contraseña de esta cuenta.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "Otras opciones:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "Enviar siempre los registros de fallos";
@@ -621,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "Se requiere una conexión activa a Internet para ver las actividades";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "Se necesita una conexión a internet activa para ver los planes";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -671,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "Estadísticas anuales del sitio";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "Anónimo";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "Respuesta";
 
@@ -692,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "Apariencia";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "Identificación de Apple fallida.\nPor favor, asegúrate de que has accedido a iCloud con un ID de Apple que use identificación de dos factores.";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "Aplica el ajuste";
@@ -778,6 +811,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "Identificación fallida";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "Código de identificación";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "Se requiere autenticación para el host: %@";
@@ -888,6 +925,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "Sé el primero en comentar";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Sé el primero en escribir un comentario.";
 
 /* Beauty site intent topic */
 "Beauty" = "Belleza";
@@ -1024,12 +1064,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button to copy post text" = "Botón para copiar el texto de la entrada";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "Al continuar, aceptas nuestros _términos del servicio_.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "Al registrar este dominio aceptas nuestros <a>Términos y condiciones<\/a>.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "Al configurar Jetpack aceptas nuestros\n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "Al registrarte aceptas nuestros _Términos del servicio_.";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "PERSONALIZAR";
@@ -1043,6 +1089,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "El acceso a la cámara es necesario para escanear códigos de acceso";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "No se puede solicitar el enlace";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "No se puede publicar una página vacía";
 
@@ -1052,6 +1101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1061,6 +1111,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1079,6 +1130,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1106,6 +1158,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "Cancelando…";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "No se puede acceder al sitio en esta dirección. Por favor, vuelve a comprobarlo e inténtalo de nuevo.";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "¿No puedes decidirte? Puedes cambiar el tema en cualquier momento.";
 
@@ -1113,7 +1168,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Pie de ilustración";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "¡Cuidado!";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1122,7 +1178,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Categorías";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Categoría";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1171,6 +1228,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "Comprueba nuestros consejos destacados para aumentar tus visitas y tu tráfico";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "¡Revisa tu correo electrónico en este dispositivo!";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Comprueba tu correo electrónico en este dispositivo y toca el enlace en el correo electrónico que has recibido de WordPress.com.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "Comprueba tu correo electrónico en este dispositivo y toca el enlace del correo electrónico que has recibido de WordPress.com.\n\n¿No ves el correo electrónico? Comprueba tu carpeta de correo basura o spam.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "¡Comprueba tu correo electrónico!";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "Comprueba tu conexión a Internet y tira para actualizar la página.";
@@ -1267,6 +1336,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "Reclama tu dominio gratuito";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "Blog clásico";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "Vaciar caché de elementos multimedia del dispositivo";
 
@@ -1294,6 +1366,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Cerrar";
 
@@ -1335,6 +1408,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "Ajustes de columna";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Cómics";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1386,6 +1462,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Comentarios";
 
@@ -1453,12 +1530,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Cuentas conectadas";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Conectado pero…";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "Conectando con %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Conectar %1$@ reemplazará la conexión existente con %2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Conectando a WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Conectando...";
@@ -1489,8 +1572,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "Contacta con nosotros a través de %@";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "Estructura del contenido\nBloques: %1$li, Palabras: %2$li, Caracteres: %3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1505,6 +1592,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Continuar leyendo";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = " Continuar con Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Continuar con Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Continuando con Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "Contribuye";
@@ -1633,6 +1729,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "Crear";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Crear cuenta";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "Crear una página en blanco";
 
@@ -1653,6 +1752,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "Crea una entrada";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "Crear un sitio";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "Crea una etiqueta";
@@ -1686,6 +1788,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "Actual";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Plan actual";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Tema actual";
@@ -1788,6 +1893,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "Categoría por defecto";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Menú por defecto";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Formato de entrada por defecto";
@@ -1796,6 +1904,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "Opciones predeterminadas para entradas nuevas";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Borrar";
@@ -1853,6 +1962,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "Detalles";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "¿No querías crear una nueva cuenta? Vuelve atrás y vuelve a introducir tu dirección de correo electrónico.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "Dimensiones";
 
@@ -1900,7 +2012,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "Comentarios";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Descartar";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1922,6 +2036,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "Dominios";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "¿No tienes una cuenta? _Regístrate_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2051,6 +2168,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "Descargas";
 
+/* Name for the status of a draft post. */
+"Draft" = "Borrador";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Borradores";
 
@@ -2160,7 +2280,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "Email";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "Dirección de correo electrónico";
 
 /* Notification Settings Channel */
@@ -2244,8 +2367,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Escribe contraseña";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "Introduce la dirección del sitio WordPress que deseas conectar.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Introduce la contraseña de tu cuenta en WordPress.com.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Escribe usuario";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "Introduce la información de tu cuenta para %@.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "Introduce tu dirección de correo electrónico para acceder o crear una cuenta en WordPress.com.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "Introduce la dirección de tu sitio existente";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "Introduce tu contraseña.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "Introduce las credenciales de tu servidor";
@@ -2408,6 +2551,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "Externo";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Fallado";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "Fallo al marcar los avisos como leídos";
 
@@ -2419,9 +2565,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Failed to insert media.\nTap for more info." = "Fallo al insertar los medios.\nToca para obtener más información.";
-
-/* A message indicating that we couldn't load the user's settings. */
-"Failed to load settings" = "Error al cargar los ajustes";
 
 /* No comment provided by engineer. */
 "Failed to save files.\nPlease tap for options." = "Fallo al guardar los archivos.\nPor favor, toca para ver las opciones.";
@@ -2437,6 +2580,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "Moda";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "Destacados";
@@ -2495,6 +2641,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "Saber más";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Encuentra la dirección de tu sitio";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2517,6 +2666,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "Corrigiendo amenazas";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "Seguir";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "Seguir la conversación";
@@ -2611,6 +2763,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "Generar un nuevo enlace";
 
+/* View title for initial auth views. */
+"Get Started" = "Primeros pasos";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "Obtener un enlace de acceso por correo electrónico";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "Actívate: comenta las entradas de los blogs que sigues.";
 
@@ -2632,8 +2790,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "Inspírate";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Recuperando la información de la cuenta";
+
+/* Cancel */
+"Give Up" = "Renunciar";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "¡Pruébalo añadiendo unos cuantos bloques a tu entrada o página!";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "Ir al Lector";
@@ -2644,6 +2811,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "Ir a los ajustes de iOS";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Fallo en el registro en Google.";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2718,6 +2888,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "Icono de ayuda";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Oculto";
+
 /* Title of a button used to collapse a group */
 "Hide" = "Ocultar";
 
@@ -2786,6 +2959,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "Fallo al actualizar el icono";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "Si no encuentras el correo electrónico, comprueba tu carpeta de correo no deseado o spam.";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "Si continúas con Apple o Google y aún no tienes una cuenta de WordPress.com, crearás una cuenta y aceptas nuestros _términos del servicio_.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "Si eliminas a %1$@, ese usuario ya no podrá acceder a este sitio, aunque todo el contenido que haya creado %2$@ permanecerá en el sitio.";
@@ -2861,6 +3040,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "Incluye wp-config.php y cualquier archivo que no sea de WordPress";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "El nombre de usuario o la contraseña son incorrectos. Introduce de nuevo tus datos de acceso.";
 
 /* Title for a threat */
 "Infected core file" = "Archivo principal infectado";
@@ -2962,6 +3144,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "Presentamos las sugerencias de publicación";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "Dirección de correo electrónico no válida";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "Dirección del sitio inválida";
 
@@ -2979,6 +3164,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "URL no válida. Archivo de audio no encontrado.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "URL no válida. Por favor, vuelve a comprobarla e inténtalo de nuevo.";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "URL no válida. Por favor, introduce una URL válida.";
@@ -3000,6 +3188,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "Invitar a gente";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "Parece que este usuario\/contraseña no está asociado con este sitio.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "Parece que has introducido una contraseña incorrecta ¿Quieres intentarlo de nuevo?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "¡Es hora de bloguear en %@!";
@@ -3228,7 +3422,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "Altura de la línea";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Enlace";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3290,6 +3485,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "Cargando personas…";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Cargando plan...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Cargando planes...";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "Cargando plugin…";
 
@@ -3324,11 +3525,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "Cargando...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Local";
+
 /* Local Services site intent topic */
 "Local Services" = "Servicios locales";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "Cambios locales";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Ubicación";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Lo servicios de localización deben estar activados antes de que WordPress pueda añadir tu posición actual. Por favor, activa los servicios de localización de los ajustes de la app.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Ubicación desconocida";
 
 /* No comment provided by engineer. */
 "Lock icon" = "Icono de candado";
@@ -3336,9 +3549,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Registros de actividad por fecha de creación";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Acceder";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3348,17 +3563,33 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of a button for signing in. */
 "Log in" = "Acceder";
 
-/* LogOut confirmation text, whenever there are no local changes */
-"Log out of Jetpack?" = "¿Cerrar sesión en Jetpack?";
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Acceso fallido. Inténtalo otra vez.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "Accede o regístrate con WordPress.com";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Accede a la cuenta de WordPress.com que utilizaste para conectar a Jetpack.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "Accede a tu cuenta de WordPress.com con tu dirección de correo electrónico.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "Accede con tu nombre de usuario y contraseña de WordPress.com.";
 
 /* LogOut confirmation text, whenever there are no local changes */
-"Log out of Reader?" = "¿Salir del Lector?";
+"Log out of Jetpack?" = "¿Cerrar sesión en Jetpack?";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of WordPress?" = "¿Salir de WordPress?";
 
 /* Login Request Expired */
 "Login Request Expired" = "La petición de acceso ha expirado";
+
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "Accede con la contraseña de la cuenta";
 
 /* No comment provided by engineer. */
 "Logs" = "Registros";
@@ -3368,6 +3599,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Parece que tienes Jetpack instalado. ¡Enhorabuena! Accede con tus credenciales de WordPress.com para activar las estadísticas y los avisos.";
+
+/* Title of a button. */
+"Lost your password?" = "¿Has perdido tu contraseña?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "Mail (Por defecto)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Navegación principal";
@@ -3515,6 +3752,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "Mensaje";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "Vulnerabilidad diversa";
 
@@ -3610,6 +3850,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "Mi sitio";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "Mis sitios en WordPress";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "Mis diez mejores cafeterías";
 
@@ -3649,8 +3892,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "¿Necesitas ayuda?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "¿Necesitas ayuda para encontrar la dirección de tu sitio?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "¿Necesitas ayuda?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "¿Necesitas más ayuda?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "Necesita actualización";
@@ -3679,6 +3929,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "Nueva entrada";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Nuevo elemento";
+
 /* Placeholder text for password field */
 "New password" = "Nueva contraseña";
 
@@ -3696,7 +3949,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "Noticias";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Siguiente";
 
 /* Accessibility label for the next notification button */
@@ -3732,6 +3987,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "No hay disponible una vista previa de la URL";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "Sin título";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "No hay actividades disponibles";
 
@@ -3764,7 +4022,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "No hay comentarios";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "Sin conexión";
 
@@ -3913,6 +4172,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "Ahora no";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "¿No ves el correo electrónico? Comprueba tu carpeta de spam o correo no deseado.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "Nota:";
 
@@ -3976,7 +4238,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Lista numerada";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "Aceptar";
@@ -4033,7 +4300,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "¡Vaya!";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "¡Vaya!";
 
 /* No comment provided by engineer. */
@@ -4048,7 +4316,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "Abrir los ajustes de seguridad de Jetpack";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Abrir correo electrónico";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Abrir configuración";
 
 /* No comment provided by engineer. */
@@ -4066,6 +4339,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "Abrir enlace en una ventana o pestaña nuevas";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "Abre los ajustes de suscripción de la entrada";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "Abrir la sección «Yo»";
 
@@ -4080,6 +4356,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "Opcional: Introduce un mensaje personalizado de hasta %1$d caracteres que se enviará con tu invitación.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "O";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "O elige otra forma de identificación.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "O accede _introduciendo la dirección de tu sitio_.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "O accede con un enlace mágico";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Lista ordenada";
@@ -4128,7 +4416,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "Relleno";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Página";
 
@@ -4161,8 +4450,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "Paternidad";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Contraseña";
 
@@ -4179,8 +4471,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "Pegar el bloque después";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Pendiente";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Pendiente de revisión";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4211,6 +4507,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "Elige un nombre de usuario";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Planes";
+
 /* User action to play a video on the editor. */
 "Play video" = "Reproduce vídeo";
 
@@ -4240,6 +4540,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "Por favor, asegúrate de que el editor de bloques esté activo en tu sitio. Si no está activo no se cargará.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "Por favor, introduce la dirección completa de una web, como ejemplo.com.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "Introduce una dirección para el sitio.";
@@ -4274,11 +4577,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "Introduce una dirección válida";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "Por favor, introduce una dirección de correo electrónico válida para una cuenta de WordPress.com";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Introduce una dirección de correo válida.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "Por favor, introduce un número de teléfono válido";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Por favor, introduce la contraseña de tu cuenta en WordPress.com para acceder con tu ID de Apple.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Introduce tus credenciales";
@@ -4286,8 +4595,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Por favor, introduce tu dirección de correo electrónico.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Rellena todos los campos";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Por favor, lanza la app de WordPress, accede a WordPress.com y asegúrate de que tienes al menos un sitio. Entonces, inténtalo de nuevo.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "Por favor, sal de la sesión antes de conectar a otro sitio wordpress.com distinto";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "Por favor, inténtalo de nuevo más tarde";
@@ -4355,7 +4670,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "Idiomas populares";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Publicar";
 
@@ -4476,6 +4792,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "Aviso de privacidad para usuarios de California";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Privada";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "Problema al mostrar el bloque. \nToca para intentar la recuperación del bloque.";
 
@@ -4490,6 +4809,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "Problema al comprar tu dominio. Por favor, inténtalo de nuevo.";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Si continúas, se eliminarán de este dispositivo todos los datos de WordPress.com y se suprimirán los borradores guardados en el disco local. No perderás ninguna información previamente guardada en tus blogs de WordPress.com.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Proyectos";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "Se ha omitido la sugerencia";
@@ -4507,13 +4832,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "Fecha de publicación";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Publicar Inmediatamente";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "Publicar página el:";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "Publicar entrada el:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Publicadas";
 
@@ -4715,7 +5044,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "Responder";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Texto de respuesta";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "Responder a %1$@";
 
 /* An explaination of a setting. */
@@ -4744,6 +5078,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "Restablecer filtro de rango de fechas";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Restablecer tu contraseña";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Cambiar tamaño y recortar";
@@ -4801,6 +5138,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "Reintentar todo";
 
+/* No comment provided by engineer. */
+"Retry?" = "¿Reintentar?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "Volver a la entrada";
 
@@ -4830,6 +5170,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "Perfil";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "Se ha enviado un SMS";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "ESTADO";
 
@@ -4841,6 +5184,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4907,7 +5251,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "Analizando archivos";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Programada";
 
 /* No comment provided by engineer. */
@@ -5047,6 +5392,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "Selecciona esta temática como la de tu sitio.";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Enviar enlace";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "Enviar el enlace por correo electrónico";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "Enviar el mensaje del registro";
 
@@ -5055,6 +5406,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "Enviar una prueba de fallos";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "Enviar un enlace de verificación de correo electrónico";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "Enviar avisos por correo electrónico";
@@ -5101,11 +5455,11 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Message to show when setting save failed */
 "Settings update failed" = "Ha habido un error durante la actualización de la configuración";
 
-/* Title for a button that recommends the app to others */
-"Share Jetpack with a friend" = "Comparte Jetpack con un amigo";
+/* Spoken accessibility label */
+"Share" = "Compartir";
 
 /* Title for a button that recommends the app to others */
-"Share Reader with a friend" = "Compartir el Lector con un amigo";
+"Share Jetpack with a friend" = "Comparte Jetpack con un amigo";
 
 /* Title for a button that recommends the app to others */
 "Share WordPress with a friend" = "Comparte WordPress con un amigo";
@@ -5156,6 +5510,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "Mostrar botón de rebloguear";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "Mostrar la contraseña";
+
 /* No comment provided by engineer. */
 "Show post content" = "Muestra el contenido de la entrada";
 
@@ -5167,6 +5525,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "Mostrando estadísticas para:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "Mostrado";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Se muestra públicamente cuando comentas en blogs.";
@@ -5182,6 +5543,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "Muestra la entrada";
+
+/* View title during the sign up process. */
+"Sign Up" = "Registrarse";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "Accede con las credenciales del sitio";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Regístrate";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Regístrate en WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Registro con correo electrónico";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "Como estás con un plan gratuito verás eventos limitados en tu registro de actividad.";
@@ -5220,6 +5596,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Logros del sitio";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Dirección del sitio";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "La dirección del sitio debe tener al menos 4 caracteres.";
@@ -5304,7 +5683,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "La dirección del sitio debe contener letras.";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "El email ya se ha usado.";
 
 /* No comment provided by engineer. */
@@ -5364,6 +5743,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "Spam";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "Acelera tu sitio";
@@ -5389,6 +5771,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "Provincia";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "Página de inicio estática";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5419,6 +5804,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "Tachado";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Esbozo";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "Enviar para revisión";
@@ -5509,7 +5897,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "Tableta";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Etiqueta";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5644,6 +6033,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Términos del servicio";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Testimonios";
+
 /* Title of a button style */
 "Text Only" = "Solo texto";
 
@@ -5653,8 +6045,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "Los controles de formato de texto están dentro de la barra de herramientas situada encima del teclado mientras editas un bloque de texto";
 
+/* Button title */
+"Text me a code instead" = "Envía un código por mensaje de texto";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "Envíame un texto con un código mediante SMS";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Gracias por elegir %1$@ de %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "No parece ser un código de verificación válido.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "Eso no parece que sea un sitio WordPress.";
@@ -5676,6 +6077,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "La conexión con Facebook no puede encontrar ninguna página. Difundir no puede conectar con perfiles de Facebook, solo con páginas publicadas.";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "La cuenta de Google «%@» no coincide con ninguna cuenta de WordPress.com";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "No estás conectado a internet.";
@@ -5715,6 +6119,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "No se pudo añadir la imagen a la biblioteca de medios.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "Parece que no hay conexión a internet.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "Tipos de sitios que se pueden crear";
@@ -5758,6 +6165,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "El sitio en %1$@ usa WordPress %2$@. Se recomienda usar la última versión, o al menos %3$@";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "El sitio que hay en esta dirección no es un sitio WordPress. Para que podamos conectarnos con él, el sitio debe usar WordPress.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "No se ha podido eliminar el sitio.";
 
@@ -5799,6 +6210,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "Se ha producido un error inesperado al editar tu comentario";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "Hubo un error inesperado al cargar los comentarios.";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "Hubo un error inesperado al registrar tu dominio";
 
@@ -5807,6 +6221,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "Ha ocurrido un error inesperado al actualizar tus ajustes de avisos";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "Se ha producido un error inesperado al actualizar tu comentario";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "Ha sido un error inesperado.";
@@ -5828,6 +6245,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "Ha ocurrido un problema al comunicar con el sitio.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "Se ha producido un problema al conectar con WordPress.com. Inicia sesión de nuevo.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "Hubo un problema mostrando esta entrada.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "Hubo un problema al cargar tus datos, recarga tu página para intentarlo de nuevo.";
 
@@ -5837,12 +6260,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "Hubo un problema guardando los cambios en la gestión de compartir.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "Hubo un problema al intentar acceder a tu localización. Por favor, prueba de nuevo.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "Hubo un error al cambiar la contraseña";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "Hubo un error al cargar las actividades";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "Hubo un error cargando los planes";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "Hubo un error al cargar los plugins";
@@ -5855,6 +6284,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "Hubo un error al cargar el historial";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "Se ha producido un error al cargar el plan";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "Ha ocurrido un error al cargar el historial de exploración";
@@ -5903,6 +6335,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "Este dominio no está disponible";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "Esta dirección de correo electrónico no está registrada en WordPress.com";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "El archivo es demasiado grande para subirlo a tu sitio o no es compatible con este formato de medio.";
@@ -5983,6 +6418,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "Zona horaria";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "Se acabó el tiempo, pero no te preocupes, tu seguridad es nuestra prioridad. ¡Vuelve a intentarlo!";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "Trucos para sacar el máximo provecho a WordPress.com";
 
@@ -5996,6 +6434,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "Para continuar, por favor, introduce tu dirección de correo electrónico y nombre.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "Para crear tu nueva cuenta de WordPress.com, por favor, introduce tu dirección de correo electrónico.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "Para obtener avisos útiles en tu teléfono desde tu sitio WordPress necesitarás instalar el plugin Jetpack.";
 
@@ -6004,6 +6445,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "Para instalar plugin necesitas tener un dominio personalizado asociado a tu sitio.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "Para continuar con este ID de Apple, primero accede con tu contraseña de WordPress.com. Solo se pedirá una vez.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "Para seguir con esta cuenta de Google, por favor, primero accede con tu contraseña de WordPress.com. Esto solo se te pedirá una vez.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "Para eliminar un bloque, selecciona el bloque y haz clic en los tres puntos de la parte inferior derecha del bloque para ver los ajustes. A partir de ahí, elige la opción para eliminar el bloque.";
@@ -6078,7 +6525,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "Papelera";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "En la papelera";
 
@@ -6092,6 +6540,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "Probar y personalizar";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Intentar de nuevo";
@@ -6117,6 +6566,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "Prueba el nuevo editor de bloques";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Prueba con otro correo electrónico";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Prueba con la dirección del sitio";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "Desactivar las sugerencias";
@@ -6159,6 +6614,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "USOS";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "No fue posible conectar";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "No se pudieron cargar las entradas";
@@ -6208,6 +6666,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "No ha sido posible reproducir el vídeo";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "No ha sido posible leer el sitio de WordPress en esa URL. Pulsa «¿Necesitas ayuda?» para ver las FAQ.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "No es posible restaurar tu sitio";
 
@@ -6234,6 +6695,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "No ha sido posible subir 1 entrada, 1 archivo";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "No ha sido posible verificar la dirección de correo electrónico. Por favor, inténtalo de nuevo más tarde.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "No se han podido visitar los ajustes de Jetpack para el sitio";
@@ -6378,7 +6842,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Carga fallida";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Subido";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6396,7 +6861,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Temas subidos";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Subiendo";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6411,18 +6877,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "Utilizar";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "Usa una clave de seguridad";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "Usar el editor de bloques";
 
 /* No comment provided by engineer. */
 "Use icon button" = "Usar botón de icono";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "Usar una contraseña para acceder";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Usuario";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6437,6 +6912,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Usuarios";
+
+/* two factor code placeholder */
+"Verification code" = "Código de verificación";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "Correo electrónico de verificación enviado, revisa tu bandeja de entrada";
@@ -6569,8 +7047,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "El directorio wp-content";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Esperando a que Google termine…";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "Esperando conexión";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "Esperando a la clave de seguridad";
+
+/* View title during the Google auth process. */
+"Waiting..." = "Esperando...";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6610,6 +7098,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "Hemos tenido problemas para cargar los datos";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "Acabamos de enviar por correo electrónico un enlace a %@. Por favor, comprueba tu aplicación de correo y toca el enlace para acceder.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "Acabamos de enviar un enlace mágico a";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "Hemos creado una copia de seguridad de tu sitio %@";
 
@@ -6619,14 +7113,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "Utilizamos otras herramientas de seguimiento, incluyendo algunas de terceras partes. Lee acerca de ellas y cómo controlarlas.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "No hemos sido capaces de enviarte un correo electrónico en este momento. Por favor, inténtalo más tarde de nuevo.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Si se detectan amenazas de seguridad, te enviaremos un correo electrónico. Mientras tanto, puedes continuar usando tu sitio como siempre. Puedes volver a consultar cómo va el proceso de análisis en cualquier momento.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "Te enviaremos por correo electrónico un enlace mágico que te registrará al instante, sin necesidad de contraseña. ¡Sin errores!";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "Te enviaremos un enlace por correo electrónico para crear tu nueva cuenta de WordPress.com.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "Te avisaremos cuando tengas seguidores, comentarios y «me gusta».";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "Te avisaremos cuando tengas nuevos seguidores, comentarios y me gusta. ¿Te gustaría permitir las notificaciones push?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "Usaremos esta dirección de correo electrónico para crear tu nueva cuenta de WordPress.com.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "Estamos creando una copia de seguridad descargable de la versión de tu sitio del %1$@.";
@@ -6637,6 +7143,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Trabajamos duro para corregir estas amenazas en segundo plano. Mientras tanto puedes seguir usando tu sitio como siempre, puedes volver a comprobar el progreso en cualquier momento.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "No podemos conectar con el sitio Jetpack en esa URL. Contacta con nosotros para que te ayudemos.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "Estamos restaurando la versión de tu sitio del %1$@.";
 
@@ -6645,6 +7154,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "También hemos enviado un enlace a tu archivo.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Te hemos enviado por correo electrónico un enlace de registro para crear tu nueva cuenta de WordPress.com. Comprueba tu correo electrónico en este dispositivo y toca el enlace en el correo electrónico que has recibido de WordPress.com.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6671,6 +7183,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "Resumen semanal: %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "Te damos la bienvenida a Jetpack";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Bienvenido a WordPress";
 
 /* A message title */
 "Welcome to the Reader" = "Bienvenido al lector";
@@ -6715,6 +7233,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "¿Qué es Gravatar?";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "¿Qué es WordPress.com?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "¿Qué es un  bloque?";
 
@@ -6731,10 +7252,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "What's New in Jetpack" = "Qué novedades hay en Jetpack";
 
 /* Opens the What's New / Feature Announcement modal */
-"What's New in Reader" = "Novedades del Lector";
-
-/* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "Qué hay de nuevo en WordPress";
+
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "¿Cuál es la dirección de mi sitio?";
 
 /* Select the site's intent. Title */
 "What's your website about?" = "¿De qué trata tu web?";
@@ -6748,6 +7269,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "Cuando hagas cambios en tu sitio aquí podrás ver tu historial de actividad.";
 
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Vaya, algo salió mal y no pudimos conectarte. ¡Por favor, inténtalo de nuevo!";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "Vaya, algo ha ido mal. ¡Por favor, inténtalo de nuevo!";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "Vaya, esa clave de seguridad parece que no es válida. Por favor, inténtalo de nuevo con otra";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Vaya, eso no es un código de verificación en dos pasos. ¡Vuelve a comprobar tu código e inténtalo de nuevo!";
+
 /* No comment provided by engineer. */
 "Width Settings" = "Ajustes de anchura";
 
@@ -6760,17 +7293,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "Ajustes de la aplicación WordPress";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "Aplicaciones WordPress - Aplicaciones para cualquier pantalla";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "Blog WordPress";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "Ayuda de WordPress";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "Biblioteca de medios de WordPress";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "Ajustes de avisos de WordPress";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "Avisos de WordPress";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "Plugins WordPress";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "Perfil de WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "Lector de WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "Detalles del sitio WordPress";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "Temas WordPress";
@@ -6781,17 +7335,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "Los multisitios de WordPress no son compatibles";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress necesita permiso para acceder a la localización actual de tu dispositivo para poder añadirla a tu entrada. Por favor, actualiza tus ajustes de privacidad.";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "Raíz de WordPress";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "La versión de WordPress es demasiado vieja";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "La versión de WordPress es demasiado antigua. El sitio en %1$@ utiliza la versión %2$@ de WordPress. Recomendamos actualizarla a la versión más reciente o al menos a la %3$@";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "Cuenta de WordPress.com";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "Planes de WordPress.com";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "Temas de WordPress.com";
@@ -6822,6 +7385,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "Escribir entrada";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "Escribe una respuesta";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "Escribe una respuesta...";
 
 /* Title for the writing section in site settings screen */
@@ -6835,6 +7401,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Posición del eje Y";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "Año";
@@ -6919,6 +7488,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Displayed when the user views trashed in the posts list and there are no posts */
 "You don't have any trashed posts" = "No tienes ninguna entrada en la papelera";
 
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"You don't have permission to view this private blog." = "No tienes permiso para ver este blog privado.";
+
 /* Description for the first domain purchased with a paid plan. */
 "You have a free one-year domain registration with your plan." = "Tienes el registro de dominio gratuito por un año con tu plan.";
 
@@ -6934,7 +7506,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "No tienes configurado ningún recordatorio.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Hay cambios sin guardar.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -7021,9 +7594,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Help text that describes how the password should be. It appears while editing the password */
 "Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ & )." = "Tu contraseña debería tener al menos seis caracteres. Para hacerla más fuerte utiliza mayúsculas y minúsculas, números y símbolos como ! \" ? $ % ^ & ).";
 
-/* Message of Export Content confirmation alert */
-"Your posts, pages, and settings will be mailed to the account's email address." = "Tus entradas, páginas y ajustes se enviarán a la dirección de correo electrónico de la cuenta.";
-
 /* Message of Export Content confirmation alert; substitution is user's email address */
 "Your posts, pages, and settings will be mailed to you at %@." = "Recibirás tus entradas, páginas y ajustes por correo electrónico a %@.";
 
@@ -7032,6 +7602,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "Tu búsqueda incluye caracteres no admitidos en los dominios de WordPress.com. Los siguientes caracteres están permitidos: A-Z, a-z, 0-9.";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "La dirección de tu sitio aparece en la barra en la parte superior de la pantalla cuando visitas tu sitio en Safari.";
 
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "Tu sitio ya está protegido con VaultPress. Más abajo, puedes encontrar un enlace a tu escritorio de VaultPress.";
@@ -7111,17 +7684,23 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility identifier for an 'Add Comment' button */
 "addCommentButton.accessibilityIdentifity" = "Añadir comentario";
 
-/* Error message when user cancels login */
-"addSite.selfHosted.cancelled" = "El acceso se ha cancelado";
+/* Error message shown a URL does not point to an existing site. */
+"addSite.restApiNotAvailable" = "El sitio que hay en esta dirección no es un sitio WordPress. Para que podamos conectarnos con él, el sitio debe usar WordPress.";
+
+/* Error message shown when an receiving an invalid application-password authentication result from a self-hosted WordPress site */
+"addSite.selfHosted.authenticationFailed" = "No se ha podido iniciar sesión utilizando la identificación mediante contraseña de aplicación.";
 
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "Introduce la dirección del sitio WordPress que quieres conectar.";
 
+/* Error message when user input is not a WordPress site */
+"addSite.selfHosted.invalidUrl" = "La dirección del sitio no es válida.";
+
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "No han podido cargar los detalles del sitio WordPress";
 
-/* Error message when user signs in with an unexpected usern. The first argument is the expected username */
-"addSite.selfHosted.mismatchUser" = "Accede con el usuario conectado. Nombre de usuario: %@";
+/* Error message shown when application-password authentication is disabled on a self-hosted WordPress site */
+"addSite.selfHosted.noLoginUrlFound" = "La identificación con contraseña de aplicación debe estar activada en el sitio WordPress.";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "No se ha podido guardar el sitio WordPress, inténtalo más tarde.";
@@ -7129,17 +7708,14 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "Añadir sitio autoalojado";
 
-/* Error message when XML-RPC is disabled on the WordPress site. The first argument is detailed error message */
-"addSite.selfHosted.xmlrpcDisabled" = "No se ha podido conectar con el sitio de WordPress. XML-RPC puede haberse inhabilitado en el servidor. Ponte en contacto con tu proveedor de alojamiento para resolver este problema.";
+/* Error message when an unknown error occurred when adding a self-hosted site */
+"addSite.selfHosted.unknownError" = "Algo ha salido mal. Por favor, inténtalo de nuevo.";
 
 /* Age between dates equaling one hour. */
 "an hour" = "una hora";
 
 /* This is the string we display when prompting the user to review the Jetpack app */
 "appRatings.jetpack.prompt" = "¿Qué opinas de Jetpack?";
-
-/* This is the string we display when prompting the user to review the Reader app */
-"appRatings.reader.prompt" = "¿Qué opinas del Lector?";
 
 /* This is the string we display when prompting the user to review the WordPress app */
 "appRatings.wordpress.prompt" = "¿Qué opinas de WordPress?";
@@ -7843,6 +8419,10 @@ Example: Reply to Pamela Nguyen */
 /* A name of the ID field (it's a technical field, has to be short, displayed below everything else) */
 "entityMetadataFooterView.id" = "ID";
 
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "example.com";
+
 /* Accept button title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackAccept" = "Enviar impresiones";
 
@@ -7854,9 +8434,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackTitle" = "Compartir impresiones";
-
-/* Communicates the future removal of the option to disable the experimental editor, displayed beneath the experimental features list */
-"experimentalFeatures.editorNote" = "El Editor de bloques experimental se convertirá en el editor por defecto en una versión futura y se eliminará la posibilidad de inhabilitarlo.";
 
 /* The title for the experimental features list */
 "experimentalFeaturesList.heading" = "Funciones experimentales";
@@ -7903,8 +8480,14 @@ Example: Reply to Pamela Nguyen */
 /* A footer retry button */
 "general.pagingFooterView.retry" = "Reintentar";
 
+/* Error message format when REST API returns an error response. The first argument is error message. */
+"generic.error.rest-api-error" = "Tu sitio ha enviado una respuesta de error: %@";
+
 /* A generic title for an error */
 "generic.error.title" = "Error";
+
+/* Error message when failing to parse API responses */
+"generic.error.unparsableResponse" = "Tu sitio ha enviado una respuesta que la aplicación no ha podido procesar";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "Configura los recordatorios para publicar en el blog";
@@ -8076,42 +8659,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title of the Jetpack powered overlay. */
 "jetpack.branding.overlay.title" = "WordPress es mejor con Jetpack";
-
-/* Title for the button that starts the Jetpack connection process */
-"jetpack.connection.connect.button" = "Conecta tu sitio";
-
-/* Error message shown when WordPress.com authentication fails */
-"jetpack.connection.error.authentication" = "Cuenta de WordPress.com no válida";
-
-/* Error message shown when a connection step is attempted in an invalid order */
-"jetpack.connection.error.context" = "Este paso aún no está listo";
-
-/* Title for the retry button shown when a connection step fails */
-"jetpack.connection.retry.button" = "Reintentar";
-
-/* Status message when a connection step is pending */
-"jetpack.connection.stage.pending" = "Esperando para empezar";
-
-/* Status message when a connection step is in progress */
-"jetpack.connection.stage.processing" = "En progreso...";
-
-/* Status message when a connection step is completed successfully */
-"jetpack.connection.stage.success" = "Completado";
-
-/* Title for the finalization step in Jetpack connection flow */
-"jetpack.connection.step.finalize.title" = "Finalizar conexión";
-
-/* Title for the install step in Jetpack connection flow */
-"jetpack.connection.step.install.title" = "Instalar Jetpack";
-
-/* Title for the login step in Jetpack connection flow */
-"jetpack.connection.step.login.title" = "Acceder a WordPress.com";
-
-/* Title for the site connection step in Jetpack connection flow */
-"jetpack.connection.step.site.title" = "Conectar con tu sitio";
-
-/* Title for the user connection step in Jetpack connection flow */
-"jetpack.connection.step.user.title" = "Conecta tu cuenta de WordPress.com";
 
 /* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
 "jetpack.fullscreen.overlay.early.switch.title" = "Cambiar a la nueva aplicación de Jetpack";
@@ -8332,41 +8879,11 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "No tienes permiso para ver este blog privado.";
 
-/* Button to dismiss the re-authentication view */
-"login.appPasswordReAuth.cancelButton" = "Cancelar";
-
-/* Description explaining why the user needs to re-authenticate */
-"login.appPasswordReAuth.description" = "La contraseña asignada a la aplicación ya no existe en tu perfil.\nAccede de nuevo para crear una contraseña de aplicación para que la utilice la aplicación.";
-
-/* Button to start the re-authentication process */
-"login.appPasswordReAuth.signInButton" = "Acceder";
-
-/* Title shown when the application password is invalid */
-"login.appPasswordReAuth.title" = "Contraseña de aplicación no válida";
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "Introduce el código de verificación para tu cuenta de WordPress.com desde tu aplicación de autenticación.";
 
 /* Indicating that referrer was marked as spam */
 "marked as spam" = "marcado como spam";
-
-/* Button title when verification link sending failed */
-"me.verifyEmail.button.retry" = "Intentar otra vez";
-
-/* Button title to send verification link */
-"me.verifyEmail.button.send" = "Reenviar correo electrónico";
-
-/* Button title while verification link is being sent */
-"me.verifyEmail.button.sending" = "Enviando...";
-
-/* Button title after verification link is sent */
-"me.verifyEmail.button.sent" = "Correo electrónico enviado";
-
-/* Message for email verification card */
-"me.verifyEmail.message.noEmail" = "Verifica tu correo electrónico para asegurar tu cuenta y acceder a más funciones.\nBusca en tu bandeja de entrada el correo electrónico de confirmación, o haz clic en \"%@\" para obtener uno nuevo..";
-
-/* Message for email verification card with email address */
-"me.verifyEmail.message.withEmail" = "Verifica tu correo electrónico para proteger tu cuenta y acceder a más funciones.\nComprueba tu bandeja de entrada en %1$@ para ver si has recibido el correo electrónico de confirmación o haz clic en «%2$@» para recibir uno nuevo.";
-
-/* Title for email verification card */
-"me.verifyEmail.title" = "Verifica tu correo electrónico";
 
 /* Me tab menu items */
 "meMenu.submitFeedback" = "Enviar comentarios";
@@ -8809,6 +9326,9 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "Página superior";
 
+/* No comment provided by engineer. */
+"password" = "contraseña";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "Las tarjetas pueden mostrar contenidos diferentes en función de lo que ocurra en tu sitio. Estamos trabajando en más tarjetas y controles.";
 
@@ -8913,9 +9433,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Message shown while loading plugin details */
 "pluginDetails.loading" = "Cargando información del plugin…";
-
-/* Placeholder message shown when a plugin has no description */
-"pluginDetails.noDescription" = "Este plugin no ha proporcionado ninguna descripción.";
 
 /* Title of the changelog section in plugin details */
 "pluginDetails.section.changelog" = "Registro de cambios";
@@ -9205,6 +9722,30 @@ Example: Reply to Pamela Nguyen */
 /* An alert message explaning that by changing the visibility to private, the post will be published immediately to your site */
 "postSettings.warningPostWillBePublishedAlertMessage" = "Cambiando la visibilidad a «Privado», el post se publicará inmediatamente";
 
+/* Localized post type: `Page` */
+"postType.page" = "página";
+
+/* Localized post type: `Post` */
+"postType.post" = "entrada";
+
+/* Details for a 'Private' privacy setting */
+"postVisibility.private.details" = "Sólo visible para los administradores y editores del sitio";
+
+/* Title for a 'Private' privacy setting */
+"postVisibility.private.title" = "Privada";
+
+/* Details for a 'Password Protected' privacy setting */
+"postVisibility.protected.details" = "Visible para todos pero requiere contraseña";
+
+/* Title for a 'Password Protected' privacy setting */
+"postVisibility.protected.title" = "Protegida con contraseña";
+
+/* Details for a 'Public' (default) privacy setting */
+"postVisibility.public.details" = "Visible por todos";
+
+/* Title for a 'Public' (default) privacy setting */
+"postVisibility.public.title" = "Público";
+
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Cancelar";
 
@@ -9425,18 +9966,6 @@ Tapping on this row allows the user to edit the sharing message. */
 /* Title for the success view when the user has successfully logged in */
 "qrLoginVerifyAuthorization.completedInstructions.title" = "¡Has accedido!";
 
-/* No comment provided by engineer. */
-"reachability-utils.alert.cancel" = "Aceptar";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.retry" = "¿Reintentar?";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.title" = "Sin conexión";
-
-/* Message of error prompt shown when no internet connection is available */
-"reachability-utils.alert.utils" = "Parece que no hay conexión a internet.";
-
 /* Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog. */
 "reader.blocked.blog.message" = "El blog %@ ya no aparecerá en tu lector. Toca para deshacer.";
 
@@ -9473,26 +10002,8 @@ Tapping on this row allows the user to edit the sharing message. */
 /* A shared button title for Reader */
 "reader.button.unsubscribe" = "Cancelar la suscripción";
 
-/* Button title. Follow the comments on a post. */
-"reader.comments.buttonFollow" = "Seguir";
-
 /* Informational message, should be short. */
 "reader.comments.commentsClosed" = "Comentarios cerrados";
-
-/* Empty state view title */
-"reader.comments.emptyStateTitle" = "Sé el primero en escribir un comentario.";
-
-/* Empty state view title */
-"reader.comments.errorLoadingComments" = "Hubo un error inesperado al cargar los comentarios.";
-
-/* VoiceOver hint */
-"reader.comments.followingSettingAccessibilityIdentifier" = "Abre los ajustes de las notificaciones de la entrada";
-
-/* Error message that informs reader comments from a private blog cannot be fetched. */
-"reader.comments.noPermissionToViewPrivateBlog" = "No tienes permiso para ver este blog privado.";
-
-/* Navigation title */
-"reader.comments.title" = "Comentarios";
 
 /* Accessibility hint to inform that the author section can be tapped to see posts from the site. */
 "reader.detail.header.authorInfo.a11y.hint" = "Muestra las entradas del sitio";
@@ -9570,23 +10081,8 @@ but tapping on this button will remove their like from the post. */
 /* Screen header details */
 "reader.following.header.details" = "Mantente al día de los blogs a los que te has suscrito.";
 
-/* Empty state view */
-"reader.following.lists.emptyTitle" = "Listas vacías";
-
-/* Screen header details */
-"reader.home.header.details" = "Mantente al día de los blogs a los que te has suscrito.";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.home.title" = "Inicio";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.library.title" = "Biblioteca";
-
 /* Used in multiple contexts, usually as a screen title */
 "reader.likes.title" = "Me gustas";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.lists.title" = "Listas";
 
 /* Reader logged-out screen details */
 "reader.loggedOut.details" = "Accede con una cuenta de WordPress.com para seguir tus blogs favoritos";
@@ -9829,8 +10325,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title of a Reader tab showing Posts matching a user's search query */
 "reader.search.tab.posts" = "Entradas";
 
-/* Title of the Reader's search feature
-   Used in multiple contexts, usually as a screen title */
+/* Title of the Reader's search feature */
 "reader.search.title" = "Búsqueda";
 
 /* Screen title. Reader select interests title label text. */
@@ -9856,6 +10351,21 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Reader select interests title label text */
 "reader.select.tags.title" = "Descubre y sigue los blogs que te gustan";
+
+/* Reader sidebar menu item */
+"reader.sidebar.discover" = "Descubrir";
+
+/* Reader sidebar menu item */
+"reader.sidebar.likes" = "Me gusta";
+
+/* Reader sidebar menu item */
+"reader.sidebar.recent" = "Recientes";
+
+/* Reader sidebar menu item */
+"reader.sidebar.saved" = "Guardado";
+
+/* Reader sidebar menu item */
+"reader.sidebar.search" = "Buscar";
 
 /* Reader sidebar section title */
 "reader.sidebar.section.favorites.title" = "Favoritos";
@@ -9905,7 +10415,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Number of subscriptions on a site (singular) */
 "reader.subscriptions.subscriptionsSingular" = "%@ suscriptor";
 
-/* Used in multiple contexts, usually as a screen title */
+/* Navigation bar title */
 "reader.subscriptions.title" = "Subscripciones";
 
 /* A suggestion of topics the user might want to subscribe to */
@@ -9947,29 +10457,11 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Verb. Button title. The user is following a tag. */
 "reader.tags.following.button.title" = "Siguiendo";
 
-/* Used in multiple contexts, usually as a screen title */
-"reader.tags.title" = "Etiquetas";
-
 /* Accessibility label for unsubscribing from a tag */
 "reader.tags.unfollow.accessibility.label" = "Dejar de seguir %@";
 
 /* Field title */
 "reader.userProfile.site" = "Sitio";
-
-/* Reader Welcome screen login button */
-"reader.welcome.continueText" = "Continuar con WordPress.com";
-
-/* Reader Welcome screen */
-"reader.welcome.subtitle" = "Únete a la mayor comunidad de blogueros";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.discover" = "Descubrir";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.me" = "Yo";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.notifications" = "Avisos";
 
 /* Spoken accessibility label */
 "readerDetail.backButton.accessibilityLabel" = "Volver";
@@ -10247,14 +10739,10 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Message shown when there are no inactive plugins on the site */
 "site.plugins.empty.inactive" = "No hay plugins inactivos";
 
-/* The plugin fillter option for displaying active plugins */
-"site.plugins.filter.option.active" = "Activo";
-
-/* The plugin fillter option for displaying all plugins */
+/* The plugin fillter option for displaying active plugins
+   The plugin fillter option for displaying all plugins
+   The plugin fillter option for displaying inactive plugins */
 "site.plugins.filter.option.all" = "Todos";
-
-/* The plugin fillter option for displaying inactive plugins */
-"site.plugins.filter.option.inactive" = "Inactivo";
 
 /* Title of the plugin filter picker */
 "site.plugins.filter.title" = "Filtrar";
@@ -10806,9 +11294,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* View title for Help & Support page. */
 "support.title" = "Ayuda";
 
-/* Subject of new Zendesk ticket. */
-"support.zendesk.readerAppTicketSubject" = "Compatibilidad con el Lector para iOS";
-
 /* Title for placeholder in Tenor picker */
 "tenor.welcomeMessage" = "¡Busca GIFs para añadir a tu biblioteca de medios!";
 
@@ -10957,8 +11442,119 @@ Feel free to replace it with other bracket types that you think looks better for
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "Estado";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "Entradas y más visitas de todos los tiempos";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "Visitas de todos los tiempos";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "Visitas y visitantes de todos los tiempos";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "Mayor número de visitas";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "Más visitas";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "No se han podido cargar las estadísticas totales.";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "Crear o añadir un sitio para ver las estadísticas de todo el tiempo.";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Entradas";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "Mantente al día con la actividad de todo el tiempo en tu sitio WordPress.";
+
+/* Title of all time widget */
+"widget.alltime.title" = "Todo el tiempo";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "Accede a WordPress para ver las estadísticas de todo el tiempo.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "Accede a Jetpack para ver las estadísticas de todo el tiempo.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "Accede a Jetpack para ver las estadísticas de esta semana.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "Accede a Jetpack para ver las estadísticas de hoy.";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "Visitas de todos los tiempos";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "Visitas hoy";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "No se han podido cargar las estadísticas de esta semana.";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "Crear o añadir un sitio para ver las estadísticas de esta semana.";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "Mantente al día con la actividad de esta semana en tu sitio WordPress.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "Esta semana";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "Accede a WordPress para ver las estadísticas de esta semana.";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Comentarios";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "Las estadísticas se han trasladado a la app de Jetpack. Cambiarse es gratis y sólo lleva un minuto.";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Me gusta";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "No se han podido cargar las estadísticas del sitio.";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "No se han podido cargar las estadísticas de hoy.";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "Crear o añadir un sitio para ver las estadísticas de hoy.";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "Mantente al día con la actividad de hoy en tu sitio WordPress.";
+
+/* Title of today widget */
+"widget.today.title" = "Hoy";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "Accede a WordPress para ver las estadísticas de hoy.";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "La vista no está disponible";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Visitas";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Visitantes";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "Me gusta y comentarios de hoy";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "Visitas de hoy";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "Visitas y visitantes de hoy";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "no estará disponible en el futuro.";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "¿Vas a empezar un sitio nuevo?";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "wordpress, ayuda, soporte, faq, preguntas, debug, logs, centro de ayuda, contacto";
@@ -10983,6 +11579,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Error message that describes an unknown error had occured */
 "wordpress-api.error.unknown" = "Algo ha salido mal, vuelve a intentarlo más tarde.";
+
+/* Error message when failing to find selected media file on the user's device. */
+"wordpress.api.upload.media.fileNotFound" = "No se ha podido localizar el archivo de medios en el dispositivo";
 
 /* Jetpack Plugin Modal on WordPress primary button title */
 "wordpress.jetpack.plugin.modal.primary.button.title" = "Cambiar a la aplicación de Jetpack";
@@ -11029,21 +11628,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Error message when user signs in with an unexpected email address. The first argument is the expected email address */
 "wpComLogin.error.mismatchedEmail" = "Accede con la dirección de correo electrónico %@";
 
-/* Message shown when user denies WordPress.com login, offering option to try with different account */
-"wpComLogin.loginDenied.message" = "Puedes acceder con una cuenta diferente si necesitas otra. Toca «%@» para empezar.";
-
-/* Title of alert shown when user cancels WordPress.com login */
-"wpComLogin.loginDenied.title" = "Acceso cancelado";
-
-/* Button title for signing in with a different WordPress.com account */
-"wpComLogin.loginDenied.useDifferentAccount" = "Utilizar una cuenta distinta";
-
-/* Button title to log out the current WordPress.com account */
-"wpcom.token.alert.button.logout" = "Salir";
-
-/* Button title to Sign In to WordPress.com */
-"wpcom.token.alert.button.signin" = "Acceder";
-
 /* Message title to be displayed when the user needs to re-authenticate their WordPress.com account. */
 "wpcom.token.fix.signin" = "Iniciar sesión en WordPress.com";
 
@@ -11058,6 +11642,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "Adjunto no compatible";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Acceder con Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Dominios";

--- a/WordPress/Resources/fr.lproj/Localizable.strings
+++ b/WordPress/Resources/fr.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Translation-Revision-Date: 2025-05-14 09:54:07+0000 */
+/* Translation-Revision-Date: 2025-03-11 14:54:07+0000 */
 /* Plural-Forms: nplurals=2; plural=n > 1; */
 /* Generator: GlotPress/4.0.1 */
 /* Language: fr */
@@ -98,6 +98,9 @@
 
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "%1$@ sur %2$@ sur votre site";
+
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "Utilisation de %1$@ sur %2$@ sur votre site";
 
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ billiard";
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Sans titre)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(aucun titre)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*Johan Brandt* a répondu à votre article";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "Un bouton \"Plus\" contenant un menu déroulant qui affiche les boutons de partage";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "Un compte WordPress.com est associé aux identifiants de connexion de votre boutique. Pour continuer, nous enverrons un lien de vérification à l’adresse e-mail ci-dessus.";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "Un fichier contient un modèle de code malveillant";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "Titre du site";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "Une adresse e-mail valide est nécessaire pour envoyer un lien d’authentification. Veuillez retourner sur l’écran précédent et fournir une adresse e-mail valide.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "Un code vérification ne peut contenir seulement que des chiffres.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "ACTIF";
@@ -334,9 +349,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* My Profile 'About me' label */
 "About Me" = "À propos de moi";
-
-/* Link to About screen for Jetpack for iOS */
-"About Reader for iOS" = "À propos du Lecteur pour iOS";
 
 /* Link to About screen for WordPress for iOS */
 "About WordPress" = "À propos de WordPress";
@@ -525,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "Après %@";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "Alignement";
@@ -588,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "Adresses IP autorisées";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "On y est presque ! Veuillez saisir le code de vérification de votre app d’authentification.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Texte alternatif";
@@ -597,6 +615,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Alternatively, you can detach and edit this block separately by tapping “Detach”." = "Vous pouvez également détacher et modifier ce bloc séparément en appuyant sur « Détacher ».";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "Vous pouvez également saisir le mot de passe de ce compte.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "Ou :";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "Toujours envoyer un journal de plantage";
@@ -618,6 +642,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "Une connexion internet est nécessaire pour voir les activités.";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "Un connexion internet est nécessaire pour consulter les offres";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -668,6 +695,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "Statistiques annuelles de site";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "Anonyme";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "Réponse";
 
@@ -689,6 +719,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "Apparence";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "L’authentification Apple a échoué.\nVeuillez vérifier si vous êtes correctement connecté à iCloud avec un ID Apple qui utilise l’authentification à deux facteurs.";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "Applique le réglage";
@@ -775,6 +808,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "Échec de l’authentification";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "Code d’authentification";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "Authentification obligatoire pour l'hôte : %@";
@@ -885,6 +922,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "Poster un commentaire";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Soyez le premier à laisser un commentaire.";
 
 /* Beauty site intent topic */
 "Beauty" = "Beauté";
@@ -1018,12 +1058,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button to copy post text" = "Bouton permettant de copier le texte de l’article";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "En continuant, vous acceptez les _conditions d’utilisation_.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "En enregistrant ce domaine, vous acceptez nos <a>conditions générales<\/a>.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "En mettant en place Jetpack, vous acceptez nos\n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "En vous inscrivant, vous acceptez les conditions d’utilisation.";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "Personnaliser";
@@ -1037,6 +1083,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "Accès à l’appareil photo requis pour scanner les codes de connexion";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Impossible de faire une requête sur le lien";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "Impossible de publier une page vide";
 
@@ -1046,6 +1095,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1055,6 +1105,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1073,6 +1124,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1100,6 +1152,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "Annulation...";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "Impossible d’accéder au site de cette adresse. Veuillez vérifier une seconde fois et réessayer.";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Vous n’arrivez pas à choisir ? Vous pouvez modifier le thème à tout moment.";
 
@@ -1107,7 +1162,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Légende";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Attention !";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1116,7 +1172,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Catégories";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Catégorie";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1165,6 +1222,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "Consultez nos conseils pratiques pour augmenter vos vues et votre trafic";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "Consultez votre messagerie sur cet appareil !";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Consultez vos e-mails sur cet appareil et touchez sur le lien dans l’e-mail que vous avez reçu de WordPress.com.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "Vérifiez vos e-mails sur cet appareil et touchez le lien dans l’e-mail que vous avez reçu de WordPress.com.\n\nVous ne voyez pas cet e-mail ? Vérifiez vos indésirables.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "Vérifiez vos e-mails !";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "Vérifiez votre connexion Internet et faites glisser pour actualiser.";
@@ -1261,6 +1330,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "Demander votre domaine gratuit";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "Blog classique";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "Effacez le cache multimédia de l’appareil";
 
@@ -1288,6 +1360,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Fermer";
 
@@ -1329,6 +1402,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "Réglages de colonnes";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Comics";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1380,6 +1456,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Commentaires";
 
@@ -1447,12 +1524,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Comptes connectés";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Connecté mais…";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "Connexion à %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Connecter %1$@ remplacera l'actuelle connexion à %2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Connexion à WordPress.com ";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Connexion en cours...";
@@ -1483,8 +1566,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "Contactez-nous à %@";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "Structure de contenu\nBlocs : %1$li, mots : %2$li, caractères : %3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1499,6 +1586,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Lire la suite";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Continuer avec Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Continuer avec Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Continuez avec Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "Contribuez";
@@ -1627,6 +1723,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "Créer";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Créer compte";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "Créer une page vide";
 
@@ -1647,6 +1746,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "Créer un article";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "Créer un site";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "Créer une étiquette";
@@ -1680,6 +1782,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "Actuel";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Offre en cours";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Thème actuel";
@@ -1782,6 +1887,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "Catégorie par défaut";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Menu par défaut";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Format par défaut des articles";
@@ -1790,6 +1898,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "Paramètres par défaut pour les nouveaux articles";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Effacer";
@@ -1847,6 +1956,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "Détails";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "Vous ne voulez pas créer de nouveau compte ? Revenez en arrière et ressaisissez votre adresse e-mail.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "Dimensions";
 
@@ -1894,7 +2006,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "Discussion";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Ignorer";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1916,6 +2030,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "Domaines";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "Vous n'avez pas encore de compte ? _S'inscrire_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2045,6 +2162,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "Téléchargements";
 
+/* Name for the status of a draft post. */
+"Draft" = "Brouillon";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Brouillons";
 
@@ -2154,7 +2274,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "Adresse de messagerie";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "Adresse de contact";
 
 /* Notification Settings Channel */
@@ -2238,8 +2361,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Saisissez un mot de passe";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "Saisissez l’adresse du site WordPress que vous souhaitez connecter.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Saisir le mot de passe de votre compte WordPress.com.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Saisissez l'identifiant";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "Saisissez vos informations de compte pour %@.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "Saisissez votre adresse e-mail pour vous connecter ou créez un compte WordPress.com.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "Saisissez l’adresse de votre site actuel";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "Saisissez votre mot de passe à la place.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "Entrez vos identifiants de connexion du serveur";
@@ -2402,6 +2545,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "Externe";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Échec";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "Impossible de marquer les notifications comme lues";
 
@@ -2413,9 +2559,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Failed to insert media.\nTap for more info." = "Échec d’insertion du média.\nAppuyez pour plus d’informations.";
-
-/* A message indicating that we couldn't load the user's settings. */
-"Failed to load settings" = "Échec du chargement des réglages";
 
 /* No comment provided by engineer. */
 "Failed to save files.\nPlease tap for options." = "L’enregistrement des fichiers a échoué.\nVeuillez toucher pour accéder aux options.";
@@ -2431,6 +2574,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "Mode";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "Mis en avant";
@@ -2489,6 +2635,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "En savoir plus";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Trouver l’adresse de votre site";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2511,6 +2660,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "Correction des menaces";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "Suivre ";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "Suivre la discussion";
@@ -2602,6 +2754,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "Générer un nouveau lien";
 
+/* View title for initial auth views. */
+"Get Started" = "Premiers pas";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "Obtenir un lien de connexion par e-mail";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "Soyez actif  ! Commentez sur les articles des blogs auxquels vous êtes abonnés.";
 
@@ -2623,8 +2781,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "Inspiration";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Obtention des informations du compte";
+
+/* Cancel */
+"Give Up" = "Abandonner";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "Essayez-le en ajoutant quelques blocs à votre article ou votre page !";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "Allez au lecteur";
@@ -2635,6 +2802,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "Accéder aux paramètres iOS";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "La connexion Google a échoué.";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2709,6 +2879,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "Icône d’aide";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Caché";
+
 /* Title of a button used to collapse a group */
 "Hide" = "Masquer";
 
@@ -2777,6 +2950,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "La mise à jour de l’icône a échoué";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "Si vous ne trouvez pas l’e-mail, vérifiez votre dossier de courrier indésirable ou de spam.";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "Si vous continuez avec Apple ou Google sans disposer au préalable d’un compte WordPress.com, vous créez un compte et acceptez nos _conditions d’utilisation_.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "Si vous supprimez %1$@, cet utilisateur ne pourra plus accéder à ce site mais le contenu ayant été créé par %2$@ restera sur le site.";
@@ -2852,6 +3031,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "Comprend wp-config.php et des fichiers non liés à WordPress";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Identifiant ou mot de passe incorrect. Veuillez ressaisir vos identifiants de connexion.";
 
 /* Title for a threat */
 "Infected core file" = "Fichier core infecté";
@@ -2953,6 +3135,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "Présentation des invites pour bloguer";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "Adresse de messagerie non valide";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "Adresse du site invalide";
 
@@ -2970,6 +3155,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "URL non valide. Fichier audio non trouvé.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "URL non valide. Veuillez vérifier une seconde fois et réessayer.";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "URL non valide. Veuillez entrer une URL valide.";
@@ -2991,6 +3179,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "Inviter des personnes";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "Il semblerait que cet identifiant\/mot de passe n’est pas associé à ce site.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "Il semblerait que vous avez saisi un mot de passe incorrect. Voulez-vous réessayer ?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "C’est l’heure de bloguer sur %@ !";
@@ -3219,7 +3413,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "hauteur de ligne";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Lien";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3281,6 +3476,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "Chargement des gens…";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Chargement des offres...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Chargement des offres...";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "Chargement de l’extension…";
 
@@ -3315,11 +3516,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "Chargement...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Local";
+
 /* Local Services site intent topic */
 "Local Services" = "Services locaux";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "Changements locaux";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Emplacement";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Les services de localisation doivent être activées avant que WordPress ne puisse ajouter votre lieu actuel. Veuillez activer les services de localisation à partir des réglages de l'application.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Lieu inconnu";
 
 /* No comment provided by engineer. */
 "Lock icon" = "Icône de verrouillage";
@@ -3327,9 +3540,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Fichiers logs par date de création";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Connexion";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3339,17 +3554,33 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of a button for signing in. */
 "Log in" = "Connexion";
 
-/* LogOut confirmation text, whenever there are no local changes */
-"Log out of Jetpack?" = "Se déconnecter de Jetpack ?";
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "La connexion a échoué. Veuillez réessayer.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "Se connecter ou s’inscrire avec WordPress.com";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Connectez-vous à votre compte WordPress.com que vous utilisez pour connecter Jetpack.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "Connectez-vous à votre compte WordPress.com avec votre adresse de messagerie.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "Connectez-vous avec votre identifiant WordPress.com et votre mot de passe.";
 
 /* LogOut confirmation text, whenever there are no local changes */
-"Log out of Reader?" = "Se déconnecter du Lecteur ?";
+"Log out of Jetpack?" = "Se déconnecter de Jetpack ?";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of WordPress?" = "Se déconnecter de WordPress ?";
 
 /* Login Request Expired */
 "Login Request Expired" = "Demande de connexion expirée";
+
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "Connexion avec le mot de passe du compte";
 
 /* No comment provided by engineer. */
 "Logs" = "Logs";
@@ -3359,6 +3590,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Il semble que vous ayez activé Jetpack sur votre site. Félicitations !\nConnectez-vous avec vos identifiants WordPress.com ci-dessous pour activer les statistiques et notifications.";
+
+/* Title of a button. */
+"Lost your password?" = "Mot de passe oublié ?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "Mail (Défaut)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Navigation principale";
@@ -3506,6 +3743,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "Message";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "Vulnérabilité diverse";
 
@@ -3601,6 +3841,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "Mon site";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "Mes sites dans WordPress";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "Mon top 10 des cafés";
 
@@ -3640,8 +3883,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Besoin d'aide ?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "Besoin d’aide pour trouver l’adresse de votre site ?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "Besoin d’aide ?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Besoin de plus d’aide ?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "Mise à jour nécessaire";
@@ -3670,6 +3920,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "Nouvel article";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Nouvel élément";
+
 /* Placeholder text for password field */
 "New password" = "Nouveau mot de passe";
 
@@ -3687,7 +3940,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "Actualités";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Suivant";
 
 /* Accessibility label for the next notification button */
@@ -3723,6 +3978,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "Aucune URL d’aperçu disponible";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "Aucun titre";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "Aucune activité disponible";
 
@@ -3755,7 +4013,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "Pas de commentaire pour l'instant";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "Aucune connexion";
 
@@ -3904,6 +4163,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "Pas maintenant";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "Vous ne voyez pas l’e-mail ? Vérifiez votre dossier de courrier indésirable.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "Remarque :";
 
@@ -3967,7 +4229,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Liste numérotée";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -4024,7 +4291,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "Oups";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Oups !";
 
 /* No comment provided by engineer. */
@@ -4039,7 +4307,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "Ouvrir les réglages Jetpack Security";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Ouvrir la messagerie";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Ouvrir les paramètres";
 
 /* No comment provided by engineer. */
@@ -4057,6 +4330,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "Ouvrir le lien dans une nouvelle fenêtre\/un nouvel onglet";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "Ouvrir les réglages d’abonnement pour l’article";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "Ouvrir la section « Me »";
 
@@ -4071,6 +4347,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "Facultatif : saisissez un message personnalisé de %1$d caractères au maximum à joindre à votre invitation.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "Ou";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "Vous pouvez aussi choisir un autre mode d'authentification.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "Ou connectez-vous en _saisissez l’adresse de votre site_.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "Ou connectez-vous à l’aide d’un lien magique";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Liste ordonnée";
@@ -4119,7 +4407,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "Padding";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Page";
 
@@ -4152,8 +4441,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "Parentalité";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Mot de passe";
 
@@ -4170,8 +4462,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "Coller le bloc après";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "En attente";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "En attente de relecture";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4202,6 +4498,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "Sélectionner un identifiant";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Offres";
+
 /* User action to play a video on the editor. */
 "Play video" = "Lancer la vidéo";
 
@@ -4231,6 +4531,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "Vérifiez que l’éditeur de blocs est activé sur votre site. S’il n’est pas activé, il ne se chargera pas.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "Veuillez saisir une adresse complète de site web comme exemple.fr.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "Saisissez une adresse de site.";
@@ -4265,11 +4568,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "Veuillez saisir une adresse valide";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "Veuillez saisir une adresse e-mail valide pour un compte WordPress.com.";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Saisissez une adresse e-mail valide.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "Veuillez saisir un numéro de téléphone valide";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Veuillez saisir le mot de passe de votre compte WordPress.com, afin de vous connecter avec votre identifiant Apple ID.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Veuillez saisir vos identifiants";
@@ -4277,8 +4586,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Veuillez saisir votre adresse e-mail.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Veuillez remplir tous les champs";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Veuillez lancer l’app WordPress, connectez-vous à WordPress.com et assurez vous d’avoir au moins un site, puis réessayer. ";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "Veuillez vous déconnecter avant de connecté un site WordPress.com différent.";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "Veuillez réessayer ultérieurement";
@@ -4346,7 +4661,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "Langues populaires";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Article ";
 
@@ -4467,6 +4783,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "Avis de confidentialité pour les utilisateurs californiens";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Privé";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "Problème d’affichage du bloc. \nAppuyez pour tenter de restaurer le bloc.";
 
@@ -4481,6 +4800,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "Problème lors de l'achat de votre domaine. Veuillez réessayer.";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Si vous poursuivez, toutes les données WordPress.com seront supprimées de cet appareil et tous les brouillons enregistrés localement seront effacés. Vous ne perdrez pas ce qui est déjà enregistré dans vos blogs WordPress.com.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Projets";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "Invite ignorée";
@@ -4498,13 +4823,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "Date de publication";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Publier immédiatement";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "Publier la page sur :";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "Publication de l’article sur :";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Publié";
 
@@ -4706,7 +5035,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "Répondre";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Texte de réponse";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "Répondre à %1$@";
 
 /* An explaination of a setting. */
@@ -4735,6 +5069,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "Réinitialiser le filtre Période";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Réinitialiser votre mot de passe";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Redimensionner et recadrer";
@@ -4792,6 +5129,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "Tout réessayez ";
 
+/* No comment provided by engineer. */
+"Retry?" = "Réessayer ?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "Retourner à l’article";
 
@@ -4821,6 +5161,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "Rôle";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS envoyé";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "ÉTAT";
 
@@ -4832,6 +5175,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4898,7 +5242,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "Analyse des fichiers";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Prévu";
 
 /* No comment provided by engineer. */
@@ -5038,6 +5383,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "Sélectionne ce thème pour refléter l’intention de votre site.";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Envoyer le lien";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "Envoyer un lien par e-mail";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "Envoyer un message de journal";
 
@@ -5046,6 +5397,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "Envoyer un test de plantage";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "Envoyer le lien de vérification par e-mail";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "Envoyez les notifications par e-mail";
@@ -5092,11 +5446,11 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Message to show when setting save failed */
 "Settings update failed" = "Échec de la mise à jour des paramètres";
 
-/* Title for a button that recommends the app to others */
-"Share Jetpack with a friend" = "Partager Jetpack avec un ami";
+/* Spoken accessibility label */
+"Share" = "Partager";
 
 /* Title for a button that recommends the app to others */
-"Share Reader with a friend" = "Partager le Lecteur avec un ami";
+"Share Jetpack with a friend" = "Partager Jetpack avec un ami";
 
 /* Title for a button that recommends the app to others */
 "Share WordPress with a friend" = "Partager WordPress avec un ami";
@@ -5147,6 +5501,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "Afficher le bouton Rebloguer";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "Mot de passe affiché";
+
 /* No comment provided by engineer. */
 "Show post content" = "Afficher le contenu de l’article";
 
@@ -5158,6 +5516,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "Afficher les statistiques pour :";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "Affiché";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Affichée publiquement quand vous commentez sur des blogs.";
@@ -5173,6 +5534,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "Afficher l’article ";
+
+/* View title during the sign up process. */
+"Sign Up" = "S’inscrire";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "Connexion avec les identifiants de connexion du site";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Inscription";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "S’inscrire à WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "S’inscrire avec une adresse e-mail";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "Puisque vous êtes sur un plan gratuit, vous ne voyez que des évènements limités dans votre journal d’activités.";
@@ -5211,6 +5587,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Réussites relatives au site";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Adresse de site";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "L'adresse du site doit au moins contenir 4 caractères.";
@@ -5295,7 +5674,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "L'adresse du site doit également contenir des lettres !";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Cette adresse e-mail est déjà utilisée !";
 
 /* No comment provided by engineer. */
@@ -5355,6 +5734,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "Indésirable";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "Accélerez votre site";
@@ -5380,6 +5762,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "État";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "Page d’accueil statique";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5410,6 +5795,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "Barrer";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Pré-chargée";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "Soumettre pour évaluation";
@@ -5500,7 +5888,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "Tablette";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Étiquette";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5635,6 +6024,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Conditions d'utilisation";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Témoignages";
+
 /* Title of a button style */
 "Text Only" = "Texte seul";
 
@@ -5644,8 +6036,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "Les contrôles de mise en forme du texte se trouvent dans la barre d’outils placée au-dessus du clavier lors de l’édition d’un bloc paragraphe";
 
+/* Button title */
+"Text me a code instead" = "Envoyez-moi un code à la place.";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "M’envoyer un code par SMS";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Merci d'avoir choisi %1$@ de %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "Cela ne semble pas être un code de vérification valide.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "Ce site ne ressemble pas à un site WordPress.";
@@ -5667,6 +6068,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "La connexion à Facebook ne trouve aucune page. Publicize ne peut pas se connecter aux profils, seulement au pages publiées.";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "Le compte Google « %@ » ne correspond pas avec le compte WordPress.com.";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "La connexion Internet semble inactive. ";
@@ -5706,6 +6110,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "L’image n’a pas pu être ajoutée à la médiathèque.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "La connexion Internet semble inactive.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "Les types de sites pouvant être créés";
@@ -5749,6 +6156,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Votre site %1$@ utilise WordPress %2$@. Nous recommandons fortement de le mettre à jour à la version la plus récente, ou au minimum la version %3$@.";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "Le site à cette adresse n’est pas un site WordPress. Pour pouvoir s’y connecter, le site doit utiliser WordPress.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "Ce site ne peux pas être supprimé.";
 
@@ -5790,6 +6201,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "Une erreur inattendue est survenue lors de la modification de votre commentaire";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "Une erreur inattendue est survenue lors du chargement des commentaires.";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "Une erreur inattendue est survenue lors de l'enregistrement de votre domaine";
 
@@ -5798,6 +6212,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "Une erreur inattendue est survenue lors de la mise à jour de vos paramètres de notification";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "Une erreur inattendue est survenue lors de la mise à jour de votre commentaire";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "Une erreur inattendue est survenue.";
@@ -5819,6 +6236,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "Un problème est survenu lors de la communication avec le site.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "Un problème est survenu lors de la connexion à WordPress.com. Veuillez vous reconnecter.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "Un problème est survenu lors de l’affichage de cet article.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "Un problème a eu lieu lors du chargement des données. Rafraichissez votre page pour réessayer.";
 
@@ -5828,12 +6251,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "Un problème est survenu lors de l'enregistrement des modifications à la gestion du partage.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "Il y a eu un problème en tentant d'accéder à votre localisation. Veuillez essayer à nouveau.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "Une erreur s’est produite lors du changement de mot de passe.";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "Une erreur est survenue lors du chargement des activités.";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "Un problème est survenu lors du chargement des offres";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "Une erreur est survenue lors du chargement des extensions";
@@ -5846,6 +6275,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "Une erreur est survenue lors du chargement de l'historique.";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "Une erreur s’est produite lors du chargement du plan.";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "Une erreur s’est produite lors du chargement de l’historique de l’analyse.";
@@ -5894,6 +6326,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "Ce domaine n’est pas disponible";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "Cette adresse e-mail n’est pas enregistrée sur WordPress.com.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "Ce fichier est trop lourd pour être téléverser sur votre site ou il ne supporte pas ce format de fichier.";
@@ -5974,6 +6409,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "Fuseau horaire";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "Le temps est écoulé, mais ne vous inquiétez pas : votre sécurité est notre priorité. Veuillez réessayer.";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "Conseils pour tirer le meilleur de WordPress.com.";
 
@@ -5987,6 +6425,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "Pour continuer, veuillez saisir votre adresse e-mail et votre nom.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "Pour créer votre nouveau compte WordPress.com, veuillez saisir votre adresse e-mail.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "Pour obtenir des notifications utiles sur votre téléphone à partir de votre site WordPress, vous devez installer l'extension Jetpack.";
 
@@ -5995,6 +6436,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "Pour installer des extensions, un nom de domaine personnalisé doit être associé à votre site.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "Pour procéder à cette étape avec cet identifiant Apple, veuillez d’abord vous connecter avec votre mot de passe WordPress.com. Cela ne vous sera demandé qu’une seule fois.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "Pour effectuer cela avec ce compte Google, veuillez d’abord vous connecter avec votre mot de passe WordPress.com. Cela sera demandé une seule fois.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "Pour supprimer un bloc, sélectionnez-le et cliquez sur les trois points en bas à droite du bloc pour afficher les réglages. À partir de là, choisissez l’option pour supprimer le bloc.";
@@ -6069,7 +6516,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "Déplacer vers la corbeille";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "Mis à la corbeille";
 
@@ -6083,6 +6531,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "Essayer et personnaliser";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Recommencez";
@@ -6108,6 +6557,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "Essayer le nouvel éditeur de blocs";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Essayer avec une autre adresse de messagerie";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Essayer avec l’adresse du site";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "Désactiver les invites";
@@ -6150,6 +6605,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "UTILISATIONS";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "Impossible de connecter";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "Impossible de charger les articles";
@@ -6199,6 +6657,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Impossible de lancer la vidéo";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Impossible de trouver un site WordPress à cette adresse. Touchez « Besoin d'aide ? » pour voir la FAQ.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Impossible de restaurer votre site";
 
@@ -6225,6 +6686,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "Impossible de téléverser un article, un fichier";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "Impossible de vérifier l’adresse e-mail. Veuillez réessayer ultérieurement.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "Impossible de visiter les réglages Jetpack du site";
@@ -6369,7 +6833,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Le téléversement a échoué";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Téléversé";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6387,7 +6852,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Thèmes téléversés";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Téléversement";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6402,18 +6868,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "Utilise";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "Utiliser une clé de sécurité";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "Utiliser l’éditeur de blocs";
 
 /* No comment provided by engineer. */
 "Use icon button" = "Utiliser le bouton d’icône";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "Utilisez le mot de passe pour la connexion";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Identifiant";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6428,6 +6903,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Utilisateurs";
+
+/* two factor code placeholder */
+"Verification code" = "Code de vérification";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "E-mail de vérification envoyé. Vérifiez votre boîte de réception.";
@@ -6560,8 +7038,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "Répertoire WP-content";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "En attente de la fin du processus Google…";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "En attente de connexion";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "En attente de la clé de sécurité";
+
+/* View title during the Google auth process. */
+"Waiting..." = "En attente…";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6598,6 +7086,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "Nous avons rencontré un problème lors du chargement des données";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "Nous venons de vous envoyer par e-mail un lien sur %@. Veuillez vérifier votre application d’e-mail et touchez le lien pour vous connecter.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "Nous venons d'envoyer un lien magique à ";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "Nous avons créé une sauvegarde de votre site en date du %@  !";
 
@@ -6607,14 +7101,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "Nous utilisons d’autres outils de suivi dont certains proviennent de services tiers. En lire plus sur ceux-ci et comment les contrôler.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "Nous n’avons pas encore pu vous envoyer un e-mail. Veuillez réessayer ultérieurement.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Nous vous enverrons un e-mail en cas de menace de sécurité. Pendant ce temps, vous pouvez continuer à utiliser votre site comme d’habitude, tout en revenant de temps à autre pour vérifier la progression de l’analyse.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "Nous allons vous envoyer un lien magique qui vous connectera instantanément, sans mot de passe. Fini la frappe au clavier !";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "Nous allons vous envoyer un e-mail d’inscription contenant un lien magique pour créer votre nouveau compte WordPress.com.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "Nous vous notifierons lorsque vous aurez des abonnés, commentaires et « J’aime ».";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "Nous vous notifierons lorsque vous aurez des abonnés, des commentaires et des mentions J’aime. Voulez-vous autoriser les notifications push ?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "Nous utiliserons cette adresse e-mail pour créer votre nouveau compte WordPress.com.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "Nous créons une sauvegarde téléchargeable de votre site tel qu’il était le %1$@.";
@@ -6625,6 +7131,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Nous rencontrons des difficultés à résoudre ces menaces en arrière-plan. Pendant ce temps, vous pouvez continuer à utiliser votre site comme d’habitude, tout en revenant de temps à autre pour vérifier la progression de l’analyse.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "Impossible de se connecter au site Jetpack à cette URL. Contactez-nous pour une assistance.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "Nous sommes en train de restaurer votre site tel qu’il était le %1$@.";
 
@@ -6633,6 +7142,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "Nous vous avons également envoyé par e-mail un lien vers votre fichier.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Nous vous avons envoyé un lien d’inscription pour créer votre nouveau compte WordPress.com. Consultez vos e-mails sur cet appareil et touchez le lien dans l’e-mail que vous avez reçu de WordPress.com.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6659,6 +7171,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "Résumé hebdomadaire : %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "Bienvenue sur Jetpack";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Bienvenue chez WordPress";
 
 /* A message title */
 "Welcome to the Reader" = "Bienvenue dans le lecteur";
@@ -6703,6 +7221,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "Qu’est-ce que Gravatar ?";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "Qu’est-ce que WordPress.com ?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "Qu'est-ce qu'un bloc ?";
 
@@ -6719,10 +7240,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "What's New in Jetpack" = "Nouveautés Jetpack";
 
 /* Opens the What's New / Feature Announcement modal */
-"What's New in Reader" = "Nouveautés du Lecteur";
-
-/* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "Quoi de neuf dans WordPress";
+
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "Qu’elle est l’adresse de mon site ?";
 
 /* Select the site's intent. Title */
 "What's your website about?" = "De quoi parle votre site Web ?";
@@ -6736,6 +7257,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "Quand vous faites des changements à votre site vous pourrez voir l’historique de votre activité ici.";
 
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Oups, quelque chose s’est mal passé et nous ne pouvons pas vous connecter. Veuillez réessayer !";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "Oups, une erreur s’est produite. Veuillez réessayer.";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "Oups, cette clé de sécurité ne semble pas valide. Veuillez réessayer avec une autre clé";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Oups, ce n’est pas un code de vérification deux facteurs valide. Vérifiez à nouveau et réessayez.";
+
 /* No comment provided by engineer. */
 "Width Settings" = "Réglages de largeur";
 
@@ -6748,17 +7281,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "Réglage de l’app WordPress";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "Applications WordPress - Des applications pour tous les écrans";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "Blog WordPress";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "Aide de WordPress";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "Médiathèque WordPress";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "Réglages de notification de WordPress";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "Notifications de WordPress";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "Extensions WordPress";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "Profil WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "Lecteur de WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "Détails du site WordPress";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "Thèmes WordPress";
@@ -6769,17 +7323,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "Les multisites WordPress ne sont pas pris en charge";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress a dans un premier temps besoin de la permission d'accéder au lieu actuel de votre appareil pour l'ajouter à votre article. Veuillez mettre à jour vos réglages de vie privée.";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "Racine WordPress";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "La version de WordPress est trop ancienne";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Votre version de WordPress est trop ancienne. Le site sur %1$@ utilise WordPress %2$@. Nous vous recommandons de mettre à jour à la dernière version ou au moins %3$@.";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "Compte WordPress.com";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "Offres WordPress.com";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "Thèmes WordPress.com";
@@ -6810,6 +7373,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "Écrire un article";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "Écrire une réponse";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "Écrire une réponse...";
 
 /* Title for the writing section in site settings screen */
@@ -6823,6 +7389,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Position de l’axe Y";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "Année";
@@ -6907,6 +7476,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Displayed when the user views trashed in the posts list and there are no posts */
 "You don't have any trashed posts" = "Vous n’avez aucun article dans la corbeille";
 
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"You don't have permission to view this private blog." = "Vous n’avez pas le droit de voir ce blog privé.";
+
 /* Message alert when attempting to delete site with purchases */
 "You have active premium upgrades on your site. Please cancel your upgrades prior to deleting your site." = "Vous avez activé les extensions payantes sur votre site. Veuillez d’abord annuler cette option payante avant d'effacer votre site.";
 
@@ -6919,7 +7491,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "Vous n’avez aucun rappel défini.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Des modifications n'ont pas été enregistrées.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -7006,9 +7579,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Help text that describes how the password should be. It appears while editing the password */
 "Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ & )." = "Votre mot de passe doit être d’au moins 6 caractères. Pour qu’il soit plus fort, utilisez des minuscules et des majuscules, des chiffres et des symboles comme ! \" ? $ % ^ & ).";
 
-/* Message of Export Content confirmation alert */
-"Your posts, pages, and settings will be mailed to the account's email address." = "Vos articles, pages, et réglages vous seront envoyés par e-mail à l’adresse associée à votre compte.";
-
 /* Message of Export Content confirmation alert; substitution is user's email address */
 "Your posts, pages, and settings will be mailed to you at %@." = "Vos articles, pages et réglages vous seront envoyés par e-mail à %@.";
 
@@ -7017,6 +7587,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "Votre recherche contient des caractères non pris en charge dans les domaines WordPress.com. Les caractères suivants sont autorisés : A–Z, a–z, 0–9.";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "L’adresse de votre site apparait dans la barre en haut de l’écran quand vous le visitez dans Safari.";
 
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "Votre site est déjà protégé par VaultPress. Vous trouverez ci-dessous un lien vers votre tableau de bord VaultPress.";
@@ -7096,17 +7669,23 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility identifier for an 'Add Comment' button */
 "addCommentButton.accessibilityIdentifity" = "Ajouter un commentaire";
 
-/* Error message when user cancels login */
-"addSite.selfHosted.cancelled" = "La connexion a été annulée";
+/* Error message shown a URL does not point to an existing site. */
+"addSite.restApiNotAvailable" = "Le site à cette adresse n’est pas un site WordPress. Pour que nous puissions nous y connecter, le site doit utiliser WordPress.";
+
+/* Error message shown when an receiving an invalid application-password authentication result from a self-hosted WordPress site */
+"addSite.selfHosted.authenticationFailed" = "Impossible de se connecter à l’aide de l’authentification par mot de passe d’application.";
 
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "Saisissez l’adresse du site WordPress que vous souhaitez connecter.";
 
+/* Error message when user input is not a WordPress site */
+"addSite.selfHosted.invalidUrl" = "L’adresse de site n’est pas valide.";
+
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "Impossible de charger les détails du site WordPress";
 
-/* Error message when user signs in with an unexpected usern. The first argument is the expected username */
-"addSite.selfHosted.mismatchUser" = "Veuillez vous connecter avec l’utilisateur connecté. Identifiant : %@";
+/* Error message shown when application-password authentication is disabled on a self-hosted WordPress site */
+"addSite.selfHosted.noLoginUrlFound" = "L’authentification par mot de passe d’application doit être activée sur le site WordPress.";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "Impossible d’enregistrer le site WordPress, veuillez réessayer plus tard.";
@@ -7114,17 +7693,14 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "Ajouter un site auto-hébergé";
 
-/* Error message when XML-RPC is disabled on the WordPress site. The first argument is detailed error message */
-"addSite.selfHosted.xmlrpcDisabled" = "Connexion au site WordPress impossible. XML-RPC peut avoir été désactivé sur le serveur. Veuillez contacter votre hébergeur pour résoudre ce problème.";
+/* Error message when an unknown error occurred when adding a self-hosted site */
+"addSite.selfHosted.unknownError" = "Un problème est survenu. Veuillez réessayer.";
 
 /* Age between dates equaling one hour. */
 "an hour" = "une heure";
 
 /* This is the string we display when prompting the user to review the Jetpack app */
 "appRatings.jetpack.prompt" = "Que pensez-vous de Jetpack ?";
-
-/* This is the string we display when prompting the user to review the Reader app */
-"appRatings.reader.prompt" = "Que pensez-vous du Lecteur ?";
 
 /* This is the string we display when prompting the user to review the WordPress app */
 "appRatings.wordpress.prompt" = "Que pensez-vous de WordPress ?";
@@ -7368,14 +7944,8 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 /* Verb. Dismisses the blogging prompt notification. */
 "bloggingPrompt.pushNotification.customActionDescription.dismiss" = "Ignorer";
 
-/* Title of the set goals button in the Blogging Reminders Settings flow. */
-"bloggingRemindersPrompt.intro.continueButton" = "Définir des rappels";
-
 /* Description on the first screen of the Blogging Reminders Settings flow called aftet post publishing. */
 "bloggingRemindersPrompt.intro.details" = "Configurez vos rappels de blog les jours où vous souhaitez publier.";
-
-/* Title of the Blogging Reminders Settings screen. */
-"bloggingRemindersPrompt.intro.title" = "Rappels de blog";
 
 /* Add self-hosted site button */
 "button.addSelfHostedSite" = "Ajouter un site auto-hébergé";
@@ -7798,8 +8368,9 @@ Example: Reply to Pamela Nguyen */
 /* Shared empty state view */
 "emptyStateView.noSearchResult.title" = "Aucun résultat";
 
-/* A name of the ID field (it's a technical field, has to be short, displayed below everything else) */
-"entityMetadataFooterView.id" = "ID";
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "exemple.com";
 
 /* Accept button title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackAccept" = "Envoyer des commentaires";
@@ -7812,9 +8383,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackTitle" = "Partager votre avis";
-
-/* Communicates the future removal of the option to disable the experimental editor, displayed beneath the experimental features list */
-"experimentalFeatures.editorNote" = "L’éditeur de blocs expérimental deviendra l’option par défaut dans une prochaine version et il ne sera plus possible de le désactiver.";
 
 /* The title for the experimental features list */
 "experimentalFeaturesList.heading" = "Fonctionnalités expérimentales";
@@ -7856,13 +8424,19 @@ Example: Reply to Pamela Nguyen */
 "freeToPaidPlans.resultView.title" = "Tout est prêt !";
 
 /* A generic error message for a footer view in a list with pagination */
-"general.pagingFooterView.errorMessage" = "Une erreur s‘est produite";
+"general.pagingFooterView.errorMessage" = "Une erreur s'est produite";
 
 /* A footer retry button */
 "general.pagingFooterView.retry" = "Réessayer";
 
+/* Error message format when REST API returns an error response. The first argument is error message. */
+"generic.error.rest-api-error" = "Votre site a renvoyé une erreur : %@";
+
 /* A generic title for an error */
 "generic.error.title" = "Erreur";
+
+/* Error message when failing to parse API responses */
+"generic.error.unparsableResponse" = "Votre site a envoyé une réponse que l’application n’a pas pu analyser";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "Définir vos rappels de blog";
@@ -8034,42 +8608,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title of the Jetpack powered overlay. */
 "jetpack.branding.overlay.title" = "WordPress est mieux avec Jetpack";
-
-/* Title for the button that starts the Jetpack connection process */
-"jetpack.connection.connect.button" = "Connecter votre site";
-
-/* Error message shown when WordPress.com authentication fails */
-"jetpack.connection.error.authentication" = "Compte WordPress.com non valide";
-
-/* Error message shown when a connection step is attempted in an invalid order */
-"jetpack.connection.error.context" = "Cette étape n’est pas encore prête";
-
-/* Title for the retry button shown when a connection step fails */
-"jetpack.connection.retry.button" = "Réessayer";
-
-/* Status message when a connection step is pending */
-"jetpack.connection.stage.pending" = "En attente de démarrage";
-
-/* Status message when a connection step is in progress */
-"jetpack.connection.stage.processing" = "En cours…";
-
-/* Status message when a connection step is completed successfully */
-"jetpack.connection.stage.success" = "Terminé";
-
-/* Title for the finalization step in Jetpack connection flow */
-"jetpack.connection.step.finalize.title" = "Finaliser la connexion";
-
-/* Title for the install step in Jetpack connection flow */
-"jetpack.connection.step.install.title" = "Installer Jetpack";
-
-/* Title for the login step in Jetpack connection flow */
-"jetpack.connection.step.login.title" = "Connexion à WordPress.com";
-
-/* Title for the site connection step in Jetpack connection flow */
-"jetpack.connection.step.site.title" = "Se connecter votre site";
-
-/* Title for the user connection step in Jetpack connection flow */
-"jetpack.connection.step.user.title" = "Se connecter à votre compte WordPress.com";
 
 /* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
 "jetpack.fullscreen.overlay.early.switch.title" = "Passer à la nouvelle application Jetpack";
@@ -8290,41 +8828,11 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "Vous n’avez pas le droit de voir ce blog privé.";
 
-/* Button to dismiss the re-authentication view */
-"login.appPasswordReAuth.cancelButton" = "Annuler";
-
-/* Description explaining why the user needs to re-authenticate */
-"login.appPasswordReAuth.description" = "Le mot de passe d’application assigné à l’application n’existe plus dans votre profil.\nVeuillez vous reconnecter pour créer un nouveau mot de passe d’application à utiliser.";
-
-/* Button to start the re-authentication process */
-"login.appPasswordReAuth.signInButton" = "Se connecter";
-
-/* Title shown when the application password is invalid */
-"login.appPasswordReAuth.title" = "Mot de passe d’application non valide";
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "Veuillez saisir le code de vérification de votre application d’authentification en 2 étapes pour votre compte WordPress.com.";
 
 /* Indicating that referrer was marked as spam */
 "marked as spam" = "marqué comme indésirable";
-
-/* Button title when verification link sending failed */
-"me.verifyEmail.button.retry" = "Réessayer";
-
-/* Button title to send verification link */
-"me.verifyEmail.button.send" = "Renvoyer l’e-mail";
-
-/* Button title while verification link is being sent */
-"me.verifyEmail.button.sending" = "Envoi en cours…";
-
-/* Button title after verification link is sent */
-"me.verifyEmail.button.sent" = "E-mail envoyé";
-
-/* Message for email verification card */
-"me.verifyEmail.message.noEmail" = "Confirmez votre adresse e-mail pour sécuriser votre compte et accéder à d’autres fonctionnalités.\nConsultez l’e-mail de confirmation dans votre boîte de réception ou cliquez sur « %@ » pour en recevoir un nouveau.";
-
-/* Message for email verification card with email address */
-"me.verifyEmail.message.withEmail" = "Confirmez votre adresse e-mail pour sécuriser votre compte et accéder à d’autres fonctionnalités.\nConsultez l’e-mail de confirmation dans votre boîte de réception à l’adresse %1$@ ou cliquez sur « %2$@ » pour en recevoir un nouveau.";
-
-/* Title for email verification card */
-"me.verifyEmail.title" = "Confirmer votre adresse e-mail";
 
 /* Me tab menu items */
 "meMenu.submitFeedback" = "Envoyer un commentaire";
@@ -8424,9 +8932,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Bottom toolbar title in the selection mode */
 "mediaLibrary.toolbarSelectItemsPrompt" = "Sélectionner des éléments";
-
-/* A name of the action in the context menu */
-"mediaPicker.imagePlayground" = "Terrain de jeu d'images";
 
 /* Message for alert when access to camera is not granted */
 "mediaPicker.noCameraAccessMessage" = "Cette application nécessite une autorisation pour accéder à l’appareil photo et capturer de nouveaux médias. Pour ce faire, veuillez modifier les réglages de confidentialité.";
@@ -8630,7 +9135,7 @@ Example: Reply to Pamela Nguyen */
 "noLogs.empty" = "Aucune entrée de journal dans cet intervalle";
 
 /* A generic error message displayed on the atomic logs screen. */
-"noLogs.error" = "Une erreur s‘est produite";
+"noLogs.error" = "Une erreur s’est produite";
 
 /* Button title for the retry button on the atomic logs screen. */
 "noLogs.retry" = "Réessayer";
@@ -8761,6 +9266,9 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "Page parente";
 
+/* No comment provided by engineer. */
+"password" = "mot de passe";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "Le contenu des cartes peut varier en fonction de l’activité de votre site. D’autres cartes et commandes sont en cours d’élaboration.";
 
@@ -8866,9 +9374,6 @@ Example: Reply to Pamela Nguyen */
 /* Message shown while loading plugin details */
 "pluginDetails.loading" = "Chargement des informations de l’extension…";
 
-/* Placeholder message shown when a plugin has no description */
-"pluginDetails.noDescription" = "Cette extension n’a fourni aucune description.";
-
 /* Title of the changelog section in plugin details */
 "pluginDetails.section.changelog" = "Journal des modifications";
 
@@ -8940,9 +9445,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Post Editor / Button in the 'More' menu */
 "postEditor.moreMenu.saveDraft" = "Enregistrer le brouillon";
-
-/* Post Editor / Button in the 'More' menu */
-"postEditor.moreMenu.sendFeedback" = "Envoyer un commentaire";
 
 /* Post Editor / Button in the 'More' menu */
 "postEditor.moreMenu.visualEditor" = "Éditeur visuel";
@@ -9112,12 +9614,6 @@ Example: Reply to Pamela Nguyen */
 /* A default value for an post without a title */
 "postSaveErrorMessage.postUntitled" = "Sans titre";
 
-/* Cancel upload button in Post Settings / Featured Image cell */
-"postSettings.featuredImage.cancelUpload" = "Annuler le chargement";
-
-/* Replace image upload button in Post Settings / Featured Image cell */
-"postSettings.featuredImage.replaceImage" = "Remplacer";
-
 /* Button in Post Settings */
 "postSettings.featuredImage.setFeaturedImageButton" = "Définir l’image mise en avant";
 
@@ -9141,6 +9637,24 @@ Example: Reply to Pamela Nguyen */
 
 /* An alert message explaning that by changing the visibility to private, the post will be published immediately to your site */
 "postSettings.warningPostWillBePublishedAlertMessage" = "En réglant la visibilité sur « Privé », l’article sera publié immédiatement";
+
+/* Localized post type: `Post` */
+"postType.post" = "article";
+
+/* Details for a 'Private' privacy setting */
+"postVisibility.private.details" = "Uniquement visible pour les administrateurs et les éditeurs du site";
+
+/* Title for a 'Private' privacy setting */
+"postVisibility.private.title" = "Privé";
+
+/* Details for a 'Password Protected' privacy setting */
+"postVisibility.protected.details" = "Visible pour tous mais nécessite un mot de passe";
+
+/* Title for a 'Password Protected' privacy setting */
+"postVisibility.protected.title" = "Protégé par un mot de passe";
+
+/* Details for a 'Public' (default) privacy setting */
+"postVisibility.public.details" = "Visible pour tout le monde";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Annuler";
@@ -9359,18 +9873,6 @@ Tapping on this row allows the user to edit the sharing message. */
 /* Title for the success view when the user has successfully logged in */
 "qrLoginVerifyAuthorization.completedInstructions.title" = "Connexion établie.";
 
-/* No comment provided by engineer. */
-"reachability-utils.alert.cancel" = "OK";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.retry" = "Réessayer ?";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.title" = "Pas de connexion";
-
-/* Message of error prompt shown when no internet connection is available */
-"reachability-utils.alert.utils" = "La connexion Internet semble inactive.";
-
 /* Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog. */
 "reader.blocked.blog.message" = "Le blog %@ n’apparaîtra plus dans votre lecteur. Appuyez pour annuler.";
 
@@ -9390,16 +9892,10 @@ Tapping on this row allows the user to edit the sharing message. */
 "reader.blog.search.no.results.title" = "Aucun résultat";
 
 /* A shared button title for Reader */
-"reader.button.addToFavorites" = "Ajouter aux favoris";
-
-/* A shared button title for Reader */
 "reader.button.notificationSettings" = "Réglages de notification";
 
 /* A shared button title for Reader */
-"reader.button.removeFromFavorites" = "Retirer des favoris";
-
-/* A shared button title for Reader */
-"reader.button.subscribe" = "S’abonner";
+"reader.button.removeFromFavorites" = "Supprimer des favoris";
 
 /* Reader sidebar button title */
 "reader.button.unfollow" = "Se désabonner";
@@ -9407,26 +9903,8 @@ Tapping on this row allows the user to edit the sharing message. */
 /* A shared button title for Reader */
 "reader.button.unsubscribe" = "Se désabonner";
 
-/* Button title. Follow the comments on a post. */
-"reader.comments.buttonFollow" = "S’abonner";
-
 /* Informational message, should be short. */
 "reader.comments.commentsClosed" = "Commentaires fermés";
-
-/* Empty state view title */
-"reader.comments.emptyStateTitle" = "Soyez la première personne à laisser un commentaire.";
-
-/* Empty state view title */
-"reader.comments.errorLoadingComments" = "Une erreur inattendue est survenue lors du chargement des commentaires.";
-
-/* VoiceOver hint */
-"reader.comments.followingSettingAccessibilityIdentifier" = "Ouvrir les réglages de notification de l’article";
-
-/* Error message that informs reader comments from a private blog cannot be fetched. */
-"reader.comments.noPermissionToViewPrivateBlog" = "Vous n’avez pas le droit de voir ce blog privé.";
-
-/* Navigation title */
-"reader.comments.title" = "Commentaires";
 
 /* Accessibility hint to inform that the author section can be tapped to see posts from the site. */
 "reader.detail.header.authorInfo.a11y.hint" = "Affiche les articles du site";
@@ -9504,23 +9982,8 @@ but tapping on this button will remove their like from the post. */
 /* Screen header details */
 "reader.following.header.details" = "Soyez à jour dans les blogs auxquels vous êtes abonné(e).";
 
-/* Empty state view */
-"reader.following.lists.emptyTitle" = "Listes vides";
-
-/* Screen header details */
-"reader.home.header.details" = "Soyez à jour dans les blogs auxquels vous êtes abonné(e).";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.home.title" = "Accueil";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.library.title" = "Bibliothèque";
-
 /* Used in multiple contexts, usually as a screen title */
 "reader.likes.title" = "Mentions J’aime";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.lists.title" = "Listes";
 
 /* Reader logged-out screen details */
 "reader.loggedOut.details" = "Se connecter avec un compte WordPress.com pour suivre vos blogs préférés";
@@ -9593,7 +10056,7 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 "reader.notice.user.blocked" = "reader.notice.user.block.failed";
 
 /* Button accessibility label */
-"reader.post.buttonBookmark.accessibilityLabel" = "Marque-page";
+"reader.post.buttonBookmark.accessibilityLabel" = "Signet";
 
 /* Button accessibility label */
 "reader.post.buttonComment.accessibilityLabel" = "Afficher les commentaires";
@@ -9638,9 +10101,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 "reader.postContextMenu.manageNotifications" = "Gérer les notifications";
 
 /* Context menu action */
-"reader.postContextMenu.markRead" = "Marquer comme lu";
-
-/* Context menu action */
 "reader.postContextMenu.markUnread" = "Marquer comme non lu";
 
 /* Context menu action */
@@ -9654,9 +10114,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Context menu action */
 "reader.postContextMenu.viewInBrowser" = "Voir dans le navigateur";
-
-/* Reader post details view placeholder when blog name not avail */
-"reader.postDetails.blog" = "blog";
 
 /* Button title */
 "reader.postDetails.viewFullPost" = "Voir l’article entier";
@@ -9693,12 +10150,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Describes that the slider is used to customize the text size in the Reader. */
 "reader.preferences.control.sizeSlider.description" = "Taille";
-
-/* Text for a small label in the navigation bar that hints that this is an experimental feature.
-
-The enclosing angled brackets ('<' and '>') are decorative and only intended as a flavor.
-Feel free to replace it with other bracket types that you think looks better for the locale. */
-"reader.preferences.navBar.experimental.label" = "<Experimental>";
 
 /* Description text for the preview section of Reader Preferences */
 "reader.preferences.preview.body.text" = "Choisissez vos couleurs, polices et tailles. Prévisualisez votre sélection ici et lisez des articles avec vos styles une fois que vous aurez terminé.";
@@ -9760,8 +10211,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title of a Reader tab showing Posts matching a user's search query */
 "reader.search.tab.posts" = "Articles";
 
-/* Title of the Reader's search feature
-   Used in multiple contexts, usually as a screen title */
+/* Title of the Reader's search feature */
 "reader.search.title" = "Rechercher";
 
 /* Screen title. Reader select interests title label text. */
@@ -9787,6 +10237,21 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Reader select interests title label text */
 "reader.select.tags.title" = "Découvrir et suivre des blogs que vous aimez";
+
+/* Reader sidebar menu item */
+"reader.sidebar.discover" = "Découvrir";
+
+/* Reader sidebar menu item */
+"reader.sidebar.likes" = "Mentions J’aime";
+
+/* Reader sidebar menu item */
+"reader.sidebar.recent" = "Récents";
+
+/* Reader sidebar menu item */
+"reader.sidebar.saved" = "Enregistrés";
+
+/* Reader sidebar menu item */
+"reader.sidebar.search" = "Rechercher";
 
 /* Reader sidebar section title */
 "reader.sidebar.section.favorites.title" = "Favoris";
@@ -9833,7 +10298,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Number of subscriptions on a site (singular) */
 "reader.subscriptions.subscriptionsSingular" = "%@ abonné";
 
-/* Used in multiple contexts, usually as a screen title */
+/* Navigation bar title */
 "reader.subscriptions.title" = "Abonnements";
 
 /* A suggestion of topics the user might want to subscribe to */
@@ -9875,23 +10340,8 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Verb. Button title. The user is following a tag. */
 "reader.tags.following.button.title" = "Abonné";
 
-/* Used in multiple contexts, usually as a screen title */
-"reader.tags.title" = "Étiquettes";
-
 /* Accessibility label for unsubscribing from a tag */
 "reader.tags.unfollow.accessibility.label" = "Se désabonner de %@";
-
-/* Reader Welcome screen login button */
-"reader.welcome.continueText" = "Continuer avec WordPress.com";
-
-/* Reader Welcome screen */
-"reader.welcome.subtitle" = "Rejoindre la plus grande communauté de blogueurs";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.me" = "Moi";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.notifications" = "Notifications";
 
 /* Spoken accessibility label */
 "readerDetail.backButton.accessibilityLabel" = "Retour";
@@ -10166,14 +10616,10 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Message shown when there are no inactive plugins on the site */
 "site.plugins.empty.inactive" = "Aucune extension inactive";
 
-/* The plugin fillter option for displaying active plugins */
-"site.plugins.filter.option.active" = "Actives";
-
-/* The plugin fillter option for displaying all plugins */
+/* The plugin fillter option for displaying active plugins
+   The plugin fillter option for displaying all plugins
+   The plugin fillter option for displaying inactive plugins */
 "site.plugins.filter.option.all" = "Tout";
-
-/* The plugin fillter option for displaying inactive plugins */
-"site.plugins.filter.option.inactive" = "Inactives";
 
 /* Title of the plugin filter picker */
 "site.plugins.filter.title" = "Filtre";
@@ -10201,9 +10647,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Accessibility hint for actions when displaying media items. */
 "siteMedia.cellAccessibilityHint" = "Sélectionnez un média.";
-
-/* Title for the URL field */
-"siteMedia.details.url" = "URL";
 
 /* Accessibility hint for media item preview for user's viewing an item in their media library */
 "siteMediaItem.contentViewAccessibilityHint" = "Appuyer pour voir le média en plein écran";
@@ -10704,9 +11147,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* View title for Help & Support page. */
 "support.title" = "Aide";
 
-/* Subject of new Zendesk ticket. */
-"support.zendesk.readerAppTicketSubject" = "Assistance Lecteur pour iOS";
-
 /* Title for placeholder in Tenor picker */
 "tenor.welcomeMessage" = "Recherchez des GIF pour les ajouter à votre bibliothèque de médias !";
 
@@ -10840,9 +11280,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Verb. Dismiss the web view screen. */
 "webKit.button.dismiss" = "Ignorer";
 
-/* Button label to share a web page */
-"webKit.button.share" = "Partager";
-
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterEndDate" = "Date de fin";
 
@@ -10855,8 +11292,119 @@ Feel free to replace it with other bracket types that you think looks better for
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "État";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "Articles et articles les plus vus depuis la création";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "Vues depuis la création";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "Vues et visiteurs depuis la création";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "Record de vues";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "Articles les plus vus";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "Impossible de charger toutes les statistiques.";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "Créez ou ajoutez un site pour voir toutes les statistiques.";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Articles";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "Gardez toujours un œil sur l'activité de votre site WordPress depuis sa création.";
+
+/* Title of all time widget */
+"widget.alltime.title" = "Depuis le début";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "Connectez-vous à WordPress pour voir les statistiques depuis la création du site.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "Connectez-vous à Jetpack pour voir les statistiques depuis la création du site.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "Connectez-vous à Jetpack pour voir les statistiques de cette semaine.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "Connectez-vous à Jetpack pour voir les statistiques du jour.";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "Vues depuis la création";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "Vues du jour";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "Impossible de charger les statistiques de la semaine.";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "Créez ou ajoutez un site pour voir les statistiques de la semaine.";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "Gardez toujours un œil sur l'activité hebdomadaire de votre site WordPress.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "Cette Semaine";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "Connectez-vous à WordPress pour voir les statistiques de cette semaine.";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Commentaires";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "Les statistiques sont désormais disponibles dans l’application Jetpack. Passer d’une application à l’autre est gratuit et ne prend qu’une minute.";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "J’aime";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "Impossible de charger les statistiques pour le site.";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "Impossible de charger les statistiques du jour.";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "Créez ou ajoutez un site pour voir les statistiques du jour.";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "Gardez toujours un œil sur l'activité quotidienne de votre site WordPress.";
+
+/* Title of today widget */
+"widget.today.title" = "Aujourd'hui";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "Connectez-vous à WordPress pour voir les statistiques du jour.";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "Cette vue n'est pas disponible";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Vues";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Visiteurs";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "J’aime et commentaires du jour";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "Vues du jour";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "Vues et visiteurs du jour";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "ne sera plus disponible dans le futur.";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "Vous lancez un nouveau site ?";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "wordpress, aide, support, faq, questions, debug, logs, centre d’aide, contact";
@@ -10881,6 +11429,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Error message that describes an unknown error had occured */
 "wordpress-api.error.unknown" = "Un problème est survenu, veuillez réessayer ultérieurement.";
+
+/* Error message when failing to find selected media file on the user's device. */
+"wordpress.api.upload.media.fileNotFound" = "Impossible de localiser le fichier média sur l’appareil";
 
 /* Jetpack Plugin Modal on WordPress primary button title */
 "wordpress.jetpack.plugin.modal.primary.button.title" = "Basculer vers l’application Jetpack";
@@ -10927,21 +11478,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Error message when user signs in with an unexpected email address. The first argument is the expected email address */
 "wpComLogin.error.mismatchedEmail" = "Veuillez vous connecter avec l’adresse e-mail %@";
 
-/* Message shown when user denies WordPress.com login, offering option to try with different account */
-"wpComLogin.loginDenied.message" = "Vous pouvez vous connecter avec un autre compte si nécessaire. Appuyez sur « %@ » pour commencer.";
-
-/* Title of alert shown when user cancels WordPress.com login */
-"wpComLogin.loginDenied.title" = "Connexion annulée";
-
-/* Button title for signing in with a different WordPress.com account */
-"wpComLogin.loginDenied.useDifferentAccount" = "Utiliser un autre compte";
-
-/* Button title to log out the current WordPress.com account */
-"wpcom.token.alert.button.logout" = "Se déconnecter";
-
-/* Button title to Sign In to WordPress.com */
-"wpcom.token.alert.button.signin" = "Se connecter";
-
 /* Message title to be displayed when the user needs to re-authenticate their WordPress.com account. */
 "wpcom.token.fix.signin" = "Se connecter à WordPress.com";
 
@@ -10956,6 +11492,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "Pièce jointe non prise en charge";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Connectez-vous avec Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Domaines";

--- a/WordPress/Resources/he.lproj/Localizable.strings
+++ b/WordPress/Resources/he.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Translation-Revision-Date: 2025-05-13 13:54:08+0000 */
+/* Translation-Revision-Date: 2025-03-11 16:54:08+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
 /* Generator: GlotPress/4.0.1 */
 /* Language: he_IL */
@@ -98,6 +98,9 @@
 
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "%1$@ מתוך %2$@ באתר שלך";
+
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "%1$@ מתוך %2$@ נוצלו באתר שלך";
 
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ מיליון מליארדים";
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(ללא כותרת)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(חסרה כותרת)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*ישראל ישראלי* הגיב לפוסט שלך";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "הכפתור 'עוד' כולל תפריט נפתח שמציג כפתורי שיתוף";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "חשבון WordPress.com מחובר לפרטי הכניסה שלך לחנות. כדי להמשיך, נשלח לך קישור לאימות אל כתובת האימייל שמצוינת למעלה.";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "קובץ שמכיל תבנית של קוד זדוני";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "כותרת אתר";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "דרושה כתובת אימייל תקפה כדי שנוכל לשלוח קישור לאימות. יש לחזור למסך הקודם ולהזין כתובת אימייל תקפה.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "קוד אימות מכיל מספרים בלבד.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "פעיל";
@@ -334,9 +349,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* My Profile 'About me' label */
 "About Me" = "אודותיי";
-
-/* Link to About screen for Jetpack for iOS */
-"About Reader for iOS" = "מידע לגבי Reader עבור iOS";
 
 /* Link to About screen for WordPress for iOS */
 "About WordPress" = "אודות WordPress";
@@ -525,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "אחרי %@";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "יישור";
@@ -588,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "כתובות IP ברשימת ההיתרים";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "כמעט סיימת! יש להזין את קוד האימות מאפליקציית האימות.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "טקסט חלופי";
@@ -600,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "Alternatively, you can flatten the content by ungrouping the block.";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "לחלופין, ניתן להזין את הסיסמה של החשבון.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "לחלופין:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "תמיד לשלוח דוחות קריסה";
@@ -621,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "נחוץ חיבור פעיל לאינטרנט כדי להציג פעילויות";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "נחוץ חיבור פעיל לאינטרנט כדי להציג תוכניות";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -671,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "נתונים סטטיסטיים שנתיים של האתר";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "אנונימי";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "תשובה";
 
@@ -692,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "עיצוב";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "אימות אפל נכשל.\nבבקשה תוודא שאתה רשום לiCloud עם Apple ID שמשתמש באימות דו שלבי.";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "הפעולה מחילה את ההגדרות";
@@ -778,6 +811,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "האימות נכשל";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "קוד אימות";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "נדרש אימות עבור חברת האחסון: ‎%@";
@@ -888,6 +925,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "יש לך אפשרות לרשום את התגובה הראשונה";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "נשמח לקבל תגובה ראשונה ממך.";
 
 /* Beauty site intent topic */
 "Beauty" = "טיפוח היופי";
@@ -1024,12 +1064,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button to copy post text" = "כפתור להעתקת הטקסט של הפוסט";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "המשך הפעולה מהווה את הסכמתך לתנאי השימוש שלנו.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "רישום לדומיין מהווה הסכמה מצדך <a>לתנאים ולהתניות שלנו<\/a>.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "ההגדרה של Jetpack מהווה את ההסכמה שלך אל \n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "ביצוע ההרשמה מהווה את הסכמתך לתנאי השימוש שלנו.";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "התאמה אישית";
@@ -1043,6 +1089,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "נדרשת גישה למצלמה כדי לסרוק קודים של התחברות";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "לא ניתן לבקש קישור";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "לא ניתן לפרסם עמוד ריק";
 
@@ -1052,6 +1101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1061,6 +1111,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1079,6 +1130,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1106,6 +1158,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "מבטל...";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "לא ניתן לגשת לאתר בכתובת זו. יש לבדוק שנית ולנסות שוב.";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "לא הצלחת להחליט? תהיה לך אפשרות לשנות את ערכת העיצוב בכל עת.";
 
@@ -1113,7 +1168,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "כיתוב";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "בזהירות!";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1122,7 +1178,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "קטגוריות";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "קטגוריה";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1171,6 +1228,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "מומלץ לעיין בעצות המובילות שלנו כדי להגדיל את כמות הצפיות והתעבורה";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "יש לבדוק את תיבת האימייל במכשיר זה!";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "בדוק את האימייל שלך במכשיר הנוכחי, ולחץ על הלינק שקיבלת מוורדפרס.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "עליך לבדוק את האימייל ממכשיר זה ולהקיש על הקישור בהודעה שקיבלת מ-WordPress.com.\n\nלא רואה את האימייל? כדאי לבדוק בתיבת הספאם או בדואר הזבל.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "יש לבדוק את תיבת האימייל!";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "יש לבדוק את החיבור לאינטרנט ולמשוך כדי לרענן את העמוד.";
@@ -1267,6 +1336,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "לקבל דומיין בחינם";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "בלוג קלאסי";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "מחיקה של מטמון המדיה במכשיר";
 
@@ -1294,6 +1366,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "סגור";
 
@@ -1335,6 +1408,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "הגדרות טורים";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "קומיקס";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1386,6 +1462,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "תגובות";
 
@@ -1453,12 +1530,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "חשבונות מחוברים";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "מחובר, עם זאת...";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "מתחבר אל %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "החיבור ל-%1$@ יחליף את החיבור הקיים ל-%2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "מתחבר לוורדפרס.קום";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "מתחבר...";
@@ -1489,8 +1572,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "ניתן ליצור אתנו קשר בכתובת %@";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "מבנה תוכן\nבלוקים: ⁦%1$li⁩, מילים: %2$li, תווים: %3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1505,6 +1592,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "המשך קריאה";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "להמשיך עם Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "להמשיך עם Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "להמשיך עם Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "להשתתף";
@@ -1633,6 +1729,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "ליצור";
 
+/* The button title text for creating a new account. */
+"Create Account" = "צור חשבון";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "ליצור עמוד ריק";
 
@@ -1653,6 +1752,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "יצירת פוסט";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "ליצור אתר";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "יצירת תגית";
@@ -1686,6 +1788,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "נוכחי";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "תוכנית נוכחית";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "תבנית נוכחית";
@@ -1788,6 +1893,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "קטגוריית ברירת מחדל";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "תפריט ברירת מחדל";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "סוג ברירת מחדל של פוסט";
@@ -1796,6 +1904,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "ברירות מחדל עבור פוסטים חדשים";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "מחק";
@@ -1853,6 +1962,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "פרטים";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "לא התכוונת ליצור חשבון חדש? יש לחזור אחורה כדי להזין מחדש את כתובת האימייל שלך.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "מידות";
 
@@ -1900,7 +2012,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "דיון";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "בטל";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1922,6 +2036,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "דומיינים";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "אין לך חשבון עדיין? _הרשמה_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2051,6 +2168,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "הורדות";
 
+/* Name for the status of a draft post. */
+"Draft" = "טיוטה";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "טיוטות";
 
@@ -2160,7 +2280,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "כתובת אימייל";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "כתובת אימייל";
 
 /* Notification Settings Channel */
@@ -2244,8 +2367,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "הזן סיסמה";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "יש להזין את הכתובת האתר ב-WordPress שאליו ברצונך להתחבר.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "יש להזין את הסיסמה לחשבון WordPress.com שלך.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "הזן שם משתמש";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "להזין את פרטי החשבון שלך ב-%@";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "יש להזין את כתובת האימייל שלך כדי להתחבר או ליצור חשבון ב-WordPress.com.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "יש להזין את הכתובת של האתר החדש שלך";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "במקום זאת יש להזין סיסמה.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "יש להזין את פרטי הכניסה של השרת";
@@ -2408,6 +2551,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "חיצוני";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "נכשל";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "סימון ההודעות כ'נקרא' נכשל";
 
@@ -2419,9 +2565,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Failed to insert media.\nTap for more info." = "ההוספה של המדיה נכשלה.\nיש להקיש לפרטים נוספים.";
-
-/* A message indicating that we couldn't load the user's settings. */
-"Failed to load settings" = "הטעינה של ההגדרות נכשלה";
 
 /* No comment provided by engineer. */
 "Failed to save files.\nPlease tap for options." = "שמירת קבצים נכשלה.\nיש להקיש לאפשרויות.";
@@ -2437,6 +2580,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "אופנה";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "מרכזיים";
@@ -2495,6 +2641,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "למידע נוסף";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "למצוא את הכותרת של האתר שלך";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2517,6 +2666,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "מתקן את האיומים";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "עקוב";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "מעקב אחר השיחה";
@@ -2611,6 +2763,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "ליצור קישור חדש";
 
+/* View title for initial auth views. */
+"Get Started" = "מתחילים כאן";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "לקבל קישור לכניסה באימייל";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "לפעול במרץ! הוספת תגובה על פוסטים בבלוגים תחת מעקב שלך.";
 
@@ -2632,8 +2790,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "לקבל השראה";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "טוען פרטי חשבון";
+
+/* Cancel */
+"Give Up" = "לוותר";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "אפשר לנסות את האפשרויות על ידי הוספה של כמה בלוקים לפוסט או לעמוד שלך!";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "מעבר אל Reader";
@@ -2644,6 +2811,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "מעבר אל הגדרות iOS";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "ההרשמה ל-Google נכשלה.";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2718,6 +2888,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "סמל עזרה";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "מוסתר";
+
 /* Title of a button used to collapse a group */
 "Hide" = "להסתיר";
 
@@ -2786,6 +2959,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "עדכון הסמל נכשל";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "אם לא הצלחת למצוא את הודעת האימייל, כדאי לחפש בתיבה של דואר הזבל או הספאם";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "אם בחרת להמשיך עם Apple או עם Google ועדיין אין לך חשבון ב-WordPress.com, חשבון ייווצר עבורך ויש הסכמה מצידך לתנאי השירות שלנו.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "לאחר הסרתו של המשתמש %1$@, לא תהיה לו עוד גישה לאתר זה אך כל התוכן שנוצר על ידי %2$@ יישאר באתר.";
@@ -2861,6 +3040,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "כולל wp-config.php וקבצים שאינם WordPress";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "שם משתמש או סיסמה לא נכונים. יש לנסות להזין שוב את פרטי ההתחברות.";
 
 /* Title for a threat */
 "Infected core file" = "קובץ ליבה נגוע";
@@ -2962,6 +3144,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "שמחים להציג את האפשרות 'הצעות כתיבה בבלוג'";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "כתובת אימייל לא תקפה";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "כתובת אתר לא תקנית";
 
@@ -2979,6 +3164,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "כתובת URL לא תקינה. לא נמצא קובץ אודיו.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "כתובת URL לא תקינה. יש לבדוק שנית ולנסות שוב.";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "כתובת URL לא תקינה. נא להזין כתובת אינטרנט תקנית";
@@ -3000,6 +3188,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "להזמין אנשים";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "נראה ששם המשתמש או הסיסמה לא רשומים באתר זה.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "כנראה שהזנת סיסמה שגויה. רוצה לנסות שוב?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "הגיע הזמן לכתוב בלוג ביום %@!";
@@ -3228,7 +3422,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "גובה השורה";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "קישור";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3290,6 +3485,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "טוען אנשים...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "טוען תוכנית...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "טוען תוכנית...";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "טוען תוסף...";
 
@@ -3324,11 +3525,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "טוען...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "מקומי";
+
 /* Local Services site intent topic */
 "Local Services" = "שירותים מקומיים";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "שינויים מקומיים";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "מיקום";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "יש להפעיל שירותי מיקום לפני ש-WordPress תוכל להוסיף את מיקומך הנוכחי. יש להפעיל שירותי מיקום תחת 'הגדרות'.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "מיקום לא ידוע";
 
 /* No comment provided by engineer. */
 "Lock icon" = "סמל מנעול";
@@ -3336,9 +3549,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "קובצי יומן לפי תאריך יצירה";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "התחבר";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3348,17 +3563,33 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of a button for signing in. */
 "Log in" = "התחברות";
 
-/* LogOut confirmation text, whenever there are no local changes */
-"Log out of Jetpack?" = "האם להתנתק מ-Jetpack?";
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "התחברות נכשלה. נא לנסות שנית.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "יש להתחבר או להירשם עם WordPress.com";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "יש להיכנס לחשבון WordPress.com שדרכו חיברת את Jetpack.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "יש להתחבר לחשבון שלך ב-WordPress.com באמצעות כתובת האימייל שלך.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "יש להתחבר באמצעות שם המשתמש והסיסמה של WordPress.com.‏";
 
 /* LogOut confirmation text, whenever there are no local changes */
-"Log out of Reader?" = "האם להתנתק מ-Reader?";
+"Log out of Jetpack?" = "האם להתנתק מ-Jetpack?";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of WordPress?" = "האם להתנתק מ-WordPress?";
 
 /* Login Request Expired */
 "Login Request Expired" = "פג תוקף בקשת ההתחברות";
+
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "להתחבר עם הסיסמה של החשבון";
 
 /* No comment provided by engineer. */
 "Logs" = "לוגים";
@@ -3368,6 +3599,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "נראה כי באתר שלך מוגדר Jetpack. ברכותינו! יש להיכנס עם פרטי הכניסה של WordPress.com כדי לאפשר סטטיסטיקות והתראות.";
+
+/* Title of a button. */
+"Lost your password?" = "שחזור סיסמה";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "אימייל (ברירת מחדל)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "ניווט ראשי";
@@ -3515,6 +3752,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "הודעה";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "מאפיינים פגיעים שונים";
 
@@ -3610,6 +3850,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "אתר שלי";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "האתרים שלי ב-WordPress";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "העשירייה הפותחת של בתי הקפה האהובים עלי";
 
@@ -3649,8 +3892,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "עזרה";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "צריך עזרה במציאת כתובת האתר שלך?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "דרושה עזרה?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "צריכים עזרה נוספת?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "נדרש עדכון";
@@ -3679,6 +3929,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "פוסט חדש";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "פריט חדש";
+
 /* Placeholder text for password field */
 "New password" = "סיסמה חדשה";
 
@@ -3696,7 +3949,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "חדשות";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "הבא";
 
 /* Accessibility label for the next notification button */
@@ -3732,6 +3987,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "אין תצוגה מקדימה זמינה של ה-URL";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "ללא כותרת";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "אין פעילויות זמינות";
 
@@ -3764,7 +4022,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "עדיין אין תגובות";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "אין חיבור";
 
@@ -3913,6 +4172,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "לא עכשיו";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "לא קיבלת את האימייל? בדוק את הספאם או תיקיית הזבל במייל.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "הערה:";
 
@@ -3976,7 +4238,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "רשימה ממוספרת";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "אוקיי";
@@ -4033,7 +4300,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "אופס";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "אופפפס!";
 
 /* No comment provided by engineer. */
@@ -4048,7 +4316,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "לפתוח את ההגדרות של Jetpack Security";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "פתיחת דואר";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "פתיחת הגדרות";
 
 /* No comment provided by engineer. */
@@ -4066,6 +4339,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "פתיחת קישור בחלון חדש\/כרטיסייה חדשה";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "לפתוח את הגדרות הרישום לעדכונים בפוסט";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "לפתוח את המקטע 'אני'";
 
@@ -4080,6 +4356,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "אופציונלי: ניתן להזין הודעה מותאמת אישית של עד ⁦%1$d⁩ תווים שתישלח עם ההזמנה.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "או";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "לחלופין, יש לבחור אמצעי אימות אחר.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "לחלופין, ניתן להתחבר באמצעות _הזנת הכתובת של האתר שלך_.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "לחלופין, ניתן להתחבר באמצעות קישור ישיר";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "רשימה מסודרת";
@@ -4128,7 +4416,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "מרווחים";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "עמוד";
 
@@ -4161,8 +4450,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "הורות";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "סיסמה";
 
@@ -4179,8 +4471,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "להדביק את הבלוק אחרי";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "ממתין לאישור";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "ממתין לאישור";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4211,6 +4507,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "בחירת שם משתמש";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "תוכניות";
+
 /* User action to play a video on the editor. */
 "Play video" = "הפעלת וידאו";
 
@@ -4240,6 +4540,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "כדאי לוודא שעורך הבלוקים הופעל באתר שלך. אם הוא לא הופעל, הוא לא ייטען.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "יש להזין את כתובת האתר המלאה, לדוגמה example.com.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "נא להזין כתובת אתר.";
@@ -4274,11 +4577,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "נא להזין כתובת תקינה";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "יש להזין כתובת אימייל תקפה לחשבון WordPress.com.";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "נא להזין כתובת אימייל תקינה.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "יש להזין מספר טלפון תקף";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "עליך להזין את הסיסמה לחשבון שלך ב-WordPress.com כדי להתחבר עם ה-Apple ID שלך.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "הזינו את הפרטים";
@@ -4286,8 +4595,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "יש להזין את כתובת האימייל שלך.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "נא למלא את כל השדות";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "יש להפעיל את האפליקציה של WordPress.com, להתחבר ל-WordPress.com ולוודא שיש ברשותך לפחות אתר אחד. לאחר מכן, יש לנסות שוב.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "יש להתנתק לפני ההתחברות לאתר WordPress.com שונה";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "יש לנסות שוב מאוחר יותר";
@@ -4352,7 +4667,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "שפות פופולאריות";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "פוסט";
 
@@ -4473,6 +4789,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "הצהרת פרטיות למשתמשים מקליפורניה";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "פרטי";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "בעיה בהצגת הבלוק \nTap to attempt block recovery.";
 
@@ -4487,6 +4806,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "יש בעיה ברכישת הדומיין שלך. יש לנסות שוב.";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "המשך התהליך יסיר את כל המידע של וורדפרס.קום מהמכשיר, וימחק את כל הטיוטות שנשמרו מקומית. מידע שכבר נשמר באתר(ים) בוורדפרס.קום לא ילך לאיבוד.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "פרויקטים";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "דילגת על ההצעה";
@@ -4504,13 +4829,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "תאריך פרסום";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "פרסום מיידי";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "לפרסם את העמוד במיקום:";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "פרסום הפוסט באתר:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "פורסם";
 
@@ -4712,7 +5041,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "תגובה";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "טקסט תגובה";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "לענות ל-%1$@";
 
 /* An explaination of a setting. */
@@ -4741,6 +5075,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "לאפס את המסנן של טווח התאריכים";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "יש לאפס את הסיסמה שלך";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "שינוי גודל וחיתוך";
@@ -4798,6 +5135,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "ניסיון חוזר של הכול";
 
+/* No comment provided by engineer. */
+"Retry?" = "לנסות שנית?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "חזרה לפוסט";
 
@@ -4827,6 +5167,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "תפקיד";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS נשלח";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "סטטוס";
 
@@ -4838,6 +5181,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4904,7 +5248,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "סורק קבצים";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "מתוזמן לפרסום";
 
 /* No comment provided by engineer. */
@@ -5044,6 +5389,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "בוחר את הנושא הזה כמרכז האתר שלך.";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "שליחת קישור";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "לשלוח את הקישור באימייל";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "לשלוח הודעה ליומן";
 
@@ -5052,6 +5403,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "לשלוח כסף לבדיקה";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "לשלוח קישור לאימות באימייל";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "שליחת הודעות באמצעות האימייל";
@@ -5098,11 +5452,11 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Message to show when setting save failed */
 "Settings update failed" = "עדכון הגדרות נכשל";
 
-/* Title for a button that recommends the app to others */
-"Share Jetpack with a friend" = "לשתף את Jetpack עם חברים";
+/* Spoken accessibility label */
+"Share" = "שיתוף";
 
 /* Title for a button that recommends the app to others */
-"Share Reader with a friend" = "לשתף את Reader עם חברים";
+"Share Jetpack with a friend" = "לשתף את Jetpack עם חברים";
 
 /* Title for a button that recommends the app to others */
 "Share WordPress with a friend" = "לשתף את WordPress עם חברים";
@@ -5153,6 +5507,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "הצגת לחצן פרסום מחדש בבלוג";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "להציג סיסמה";
+
 /* No comment provided by engineer. */
 "Show post content" = "להציג את תוכן הפוסט";
 
@@ -5164,6 +5522,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "מציג נתונים סטטיסטיים עבור:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "מוצג";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "תוצג באופן ציבורי כשתגיב על בלוגים.";
@@ -5179,6 +5540,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "מציג את הפוסט";
+
+/* View title during the sign up process. */
+"Sign Up" = "הרשמה";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "להתחבר עם פרטי הכניסה של האתר";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "התחבר";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "הרשמה ל-WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "הרשמה באמצעות אימייל";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "מאחר שנרשמת לתוכנית החינמית, מספר האירועים שיוצגו ביומן הפעילות שלך מוגבל.";
@@ -5217,6 +5593,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "הישגי האתר";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "כתובת אתר";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "כתובת אתר צריכה להכיל לפחות 4 תווים.";
@@ -5301,7 +5680,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "כתובת האתר חייבת להכיל גם אותיות!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "כתובת המייל כבר נמצאת בשימוש!";
 
 /* No comment provided by engineer. */
@@ -5361,6 +5740,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "תגובות זבל";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "הגברת המהירות של האתר שלך";
@@ -5386,6 +5768,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "מדינה";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "עמוד בית קבוע";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5416,6 +5801,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "קו חוצה";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Stub";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "הגשה לאישור";
@@ -5506,7 +5894,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "טאבלט";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "תגית";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5641,6 +6030,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "תנאי שימוש";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "המלצות";
+
 /* Title of a button style */
 "Text Only" = "טקסט בלבד";
 
@@ -5650,8 +6042,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "הפקדים לעיצוב טקסט נמצאים בתוך סרגל הכלים שממוקם מעל המקלדת כאשר עורכים בלוק טקסט";
 
+/* Button title */
+"Text me a code instead" = "שליחת קוד במקום";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "שלחו לי קוד ב-SMS";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "תודה שבחרת ב-%1$@ מאת %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "נראה שזה לא קוד אימות חוקי.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "זה לא נראה כמו אתר של WordPress.";
@@ -5673,6 +6074,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "החיבור עם פייסבוק לא הצליח למצוא דפים. השיתוף האוטומטי לא יכול להתחבר אל פרופילים בפייסבוק, רק לדפים שפורסמו.";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "חשבון ה-Google‏ \"%@\" לא תואם לשום חשבון ב-WordPress.com‏";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "לא נמצא חיבור לאינטרנט.";
@@ -5712,6 +6116,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "לא ניתן להוסיף את התמונה לספריית המדיה.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "החיבור לאינטרנט לא מחובר.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "סוגי האתרים שאפשר ליצור";
@@ -5755,6 +6162,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "האתר %1$@ משתמש בוורדפרס %2$@. מומלץ לשדרג לגרסה העדכנית ביותר, או לפחות לגרסה %3$@.";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "כתובת האתר שהזנת אינה עבור אתר ב-WordPress. כדי שנוכל להתחבר לאתר, האתר חייב להשתמש בפלטפורמה של WordPress.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "לא ניתן למחוק את האתר.";
 
@@ -5796,6 +6207,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "חלה שגיאה בלתי צפויה בעת עריכת התגובה";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "אירעה שגיאה לא צפויה בעת טעינת התגובות.";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "אירעה שגיאה לא צפויה בעת רישום הדומיין שלך";
 
@@ -5804,6 +6218,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "אירעה שגיאה לא צפויה בעת עדכון ההגדרות של הודעות שלך";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "אירעה שגיאה לא צפויה בעת עדכון התגובה שלך";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "אירעה שגיאה לא צפויה.";
@@ -5825,6 +6242,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "הייתה בעיה בתקשורת עם האתר הזה.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "בעיה בהתחברות ל-WordPress.com. נא לנסות להתחבר שוב.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "אירעה בעיה בעת הצגת הפוסט.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "הייתה בעיה בטעינת הנתונים שלך, יש לרענן את העמוד ולנסות שוב.";
 
@@ -5834,12 +6257,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "אירעה בעיה בשמירת השינויים בניהול השיתוף.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "אירעה בעיה בניסיון לגשת למיקום שלך. יש לנסות שוב מאוחר יותר.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "אירעה בעיה בשינוי הסיסמה";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "אירעה שגיאה בטעינת הפעילויות";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "אירעה שגיאה בעת טעינת התוכניות";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "אירעה שגיאה בעת העלאת התוספים";
@@ -5852,6 +6281,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "אירעה שגיאה בעת טעינת ההיסטוריה";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "אירעה שגיאה בעת טעינת התוכנית";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "אירעה שגיאה בעת טעינת ההיסטוריה של הסריקה";
@@ -5900,6 +6332,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "הדומיין לא זמין";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "כתובת האימייל הזו לא רשומה ב-WordPress.com.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "הקובץ גדול מדי להעלאה לאתר שלך או שהפורמט של הקובץ אינו נתמך.";
@@ -5980,6 +6415,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "אזור זמן";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "נגמר הזמן הקצוב, אבל לא לדאוג: האבטחה שלך בעדיפות ראשונה אצלנו. יש לנסות שוב!";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "טיפים כדי להפיק את המיטב מ-WordPress.com.";
 
@@ -5993,6 +6431,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "יש להזין את כתובת האימייל והשם שלך כדי להמשיך.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "כדי ליצור חשבון WordPress.com חדש, יש להזין את כתובת האימייל שלך.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "כדי לקבל הודעות מועילות לטלפון מאתר שלך ב-WordPress, עליך להתקין את התוסף של Jetpack.";
 
@@ -6001,6 +6442,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "כדי להתקין תוספים, עליך לספק דומיין מותאם אישית שמקושר לאתר שלך.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "כדי להמשיך עם חשבון Apple ID זה, ראשית יש להתחבר עם הסיסמה שלך ב-WordPress.com. נבקש את הנתון הזה פעם אחת בלבד.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "כדי להמשיך עם חשבון Google, ראשית יש להתחבר עם הסיסמה שלך ב-WordPress.com. נבקש את הנתון הזה פעם אחת בלבד.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "כדי להסיר בלוק, יש לבחור את הבלוק, ללחוץ על שלוש הנקודות בפינה הימנית התחתונה של הבלוק ולהציג את ההגדרות. במקטע הזה יש לבחור באפשרות להסיר את הבלוק.";
@@ -6075,7 +6522,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "לאשפה";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "הועבר לפח";
 
@@ -6089,6 +6537,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "התנסות והתאמה אישית";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "לנסות שוב";
@@ -6114,6 +6563,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "כדאי לנסות את עורך הבלוקים החדש";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "ניתן לנסות באמצעות כתובת אימייל שונה";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "ניתן לנסות באמצעות כתובת האתר";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "להשבית הצעות כתיבה";
@@ -6156,6 +6611,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "שימוש";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "אי אפשר להתחבר";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "לא ניתן לטעון את הפוסטים";
@@ -6205,6 +6663,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "אין אפשרות לנגן את הווידאו";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "לא ניתן לקרוא את אתר WordPress בכתובת URL זו. יש להקיש על 'נדרשת עזרה נוספת?' כדי להציג את השאלות הנפוצות.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "לא ניתן לשחזר את האתר שלך";
 
@@ -6231,6 +6692,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "אין אפשרות להעלות פוסט אחד עם קובץ אחד";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "אין אפשרות לאמת את כתובת האימייל. יש לנסות שוב מאוחר יותר.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "לא ניתן לבקר בהגדרות של Jetpack לאתר";
@@ -6375,7 +6839,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "העלאה נכשלה";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "הועלה";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6393,7 +6858,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "תבניות שהועלו";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "מעלה";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6408,18 +6874,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "שימוש";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "להשתמש במפתח אבטחה";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "להשתמש בעורך הבלוקים";
 
 /* No comment provided by engineer. */
 "Use icon button" = "הכפתור 'להשתמש בסמל'";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "להשתמש בסיסמה כדי להתחבר";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "שם משתמש";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6434,6 +6909,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "משתמשים";
+
+/* two factor code placeholder */
+"Verification code" = "קוד אימות";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "אימייל האימות נשלח, יש לבדוק את תיבת הדואר הנכנס שלך.";
@@ -6566,8 +7044,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "ספרייה של תוכן WP";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "ממתין להשלמת הפעולה על ידי Google...";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "ממתין לחיבור";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "ממתין למפתח אבטחה";
+
+/* View title during the Google auth process. */
+"Waiting..." = "ממתין...";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6604,6 +7092,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "לא הצלחנו לטעון נתונים";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "זה עתה שלחנו לך הודעת אימייל עם קישור אל %@. יש לבדוק את האפליקציה של האימייל שלך ולהקיש על הקישור כדי להתחבר.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "שלחנו כעת קישור ישיר אל";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "יצרנו בהצלחה גיבוי של האתר שלך לפי הגרסה שלו מתאריך %@";
 
@@ -6613,14 +7107,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "אנחנו משתמשים בכלים למעקב, כולל כלים של צד שלישי. אפשר לקרוא פרטים על אלו על אלו ועל אופן השליטה בהם.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "לא הצלחנו לשלוח אליך אימייל בשלב זה. יש לנסות שוב מאוחר יותר.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "אנחנו נשלח אליך אימייל אם יימצאו איומי אבטחה. בינתיים, אפשר להמשיך להשתמש באתר כרגיל ולחזור לבדוק את ההתקדמות בכל שלב.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "נשלח לך קישור מיוחד להתחברות מיידית, ללא צורך בסיסמה. לא צריך לחפש או לנחש!";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "נשלח אליך אימייל עם קישור להרשמה כדי ליצור את חשבון חדש ב-WordPress.com.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "אנחנו נודיע לך כאשר יש לך עוקבים, תגובות או לייקים חדשים.";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "אנחנו נודיע לך כאשר יהיו לך עוקבים, תגובות או לייקים חדשים. האם ברצונך לאפשר הודעות דחיפה?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "אנחנו נשתמש בכתובת האימייל הזאת כדי ליצור את החשבון החדש שלך ב-WordPress.com.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "אנחנו יוצרים גיבוי להורדה של האתר שלך מתאריך %1$@.";
@@ -6631,6 +7137,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "אנחנו משקיעים המון מאמצים כדי לתקן את האיומים האלה ברקע. בינתיים, אפשר להמשיך להשתמש באתר כרגיל ולחזור לבדוק את ההתקדמות בכל שלב.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "אין אפשרות להתחבר לאתר Jetpack בכתובת URL זו. יש ליצור אתנו קשר לעזרה.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "אנחנו משחזרים את האתר שלך לגרסה מתאריך %1$@.";
 
@@ -6639,6 +7148,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "בנוסף, שלחנו לך הודעת אימייל עם קישור לקובץ שלך.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "שלחנו לך קישור הרשמה ליצירת חשבון WordPress.com חדש. בדוק את האימייל שלך במכשיר הנוכחי, ותקיש על הלינק שקיבלת מ WordPress.com.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6665,6 +7177,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "סיכום שבועי: %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "ברוך בואך אל Jetpack";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "ברוכים הבאים לוורדפרס";
 
 /* A message title */
 "Welcome to the Reader" = "ברוכים הבאים ל-Reader";
@@ -6709,6 +7227,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "מה זה Gravatar?";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "מה זה WordPress.com?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "מהו בלוק?";
 
@@ -6725,10 +7246,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "What's New in Jetpack" = "מה חדש ב-Jetpack";
 
 /* Opens the What's New / Feature Announcement modal */
-"What's New in Reader" = "מה חדש ב-Reader";
-
-/* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "מה חדש בוורדפרס";
+
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "מה כתובת האתר שלי?";
 
 /* Select the site's intent. Title */
 "What's your website about?" = "במה עוסק האתר שלך?";
@@ -6742,6 +7263,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "בעת ביצוע שינויים באתר שלך, אפשר לראות את היסטוריית הפעילות כאן.";
 
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "משהו השתבש ולא ניתן לבצע חיבור לחשבון. יש לנסות שוב!";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "אופס, משהו השתבש. יש לנסות שוב!";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "אופס, נראה שיש לנו כאן מפתח אבטחה לא תקף. נא לנסות שוב עם מפתח אחר";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "הקוד לאימות דו-שלבי אינו תקף. יש לבדוק שוב את הקוד ולנסות שנית!";
+
 /* No comment provided by engineer. */
 "Width Settings" = "הגדרות רוחב";
 
@@ -6754,17 +7287,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "הגדרות האפליקציה של WordPress";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "האפליקציה של WordPress – יישומים לכל סוגי המסכים";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "אתר וורדפרס";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "עזרה של WordPress";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "ספריית המדיה של WordPress";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "הגדרות של הודעות ב-WordPress";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "הודעות WordPress";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "תוספים של WordPress";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "פרופיל WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "WordPress Reader";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "פרטי האתר של WordPress";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "ערכות עיצוב של WordPress";
@@ -6775,17 +7329,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "ריבוי אתרי WordPress אינו נתמך";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress זקוקה להרשאה כדי לגשת למיקום הנוכחי של המכשיר שלך כדי להוסיף אותו לפוסט. יש לעדכן את הגדרות הפרטיות.";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "בסיס של WordPress";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "גרסת וורדפרס ישנה מדי";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "גרסת WordPress ישנה מדי. האתר %1$@ משתמש ב-WordPress בגרסה %2$@. מומלץ לשדרג לגרסה העדכנית ביותר, או לפחות לגרסה %3$@";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "חשבון וורדפרס.קום";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "תוכניות WordPress.com";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "תבניות WordPress.com";
@@ -6816,6 +7379,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "כתיבת פוסט";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "לכתוב תגובה";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "כתוב תגובה...";
 
 /* Title for the writing section in site settings screen */
@@ -6829,6 +7395,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "מיקום של ציר Y";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "שנה";
@@ -6913,6 +7482,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Displayed when the user views trashed in the posts list and there are no posts */
 "You don't have any trashed posts" = "אין לך פוסטים שהועברו לפח";
 
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"You don't have permission to view this private blog." = "אין לך הרשאה להציג את הבלוג הפרטי הזה.";
+
 /* Description for the first domain purchased with a paid plan. */
 "You have a free one-year domain registration with your plan." = "אנחנו מעניקים לך רישום דומיין בחינם לשנה עם התוכנית שלך.";
 
@@ -6928,7 +7500,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "עדיין אין לך תזכורות.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "ביצעת שינויים שלא נשמרו.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -7015,9 +7588,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Help text that describes how the password should be. It appears while editing the password */
 "Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ & )." = "על הסיסמה להיות באורך שישה תווים לפחות. כדי להפוך אותה קשה יותר לפיצוח, כדאי להשתמש באותיות קטנות וגדולות, מספרים וסמלים כגון ! \" ? $ % ^ & ).";
 
-/* Message of Export Content confirmation alert */
-"Your posts, pages, and settings will be mailed to the account's email address." = "הפוסטים, העמודים וההגדרות שלך יישלחו באימייל לכתובת האימייל של החשבון.";
-
 /* Message of Export Content confirmation alert; substitution is user's email address */
 "Your posts, pages, and settings will be mailed to you at %@." = "הפוסטים, העמודים וההגדרות שלך יישלחו באימייל לכתובת %@.";
 
@@ -7026,6 +7596,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "החיפוש שלך כולל תווים שלא נתמכים בדומיינים של WordPress.com. התווים הבאים מותרים: A–Z‏, a–z,‏ 0–9.";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "עם הכניסה לאתר בדפדפן Safari, כתובת האתר שלך תופיע בסרגל העליון של המסך.";
 
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "האתר שלך כבר מוגן באמצעות VaultPress. אפשר למצוא את הקישור ללוח הבקרה של VaultPress למטה.";
@@ -7105,17 +7678,23 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility identifier for an 'Add Comment' button */
 "addCommentButton.accessibilityIdentifity" = "תגובה חדשה";
 
-/* Error message when user cancels login */
-"addSite.selfHosted.cancelled" = "ההתחברות בוטלה";
+/* Error message shown a URL does not point to an existing site. */
+"addSite.restApiNotAvailable" = "כתובת האתר שהזנת אינה עבור אתר ב-WordPress. כדי שנוכל להתחבר לאתר, האתר חייב להשתמש בפלטפורמה של WordPress.";
+
+/* Error message shown when an receiving an invalid application-password authentication result from a self-hosted WordPress site */
+"addSite.selfHosted.authenticationFailed" = "לא ניתן להתחבר באמצעות האימות של 'סיסמאות אפליקציה'.";
 
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "יש להזין את כתובת האתר ב-WordPress שאליו ברצונך להתחבר.";
 
+/* Error message when user input is not a WordPress site */
+"addSite.selfHosted.invalidUrl" = "כתובת האתר אינה תקינה.";
+
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "לא ניתן לטעון את פרטי האתר של WordPress";
 
-/* Error message when user signs in with an unexpected usern. The first argument is the expected username */
-"addSite.selfHosted.mismatchUser" = "יש להיכנס באמצעות המשתמש המחובר. שם משתמש: %@";
+/* Error message shown when application-password authentication is disabled on a self-hosted WordPress site */
+"addSite.selfHosted.noLoginUrlFound" = "עליך להפעיל את האימות של 'סיסמאות אפליקציה' באתר של WordPress.";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "לא ניתן לשמור את אתר WordPress, יש לנסות שוב מאוחר יותר.";
@@ -7123,17 +7702,14 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "להוסיף אתר באחסון עצמי";
 
-/* Error message when XML-RPC is disabled on the WordPress site. The first argument is detailed error message */
-"addSite.selfHosted.xmlrpcDisabled" = "לא ניתן היה להתחבר לאתר WordPress. ייתכן ש-XML-RPC הושבת בשרת. יש לפנות אל ספקית האחסון כדי לפתור את הבעיה.";
+/* Error message when an unknown error occurred when adding a self-hosted site */
+"addSite.selfHosted.unknownError" = "משהו השתבש. יש לנסות שוב.";
 
 /* Age between dates equaling one hour. */
 "an hour" = "שעה אחת";
 
 /* This is the string we display when prompting the user to review the Jetpack app */
 "appRatings.jetpack.prompt" = "מה דעתך על Jetpack?";
-
-/* This is the string we display when prompting the user to review the Reader app */
-"appRatings.reader.prompt" = "מה דעתך על Reader?";
 
 /* This is the string we display when prompting the user to review the WordPress app */
 "appRatings.wordpress.prompt" = "מה דעתך על WordPress?";
@@ -7831,6 +8407,10 @@ Example: Reply to Pamela Nguyen */
 /* A name of the ID field (it's a technical field, has to be short, displayed below everything else) */
 "entityMetadataFooterView.id" = "מזהה";
 
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "example.com";
+
 /* Accept button title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackAccept" = "לשלוח משוב";
 
@@ -7842,9 +8422,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackTitle" = "לשתף משוב";
-
-/* Communicates the future removal of the option to disable the experimental editor, displayed beneath the experimental features list */
-"experimentalFeatures.editorNote" = "'עורך הבלוקים' הניסיוני יהפוך לברירת המחדל בגרסה עתידית והאפשרות להשבית אותו תוסר.";
 
 /* The title for the experimental features list */
 "experimentalFeaturesList.heading" = "תכונות ניסיוניות";
@@ -7891,8 +8468,14 @@ Example: Reply to Pamela Nguyen */
 /* A footer retry button */
 "general.pagingFooterView.retry" = "יש לנסות שנית";
 
+/* Error message format when REST API returns an error response. The first argument is error message. */
+"generic.error.rest-api-error" = "האתר שלך שלח תגובת שגיאה: %@";
+
 /* A generic title for an error */
 "generic.error.title" = "שגיאה";
+
+/* Error message when failing to parse API responses */
+"generic.error.unparsableResponse" = "האתר שלך שלח תגובה שהאפליקציה לא יכולה לעבד";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "להגדיר תזכורת לכתיבת בלוג";
@@ -8064,42 +8647,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title of the Jetpack powered overlay. */
 "jetpack.branding.overlay.title" = "השירות של WordPress טוב יותר עם Jetpack";
-
-/* Title for the button that starts the Jetpack connection process */
-"jetpack.connection.connect.button" = "לחבר את האתר שלך";
-
-/* Error message shown when WordPress.com authentication fails */
-"jetpack.connection.error.authentication" = "חשבון WordPress.com לא תקף";
-
-/* Error message shown when a connection step is attempted in an invalid order */
-"jetpack.connection.error.context" = "שלב זה עדיין לא מוכן";
-
-/* Title for the retry button shown when a connection step fails */
-"jetpack.connection.retry.button" = "לנסות שוב";
-
-/* Status message when a connection step is pending */
-"jetpack.connection.stage.pending" = "ממתין להתחלה";
-
-/* Status message when a connection step is in progress */
-"jetpack.connection.stage.processing" = "בתהליך...";
-
-/* Status message when a connection step is completed successfully */
-"jetpack.connection.stage.success" = "הושלם";
-
-/* Title for the finalization step in Jetpack connection flow */
-"jetpack.connection.step.finalize.title" = "להשלים את החיבור";
-
-/* Title for the install step in Jetpack connection flow */
-"jetpack.connection.step.install.title" = "להתקין את Jetpack";
-
-/* Title for the login step in Jetpack connection flow */
-"jetpack.connection.step.login.title" = "להתחבר ל-WordPress.com";
-
-/* Title for the site connection step in Jetpack connection flow */
-"jetpack.connection.step.site.title" = "להתחבר לאתר שלך";
-
-/* Title for the user connection step in Jetpack connection flow */
-"jetpack.connection.step.user.title" = "להתחבר לחשבון שלך ב-WordPress.com";
 
 /* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
 "jetpack.fullscreen.overlay.early.switch.title" = "לעבור לאפליקציה החדשה של Jetpack";
@@ -8320,41 +8867,11 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "אין לך הרשאה להציג את הבלוג הפרטי הזה.";
 
-/* Button to dismiss the re-authentication view */
-"login.appPasswordReAuth.cancelButton" = "ביטול";
-
-/* Description explaining why the user needs to re-authenticate */
-"login.appPasswordReAuth.description" = "סיסמת האפליקציה שהוקצתה לאפליקציה לא קיימת עוד בפרופיל שלך.\nיש להתחבר שוב כדי ליצור סיסמת אפליקציה חדשה לשימוש האפליקציה.";
-
-/* Button to start the re-authentication process */
-"login.appPasswordReAuth.signInButton" = "התחברות";
-
-/* Title shown when the application password is invalid */
-"login.appPasswordReAuth.title" = "סיסמת האפליקציה לא תקפה";
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "יש להזין את קוד האימות מאפליקציית האימות של החשבון שלך ב-WordPress.com.";
 
 /* Indicating that referrer was marked as spam */
 "marked as spam" = "סומן כ'זבל'";
-
-/* Button title when verification link sending failed */
-"me.verifyEmail.button.retry" = "יש לנסות שוב";
-
-/* Button title to send verification link */
-"me.verifyEmail.button.send" = "לשלוח אימייל מחדש";
-
-/* Button title while verification link is being sent */
-"me.verifyEmail.button.sending" = "שולח...";
-
-/* Button title after verification link is sent */
-"me.verifyEmail.button.sent" = "האימייל נשלח";
-
-/* Message for email verification card */
-"me.verifyEmail.message.noEmail" = "עליך לאמת את כתובת האימייל שלך כדי לאבטח את החשבון ולגשת לאפשרויות נוספות.\nיש לבדוק את תיבת הדואר הנכנס לאימייל האישור, או ללחוץ על ''%@' כדי לקבל הודעה חדשה.";
-
-/* Message for email verification card with email address */
-"me.verifyEmail.message.withEmail" = "עליך לאמת את כתובת האימייל שלך כדי לאבטח את החשבון ולגשת לאפשרויות נוספות.\nיש לבדוק את תיבת הדואר הנכנס בכתובת %1$@ לאימייל האישור, או ללחוץ על '%2$@' כדי לקבל הודעה חדשה.";
-
-/* Title for email verification card */
-"me.verifyEmail.title" = "לאמת את כתובת האימייל שלך";
 
 /* Me tab menu items */
 "meMenu.submitFeedback" = "לשלוח משוב";
@@ -8797,6 +9314,9 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "עמוד הורה";
 
+/* No comment provided by engineer. */
+"password" = "סיסמה";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "הכרטיסים עשויים להציג תוכן שונה בהתאם לפעילות באתר שלך. אנחנו עובדים על הוספה של כרטיסים ופקדים נוספים.";
 
@@ -8901,9 +9421,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Message shown while loading plugin details */
 "pluginDetails.loading" = "טוען את פרטי בדומיין…";
-
-/* Placeholder message shown when a plugin has no description */
-"pluginDetails.noDescription" = "תוסף זה לא סיפק תיאור כלשהו.";
 
 /* Title of the changelog section in plugin details */
 "pluginDetails.section.changelog" = "תיעוד שינויים";
@@ -9193,6 +9710,30 @@ Example: Reply to Pamela Nguyen */
 /* An alert message explaning that by changing the visibility to private, the post will be published immediately to your site */
 "postSettings.warningPostWillBePublishedAlertMessage" = "על ידי שינוי הנראות ל'פרטי', הפוסט יפורסם באופן מיידי";
 
+/* Localized post type: `Page` */
+"postType.page" = "עמוד";
+
+/* Localized post type: `Post` */
+"postType.post" = "פוסט";
+
+/* Details for a 'Private' privacy setting */
+"postVisibility.private.details" = "זמין רק למנהלי האתר ולעורכים";
+
+/* Title for a 'Private' privacy setting */
+"postVisibility.private.title" = "פרטי";
+
+/* Details for a 'Password Protected' privacy setting */
+"postVisibility.protected.details" = "זמין לכולם אבל נדרשת סיסמה";
+
+/* Title for a 'Password Protected' privacy setting */
+"postVisibility.protected.title" = "מוגן בסיסמה";
+
+/* Details for a 'Public' (default) privacy setting */
+"postVisibility.public.details" = "זמין לכולם";
+
+/* Title for a 'Public' (default) privacy setting */
+"postVisibility.public.title" = "ציבורי";
+
 /* Button cancel */
 "postVisibilityPicker.cancel" = "ביטול";
 
@@ -9410,18 +9951,6 @@ Tapping on this row allows the user to edit the sharing message. */
 /* Title for the success view when the user has successfully logged in */
 "qrLoginVerifyAuthorization.completedInstructions.title" = "התחברת בהצלחה לחשבון!";
 
-/* No comment provided by engineer. */
-"reachability-utils.alert.cancel" = "אישור";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.retry" = "לנסות שנית?";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.title" = "אין חיבור";
-
-/* Message of error prompt shown when no internet connection is available */
-"reachability-utils.alert.utils" = "החיבור לאינטרנט לא מחובר.";
-
 /* Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog. */
 "reader.blocked.blog.message" = "הבלוג %@ לא יופיע עוד ב-Reader שלך. יש להקיש כדי לבטל.";
 
@@ -9458,26 +9987,8 @@ Tapping on this row allows the user to edit the sharing message. */
 /* A shared button title for Reader */
 "reader.button.unsubscribe" = "לבטל את ההרשמה";
 
-/* Button title. Follow the comments on a post. */
-"reader.comments.buttonFollow" = "לעקוב";
-
 /* Informational message, should be short. */
 "reader.comments.commentsClosed" = "תוכן זה סגור לתגובות";
-
-/* Empty state view title */
-"reader.comments.emptyStateTitle" = "נשמח לקבל תגובה ראשונה ממך.";
-
-/* Empty state view title */
-"reader.comments.errorLoadingComments" = "אירעה שגיאה לא צפויה בעת טעינת התגובות.";
-
-/* VoiceOver hint */
-"reader.comments.followingSettingAccessibilityIdentifier" = "לפתוח את ההגדרות של ההודעות לעדכונים בפוסט";
-
-/* Error message that informs reader comments from a private blog cannot be fetched. */
-"reader.comments.noPermissionToViewPrivateBlog" = "אין לך הרשאה להציג את הבלוג הפרטי הזה.";
-
-/* Navigation title */
-"reader.comments.title" = "תגובות";
 
 /* Accessibility hint to inform that the author section can be tapped to see posts from the site. */
 "reader.detail.header.authorInfo.a11y.hint" = "מציג פוסטים של האתר";
@@ -9555,23 +10066,8 @@ but tapping on this button will remove their like from the post. */
 /* Screen header details */
 "reader.following.header.details" = "להישאר בעניינים בבלוגים שאליהם נרשמת לקבלת עדכונים.";
 
-/* Empty state view */
-"reader.following.lists.emptyTitle" = "הרשימות ריקות";
-
-/* Screen header details */
-"reader.home.header.details" = "להישאר בעניינים בבלוגים שאליהם נרשמת לקבלת עדכונים.";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.home.title" = "עמוד הבית";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.library.title" = "ספריה";
-
 /* Used in multiple contexts, usually as a screen title */
 "reader.likes.title" = "לייקים";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.lists.title" = "רשימות";
 
 /* Reader logged-out screen details */
 "reader.loggedOut.details" = "יש להתחבר עם חשבון WordPress.com כדי לעקוב אחר הבלוגים המועדפים עליך";
@@ -9808,8 +10304,7 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title of a Reader tab showing Posts matching a user's search query */
 "reader.search.tab.posts" = "פוסטים";
 
-/* Title of the Reader's search feature
-   Used in multiple contexts, usually as a screen title */
+/* Title of the Reader's search feature */
 "reader.search.title" = "חיפוש";
 
 /* Screen title. Reader select interests title label text. */
@@ -9835,6 +10330,21 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Reader select interests title label text */
 "reader.select.tags.title" = "לגלות בלוגים שימצאו חן בעינייך ולעקוב אחריהם";
+
+/* Reader sidebar menu item */
+"reader.sidebar.discover" = "היכרות";
+
+/* Reader sidebar menu item */
+"reader.sidebar.likes" = "לייקים";
+
+/* Reader sidebar menu item */
+"reader.sidebar.recent" = "אחרונים";
+
+/* Reader sidebar menu item */
+"reader.sidebar.saved" = "נשמר";
+
+/* Reader sidebar menu item */
+"reader.sidebar.search" = "חיפוש";
 
 /* Reader sidebar section title */
 "reader.sidebar.section.favorites.title" = "מועדפים";
@@ -9881,7 +10391,7 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Number of subscriptions on a site (singular) */
 "reader.subscriptions.subscriptionsSingular" = "מנוי %@";
 
-/* Used in multiple contexts, usually as a screen title */
+/* Navigation bar title */
 "reader.subscriptions.title" = "מינויים";
 
 /* A suggestion of topics the user might want to subscribe to */
@@ -9923,26 +10433,11 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Verb. Button title. The user is following a tag. */
 "reader.tags.following.button.title" = "עוקב";
 
-/* Used in multiple contexts, usually as a screen title */
-"reader.tags.title" = "תגיות";
-
 /* Accessibility label for unsubscribing from a tag */
 "reader.tags.unfollow.accessibility.label" = "להפסיק את המעקב אחר %@";
 
 /* Field title */
 "reader.userProfile.site" = "אתר";
-
-/* Reader Welcome screen login button */
-"reader.welcome.continueText" = "להמשיך עם WordPress.com";
-
-/* Reader Welcome screen */
-"reader.welcome.subtitle" = "להצטרף לקהילת הבלוגים הגדולה בעולם";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.me" = "אני";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.notifications" = "הודעות";
 
 /* Spoken accessibility label */
 "readerDetail.backButton.accessibilityLabel" = "חזרה";
@@ -10217,14 +10712,10 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Message shown when there are no inactive plugins on the site */
 "site.plugins.empty.inactive" = "אין תוספים לא פעילים";
 
-/* The plugin fillter option for displaying active plugins */
-"site.plugins.filter.option.active" = "פעיל";
-
-/* The plugin fillter option for displaying all plugins */
+/* The plugin fillter option for displaying active plugins
+   The plugin fillter option for displaying all plugins
+   The plugin fillter option for displaying inactive plugins */
 "site.plugins.filter.option.all" = "הכול";
-
-/* The plugin fillter option for displaying inactive plugins */
-"site.plugins.filter.option.inactive" = "לא פעיל";
 
 /* Title of the plugin filter picker */
 "site.plugins.filter.title" = "לסנן";
@@ -10773,9 +11264,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* View title for Help & Support page. */
 "support.title" = "עזרה";
 
-/* Subject of new Zendesk ticket. */
-"support.zendesk.readerAppTicketSubject" = "Reader לתמיכה ב-iOS";
-
 /* Title for placeholder in Tenor picker */
 "tenor.welcomeMessage" = "אפשר לחפש קובצי GIF ולהוסיף אותם לספריית המדיה שלך!";
 
@@ -10924,8 +11412,119 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "סטטוס";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "פוסטים והתוכן הנצפה ביותר מכל הזמנים";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "צפיות מכל הזמנים";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "צפיות ומבקרים מהיום";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "כמות הצפיות הגבוהה בכל הזמנים";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "התוכן הנצפה ביותר";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "לא ניתן לטעון את הנתונים הסטטיסטיים מכל הזמנים.";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "יש ליצור או להוסיף אתר כדי לראות את הנתונים הסטטיסטיים מכל הזמנים.";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "פוסטים";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "אפשר להתעדכן לגבי הפעילות מכל הזמנים באתר שלך ב-WordPress.";
+
+/* Title of all time widget */
+"widget.alltime.title" = "כל הזמנים";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "יש להתחבר לחשבון ב-WordPress כדי להציג את הנתונים הסטטיסטיים מכל הזמנים.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "יש להתחבר לחשבון ב-Jetpack כדי להציג את הנתונים הסטטיסטיים מכל הזמנים.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "יש להתחבר לחשבון ב-Jetpack כדי להציג את הנתונים הסטטיסטיים של השבוע.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "יש להתחבר לחשבון ב-Jetpack כדי להציג את הנתונים הסטטיסטיים של היום.";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "צפיות מכל הזמנים";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "צפיות מהיום";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "לא ניתן לטעון את הנתונים הסטטיסטיים של השבוע.";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "יש ליצור או להוסיף אתר כדי לראות את הנתונים הסטטיסטיים של השבוע.";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "אפשר להתעדכן לגבי כל הפעילות החדשה השבוע באתר שלך ב-WordPress.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "השבוע";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "יש להתחבר לחשבון ב-WordPress כדי להציג את הנתונים הסטטיסטיים של השבוע.";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "תגובות";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "הנתונים הסטטיסטיים עוברים לאפליקציה של Jetpack. ההחלפה היא חינמית ואורכת דקה בלבד.";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = " לייקים";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "אין אפשרות לטעון את הנתונים הסטטיסטיים של האתר.";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "לא ניתן לטעון את הנתונים הסטטיסטיים של היום.";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "יש ליצור או להוסיף אתר כדי לראות את הנתונים הסטטיסטיים של היום.";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "אפשר להתעדכן לגבי כל הפעילות החדשה היום באתר שלך ב-WordPress.";
+
+/* Title of today widget */
+"widget.today.title" = "היום";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "יש להתחבר לחשבון ב-WordPress כדי להציג את הנתונים הסטטיסטיים של היום.";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "התצוגה לא זמינה";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "דפים נצפים";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "מבקרים";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "לייקים ותגובות מהיום";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "צפיות מהיום";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "צפיות ומבקרים מהיום";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "לא יהיה זמין בעתיד.";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "רוצה ליצור אתר חדש?";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "WordPress, עזרה, תמיכה, שאלות נפוצות, שאלות, איתור באגים, קובצי יומן, מרכז העזרה, יצירת קשר";
@@ -10950,6 +11549,9 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Error message that describes an unknown error had occured */
 "wordpress-api.error.unknown" = "משהו השתבש, יש לנסות שוב מאוחר יותר.";
+
+/* Error message when failing to find selected media file on the user's device. */
+"wordpress.api.upload.media.fileNotFound" = "לא ניתן לאתר את קובץ המדיה במכשיר";
 
 /* Jetpack Plugin Modal on WordPress primary button title */
 "wordpress.jetpack.plugin.modal.primary.button.title" = "החלפה לאפליקציה של Jetpack";
@@ -10996,21 +11598,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Error message when user signs in with an unexpected email address. The first argument is the expected email address */
 "wpComLogin.error.mismatchedEmail" = "יש להתחבר עם כתובת האימייל %@";
 
-/* Message shown when user denies WordPress.com login, offering option to try with different account */
-"wpComLogin.loginDenied.message" = "אם יש לך צורך בחשבון אחר, באפשרותך להיכנס באמצעות חשבון אחר. יש להקיש על '%@' כדי להתחיל.";
-
-/* Title of alert shown when user cancels WordPress.com login */
-"wpComLogin.loginDenied.title" = "ההתחברות בוטלה";
-
-/* Button title for signing in with a different WordPress.com account */
-"wpComLogin.loginDenied.useDifferentAccount" = "להשתמש בחשבון אחר";
-
-/* Button title to log out the current WordPress.com account */
-"wpcom.token.alert.button.logout" = "להתנתק";
-
-/* Button title to Sign In to WordPress.com */
-"wpcom.token.alert.button.signin" = "התחברות";
-
 /* Message title to be displayed when the user needs to re-authenticate their WordPress.com account. */
 "wpcom.token.fix.signin" = "התחברות ל-WordPress.com";
 
@@ -11025,6 +11612,9 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "קובץ מצורף לא נתמך";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} התחברות עם Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• דומיינים";

--- a/WordPress/Resources/hr.lproj/Localizable.strings
+++ b/WordPress/Resources/hr.lproj/Localizable.strings
@@ -20,6 +20,9 @@
 /* Empty Post Title */
 "(No Title)" = "(bez naslova)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(bez naslova)";
+
 /* No comment provided by engineer. */
 "Add image or video" = "Dodaj sliku ili video";
 
@@ -35,6 +38,9 @@
 
 /* Title of the completion screen of the Blogging Reminders Settings screen. */
 "All set!" = "Sve je spremno!";
+
+/* the comment has an anonymous author. */
+"Anonymous" = "Anonimno";
 
 /* Approve action. Verb
    Approve comment (verb)
@@ -73,6 +79,7 @@
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -82,6 +89,7 @@
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -100,6 +108,7 @@
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -119,6 +128,7 @@
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Zatvori";
 
@@ -135,6 +145,7 @@
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Komentari";
 
@@ -143,6 +154,9 @@
 
 /* Verb. Title for Jetpack Restore confirm button. */
 "Confirm" = "Potvrdi";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Spajanje sa WordPress.com";
 
 /* Period Stats 'Countries' header */
 "Countries" = "Države";
@@ -168,6 +182,7 @@
 "Dashboard" = "Nadzorna ploča";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Obriši";
@@ -194,7 +209,9 @@
 /* Menus alert button title to discard changes. */
 "Discard Changes" = "Odbaci promjene";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Odbaci";
 
 /* A done button
@@ -212,6 +229,9 @@
 
 /* No comment provided by engineer. */
 "Double tap to add a link." = "Dodirnite dva puta da biste dodali poveznicu.";
+
+/* Name for the status of a draft post. */
+"Draft" = "Skica";
 
 /* Editing GIF alert default action button.
    Edits a Comment
@@ -232,7 +252,10 @@
 /* Title for the editor settings section */
 "Editor" = "Uređivač";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "Adresa E-pošte";
 
 /* Title for the Emoji section */
@@ -248,6 +271,9 @@
    Generic popup title for any type of error. */
 "Error" = "Greška";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Neuspjelo";
+
 /* Label for the Featured Image area in post settings. */
 "Featured Image" = "Istaknuta Slika";
 
@@ -257,6 +283,9 @@
 /* Help button
    Open editor help options */
 "Help" = "Pomoć";
+
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Skriveno";
 
 /* Example post content used in the login prologue screens. */
 "I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next" = "Inspiriran sam radovima fotografa Camerona Karstena. Pokušavat ću primjenjivati te tehnike na svoje sljedeće";
@@ -302,7 +331,8 @@
 /* Left alignment for an image. Should be the same as in core WP. */
 "Left" = "Lijevo";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Poveznica";
 
 /* Loading tags
@@ -312,19 +342,33 @@
    Text displayed while loading time zones */
 "Loading..." = "Učitavam...";
 
-/* Label for logging in to WordPress.com account
+/* Status for Media object that is only exists locally. */
+"Local" = "Lokalno";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Lokacija nepoznata";
+
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Prijavi se";
 
 /* Title of a button for signing in. */
 "Log in" = "Prijava";
+
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Prijava nije uspjela. Molimo pokušajte ponovo.";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of Jetpack?" = "Jeste li sigurni da se želite odjaviti s Jetpacka?";
 
 /* No comment provided by engineer. */
 "Logs" = "Zapisnici";
+
+/* Title of a button. */
+"Lost your password?" = "Izgubili ste lozinku?";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Glavni izbornik";
@@ -369,7 +413,9 @@
 "Newest" = "Najnovije";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Sljedeće";
 
 /* Label for a cancel button */
@@ -395,7 +441,12 @@
    Title of the 'Notifications' tab - used for spotlight indexing on iOS. */
 "Notifications" = "Obavijesti";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -421,20 +472,30 @@
 /* Title for selecting parent category of a category */
 "Parent Category" = "Matična Kategorija";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Lozinka";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Na čekanju";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Čeka recenziju";
 
 /* Label for date periods. */
 "Period" = "Vremensko razdoblje";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Molimo unesite vaše podatke";
+
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Molimo vas da popunite sva polja";
 
 /* Header of section in Plugin Directory showing popular plugins
    Screen title, where users can see the most popular plugins */
@@ -458,12 +519,19 @@
 /* Title of button that displays the App's privacy policy */
 "Privacy Policy" = "Pravila privatnosti";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Privatno";
+
 /* Label for the publish (verb) button. Tapping publishes a draft post.
    Publish post action on share extension site picker screen.
    Section title for the publish table section in the blog details screen */
 "Publish" = "Objavi";
 
-/* Period Stats 'Published' header
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Objavi Odmah";
+
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Objavljeno";
 
@@ -498,11 +566,15 @@
    User action to retry media upload. */
 "Retry" = "Pokušaj Ponovno";
 
+/* No comment provided by engineer. */
+"Retry?" = "Pokušati Ponovno?";
+
 /* Right alignment for an image. Should be the same as in core WP. */
 "Right" = "Desno";
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -515,7 +587,8 @@
 /* Title for a notice informing the user their scan has completed */
 "Scan Finished" = "Skeniranje završeno";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Tempirano";
 
 /* Title of Stats section that shows search engine referrer traffic. */
@@ -532,6 +605,12 @@
    Title for screen that allows configuration of your blog/site settings.
    Title for the Jetpack Security Settings Screen */
 "Settings" = "Postavke";
+
+/* Spoken accessibility label */
+"Share" = "Podijeli ";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Registracija";
 
 /* Header for a single site, shown in Notification user profile. */
 "Site" = "Sjedište";
@@ -561,7 +640,8 @@
    Theme Support action title */
 "Support" = "Podrška";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Tag";
 
 /* Label for selecting the blogs tags
@@ -583,6 +663,9 @@
 /* Message informing the user that posts page cannot be edited */
 "The content of your latest posts page is automatically generated and cannot be edited." = "Sadržaj najnovijih objava je automatski stvoren te se ne može uređivati.";
 
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "Izgleda da nema internet konekcije.";
+
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Web stranica na %1$@ koristi WordPress %2$@. Preporučamo da ažurirate na najnoviju inačicu, ili barem %3$@";
 
@@ -590,6 +673,9 @@
    Themes option in the blog details
    Title of Themes browser page */
 "Themes" = "Teme";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "Pojavila se greška prilikom učitavanja plana";
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
@@ -607,6 +693,7 @@
 "Trust" = "Vjeruj";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Pokušajte ponovno";
@@ -653,18 +740,23 @@
    Updating label title */
 "Updating" = "Ažuriranje ";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Preneseno";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Prenosim";
 
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Korisničko ime";
 
 /* Description for the version label in the What's new page. */
@@ -701,6 +793,9 @@
 /* Example Reader feed title */
 "Web News" = "Web novosti";
 
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Dobro došli u WordPress";
+
 /* No comment provided by engineer. */
 "What is alt text?" = "Što je alternativni tekst?";
 
@@ -709,6 +804,9 @@
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "WordPressov blog";
+
+/* Siri Suggestion to open Support */
+"WordPress Help" = "WordPressova pomoć";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "WordPress inačica prestara";
@@ -730,7 +828,8 @@
 /* Prompt shown on the completion screen of the Blogging Reminders Settings screen. */
 "You can update this any time via My Site > Site Settings" = "Ovo možete ažurirati bilo kada preko Moje sjedište > Postavke sjedišta";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Imate izmjene koje nisu snimljene.";
 
 /* Example Likes notification displayed in the prologue carousel of the app. Number of likes should marked with * characters and will be displayed as bold text. */
@@ -747,4 +846,22 @@
 
 /* This text is required by Apple to be part of the translations but is not shown to the users. You can use the English version verbatim without translation for this entry. */
 "ios-widget.tVvJ9c" = "Select Site Intent";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Postovi";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Komentari";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Likes";
+
+/* Title of today widget */
+"widget.today.title" = "Danas";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Pregledi";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Posjetitelji";
 

--- a/WordPress/Resources/hu.lproj/Localizable.strings
+++ b/WordPress/Resources/hu.lproj/Localizable.strings
@@ -6,11 +6,17 @@
 /* Empty Post Title */
 "(No Title)" = "(Nincs cím)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(nincs cím)";
+
 /* No comment provided by engineer. */
 "Activity Logs" = "Tevékenységi napló";
 
 /* Title for the advanced section in site settings screen */
 "Advanced" = "Haladó";
+
+/* the comment has an anonymous author. */
+"Anonymous" = "Névtelen";
 
 /* Approve action. Verb
    Approve comment (verb)
@@ -36,6 +42,7 @@
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -45,6 +52,7 @@
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -63,6 +71,7 @@
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -85,6 +94,7 @@
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Bezár";
 
@@ -101,6 +111,7 @@
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Hozzászólások";
 
@@ -110,9 +121,15 @@
 /* Verb. Title for Jetpack Restore confirm button. */
 "Confirm" = "Megerősítés";
 
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Kapcsolódás a WordPress.com-hoz";
+
 /* Label for list of countries.
    Register Domain - Domain contact information field Country */
 "Country" = "Ország";
+
+/* The button title text for creating a new account. */
+"Create Account" = "Fiók létrehozása";
 
 /* No comment provided by engineer. */
 "Current" = "Jelenlegi";
@@ -121,6 +138,7 @@
 "Dashboard" = "Vezérlőpult";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Törlés";
@@ -135,7 +153,9 @@
    Menus button title for canceling/discarding changes made. */
 "Discard" = "Elvet";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Elutasítás";
 
 /* A done button
@@ -150,6 +170,9 @@
    Title for button that will dismiss this view
    Title for the button that will dismiss this view. */
 "Done" = "Kész";
+
+/* Name for the status of a draft post. */
+"Draft" = "Vázlat";
 
 /* Editing GIF alert default action button.
    Edits a Comment
@@ -176,7 +199,10 @@
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "E-mail cím";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "E-mail cím";
 
 /* Message to show to user when he tries to add a self-hosted site that is an empty URL. */
@@ -192,15 +218,27 @@
    Generic popup title for any type of error. */
 "Error" = "Hiba";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Sikertelen";
+
 /* Label for the Featured Image area in post settings. */
 "Featured Image" = "Kiemelt kép";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "Követés";
 
 /* Label for number of followers. */
 "Followers" = "Követők";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Fiók információk beszerzése";
+
 /* Help button
    Open editor help options */
 "Help" = "Segítség";
+
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Rejtett";
 
 /* No comment provided by engineer. */
 "Hide keyboard" = "Billentyűzet elrejtése";
@@ -259,12 +297,20 @@
    Text displayed while loading time zones */
 "Loading..." = "Betöltés...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Helyi";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Ismeretlen helyzet";
+
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Naplófájlok létrehozás szerint";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Bejelentkezés";
 
 /* Title of a button for signing in. */
@@ -272,6 +318,9 @@
 
 /* No comment provided by engineer. */
 "Logs" = "Naplózás";
+
+/* Title of a button. */
+"Lost your password?" = "Elfelejtett jelszó";
 
 /* Button leading to a screen where users can manage their installed plugins
    Screen title, where users can see all their installed plugins.
@@ -309,7 +358,9 @@
 "New Post" = "Új bejegyzés";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Következő";
 
 /* Label for a cancel button */
@@ -344,7 +395,12 @@
    Title of the 'Notifications' tab - used for spotlight indexing on iOS. */
 "Notifications" = "Értesítések";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -370,14 +426,21 @@
 /* Title for selecting parent category of a category */
 "Parent Category" = "Szülő kategória";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Jelszó";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Függőben Lévő";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Ellenőrzésre vár";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "Adjuk meg honlap címét!";
@@ -385,11 +448,14 @@
 /* No comment provided by engineer. */
 "Please enter a username." = "Adjuk meg a felhasználónevet!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Adjunk meg valós e-mail címet!";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Kérlek, add meg a bejelentkezési adataid";
+
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Töltsünk ki minden mezőt";
 
 /* Prompt for the user to retry a failed action again later */
 "Please try again later." = "Próbáljuk meg később.";
@@ -418,12 +484,19 @@
 /* Title of button that displays the App's privacy policy */
 "Privacy Policy" = "Adatvédelmi irányelvek";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Magánjellegű";
+
 /* Label for the publish (verb) button. Tapping publishes a draft post.
    Publish post action on share extension site picker screen.
    Section title for the publish table section in the blog details screen */
 "Publish" = "Közzététel";
 
-/* Period Stats 'Published' header
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Azonnali közzététel";
+
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Közzétéve";
 
@@ -463,8 +536,12 @@
    User action to retry media upload. */
 "Retry" = "Újra";
 
+/* No comment provided by engineer. */
+"Retry?" = "Újra?";
+
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -474,7 +551,8 @@
 /* Menus save button title while it is saving a Menu. */
 "Saving..." = "Mentés...";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Ütemezve";
 
 /* Title of Stats section that shows search engine referrer traffic. */
@@ -485,6 +563,9 @@
    Title for screen that allows configuration of your blog/site settings.
    Title for the Jetpack Security Settings Screen */
 "Settings" = "Beállítások";
+
+/* Spoken accessibility label */
+"Share" = "Megosztás";
 
 /* Title for the Language Picker View */
 "Site Language" = "Honlap nyelve";
@@ -516,7 +597,7 @@
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Sajnos, a honlap címben betűknek is lennie kell!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Sajnos, ez az e-mail cím már használatban van!";
 
 /* No comment provided by engineer. */
@@ -585,6 +666,9 @@
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "Úgy tűnik, hogy nincs internetkapcsolat.";
 
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "Az internet kapcsolat megszakadt.";
+
 /* No comment provided by engineer. */
 "The site address must be shorter than 64 characters." = "A címnek 64 karakternél rövidebbnek kell lennie.";
 
@@ -604,6 +688,7 @@
 "Today" = "Ma";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Próbáljuk újra";
@@ -633,18 +718,23 @@
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Sikertelen feltöltés";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Feltöltve";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Feltöltés";
 
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Felhasználónév";
 
 /* No comment provided by engineer. */
@@ -681,6 +771,9 @@
    Today's Stats 'Visitors' label */
 "Visitors" = "Látogatók";
 
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Üdvözöl a WordPress";
+
 /* No comment provided by engineer. */
 "WordPress version too old" = "A WordPress verziója túl régi";
 
@@ -698,7 +791,8 @@
 /* No comment provided by engineer. */
 "You cannot use that email address to signup. We are having problems with them blocking some of our email. Please use another email provider." = "Ez az e-mail cím nem használható. Ugyanis, ennél a szolgáltatónál fennakadnak az általunk külödött levelek. Válasszunk másik e-mail szolgáltatót.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Nem mentett változtatások vannak.";
 
 /* (placeholder) Help the user enter a URL into the field */
@@ -709,4 +803,22 @@
 
 /* This text is required by Apple to be part of the translations but is not shown to the users. You can use the English version verbatim without translation for this entry. */
 "ios-widget.tVvJ9c" = "Select Site Intent";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Bejegyzések";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Hozzászólások";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Likes";
+
+/* Title of today widget */
+"widget.today.title" = "Ma";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Megtekintések";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Látogatók";
 

--- a/WordPress/Resources/id.lproj/Localizable.strings
+++ b/WordPress/Resources/id.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Translation-Revision-Date: 2025-05-13 10:54:07+0000 */
+/* Translation-Revision-Date: 2025-03-11 11:54:07+0000 */
 /* Plural-Forms: nplurals=2; plural=n > 1; */
 /* Generator: GlotPress/4.0.1 */
 /* Language: id */
@@ -98,6 +98,9 @@
 
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "%1$@ dari %2$@ di situs Anda";
+
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "%1$@ dari %2$@ digunakan di situs Anda";
 
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ kuadriliun";
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Tidak Berjudul)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(tanpa judul)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*Johan Brandt* menanggapi pos Anda";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "Tombol \"lagi\" berisi menu buka bawah yang menampilkan tombol berbagi";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "Akun WordPress.com terhubung ke kredensial toko Anda. Untuk melanjutkan, kami akan mengirimkan tautan verifikasi ke alamat email di atas.";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "Sebuah file mengandung pola kode berbahaya";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "Judul untuk situs";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "Alamat email valid diperlukan untuk mengirimkan tautan autentikasi. Kembali ke layar sebelumnya dan berikan alamat email yang valid.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "Kode verifikasi hanya berisi angka.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "AKTIF";
@@ -334,9 +349,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* My Profile 'About me' label */
 "About Me" = "Tentang Saya";
-
-/* Link to About screen for Jetpack for iOS */
-"About Reader for iOS" = "Tentang Pembaca untuk iOS";
 
 /* Link to About screen for WordPress for iOS */
 "About WordPress" = "Tentang WordPress";
@@ -525,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "Setelah %@";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "Perataan";
@@ -588,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "Alamat IP yang diizinkan";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "Hampir selesai! Masukkan kode verifikasi dari aplikasi pengautentikasi.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Teks Alt";
@@ -600,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "Atau, Anda dapat meratakan konten dengan membatalkan pengelompokan blok.";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "Atau, Anda bisa memasukkan kata sandi untuk akun ini.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "Atau:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "Selalu Kirim Log Crash";
@@ -621,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "Diperlukan koneksi internet yang aktif untuk melihat aktivitas";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "Diperlukan koneksi internet yang aktif untuk melihat paket";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -671,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "Statistik Situs Tahunan";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "Anonim";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "Jawaban";
 
@@ -692,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "Tampilan";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "Autentikasi Apple gagal.\nPastikan Anda masuk ke iCloud dengan ID Apple yang menggunakan autentikasi dua faktor.";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "Menerapkan pengaturan";
@@ -778,6 +811,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "Autentikasi Gagal";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "Kode autentikasi";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "Autentikasi diperlukan untuk host: %@";
@@ -888,6 +925,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "Jadilah yang pertama memberi komentar";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Jadilah yang pertama berkomentar.";
 
 /* Beauty site intent topic */
 "Beauty" = "Kecantikan";
@@ -1024,12 +1064,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button to copy post text" = "Tombol untuk menyalin teks pos";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "Dengan melanjutkan, Anda menyetujui _Ketentuan Layanan_ kami.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "Dengan mendaftarkan domain ini, Anda menyetujui <a>Syarat dan Ketentuan<\/a>.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "Dengan menyiapkan Jetpack, Anda menyetujui\n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "Dengan mendaftar, berarti Anda menyetujui _Ketentuan Layanan_ kami.";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "SESUAIKAN";
@@ -1043,6 +1089,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "Akses kamera diperlukan untuk memindai kode login";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Tidak Dapat Meminta Tautan";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "Tidak dapat memublikasikan halaman kosong";
 
@@ -1052,6 +1101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1061,6 +1111,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1079,6 +1130,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1106,6 +1158,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "Membatalkan...";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "Tidak dapat mengakses situs dengan alamat ini. Periksa lagi lalu coba lagi.";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Bingung memilih? Anda dapat mengganti tema kapan saja.";
 
@@ -1113,7 +1168,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Keterangan";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Hati-hati!";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1122,7 +1178,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Kategori-kategori";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Kategori";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1171,6 +1228,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "Cek tips terbaik kami untuk meningkatkan pratinjau dan kunjungan Anda";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "Periksa email Anda di perangkat ini!";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Periksa e-mail Anda di perangkat ini, dan klik tautan pada e-mail yang Anda terima dari WordPress.com";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "Periksa e-mail Anda di perangkat ini, dan klik tautan pada e-mail yang Anda terima dari WordPress.com\n\nTidak melihat e-mailnya? Periksa folder Spam atau Sampah.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "Periksa email Anda!";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "Periksa koneksi internet Anda dan muat ulang halaman.";
@@ -1267,6 +1336,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "Klaim domain gratis Anda";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "Blog Klasik";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "Hapus Cache Media Perangkat";
 
@@ -1294,6 +1366,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Tutup";
 
@@ -1335,6 +1408,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "Pengaturan Kolom";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Komik";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1386,6 +1462,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Komentar-komentar";
 
@@ -1453,12 +1530,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Akun yang Terhubung";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Terhubung, Tetapi…";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "Menghubungkan %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Menghubungkan %1$@ akan mengganti koneksi yang ada menjadi %2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Menghubungkan ke WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Menghubungkan...";
@@ -1489,8 +1572,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "Hubungi kami di %@";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "Struktur Konten\nBlok: %1$li, Kata: %2$li, Karakter: %3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1505,6 +1592,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Lanjutkan membaca";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Lanjutkan dengan Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Lanjutkan dengan Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Melanjutkan dengan Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "Kontribusi";
@@ -1633,6 +1729,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "Buat";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Ciptakan Akun";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "Buat Halaman Kosong";
 
@@ -1653,6 +1752,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "Buat Pos";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "Buat Situs";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "Buat Tag";
@@ -1686,6 +1788,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "Saat ini";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Paket Saat Ini";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Tema Saat Ini";
@@ -1788,6 +1893,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "Kategori Default";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Menu Default";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Format Pos Default";
@@ -1796,6 +1904,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "Default untuk Pos Baru";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Hapus";
@@ -1853,6 +1962,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "Rincian";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "Tidak ingin membuat akun baru? Silakan kembali dan masukkan lagi alamat email Anda.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "Dimensi";
 
@@ -1900,7 +2012,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "Diskusi";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Hentikan";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1922,6 +2036,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "Domain";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "Belum memiliki akun? _Daftar_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2051,6 +2168,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "Unduhan";
 
+/* Name for the status of a draft post. */
+"Draft" = "Draf";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Konsep";
 
@@ -2160,7 +2280,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "Alamat Surel";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "Alamat email";
 
 /* Notification Settings Channel */
@@ -2244,8 +2367,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Masukkan kata sandi";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "Masukkan alamat situs WordPress yang ingin Anda hubungkan.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Masukkan kata sandi akun WordPress.com Anda.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Masukkan nama pengguna";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "Masukkan informasi akun Anda untuk %@.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "Masukkan alamat email Anda untuk login atau membuat akun WordPress.com.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "Masukkan alamat situs Anda saat ini";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "Masukkan kata sandi saja.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "Masukkan kredensial server Anda";
@@ -2408,6 +2551,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "Eksternal";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Gagal";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "Gagal menandai Pemberitahuan sebagai sudah dibaca";
 
@@ -2419,9 +2565,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Failed to insert media.\nTap for more info." = "Gagal menyisipkan media.\nKetuk untuk info selengkapnya.";
-
-/* A message indicating that we couldn't load the user's settings. */
-"Failed to load settings" = "Gagal memuat pengaturan";
 
 /* No comment provided by engineer. */
 "Failed to save files.\nPlease tap for options." = "Gagal menyimpan file.\nKetuk untuk melihat pilihan.";
@@ -2437,6 +2580,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "Gaya";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "Unggulan";
@@ -2495,6 +2641,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "Cari tahu selengkapnya";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Temukan alamat situs Anda";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2517,6 +2666,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "Memperbaiki Ancaman";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "Ikuti";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "Ikuti Percakapan";
@@ -2611,6 +2763,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "Hasilkan tautan baru";
 
+/* View title for initial auth views. */
+"Get Started" = "Memulai";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "Dapatkan tautan login lewat email";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "Aktiflah! Komentari pos dari blog yang Anda ikuti.";
 
@@ -2632,8 +2790,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "Dapatkan Inspirasi";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Mencari informasi akun";
+
+/* Cancel */
+"Give Up" = "Menyerah";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "Cobalah dengan menambahkan beberapa blok ke artikel atau halaman Anda!";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "Buka Pembaca";
@@ -2644,6 +2811,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "Buka Pengaturan iOS";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Pendaftaran Google gagal.";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2718,6 +2888,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "Ikon bantuan";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Tersembunyi";
+
 /* Title of a button used to collapse a group */
 "Hide" = "Sembunyikan";
 
@@ -2786,6 +2959,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "Pembaruan ikon gagal";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "Jika tidak dapat menemukan emailnya, periksa tong sampah atau folder email spam Anda";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "Jika Anda melanjutkan dengan Apple atau Google dan belum memiliki akun WordPress.com, Anda akan membuat akun dan menyetujui _Ketentuan Layanan_ kami.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "Jika Anda menghapus %1$@, pengguna itu tak lagi bisa mengakses situs ini, tetapi segala konten yang dibuat oleh %2$@ tetap ada di situs.";
@@ -2861,6 +3040,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "Mencakup wp-config php dan file apa pun selain WordPress";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Nama pengguna atau kata sandi salah. Silakan coba masukkan rincian masuk Anda kembali.";
 
 /* Title for a threat */
 "Infected core file" = "File inti yang terinfeksi";
@@ -2962,6 +3144,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "Memperkenalkan Prompt Blogging";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "Alamat Email Tidak Valid";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "Alamat Situs Tak Sah";
 
@@ -2979,6 +3164,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "URL tidak valid. Berkas audio tidak ditemukan.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "URL tidak valid. Periksa lagi lalu coba lagi.";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "URL tidak valid. Silakan masukkan URL yang benar.";
@@ -3000,6 +3188,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "Undang Orang-orang";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "Sepertinya nama pengguna\/kata sandi ini tidak terkait dengan situs ini.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "Sepertinya Anda memasukkan kata sandi yang salah. Ingin mencoba lagi?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "Waktunya menulis pos pada %@!";
@@ -3228,7 +3422,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "Ketinggian Baris";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Tautan";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3290,6 +3485,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "Memuat Orang-orang...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Memuat Paket...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Memuat paket...";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "Memuat Plugin...";
 
@@ -3324,11 +3525,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "Memuat...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Lokal";
+
 /* Local Services site intent topic */
 "Local Services" = "Layanan lokal";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "Perubahan lokal";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Lokasi";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Layanan Lokasi harus diaktifkan sebelum WordPress dapat menambahkan lokasi terkini Anda. Harap aktifkan Layanan Lokasi dari aplikasi Pengaturan.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Lokasi tidak diketahui";
 
 /* No comment provided by engineer. */
 "Lock icon" = "Ikon kunci";
@@ -3336,9 +3549,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Log File Berdasarkan Tanggal Pembuatan";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Masuk";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3348,17 +3563,33 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of a button for signing in. */
 "Log in" = "Login";
 
-/* LogOut confirmation text, whenever there are no local changes */
-"Log out of Jetpack?" = "Logout dari Jetpack?";
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Login gagal. Silakan coba lagi.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "Login atau daftar dengan WordPress.com";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Login ke akun WordPress.com yang Anda gunakan untuk menghubungkan Jetpack.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "Login ke akun WordPress.com Anda dengan alamat email.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "Login dengan nama pengguna dan kata sandi WordPress.com Anda.";
 
 /* LogOut confirmation text, whenever there are no local changes */
-"Log out of Reader?" = "Logout dari Pembaca?";
+"Log out of Jetpack?" = "Logout dari Jetpack?";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of WordPress?" = "Logout dari WordPress?";
 
 /* Login Request Expired */
 "Login Request Expired" = "Permintaan Masuk Kedaluwarsa";
+
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "Login dengan kata sandi akun";
 
 /* No comment provided by engineer. */
 "Logs" = "Log";
@@ -3368,6 +3599,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Sepertinya Anda telah menyiapkan Jetpack di situs Anda. Selamat! Login dengan kredensial WordPress.com Anda untuk mengaktifkan Statistik dan Pemberitahuan.";
+
+/* Title of a button. */
+"Lost your password?" = "Lupa sandi Anda?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "Mail (Asal)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Navigasi Utama";
@@ -3515,6 +3752,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "Pesan";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "Kerentanan lain-lain";
 
@@ -3610,6 +3850,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "Situs Saya";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "Situs Saya di WordPress";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "Sepuluh Kafe Favorit Saya";
 
@@ -3649,8 +3892,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Butuh Bantuan?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "Perlu bantuan untuk menemukan alamat situs Anda?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "Perlu bantuan?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Butuh bantuan lebih lanjut?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "Perlu Pembaruan";
@@ -3679,6 +3929,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "Postingan Baru";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Item baru";
+
 /* Placeholder text for password field */
 "New password" = "Kata sandi baru";
 
@@ -3696,7 +3949,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "Berita";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Lanjut";
 
 /* Accessibility label for the next notification button */
@@ -3732,6 +3987,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "Tidak tersedia URL Pratinjau";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "Tanpa Judul";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "Tidak ada aktivitas";
 
@@ -3764,7 +4022,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "Belum ada komentar";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "Tak ada koneksi";
 
@@ -3913,6 +4172,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "Jangan sekarang";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "Tidak melihat e-mailnya? Periksa folder Spam atau Sampah.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "Catatan:";
 
@@ -3976,7 +4238,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Daftar Bernomor";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -4033,7 +4300,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "Aduh";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Maaf!";
 
 /* No comment provided by engineer. */
@@ -4048,7 +4316,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "Buka pengaturan Jetpack Security";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Buka Email";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Buka Pengaturan";
 
 /* No comment provided by engineer. */
@@ -4066,6 +4339,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "Buka tautan di jendela\/tab baru";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "Buka pengaturan langganan untuk pos";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "Buka Bagian Me";
 
@@ -4080,6 +4356,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "Opsional: Masukkan pesan khusus hingga %1$d karakter untuk disertakan dalam undangan Anda.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "Atau";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "Atau pilih bentuk autentikasi lainnya.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "Atau login dengan _memasukkan alamat situs Anda_.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "Atau login dengan tautan ajaib";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Daftar Berurutan";
@@ -4128,7 +4416,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "Padding";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Halaman";
 
@@ -4161,8 +4450,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "Pengasuhan";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Kata sandi";
 
@@ -4179,8 +4471,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "Tempel blok setelah";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Tertunda";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Menunggu ulasan";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4211,6 +4507,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "Pilih nama pengguna";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Paket";
+
 /* User action to play a video on the editor. */
 "Play video" = "Putar Video";
 
@@ -4240,6 +4540,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "Pastikan editor blok di situs Anda sudah diaktifkan. Jika belum diaktifkan, editor blok tidak akan termuat.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "Masukkan alamat situs web lengkap, seperti contoh.com.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "Silahkan masukkan alamat situs.";
@@ -4274,11 +4577,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "Harap masukkan alamat yang valid";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "Harap masukkan alamat email yang valid untuk akun WordPress.com.";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Silahkan masukkan alamat surel yang sah.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "Masukkan nomor telepon yang valid";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Masukkan kata sandi akun WordPress.com Anda untuk login dengan ID Apple.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Masukkan kredensial Anda";
@@ -4286,8 +4595,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Masukkan alamat email Anda.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Silahkan isi semua ruas";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Buka aplikasi WordPress, login ke WordPress.com, pastikan Anda memiliki setidaknya satu situs, lalu coba lagi.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "Harap logout sebelum menyambungkan ke situs wordpress.com lain";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "Nanti silakan dicoba lagi";
@@ -4355,7 +4670,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "Bahasa populer";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Postingan";
 
@@ -4476,6 +4792,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "Pemberitahuan privasi untuk pengguna di California";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Privat";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "Terjadi masalah saat menampilkan blok \nTap to attempt block recovery.";
 
@@ -4490,6 +4809,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "Terdapat masalah saat membeli domain Anda. Coba lagi.";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Melanjutkan tindakan ini akan menghapus semua data WordPress.com dari perangkat ini, dan menghapus semua draf yang disimpan secara lokal. Anda tidak akan kehilangan apa pun yang sudah disimpan di blog WordPress.com.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Proyek";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "Prompt dilewati";
@@ -4507,13 +4832,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "Tanggal Publikasi";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Terbitkan Segera";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "Menerbitkan halaman pada:";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "Terbitkan pos di:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Dipublikasikan";
 
@@ -4715,7 +5044,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "Balasan";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Teks Jawab";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "Balas ke %1$@";
 
 /* An explaination of a setting. */
@@ -4744,6 +5078,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "Atur ulang penyaringan Rentang Tanggal";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Reset kata sandi";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Ubah Ukuran & Potong";
@@ -4801,6 +5138,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "Coba lagi semuanya";
 
+/* No comment provided by engineer. */
+"Retry?" = "Ulang?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "Kembali ke pos";
 
@@ -4830,6 +5170,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "Peran";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS Terkirim";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "STATUS";
 
@@ -4841,6 +5184,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4907,7 +5251,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "Memindai berkas";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Terjadwal";
 
 /* No comment provided by engineer. */
@@ -5047,6 +5392,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "Pilih topik ini sebagai tema situs Anda.";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Kirim Tautan";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "Kirim Tautan Lewat Email";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "Kirimkan Pesan Log";
 
@@ -5055,6 +5406,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "Kirim Uji Crash";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "Kirim tautan verifikasi email";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "Mengirim pemberitahuan melalui email";
@@ -5101,11 +5455,11 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Message to show when setting save failed */
 "Settings update failed" = "Pembaruan pengaturan gagal";
 
-/* Title for a button that recommends the app to others */
-"Share Jetpack with a friend" = "Rekomendasikan Jetpack pada teman";
+/* Spoken accessibility label */
+"Share" = "Sebarkan";
 
 /* Title for a button that recommends the app to others */
-"Share Reader with a friend" = "Berbagi Pembaca dengan teman";
+"Share Jetpack with a friend" = "Rekomendasikan Jetpack pada teman";
 
 /* Title for a button that recommends the app to others */
 "Share WordPress with a friend" = "Bagikan WordPress dengan teman";
@@ -5156,6 +5510,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "Tampilkan tombol Blog Ulang";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "Tampilkan kata sandi";
+
 /* No comment provided by engineer. */
 "Show post content" = "Tampilkan konten pos";
 
@@ -5167,6 +5525,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "Menampilkan statistik untuk:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "Ditampilkan";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Ditampilkan secara publik saat Anda mengomentari blog.";
@@ -5182,6 +5543,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "Menampilkan pos";
+
+/* View title during the sign up process. */
+"Sign Up" = "Mendaftar";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "Login dengan kredensial situs";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Mendaftar";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Mendaftar WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Daftar dengan Email";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "Karena menggunakan paket gratis, Anda akan melihat sedikit kejadian di Log Aktivitas Anda.";
@@ -5220,6 +5596,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Prestasi situs";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Alamat situs";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "Alamat situs harus minimal 4 karakter.";
@@ -5304,7 +5683,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Maaf, alamat situs harus mengandung huruf juga!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Maaf, alamat surel tersebut sudah terpakai!";
 
 /* No comment provided by engineer. */
@@ -5364,6 +5743,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "Spam";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "Tingkatkan kecepatan situs Anda";
@@ -5389,6 +5771,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "Status";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "Beranda Statis";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5419,6 +5804,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "Coretan";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Stub";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "Kirim untuk Ditinjau";
@@ -5509,7 +5897,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "Tablet";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Tag";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5644,6 +6033,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Pernyataan Layanan";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Testimoni";
+
 /* Title of a button style */
 "Text Only" = "Hanya Teks";
 
@@ -5653,8 +6045,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "Kontrol pemformatan teks terletak di dalam bilah peralatan yang ada di atas keyboard saat menyunting blok teks";
 
+/* Button title */
+"Text me a code instead" = "Kirimi saya kode saja";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "Kirimkan kode melalui SMS";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Terima kasih telah memilih %1$@ dari %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "Sepertinya itu bukan kode verifikasi yang valid.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "Sepertinya itu bukan situs WordPress.";
@@ -5676,6 +6077,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "Koneksi Facebook tidak dapat menemukan Halaman apa pun. Publikasikan tidak dapat terhubung ke Profil Facebook, hanya Halaman yang dipublikasikan.";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "Akun Google \"%@\" tidak cocok dengan akun apa pun di WordPress.com";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "Sepertinya koneksi Internet-nya terputus.";
@@ -5715,6 +6119,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "Gambar tidak bisa ditambahkan ke Pustaka Media.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "Sepertinya koneksi internet-nya terputus.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "Berbagai macam situs yang dapat dibuat";
@@ -5758,6 +6165,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Situs di %1$@ menggunakan WordPress %2$@. Kami merekomendasikan agar diperbarui ke versi terbaru, atau sekurang-kurangnya %3$@";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "Situs di alamat ini bukan situs WordPress. Agar kami dapat menghubungkannya, situs harus menggunakan WordPress.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "Situs tidak dapat dihapus.";
 
@@ -5799,6 +6210,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "Telah terjadi kesalahan yang tidak terduga saat menyunting komentar Anda";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "Terjadi error yang tidak terduga saat memuat komentar.";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "Terjadi error yang tidak terduga saat mendaftarkan domain Anda";
 
@@ -5807,6 +6221,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "Terjadi kesalahan yang tidak terduga saat memperbarui Pengaturan Pemberitahuan";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "Terjadi kesalahan yang tidak terduga saat memperbarui komentar Anda";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "Terjadi error yang tidak diharapkan.";
@@ -5828,6 +6245,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "Ada kendala saat berkomunikasi dengan situs.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "Ada masalah saat berusaha terhubung dengan WordPress.com. Silakan login lagi.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "Ada masalah saat menampilkan pos ini.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "Terjadi masalah saat memuat data Anda, segarkan halaman untuk mencoba lagi.";
 
@@ -5837,12 +6260,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "Ada masalah saat menyimpan perubahan untuk manajemen berbagi.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "Ada masalah saat mencoba mengakses lokasi Anda. Harap coba lagi nanti.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "Terjadi error ketika mengganti kata sandi";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "Ada error saat memuat aktivitas";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "Ada masalah memuat paket";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "Terjadi error saat memuat plugin";
@@ -5855,6 +6284,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "Terjadi error saat memuat riwayat";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "Terjadi kesalahan ketika memuat paket";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "Terjadi error saat memuat riwayat pindai";
@@ -5903,6 +6335,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "Domain ini tidak tersedia";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "Alamat email ini tidak terdaftar di WordPress.com.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "File ini terlalu besar untuk diunggah ke situs Anda atau file tidak didukung format media ini.";
@@ -5983,6 +6418,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "Zona Waktu";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "Waktu habis, tetapi jangan khawatir, keamanan Anda menjadi prioritas kami. Coba lagi!";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "Kiat untuk mendapat maksimal dari WordPress.com.";
 
@@ -5996,6 +6434,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "Untuk melanjutkan, masukkan alamat email dan nama Anda.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "Untuk membuat akun WordPress.com Anda yang baru, masukkan alamat email Anda.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "Untuk mendapatkan pemberitahuan yang informatif dari situs WordPress di ponsel, Anda perlu menginstal plugin Jetpack.";
 
@@ -6004,6 +6445,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "Untuk menginstal plugin, Anda harus memiliki domain kustom yang terkait dengan situs Anda.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "Untuk melanjutkan dengan ID Apple ini, harap login terlebih dahulu dengan kata sandi WordPress.com Anda. Hal ini hanya akan ditanyakan sekali.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "Untuk melanjutkan dengan akun Google ini, harap login terlebih dahulu dengan kata sandi WordPress.com Anda. Hal ini hanya akan ditanyakan sekali.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "Untuk menghapus blok, pilih blok dan klik tiga titik di kanan bawah blok untuk melihat pengaturan. Dari sana, pilih pilihan untuk menghapus blok.";
@@ -6078,7 +6525,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "Buang";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "Dibuang";
 
@@ -6092,6 +6540,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "Coba & Sesuaikan";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Coba Lagi";
@@ -6117,6 +6566,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "Coba Editor Blok yang baru";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Coba dengan email lain";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Coba dengan alamat situs";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "Matikan prompt";
@@ -6159,6 +6614,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "PENGGUNAAN";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "Tidak Dapat Terhubung";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "Tidak Dapat Memuat Pos.";
@@ -6208,6 +6666,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Tidak dapat memutar video";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Tidak dapat membaca situs WordPress pada URL tersebut. Ketuk 'Butuh bantuan lainnya?' untuk melihat Tanya-Jawab.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Tidak dapat memulihkan situs Anda";
 
@@ -6234,6 +6695,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "Gagal mengunggah 1 pos, 1 file";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "Tidak dapat memverifikasi alamat email. Silakan coba lagi nanti.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "Tidak dapat membuka pengaturan Jetpack situs";
@@ -6378,7 +6842,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Unggah gagal";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Terunggah";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6396,7 +6861,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Tema yang diunggah";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Mengunggah";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6411,18 +6877,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "Gunakan";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "Gunakan kunci keamanan";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "Gunakan penyunting blok";
 
 /* No comment provided by engineer. */
 "Use icon button" = "Gunakan tombol ikon";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "Gunakan kata sandi untuk login";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Nama pengguna";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6437,6 +6912,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Pengguna";
+
+/* two factor code placeholder */
+"Verification code" = "Kode verifikasi";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "Email verifikasi telah dikirim, periksa kotak masuk Anda.";
@@ -6569,8 +7047,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "Direktori konten-WP";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Menunggu Google untuk menyelesaikan…";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "Menunggu koneksi";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "Menunggu kunci keamanan";
+
+/* View title during the Google auth process. */
+"Waiting..." = "Menunggu...";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6610,6 +7098,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "Kami kesulitan memuat data";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "Kami baru saja mengirim tautan ke email %@. Harap periksa aplikasi email Anda dan ketuk tautan untuk login.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "Kami baru saja mengirimkan tautan ajaib ke ";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "Kami berhasil membuat cadangan situs Anda pada %@";
 
@@ -6619,14 +7113,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "Kami menggunakan alat pelacakan lainnya, termasuk beberapa dari pihak ketiga. Baca tentang hal ini dan cara mengontrolnya.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "Kami tidak dapat mengirimkan email kepada Anda. Coba lagi nanti.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Kami akan mengirimkan email pada Anda jika ditemukan ancaman keamanan. Sementara itu Anda dapat terus menggunakan situs seperti biasa, Anda dapat memeriksa kembali progresnya kapan saja.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "Kami akan mengirimkan email berisi link ajaib yang bisa Anda gunakan untuk login dalam sekejap, tanpa kata sandi. Tak perlu lagi repot mengetik!";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "Kami akan mengirimi Anda email berisi tautan pendaftaran untuk membuat akun WordPress.com baru.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "Kami akan memberi tahu Anda saat mendapatkan pengikut, komentar, dan suka.";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "Kami akan mengirim notifikasi saat Anda mendapatkan pengikut, komentar, dan suka. Apakah Anda ingin mengizinkan pemberitahuan push?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "Kami akan menggunakan alamat email ini untuk membuat akun WordPress.com baru Anda.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "Kami sedang membuat cadangan situs yang dapat Anda unduh dari %1$@.";
@@ -6637,6 +7143,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Kami kesulitan memperbaiki ancaman ini di latar belakang. Sementara itu, Anda dapat terus menggunakan situs seperti biasa dan memeriksa kembali progresnya kapan saja.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "Kami tidak bisa terhubung ke situs Jetpack di URL tersebut. Hubungi kami untuk mendapatkan bantuan.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "Kami telah memulihkan situs Anda kembali ke %1$@.";
 
@@ -6645,6 +7154,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "Kami juga telah mengirimkan email berisi tautan ke file Anda.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Kami telah mengirimi Anda email berisi tautan pendaftaran untuk membuat akun WordPress.com baru. Periksa email Anda di perangkat ini, dan ketuk tautan dalam email yang Anda terima dari WordPress.com";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6671,6 +7183,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "Ringkasan Mingguan: %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "Selamat Datang di Jetpack";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Selamat Datang di WordPress";
 
 /* A message title */
 "Welcome to the Reader" = "Selamat Datang di Pembaca";
@@ -6715,6 +7233,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "Apa itu Gravatar?";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "Apa itu WordPress.com?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "Apakah blok?";
 
@@ -6731,10 +7252,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "What's New in Jetpack" = "Yang Baru dari Jetpack";
 
 /* Opens the What's New / Feature Announcement modal */
-"What's New in Reader" = "Yang Baru di Pembaca";
-
-/* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "Apa yang Baru di WordPress";
+
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "Apa alamat situs saya?";
 
 /* Select the site's intent. Title */
 "What's your website about?" = "Situs Anda berbicara tentang apa?";
@@ -6748,6 +7269,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "Saat membuat perubahan pada situs, Anda akan dapat melihat riwayat aktivitas di sini.";
 
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Ups, terjadi kesalahan dan Anda tidak dapat login. Coba lagi!";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "Ups, sepertinya ada yang salah. Coba lagi!";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "Ups, tampaknya kunci keamanan tidak valid. Silakan coba lagi dengan kunci lain";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Ups, kode verifikasi dua faktor tersebut tidak valid. Periksa kembali kode Anda kemudian coba lagi!";
+
 /* No comment provided by engineer. */
 "Width Settings" = "Pengaturan Lebar";
 
@@ -6760,17 +7293,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "Pengaturan Aplikasi WordPress";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "Aplikasi WordPress - Aplikasi untuk semua layar";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "Blog WordPress";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "Bantuan WordPress";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "Pustaka Media WordPress";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "Pengaturan Pemberitahuan WordPress";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "Pemberitahuan WordPress";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "Plugin WordPress";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "Profil WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "Pembaca WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "Detail Situs WordPress";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "Tema WordPress";
@@ -6781,17 +7335,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "Multisitus WordPress tidak didukung";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress membutuhkan izin untuk mengakses lokasi terkini perangkat Anda untuk ditambahkan ke pos Anda. Harap perbarui pengaturan privasi Anda.";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "Root WordPress";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "Versi WordPress terlalu tua";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Versi WordPress terlalu usang. Situs di %1$@ menggunakan WordPress %2$@. Kami merekomendasikan agar diperbarui ke versi terbaru, atau sekurang-kurangnya %3$@";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "Akun WordPress.com";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "Paket WordPress.com";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "Tema WordPress.com";
@@ -6822,6 +7385,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "Tulis Pos";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "Tulis balasan";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "Tulis balasan...";
 
 /* Title for the writing section in site settings screen */
@@ -6835,6 +7401,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Posisi Sumbu Y";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "Tahun";
@@ -6919,6 +7488,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Displayed when the user views trashed in the posts list and there are no posts */
 "You don't have any trashed posts" = "Anda tidak memiliki pos yang dibuang";
 
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"You don't have permission to view this private blog." = "Anda tidak memiliki izin untuk melihat blog pribadi ini.";
+
 /* Description for the first domain purchased with a paid plan. */
 "You have a free one-year domain registration with your plan." = "Anda memiliki registrasi domain gratis selama satu tahun dengan paket Anda.";
 
@@ -6934,7 +7506,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "Pengingat tidak disetel.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Anda belum menyimpan perubahan.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -7021,9 +7594,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Help text that describes how the password should be. It appears while editing the password */
 "Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ & )." = "Kata sandi Anda setidaknya harus berisi enam karakter. Agar lebih kuat, gunakan huruf besar dan kecil, angka, dan simbol seperti ! \" ? $ % ^ & ).";
 
-/* Message of Export Content confirmation alert */
-"Your posts, pages, and settings will be mailed to the account's email address." = "Pos, halaman, dan pengaturan akan dikirimkan ke alamat email akun.";
-
 /* Message of Export Content confirmation alert; substitution is user's email address */
 "Your posts, pages, and settings will be mailed to you at %@." = "Pos, laman, dan pengaturan Anda akan dikirim melalui alamat email %@.";
 
@@ -7032,6 +7602,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "Pencarian Anda menyertakan karakter yang tidak didukung di domain WordPress.com. Hanya karakter berikut yang diperbolehkan: A–Z, a–z, 0–9.";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "Alamat situs Anda ditampilkan di bar bagian atas layar ketika Anda mengunjungi situs dengan Safari.";
 
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "Situs Anda sudah dilindungi oleh VaultPress. Anda dapat menemukan tautan ke dasbor VaultPress di bawah ini.";
@@ -7111,17 +7684,23 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility identifier for an 'Add Comment' button */
 "addCommentButton.accessibilityIdentifity" = "Tambah Komentar";
 
-/* Error message when user cancels login */
-"addSite.selfHosted.cancelled" = "Login dibatalkan";
+/* Error message shown a URL does not point to an existing site. */
+"addSite.restApiNotAvailable" = "Situs di alamat ini bukan situs WordPress. Agar kami dapat menghubungkannya, situs harus menggunakan WordPress.";
+
+/* Error message shown when an receiving an invalid application-password authentication result from a self-hosted WordPress site */
+"addSite.selfHosted.authenticationFailed" = "Tidak dapat login dengan autentikasi Kata Sandi Aplikasi.";
 
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "Masukkan alamat situs WordPress yang ingin Anda hubungkan.";
 
+/* Error message when user input is not a WordPress site */
+"addSite.selfHosted.invalidUrl" = "Alamat email tidak valid.";
+
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "Tidak dapat memuat detail situs WordPress";
 
-/* Error message when user signs in with an unexpected usern. The first argument is the expected username */
-"addSite.selfHosted.mismatchUser" = "Harap login dengan kredensial pengguna yang sudah login. Nama pengguna: %@";
+/* Error message shown when application-password authentication is disabled on a self-hosted WordPress site */
+"addSite.selfHosted.noLoginUrlFound" = "Autentikasi Kata Sandi Aplikasi perlu diaktifkan di situs WordPress.";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "Tidak dapat menyimpan situs WordPress. Coba lagi.";
@@ -7129,17 +7708,14 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "Tambahkan Situs yang Dihosting Sendiri";
 
-/* Error message when XML-RPC is disabled on the WordPress site. The first argument is detailed error message */
-"addSite.selfHosted.xmlrpcDisabled" = "Tidak dapat terhubung ke situs WordPress. XML-RPC mungkin telah dinonaktifkan di server. Hubungi penyedia hosting Anda untuk mengatasi kendala ini.";
+/* Error message when an unknown error occurred when adding a self-hosted site */
+"addSite.selfHosted.unknownError" = "Terjadi masalah. Coba lagi.";
 
 /* Age between dates equaling one hour. */
 "an hour" = "satu jam";
 
 /* This is the string we display when prompting the user to review the Jetpack app */
 "appRatings.jetpack.prompt" = "Apa pendapat Anda tentang Jetpack?";
-
-/* This is the string we display when prompting the user to review the Reader app */
-"appRatings.reader.prompt" = "Apa pendapat Anda tentang Pembaca?";
 
 /* This is the string we display when prompting the user to review the WordPress app */
 "appRatings.wordpress.prompt" = "Apa pendapat Anda tentang WordPress?";
@@ -7843,6 +8419,10 @@ Example: Reply to Pamela Nguyen */
 /* A name of the ID field (it's a technical field, has to be short, displayed below everything else) */
 "entityMetadataFooterView.id" = "ID";
 
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "contoh.com";
+
 /* Accept button title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackAccept" = "Kirim feedback";
 
@@ -7854,9 +8434,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackTitle" = "Bagikan Feedback";
-
-/* Communicates the future removal of the option to disable the experimental editor, displayed beneath the experimental features list */
-"experimentalFeatures.editorNote" = "Editor Blok Eksperimental akan menjadi pengaturan asal di rilis mendatang dan fitur untuk menonaktifkannya akan dihapus.";
 
 /* The title for the experimental features list */
 "experimentalFeaturesList.heading" = "Fitur Eksperimental";
@@ -7903,8 +8480,14 @@ Example: Reply to Pamela Nguyen */
 /* A footer retry button */
 "general.pagingFooterView.retry" = "Coba lagi";
 
+/* Error message format when REST API returns an error response. The first argument is error message. */
+"generic.error.rest-api-error" = "Situs Anda mengirimkan respons error: %@";
+
 /* A generic title for an error */
 "generic.error.title" = "Eror";
+
+/* Error message when failing to parse API responses */
+"generic.error.unparsableResponse" = "Situs Anda mengirimkan respons yang tidak dapat diurai aplikasi";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "Siapkan pengingat blogging";
@@ -8076,42 +8659,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title of the Jetpack powered overlay. */
 "jetpack.branding.overlay.title" = "WordPress berfungsi lebih baik dengan Jetpack";
-
-/* Title for the button that starts the Jetpack connection process */
-"jetpack.connection.connect.button" = "Hubungkan situs Anda";
-
-/* Error message shown when WordPress.com authentication fails */
-"jetpack.connection.error.authentication" = "Akun WordPress.com tidak valid";
-
-/* Error message shown when a connection step is attempted in an invalid order */
-"jetpack.connection.error.context" = "Langkah ini belum siap";
-
-/* Title for the retry button shown when a connection step fails */
-"jetpack.connection.retry.button" = "Coba lagi";
-
-/* Status message when a connection step is pending */
-"jetpack.connection.stage.pending" = "Menunggu untuk memulai";
-
-/* Status message when a connection step is in progress */
-"jetpack.connection.stage.processing" = "Sedang berlangsung...";
-
-/* Status message when a connection step is completed successfully */
-"jetpack.connection.stage.success" = "Selesai";
-
-/* Title for the finalization step in Jetpack connection flow */
-"jetpack.connection.step.finalize.title" = "Selesaikan Penyambungan";
-
-/* Title for the install step in Jetpack connection flow */
-"jetpack.connection.step.install.title" = "Instal Jetpack";
-
-/* Title for the login step in Jetpack connection flow */
-"jetpack.connection.step.login.title" = "Login ke WordPress.com";
-
-/* Title for the site connection step in Jetpack connection flow */
-"jetpack.connection.step.site.title" = "Hubungkan ke situs Anda";
-
-/* Title for the user connection step in Jetpack connection flow */
-"jetpack.connection.step.user.title" = "Hubungkan akun WordPress.com Anda";
 
 /* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
 "jetpack.fullscreen.overlay.early.switch.title" = "Ganti ke aplikasi Jetpack baru";
@@ -8332,41 +8879,11 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "Anda tidak memiliki izin untuk melihat blog pribadi ini.";
 
-/* Button to dismiss the re-authentication view */
-"login.appPasswordReAuth.cancelButton" = "Batalkan";
-
-/* Description explaining why the user needs to re-authenticate */
-"login.appPasswordReAuth.description" = "Kata sandi yang ditetapkan untuk aplikasi sudah tidak ada lagi di profil Anda.\nLogin lagi untuk membuat kata sandi baru untuk digunakan oleh aplikasi.";
-
-/* Button to start the re-authentication process */
-"login.appPasswordReAuth.signInButton" = "Login";
-
-/* Title shown when the application password is invalid */
-"login.appPasswordReAuth.title" = "Kata sandi aplikasi tidak valid";
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "Masukkan kode verifikasi untuk akun WordPress.com Anda dari aplikasi pengautentikasi.";
 
 /* Indicating that referrer was marked as spam */
 "marked as spam" = "ditandai sebagai spam";
-
-/* Button title when verification link sending failed */
-"me.verifyEmail.button.retry" = "Coba Lagi";
-
-/* Button title to send verification link */
-"me.verifyEmail.button.send" = "Kirim ulang email";
-
-/* Button title while verification link is being sent */
-"me.verifyEmail.button.sending" = "Mengirim...";
-
-/* Button title after verification link is sent */
-"me.verifyEmail.button.sent" = "Email terkirim";
-
-/* Message for email verification card */
-"me.verifyEmail.message.noEmail" = "Verifikasi email Anda untuk mengamankan akun dan mengakses lebih banyak fitur.\nPeriksa email konfirmasi di inbox Anda, atau klik '%@' untuk mendapatkan email konfirmasi baru.";
-
-/* Message for email verification card with email address */
-"me.verifyEmail.message.withEmail" = "Verifikasi email Anda untuk mengamankan akun dan mengakses lebih banyak fitur.\nPeriksa email konfirmasi di inbox Anda di %1$@, atau klik '%2$@' untuk mendapatkan email konfirmasi baru.";
-
-/* Title for email verification card */
-"me.verifyEmail.title" = "Verifikasi Email Anda";
 
 /* Me tab menu items */
 "meMenu.submitFeedback" = "Beri Feedback";
@@ -8809,6 +9326,9 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "Halaman Induk";
 
+/* No comment provided by engineer. */
+"password" = "Kata sandi";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "Kartu bisa saja menampilkan konten yang berbeda, tergantung pada apa yang terjadi di situs Anda. Kami terus mengembangkan fitur kartu dan kontrol.";
 
@@ -8913,9 +9433,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Message shown while loading plugin details */
 "pluginDetails.loading" = "Memuat informasi plugin…";
-
-/* Placeholder message shown when a plugin has no description */
-"pluginDetails.noDescription" = "Plugin ini belum memberikan deskripsi apa pun.";
 
 /* Title of the changelog section in plugin details */
 "pluginDetails.section.changelog" = "Log perubahan";
@@ -9202,6 +9719,30 @@ Example: Reply to Pamela Nguyen */
 /* An alert message explaning that by changing the visibility to private, the post will be published immediately to your site */
 "postSettings.warningPostWillBePublishedAlertMessage" = "Dengan mengubah visibilitas ke \"Pribadi\", pos Anda akan segera diterbitkan.";
 
+/* Localized post type: `Page` */
+"postType.page" = "halaman";
+
+/* Localized post type: `Post` */
+"postType.post" = "pos";
+
+/* Details for a 'Private' privacy setting */
+"postVisibility.private.details" = "Hanya dapat dilihat oleh admin dan editor situs.";
+
+/* Title for a 'Private' privacy setting */
+"postVisibility.private.title" = "Privat";
+
+/* Details for a 'Password Protected' privacy setting */
+"postVisibility.protected.details" = "Dapat dilihat semua orang dengan memasukkan kata sandi.";
+
+/* Title for a 'Password Protected' privacy setting */
+"postVisibility.protected.title" = "Dilindungi kata sandi";
+
+/* Details for a 'Public' (default) privacy setting */
+"postVisibility.public.details" = "Dapat dilihat oleh semua orang.";
+
+/* Title for a 'Public' (default) privacy setting */
+"postVisibility.public.title" = "Publik";
+
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Batal";
 
@@ -9422,18 +9963,6 @@ Tapping on this row allows the user to edit the sharing message. */
 /* Title for the success view when the user has successfully logged in */
 "qrLoginVerifyAuthorization.completedInstructions.title" = "Anda sudah login!";
 
-/* No comment provided by engineer. */
-"reachability-utils.alert.cancel" = "Oke";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.retry" = "Coba lagi?";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.title" = "Tidak Ada Koneksi";
-
-/* Message of error prompt shown when no internet connection is available */
-"reachability-utils.alert.utils" = "Sepertinya koneksi internet terputus.";
-
 /* Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog. */
 "reader.blocked.blog.message" = "Blog %@ tidak akan muncul lagi di pembaca Anda. Ketuk untuk mengurungkan.";
 
@@ -9470,26 +9999,8 @@ Tapping on this row allows the user to edit the sharing message. */
 /* A shared button title for Reader */
 "reader.button.unsubscribe" = "Berhenti Berlangganan";
 
-/* Button title. Follow the comments on a post. */
-"reader.comments.buttonFollow" = "Ikuti";
-
 /* Informational message, should be short. */
 "reader.comments.commentsClosed" = "Komentar Ditutup";
-
-/* Empty state view title */
-"reader.comments.emptyStateTitle" = "Jadilah yang pertama berkomentar.";
-
-/* Empty state view title */
-"reader.comments.errorLoadingComments" = "Terjadi error yang tidak terduga saat memuat komentar.";
-
-/* VoiceOver hint */
-"reader.comments.followingSettingAccessibilityIdentifier" = "Buka pengaturan pemberitahuan untuk pos";
-
-/* Error message that informs reader comments from a private blog cannot be fetched. */
-"reader.comments.noPermissionToViewPrivateBlog" = "Anda tidak memiliki izin untuk melihat blog pribadi ini.";
-
-/* Navigation title */
-"reader.comments.title" = "Komentar";
 
 /* Accessibility hint to inform that the author section can be tapped to see posts from the site. */
 "reader.detail.header.authorInfo.a11y.hint" = "Melihat pos dari situs";
@@ -9567,23 +10078,8 @@ but tapping on this button will remove their like from the post. */
 /* Screen header details */
 "reader.following.header.details" = "Ikuti perkembangan terkini melalui blog langganan Anda.";
 
-/* Empty state view */
-"reader.following.lists.emptyTitle" = "Daftar Kosong";
-
-/* Screen header details */
-"reader.home.header.details" = "Ikuti perkembangan terkini blog langganan Anda.";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.home.title" = "Beranda";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.library.title" = "Pustaka";
-
 /* Used in multiple contexts, usually as a screen title */
 "reader.likes.title" = "Suka";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.lists.title" = "Daftar";
 
 /* Reader logged-out screen details */
 "reader.loggedOut.details" = "Login dengan akun WordPress.com untuk mengikuti blog favorit Anda";
@@ -9826,8 +10322,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title of a Reader tab showing Posts matching a user's search query */
 "reader.search.tab.posts" = "Pos";
 
-/* Title of the Reader's search feature
-   Used in multiple contexts, usually as a screen title */
+/* Title of the Reader's search feature */
 "reader.search.title" = "Cari";
 
 /* Screen title. Reader select interests title label text. */
@@ -9853,6 +10348,21 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Reader select interests title label text */
 "reader.select.tags.title" = "Temukan dan ikuti blog yang Anda sukai";
+
+/* Reader sidebar menu item */
+"reader.sidebar.discover" = "Temukan";
+
+/* Reader sidebar menu item */
+"reader.sidebar.likes" = "Suka";
+
+/* Reader sidebar menu item */
+"reader.sidebar.recent" = "Terbaru";
+
+/* Reader sidebar menu item */
+"reader.sidebar.saved" = "Disimpan";
+
+/* Reader sidebar menu item */
+"reader.sidebar.search" = "Cari";
 
 /* Reader sidebar section title */
 "reader.sidebar.section.favorites.title" = "Favorit";
@@ -9902,7 +10412,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Number of subscriptions on a site (singular) */
 "reader.subscriptions.subscriptionsSingular" = "%@ pelanggan";
 
-/* Used in multiple contexts, usually as a screen title */
+/* Navigation bar title */
 "reader.subscriptions.title" = "Langganan";
 
 /* A suggestion of topics the user might want to subscribe to */
@@ -9944,26 +10454,11 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Verb. Button title. The user is following a tag. */
 "reader.tags.following.button.title" = "Mengikuti";
 
-/* Used in multiple contexts, usually as a screen title */
-"reader.tags.title" = "Tag";
-
 /* Accessibility label for unsubscribing from a tag */
 "reader.tags.unfollow.accessibility.label" = "Batal Mengikuti %@";
 
 /* Field title */
 "reader.userProfile.site" = "Situs";
-
-/* Reader Welcome screen login button */
-"reader.welcome.continueText" = "Lanjutkan dengan WordPress.com";
-
-/* Reader Welcome screen */
-"reader.welcome.subtitle" = "Bergabung dengan komunitas blogging terbesar";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.me" = "Saya";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.notifications" = "Pemberitahuan";
 
 /* Spoken accessibility label */
 "readerDetail.backButton.accessibilityLabel" = "Kembali";
@@ -10241,14 +10736,10 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Message shown when there are no inactive plugins on the site */
 "site.plugins.empty.inactive" = "Tidak ada plugin yang tidak aktif";
 
-/* The plugin fillter option for displaying active plugins */
-"site.plugins.filter.option.active" = "Aktif";
-
-/* The plugin fillter option for displaying all plugins */
+/* The plugin fillter option for displaying active plugins
+   The plugin fillter option for displaying all plugins
+   The plugin fillter option for displaying inactive plugins */
 "site.plugins.filter.option.all" = "Semua";
-
-/* The plugin fillter option for displaying inactive plugins */
-"site.plugins.filter.option.inactive" = "Nonaktif";
 
 /* Title of the plugin filter picker */
 "site.plugins.filter.title" = "Saring";
@@ -10800,9 +11291,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* View title for Help & Support page. */
 "support.title" = "Bantuan";
 
-/* Subject of new Zendesk ticket. */
-"support.zendesk.readerAppTicketSubject" = "Pembaca untuk Dukungan iOS";
-
 /* Title for placeholder in Tenor picker */
 "tenor.welcomeMessage" = "Cari GIF untuk ditambahkan ke Pustaka Media Anda!";
 
@@ -10951,8 +11439,119 @@ Feel free to replace it with other bracket types that you think looks better for
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "Status";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "Pos Sepanjang Waktu & Penayangan Terbanyak";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "Penayangan Sepanjang Waktu";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "Penayangan & Pengunjung Sepanjang Waktu";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "Terbanyak dilihat";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "Penayangan Terbanyak";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "Tidak dapat memuat statistik sepanjang waktu.";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "Buat atau tambahkan situs untuk melihat statistik sepanjang waktu.";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Tulisan-tulisan";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "Dapatkan kabar terbaru tentang seluruh aktivitas hingga hari ini di situs WordPress Anda.";
+
+/* Title of all time widget */
+"widget.alltime.title" = "Semua Waktu";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "Login ke WordPress untuk melihat statistik hingga hari ini.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "Login ke Jetpack untuk melihat semua statistik.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "Login ke Jetpack untuk melihat statistik hari ini.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "Login ke Jetpack untuk melihat statistik hari ini.";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "Penayangan Sepanjang Waktu";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "Penayangan Hari Ini";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "Tidak dapat memuat statistik minggu ini.";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "Buat atau tambahkan situs untuk melihat statistik minggu ini.";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "Dapatkan kabar terbaru tentang aktivitas minggu ini di situs WordPress Anda.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "Minggu Ini";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "Login ke WordPress untuk melihat statistik minggu ini.";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Komentar-komentar";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "Statistik telah beralih ke aplikasi Jetpack. Beralihlah ke aplikasi—gratis dan prosesnya cepat!";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Suka";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "Tidak dapat memuat statistik situs.";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "Tidak dapat memuat statistik hari ini.";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "Buat atau tambahkan situs untuk melihat statistik hari ini.";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "Dapatkan kabar terbaru tentang aktivitas hari ini di situs WordPress Anda.";
+
+/* Title of today widget */
+"widget.today.title" = "Hari ini";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "Login ke WordPress untuk melihat statistik hari ini.";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "Pratinjau tidak tersedia";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Kunjungan";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Pengunjung";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "Suka & Komentar Hari Ini";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "Penayangan Hari Ini";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "Penayangan & Pengunjung Hari Ini";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "akan tidak tersedia di waktu mendatang.";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "Memulai situs baru?";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "wordpress, bantuan, dukungan, tanya jawab umum, pertanyaan, debug, log, pusat bantuan, kontak";
@@ -10977,6 +11576,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Error message that describes an unknown error had occured */
 "wordpress-api.error.unknown" = "Terjadi masalah. Silakan coba lagi nanti.";
+
+/* Error message when failing to find selected media file on the user's device. */
+"wordpress.api.upload.media.fileNotFound" = "Tidak dapat menemukan lokasi berkas media di perangkat";
 
 /* Jetpack Plugin Modal on WordPress primary button title */
 "wordpress.jetpack.plugin.modal.primary.button.title" = "Ganti ke aplikasi Jetpack";
@@ -11023,21 +11625,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Error message when user signs in with an unexpected email address. The first argument is the expected email address */
 "wpComLogin.error.mismatchedEmail" = "Silakan login dengan alamat email %@";
 
-/* Message shown when user denies WordPress.com login, offering option to try with different account */
-"wpComLogin.loginDenied.message" = "Anda bisa login dengan akun lain jika memerlukan akun yang berbeda. Ketuk \"%@\" untuk memulai.";
-
-/* Title of alert shown when user cancels WordPress.com login */
-"wpComLogin.loginDenied.title" = "Login Dibatalkan";
-
-/* Button title for signing in with a different WordPress.com account */
-"wpComLogin.loginDenied.useDifferentAccount" = "Gunakan Akun Lain";
-
-/* Button title to log out the current WordPress.com account */
-"wpcom.token.alert.button.logout" = "Logout";
-
-/* Button title to Sign In to WordPress.com */
-"wpcom.token.alert.button.signin" = "Login";
-
 /* Message title to be displayed when the user needs to re-authenticate their WordPress.com account. */
 "wpcom.token.fix.signin" = "Login ke WordPress.com";
 
@@ -11052,6 +11639,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "Lampiran tidak didukung";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Login dengan Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Domain";

--- a/WordPress/Resources/is.lproj/Localizable.strings
+++ b/WordPress/Resources/is.lproj/Localizable.strings
@@ -62,6 +62,9 @@
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Án titils)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(ekkert heiti)";
+
 /* Menus button text for adding a new menu to a site. */
 "+ Add new menu" = "+ Bæta við nýrri valmynd";
 
@@ -70,6 +73,9 @@
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "Nafn á vef";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "Gilt netfang er nauðsynlegt til þess að fá auðkenningartengil í tölvupósti. Vinsamlegast farðu til baka á fyrri skjámynd og sláðu inn gilt netfang.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "VIRKT";
@@ -144,6 +150,9 @@
    Label for the alt for a media asset (image) */
 "Alt Text" = "Skýringartexti";
 
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "Virk tenging við internetið er nauðsynleg til þess að skoða áskriftarleiðir";
+
 /* An error description explaining that a Menu could not be created. */
 "An error occurred creating the Menu." = "Villa kom upp við að búa til valmynd.";
 
@@ -170,6 +179,9 @@
 
 /* Error message shown when a media upload fails for unknown reason and the user should try again. */
 "An unknown error occurred. Please try again." = "Óþekkt villa kom upp. Vinsamlegast reynið aftur.";
+
+/* the comment has an anonymous author. */
+"Anonymous" = "Nafnlaust";
 
 /* App Settings Title
    Link to App Settings section
@@ -239,6 +251,9 @@
    Previous web page */
 "Back" = "Til baka";
 
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Vertu fyrst(ur) til þess að rita athugasemd.";
+
 /* Accessibility label for block quote button on formatting toolbar.
    Discoverability title for block quote keyboard shortcut. */
 "Block Quote" = "Tilvitnun";
@@ -268,9 +283,13 @@
 /* Accessibility label for taking an image or video with the camera on formatting toolbar. */
 "Camera" = "Myndavél";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Gat ekki óskað eftir tengli";
+
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -280,6 +299,7 @@
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -298,6 +318,7 @@
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -320,13 +341,15 @@
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Myndatexti";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Varlega!";
 
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Flokkar";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Flokkur";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -359,6 +382,7 @@
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Loka";
 
@@ -370,6 +394,9 @@
 
 /* Close Comments Title */
 "Close commenting" = "Loka fyrir athuagsemdir";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Teiknimyndir";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -393,6 +420,7 @@
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Athugasemdir";
 
@@ -448,6 +476,9 @@
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Tenging við %1$@ mun koma í staðinn fyrir tengingu við %2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Tengist WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Tengist…";
@@ -505,6 +536,9 @@
    Register Domain - Domain contact information field Country */
 "Country" = "Land";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Stofna aðgang";
+
 /* Button to progress to the next step
    Site creation. Step 1. Screen title
    Title for the button to progress with creating the site with the selected design. */
@@ -515,6 +549,9 @@
 
 /* No comment provided by engineer. */
 "Current" = "Efst á baugi";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Núverandi áskriftarleið";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Þema í notkun";
@@ -536,6 +573,9 @@
    Title for selecting a default category for a post */
 "Default Category" = "Sjálfgefinn flokkur";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Sjálfgefin valmynd";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Stöðluð Gerð Færslu";
@@ -544,6 +584,7 @@
 "Defaults for New Posts" = "Sjálfgildi fyrir nýjar færslur";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Eyða";
@@ -620,7 +661,9 @@
    Title for the Discussion Settings Screen */
 "Discussion" = "Umræða";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Loka";
 
 /* Display Name label text.
@@ -643,6 +686,9 @@
    Title for button that will dismiss this view
    Title for the button that will dismiss this view. */
 "Done" = "Búinn";
+
+/* Name for the status of a draft post. */
+"Draft" = "Drög";
 
 /* Editing GIF alert default action button.
    Edits a Comment
@@ -744,6 +790,9 @@
 /* Section title for the external table section in the blog details screen */
 "External" = "Útvært";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Tókst ekki";
+
 /* Error message to show to use when media insertion on a post fails */
 "Failed to insert media.\n Please tap for options." = "Tókst ekki að setja skrá inn í færsluna þína.\n Ýttu til þess að skoða valkosti.";
 
@@ -779,6 +828,9 @@
    User's First Name */
 "First Name" = "Eiginnafn";
 
+/* Button title. Follow the comments on a post. */
+"Follow" = "Fylgja";
+
 /* User role badge */
 "Follower" = "Fylgjandi";
 
@@ -802,6 +854,12 @@
 
 /* Displayed in the Notifications Tab as a message, when the Follow Filter shows no notifications */
 "Get noticed: comment on posts you've read." = "Vektu eftirtekt: skrifaðu athugasemdir við færslur sem þú hefur lesið.";
+
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Sæki upplýsingar um aðgang";
+
+/* Cancel */
+"Give Up" = "Gefast upp";
 
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
@@ -839,6 +897,9 @@
    Open editor help options
    Title of the 'Help & Support' screen within the 'Me' tab - used for spotlight indexing on iOS. */
 "Help & Support" = "Hjálp & aðstoð";
+
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Falinn";
 
 /* Title of a button used to collapse a group */
 "Hide" = "Hylja";
@@ -879,6 +940,9 @@
 
 /* Describes a standard *.wordpress.com site domain */
 "Included with Site" = "Fylgir með vefnum";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Ógilt notandanafn eða lykilorð. Vinsamlegast sláðu inn innskráningarupplýsingar þínar aftur.";
 
 /* WordPress.com Community Footer Text */
 "Information on WordPress.com courses and events (online & in-person)." = "Upplýsingar um WordPress.com námskeið og viðburði (á netinu & í kjötheimum).";
@@ -994,7 +1058,8 @@
 /* Setting: indicates if Replies to your comments will be notified */
 "Likes on my posts" = "Líkar við færslurnar mínar";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Tengill";
 
 /* Menus title label when editing a menu item as a link. */
@@ -1017,6 +1082,12 @@
 /* Menus label text displayed while menus are loading */
 "Loading Menus..." = "Hleð inn valmyndum...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Hleð inn áskriftarleið...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Hleð inn áskriftarleiðum...";
+
 /* Menus label text displayed when a menu is loading. */
 "Loading menu..." = "Hleð inn valmynd...";
 
@@ -1027,23 +1098,43 @@
    Text displayed while loading time zones */
 "Loading..." = "Hleð...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Staðvært";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Staðsetning";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Location Services verður að vera virk áður en WordPress getur bætt núverandi staðsetningu þinni við. Vinsamlegast virkjaðu Location Services í Settings forritinu.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Staðsetning óþekkt";
+
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Atburðaskrár eftir dagsetningu";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Innskrá";
 
 /* Button for confirming logging out from WordPress.com account
    Label for logging out from WordPress.com account */
 "Log Out" = "Skrá út";
 
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Innskráning mistókst. Vinsamlegast reyndu aftur.";
+
 /* Login Request Expired */
 "Login Request Expired" = "Innskráningarbeiðni rann út";
 
 /* No comment provided by engineer. */
 "Logs" = "Annálar";
+
+/* Title of a button. */
+"Lost your password?" = "Tapað lykilorð?";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Aðalvalmynd";
@@ -1139,6 +1230,9 @@
 /* New Post 3D Touch Shortcut */
 "New Post" = "Ný færsla";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Nýtt atriði";
+
 /* Screen title, where users can see the newest plugins */
 "Newest" = "Nýjustu";
 
@@ -1146,7 +1240,9 @@
 "Newest first" = "Nýjast fyrst";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Næsta";
 
 /* Accessibility label for the next notification button */
@@ -1178,7 +1274,8 @@
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "Engar athugasemdir enn";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "Ekkert samband";
 
@@ -1249,7 +1346,12 @@
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Númeraður listi";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "Í lagi";
@@ -1285,13 +1387,19 @@
    Title for the view when there's an error loading time zones */
 "Oops" = "Úbbs";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Úbbs!";
 
 /* Opens iOS's Device Settings for WordPress App */
 "Open Device Settings" = "Opna stillingar tækis";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Opna Mail";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Opna Settings";
 
 /* No comment provided by engineer. */
@@ -1328,7 +1436,8 @@
    Other Sites Notification Settings Title */
 "Other Sites" = "Aðrir vefir";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Síða";
 
@@ -1345,14 +1454,21 @@
 /* Title for selecting parent category of a category */
 "Parent Category" = "Yfirflokkur";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Lykilorð";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Í bið";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Bíður yfirlestrar";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -1365,6 +1481,10 @@
 /* Section title for the personalize table section in the blog details screen. */
 "Personalize" = "Sérsníða";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Áskriftarleiðir";
+
 /* Politely asks the user to check their internet connection before trying again. */
 "Please check your internet connection and try again." = "Vinsamlegast athugaðu tenginguna þína við internetið og reyndu aftur.";
 
@@ -1374,11 +1494,14 @@
 /* No comment provided by engineer. */
 "Please enter a username." = "Vinsamlegast sláðu inn notandanafn.";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Vinsamlega sláðu inn gilt netfang";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Vinsamlegast sláðu inn aðgangsupplýsingar þínar.";
+
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Vinsamlegast fylltu alla reiti út";
 
 /* No comment provided by engineer. */
 "Please try entering your login details again." = "Vinsamlegast reyndu að slá inn innskráningarupplýsingar þínar aftur.";
@@ -1390,7 +1513,8 @@
 /* Section title for Popular Languages */
 "Popular languages" = "Vinsæl tungumál";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Færsla";
 
@@ -1439,12 +1563,25 @@
 /* Title of button that displays the App's privacy policy */
 "Privacy Policy" = "Persónuverndarstefna";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Einkamál";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Með því að halda áfram eyðast öll WordPress.com gögn út úr þessu tæki, einnig eyðast öll vistuð staðvær drög. Þú munt ekki tapa neinu sem þú hefur nú þegar vistað á WordPress.com blogg.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Verkefni";
+
 /* Label for the publish (verb) button. Tapping publishes a draft post.
    Publish post action on share extension site picker screen.
    Section title for the publish table section in the blog details screen */
 "Publish" = "Birta";
 
-/* Period Stats 'Published' header
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Birta strax";
+
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Birt";
 
@@ -1520,6 +1657,9 @@
    Verb. Button title. Reply to a comment. */
 "Reply" = "Svara";
 
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Svartexti";
+
 /* An explaination of a setting. */
 "Require manual approval for comments that include more than this number of links." = "Krefjast samþykkis fyrir athugasemdir með fleiri en þennan fjölda tengla.";
 
@@ -1560,6 +1700,9 @@
    User action to retry media upload. */
 "Retry" = "Reyna aftur";
 
+/* No comment provided by engineer. */
+"Retry?" = "Reyna aftur?";
+
 /* Cancels a pending Email Change */
 "Revert Pending Change" = "Afturkalla yfirvofandi breytingu";
 
@@ -1574,8 +1717,12 @@
    User's Role */
 "Role" = "Hlutverk";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS sent";
+
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -1585,7 +1732,8 @@
 /* Menus save button title while it is saving a Menu. */
 "Saving..." = "Vista...";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Tímaáætlað";
 
 /* Title of Stats section that shows search engine referrer traffic. */
@@ -1615,6 +1763,9 @@
 /* Menus alert message for alerting the user to unsaved changes while trying to select a different menu. */
 "Selecting a different menu will discard changes you've made to the current menu. Are you sure you want to continue?" = "Með því að velja aðra valmynd, tapar þú breytingum sem þú hefur gert á núverandi valmynd. Ertu viss um að þú viljir halda áfram?";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Senda tengil";
+
 /* Settings: Sending Pingbacks */
 "Send Pingbacks" = "Senda tilvísanir";
 
@@ -1638,6 +1789,9 @@
 
 /* Message to show when setting save failed */
 "Settings update failed" = "Uppfærsla á stillingum mistókst";
+
+/* Spoken accessibility label */
+"Share" = "Deila";
 
 /* Aztec's Text Placeholder
    Share Extension Content Body Text Placeholder */
@@ -1718,7 +1872,7 @@
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Því miður, vefföng verða líka að hafa bókstafi!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Því miður, þetta netfang er nú þegar í notkun!";
 
 /* No comment provided by engineer. */
@@ -1799,7 +1953,8 @@
    Theme Support action title */
 "Support" = "Aðstoð";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Efnisorð";
 
 /* Label for tagline blog setting
@@ -1824,6 +1979,9 @@
 
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Notendaskilmálar";
+
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Reynslusögur";
 
 /* Title of a button style */
 "Text Only" = "Einungis texti";
@@ -1860,6 +2018,9 @@
 
 /* Message for when the certificate for the server is invalid. The %@ placeholder will be replaced the a host name, received from the API. */
 "The certificate for this server is invalid. You might be connecting to a server that is pretending to be “%@” which could put your confidential information at risk.\n\nWould you like to trust the certificate anyway?" = "Skírteinið fyrir þennan netþjón er ógilt. Þú gætir verið að tengjast við netþjón sem er að þykjast vera “%@” og gæti það ógnað upplýsingaöryggi þínu.\n\nViltu treysta skírteininu engu að síður?";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "Ekkert samband virðist vera við internetið.";
 
 /* Footer Text displayed in Blog Language Settings View */
 "The language in which this site is primarily written." = "Tungumálið sem þessi vefur er aðallega skrifaður í.";
@@ -1914,17 +2075,35 @@
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "Það kom upp óvænt villa við að uppfæra tilkynninga-stillingarnar þínar";
 
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "Það kom upp óvænt villa við að uppfæra athugasemdina þína";
+
 /* Informs the user about an issue connecting to the third-party sharing service. The `%@` is a placeholder for the service name. */
 "There is an issue connecting to %@. Reconnect to continue publicizing." = "Það er vandamál við að tengjast %@. Tengdu aftur til þess að halda birtingu áfram.";
 
 /* Error message informing the user that there was a problem blocking posts from a site from their reader. */
 "There was a problem blocking posts from the specified site." = "Það kom upp vandamál við að loka fyrir færslur frá þessum vef.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "Það kom upp vandamál við að tengjast WordPress.com. Vinsamlegast reyndu innskráningu aftur.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "Það kom upp vandamál við að sýna þessa færslu.";
+
 /* Error message informing the user that there was a problem clearing the block on site preventing its posts from displaying in the reader. */
 "There was a problem removing the block for specified site." = "Það kom upp vandamál við að fjarlægja lokun fyrir þennan vef.";
 
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "Það kom upp vandamál við að vista breytingar á deilistjórnun.";
+
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "Það kom upp vandamál við að nálgast upplýsingar um staðsetningu þína. Vinsamlegast reynið aftur síðar.";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "Það kom upp villa við að hlaða inn áskriftarleiðum";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "Það kom upp villa við að hlaða inn áskriftarleið";
 
 /* Updating Role failed error message */
 "There was an error updating @%@" = "Það kom upp villa við að uppfæra @%@";
@@ -1978,7 +2157,8 @@
    Trashes the comment */
 "Trash" = "Rusl";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "Hent í ruslið";
 
@@ -1989,6 +2169,7 @@
 "Try & Customize" = "Prófaðu & sérsníddu";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Reyna aftur";
@@ -2084,10 +2265,12 @@
 /* Title for button displayed when the user has an empty media library */
 "Upload Media" = "Halaðu upp skrá";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Efni upphlaðið";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Hlaða upp";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -2097,11 +2280,14 @@
 "Use" = "Nota";
 
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Notandanafn";
 
 /* Setting: indicates if Mentions will be notified */
@@ -2113,6 +2299,9 @@
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Notendur";
+
+/* two factor code placeholder */
+"Verification code" = "Staðfestingarkóði";
 
 /* Push Authentication Alert Title */
 "Verify Log In" = "Staðfesta innskráningu";
@@ -2206,14 +2395,23 @@
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "WordPress Blog";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress þarf leyfi til þess að nálgast núverandi staðsetningu tækisins þíns svo hægt sé að bæta henni við í færsluna þína. Vinsamlegast uppfærðu persónuverndarstillingarnar þínar.";
+
 /* No comment provided by engineer. */
 "WordPress version too old" = "WordPress útgáfa orðin of gömul";
+
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "WordPress útgáfa orðin of gömul. Vefurinn %1$@ notar WordPress %2$@. Við mælum með uppfærslu í nýjustu útgáfu eða í það minnsta %3$@";
 
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "WordPress.com aðgangur";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "WordPress.com áskriftarleiðir";
 
 /* WordPress.com Notification Settings Title */
 "WordPress.com Updates" = "WordPress.com uppfærslur";
@@ -2250,7 +2448,8 @@
 /* Message alert when attempting to delete site with purchases */
 "You have active premium upgrades on your site. Please cancel your upgrades prior to deleting your site." = "Þú hefur virkar keyptar uppfærslur á vefnum þínum. Vinsamlegast segðu upp uppfærslunum áður en þú eyðir vefnum þínum.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Þú átt óvistaðar breytingar.";
 
 /* Error message informing the user that being logged into a WordPress.com account is required. */
@@ -2294,6 +2493,24 @@
 
 /* Header of delete screen section listing things that will be deleted. */
 "these items will be deleted:" = "eftirfarandi atriðum verður eytt:";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Færslur";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Athugasemdir";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Líkar við";
+
+/* Title of today widget */
+"widget.today.title" = "Í dag";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Flettingar";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Gestir";
 
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "verður ekki í boði í framtíðinni.";

--- a/WordPress/Resources/it.lproj/Localizable.strings
+++ b/WordPress/Resources/it.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Translation-Revision-Date: 2025-05-13 09:54:09+0000 */
+/* Translation-Revision-Date: 2025-03-11 10:54:08+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
 /* Generator: GlotPress/4.0.1 */
 /* Language: it */
@@ -98,6 +98,9 @@
 
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "%1$@ di %2$@ sul tuo sito";
+
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "%1$@ di %2$@ utilizzato sul tuo sito";
 
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ quadrilioni";
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(senza titolo)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(senza titolo)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*Johan Brandt* ha risposto al tuo articolo";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "Un pulsante \"Altro\" contiene un menu a tendina che mostra i pulsanti di condivisione";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "Un account WordPress.com è collegato alle credenziali del tuo negozio. Per continuare, invieremo un link di verifica all'indirizzo email sopra indicato.";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "Un file contiene un modello di codice dannoso";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "Il titolo del sito";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "Per inviare un link di autenticazione tramite email, è necessario un indirizzo email valido. Torna alla schermata precedente e fornisci un indirizzo email valido.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "Un codice di verifica contiene solo numeri.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "ATTIVO";
@@ -334,9 +349,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* My Profile 'About me' label */
 "About Me" = "Su di me";
-
-/* Link to About screen for Jetpack for iOS */
-"About Reader for iOS" = "Informazioni su Reader per iOS";
 
 /* Link to About screen for WordPress for iOS */
 "About WordPress" = "Informazioni su WordPress";
@@ -525,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "Dopo di %@";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "Allineamento";
@@ -588,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "Indirizzi IP consentiti inclusi nell'elenco";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "Ci siamo quasi! Inserisci il codice di verifica dalla tua app di autenticazione.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Testo Alt (alternativo)";
@@ -600,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "In alternativa, puoi uniformare i contenuti separando il blocco.";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "In alternativa, puoi inserire la password per questo account.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "In alternativa:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "Invia sempre i registri di crash";
@@ -621,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "È necessaria una connessione Internet funzionante per visualizzare le attività";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "È necessario avere una connessione internet attiva per visualizzare i piani";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -671,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "Statistiche annuali del sito";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "Anonimo";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "Risposta";
 
@@ -692,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "Aspetto";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "Autenticazione Apple fallita.\nAssicurati di essere loggato in iCloud con un Apple ID che usa l'autenticazione a due fattori.";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "Si applica alla configurazione";
@@ -778,6 +811,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "Autenticazione non riuscita";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "Codice di autenticazione";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "&Egrave; richiesta l'autenticazione per l'host: %@";
@@ -888,6 +925,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "Sii il primo a scrivere un commento";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Sii il primo a lasciare un commento.";
 
 /* Beauty site intent topic */
 "Beauty" = "Bellezza";
@@ -1024,12 +1064,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button to copy post text" = "Pulsante per copiare il testo dell'articolo";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "Continuando, accetti i nostri _Termini di servizio_.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "Registrando questo dominio, accetti ai nostri <a>Termini e condizioni<\/a>.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "Configurando Jetpack accetti i nostri\n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "Iscrivendoti, accetti i nostri _Termini di servizio_.";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "PERSONALIZZA";
@@ -1043,6 +1089,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "Per scansionare i codici di accesso è necessario accedere alla fotocamera";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Può non essere necessario il collegamento";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "Non è possibile pubblicare una pagina vuota";
 
@@ -1052,6 +1101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1061,6 +1111,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1079,6 +1130,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1106,6 +1158,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "Annullamento in corso...";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "Impossibile accedere al sito con questo indirizzo. Controlla e riprova.";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Non riesci a decidere? Puoi cambiare tema in qualsiasi momento.";
 
@@ -1113,7 +1168,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Didascalia";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Stai attento!";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1122,7 +1178,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Categorie";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Categoria";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1171,6 +1228,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "Dai un'occhiata ai nostri migliori suggerimenti per aumentare le visualizzazioni e il traffico";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "Controlla la tua email su questo dispositivo!";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Controlla la tua casella di posta su questo dispositivo e segui il link contenuto nell'email ricevuta da WordPress.com.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "Controlla la tua casella di posta su questo dispositivo e segui il link contenuto nell'email ricevuta da WordPress.com.\n\nNon trovi l'email? Controlla la cartella dello spam o della posta indesiderata.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "Controlla l'email!";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "Controlla la connessione a Internet e aggiorna.";
@@ -1267,6 +1336,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "Richiedi il tuo dominio gratuito";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "Blog classico";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "Cancella cache file multimediali sul dispositivo";
 
@@ -1294,6 +1366,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Chiudi";
 
@@ -1335,6 +1408,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "Impostazioni delle colonne";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Fumetti";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1386,6 +1462,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Commenti";
 
@@ -1453,12 +1530,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Account connessi";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Connesso ma…";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "Connessione di %@ in corso";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "La connessione a %1$@ sostituirà quella esistente a %2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Connessione con WordPress.com in corso";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Connessione in corso...";
@@ -1489,8 +1572,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "Contattaci all'indirizzo %@";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "Struttura del contenuto\nBlocchi: %1$li, parole: %2$li, caratteri%3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1505,6 +1592,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Continua a leggere";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Continua con Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Continua con Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Continua con Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "Contribuisci";
@@ -1633,6 +1729,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "Crea";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Crea un Account";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "Crea pagina vuota";
 
@@ -1653,6 +1752,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "Crea un articolo";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "Crea un sito";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "Crea una tag";
@@ -1686,6 +1788,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "Corrente";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Piano attuale";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Tema Corrente";
@@ -1788,6 +1893,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "Categoria predefinita";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Menu predefinito";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Formato articoli predefinito";
@@ -1796,6 +1904,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "Valori predefiniti per i nuovi articoli";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Elimina";
@@ -1853,6 +1962,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "Dettagli";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "Non volevi creare un nuovo account? Torna indietro per inserire nuovamente l'indirizzo email.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "Dimensioni";
 
@@ -1900,7 +2012,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "Discussione";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Ignora";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1922,6 +2036,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "Domini";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "Non hai un account? _Registrati_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2051,6 +2168,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "Download";
 
+/* Name for the status of a draft post. */
+"Draft" = "Bozza";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Bozze";
 
@@ -2160,7 +2280,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "Indirizzo email";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "Indirizzo email";
 
 /* Notification Settings Channel */
@@ -2244,8 +2367,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Inserisci la password";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "Immetti l'indirizzo del sito WordPress che desideri connettere.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Digita la password per il tuo account WordPress.com.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Inserisci il nome utente";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "Inserisci le informazioni sull’account per %@.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "Inserisci il tuo indirizzo email per accedere o creare un account WordPress.com.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "Inserisci l'indirizzo del sito esistente";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "Immetti la password.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "Inserisci le tue credenziali del server";
@@ -2408,6 +2551,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "Esterno";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Fallito";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "Contrassegno delle notifiche come lette non riuscito";
 
@@ -2419,9 +2565,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Failed to insert media.\nTap for more info." = "Impossibile inserire elementi multimediali.\nTocca per ulteriori informazioni.";
-
-/* A message indicating that we couldn't load the user's settings. */
-"Failed to load settings" = "Impossibile caricare le impostazioni";
 
 /* No comment provided by engineer. */
 "Failed to save files.\nPlease tap for options." = "Impossibile salvare i file.\nTocca per le opzioni.";
@@ -2437,6 +2580,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "Moda";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "In evidenza";
@@ -2495,6 +2641,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "Scopri di più";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Trova l'indirizzo per il tuo sito";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2517,6 +2666,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "Risoluzione delle minacce";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "Segui";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "Segui la conversazione";
@@ -2611,6 +2763,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "Genera un nuovo link";
 
+/* View title for initial auth views. */
+"Get Started" = "Inizia ora";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "Ottieni un link di accesso tramite email";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "Impegnati! Commenta gli articoli dei blog che segui.";
 
@@ -2632,8 +2790,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "Lasciati ispirare";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Recupero informazioni account";
+
+/* Cancel */
+"Give Up" = "Rinuncia";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "Prova aggiungendo alcuni blocchi al post o alla pagina.";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "Vai al Reader";
@@ -2644,6 +2811,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "Vai alle impostazioni iOS";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Accesso a Google non riuscito.";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2718,6 +2888,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "Icona della guida";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Nascosto";
+
 /* Title of a button used to collapse a group */
 "Hide" = "Nascondi";
 
@@ -2786,6 +2959,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "Aggiornamento icona fallito";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "Se non riesci a trovare l'email, controlla la cartella della posta indesiderata o dello spam";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "Se continui con Apple o Google e non hai già un account WordPress.com, crei un account e accetti i nostri _Termini di servizio_.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "Se rimuovi %1$@, tale utente non potrà più accedere a questo sito, ma qualsiasi contenuto creato da %2$@ rimarrà sul sito.";
@@ -2861,6 +3040,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "Include wp-config.php e qualsiasi file non WordPress";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Nome utente o password non corretti. Inserisci di nuovo le informazioni di accesso.";
 
 /* Title for a threat */
 "Infected core file" = "File di base infetto";
@@ -2962,6 +3144,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "Presentazione delle Richieste di blog";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "Indirizzo email non valido";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "Indirizzo del sito non valido";
 
@@ -2979,6 +3164,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "URL non valido. File audio non trovato.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "URL non valido. Controlla e riprova.";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "URL non valido. Inserisci un URL valido.";
@@ -3000,6 +3188,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "Invita delle persone";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "Sembra che questo nome utente\/questa password non sia associato\/a a questo sito.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "Sembra che tu abbia immesso una password errata. Vuoi riprovare?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "È ora di pubblicare sul blog di %@!";
@@ -3228,7 +3422,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "Altezza linea";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Link";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3290,6 +3485,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "Caricamento persone in corso...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Caricamento del piano in corso ...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Caricamento piani...";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "Caricamento del plugin in corso...";
 
@@ -3324,11 +3525,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "Caricamento...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Telefono";
+
 /* Local Services site intent topic */
 "Local Services" = "Servizi locali";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "Modifiche locali";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Località";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Il Servizio di Localizzazione deve essere abilitato prima che WordPress possa aggiungere la tua posizione. Abilita il Servizio di Localizzazione dalle impostazioni.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Posizione sconosciuta";
 
 /* No comment provided by engineer. */
 "Lock icon" = "Icona di blocco";
@@ -3336,9 +3549,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "I log file ordinati per data di creazione";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Accedi";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3348,17 +3563,33 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of a button for signing in. */
 "Log in" = "Login";
 
-/* LogOut confirmation text, whenever there are no local changes */
-"Log out of Jetpack?" = "Uscire da Jetpack?";
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Accesso fallito. Riprova.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "Accedi o iscriviti con WordPress.com";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Accedi all'account WordPress.com che hai utilizzato per connettere Jetpack.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "Accedi al tuo account WordPress.com con il tuo indirizzo email.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "Accedi con il nome utente e la password di WordPress.com.";
 
 /* LogOut confirmation text, whenever there are no local changes */
-"Log out of Reader?" = "Uscire da Reader?";
+"Log out of Jetpack?" = "Uscire da Jetpack?";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of WordPress?" = "Desideri disconnetterti da WordPress?";
 
 /* Login Request Expired */
 "Login Request Expired" = "Richiesta di login scaduta";
+
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "Accedi con password dell'account";
 
 /* No comment provided by engineer. */
 "Logs" = "I log";
@@ -3368,6 +3599,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Sembra che hai Jetpack installato sul tuo sito. Complimenti!\nAccedi con le tue credenziali WordPress.com per attivare le Statistiche e le Notifiche.";
+
+/* Title of a button. */
+"Lost your password?" = "Password dimenticata?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "Mail (Impostazione predefinita)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Navigazione principale";
@@ -3515,6 +3752,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "Messaggio";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "Varie vulnerabilità";
 
@@ -3610,6 +3850,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "Il mio sito";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "I miei siti in WordPress";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "La Top Ten dei bar";
 
@@ -3649,8 +3892,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Hai bisogno di aiuto?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "Hai bisogno di aiuto per trovare l'indirizzo del tuo sito?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "Serve aiuto?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Serve altro aiuto?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "È necessario l'aggiornamento";
@@ -3679,6 +3929,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "Nuovo articolo";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Nuova voce";
+
 /* Placeholder text for password field */
 "New password" = "Nuova password";
 
@@ -3696,7 +3949,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "Notizie";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Successivo";
 
 /* Accessibility label for the next notification button */
@@ -3732,6 +3987,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "Nessun URL di anteprima disponibile";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "Nessun titolo";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "Nessuna attività disponibile";
 
@@ -3764,7 +4022,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "Nessun commento";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "Nessuna connessione";
 
@@ -3913,6 +4172,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "Non ora";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "Non trovi l'email? Controlla la cartella dello spam o della posta indesiderata.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "Nota:";
 
@@ -3976,7 +4238,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Lista numerata";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -4033,7 +4300,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "Ops";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Oops!";
 
 /* No comment provided by engineer. */
@@ -4048,7 +4316,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "Apri le impostazioni di Jetpack Security";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Apri email";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Apri impostazioni";
 
 /* No comment provided by engineer. */
@@ -4066,6 +4339,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "Apri il link in una nuova finestra\/scheda";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "Apri le impostazioni dell'abbonamento all'articolo";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "Apri la sezione Io";
 
@@ -4080,6 +4356,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "Opzionale: inserisci un messaggio personalizzato contenente fino a %1$d caratteri da inviare con l'invito.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "Or";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "Oppure scegli un'altra forma di autenticazione.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "Altrimenti, accedi _inserendo l'indirizzo del tuo sito_.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "Oppure accedi con il link magico";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Elenco ordinato";
@@ -4128,7 +4416,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "Spaziatura interna";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Pagina";
 
@@ -4161,8 +4450,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "Essere genitori";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Password";
 
@@ -4179,8 +4471,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "Incolla blocco dopo";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "In sospeso";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "In attesa di revisione";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4211,6 +4507,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "Scegli il nome utente";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Piani";
+
 /* User action to play a video on the editor. */
 "Play video" = "Riproduci il video";
 
@@ -4240,6 +4540,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "Controlla che l'editor a blocchi sia attivato sul tuo sito. Se non è attivato, non sarà possibile procedere al caricamento.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "Inserisci un indirizzo di sito web completo, come example.com.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "Per favore, inserire un indirizzo per il sito.";
@@ -4274,11 +4577,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "Inserisci un indirizzo email valido";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "Inserisci un indirizzo email valido per un account WordPress.com.";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Inserisci un indirizzo email valido.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "Inserisci un numero di telefono valido";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Digita la password del tuo account WordPress.com per accedere con il tuo Apple ID.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Si prega di inserire i dati di accesso";
@@ -4286,8 +4595,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Inserisci il tuo indirizzo email.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Si prega di riempire tutti i campi";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Avvia l'app WordPress, accedi a WordPress.com e assicurati di avere almeno un sito, quindi riprova.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "Disconnettiti prima di connetterti a un sito WordPress.com differente";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "Riprova più tardi.";
@@ -4355,7 +4670,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "Lingue popolari";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Invia";
 
@@ -4476,6 +4792,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "Nota sulla privacy per utenti in California";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Privato";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "Problema durante la visualizzazione del blocco. \nTocca per tentare il ripristino del blocco.";
 
@@ -4490,6 +4809,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "Problema nell'acquisto del tuo dominio. Riprova.";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Procedendo tutti i dati relativi a WordPress.com e le bozze salvate localmente saranno rimossi da questo dispositivo. Non perderai nulla di quanto già stato salvato sui blog WordPress.com.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Progetti";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "Richiesta ignorata";
@@ -4507,13 +4832,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "Data di pubblicazione";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "In questo momento";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "Pubblicazione della pagina su:";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "Pubblica articolo su:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Pubblicato";
 
@@ -4715,7 +5044,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "Rispondi";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Testo di risposta";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "Rispondi a %1$@";
 
 /* An explaination of a setting. */
@@ -4744,6 +5078,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "Ripristina il filtro dell'intervallo di date";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Reimposta la password";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Ridimensiona & Ritaglia";
@@ -4801,6 +5138,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "Recupera tutto";
 
+/* No comment provided by engineer. */
+"Retry?" = "Riprovare?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "Torna all’articolo";
 
@@ -4830,6 +5170,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "Ruolo";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "Sms inviato";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "STATO";
 
@@ -4841,6 +5184,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4907,7 +5251,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "Scansione dei file";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Programmato";
 
 /* No comment provided by engineer. */
@@ -5047,6 +5392,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "Seleziona il tema come intento del tuo sito.";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Invia link";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "Invia link tramite email";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "Invia messaggio del registro";
 
@@ -5055,6 +5406,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "Invia crash test";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "Invia link di verifica dell'email";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "Invia notifiche via email";
@@ -5101,11 +5455,11 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Message to show when setting save failed */
 "Settings update failed" = "Aggiornamento impostazioni fallito";
 
-/* Title for a button that recommends the app to others */
-"Share Jetpack with a friend" = "Condividi Jetpack con un amico";
+/* Spoken accessibility label */
+"Share" = "Condividi";
 
 /* Title for a button that recommends the app to others */
-"Share Reader with a friend" = "Condividi Reader con un amico";
+"Share Jetpack with a friend" = "Condividi Jetpack con un amico";
 
 /* Title for a button that recommends the app to others */
 "Share WordPress with a friend" = "Condividi WordPress con un amico";
@@ -5156,6 +5510,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "Visulizza il pulsante Ripubblica";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "Mostra password";
+
 /* No comment provided by engineer. */
 "Show post content" = "Mostra contenuti articolo";
 
@@ -5167,6 +5525,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "Mostra statistiche per:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "Mostrata";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Mostrato pubblicamente quando commenti sui blog.";
@@ -5182,6 +5543,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "Mostra l’articolo";
+
+/* View title during the sign up process. */
+"Sign Up" = "Registrati";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "Accedi con le credenziali del sito";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Registrazione";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Iscriviti a WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Registrati con l'email";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "Poiché hai un piano Gratuito, nel Log delle attività visualizzerai un numero limitato di eventi.";
@@ -5220,6 +5596,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Traguardi del sito";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Indirizzo sito";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "L'indirizzo del sito deve contenere almeno 4 caratteri.";
@@ -5304,7 +5683,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Spiacenti, l'indirizzo del sito deve contenere anche lettere!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Spiacenti, l'indirizzo email che hai inserito è già in uso!";
 
 /* No comment provided by engineer. */
@@ -5364,6 +5743,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "Spam";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "Accelera il tuo sito";
@@ -5389,6 +5771,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "Stato";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "Homepage statica";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5419,6 +5804,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "Barrato";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Stub";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "Invia per la Revisione";
@@ -5509,7 +5897,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "Tablet";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Tag";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5644,6 +6033,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Termini del Servizio";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Testimonial";
+
 /* Title of a button style */
 "Text Only" = "Solo testo";
 
@@ -5653,8 +6045,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "I controlli relativi alla formattazione del testo sono localizzati all'interno della barra degli strumenti posizionata sulla tastiera mentre modifichi un blocco di testo";
 
+/* Button title */
+"Text me a code instead" = "Inviami un codice invece";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "Inviami un codice tramite SMS";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Grazie per aver scelto %1$@ di %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "Il codice di verifica non sembra essere valido.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "Questo non sembra un sito WordPress.";
@@ -5676,6 +6077,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "La connessione a Facebook non riesce a trovare pagine. Pubblicizza non può connettersi ai profili Facebook, bensì solo alle pagine pubblicate.";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "L'account Google \"%@\" non corrisponde a nessun account su WordPress.com";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "La connessione Internet appare mancante.";
@@ -5715,6 +6119,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "L'immagine non può essere aggiuntoa alla libreria dei media. ";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "La connessione ad internet non è attiva.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "Tipi di siti che puoi creare";
@@ -5758,6 +6165,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Il sito su %1$@ utilizza WordPress %2$@. Ti raccomandiamo di aggiornarlo all'ultima versione o almeno alla versione %3$@";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "Il sito a questo indirizzo non è un sito WordPress. Per poterci connettere, il sito deve utilizzare WordPress.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "Il sito non può essere eliminato.";
 
@@ -5799,6 +6210,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "Si è verificato un errore inaspettato durante la modifica del tuo commento";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "C'è stato un errore inatteso durante il caricamento dei commenti.";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "Si è verificato un errore imprevisto durante la registrazione del tuo dominio";
 
@@ -5807,6 +6221,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "Si è verificato un errore inatteso mentre venivano aggiornate le Impostazioni di notifica";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "Si è verificato un errore inaspettato durante il caricamento del tuo commento";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "Si è verificato un errore imprevisto.";
@@ -5828,6 +6245,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "Si è verificato un problema durante la comunicazione con il sito.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "Si è verificato un problema con la connessione a WordPress.com. Esegui nuovamente l'accesso.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "C'è stato un problema nel mostrare questo articolo.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "C’è stato un problema durante il caricamento dei tuoi dati, ricarica la pagina per riprovare.";
 
@@ -5837,12 +6260,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "Si è verificato un problema nel salvataggio dei cambiamenti alla gestione delle condivisioni.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "Si è verificato un problema cercando di accedere alla tua posizione. Prova più tardi.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "Si è verificato un errore durante la modifica della password";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "Si è verificato un errore durante il caricamento delle attività";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "Si è verificato un errore nel caricamento dei piani";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "C'è stato un errore caricando i plugin";
@@ -5855,6 +6284,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "Si è verificato un errore durante il caricamento della cronologia";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "Si è verificato un errore caricando il piano";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "Si è verificato un errore durante il caricamento della cronologia di scansione";
@@ -5903,6 +6335,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "Questo dominio non è disponibile";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "Questo indirizzo email non è registrato su WordPress.com.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "Il file è troppo grande per essere caricato sul tuo sito o non supporta il formato multimediale.";
@@ -5983,6 +6418,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "Fuso orario";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "Il tempo è scaduto, ma non preoccuparti: la tua sicurezza è la nostra priorità. Riprova.";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "Suggerimenti per utilizzare al meglio WordPress.com.";
 
@@ -5996,6 +6434,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "Inserisci indirizzo email e nome per continuare.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "Per creare il tuo nuovo account WordPress.com, inserisci il tuo indirizzo email.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "Per ricevere le utili notifiche dal tuo sito WordPress sul tuo telefono, sarà necessario installare il plugin di Jetpack.";
 
@@ -6004,6 +6445,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "Per installare i plugin, il dominio personalizzato deve essere associato al tuo sito.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "Per procedere con questo ID Apple, accedi prima con la tua password di WordPress.com. Sarà chiesta una volta sola.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "Per procedere con questo account Google, accedi prima con la tua password di WordPress.com. Sarà chiesta una volta sola.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "Per rimuovere un blocco, selezionalo e fai clic sui tre puntini nella parte inferiore destra del blocco per visualizzare le impostazioni. Da qui, scegli l'opzione per rimuovere il blocco.";
@@ -6078,7 +6525,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "Elimina";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "Cestinato";
 
@@ -6092,6 +6540,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "Prova e personalizza";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Riprova";
@@ -6117,6 +6566,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "Prova il nuovo editor a blocchi";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Prova con un'altra email";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Prova con l'indirizzo del sito";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "Disattiva richieste";
@@ -6159,6 +6614,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "USA";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "Impossibile connettersi";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "Impossibile caricare gli articoli";
@@ -6208,6 +6666,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Impossibile riprodurre il video";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Non è stato trovato un sito WordPress all'URL che hai inserito. Tocca 'Bisogno di Aiuto?' per visualizzare le FAQ.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Impossibile ripristinare il sito";
 
@@ -6234,6 +6695,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "Impossibile caricare 1 articolo e 1 file";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "Impossibile verificare l'indirizzo email. Riprova più tardi.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "Impossibile visitare le impostazioni di Jetpack per il sito";
@@ -6378,7 +6842,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Upload fallito";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Caricato";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6396,7 +6861,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Carica temi";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Invio in corso";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6411,18 +6877,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "Usa";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "Usa una chiave di sicurezza";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "Usa editor a blocchi";
 
 /* No comment provided by engineer. */
 "Use icon button" = "Usa pulsante icona";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "Usa la password per accedere";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Nome utente";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6437,6 +6912,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Utenti";
+
+/* two factor code placeholder */
+"Verification code" = "Codice di verifica";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "Email di verifica inviata, controlla la posta in arrivo.";
@@ -6569,8 +7047,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "Directory wp-content";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "In attesa di Google per il completamento…";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "In attesa della connessione";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "In attesa della chiave di sicurezza";
+
+/* View title during the Google auth process. */
+"Waiting..." = "In attesa...";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6610,6 +7098,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "Abbiamo riscontrato difficoltà con il caricamento dei dati";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "Abbiamo appena inviato un link tramite email a %@. Controlla la tua app di posta e tocca il link per accedere.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "Abbiamo appena inviato un link magico a";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "Abbiamo creato correttamente un backup del sito a partire dal %@";
 
@@ -6619,14 +7113,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "Utilizziamo altri strumenti di tracciamento, compresi alcuni di terzi. Leggi le informazioni sugli strumenti e come utilizzarli.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "Al momento non siamo stati in grado di inviarti un'email. Riprova più tardi.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Ti invieremo un'email se vengono trovate minacce alla sicurezza. Nel frattempo continua pure a utilizzare tranquillamente il sito come al solito; potrai controllare l'andamento in qualsiasi momento.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "Ti invieremo per email un link per accedere subito, senza password. Non ci sarà più bisogno di digitare la password!";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "Ti invieremo un link di iscrizione via email per creare il tuo nuovo account WordPress.com.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "Ti invieremo delle notifiche quando riceverai follower, commenti e like.";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "Ti invieremo delle notifiche quando riceverai nuovi follower, commenti e Mi piace. Desideri consentire le notifiche push?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "Useremo questo indirizzo email per creare un nuovo account WordPress.com.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "Stiamo creando un backup scaricabile del sito dal giorno %1$@.";
@@ -6637,6 +7143,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Stiamo facendo il possibile per risolvere queste minacce in background. Nel frattempo continua pure a utilizzare tranquillamente il sito come al solito; potrai controllare l'andamento in qualsiasi momento.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "Impossibile connettere il sito Jetpack associato a questo URL. Contattaci per assistenza.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "Stiamo ripristinando il tuo sito al giorno %1$@.";
 
@@ -6645,6 +7154,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "Ti abbiamo anche inviato un'email con un link al file.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Ti abbiamo inviato via email un link di iscrizione per creare il tuo nuovo account WordPress.com. Controlla la tua email su questo dispositivo e tocca il link nell'email ricevuta da WordPress.com.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6671,6 +7183,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "Resoconto settimanale: %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "Sei su Jetpack";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Benvenuti in WordPress";
 
 /* A message title */
 "Welcome to the Reader" = "Benvenuto al Reader";
@@ -6715,6 +7233,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "Cos'è Gravatar?";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "Cos'è WordPress.com?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "Che cos'è un blocco?";
 
@@ -6731,10 +7252,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "What's New in Jetpack" = "Novità di Jetpack";
 
 /* Opens the What's New / Feature Announcement modal */
-"What's New in Reader" = "Novità in Reader";
-
-/* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "Novità in WordPress";
+
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "Qual'è l'indirizzo del mio sito?";
 
 /* Select the site's intent. Title */
 "What's your website about?" = "Di che cosa parla il tuo sito web?";
@@ -6748,6 +7269,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "Quando fai modifiche al sito puoi vedere lo storico attività qui.";
 
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Qualche cosa è andato storto e non siamo riusciti ad autenticarti. Riprova!";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "Siamo spiacenti, si è verificato un problema. Riprova.";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "Siamo spiacenti, la chiave di sicurezza sembra non essere valida. Riprova con un'altra chiave";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Questo non è un codice di autenticazione a due fattori valido. Controlla il tuo codice e riprova!";
+
 /* No comment provided by engineer. */
 "Width Settings" = "Impostazioni larghezza";
 
@@ -6760,17 +7293,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "Impostazioni dell’app WordPress";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "App WordPress: app per qualsiasi schermata";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "WordPress blog";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "Assistenza WordPress";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "WordPress Libreria Media";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "Impostazioni di notifica WordPress";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "Notifiche WordPress";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "Plugin WordPress";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "Profilo WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "Reader WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "Dettagli del sito WordPress";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "Temi WordPress";
@@ -6781,17 +7335,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "Multisiti WordPress non supportati";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress richiede il permesso di accedere alla tua posizione attuale per poterla aggiungere al tuo articolo. Aggiorna le tue impostazioni per la privacy.";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "Root WordPress";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "Versione di WordPress troppo vecchia";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "La versione di WordPress è troppo vecchia Il sito %1$@ usa WordPress %2$@. Ti suggeriamo di aggiornare all'ultima versione, o, almeno, alla versione %3$@";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "Account WordPress.com";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "Piani WordPress.com";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "Temi WordPress.com";
@@ -6822,6 +7385,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "Scrivi articolo";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "Scrivi una risposta";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "Rispondi...";
 
 /* Title for the writing section in site settings screen */
@@ -6835,6 +7401,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Posizione asse Y";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "Anno";
@@ -6919,6 +7488,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Displayed when the user views trashed in the posts list and there are no posts */
 "You don't have any trashed posts" = "Non sono presenti articoli nel cestino";
 
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"You don't have permission to view this private blog." = "Non disponi dell'autorizzazione per visualizzare questo blog privato.";
+
 /* Description for the first domain purchased with a paid plan. */
 "You have a free one-year domain registration with your plan." = "Con il tuo piano hai la registrazione del dominio per un anno gratuitamente.";
 
@@ -6934,7 +7506,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "Non ci sono promemoria impostati.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Hai delle modifiche non salvate.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -7021,9 +7594,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Help text that describes how the password should be. It appears while editing the password */
 "Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ & )." = "La password deve contenere almeno sei caratteri. Per renderla più efficace, usa lettere maiuscole e minuscole, numeri e simboli come ! \" ? $ % ^ & ).";
 
-/* Message of Export Content confirmation alert */
-"Your posts, pages, and settings will be mailed to the account's email address." = "I tuoi articoli, le tue pagine e le tue impostazioni verranno inviati all'indirizzo e-mail dell'account.";
-
 /* Message of Export Content confirmation alert; substitution is user's email address */
 "Your posts, pages, and settings will be mailed to you at %@." = "I tuoi articoli, pagine e impostazioni ti saranno inviati via email a %@.";
 
@@ -7032,6 +7602,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "La tua ricerca include caratteri non supportati nei domini WordPress.com. Sono consentiti i seguenti caratteri: A–Z, a–z, 0–9.";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "L'indirizzo del tuo sito viene visualizzato sulla barra nella parte superiore dello schermo quando visiti il tuo sito su Safari.";
 
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "Il tuo sito è già protetto da VaultPress. Di seguito trovi un link alla tua bacheca VaultPress.";
@@ -7111,17 +7684,23 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility identifier for an 'Add Comment' button */
 "addCommentButton.accessibilityIdentifity" = "Aggiungi commento";
 
-/* Error message when user cancels login */
-"addSite.selfHosted.cancelled" = "L'accesso è stato annullato";
+/* Error message shown a URL does not point to an existing site. */
+"addSite.restApiNotAvailable" = "Il sito a questo indirizzo non è un sito WordPress. Per permettere la connessione, il sito deve utilizzare WordPress.";
+
+/* Error message shown when an receiving an invalid application-password authentication result from a self-hosted WordPress site */
+"addSite.selfHosted.authenticationFailed" = "Impossibile accedere utilizzando l'autenticazione Application Password";
 
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "Inserisci l'indirizzo del sito WordPress che desideri connettere.";
 
+/* Error message when user input is not a WordPress site */
+"addSite.selfHosted.invalidUrl" = "L'indirizzo del sito non è valido.";
+
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "Impossibile caricare i dettagli del sito WordPress";
 
-/* Error message when user signs in with an unexpected usern. The first argument is the expected username */
-"addSite.selfHosted.mismatchUser" = "Accedi con l'utente che ha effettuato l'accesso. Nome utente: %@";
+/* Error message shown when application-password authentication is disabled on a self-hosted WordPress site */
+"addSite.selfHosted.noLoginUrlFound" = "L'autenticazione Application Password deve essere abilitata nel sito WordPress.";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "Impossibile salvare il sito WordPress, riprova più tardi.";
@@ -7129,17 +7708,14 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "Aggiungi il sito ospitato personalmente";
 
-/* Error message when XML-RPC is disabled on the WordPress site. The first argument is detailed error message */
-"addSite.selfHosted.xmlrpcDisabled" = "Impossibile connettersi al sito WordPress. XML-RPC potrebbe essere stato disabilitato sul server. Contatta il fornitore del servizio di hosting per risolvere questo problema.";
+/* Error message when an unknown error occurred when adding a self-hosted site */
+"addSite.selfHosted.unknownError" = "Si è verificato un problema. Riprova.";
 
 /* Age between dates equaling one hour. */
 "an hour" = "un'ora";
 
 /* This is the string we display when prompting the user to review the Jetpack app */
 "appRatings.jetpack.prompt" = "Che cosa pensi di Jetpack?";
-
-/* This is the string we display when prompting the user to review the Reader app */
-"appRatings.reader.prompt" = "Cosa ne pensi di Reader?";
 
 /* This is the string we display when prompting the user to review the WordPress app */
 "appRatings.wordpress.prompt" = "Che cosa pensi di WordPress?";
@@ -7831,6 +8407,10 @@ Example: Reply to Pamela Nguyen */
 /* Shared empty state view */
 "emptyStateView.noSearchResult.title" = "Nessun risultato";
 
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "example.com";
+
 /* Accept button title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackAccept" = "Invia feedback";
 
@@ -7842,9 +8422,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackTitle" = "Condividi il feedback";
-
-/* Communicates the future removal of the option to disable the experimental editor, displayed beneath the experimental features list */
-"experimentalFeatures.editorNote" = "L'Editor a blocchi sperimentale diventerà l'editor predefinito in una prossima versione e verrà rimossa la possibilità di disattivarlo.";
 
 /* The title for the experimental features list */
 "experimentalFeaturesList.heading" = "Funzionalità sperimentali";
@@ -7891,8 +8468,14 @@ Example: Reply to Pamela Nguyen */
 /* A footer retry button */
 "general.pagingFooterView.retry" = "Riprova";
 
+/* Error message format when REST API returns an error response. The first argument is error message. */
+"generic.error.rest-api-error" = "Il sito ha inviato una risposta di errore: %@";
+
 /* A generic title for an error */
 "generic.error.title" = "Errore";
+
+/* Error message when failing to parse API responses */
+"generic.error.unparsableResponse" = "Il sito ha inviato una risposta che non è stata analizzata dall'app";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "Imposta promemoria relativi al blog";
@@ -8064,42 +8647,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title of the Jetpack powered overlay. */
 "jetpack.branding.overlay.title" = "WordPress è migliore insieme a Jetpack";
-
-/* Title for the button that starts the Jetpack connection process */
-"jetpack.connection.connect.button" = "Connetti il tuo sito";
-
-/* Error message shown when WordPress.com authentication fails */
-"jetpack.connection.error.authentication" = "Account WordPress.com non valido";
-
-/* Error message shown when a connection step is attempted in an invalid order */
-"jetpack.connection.error.context" = "Questo passaggio non è ancora disponibile";
-
-/* Title for the retry button shown when a connection step fails */
-"jetpack.connection.retry.button" = "Riprova";
-
-/* Status message when a connection step is pending */
-"jetpack.connection.stage.pending" = "In attesa dell'avvio";
-
-/* Status message when a connection step is in progress */
-"jetpack.connection.stage.processing" = "In corso...";
-
-/* Status message when a connection step is completed successfully */
-"jetpack.connection.stage.success" = "Completata";
-
-/* Title for the finalization step in Jetpack connection flow */
-"jetpack.connection.step.finalize.title" = "Completa la connessione";
-
-/* Title for the install step in Jetpack connection flow */
-"jetpack.connection.step.install.title" = "Installa Jetpack";
-
-/* Title for the login step in Jetpack connection flow */
-"jetpack.connection.step.login.title" = "Accedi a WordPress.com";
-
-/* Title for the site connection step in Jetpack connection flow */
-"jetpack.connection.step.site.title" = "Connettiti al tuo sito";
-
-/* Title for the user connection step in Jetpack connection flow */
-"jetpack.connection.step.user.title" = "Connettiti al tuo account WordPress.com";
 
 /* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
 "jetpack.fullscreen.overlay.early.switch.title" = "Passa alla nuova app Jetpack";
@@ -8320,41 +8867,11 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "Non disponi dell'autorizzazione per visualizzare questo blog privato.";
 
-/* Button to dismiss the re-authentication view */
-"login.appPasswordReAuth.cancelButton" = "Annulla";
-
-/* Description explaining why the user needs to re-authenticate */
-"login.appPasswordReAuth.description" = "La password dell'applicazione assegnata all'app non esiste più sul tuo profilo.\nAccedi di nuovo per creare una nuova password dell'applicazione da utilizzare per l'app.";
-
-/* Button to start the re-authentication process */
-"login.appPasswordReAuth.signInButton" = "Accedi";
-
-/* Title shown when the application password is invalid */
-"login.appPasswordReAuth.title" = "Password dell'applicazione non valida";
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "Inserisci il codice di verifica per l'account WordPress.com dalla tua app di autenticazione.";
 
 /* Indicating that referrer was marked as spam */
 "marked as spam" = "contrassegnato come spam";
-
-/* Button title when verification link sending failed */
-"me.verifyEmail.button.retry" = "Riprova";
-
-/* Button title to send verification link */
-"me.verifyEmail.button.send" = "Invia di nuovo l'e-mail";
-
-/* Button title while verification link is being sent */
-"me.verifyEmail.button.sending" = "Invio in corso...";
-
-/* Button title after verification link is sent */
-"me.verifyEmail.button.sent" = "E-mail inviata";
-
-/* Message for email verification card */
-"me.verifyEmail.message.noEmail" = "Verifica la tua e-mail per mettere in sicurezza il tuo account e accedere a più funzionalità.\nControlla la tua casella di posta per l'e-mail di conferma, oppure fai clic su '%@' per riceverne una nuova.";
-
-/* Message for email verification card with email address */
-"me.verifyEmail.message.withEmail" = "Verifica la tua e-mail per mettere in sicurezza il tuo account e accedere a più funzionalità.\nControlla la tua casella di posta %1$@ per l'e-mail di conferma, oppure fai clic su '%2$@' per riceverne una nuova.";
-
-/* Title for email verification card */
-"me.verifyEmail.title" = "Verifica la tua e-mail";
 
 /* Me tab menu items */
 "meMenu.submitFeedback" = "Invia feedback";
@@ -8797,6 +9314,9 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "Pagina principale";
 
+/* No comment provided by engineer. */
+"password" = "password";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "Le schede possono mostrare contenuti diversi a seconda di ciò che sta accadendo sul tuo sito. Stiamo lavorando su più schede e controlli.";
 
@@ -8898,9 +9418,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Message shown while loading plugin details */
 "pluginDetails.loading" = "Caricamento delle informazioni del plugin in corso…";
-
-/* Placeholder message shown when a plugin has no description */
-"pluginDetails.noDescription" = "Questo plugin non ha fornito alcuna descrizione.";
 
 /* Title of the changelog section in plugin details */
 "pluginDetails.section.changelog" = "Log delle modifiche";
@@ -9187,6 +9704,30 @@ Example: Reply to Pamela Nguyen */
 /* An alert message explaning that by changing the visibility to private, the post will be published immediately to your site */
 "postSettings.warningPostWillBePublishedAlertMessage" = "Cambiando la visibilità in \"Privata\", l'articolo verrà pubblicato immediatamente";
 
+/* Localized post type: `Page` */
+"postType.page" = "pagina";
+
+/* Localized post type: `Post` */
+"postType.post" = "articolo";
+
+/* Details for a 'Private' privacy setting */
+"postVisibility.private.details" = "Visibile solo agli amministratori e agli editori del sito";
+
+/* Title for a 'Private' privacy setting */
+"postVisibility.private.title" = "Privato";
+
+/* Details for a 'Password Protected' privacy setting */
+"postVisibility.protected.details" = "Visibile a tutti, ma richiede una password";
+
+/* Title for a 'Password Protected' privacy setting */
+"postVisibility.protected.title" = "Protetto da password";
+
+/* Details for a 'Public' (default) privacy setting */
+"postVisibility.public.details" = "Visibile a tutti";
+
+/* Title for a 'Public' (default) privacy setting */
+"postVisibility.public.title" = "Pubblico";
+
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Annulla";
 
@@ -9407,15 +9948,6 @@ Tapping on this row allows the user to edit the sharing message. */
 /* Title for the success view when the user has successfully logged in */
 "qrLoginVerifyAuthorization.completedInstructions.title" = "Sei connesso!";
 
-/* No comment provided by engineer. */
-"reachability-utils.alert.retry" = "Riprovare?";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.title" = "Nessuna connessione";
-
-/* Message of error prompt shown when no internet connection is available */
-"reachability-utils.alert.utils" = "La connessione a internet non è attiva.";
-
 /* Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog. */
 "reader.blocked.blog.message" = "Il blog %@ non comparirà più nel lettore. Tocca per annullare.";
 
@@ -9452,26 +9984,8 @@ Tapping on this row allows the user to edit the sharing message. */
 /* A shared button title for Reader */
 "reader.button.unsubscribe" = "Smetti di seguire";
 
-/* Button title. Follow the comments on a post. */
-"reader.comments.buttonFollow" = "Segui";
-
 /* Informational message, should be short. */
 "reader.comments.commentsClosed" = "Commenti disattivati";
-
-/* Empty state view title */
-"reader.comments.emptyStateTitle" = "Sii il primo a lasciare un commento.";
-
-/* Empty state view title */
-"reader.comments.errorLoadingComments" = "C'è stato un errore inatteso durante il caricamento dei commenti.";
-
-/* VoiceOver hint */
-"reader.comments.followingSettingAccessibilityIdentifier" = "Apri impostazioni di notifica per l'articolo";
-
-/* Error message that informs reader comments from a private blog cannot be fetched. */
-"reader.comments.noPermissionToViewPrivateBlog" = "Non disponi dell'autorizzazione per visualizzare questo blog privato.";
-
-/* Navigation title */
-"reader.comments.title" = "Commenti";
 
 /* Accessibility hint to inform that the author section can be tapped to see posts from the site. */
 "reader.detail.header.authorInfo.a11y.hint" = "Visualizza articoli dal sito";
@@ -9549,20 +10063,8 @@ but tapping on this button will remove their like from the post. */
 /* Screen header details */
 "reader.following.header.details" = "Non perderti gli aggiornamenti dei blog che segui.";
 
-/* Empty state view */
-"reader.following.lists.emptyTitle" = "Elenchi vuoti";
-
-/* Screen header details */
-"reader.home.header.details" = "Non perderti gli aggiornamenti dei blog che segui.";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.library.title" = "Libreria";
-
 /* Used in multiple contexts, usually as a screen title */
 "reader.likes.title" = "Mi piace";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.lists.title" = "Elenchi";
 
 /* Reader logged-out screen details */
 "reader.loggedOut.details" = "Accedi con un account WordPress.com per seguire i tuoi blog preferiti";
@@ -9802,8 +10304,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title of a Reader tab showing Posts matching a user's search query */
 "reader.search.tab.posts" = "Articoli";
 
-/* Title of the Reader's search feature
-   Used in multiple contexts, usually as a screen title */
+/* Title of the Reader's search feature */
 "reader.search.title" = "Cerca";
 
 /* Screen title. Reader select interests title label text. */
@@ -9829,6 +10330,21 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Reader select interests title label text */
 "reader.select.tags.title" = "Scopri e segui i blog che ami";
+
+/* Reader sidebar menu item */
+"reader.sidebar.discover" = "Scopri";
+
+/* Reader sidebar menu item */
+"reader.sidebar.likes" = "Mi piace";
+
+/* Reader sidebar menu item */
+"reader.sidebar.recent" = "Recente";
+
+/* Reader sidebar menu item */
+"reader.sidebar.saved" = "Salvato";
+
+/* Reader sidebar menu item */
+"reader.sidebar.search" = "Cerca";
 
 /* Reader sidebar section title */
 "reader.sidebar.section.favorites.title" = "Preferiti";
@@ -9875,7 +10391,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Number of subscriptions on a site (singular) */
 "reader.subscriptions.subscriptionsSingular" = "%@ abbonato";
 
-/* Used in multiple contexts, usually as a screen title */
+/* Navigation bar title */
 "reader.subscriptions.title" = "Abbonamenti";
 
 /* A suggestion of topics the user might want to subscribe to */
@@ -9914,26 +10430,11 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Verb. Button title. The user is following a tag. */
 "reader.tags.following.button.title" = "Segui";
 
-/* Used in multiple contexts, usually as a screen title */
-"reader.tags.title" = "Tag";
-
 /* Accessibility label for unsubscribing from a tag */
 "reader.tags.unfollow.accessibility.label" = "Smetti di seguire %@";
 
 /* Field title */
 "reader.userProfile.site" = "Sito";
-
-/* Reader Welcome screen login button */
-"reader.welcome.continueText" = "Continua con WordPress.com";
-
-/* Reader Welcome screen */
-"reader.welcome.subtitle" = "Unisciti alla più grande community di blogging";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.me" = "Io";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.notifications" = "Notifiche";
 
 /* Spoken accessibility label */
 "readerDetail.backButton.accessibilityLabel" = "Indietro";
@@ -10202,14 +10703,10 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Message shown when there are no inactive plugins on the site */
 "site.plugins.empty.inactive" = "Nessun plugin inattivo";
 
-/* The plugin fillter option for displaying active plugins */
-"site.plugins.filter.option.active" = "Attivo";
-
-/* The plugin fillter option for displaying all plugins */
+/* The plugin fillter option for displaying active plugins
+   The plugin fillter option for displaying all plugins
+   The plugin fillter option for displaying inactive plugins */
 "site.plugins.filter.option.all" = "Tutti";
-
-/* The plugin fillter option for displaying inactive plugins */
-"site.plugins.filter.option.inactive" = "Inattivo";
 
 /* Title of the plugin filter picker */
 "site.plugins.filter.title" = "Filtra";
@@ -10758,9 +11255,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* View title for Help & Support page. */
 "support.title" = "Aiuto";
 
-/* Subject of new Zendesk ticket. */
-"support.zendesk.readerAppTicketSubject" = "Reader per supporto iOS";
-
 /* Title for placeholder in Tenor picker */
 "tenor.welcomeMessage" = "Cerca per trovare GIF da aggiungere alla tua Libreria multimediale!";
 
@@ -10909,8 +11403,119 @@ Feel free to replace it with other bracket types that you think looks better for
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "Stato";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "Articoli totali e maggior parte delle visualizzazioni";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "Visualizzazioni totali";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "Visualizzazioni e visitatori totali";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "Record di visualizzazioni";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "Maggior parte delle visualizzazioni";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "Impossibile caricare le statistiche complessivee.";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "Crea o aggiungi un sito per vedere le statistiche complessive";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Articoli";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "Rimani aggiornato sulle attività del tuo sito WordPress dalla sua creazione.";
+
+/* Title of all time widget */
+"widget.alltime.title" = "Dall'inizio";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "Accedi a WordPress per vedere le statistiche dalla creazione del sito.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "Accedi a Jetpack per vedere le statistiche dalla creazione del sito.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "Accedi a Jetpack per visualizzare le statistiche di questa settimana.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "Accedi a Jetpack per visualizzare le statistiche di oggi.";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "Visualizzazioni totali";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "Visualizzazioni odierne";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "Impossibile caricare le statistiche di questa settimana.";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "Crea o aggiungi un sito per vedere le statistiche di questa settimana.";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "Rimani aggiornato con l'attività di questa settimana sul tuo sito WordPress.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "Questa settimana";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "Accedi a WordPress per visualizzare le statistiche di questa settimana.";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Commenti";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "Le statistiche sono state spostate nell'app Jetpack. Il passaggio è gratuito e richiede solo un minuto.";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Like";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "Impossibile caricare le statistiche del sito.";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "Impossibile caricare le statistiche di oggi,";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "Crea o aggiungi un sito per vedere le statistiche di oggi.";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "Rimani aggiornato con l'attività di oggi sul tuo sito WordPress.";
+
+/* Title of today widget */
+"widget.today.title" = "Oggi";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "Accedi a WordPress per vedere le statistiche di oggi.";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "Questa vista non è disponibile";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Visualizzazioni";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Visitatori";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "Mi piace e commenti odierni";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "Visualizzazioni odierne";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "Visualizzazioni e visitatori odierni";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "non sarà più disponibile.";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "Vuoi creare un nuovo sito?";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "wordpress, aiuto, supporto, faq, domande, debug, log, centro assistenza, contatti";
@@ -10935,6 +11540,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Error message that describes an unknown error had occured */
 "wordpress-api.error.unknown" = "Si è verificato un problema. Riprova più tardi.";
+
+/* Error message when failing to find selected media file on the user's device. */
+"wordpress.api.upload.media.fileNotFound" = "Impossibile trovare il file multimediale sul dispositivo";
 
 /* Jetpack Plugin Modal on WordPress primary button title */
 "wordpress.jetpack.plugin.modal.primary.button.title" = "Passa all'app Jetpack";
@@ -10981,21 +11589,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Error message when user signs in with an unexpected email address. The first argument is the expected email address */
 "wpComLogin.error.mismatchedEmail" = "Accedi con l'indirizzo e-mail %@";
 
-/* Message shown when user denies WordPress.com login, offering option to try with different account */
-"wpComLogin.loginDenied.message" = "Se ne hai bisogno, puoi accedere con un account diverso. Tocca \"%@\" per iniziare.";
-
-/* Title of alert shown when user cancels WordPress.com login */
-"wpComLogin.loginDenied.title" = "Accesso annullato";
-
-/* Button title for signing in with a different WordPress.com account */
-"wpComLogin.loginDenied.useDifferentAccount" = "Utilizza un account diverso";
-
-/* Button title to log out the current WordPress.com account */
-"wpcom.token.alert.button.logout" = "Esci";
-
-/* Button title to Sign In to WordPress.com */
-"wpcom.token.alert.button.signin" = "Accedi";
-
 /* Message title to be displayed when the user needs to re-authenticate their WordPress.com account. */
 "wpcom.token.fix.signin" = "Accedi a WordPress.com";
 
@@ -11010,6 +11603,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "Allegato non supportato";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Accedi con Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Domini";

--- a/WordPress/Resources/ja.lproj/Localizable.strings
+++ b/WordPress/Resources/ja.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Translation-Revision-Date: 2025-05-13 09:54:08+0000 */
+/* Translation-Revision-Date: 2025-03-11 09:54:08+0000 */
 /* Plural-Forms: nplurals=1; plural=0; */
 /* Generator: GlotPress/4.0.1 */
 /* Language: ja_JP */
@@ -98,6 +98,9 @@
 
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "サイトの %1$@ \/ %2$@";
+
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "サイトの利用量: %1$@ \/ %2$@";
 
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ (単位 : 1,000兆)";
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(無題)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(タイトルなし)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*Johan Brandt* さんが投稿に返信しました";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "「その他」ボタンには共有ボタンを表示するドロップダウンリストが含まれています";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "WordPress.com アカウントはストアのログイン情報に連携されています。 続行する場合は、上のメールアドレスに認証リンクが届きます。";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "ファイルには、悪意のあるコードが含まれています";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "サイトのタイトル";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "認証リンクをメールで送信するには、有効なメールアドレスが必要です。前の画面に戻り、有効なメールアドレスを入力してください。";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "認証コードは数字だけで構成されます。";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "有効";
@@ -334,9 +349,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* My Profile 'About me' label */
 "About Me" = "自己紹介";
-
-/* Link to About screen for Jetpack for iOS */
-"About Reader for iOS" = "Reader for iOS について";
 
 /* Link to About screen for WordPress for iOS */
 "About WordPress" = "WordPress について";
@@ -525,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "%@の後";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "配置";
@@ -588,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "許可リストに登録された IP アドレス";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "もう少しで完了です。認証アプリから認証コードを入力してください。";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "代替テキスト";
@@ -600,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "あるいは、ブロックのグループ化を解除してコンテンツをフラットにすることもできます。";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "または、このアカウントのパスワードを入力することもできます。";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "もしくは、";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "クラッシュログを常に送信";
@@ -621,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "アクティビティを表示するには有効なインターネット接続が必要です";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "プランを表示するには有効なインターネット接続が必要です";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -671,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "年間サイト統計情報";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "匿名";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "回答";
 
@@ -692,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "外観";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "Apple の認証に失敗しました。\n二要素認証を使用している Apple ID で iCloud にログイン中かどうか確認してください。";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "設定を適用";
@@ -778,6 +811,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "認証できませんでした";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "認証コード";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "ホストに必要な認証:%@";
@@ -888,6 +925,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "最初のコメントを投稿";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "最初のコメントを投稿してみましょう。";
 
 /* Beauty site intent topic */
 "Beauty" = "美容";
@@ -1024,12 +1064,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button to copy post text" = "投稿内容をコピーするボタン";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "継続すると、利用規約に合意したことになります。";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "このドメインを登録することで、当社の<a>利用規約<\/a>に合意したことになります。";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "Jetpack を設定することで、%@に\n同意したものとみなされます。";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "登録することで、利用規約に合意したことになります。";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "カスタマイズ";
@@ -1043,6 +1089,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "ログインコードをスキャンするにはカメラへのアクセスが必要です";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "リンクをリクエストできません";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "空のページは公開できません";
 
@@ -1052,6 +1101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1061,6 +1111,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1079,6 +1130,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1106,6 +1158,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "キャンセル中...";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "このアドレスのサイトにアクセスできません。 もう一度確認してから、やり直してください。";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "決められませんか ? テーマはいつでも変更できます。";
 
@@ -1113,7 +1168,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "キャプション";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "ご注意ください。";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1122,7 +1178,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "カテゴリー";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "カテゴリー";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1171,6 +1228,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "よく読まれているヒントを確認して表示数とトラフィックを増やす";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "この端末でメールアドレスを確認してください。";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "この端末でメールをチェックして、WordPress.com から届いたメールにあるリンクをタップしてください。";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "この端末でメールを確認し、WordPress.com から届いたメールの中にあるリンクをタップしてください。\n\nメールが表示されない場合は、迷惑メールフォルダーを確認してみてください。";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "メールをご確認ください。";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "インターネット接続を確認し、画面を下に引っ張って更新してください。";
@@ -1267,6 +1336,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "無料ドメインを取得";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "クラシックブログ";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "端末のメディアキャッシュを消去";
 
@@ -1294,6 +1366,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "閉じる";
 
@@ -1335,6 +1408,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "カラム設定";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "コミック";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1386,6 +1462,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "コメント";
 
@@ -1453,12 +1530,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "連携済みアカウント";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "接続されたが…";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "%@ に連携中";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "%1$@ に接続すると、それにより %2$@ への既存の接続は置き換えられます。";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "WordPress.com に接続中";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "連携中…";
@@ -1489,8 +1572,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "%@ までお問い合わせください";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "コンテンツの構造\nブロック数 : %1$li、単語数 : %2$li、文字数 : %3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1505,6 +1592,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "続きを読む";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Apple で続ける";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Google で続ける";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Apple と連携しています";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "参加";
@@ -1633,6 +1729,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "作成";
 
+/* The button title text for creating a new account. */
+"Create Account" = "アカウントを作成";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "空のページを作成";
 
@@ -1653,6 +1752,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "投稿の作成";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "サイトを作成";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "タグの作成";
@@ -1686,6 +1788,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "最新";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "現在のプラン";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "現在のテーマ";
@@ -1788,6 +1893,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "デフォルトカテゴリー";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "デフォルトメニュー";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "デフォルト投稿フォーマット";
@@ -1796,6 +1904,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "新しい投稿のデフォルト";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "削除";
@@ -1853,6 +1962,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "詳細";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "新しいアカウントを作成しない場合は、 戻ってメールアドレスを再度入力してください。";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "サイズ";
 
@@ -1900,7 +2012,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "ディスカッション";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "非表示にする";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1922,6 +2036,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "ドメイン";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "アカウントをお持ちでない場合は_登録_してください";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2051,6 +2168,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "ダウンロード";
 
+/* Name for the status of a draft post. */
+"Draft" = "下書き";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "下書き";
 
@@ -2160,7 +2280,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "メールアドレス";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "メールアドレス";
 
 /* Notification Settings Channel */
@@ -2244,8 +2367,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "パスワードを入力";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "連携する WordPress サイトのアドレスを入力してください。";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "WordPress.com アカウント用のパスワードを入力します。";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "ユーザー名を入力";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "%@ のアカウント情報を入力してください。";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "メールアドレスを入力してログインするか、WordPress.com アカウントを作成します。";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "既存のサイトアドレスを入力";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "代わりにパスワードを入力することもできます。";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "サーバーの認証情報を入力";
@@ -2408,6 +2551,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "外部";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "失敗しました";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "「通知」を既読としてマークできませんでした";
 
@@ -2419,9 +2565,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Failed to insert media.\nTap for more info." = "メディアの挿入に失敗しました。\nタップして詳細をご覧ください。";
-
-/* A message indicating that we couldn't load the user's settings. */
-"Failed to load settings" = "設定を読み込めませんでした";
 
 /* No comment provided by engineer. */
 "Failed to save files.\nPlease tap for options." = "ファイルの保存に失敗しました。\nタップすると、オプションが表示されます。";
@@ -2437,6 +2580,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "ファッション";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "おすすめ";
@@ -2495,6 +2641,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "さらに詳しく";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "サイトアドレスを検索";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2517,6 +2666,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "脅威の修正";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "フォロー";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "会話をフォロー";
@@ -2611,6 +2763,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "新規リンクを作成";
 
+/* View title for initial auth views. */
+"Get Started" = "今すぐ始める";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "ログインリンクをメールで取得";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "フォロー中のブログの記事にコメントを書いてみましょう。";
 
@@ -2632,8 +2790,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "インスピレーションを受ける";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "アカウント情報を取得中";
+
+/* Cancel */
+"Give Up" = "諦める";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "投稿やページにブロックをいくつか追加して、どのようになるか見てみましょう。";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "Reader に移動";
@@ -2644,6 +2811,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "iOS 設定に移動";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Google の登録に失敗しました。";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2718,6 +2888,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "ヘルプアイコン";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "非表示";
+
 /* Title of a button used to collapse a group */
 "Hide" = "非表示";
 
@@ -2786,6 +2959,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "アイコンを更新できませんでした";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "メールが見つからない場合は、迷惑メールやスパムのフォルダーを確認してください";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "Apple または Google を引き続き使用し、WordPress.com アカウントをまだお持ちでない場合は、アカウントを作成して WordPress.com の利用規約に同意します。";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "%1$@ を削除するとこのユーザーはこのサイトにアクセスできなくなりますが、%2$@ が作成したすべてのコンテンツはサイト上に残ります。";
@@ -2861,6 +3040,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "wp-config.php とすべての非 WordPress ファイルを含む";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "ユーザー名またはパスワードが間違っています。もう一度ログイン詳細を入力し直してください。";
 
 /* Title for a threat */
 "Infected core file" = "感染したコアファイル";
@@ -2962,6 +3144,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "ブログのプロンプトのご紹介";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "無効なメールアドレスです";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "無効なサイトアドレスです";
 
@@ -2979,6 +3164,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "無効な URL。音声ファイルが見つかりません。";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "無効な URL です。 もう一度確認してから、やり直してください。";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "無効な URL。 正しい URL を入力してください。";
@@ -3000,6 +3188,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "他の人を招待";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "このユーザー名またはパスワードは、このサイトに関連付けられていないようです。";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "入力したパスワードが正しくないようです。もう一度試しますか ?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "%@ のブログに投稿する日です !";
@@ -3228,7 +3422,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "行の高さ";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "リンク";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3290,6 +3485,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "人物を読み込んでいます...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "プランを読み込み中…";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "プランを読み込み中…";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "プラグインを読み込んでいます...";
 
@@ -3324,11 +3525,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "読み込み中…";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "ローカル";
+
 /* Local Services site intent topic */
 "Local Services" = "地域サービス";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "ローカルでの変更";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "位置情報";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "WordPress が現在位置を追加するには、事前に位置情報サービスを有効にしておく必要があります。設定アプリから位置情報サービスを有効にしてください。";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "位置情報不明";
 
 /* No comment provided by engineer. */
 "Lock icon" = "錠のアイコン";
@@ -3336,9 +3549,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "ログファイル (作成日順)";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "ログイン";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3348,17 +3563,33 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of a button for signing in. */
 "Log in" = "ログイン";
 
-/* LogOut confirmation text, whenever there are no local changes */
-"Log out of Jetpack?" = "Jetpack からログアウトしますか ?";
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "ログインに失敗しました。もう一度お試しください。";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "WordPress.com でログインまたは登録";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Jetpack を接続するのに使用した WordPress.com アカウントにログインします。";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "メールアドレスで WordPress.com アカウントにログインします。";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "WordPress.com のユーザー名とパスワードでログインしてください。";
 
 /* LogOut confirmation text, whenever there are no local changes */
-"Log out of Reader?" = "Reader からログアウトしますか ?";
+"Log out of Jetpack?" = "Jetpack からログアウトしますか ?";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of WordPress?" = "WordPress からログアウトしますか ?";
 
 /* Login Request Expired */
 "Login Request Expired" = "ログインリクエスト期限切れ";
+
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "アカウントパスワードでログイン";
 
 /* No comment provided by engineer. */
 "Logs" = "ログ";
@@ -3368,6 +3599,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "サイトで Jetpack を設定済みのようです。統計情報と通知機能を有効化するには WordPress.com のアカウント情報でログインしてください。";
+
+/* Title of a button. */
+"Lost your password?" = "パスワードをお忘れですか ?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "メールアドレス (デフォルト)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "メインナビゲーション";
@@ -3515,6 +3752,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "メッセージ";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "様々な脆弱性";
 
@@ -3610,6 +3850,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "マイサイト";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "WordPress での参加サイト";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "私のお気に入りカフェトップ10";
 
@@ -3649,8 +3892,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "お困りですか ?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "自分のサイトアドレスを忘れましたか ?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "お困りですか ?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "問題が解決しない場合";
 
 /* Describes a status of a plugin */
 "Needs Update" = "更新が必要";
@@ -3679,6 +3929,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "新規投稿";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "新規項目";
+
 /* Placeholder text for password field */
 "New password" = "新規パスワード";
 
@@ -3696,7 +3949,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "ニュース";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "次へ";
 
 /* Accessibility label for the next notification button */
@@ -3732,6 +3987,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "利用可能なプレビューの URL がありません";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "無題";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "アクティビティはありません";
 
@@ -3764,7 +4022,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "コメントはまだありません";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "接続できません";
 
@@ -3913,6 +4172,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "後で";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "メールが表示されない場合は、 スパムメールや迷惑メールのフォルダーを確認してください。";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "注:";
 
@@ -3976,7 +4238,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "番号付きリスト";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -4033,7 +4300,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "おっと";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "おっと。";
 
 /* No comment provided by engineer. */
@@ -4048,7 +4316,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "Jetpack セキュリティの設定を開く";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "メールを開く";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "設定を開く";
 
 /* No comment provided by engineer. */
@@ -4066,6 +4339,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "リンクを新ウィンドウまたはタブで開く";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "投稿の購読設定を開く";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "Me セクションを開く";
 
@@ -4080,6 +4356,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "オプション:  招待状と一緒に送信する最大%1$d文字のカスタムメッセージを入力します。";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "OR";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "または別の認証形式を選択してください。";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "または、サイトアドレスを入力してログインしてください。";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "またはマジックリンクでログイン";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "番号つきリスト";
@@ -4128,7 +4416,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "パディング";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "ページ";
 
@@ -4161,8 +4450,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "育児";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "パスワード";
 
@@ -4179,8 +4471,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "ブロックを後にペースト";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "承認待ち";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "レビュー待ち";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4211,6 +4507,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "ユーザー名を選択";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "プラン";
+
 /* User action to play a video on the editor. */
 "Play video" = "動画を再生";
 
@@ -4240,6 +4540,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "サイトでブロックエディターが有効になっていることを確認してください。 有効になっていない場合、読み込むことができません。";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "サイトの完全なアドレス (例 : example.com) を入力してください。";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "サイトアドレスを入力してください。";
@@ -4274,11 +4577,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "有効なメールアドレスを入力してください";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "WordPress.com アカウントの有効なメールアドレスを入力してください。";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "正しいメールアドレスを入力してください。";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "有効な電話番号を入力してください";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Apple ID でログインするには、WordPress.com のアカウントのパスワードを入力してください。";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "ログイン情報を入力してください";
@@ -4286,8 +4595,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "メールアドレスを入力してください。";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "すべての欄に記入してください";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "WordPress アプリを起動して WordPress.com にログインし、1つ以上のサイトがあることを確認してから、もう一度お試しください。";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "別の wordpress.com サイトに接続する前にログアウトしてください";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "後ほど、もう一度お試しください";
@@ -4352,7 +4667,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "人気の言語";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "投稿";
 
@@ -4473,6 +4789,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "カリフォルニア州のユーザーへのプライバシー通知";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "プライベート";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "ブロックの表示中に問題が発生しました。 \nタップしてブロックの回復を試みます。";
 
@@ -4487,6 +4806,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "ドメインの購入で問題が発生しました。もう一度やり直してください。";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "次へ進むと、この端末からすべての WordPress.com データとローカルで保存された下書きを削除します。WordPress.com のサイト上ですでに保存した内容が消失することはありません。";
+
+/* Menu item label for linking a project page. */
+"Projects" = "プロジェクト";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "プロンプトがスキップされました";
@@ -4504,13 +4829,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "公開日";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "すぐに公開";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "次にページを公開:";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "以下の投稿に公開:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "公開済み";
 
@@ -4712,7 +5041,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "返信";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "返信テキスト";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "%1$@ への返信";
 
 /* An explaination of a setting. */
@@ -4741,6 +5075,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "日付範囲フィルターを再設定";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "パスワードをリセット";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "サイズ変更・切り抜き";
@@ -4798,6 +5135,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "すべて再試行";
 
+/* No comment provided by engineer. */
+"Retry?" = "再試行しますか ?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "投稿へ戻る";
 
@@ -4827,6 +5167,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "権限グループ";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS 送信完了";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "ステータス";
 
@@ -4838,6 +5181,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4904,7 +5248,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "ファイルをスキャンしています";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "予約済み";
 
 /* No comment provided by engineer. */
@@ -5044,6 +5389,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "サイトの目的としてこのテーマを選択します。";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "リンクを送信";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "リンクをメールで送信";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "ログメッセージを送信";
 
@@ -5052,6 +5403,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "テストクラッシュを送信";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "メール認証リンクを送信";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "通知をメールで送信する";
@@ -5098,11 +5452,11 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Message to show when setting save failed */
 "Settings update failed" = "設定更新に失敗";
 
-/* Title for a button that recommends the app to others */
-"Share Jetpack with a friend" = "Jetpack を友達とシェア";
+/* Spoken accessibility label */
+"Share" = "共有";
 
 /* Title for a button that recommends the app to others */
-"Share Reader with a friend" = "Reader を友達と共有";
+"Share Jetpack with a friend" = "Jetpack を友達とシェア";
 
 /* Title for a button that recommends the app to others */
 "Share WordPress with a friend" = "WordPress を友達と共有する";
@@ -5153,6 +5507,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "リブログボタンを表示";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "パスワードを表示";
+
 /* No comment provided by engineer. */
 "Show post content" = "投稿の内容を表示";
 
@@ -5164,6 +5522,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "統計を表示:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "表示内容";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "ブログにコメントする際に公開表示されます。";
@@ -5179,6 +5540,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "投稿を表示";
+
+/* View title during the sign up process. */
+"Sign Up" = "登録";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "サイトのログイン情報でログイン";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "登録";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "WordPress.com に登録";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "メールアドレスで登録";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "無料プランをご利用のため、アクティビティログで確認できるイベントは限られています。";
@@ -5217,6 +5593,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "サイト達成記録";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "サイトアドレス";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "サイトアドレスは4文字以上にしてください。";
@@ -5301,7 +5680,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "サイトアドレスには半角英字を含める必要があります。";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "ご指定のメールアドレスはすでに使われています。";
 
 /* No comment provided by engineer. */
@@ -5361,6 +5740,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "スパム";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "サイトをスピードアップ";
@@ -5386,6 +5768,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "州";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "固定ホームページ";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5416,6 +5801,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "打ち消し線";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "スタブ";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "提出してレビューを要求";
@@ -5506,7 +5894,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "タブレット";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "タグ";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5641,6 +6030,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "利用規約";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "お客様の声";
+
 /* Title of a button style */
 "Text Only" = "テキストのみ";
 
@@ -5650,8 +6042,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "書式設定コントロールは、テキストブロックの編集中に表示されるキーボードの上に位置するツールバー内にあります";
 
+/* Button title */
+"Text me a code instead" = "代わりに SMS でコードを送信する";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "SMS 経由でコードを送信";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "%1$@ (%2$@) のご利用ありがとうございます";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "正しい認証コードではないようです。";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "WordPress サイトではないようです。";
@@ -5673,6 +6074,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "Facebook との連携でページが見つかりません。パブリサイズで Facebook のプロフィールに連携できません。連携できるのは公開されているページのみです。";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "Google アカウント「%@」が WordPress.com のアカウントと一致しません";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "インターネットに接続していないようです。";
@@ -5712,6 +6116,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "画像をメディアライブラリに追加できませんでした。";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "インターネットに接続されていないようです。";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "作成可能なサイトの種類";
@@ -5755,6 +6162,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "%1$@ のサイトは WordPress %2$@ を使っています。最新版または最低でも %3$@ に更新することをおすすめします。";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "このアドレスのサイトは WordPress のサイトではありません。接続するには、接続先のサイトが WordPress を使用している必要があります。";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "サイトを削除できませんでした。";
 
@@ -5796,6 +6207,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "コメントの編集中に予期しないエラーが発生しました";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "コメントの読み込み中に予期しないエラーが発生しました。";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "ドメインの登録中に予期せぬエラーが発生しました";
 
@@ -5804,6 +6218,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "通知設定を更新する際に予期しないエラーが発生しました";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "コメントの更新中に予期しないエラーが発生しました";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "予期しないエラーが発生しました。";
@@ -5825,6 +6242,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "サイトとの通信中に問題が発生しました。";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "WordPress.com へ接続する際に問題が発生しました。もう一度ログインしてください。";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "この投稿を表示する際に問題が発生しました。";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "データの読み込み中に問題が発生しました。ページを更新してもう一度お試しください。";
 
@@ -5834,12 +6257,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "共有管理への変更を保存する際に問題が発生しました。";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "位置情報にアクセスしようとした際に問題が発生しました。後ほどもう一度お試しください。";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "パスワードの変更時にエラーが発生しました";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "アクティビティを読み込み中にエラーが発生しました";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "プラン読み込みエラー";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "プラグインの読み込みでエラーが発生しました";
@@ -5852,6 +6281,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "履歴の読み込み中にエラーが発生しました";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "プランを読み込む際にエラーが発生しました";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "スキャンの履歴の読み込み中にエラーが発生しました";
@@ -5900,6 +6332,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "このドメインは利用できません";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "このメールアドレスは WordPress.com に登録されていません。";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "このファイルは、大きすぎるためサイトにアップロードできないか、またはサポートされていないメディア形式です。";
@@ -5980,6 +6415,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "タイムゾーン";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "時間切れですがご心配は要りません。皆さまの安全が当社の最優先事項です。 もう一度お試しください。";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "WordPress.com を最大限に活用するためのヒント。";
 
@@ -5993,6 +6431,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "続行するには、メールアドレスと名前を入力してください。";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "新しい WordPress.com アカウントを作成するには、メールアドレスを入力してください。";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "スマートフォンで WordPress サイトからの役立つ通知を受信するには、Jetpack プラグインをインストールする必要があります。";
 
@@ -6001,6 +6442,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "プラグインをインストールするには、カスタムドメインをサイトに関連付ける必要があります。";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "この Apple ID で先に進むには、最初に WordPress.com パスワードを使用してログインしてください。これは一度しか尋ねられません。";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "この Google アカウントで先に進むには、最初に WordPress.com パスワードを使用してログインしてください。これは一度しか尋ねられません。";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "ブロックを削除するには、そのブロックを選択し、ブロックの右下にある3つの点をクリックして設定を表示します。 ここで、ブロックを削除するオプションを選択します。";
@@ -6075,7 +6522,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "ゴミ箱";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "ゴミ箱";
 
@@ -6089,6 +6537,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "お試し & カスタマイズ";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "もう一度お試しください";
@@ -6114,6 +6563,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "新しいブロックエディターを試す";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "別のメールで試す";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "サイトアドレスで試す";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "プロンプトをオフにする";
@@ -6156,6 +6611,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "使用";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "接続できない";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "投稿を読み込めません";
@@ -6205,6 +6663,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "動画を再生できません";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "その URL の WordPress サイトを読み込めません。 「ヘルプが必要ですか ?」をタップして FAQ を表示してください。";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "サイトを復元できません";
 
@@ -6231,6 +6692,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "1件の投稿、1つのファイルをアップロードできません";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "メールアドレスを検証できません。後ほど、もう一度お試しください。";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "サイトの Jetpack 設定にアクセスできません";
@@ -6375,7 +6839,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "アップロードに失敗しました";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "アップロード完了";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6393,7 +6858,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "アップロードしたテーマ";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "アップロード中";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6408,18 +6874,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "使用";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "セキュリティキーを使用";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "ブロックエディターを使用";
 
 /* No comment provided by engineer. */
 "Use icon button" = "アイコンボタンを使用";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "パスワードを使用してログイン";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "ユーザー名";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6434,6 +6909,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "ユーザー";
+
+/* two factor code placeholder */
+"Verification code" = "認証コード";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "認証メールが送信されました。受信トレイを確認してください。";
@@ -6566,8 +7044,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "WP-content ディレクトリ";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Google が完了するのを待機しています…";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "接続を待機中";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "セキュリティキーの待機中";
+
+/* View title during the Google auth process. */
+"Waiting..." = "待機中…";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6604,6 +7092,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "データの読み込みの際に問題がありました";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "メールアドレス「%@」宛てにリンクを送信しました。お使いのメールソフトをチェックして、ログインリンクをタップしてください。";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "マジックリンクを次のアドレスに送信しました: ";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "%@の時点でのサイトのバックアップが正常に作成されました";
 
@@ -6613,14 +7107,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "サードパーティのものを含め、他の追跡ツールを使用します。それらについての詳細と設定方法についてお読みください。";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "メールを送信できませんでした。後ほど、もう一度お試しください。";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "セキュリティの脅威が検出されたらメールをお送りいたします。 その間、通常通りサイトを使用でき、いつでも進行状況を確認できます。";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "パスワードなしですぐにログインできるマジックリンクのメールをお送りします。面倒なタイピングとはさよならです。";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "新しい WordPress.com アカウントを作成するための登録リンクをメールでお送りします。";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "フォロワー、コメント、いいねが追加されたときに通知します。";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "新しくフォロワー、コメント、いいねが追加されたときに通知します。プッシュ通知を許可しますか ?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "このメールアドレスを新しい WordPress.com アカウントの作成に使用します。";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "%1$@ からダウンロード可能なサイトのバックアップを作成中です。";
@@ -6631,6 +7137,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "バックグラウンドでこれらの脅威を修正しています。 その間、通常通りサイトを使用でき、いつでも進行状況を確認できます。";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "その URL の Jetpack サイトと連携することはできません。サポートにご連絡ください。";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "サイトを %1$@ に復元しています。";
 
@@ -6639,6 +7148,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "ファイルへのリンクはメールでも送信されました。";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "新しい WordPress.com アカウントを作成するための登録リンクをメールでお送りしました。 このデバイスでメールをチェックして、WordPress.com から届いたメールにあるリンクをタップしてください。";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6665,6 +7177,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "1週間のまとめ: %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "Jetpack へようこそ";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "WordPress へようこそ";
 
 /* A message title */
 "Welcome to the Reader" = "Reader へようこそ";
@@ -6709,6 +7227,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "Gravatar とは";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "WordPress.com とは何ですか ?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "ブロックとは";
 
@@ -6725,10 +7246,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "What's New in Jetpack" = "Jetpack の最新情報";
 
 /* Opens the What's New / Feature Announcement modal */
-"What's New in Reader" = "Reader の新機能";
-
-/* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "WordPress の新機能";
+
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "ご使用のサイトアドレス。";
 
 /* Select the site's intent. Title */
 "What's your website about?" = "どのような内容のサイトですか ?";
@@ -6742,6 +7263,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "サイトに変更を加えた後は、ここでそのアクティビティ履歴を確認できます。";
 
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "エラーが発生し、ログインできませんでした。もう一度お試しください。";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "エラーが発生しました。 もう一度お試しください。";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "そのセキュリティキーは有効ではないようです。 今度は別のキーでお試しください。";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "正しい二段階認証コードではありません。コードを再確認してもう一度お試しください。";
+
 /* No comment provided by engineer. */
 "Width Settings" = "幅の設定";
 
@@ -6754,17 +7287,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "WordPress アプリ設定";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "WordPress アプリ - さまざまな画面で利用できるアプリ";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "WordPress ブログ";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "WordPress ヘルプ";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "WordPress メディアライブラリ";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "WordPress 通知設定";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "WordPress 通知";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "WordPress プラグイン";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "WordPress プロフィール";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "WordPress Reader";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "WordPress サイト詳細";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "WordPress テーマ";
@@ -6775,17 +7329,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "WordPress マルチサイトには対応していません";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress が端末の現在位置にアクセスして投稿に追加するためには許可が必要です。プライバシー設定を更新してください。";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "WordPress ルート";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "WordPress のバージョンが古すぎます。";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "WordPress バージョンが古すぎます。%1$@ のサイトは WordPress %2$@ を使用しています。最新バージョンか、最低でも %3$@ に更新することをおすすめします。";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "WordPress.com アカウント";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "WordPress.com プラン";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "WordPress.com テーマ";
@@ -6816,6 +7379,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "投稿を作成";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "コメントする";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "コメントする";
 
 /* Title for the writing section in site settings screen */
@@ -6829,6 +7395,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Y軸位置";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "年";
@@ -6913,6 +7482,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Displayed when the user views trashed in the posts list and there are no posts */
 "You don't have any trashed posts" = "ゴミ箱内の投稿はありません";
 
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"You don't have permission to view this private blog." = "この非公開ブログの閲覧権限がありません。";
+
 /* Description for the first domain purchased with a paid plan. */
 "You have a free one-year domain registration with your plan." = "このプランには、1年間の無料ドメイン登録が含まれています。";
 
@@ -6928,7 +7500,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "リマインダーが設定されていません。";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "保存していない変更点があります。";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -7015,9 +7588,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Help text that describes how the password should be. It appears while editing the password */
 "Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ & )." = "パスワードは6文字以上にする必要があります。さらに強力なパスワードを作成するには、大文字小文字、数字、! \" ? $ % ^ & ) などの記号を使用してください。";
 
-/* Message of Export Content confirmation alert */
-"Your posts, pages, and settings will be mailed to the account's email address." = "投稿、ページ、設定がアカウントのメールアドレスに送信されます。";
-
 /* Message of Export Content confirmation alert; substitution is user's email address */
 "Your posts, pages, and settings will be mailed to you at %@." = "投稿、ページ、および設定は %@ にメールで送信されます。";
 
@@ -7026,6 +7596,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "検索内容に WordPress.com のドメインではサポートされていない文字が含まれています。 サポートされている文字は A–Z、a–z、0–9です。";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "Safari でサイトにアクセスすると、画面の上部にあるバーにサイトアドレスが表示されます。";
 
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "サイトはすでに VaultPress で保護されています。 VaultPress ダッシュボードへのリンクは以下にあります。";
@@ -7105,17 +7678,23 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility identifier for an 'Add Comment' button */
 "addCommentButton.accessibilityIdentifity" = "コメントする";
 
-/* Error message when user cancels login */
-"addSite.selfHosted.cancelled" = "ログインがキャンセルされました";
+/* Error message shown a URL does not point to an existing site. */
+"addSite.restApiNotAvailable" = "このアドレスのサイトは WordPress のサイトではありません。 接続するには、接続先のサイトが WordPress を使用している必要があります。";
+
+/* Error message shown when an receiving an invalid application-password authentication result from a self-hosted WordPress site */
+"addSite.selfHosted.authenticationFailed" = "アプリケーションのパスワード認証でログインできません。";
 
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "連携する WordPress サイトのアドレスを入力してください。";
 
+/* Error message when user input is not a WordPress site */
+"addSite.selfHosted.invalidUrl" = "このサイトのアドレスは無効です。";
+
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "WordPress サイトの情報を読み込めません。";
 
-/* Error message when user signs in with an unexpected usern. The first argument is the expected username */
-"addSite.selfHosted.mismatchUser" = "ログイン中のユーザーでログインしてください。 ユーザー名: %@";
+/* Error message shown when application-password authentication is disabled on a self-hosted WordPress site */
+"addSite.selfHosted.noLoginUrlFound" = "WordPress サイトでアプリケーションのパスワード認証を有効にする必要があります。";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "WordPress サイトを保存できません。しばらくしてからもう一度お試しください。";
@@ -7123,17 +7702,14 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "インストール型サイトを追加";
 
-/* Error message when XML-RPC is disabled on the WordPress site. The first argument is detailed error message */
-"addSite.selfHosted.xmlrpcDisabled" = "WordPress サイトに接続できませんでした。 サーバーで XML-RPC が無効になっている可能性があります。 この問題を解決するには、ホスティングサービスに連絡してください。";
+/* Error message when an unknown error occurred when adding a self-hosted site */
+"addSite.selfHosted.unknownError" = "問題が発生しました。 もう一度お試しください。";
 
 /* Age between dates equaling one hour. */
 "an hour" = "1時間";
 
 /* This is the string we display when prompting the user to review the Jetpack app */
 "appRatings.jetpack.prompt" = "Jetpack についてどう思いますか ?";
-
-/* This is the string we display when prompting the user to review the Reader app */
-"appRatings.reader.prompt" = "Reader はいかがですか ?";
 
 /* This is the string we display when prompting the user to review the WordPress app */
 "appRatings.wordpress.prompt" = "WordPress アプリについてどう思いますか ?";
@@ -7825,6 +8401,10 @@ Example: Reply to Pamela Nguyen */
 /* A name of the ID field (it's a technical field, has to be short, displayed below everything else) */
 "entityMetadataFooterView.id" = "ID";
 
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "example.com";
+
 /* Accept button title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackAccept" = "フィードバックを送る";
 
@@ -7836,9 +8416,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackTitle" = "フィードバックを共有";
-
-/* Communicates the future removal of the option to disable the experimental editor, displayed beneath the experimental features list */
-"experimentalFeatures.editorNote" = "試験用のブロックエディターは将来のリリースでデフォルトになり、無効化する機能は削除されます。";
 
 /* The title for the experimental features list */
 "experimentalFeaturesList.heading" = "試験用の機能";
@@ -7885,8 +8462,14 @@ Example: Reply to Pamela Nguyen */
 /* A footer retry button */
 "general.pagingFooterView.retry" = "再試行";
 
+/* Error message format when REST API returns an error response. The first argument is error message. */
+"generic.error.rest-api-error" = "あなたのサイトから次のエラー応答が送信されました: %@";
+
 /* A generic title for an error */
 "generic.error.title" = "エラー";
+
+/* Error message when failing to parse API responses */
+"generic.error.unparsableResponse" = "あなたのサイトからアプリで解析できないという応答が送信されました";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "ブログ投稿のリマインダーを設定";
@@ -8058,42 +8641,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title of the Jetpack powered overlay. */
 "jetpack.branding.overlay.title" = "WordPress が Jetpack でパワーアップ";
-
-/* Title for the button that starts the Jetpack connection process */
-"jetpack.connection.connect.button" = "サイトを接続";
-
-/* Error message shown when WordPress.com authentication fails */
-"jetpack.connection.error.authentication" = "WordPress.com アカウントが無効です";
-
-/* Error message shown when a connection step is attempted in an invalid order */
-"jetpack.connection.error.context" = "このステップはまだ準備ができていません";
-
-/* Title for the retry button shown when a connection step fails */
-"jetpack.connection.retry.button" = "再試行";
-
-/* Status message when a connection step is pending */
-"jetpack.connection.stage.pending" = "開始を待機中";
-
-/* Status message when a connection step is in progress */
-"jetpack.connection.stage.processing" = "進行中...";
-
-/* Status message when a connection step is completed successfully */
-"jetpack.connection.stage.success" = "完了";
-
-/* Title for the finalization step in Jetpack connection flow */
-"jetpack.connection.step.finalize.title" = "接続を完了";
-
-/* Title for the install step in Jetpack connection flow */
-"jetpack.connection.step.install.title" = "Jetpack をインストール";
-
-/* Title for the login step in Jetpack connection flow */
-"jetpack.connection.step.login.title" = "WordPress.com にログイン";
-
-/* Title for the site connection step in Jetpack connection flow */
-"jetpack.connection.step.site.title" = "サイトに接続";
-
-/* Title for the user connection step in Jetpack connection flow */
-"jetpack.connection.step.user.title" = "WordPress.com アカウントに連携";
 
 /* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
 "jetpack.fullscreen.overlay.early.switch.title" = "新しい Jetpack アプリに切り替える";
@@ -8314,38 +8861,11 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "この非公開ブログの閲覧権限がありません。";
 
-/* Button to dismiss the re-authentication view */
-"login.appPasswordReAuth.cancelButton" = "キャンセル";
-
-/* Description explaining why the user needs to re-authenticate */
-"login.appPasswordReAuth.description" = "アプリに割り当てられたアプリケーションパスワードが、もうプロフィールに存在しません。\nアプリで使用する新しいアプリケーションパスワードを作成するには、もう一度ログインしてください。";
-
-/* Button to start the re-authentication process */
-"login.appPasswordReAuth.signInButton" = "ログイン";
-
-/* Title shown when the application password is invalid */
-"login.appPasswordReAuth.title" = "アプリケーションパスワードが無効です";
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "WordPress.com アカウントの認証アプリから認証コードを入力してください。";
 
 /* Indicating that referrer was marked as spam */
 "marked as spam" = "スパムとしてマーク";
-
-/* Button title when verification link sending failed */
-"me.verifyEmail.button.retry" = "もう一度試す";
-
-/* Button title to send verification link */
-"me.verifyEmail.button.send" = "メールを再送信";
-
-/* Button title while verification link is being sent */
-"me.verifyEmail.button.sending" = "送信中...";
-
-/* Button title after verification link is sent */
-"me.verifyEmail.button.sent" = "メールを送信しました";
-
-/* Message for email verification card */
-"me.verifyEmail.message.noEmail" = "メールアドレスを確認してアカウントの安全を確保し、より多くの機能を利用します。\n受信箱で確認メールが届いていることを確認するか、「%@」をクリックして新しいメールを受信します。";
-
-/* Title for email verification card */
-"me.verifyEmail.title" = "メールアドレスを確認";
 
 /* Me tab menu items */
 "meMenu.submitFeedback" = "フィードバックを送る";
@@ -8788,6 +9308,9 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "親ページ";
 
+/* No comment provided by engineer. */
+"password" = "パスワード";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "サイトで発生した内容に基づいてカードにはさまざまなコンテンツが表示されることがあります。 さらに多くのカードやコントロールに取り組んでいます。";
 
@@ -8892,9 +9415,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Message shown while loading plugin details */
 "pluginDetails.loading" = "プラグイン情報を読み込んでいます…";
-
-/* Placeholder message shown when a plugin has no description */
-"pluginDetails.noDescription" = "このプラグインには説明がありません。";
 
 /* Title of the changelog section in plugin details */
 "pluginDetails.section.changelog" = "変更履歴";
@@ -9184,6 +9704,30 @@ Example: Reply to Pamela Nguyen */
 /* An alert message explaning that by changing the visibility to private, the post will be published immediately to your site */
 "postSettings.warningPostWillBePublishedAlertMessage" = "表示状態を「非公開」に変更すると、投稿はすぐに投稿されます";
 
+/* Localized post type: `Page` */
+"postType.page" = "ページ";
+
+/* Localized post type: `Post` */
+"postType.post" = "投稿";
+
+/* Details for a 'Private' privacy setting */
+"postVisibility.private.details" = "サイト管理者と編集者にだけ表示されます";
+
+/* Title for a 'Private' privacy setting */
+"postVisibility.private.title" = "非公開";
+
+/* Details for a 'Password Protected' privacy setting */
+"postVisibility.protected.details" = "誰でも見ることができますが、パスワードが必要です";
+
+/* Title for a 'Password Protected' privacy setting */
+"postVisibility.protected.title" = "パスワード保護";
+
+/* Details for a 'Public' (default) privacy setting */
+"postVisibility.public.details" = "すべての人に表示";
+
+/* Title for a 'Public' (default) privacy setting */
+"postVisibility.public.title" = "公開";
+
 /* Button cancel */
 "postVisibilityPicker.cancel" = "キャンセル";
 
@@ -9401,15 +9945,6 @@ Tapping on this row allows the user to edit the sharing message. */
 /* Title for the success view when the user has successfully logged in */
 "qrLoginVerifyAuthorization.completedInstructions.title" = "ログインしました !";
 
-/* No comment provided by engineer. */
-"reachability-utils.alert.retry" = "再試行しますか ?";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.title" = "接続できません";
-
-/* Message of error prompt shown when no internet connection is available */
-"reachability-utils.alert.utils" = "インターネットに接続されていないようです。";
-
 /* Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog. */
 "reader.blocked.blog.message" = "ブログ %@ がリーダーに表示されなくなります。 タップして元に戻します。";
 
@@ -9446,26 +9981,8 @@ Tapping on this row allows the user to edit the sharing message. */
 /* A shared button title for Reader */
 "reader.button.unsubscribe" = "購読解除";
 
-/* Button title. Follow the comments on a post. */
-"reader.comments.buttonFollow" = "フォロー";
-
 /* Informational message, should be short. */
 "reader.comments.commentsClosed" = "コメントは受け付けていません";
-
-/* Empty state view title */
-"reader.comments.emptyStateTitle" = "最初のコメントを投稿してみましょう。";
-
-/* Empty state view title */
-"reader.comments.errorLoadingComments" = "コメントの読み込み中に予期しないエラーが発生しました。";
-
-/* VoiceOver hint */
-"reader.comments.followingSettingAccessibilityIdentifier" = "投稿の通知設定を開く";
-
-/* Error message that informs reader comments from a private blog cannot be fetched. */
-"reader.comments.noPermissionToViewPrivateBlog" = "この非公開ブログの閲覧権限がありません。";
-
-/* Navigation title */
-"reader.comments.title" = "コメント";
 
 /* Accessibility hint to inform that the author section can be tapped to see posts from the site. */
 "reader.detail.header.authorInfo.a11y.hint" = "サイトからの投稿を表示します";
@@ -9543,23 +10060,8 @@ but tapping on this button will remove their like from the post. */
 /* Screen header details */
 "reader.following.header.details" = "購読しているブログの最新情報をチェックしましょう。";
 
-/* Empty state view */
-"reader.following.lists.emptyTitle" = "リストが空です";
-
-/* Screen header details */
-"reader.home.header.details" = "購読しているブログの最新情報をチェックしましょう。";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.home.title" = "ホーム";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.library.title" = "ライブラリ";
-
 /* Used in multiple contexts, usually as a screen title */
 "reader.likes.title" = "いいね";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.lists.title" = "リスト";
 
 /* Reader logged-out screen details */
 "reader.loggedOut.details" = "WordPress.com アカウントでログインしてお気に入りのブログをフォロー";
@@ -9796,8 +10298,7 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title of a Reader tab showing Posts matching a user's search query */
 "reader.search.tab.posts" = "投稿";
 
-/* Title of the Reader's search feature
-   Used in multiple contexts, usually as a screen title */
+/* Title of the Reader's search feature */
 "reader.search.title" = "検索";
 
 /* Screen title. Reader select interests title label text. */
@@ -9823,6 +10324,21 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Reader select interests title label text */
 "reader.select.tags.title" = "お気に入りのブログを探してフォロー";
+
+/* Reader sidebar menu item */
+"reader.sidebar.discover" = "見つける";
+
+/* Reader sidebar menu item */
+"reader.sidebar.likes" = "いいね";
+
+/* Reader sidebar menu item */
+"reader.sidebar.recent" = "最近";
+
+/* Reader sidebar menu item */
+"reader.sidebar.saved" = "保存済み";
+
+/* Reader sidebar menu item */
+"reader.sidebar.search" = "検索";
 
 /* Reader sidebar section title */
 "reader.sidebar.section.favorites.title" = "お気に入り";
@@ -9869,7 +10385,7 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Number of subscriptions on a site (singular) */
 "reader.subscriptions.subscriptionsSingular" = "%@人の購読者";
 
-/* Used in multiple contexts, usually as a screen title */
+/* Navigation bar title */
 "reader.subscriptions.title" = "サブスクリプション";
 
 /* A suggestion of topics the user might want to subscribe to */
@@ -9911,26 +10427,11 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Verb. Button title. The user is following a tag. */
 "reader.tags.following.button.title" = "フォロー中";
 
-/* Used in multiple contexts, usually as a screen title */
-"reader.tags.title" = "タグ";
-
 /* Accessibility label for unsubscribing from a tag */
 "reader.tags.unfollow.accessibility.label" = "%@ のフォローを解除";
 
 /* Field title */
 "reader.userProfile.site" = "サイト";
-
-/* Reader Welcome screen login button */
-"reader.welcome.continueText" = "WordPress.com で続ける";
-
-/* Reader Welcome screen */
-"reader.welcome.subtitle" = "最大のブログコミュニティに参加";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.me" = "自分";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.notifications" = "通知";
 
 /* Spoken accessibility label */
 "readerDetail.backButton.accessibilityLabel" = "戻る";
@@ -10199,14 +10700,10 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Message shown when there are no inactive plugins on the site */
 "site.plugins.empty.inactive" = "停止中のプラグインはありません";
 
-/* The plugin fillter option for displaying active plugins */
-"site.plugins.filter.option.active" = "有効";
-
-/* The plugin fillter option for displaying all plugins */
+/* The plugin fillter option for displaying active plugins
+   The plugin fillter option for displaying all plugins
+   The plugin fillter option for displaying inactive plugins */
 "site.plugins.filter.option.all" = "すべて";
-
-/* The plugin fillter option for displaying inactive plugins */
-"site.plugins.filter.option.inactive" = "無効";
 
 /* Title of the plugin filter picker */
 "site.plugins.filter.title" = "フィルター";
@@ -10755,9 +11252,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* View title for Help & Support page. */
 "support.title" = "ヘルプ";
 
-/* Subject of new Zendesk ticket. */
-"support.zendesk.readerAppTicketSubject" = "Reader for iOS のサポート";
-
 /* Title for placeholder in Tenor picker */
 "tenor.welcomeMessage" = "GIF を検索して、メディアライブラリに追加してください。";
 
@@ -10906,8 +11400,119 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "ステータス";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "全期間の投稿数と最多の表示数";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "全期間の表示数";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "全期間の表示数と訪問者";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "過去最高の表示数";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "最多の表示数";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "全期間の統計情報を読み込めません。";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "サイトを作成または追加して、全期間の統計情報を表示します。";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "投稿";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "全期間のアクティビティを確認して WordPress サイトの最新情報を常に把握しましょう。";
+
+/* Title of all time widget */
+"widget.alltime.title" = "すべての期間";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "WordPress にログインして全期間の統計情報を確認しましょう。";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "Jetpack にログインして全期間の統計情報を確認しましょう。";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "Jetpack にログインして今週の統計情報を確認しましょう。";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "Jetpack にログインして今日の統計情報を確認しましょう。";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "全期間の表示数";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "今日の閲覧数";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "今週の統計情報を読み込めません。";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "サイトを作成または追加して、今週の統計情報を表示します。";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "今週のアクティビティを確認して WordPress サイトの最新情報を常に把握しましょう。";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "今週";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "WordPress にログインして今週の統計情報を確認しましょう。";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "コメント";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "統計情報は Jetpack アプリに移動しました。わずかな時間で無料で移行できます。";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "いいね";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "サイト統計情報を読み込めません。";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "今日の統計情報を読み込めません。";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "サイトを作成または追加して、今日の統計情報を表示します。";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "今日のアクティビティを確認して WordPress サイトの最新情報を常に把握しましょう。";
+
+/* Title of today widget */
+"widget.today.title" = "今日";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "WordPress にログインして今日の統計情報を確認しましょう。";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "プレビューは利用できません";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "表示数";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "訪問者";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "今日のいいねとコメント";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "今日の表示数";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "今日の表示数と訪問者数";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "は、いずれ利用できなくなります。";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "新規サイトを作成しますか ?";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "wordpress, ヘルプ, サポート, よくある質問, 質問, デバッグ, ログ, ヘルプセンター, お問い合わせ";
@@ -10932,6 +11537,9 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Error message that describes an unknown error had occured */
 "wordpress-api.error.unknown" = "エラーが発生しました。後ほどもう一度お試しください。";
+
+/* Error message when failing to find selected media file on the user's device. */
+"wordpress.api.upload.media.fileNotFound" = "端末にメディアファイルが見つかりません";
 
 /* Jetpack Plugin Modal on WordPress primary button title */
 "wordpress.jetpack.plugin.modal.primary.button.title" = "Jetpack アプリに切り替える";
@@ -10978,21 +11586,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Error message when user signs in with an unexpected email address. The first argument is the expected email address */
 "wpComLogin.error.mismatchedEmail" = "メールアドレス %@ でログインしてください。";
 
-/* Message shown when user denies WordPress.com login, offering option to try with different account */
-"wpComLogin.loginDenied.message" = "別のアカウントが必要な場合は、別のアカウントでログインできます。 「%@」をタップして開始します。";
-
-/* Title of alert shown when user cancels WordPress.com login */
-"wpComLogin.loginDenied.title" = "ログインをキャンセルしました";
-
-/* Button title for signing in with a different WordPress.com account */
-"wpComLogin.loginDenied.useDifferentAccount" = "別のアカウントを使用";
-
-/* Button title to log out the current WordPress.com account */
-"wpcom.token.alert.button.logout" = "ログアウト";
-
-/* Button title to Sign In to WordPress.com */
-"wpcom.token.alert.button.signin" = "ログイン";
-
 /* Message title to be displayed when the user needs to re-authenticate their WordPress.com account. */
 "wpcom.token.fix.signin" = "WordPress.com にログイン";
 
@@ -11007,6 +11600,9 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "サポート対象外の添付ファイル";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Google アカウントでログイン。";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "•ドメイン";

--- a/WordPress/Resources/ko.lproj/Localizable.strings
+++ b/WordPress/Resources/ko.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Translation-Revision-Date: 2025-05-13 09:54:09+0000 */
+/* Translation-Revision-Date: 2025-03-11 09:54:08+0000 */
 /* Plural-Forms: nplurals=1; plural=0; */
 /* Generator: GlotPress/4.0.1 */
 /* Language: ko_KR */
@@ -98,6 +98,9 @@
 
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "사이트에서 %2$@ 중 %1$@";
+
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "%2$@ 중 %1$@가 사이트에서 사용됨";
 
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@천조 개";
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(제목 없음)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(제목 없음)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*요한 브란트*가 글에 답했습니다";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "\"더 보기\" 버튼에는 공유 버튼을 표시하는 드롭다운이 있습니다.";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "워드프레스닷컴 계정이 스토어 자격 증명에 연결되어 있습니다. 계속하시겠다면 위의 이메일 주소에 대한 확인 링크를 보내드리겠습니다.";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "파일에 악성 코드 패턴이 있음";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "사이트 제목";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "인증 링크를 메일로 발송하려면 유효한 이메일 주소가 필요합니다. 이전 화면으로 돌아가서 유효한 이메일 주소를 입력하세요.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "확인 코드에는 숫자만 사용할 수 있습니다.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "활성";
@@ -522,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "%@ 뒤";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "에어메일";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "정렬";
@@ -585,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "허용 목록에 포함된 IP 주소";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "마지막 부분입니다! 인증 앱의 확인 코드를 입력하세요.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "대체 텍스트";
@@ -597,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "그 대신에 블록 그룹 해제를 통해 콘텐츠를 평평하게 하실 수 있습니다.";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "또는 이 계정에 대한 비밀번호를 입력하셔도 됩니다.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "또는:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "언제나 충돌 기록 보내기";
@@ -618,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "활동을 보려면 인터넷에 연결되어야 합니다.";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "요금제를 보려면 인터넷에 연결되어야 합니다.";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -668,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "연간 사이트 통계";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "익명";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "답변";
 
@@ -689,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "외모";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "애플 인증을 실패했습니다.\n2단계 인증을 사용하는 애플 ID로 아이클라우드에 로그인했는지 확인하시기 바랍니다.";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "설정 적용";
@@ -775,6 +811,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "인증 실패";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "확인 코드";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "호스트 인증 필요: %@";
@@ -885,6 +925,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "첫 번째 댓글 달기";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "먼저 댓글을 남겨주세요.";
 
 /* Beauty site intent topic */
 "Beauty" = "미용";
@@ -1021,12 +1064,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button to copy post text" = "글 텍스트 복사 버튼";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "계속하는 것은, _약관_에 동의하는 것입니다.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "이 도메인을 등록하면 <a>이용 약관<\/a>에 동의하는 것입니다.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "젯팩을 설치하면 %@에 동의하는 것입니다. ";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "가입하려면 _서비스 약관_에 동의해야 합니다.";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "사용자 정의";
@@ -1040,6 +1089,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "로그인 코드를 스캔하려면 카메라 접근 필요";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "링크를 요청할 수 없음";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "빈 페이지를 발행할 수 없습니다";
 
@@ -1049,6 +1101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1058,6 +1111,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1076,6 +1130,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1103,6 +1158,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "취소 중...";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "이 주소의 사이트에 접근할 수 없습니다. 다시 확인하고 다시 시도하세요.";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "결정할 수 없나요? 언제든지 테마를 변경할 수 있습니다.";
 
@@ -1110,7 +1168,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "캡션";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "조심하세요!";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1119,7 +1178,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "카테고리";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "카테고리";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1168,6 +1228,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "조회수와 트래픽을 늘리는 상위 팁을 확인하세요.";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "이 기기에서 이메일을 확인하세요!";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "이 장치에서 이메일을 확인하고, 워드프레스닷컴에서 받은 이메일의 링크를 누르세요.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "이 장치에서 이메일을 확인하고, 워드프레스.com에서 받은 이메일에 있는 링크를 탭합니다.\n\n아직 이메일이 보이지 않으신가요? 스팸 또는 정크 메일 폴더를 확인하세요.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "이메일을 확인바랍니다!";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "인터넷 연결을 확인하고 끌어서 페이지를 새로 고치세요.";
@@ -1264,6 +1336,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "무료 도메인 신청";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "클래식 블로그";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "기기 미디어 캐시 지우기";
 
@@ -1291,6 +1366,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "닫기";
 
@@ -1332,6 +1408,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "열 설정";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "코믹";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1383,6 +1462,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "댓글";
 
@@ -1450,12 +1530,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "연결된 계정";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "연결되었습니다. 하지만…";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "%@ 연결 중";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "%1$@에 연결하면 %2$@에 대한 기존 연결이 대체됩니다.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "워드프레스닷컴에 접속 중입니다";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "연결 중...";
@@ -1486,8 +1572,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "%@(으)로 문의하기";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "콘텐츠 구성\n블록: %1$li, 단어: %2$li, 글자: %3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1502,6 +1592,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "계속 읽기";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Apple로 계속하기";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Google로 계속하기";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Apple 로 계속하기";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "공동 작업";
@@ -1630,6 +1729,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "만들기";
 
+/* The button title text for creating a new account. */
+"Create Account" = "계정 만들기";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "빈 페이지 만들기";
 
@@ -1650,6 +1752,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "게시글 작성";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "사이트 생성";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "태그 만들기";
@@ -1683,6 +1788,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "현재";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "현재 요금제";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "현재 테마";
@@ -1785,6 +1893,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "기본 카테고리";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "기본 메뉴";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "기본 글 형식";
@@ -1793,6 +1904,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "새 글의 기본값";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "삭제";
@@ -1850,6 +1962,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "세부사항";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "새 계정을 만들 계획이 없으신가요? 뒤로 이동하여 이메일 주소를 다시 입력하세요.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "크기";
 
@@ -1897,7 +2012,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "토론";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "무시";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1919,6 +2036,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "도메인";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "아직 계정이 없으신가요? _가입_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2048,6 +2168,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "다운로드";
 
+/* Name for the status of a draft post. */
+"Draft" = "임시 글";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "임시글";
 
@@ -2157,7 +2280,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "이메일 주소";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "이메일 주소";
 
 /* Notification Settings Channel */
@@ -2241,8 +2367,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "비밀번호 입력";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "연결하려는 워드프레스 사이트의 주소를 입력하세요.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "워드프레스닷컴 계정에 대한 비밀번호를 입력합니다.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "사용자명 입력";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "%@에 대한 계정 정보를 입력하세요.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "로그인하거나 워드프레스닷컴 계정을 만드려면 이메일 주소를 입력하세요.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "존재하는 사이트 주소를 입력하세요";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "비밀번호를 입력하세요.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "서버 자격 증명을 입력하세요.";
@@ -2405,6 +2551,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "외부";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "실패함";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "알림을 읽음으로 표시 실패";
 
@@ -2416,9 +2565,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Failed to insert media.\nTap for more info." = "미디어를 삽입하지 못했습니다.\n자세히 알아보려면 누르세요.";
-
-/* A message indicating that we couldn't load the user's settings. */
-"Failed to load settings" = "설정 로드 실패";
 
 /* No comment provided by engineer. */
 "Failed to save files.\nPlease tap for options." = "파일을 저장하지 못했습니다.\n옵션을 보려면 누르세요.";
@@ -2434,6 +2580,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "패션";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "패스트메일";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "대표";
@@ -2492,6 +2641,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "더 찾아보기";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "사이트 주소 찾기";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2514,6 +2666,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "위협 해결 중";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "팔로우";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "대화 팔로우";
@@ -2608,6 +2763,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "새 링크 생성";
 
+/* View title for initial auth views. */
+"Get Started" = "시작하세요";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "이메일로 로그인 링크 얻기";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "다른 사용자와 소통하세요! 팔로우하는 블로그의 글에 댓글을 달아보세요.";
 
@@ -2629,8 +2790,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "영감받기";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "계정 정보 받기";
+
+/* Cancel */
+"Give Up" = "포기";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "글 또는 페이지에 블록을 몇 개만 추가하여 시도해 보세요!";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "지메일";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "리더로 이동";
@@ -2641,6 +2811,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "iOS 설정으로 이동";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Google 가입에 실패했습니다.";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2715,6 +2888,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "도움말 아이콘";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "숨김";
+
 /* Title of a button used to collapse a group */
 "Hide" = "숨기기";
 
@@ -2783,6 +2959,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "아이콘 업데이트 실패";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "이메일을 찾을 수 없으면 정크 또는 스팸 이메일 폴더를 확인해 보세요.";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "애플이나 구글로 계속하기를 원하고 이미 워드프레스닷컴 계정을 가지고 있지 않다면, 계정을 만들고 _약관_에 동의하는 것으로 간주합니다.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "%1$@를 삭제한다면 사용자는 더 이상 사이트를 이용할 수 없지만, %2$@가 만든 콘텐츠는 그대로 남아 있습니다.";
@@ -2858,6 +3040,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "wp-config.php 및 비 WordPress 파일 포함";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "사용자명이나 비밀번호가 올바르지 않습니다. 로그인 정보를 다시 입력해 주세요.";
 
 /* Title for a threat */
 "Infected core file" = "감염된 코어 파일";
@@ -2959,6 +3144,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "블로깅 프롬프트 소개";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "유효하지 않은 이메일 주소";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "유효하지 않은 사이트 주소";
 
@@ -2976,6 +3164,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "유효하지 않은 URL입니다. 오디오 파일을 찾을 수 없습니다.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "유효하지 않은 URL. 다시 확인하고 다시 시도하세요.";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "유효하지 않은 URL입니다. 유효한 URL을 입력하세요.";
@@ -2997,6 +3188,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "사람 초대하기";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "이 사용자명\/비밀번호가 이 사이트에 연결되어 있지 않은 것 같습니다.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "잘못된 비밀번호를 입력하신 것 같습니다. 다시 시도해보시겠어요?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "%@의 블로깅 시간입니다!";
@@ -3225,7 +3422,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "줄 간격";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "링크";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3287,6 +3485,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "사용자 로드 중...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "요금제 로드 중...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "요금제 로드 중...";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "플러그인 로드 중...";
 
@@ -3321,11 +3525,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "로딩 중...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "로컬";
+
 /* Local Services site intent topic */
 "Local Services" = "지역 봉사";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "로컬 변경";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "위치";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "워드프레스가 현재 위치를 추가하려면 위치 서비스가 활성화되어 있어야 합니다. 설정 앱에서 위치 서비스를 활성화하세요.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "위치 알 수 없음";
 
 /* No comment provided by engineer. */
 "Lock icon" = "잠금 아이콘";
@@ -3333,9 +3549,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "작성일자별 로그 파일";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "로그인";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3345,17 +3563,33 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of a button for signing in. */
 "Log in" = "로그인";
 
-/* LogOut confirmation text, whenever there are no local changes */
-"Log out of Jetpack?" = "젯팩에서 로그아웃하시나요?";
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "로그인에 실패했습니다. 다시 시도하세요.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "워드프레스닷컴을 통해 로그인하거나 가입";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "젯팩에 연결하는 데 사용한 워드프레스닷컴 계정으로 로그인하세요.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "이메일 주소로 워드프레스닷컴 계정에 로그인하세요.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "워드프레스닷컴 사용자 이름과 비밀번호로 로그인합니다";
 
 /* LogOut confirmation text, whenever there are no local changes */
-"Log out of Reader?" = "리더에서 로그아웃하시나요?";
+"Log out of Jetpack?" = "젯팩에서 로그아웃하시나요?";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of WordPress?" = "워드프레스에서 로그아웃하시겠습니까?";
 
 /* Login Request Expired */
 "Login Request Expired" = "로그인 요청 만료됨";
+
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "계정 비밀번호로 로그인";
 
 /* No comment provided by engineer. */
 "Logs" = "로그";
@@ -3365,6 +3599,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "젯팩을 설치해 두셨네요, 축하합니다!\n아래의 Wordpress.com 정보로 로그인 해서 알림과 통계를 활성화하세요.";
+
+/* Title of a button. */
+"Lost your password?" = "비밀번호 분실?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "메일 (기본)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "메인 내비게이션";
@@ -3512,6 +3752,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "메시지";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "마이크로소프트 아웃룩";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "기타 취약성";
 
@@ -3607,6 +3850,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "내 사이트";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "내 워드프레스 사이트";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "상위 10개 카페";
 
@@ -3646,8 +3892,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "도움이 필요하세요?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "사이트 주소를 찾는 데 도움이 필요하세요?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "도움이 필요하세요?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "더 많은 도움이 필요하세요?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "업데이트 필요";
@@ -3676,6 +3929,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "새 글";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "새 항목";
+
 /* Placeholder text for password field */
 "New password" = "새 비밀번호";
 
@@ -3693,7 +3949,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "뉴스";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "다음";
 
 /* Accessibility label for the next notification button */
@@ -3729,6 +3987,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "사용 가능한 미리보기 URL이 없습니다";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "제목 없음";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "사용할 수 있는 활동이 없습니다";
 
@@ -3761,7 +4022,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "아직 댓글이 없습니다";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "연결 없음";
 
@@ -3910,6 +4172,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "지금 안 함";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "이메일이 보이지 않으세요? 스팸이나 정크 메일 폴더를 확인하세요.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "참고:";
 
@@ -3973,7 +4238,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "번호 목록";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -4030,7 +4300,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "이런";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "이런!";
 
 /* No comment provided by engineer. */
@@ -4045,7 +4316,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "젯팩 보안 설정 열기";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "메일 열기";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "설정 열기";
 
 /* No comment provided by engineer. */
@@ -4063,6 +4339,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "새 창\/탭에서 링크 열기";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "글에 대한 구독 설정 열기";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "미 섹션 열기";
 
@@ -4077,6 +4356,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "선택 사항: 초대를 보내는데 %1$d 문자까지 사용자 정의 안내문을 입력하세요.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "또는";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "또는 다른 인증 양식을 선택해 주세요.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "또는 사이트 주소를 입력하여 로그인하세요.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "또는 매직 링크로 로그인";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "순서 있는 목록";
@@ -4125,7 +4416,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "안쪽 여백";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "페이지";
 
@@ -4158,8 +4450,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "육아";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "비밀번호";
 
@@ -4176,8 +4471,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "이후에 블록 붙여넣기";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "대기중";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "대기중인 리뷰";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4208,6 +4507,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "사용자명 선택";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "요금제";
+
 /* User action to play a video on the editor. */
 "Play video" = "비디오 재생";
 
@@ -4237,6 +4540,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "사이트에서 블록 편집기가 활성화되었는지 확인하세요. 활성화하지 않으면 로드되지 않습니다.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "example.com과 같은 완전한 웹사이트 주소를 입력하세요.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "사이트 주소를 입력해주세요.";
@@ -4271,11 +4577,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "유효한 이메일 주소를 입력하세요.";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "워드프레스닷컴 계정의 유효한 이메일 주소를 입력하세요.";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "유효한 이메일 주소를 입력해주세요.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "유효한 전화번호를 입력하세요";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Apple ID로 로그인하려면 워드프레스닷컴 계정의 비밀번호를 입력하세요.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "자격을 입력하세요";
@@ -4283,8 +4595,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "이메일 주소를 입력하세요.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "모든 란을 채워주세요";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "워드프레스 앱을 시작하고 워드프레스닷컴에 로그인하여 적어도 하나의 사이트가 있는지 확인한 후 다시 시도하세요.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "다른 워드프레스닷컴 사이트에 접속하기 전에 로그아웃하세요.";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "나중에 다시 시도하시기 바랍니다";
@@ -4352,7 +4670,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "인기 언어";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "게시물";
 
@@ -4473,6 +4792,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "캘리포니아 사용자를 위한 개인정보 공지";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "개인용";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "블록 표시 중 문제가 발생했습니다. \n눌러서 블록 복구를 시도하세요.";
 
@@ -4487,6 +4809,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "도메인을 구매하는 중에 문제가 발생했습니다. 다시 시도하세요.";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "계속하면 이 장치에서 모든 워드프레스닷컴 데이터가 제거되고 로컬로 저장된 임시글이 삭제됩니다. 워드프레스닷컴 블로그에 이미 저장된 내용은 손실되지 않습니다.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "프로젝트";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "프롬프트 건너뜀";
@@ -4504,13 +4832,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "발행일";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "즉시 발행";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "페이지 발행 중:";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "글 발행 날짜:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "발행됨";
 
@@ -4712,7 +5044,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "응답";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "회신 메시지";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "%1$@에 회신";
 
 /* An explaination of a setting. */
@@ -4741,6 +5078,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "날짜 범위 필터 재설정하기";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "비밀번호 재설정하기";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "크기 조정 및 자르기";
@@ -4798,6 +5138,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "모두 재시도";
 
+/* No comment provided by engineer. */
+"Retry?" = "재실행하시겠습니까?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "글로 돌아가기";
 
@@ -4827,6 +5170,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "역할";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS 전송됨";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "상태";
 
@@ -4838,6 +5184,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4904,7 +5251,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "파일 검사하는 중";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "예약됨";
 
 /* No comment provided by engineer. */
@@ -5044,6 +5392,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "사이트의 의도로 이 주제를 선택하세요.";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "링크 전송";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "이메일로 링크 보내기";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "기록 메시지 보내기";
 
@@ -5052,6 +5406,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "시험 충돌 보내기";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "이메일 확인 링크 보내기";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "이메일로 알림 보내기";
@@ -5098,11 +5455,11 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Message to show when setting save failed */
 "Settings update failed" = "설정 업데이트 실패";
 
-/* Title for a button that recommends the app to others */
-"Share Jetpack with a friend" = "친구와 젯팩 공유";
+/* Spoken accessibility label */
+"Share" = "공유";
 
 /* Title for a button that recommends the app to others */
-"Share Reader with a friend" = "친구와 리더 공유";
+"Share Jetpack with a friend" = "친구와 젯팩 공유";
 
 /* Title for a button that recommends the app to others */
 "Share WordPress with a friend" = "친구와 WordPress 공유";
@@ -5153,6 +5510,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "리블로그 버튼 표시";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "비밀번호 보이기";
+
 /* No comment provided by engineer. */
 "Show post content" = "글 콘텐츠 보기";
 
@@ -5164,6 +5525,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "다음에 대한 통계 표시:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "표시됨";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "블로그에 댓글을 달 때 공개됩니다.";
@@ -5179,6 +5543,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "글을 표시합니다.";
+
+/* View title during the sign up process. */
+"Sign Up" = "가입하기";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "사이트 자격 증명으로 로그인";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "회원가입";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "워드프레스에 로그인";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "이메일로 가입";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "무료 요금제 사용자이므로 활동 로그에 제한된 이벤트가 표시됩니다.";
@@ -5217,6 +5596,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "사이트 작성 글";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "사이트 주소";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "사이트 주소는 최소한 4 글자 이상이어야 합니다.";
@@ -5301,7 +5683,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "죄송합니다. 사이트 주소는 글자도 포함돼야 합니다!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "죄송합니다. 해당 이메일 주소는 이미 사용되고 있습니다!";
 
 /* No comment provided by engineer. */
@@ -5361,6 +5743,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "스팸";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "스파크";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "사이트 속도 향상";
@@ -5386,6 +5771,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "주";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "정적인 홈페이지";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5416,6 +5804,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "취소선";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "스텁";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "검토를 위해 제출";
@@ -5506,7 +5897,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "태블릿";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "태그";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5641,6 +6033,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "서비스 약관";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "추천 글";
+
 /* Title of a button style */
 "Text Only" = "텍스트만";
 
@@ -5650,8 +6045,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "텍스트 서식 지정 컨트롤은 텍스트 블록을 편집하는 동안 키보드 위에 배치되는 도구 모음 내에 있습니다.";
 
+/* Button title */
+"Text me a code instead" = "코드를 문자로 대신 받기";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "나에게 SMS 문자 메시지로 코드 보내기";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "%1$@(%2$@ 제공)을(를) 선택해 주셔서 감사합니다.";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "유효한 확인 코드가 아닌 것 같습니다.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "워드프레스 사이트가 아닌 것 같습니다.";
@@ -5673,6 +6077,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "페이스북 페이지를 찾을 수 없습니다. 페이스북 프로필은 연결할 수 없으며 공개된 페이지로만 연결할 수 있습니다.";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "Google 계정 \"%@\"이(가) 워드프레스닷컴의 계정과 일치하지 않습니다.";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "인터넷 연결이 오프라인인 것 같습니다.";
@@ -5712,6 +6119,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "이미지를 미디어 라이브러리에 추가할 수 없었습니다.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "인터넷 연결이 오프라인인 것 같습니다.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "만들 수 있는 사이트 종류";
@@ -5755,6 +6165,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "%1$@의 사이트는 워드프레스 %2$@를 사용합니다. 최신 버전이나 최소한 %3$@으로 업데이트하기를 권장합니다.  ";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "이 주소의 사이트는 워드프레스 사이트가 아닙니다. 연결하려면 사이트에서 워드프레스를 사용해야 합니다.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "사이트를 삭제할 수 없습니다.";
 
@@ -5796,6 +6210,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "댓글 편집 중에 예기치 않은 오류가 발생했습니다.";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "댓글을 로드하는 중에 예기치 않은 오류가 발생했습니다.";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "도메인을 등록하는 중에 예기치 않은 오류가 발생했습니다.";
 
@@ -5804,6 +6221,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "알림 설정을 업데이트하는 중에 예기치 않은 오류가 발생했습니다.";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "댓글을 업데이트하는 중에 예기치 않은 오류가 발생했습니다.";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "예기치 않은 오류가 발생했습니다.";
@@ -5825,6 +6245,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "사이트와 통신하는 중 문제가 발생했습니다.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "워드프레스닷컴에 연결하는 중 문제가 발생했습니다. 다시 로그인해주세요.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "글을 표시하는 데 문제가 있습니다.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "데이터 로드 중에 문제가 발생했습니다. 페이지를 새로 고치고 다시 시도하세요.";
 
@@ -5834,12 +6260,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "공유 관리 변경 사항을 저장하는 데 문제가 발생했습니다.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "위치 액세스 시도 중 문제가 발생했습니다. 나중에 다시 시도해 주세요.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "비밀번호를 변경하는 중에 오류가 발생했습니다.";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "활동 로드하는 중 오류가 발생했습니다.";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "요금제를 로드하는 중 오류가 발생했습니다.";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "플러그인을 로드하는 중 오류가 발생했습니다.";
@@ -5852,6 +6284,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "기록을 읽어오는 과정에서 오류가 발생했습니다.";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "요금제를 로드하는 중에 오류가 발생했습니다.";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "스캔 기록 로드 중 오류가 발생했습니다.";
@@ -5900,6 +6335,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "이 도메인을 사용할 수 없습니다";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "이 이메일 주소는 워드프레스닷컴에 등록되어 있지 않습니다.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "이 파일은 너무 커서 사이트에 업로드할 수 없거나 이 미디어 형식을 지원하지 않습니다.";
@@ -5980,6 +6418,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "시간대";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "시간이 다 되었지만, 걱정하지 마세요. 보안이 무엇보다 중요합니다. 다시 시도해 보세요!";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "워드프레스닷컴을 최대한 활용하기 위한 팁.";
 
@@ -5993,6 +6434,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "계속하려면 이메일 주소와 이름을 입력하세요.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "새 워드프레스닷컴 계정을 만들려면 이메일 주소를 입력하세요.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "휴대폰에서 워드프레스 사이트로부터 유용한 알림을 가져오려면 젯팩 플러그인을 설치해야 합니다.";
 
@@ -6001,6 +6445,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "플러그인을 설치하려면 사이트와 연결된 사용자 정의 도메인이 있어야 합니다.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "애플 ID로 계속하려면, 먼저 워드프레스닷컴 비밀번호로 로그인하시기 바랍니다. 한 번만 요청될 것입니다.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "이 Google 계정을 진행하려면 먼저 워드프레스닷컴 비밀번호로 로그인하세요. 이 메시지는 한 번만 표시됩니다.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "블록을 제거하려면 블록을 선택하고 블록의 오른쪽 하단에 있는 점 3개를 클릭하여 설정을 봅니다. 블록을 제거하는 옵션을 설정에서 선택합니다.";
@@ -6075,7 +6525,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "휴지통";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "삭제됨";
 
@@ -6089,6 +6540,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "사용 및 사용자 정의하기";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "재시도";
@@ -6114,6 +6566,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "새 블록 편집기 시도";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "다른 이메일로 시도";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "사이트 주소로 시도";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "프롬프트 끄기";
@@ -6156,6 +6614,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "사용";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "연결할 수 없음";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "게시글을 로드할 수 없습니다";
@@ -6205,6 +6666,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "비디오를 재생할 수 없음";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "해당 URL에서 워드프레스 사이트를 읽을 수 없습니다. '더 많은 도움이 필요하세요?'를 눌러 FAQ를 보세요.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "사이트를 복원할 수 없음";
 
@@ -6231,6 +6695,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "1개 글, 1개 파일을 업로드할 수 없음";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "이메일 주소를 확인할 수 없습니다. 나중에 다시 시도하세요.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "사이트에 대한 젯팩 설정을 방문할 수 없습니다.";
@@ -6375,7 +6842,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "업로드 실패";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "업로드됨";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6393,7 +6861,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "업로드된 테마";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "업로드 중";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6408,18 +6877,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "사용";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "보안 키 사용";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "블록 편집기 사용";
 
 /* No comment provided by engineer. */
 "Use icon button" = "아이콘 버튼 사용";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "로그인 비밀번호 사용";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "사용자명";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6434,6 +6912,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "사용자";
+
+/* two factor code placeholder */
+"Verification code" = "확인 코드";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "확인 이메일을 보냈습니다. 받은 편지함을 확인하세요.";
@@ -6566,8 +7047,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "WP-content 디렉터리";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Google에서 완료하기를 기다리는 중…";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "연결 대기 중";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "보안 키 기다리는 중";
+
+/* View title during the Google auth process. */
+"Waiting..." = "기다리는 중...";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6607,6 +7098,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "데이터를 로드하는 중 문제가 발생했습니다.";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "링크를 이메일(%@)로 보냈습니다. 메일앱을 확인하고 링크를 눌러 로그인하시기 바랍니다.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "방금 다음으로 매직 링크를 보내드렸습니다.";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "%@에 사이트 백업이 만들어졌습니다.";
 
@@ -6616,14 +7113,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "워드프레스는 타사 제품을 포함한 다른 추적 도구를 사용합니다. 이 도구에 대해 읽고 제어하는 방법에 대해 알아보세요.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "지금은 회원님에게 이메일을 보낼 수 없습니다. 나중에 다시 시도하세요.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "보안 위협을 발견하면 이메일을 보낼 것입니다. 그 동안 정상적으로 사이트를 계속 사용하고, 언제든지 진행 상황을 다시 확인할 수 있습니다.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "암호 없이 즉시 로그인되는 링크를 이메일로 보내드립니다. 더 이상 암호를 직접 입력할 필요가 없습니다!";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "새 워드프레스닷컴 계정을 만드는 등록 링크를 이메일할 것입니다.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "팔로워, 댓글 및 좋아요를 받으시면 알려 드립니다.";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "새 팔로워, 댓글과 좋아요를 받으시면 알립니다. 푸시 알림을 허용하시겠습니까?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "이 이메일 주소를 사용하여 새 워드프레스닷컴 계정을 만듭니다.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "다운로드 가능한 사이트 백업을 %1$@에서 만드는 중입니다.";
@@ -6634,6 +7143,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "백그라운드에서 이러한 위협을 해결하기 위해 노력하는 중입니다. 그동안 정상적으로 사이트를 계속 사용하고, 언제든지 진행 상황을 다시 확인하실 수 있습니다.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "현재 URL에서 젯팩 사이트에 연결할 수 없습니다. 도움이 필요하면 연락하세요.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "사이트를 %1$@(으)로 다시 복원하는 중입니다.";
 
@@ -6642,6 +7154,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "파일 링크도 이메일로 보내드렸습니다.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "새 워드프레스닷컴 계정을 만드는 등록 링크를 이메일했습니다. 이 장치에서 이메일을 확인하고, 워드프레스닷컴에서 받은 이메일의 링크를 누르세요.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6668,6 +7183,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "주간 총정리: %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "젯팩 시작";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "워드프레스에 오신 것을 환영합니다";
 
 /* A message title */
 "Welcome to the Reader" = "리더에 오신 것을 환영합니다.";
@@ -6712,6 +7233,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "그라바타가 무엇인가요?";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "워드프레스닷컴이 무엇인가요?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "블록이란 무엇인가요?";
 
@@ -6728,10 +7252,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "What's New in Jetpack" = "젯팩의 새로운 기능";
 
 /* Opens the What's New / Feature Announcement modal */
-"What's New in Reader" = "리더의 새로운 기능";
-
-/* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "워드프레스 새소식";
+
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "내 사이트 주소는 무엇인가요?";
 
 /* Select the site's intent. Title */
 "What's your website about?" = "웹사이트의 주제가 무엇인가요?";
@@ -6745,6 +7269,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "사이트를 변경하면 여기서 활동 내역을 볼 수 있습니다.";
 
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "문제가 발생하여 로그인할 수 없습니다. 다시 시도하세요.";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "오류가 발생했습니다. 다시 시도해 보세요!";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "죄송합니다. 보안 키가 유효하지 않은 것 같습니다. 다른 것으로 시도해 보세요.";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "2단계 인증코드가 맞지 않습니다. 코드를 다시 확인하시고 입력하여 주시기 바랍니다.";
+
 /* No comment provided by engineer. */
 "Width Settings" = "폭 설정";
 
@@ -6757,17 +7293,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "워드프레스";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "워드프레스 앱 설정";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "WordPress 앱 - 모든 화면에 알맞은 앱";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "워드프레스 블로그";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "워드프레스 도움말";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "워드프레스 미디어 라이브러리";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "워드프레스 알림 설정";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "워드프레스 알림";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "워드프레스 플러그인";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "워드프레스 프로필";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "워드프레스 리더";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "워드프레스 사이트 세부정보";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "워드프레스 테마";
@@ -6778,17 +7335,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "WordPress 멀티사이트는 지원되지 않습니다.";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "워드프레스가 귀하의 글에 현재 위치를 추가하려면 장치의 현재 위치에 액세스할 수 있는 권한이 필요합니다. 프라이버시 설정을 업데이트하세요.";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "워드프레스 루터";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "워드프레스 버전이 너무 오래됐습니다";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "워드프레스 버전이 너무 오래됐습니다. %1$@의 사이트는 워드프레스 %2$@을(를) 사용합니다. 최신 버전 또는 %3$@ 이상으로 업데이트하세요.";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "WordPress.com 계정";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "워드프레스닷컴 요금제";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "WordPress.com 테마";
@@ -6819,6 +7385,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "글 작성";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "답글 작성";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "답변 작성...";
 
 /* Title for the writing section in site settings screen */
@@ -6832,6 +7401,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Y-축 위치";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "야후 메일";
 
 /* 'This Year' label for the the year. */
 "Year" = "연도";
@@ -6916,6 +7488,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Displayed when the user views trashed in the posts list and there are no posts */
 "You don't have any trashed posts" = "휴지통에 버린 글이 없습니다.";
 
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"You don't have permission to view this private blog." = "이 비공개 블로그를 볼 권한이 없습니다.";
+
 /* Description for the first domain purchased with a paid plan. */
 "You have a free one-year domain registration with your plan." = "이용 중인 요금제에 1년 무료 도메인 등록이 포함되어 있습니다.";
 
@@ -6931,7 +7506,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "설정된 알림이 없습니다.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "저장되지 않은 변경이 있습니다.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -7018,9 +7594,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Help text that describes how the password should be. It appears while editing the password */
 "Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ & )." = "비밀번호는 최소 6자 이상이어야 합니다. 영문 대소문자, 숫자와 ! \" ? $ % ^ & ) 같은 특수문자를 사용해 더 강력한 비밀번호를 만드세요.";
 
-/* Message of Export Content confirmation alert */
-"Your posts, pages, and settings will be mailed to the account's email address." = "글, 페이지 및 설정이 계정의 이메일 주소로 발송될 것입니다.";
-
 /* Message of Export Content confirmation alert; substitution is user's email address */
 "Your posts, pages, and settings will be mailed to you at %@." = "글, 페이지 및 설정이 %@(으)로 메일로 전송됩니다.";
 
@@ -7029,6 +7602,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "워드프레스닷컴 도메인에 지원되지 않는 문자가 검색에 있습니다. 허용되는 문자는 A~Z, a~z, 0~9입니다.";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "사파리에서 사이트를 방문할 때 화면 상단에 있는 막대에 사이트 주소가 보입니다.";
 
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "사이트가 이미 VaultPress로 보호되고 있습니다. 아래에서 VaultPress 알림판 링크를 찾을 수 있습니다.";
@@ -7108,17 +7684,23 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility identifier for an 'Add Comment' button */
 "addCommentButton.accessibilityIdentifity" = "댓글 추가";
 
-/* Error message when user cancels login */
-"addSite.selfHosted.cancelled" = "로그인이 취소되었음";
+/* Error message shown a URL does not point to an existing site. */
+"addSite.restApiNotAvailable" = "이 주소의 사이트는 워드프레스 사이트가 아닙니다. 연결하려면 사이트에서 워드프레스를 사용해야 합니다.";
+
+/* Error message shown when an receiving an invalid application-password authentication result from a self-hosted WordPress site */
+"addSite.selfHosted.authenticationFailed" = "애플리케이션 비밀번호 인증을 사용하여 로그인할 수 없습니다.";
 
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "연결하려는 워드프레스 사이트의 주소를 입력하세요.";
 
+/* Error message when user input is not a WordPress site */
+"addSite.selfHosted.invalidUrl" = "사이트 주소가 유효하지 않습니다.";
+
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "워드프레스 사이트 세부 정보를 로드할 수 없습니다.";
 
-/* Error message when user signs in with an unexpected usern. The first argument is the expected username */
-"addSite.selfHosted.mismatchUser" = "로그인한 사용자로 로그인하세요. 사용자명: %@";
+/* Error message shown when application-password authentication is disabled on a self-hosted WordPress site */
+"addSite.selfHosted.noLoginUrlFound" = "워드프레스 사이트에서 애플리케이션 비밀번호 인증을 사용하도록 설정해야 합니다.";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "워드프레스 사이트를 저장할 수 없습니다. 나중에 다시 시도하세요.";
@@ -7126,17 +7708,14 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "자체 호스팅 사이트 추가";
 
-/* Error message when XML-RPC is disabled on the WordPress site. The first argument is detailed error message */
-"addSite.selfHosted.xmlrpcDisabled" = "워드프레스 사이트에 연결할 수 없습니다. 서버에서 XML-RPC가 비활성화되었을 수 있습니다. 호스팅 공급업체에 문의하여 이 문제를 해결하세요.";
+/* Error message when an unknown error occurred when adding a self-hosted site */
+"addSite.selfHosted.unknownError" = "문제가 발생했습니다. 다시 시도하세요.";
 
 /* Age between dates equaling one hour. */
 "an hour" = "1시간";
 
 /* This is the string we display when prompting the user to review the Jetpack app */
 "appRatings.jetpack.prompt" = "젯팩을 어떻게 생각하시나요?";
-
-/* This is the string we display when prompting the user to review the Reader app */
-"appRatings.reader.prompt" = "리더를 어떻게 생각하시나요?";
 
 /* This is the string we display when prompting the user to review the WordPress app */
 "appRatings.wordpress.prompt" = "워드프레스를 어떻게 생각하시나요?";
@@ -7840,6 +8419,10 @@ Example: Reply to Pamela Nguyen */
 /* A name of the ID field (it's a technical field, has to be short, displayed below everything else) */
 "entityMetadataFooterView.id" = "ID";
 
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "example.com";
+
 /* Accept button title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackAccept" = "피드백 보내기";
 
@@ -7851,9 +8434,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackTitle" = "피드백 공유";
-
-/* Communicates the future removal of the option to disable the experimental editor, displayed beneath the experimental features list */
-"experimentalFeatures.editorNote" = "실험 버전 블록 편집기가 향후 릴리스에서 기본값이 되며 비활성화하는 기능은 제거될 예정입니다.";
 
 /* The title for the experimental features list */
 "experimentalFeaturesList.heading" = "실험적 기능";
@@ -7900,8 +8480,14 @@ Example: Reply to Pamela Nguyen */
 /* A footer retry button */
 "general.pagingFooterView.retry" = "재시도";
 
+/* Error message format when REST API returns an error response. The first argument is error message. */
+"generic.error.rest-api-error" = "사이트에서 오류 응답을 보냈습니다: %@";
+
 /* A generic title for an error */
 "generic.error.title" = "오류";
+
+/* Error message when failing to parse API responses */
+"generic.error.unparsableResponse" = "사이트에서 앱이 구문 분석할 수 없다는 응답을 보냈습니다.";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "블로깅 알림 설정";
@@ -8073,42 +8659,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title of the Jetpack powered overlay. */
 "jetpack.branding.overlay.title" = "워드프레스는 젯팩과 함께 사용하면 더 좋습니다.";
-
-/* Title for the button that starts the Jetpack connection process */
-"jetpack.connection.connect.button" = "사이트 연결";
-
-/* Error message shown when WordPress.com authentication fails */
-"jetpack.connection.error.authentication" = "유효하지 않은 워드프레스닷컴 계정";
-
-/* Error message shown when a connection step is attempted in an invalid order */
-"jetpack.connection.error.context" = "이 단계는 아직 준비되지 않았음";
-
-/* Title for the retry button shown when a connection step fails */
-"jetpack.connection.retry.button" = "다시 시도";
-
-/* Status message when a connection step is pending */
-"jetpack.connection.stage.pending" = "시작 대기 중";
-
-/* Status message when a connection step is in progress */
-"jetpack.connection.stage.processing" = "진행 중...";
-
-/* Status message when a connection step is completed successfully */
-"jetpack.connection.stage.success" = "완료됨";
-
-/* Title for the finalization step in Jetpack connection flow */
-"jetpack.connection.step.finalize.title" = "연결 마무리";
-
-/* Title for the install step in Jetpack connection flow */
-"jetpack.connection.step.install.title" = "젯팩 설치";
-
-/* Title for the login step in Jetpack connection flow */
-"jetpack.connection.step.login.title" = "워드프레스닷컴에 로그인";
-
-/* Title for the site connection step in Jetpack connection flow */
-"jetpack.connection.step.site.title" = "회원님 사이트에 연결";
-
-/* Title for the user connection step in Jetpack connection flow */
-"jetpack.connection.step.user.title" = "워드프레스닷컴 계정에 연결";
 
 /* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
 "jetpack.fullscreen.overlay.early.switch.title" = "새 젯팩 앱으로 전환";
@@ -8329,41 +8879,11 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "이 비공개 블로그를 볼 권한이 없습니다.";
 
-/* Button to dismiss the re-authentication view */
-"login.appPasswordReAuth.cancelButton" = "취소";
-
-/* Description explaining why the user needs to re-authenticate */
-"login.appPasswordReAuth.description" = "앱에 할당된 애플리케이션 비밀번호가 프로필에 더는 존재하지 않습니다.\n다시 로그인하여 사용할 앱의 새 애플리케이션 비밀번호를 생성하세요.";
-
-/* Button to start the re-authentication process */
-"login.appPasswordReAuth.signInButton" = "로그인";
-
-/* Title shown when the application password is invalid */
-"login.appPasswordReAuth.title" = "유효하지 않은 애플리케이션 비밀번호";
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "인증 앱에서 워드프레스닷컴 계정의 인증 코드를 입력해 주세요.";
 
 /* Indicating that referrer was marked as spam */
 "marked as spam" = "스팸으로 표시됨";
-
-/* Button title when verification link sending failed */
-"me.verifyEmail.button.retry" = "다시 시도";
-
-/* Button title to send verification link */
-"me.verifyEmail.button.send" = "이메일 다시 보내기";
-
-/* Button title while verification link is being sent */
-"me.verifyEmail.button.sending" = "보내는 중...";
-
-/* Button title after verification link is sent */
-"me.verifyEmail.button.sent" = "이메일 보냄";
-
-/* Message for email verification card */
-"me.verifyEmail.message.noEmail" = "이메일을 인증하여 계정의 보안을 유지하고 더 많은 기능에 접근하세요.\n받은 편지함에서 확정 이메일을 확인하거나 '%@'을(를) 클릭하여 새로 하나를 받으세요.";
-
-/* Message for email verification card with email address */
-"me.verifyEmail.message.withEmail" = "이메일을 인증하여 계정의 보안을 유지하고 더 많은 기능에 접근하세요.\n%1$@의 받은 편지함에서 확정 이메일을 확인하거나 '%2$@'을(를) 클릭하여 새로 하나를 받으세요.";
-
-/* Title for email verification card */
-"me.verifyEmail.title" = "이메일 인증";
 
 /* Me tab menu items */
 "meMenu.submitFeedback" = "피드백 보내기";
@@ -8806,6 +9326,9 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "상위 페이지";
 
+/* No comment provided by engineer. */
+"password" = "비밀번호";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "사이트에서 발생하는 상황에 따라 다른 콘텐츠가 카드에 표시될 수 있습니다. 더 많은 카드와 제어 기능을 연구하고 있습니다.";
 
@@ -8907,9 +9430,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Message shown while loading plugin details */
 "pluginDetails.loading" = "플러그인 정보 로드 중...";
-
-/* Placeholder message shown when a plugin has no description */
-"pluginDetails.noDescription" = "이 플러그인에서 설명이 제공되지 않았습니다.";
 
 /* Title of the changelog section in plugin details */
 "pluginDetails.section.changelog" = "변경 로그";
@@ -9196,6 +9716,30 @@ Example: Reply to Pamela Nguyen */
 /* An alert message explaning that by changing the visibility to private, the post will be published immediately to your site */
 "postSettings.warningPostWillBePublishedAlertMessage" = "공개 범위를 '비공개'로 변경하면 글이 즉시 발행됩니다.";
 
+/* Localized post type: `Page` */
+"postType.page" = "페이지";
+
+/* Localized post type: `Post` */
+"postType.post" = "글";
+
+/* Details for a 'Private' privacy setting */
+"postVisibility.private.details" = "사이트 관리자와 편집자에게만 표시";
+
+/* Title for a 'Private' privacy setting */
+"postVisibility.private.title" = "비공개";
+
+/* Details for a 'Password Protected' privacy setting */
+"postVisibility.protected.details" = "모든 사람이 볼 수 있지만 비밀번호가 필요합니다.";
+
+/* Title for a 'Password Protected' privacy setting */
+"postVisibility.protected.title" = "비밀번호 보호";
+
+/* Details for a 'Public' (default) privacy setting */
+"postVisibility.public.details" = "모든 사람에게 공개";
+
+/* Title for a 'Public' (default) privacy setting */
+"postVisibility.public.title" = "공개";
+
 /* Button cancel */
 "postVisibilityPicker.cancel" = "취소";
 
@@ -9416,18 +9960,6 @@ Tapping on this row allows the user to edit the sharing message. */
 /* Title for the success view when the user has successfully logged in */
 "qrLoginVerifyAuthorization.completedInstructions.title" = "로그인되었습니다!";
 
-/* No comment provided by engineer. */
-"reachability-utils.alert.cancel" = "확인";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.retry" = "다시 시도하나요?";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.title" = "연결 없음";
-
-/* Message of error prompt shown when no internet connection is available */
-"reachability-utils.alert.utils" = "인터넷 연결이 오프라인 상태인 것 같습니다.";
-
 /* Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog. */
 "reader.blocked.blog.message" = "블로그 %@은(는) 더 이상 리더에 표시되지 않습니다. 눌러서 취소하세요.";
 
@@ -9464,26 +9996,8 @@ Tapping on this row allows the user to edit the sharing message. */
 /* A shared button title for Reader */
 "reader.button.unsubscribe" = "구독 해지";
 
-/* Button title. Follow the comments on a post. */
-"reader.comments.buttonFollow" = "팔로우";
-
 /* Informational message, should be short. */
 "reader.comments.commentsClosed" = "댓글 작성 금지됨";
-
-/* Empty state view title */
-"reader.comments.emptyStateTitle" = "첫 번째로 댓글을 남겨보세요.";
-
-/* Empty state view title */
-"reader.comments.errorLoadingComments" = "댓글 로드 중 예기치 않은 오류가 발생했습니다.";
-
-/* VoiceOver hint */
-"reader.comments.followingSettingAccessibilityIdentifier" = "글 알림 설정 열기";
-
-/* Error message that informs reader comments from a private blog cannot be fetched. */
-"reader.comments.noPermissionToViewPrivateBlog" = "이 비공개 블로그를 볼 권한이 없습니다.";
-
-/* Navigation title */
-"reader.comments.title" = "댓글";
 
 /* Accessibility hint to inform that the author section can be tapped to see posts from the site. */
 "reader.detail.header.authorInfo.a11y.hint" = "사이트의 글 미리보기";
@@ -9561,23 +10075,8 @@ but tapping on this button will remove their like from the post. */
 /* Screen header details */
 "reader.following.header.details" = "구독한 블로그의 소식을 지속적으로 받아보세요.";
 
-/* Empty state view */
-"reader.following.lists.emptyTitle" = "목록이 비어 있음";
-
-/* Screen header details */
-"reader.home.header.details" = "구독한 블로그의 최신 소식을 받아보세요.";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.home.title" = "홈";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.library.title" = "라이브러리";
-
 /* Used in multiple contexts, usually as a screen title */
 "reader.likes.title" = "좋아요";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.lists.title" = "목록";
 
 /* Reader logged-out screen details */
 "reader.loggedOut.details" = "즐겨찾는 블로그를 팔로우하려면 워드프레스닷컴 계정으로 로그인하세요.";
@@ -9820,8 +10319,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title of a Reader tab showing Posts matching a user's search query */
 "reader.search.tab.posts" = "글";
 
-/* Title of the Reader's search feature
-   Used in multiple contexts, usually as a screen title */
+/* Title of the Reader's search feature */
 "reader.search.title" = "검색";
 
 /* Screen title. Reader select interests title label text. */
@@ -9847,6 +10345,21 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Reader select interests title label text */
 "reader.select.tags.title" = "좋아하는 블로그를 발견하고 팔로우하기";
+
+/* Reader sidebar menu item */
+"reader.sidebar.discover" = "발견";
+
+/* Reader sidebar menu item */
+"reader.sidebar.likes" = "좋아요";
+
+/* Reader sidebar menu item */
+"reader.sidebar.recent" = "최근";
+
+/* Reader sidebar menu item */
+"reader.sidebar.saved" = "저장됨";
+
+/* Reader sidebar menu item */
+"reader.sidebar.search" = "검색";
 
 /* Reader sidebar section title */
 "reader.sidebar.section.favorites.title" = "즐겨찾기";
@@ -9896,7 +10409,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Number of subscriptions on a site (singular) */
 "reader.subscriptions.subscriptionsSingular" = "%@명 구독자";
 
-/* Used in multiple contexts, usually as a screen title */
+/* Navigation bar title */
 "reader.subscriptions.title" = "구독";
 
 /* A suggestion of topics the user might want to subscribe to */
@@ -9938,26 +10451,11 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Verb. Button title. The user is following a tag. */
 "reader.tags.following.button.title" = "팔로우 중";
 
-/* Used in multiple contexts, usually as a screen title */
-"reader.tags.title" = "태그";
-
 /* Accessibility label for unsubscribing from a tag */
 "reader.tags.unfollow.accessibility.label" = "%@ 팔로우 취소";
 
 /* Field title */
 "reader.userProfile.site" = "사이트";
-
-/* Reader Welcome screen login button */
-"reader.welcome.continueText" = "워드프레스닷컴 계속하기";
-
-/* Reader Welcome screen */
-"reader.welcome.subtitle" = "최대 블로깅 커뮤니티에 가입하기";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.me" = "나에게";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.notifications" = "알림";
 
 /* Spoken accessibility label */
 "readerDetail.backButton.accessibilityLabel" = "뒤로";
@@ -10232,14 +10730,10 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Message shown when there are no inactive plugins on the site */
 "site.plugins.empty.inactive" = "비활성화된 플러그인 없음";
 
-/* The plugin fillter option for displaying active plugins */
-"site.plugins.filter.option.active" = "활성";
-
-/* The plugin fillter option for displaying all plugins */
+/* The plugin fillter option for displaying active plugins
+   The plugin fillter option for displaying all plugins
+   The plugin fillter option for displaying inactive plugins */
 "site.plugins.filter.option.all" = "전체";
-
-/* The plugin fillter option for displaying inactive plugins */
-"site.plugins.filter.option.inactive" = "비활성";
 
 /* Title of the plugin filter picker */
 "site.plugins.filter.title" = "필터";
@@ -10939,8 +11433,119 @@ Feel free to replace it with other bracket types that you think looks better for
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "상태";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "전체 글 개수 및 최고 조회수";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "전체 조회수";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "전체 조회수 및 방문자 수";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "최고 조회수";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "최고 조회수";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "모든 시간 통계를 로드할 수 없습니다.";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "모든 시간 통계를 표시할 사이트를 생성하거나 추가하세요.";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "글";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "워드프레스닷컴 사이트의 전체 활동을 최신 상태로 유지하세요.";
+
+/* Title of all time widget */
+"widget.alltime.title" = "전체";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "워드프레스에 로그인하여 전체 통계를 참조하세요.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "젯팩에 로그인하여 전체 통계를 참조하세요.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "젯팩에 로그인하여 이번 주 통계를 참조하세요.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "젯팩에 로그인하여 오늘 통계를 참조하세요.";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "전체 조회수";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "오늘 조회수";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "이번 주의 통계를 로드할 수 없습니다.";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "이번 주의 통계를 표시할 사이트를 생성하거나 추가하세요.";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "워드프레스닷컴 사이트의 이번 주 활동을 최신 상태로 유지하세요.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "이번 주";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "워드프레스에 로그인하여 이번 주 통계를 참조하세요.";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "댓글";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "통계가 젯팩 앱으로 이동했습니다. 전환은 무료이며 1분밖에 걸리지 않습니다.";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "좋아요";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "사이트 통계를 로드할 수 없습니다.";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "오늘의 통계를 로드할 수 없습니다.";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "오늘의 통계를 표시할 사이트를 생성하거나 추가하세요.";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "워드프레스닷컴 사이트의 오늘 활동을 최신 상태로 유지하세요.";
+
+/* Title of today widget */
+"widget.today.title" = "오늘";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "워드프레스에 로그인하여 오늘 통계를 참조하세요.";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "미리보기를 사용할 수 없습니다.";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "뷰";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "방문자";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "오늘의 좋아요 개수와 댓글 개수";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "오늘의 조회수";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "오늘의 조회수와 방문자 수";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "을(를) 이후에 사용할 수 없게 됩니다.";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "새로운 사이트를 제작하시나요?";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "워드프레스, 도움말, 지원, 자주 묻는 질문, 질문, 디버깅, 로그, 도움말 센터, 연락처";
@@ -10965,6 +11570,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Error message that describes an unknown error had occured */
 "wordpress-api.error.unknown" = "문제가 발생했습니다. 나중에 다시 시도하세요.";
+
+/* Error message when failing to find selected media file on the user's device. */
+"wordpress.api.upload.media.fileNotFound" = "기기에서 미디어 파일을 찾을 수 없습니다.";
 
 /* Jetpack Plugin Modal on WordPress primary button title */
 "wordpress.jetpack.plugin.modal.primary.button.title" = "젯팩 앱으로 전환";
@@ -11011,21 +11619,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Error message when user signs in with an unexpected email address. The first argument is the expected email address */
 "wpComLogin.error.mismatchedEmail" = "이메일 주소%@(으)로 로그인해 주세요.";
 
-/* Message shown when user denies WordPress.com login, offering option to try with different account */
-"wpComLogin.loginDenied.message" = "다른 것이 필요하면 다른 계정으로 로그인할 수 있습니다. \"%@\"을(를) 눌러 시작하세요.";
-
-/* Title of alert shown when user cancels WordPress.com login */
-"wpComLogin.loginDenied.title" = "로그인 취소됨";
-
-/* Button title for signing in with a different WordPress.com account */
-"wpComLogin.loginDenied.useDifferentAccount" = "다른 계정 사용";
-
-/* Button title to log out the current WordPress.com account */
-"wpcom.token.alert.button.logout" = "로그아웃";
-
-/* Button title to Sign In to WordPress.com */
-"wpcom.token.alert.button.signin" = "로그인";
-
 /* Message title to be displayed when the user needs to re-authenticate their WordPress.com account. */
 "wpcom.token.fix.signin" = "워드프레스닷컴 로그인";
 
@@ -11040,6 +11633,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "지원되지 않는 첨부 파일";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Google로 로그인합니다.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• 도메인";

--- a/WordPress/Resources/nb.lproj/Localizable.strings
+++ b/WordPress/Resources/nb.lproj/Localizable.strings
@@ -57,6 +57,9 @@
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "%1$@ av %2$@ på ditt nettsted";
 
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "%1$@ av %2$@ brukt på ditt nettsted";
+
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ billiard";
 
@@ -161,6 +164,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Uten tittel)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(ingen tittel)";
+
 /* Menus button text for adding a new menu to a site. */
 "+ Add new menu" = "+ Legg til ny meny";
 
@@ -220,6 +226,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "En tittel for siden";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "En gyldig epostadresse er påkrevd for å sende en autentiseringlenke. Vennligst gå tilbake til den forrige skjermen og skriv inn en gyldig epost.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "En bekreftelseskode inneholder bare tall.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "AKTIV";
@@ -360,6 +372,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the advanced section in site settings screen */
 "Advanced" = "Avansert";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "Justering";
@@ -411,9 +426,15 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "Alltid tillatte IP-adresser";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "Nesten fremme! Skriv inn verifiseringskoden fra autentiseringsappen din.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Alt-tekst";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "Alternativt:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "Alltid send krasjlogger";
@@ -423,6 +444,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "En aktiv internettilkobling kreves for å vise aktiviteter";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "En aktiv internettilgang kreves for å vise abonnementstyper";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -463,6 +487,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "Årlig nettstedstatistikk";
+
+/* the comment has an anonymous author. */
+"Anonymous" = "Anonym";
 
 /* Navigates to picker screen to change the app's icon
    Title of screen to change the app's icon */
@@ -624,6 +651,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* This description is used to set the accessibility label for the chart in the Insights view. */
 "Bar Chart depicting visitors for your latest post" = "Søyeldiagram som viser antall besøkende for det nyeste innlegget";
 
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Vær den første til å legge igjen en kommentar.";
+
 /* 'Best Day' label for Most Popular stat. */
 "Best Day" = "Beste dag";
 
@@ -706,6 +736,9 @@ translators: %s: Block name e.g. \"Image block\" */
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "Ved å sette opp Jetpack godtar du våre\n%@";
 
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "Ved å registrere deg, godtar du våre _Tjenestevilkår_.";
+
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "TILPASS";
 
@@ -714,6 +747,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Accessibility label for taking an image or video with the camera on formatting toolbar. */
 "Camera" = "Kamera";
+
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Kan ikke forespørre lenke";
 
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "Kan ikke publisere en tom side";
@@ -724,6 +760,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -733,6 +770,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -751,6 +789,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -782,13 +821,15 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Bildetekst";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Forsiktig!";
 
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Kategorier";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Kategori";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -825,6 +866,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title of alert when getting purchases fails */
 "Check Purchases Error" = "Sjekk feil under kjøp";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "Sjekk din e-post!";
 
 /* Default subtitle for no-results when there is no connection
    Default subtitle for no-results when there is no connection. */
@@ -873,6 +917,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Register Domain - Address information field City */
 "City" = "By\/sted";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "Klassisk blogg";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "Tøm enhetens mediehurtiglager";
 
@@ -894,6 +941,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Lukk";
 
@@ -924,6 +972,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Columns Settings" = "Kolonneinnstillinger";
 
+/* Menu item label for linking a comic page. */
+"Comics" = "Tegneserier";
+
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
 "Comment" = "Kommentar";
@@ -946,6 +997,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Kommentarer";
 
@@ -1001,12 +1053,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Tilkoblede kontoer";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Koblet til, men …";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "Kobler til %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Å koble til %1$@ vil erstatte den eksisterende tilkoblingen til %2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Kobler til WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Kobler til...";
@@ -1039,6 +1097,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1053,6 +1112,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Fortsett å lese";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Fortsett med Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Fortsett med Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Fortsetter med Apple";
 
 /* An example tag used in the login prologue screens. */
 "Cooking" = "Matlaging";
@@ -1115,6 +1183,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "Opprett";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Lag konto";
+
 /* Create New header text */
 "Create New" = "Opprett ny";
 
@@ -1147,6 +1218,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "Gjeldende";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Gjeldende abonnement";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Gjeldende tema";
@@ -1207,6 +1281,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "Standardkategori";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Standardmeny";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Standard innleggsformat";
@@ -1215,6 +1292,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "Standard for nye innlegg";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Slett";
@@ -1310,7 +1388,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "Diskusjon";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Ignorer";
 
 /* Display Name label text.
@@ -1326,6 +1406,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "Domener";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "Har du ikke en konto? _Registrer deg_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -1391,6 +1474,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "Nedlastinger";
 
+/* Name for the status of a draft post. */
+"Draft" = "Kladd";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Kladder";
 
@@ -1455,7 +1541,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "E-postadresse";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "E-postadresse";
 
 /* Notification Settings Channel */
@@ -1512,8 +1601,22 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Skriv inn passord";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "Oppgi adressen til WordPress-nettstedet du ønsker på koble til";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Skriv inn passordet til WordPress.com-kontoen din.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Skriv inn brukernavn";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "Oppgi din kontoinformasjon for %@.";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "Skriv inn passordet i stedet.";
 
 /* Generic error alert title
    Generic popup title for any type of error. */
@@ -1625,11 +1728,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "Eksterne";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Mislyktes";
+
 /* Error message to show to use when media insertion on a post fails */
 "Failed to insert media.\n Please tap for options." = "Kunne ikke sette inn medie.\nTrykk for flere valg.";
 
 /* Error message to show when wrong URL format is used to access the REST API */
 "Failed to serialize request to the REST API." = "Kunne ikke serialisere forespørselen til REST API-et.";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "Anbefalte";
@@ -1673,10 +1782,16 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "Finn ut mer";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Finn nettstedsadressen";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
 "First Name" = "Fornavn";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "Følg";
 
 /* User role badge */
 "Follower" = "Følger";
@@ -1720,11 +1835,23 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the general section in site settings screen */
 "General" = "Generelt";
 
+/* View title for initial auth views. */
+"Get Started" = "Komme i gang";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "Bli aktiv! Kommenter på innlegg fra blogger du følger.";
 
 /* Displayed in the Notifications Tab as a message, when the Follow Filter shows no notifications */
 "Get noticed: comment on posts you've read." = "Bli varslet: kommenter på innlegg du har lest.";
+
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Få mer informasjon";
+
+/* Cancel */
+"Give Up" = "Gi opp";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "Gå til Leser";
@@ -1732,6 +1859,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "Gå til iOS-innstillinger";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Registrering med Google feilet.";
 
 /* User-facing string, presented to reflect that site assembly is underway. */
 "Grabbing site URL" = "Henter nettstedets URL";
@@ -1792,6 +1922,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Help icon" = "Hjelp-ikon";
+
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Skjult";
 
 /* Title of a button used to collapse a group */
 "Hide" = "Skjul";
@@ -1874,6 +2007,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Describes a standard *.wordpress.com site domain */
 "Included with Site" = "Inkludert med side";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Feil brukernavn eller passord. Prøv å skrive inn på nytt.";
 
 /* WordPress.com Community Footer Text */
 "Information on WordPress.com courses and events (online & in-person)." = "Informasjon om WordPress.com-kurs og -hendelser (på nett og i person).";
@@ -1968,6 +2104,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the Invite Link section of the Invite Person screen. */
 "Invite Link" = "Invitasjonslenke";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "Det ser ut som dette brukernavnet\/passordet ikke er knyttet til denne siden.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "Det ser ut som du har skrevet inn feil passord. Vil du gi det et forsøk til?";
 
 /* Accessibility label for italic button on formatting toolbar.
    Discoverability title for italic formatting keyboard shortcut. */
@@ -2082,7 +2224,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* VoiceOver accessibility hint, informing the user the button can be used to like a comment */
 "Likes the Comment." = "Liker kommentaren.";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Lenke";
 
 /* Menus title label when editing a menu item as a link. */
@@ -2132,6 +2275,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "Laster inn personer...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Laster inn abonnement...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Laster alternativer...";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "Laster utvidelse...";
 
@@ -2154,15 +2303,29 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "Laster...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Lokal";
+
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "Lokale endringer";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Plassering";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Stedstjenester må være aktivert før WordPress kan legge til dine gjeldende plassering. Vennligst aktiver Stedstjenester i Innstillinger-appen.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Plassering ukjent";
 
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Loggfiler etter startdato";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Logg inn";
 
 /* Button for confirming logging out from WordPress.com account
@@ -2171,6 +2334,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title of a button for signing in. */
 "Log in" = "Logg inn";
+
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Innlogging mislyktes. Vennligst prøv igjen.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Logg inn med WordPress.com-kontoen du brukte for å koble til Jetpack.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "Logg inn på din WordPress.com-konto med din e-postadresse.";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of Jetpack?" = "Logge ut av Jetpack?";
@@ -2189,6 +2361,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Det ser ut til at du har Jetpack satt opp på ditt nettsted. Gratulerer!\nLogg inn med din WordPress.com-innlogging nedenfor for å aktivere statistikk og varslinger.";
+
+/* Title of a button. */
+"Lost your password?" = "Mistet ditt passord?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "E-post (standard)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Hovednavigasjon";
@@ -2299,6 +2477,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "Melding";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Title for the mobile web preview */
 "Mobile" = "Mobil";
 
@@ -2370,6 +2551,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "Mitt nettsted";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "Mine nettsteder i WordPress";
+
 /* Accessibility label for the Email text field.
    Header for a comment author's name, shown when editing a comment.
    Name text field placeholder */
@@ -2387,8 +2571,15 @@ translators: %s: Block name e.g. \"Image block\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Hjelp?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "Trenger du hjelp med å finne sideadressen?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "Trenger du hjelp?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Trenger du mer hjelp?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "Trenger oppdatering";
@@ -2408,6 +2599,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "Nytt innlegg";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Nytt objekt";
+
 /* Placeholder text for password field */
 "New password" = "Nytt passord";
 
@@ -2421,7 +2615,9 @@ translators: %s: Block name e.g. \"Image block\" */
 "Newest first" = "Nyeste først";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Neste";
 
 /* Accessibility label for the next notification button */
@@ -2457,6 +2653,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "Ingen forhåndsvisnings-URL er tilgjengelig";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "Uten tittel";
+
 /* Title for the view when there aren't any Activities to display in the Activity Log */
 "No activity yet" = "Ingen aktivitet ennå";
 
@@ -2480,7 +2679,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "Ingen kommentarer ennå";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "Ingen tilkobling";
 
@@ -2626,7 +2826,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Nummerert liste";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -2671,13 +2876,19 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "Oops";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Uffda!";
 
 /* Opens iOS's Device Settings for WordPress App */
 "Open Device Settings" = "Åpne enhetsinnstillinger";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Åpne Mail";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Åpne innstillinger";
 
 /* No comment provided by engineer. */
@@ -2700,6 +2911,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* WordPress.com Research Footer Text */
 "Opportunities to participate in WordPress.com research & surveys." = "Muligheter for å være med i WordPress.coms forskning og undersøkelser.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "Eller";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "Eller logg inn ved å _oppgi adressen til nettstedet_.";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Nummerert liste";
@@ -2742,7 +2959,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Register Domain - Phone number section header title */
 "PHONE" = "TELEFON";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Side";
 
@@ -2766,8 +2984,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for selecting parent category of a category */
 "Parent Category" = "Foreldrekategori";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Passord";
 
@@ -2781,8 +3002,12 @@ translators: %s: Block name e.g. \"Image block\" */
 "Paste URL" = "Lim inn URL";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Venter";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Venter på gjennomgang";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -2804,6 +3029,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "Velg brukernavn";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Abonnementer";
+
 /* User action to play a video on the editor. */
 "Play video" = "Spill av video";
 
@@ -2815,6 +3044,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message displayed on an error alert to prompt the user to contact support */
 "Please contact support for assistance." = "Vennligst kontakt kundestøtten for assistanse.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "Vennligst oppgi en komplett nettstedsadresse, som example.com.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "Vennligst skriv inn en nettstedsadresse.";
@@ -2846,11 +3078,14 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "Vennligst skriv inn en gyldig adresse";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Vennligst skriv inn en gyldig e-postadresse.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "Vennligst oppgi et gyldig telefonnummer";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Vennligst oppgi passordet til WordPress.com-konto for å logge inn med din Apple-ID.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Vennligst skriv inn dine opplysninger";
@@ -2858,8 +3093,14 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Vennligst oppgi din e-postadresse.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Vennligst fyll ut alle feltene";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Vennligst åpne WordPress-appen, logg in på WordPress.com, og sjekk at du har minst en side før du prøver igjen.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "Vennligst logg ut for du kobler til et annet wordpress.com-nettsted";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "Vennligst prøv igjen senere";
@@ -2921,7 +3162,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for Popular Languages */
 "Popular languages" = "Populære språk";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Publiser";
 
@@ -3033,6 +3275,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "Personvernnotis for brukere i California";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Privat";
+
 /* Error message title informing the user that reader content could not be loaded. */
 "Problem loading content" = "Problem med å laste innhold";
 
@@ -3042,6 +3287,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "Problemer med å kjøpe ditt domene. Vennligst prøv igjen.";
 
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Å fortsette vil fjerne alle WordPress.com-data fra enheten og slette eventuelle lokalt lagrede kladder. Du vil ikke miste noe som allerede er lagret på WordPress.com bloggen(e) din(e).";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Prosjekter";
+
 /* Label for the publish (verb) button. Tapping publishes a draft post.
    Publish post action on share extension site picker screen.
    Section title for the publish table section in the blog details screen */
@@ -3050,10 +3301,14 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the publish date button. */
 "Publish Date" = "Publiseringsdato";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Publiser umiddelbart";
+
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "Publiser innlegg på:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Publisert";
 
@@ -3209,6 +3464,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "Svar";
 
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Svartekst";
+
 /* An explaination of a setting. */
 "Require manual approval for comments that include more than this number of links." = "Krev manuell godkjenning for kommentarer som inkluderer flere lenker enn dette antallet.";
 
@@ -3229,6 +3487,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title of secondary button on alert prompting verify their accounts while attempting to publish */
 "Resend" = "Send på nytt";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Tilbakestill passordet ditt";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Endre størrelse og beskjær";
@@ -3261,6 +3522,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "Prøv alle igjen";
 
+/* No comment provided by engineer. */
+"Retry?" = "Prøv igjen?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "Returner til innlegg";
 
@@ -3287,11 +3551,15 @@ translators: %s: Block name e.g. \"Image block\" */
    User's Role */
 "Role" = "Rolle";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS sendt";
+
 /* Button label to open web page in Safari */
 "Safari" = "Safari";
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -3322,7 +3590,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus save button title while it is saving a Menu. */
 "Saving..." = "Lagrer…";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Planlagt";
 
 /* Title of Stats section that shows search engine referrer traffic. */
@@ -3413,6 +3682,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader hint (non-imperative) about what does the menu item selection button do */
 "Selects this item" = "Velg dette elementet";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Send lenke";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "Send lenke med e-post";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "Send loggmelding";
 
@@ -3461,6 +3736,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Message to show when setting save failed */
 "Settings update failed" = "Oppdatering av innstillinger feilet";
 
+/* Spoken accessibility label */
+"Share" = "Del";
+
 /* Informational text for Collect Information setting */
 "Share information with our analytics tool about your use of services while logged in to your WordPress.com account." = "Del informasjon med vårt analyseverktøy om din bruk av våre tjenester mens du er logget inn på din WordPress.com-konto.";
 
@@ -3495,6 +3773,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "Vis Gjenblogg-knapp";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "Vis passord";
+
 /* No comment provided by engineer. */
 "Show post content" = "Vis innhold av innlegg";
 
@@ -3506,6 +3788,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "Viser statistikk for:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "Vist";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Vises offentlig når du kommenterer på blogger.";
@@ -3521,6 +3806,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "Viser innlegget";
+
+/* View title during the sign up process. */
+"Sign Up" = "Registrer deg";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Meld deg inn";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Registrer deg på WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Registrer deg med epost";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "Siden du har et gratisabonnement, vil hendelsene du ser i aktivitetsloggen være begrenset.";
@@ -3553,6 +3850,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Sideprestasjoner";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Nettstedsadresse";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "Nettstedsadressen må være minst 4 tegn.";
@@ -3616,7 +3916,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Beklager, nettstedsadresser må ha bokstaver også!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Beklager, den e-postadressen er allerede i bruk!";
 
 /* No comment provided by engineer. */
@@ -3676,6 +3976,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of spam Comments filter. */
 "Spam" = "Søppel";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "Gjør siden din raskere";
@@ -3695,6 +3998,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Register Domain - Domain Address field State */
 "State" = "Delstat";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "Statisk hjemmeside";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -3722,6 +4028,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "Gjennomstreking";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Stump";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "Send inn for gjennomgang";
@@ -3794,7 +4103,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the tablet web preview */
 "Tablet" = "Nettbrett";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Stikkord";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -3869,11 +4179,20 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Bruksregler";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Kundevurdering";
+
 /* Title of a button style */
 "Text Only" = "Kun tekst";
 
+/* Button title */
+"Text me a code instead" = "Send koden på tekstmelding i stedet";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Takk for at du valgte %1$@ av %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "Det der ser ikke ut som en gyldig bekreftelseskode.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "Den siden ser ikke ut som en WordPress-side.";
@@ -3896,6 +4215,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "Facebook-tilkoblingen kan ikke finne noen sider. Publisering kan ikke koble til Facebook-profiler, kun publiserte sider.";
 
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "Google-kontoen \"%@\" matcher ikke en WordPress.com-konto";
+
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "Internettilkoblingen ser ikke ut til å virke.";
 
@@ -3916,6 +4238,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "Bildet kunne ikke legges til i Mediebiblioteket.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "Internettforbindelsen synes å være frakoblet.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "Disse typen nettsteder kan opprettes";
@@ -3940,6 +4265,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Nettstedet på %1$@ bruker WordPress %2$@. Vi anbefaler å oppdatere til siste versjon, eller i det minste %3$@";
+
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "Nettstedet på den adressen er ikke et WordPress-nettsted. For at vi skal kunne koble til må nettstedet være WordPress.";
 
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "Siden kunne ikke slettes.";
@@ -3976,6 +4305,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "Det skjedde en uventet feil mens du redigerte din kommentar";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "Det oppstod en uventet feil under lasting av kommentarene.";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "Det oppstod en uventet feil under registrering av domenet ditt";
 
@@ -3984,6 +4316,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "Det oppstod en uventet feil under oppdatering av dine varslingsinnstillinger";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "Det skjedde en feil. Klarte ikke å oppdatere din kommentar";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "En uventet feil oppstod.";
@@ -4002,6 +4337,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Error message informing the user that there was a problem blocking posts from a site from their reader. */
 "There was a problem blocking posts from the specified site." = "Det skjedde en feil. Klarte ikke å blokkere innlegg fra det nettstedet.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "Det oppstod et problem under tilkobling til WordPress.com. Vennligst logg inn igjen.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "Det oppstod et problem under visning av innlegget.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "Det oppstod et problem med lasting av dine data, last inn siden på nytt og prøv igjen.";
 
@@ -4011,6 +4352,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "Det oppstod et problem under lagring av endringer til delingsbehandling.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "Det oppstod et problem under forsøk på å få tilgang til din plassering. Prøv igjen senere.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "En feil oppstod under endring av passordet";
@@ -4018,11 +4362,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "Det oppstod en feil under lasting av aktiviteter";
 
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "Det oppstod en feil under lasting av abonnementer";
+
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "Det oppstod en feil under lasting av utvidelser";
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "Det oppstod en feil under lasting av historikken";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "Det oppstod en feil under lasting av abonnementet";
 
 /* Text displayed when there is a failure loading the plugin */
 "There was an error loading this plugin" = "Det oppstod en feil under lasting av denne utvidelsen";
@@ -4047,6 +4397,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* An error message display if the users device does not have a camera input available */
 "This app needs permission to access the Camera to capture new media, please change the privacy settings if you wish to allow this." = "Denne appen trenger tilgang til kameraet for å ta bilder og video, vennligst endre personverninnstillingene hvis du ønsker dette.";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "Denne epostadressen er ikke registrert på WordPress.com.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "Denne filen er for stor til å lastes opp til siden din, eller så støttes ikke dette medieformatet.";
@@ -4101,11 +4454,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "For å fortsette, vennligst skriv inn epost-adresse og navn.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "For å opprette en ny WordPress.com-konto, vennligst skriv inn epostadressen din.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "For å få hjelpsomme varslinger fra WordPress-siden din på mobilen, må du installere Jetpack-utvidelsen.";
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "For å installere utvidelser, må du ha et tilpasset domene knyttet til nettsiden din.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "For å fortsette med denne Google-kontoen, vennligst logg inn med WordPress.com-passordet ditt først. Du vil kun bli spurt om dette én gang.";
 
 /* Message asking the user if they want to set up Jetpack from stats */
 "To use stats on your site, you'll need to install the Jetpack plugin." = "For å bruke statistikk på siden din, må du installere Jetpack-utvidelsen.";
@@ -4165,7 +4524,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Trashes the comment */
 "Trash" = "Slett";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "Slettet";
 
@@ -4176,6 +4536,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Try & Customize" = "Prøv og tilpass";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Prøv igjen";
@@ -4192,6 +4553,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Button title on the blogging prompt's feature introduction view to answer a prompt. */
 "Try it now" = "Prøv nå";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Prøv med en annen E-post";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Prøv med nettstedsadressen";
 
 /* Title of button that displays the app's Twitter profile */
 "Twitter" = "Twitter";
@@ -4210,6 +4577,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "BRUKER";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "Klarte ikke å koble til";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "Kunne ikke laste inn innlegg";
@@ -4261,6 +4631,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "Kunne ikke laste opp 1 innlegg, 1 fil";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "Kunne ikke verifisere epostadressen. Prøv igjen senere.";
 
 /* Error reason to display when the writing of a image to a file fails */
 "Unable to write image to file" = "Kunne ikke lagre bilde til fil";
@@ -4372,7 +4745,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Opplasting feilet";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Lastet opp";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -4390,7 +4764,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Opplastede temaer";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Laster opp";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -4403,11 +4778,14 @@ translators: %s: Block name e.g. \"Image block\" */
 "Use block editor" = "Bruk blokkredigering";
 
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Brukernavn";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -4422,6 +4800,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Brukere";
+
+/* two factor code placeholder */
+"Verification code" = "Bekreftelseskode";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "Verifiserings-E-posten ble sendt, sjekk innboksen din";
@@ -4512,6 +4893,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Action title. Noun. Opens the user's WordPress Admin in an external browser. */
 "WP Admin" = "WP Admin";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Venter på at Google skal fullføre...";
+
+/* View title during the Google auth process. */
+"Waiting..." = "Venter...";
+
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
    Title for Jetpack Restore Warning screen */
@@ -4529,14 +4916,26 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "Vi bruker andre sporingsverktøy, inkludert noen fra tredjeparter. Les mer om disse og hvordan du kontrollerer dem.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "Vi kunne ikke sende deg en epost på det gjeldende tidspunkt. Vennligst prøv igjen senere.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "Vi sender deg en magisk lenke som vil logge deg inn øyeblikkelig, uten behov for passord. Ikke mer bokstav-for-bokstav-skriving!";
+
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "Vi vil varsle deg når du får følgere, kommentarer og likes.";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "Vi vil varsle deg når du får følgere, kommentarer og likes. Vil du tillate push-varslinger?";
 
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "Vi bruker denne epostadressen for å opprette din nye WordPress.com-konto.";
+
 /* Title of progress label displayed when a first plugin on a site is almost done installing. */
 "We're doing the final setup—almost done…" = "Vi holder på den det avsluttende oppsettet—snart ferdig...";
+
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "Vi kunne ikke koble til Jetpack-siden på den URL-en. Kontakt oss for hjelp.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -4547,6 +4946,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Blog Writing Settings: Weeks starts on */
 "Week starts on" = "Uken starter med";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Velkommen til WordPress";
 
 /* A message title */
 "Welcome to the Reader" = "Velkommen til leseren";
@@ -4566,6 +4968,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of section that contains plugins' change log */
 "What's New" = "Hva er nytt";
 
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "Hva er sideadressen min?";
+
 /* Text rendered at the bottom of the Discussion Moderation Keys editor */
 "When a comment contains any of these words in its content, name, URL, e-mail or IP, it will be held in the moderation queue. You can enter partial words, so \"press\" will match \"WordPress\"." = "Når en kommentar inneholder noen av disse ordene i innholdet, navnet, URLen, eposten eller IPen vil det bli hold i modereringskøen. Du kan skrive inn deler av ord, så \"press\" vil matche \"WordPress\".";
 
@@ -4575,29 +4980,65 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "Når du gjør endringer på nettsiden din, vil du kunne se aktivitetshistorikken din her.";
 
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Oisann, noe gikk galt og vi klarte ikke å logge det deg på. Vennligst prøv igjen!";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Oida, det var ikke en gyldig 2-trinnsautentiseringskode. Dobbeltsjekk koden din, og prøv igjen!";
+
 /* Help text when editing email address */
 "Will not be publicly displayed." = "Vil ikke vises offentlig.";
 
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "Innstillinger for WorfPress-appen";
+
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "WordPress-blogg";
+
+/* Siri Suggestion to open Support */
+"WordPress Help" = "Hjelp med WordPress";
 
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "WordPress-mediebiblioteket";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "Innstillinger for varslinger i WordPress";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "Varslinger for WordPress";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "Brukerprofil i WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "Leser for WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = " WordPress nettstedsdetaljer";
+
 /* Subject of new Zendesk ticket. */
 "WordPress for iOS Support" = "WordPress for iOS-kundestøtte";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress trenger tillatelse til å lese din enhets gjeldende plassering for å legge den til i innlegget ditt. Vennligst oppdater personverninnstillingene dine.";
+
 /* No comment provided by engineer. */
 "WordPress version too old" = "WordPress-versjonen er for gammel";
+
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "WordPress-versjonen er for gammel. Siden med adresse %1$@ kjører WordPress %2$@. Vi anbefaler at du oppdaterer til den nyeste versjonen, eller i det minste %3$@";
 
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "WordPress.com-konto";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "WordPress.com-abonnementer";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "WordPress.com-temaer";
@@ -4626,6 +5067,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the writing section in site settings screen */
 "Writing" = "Skriver";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "År";
@@ -4692,7 +5136,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Warning displayed before logging out. The %d placeholder will contain the number of local posts (PLURAL!) */
 "You have changes to %d posts that haven’t been uploaded to your site. Logging out now will delete those changes. Log out anyway?" = "Du har endringer på %d innlegg som ikke har blitt lastet opp til ditt nettsted. Utlogging vil slette disse endringene. Logge ut likevel?";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Du har ulagrede endringer.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -4745,6 +5190,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed when a site restore takes too long. */
 "Your restore is taking longer than usual, please check again in a few minutes." = "Din gjenoppretting tar lenger tid enn vanlig, vennligst sjekk igjen om noen få minutter.";
 
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "Sideadressen din vises i adresselinja øverst på skjermen når du besøker siden i Safari.";
+
 /* User-facing string, presented to reflect that site assembly completed successfully. */
 "Your site has been created!" = "Dit nettsted er opprettet!";
 
@@ -4790,6 +5238,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Register Domain - Address information field Country Code placeholder */
 "eg. 44" = "f.eks. 47";
 
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "example.com";
+
 /* (placeholder) Help the user enter a URL into the field */
 "http:\/\/my-site-address (URL)" = "http:\/\/min-nettsteds-adresse (URL)";
 
@@ -4802,6 +5254,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Later today */
 "later today" = "senere i dag";
 
+/* No comment provided by engineer. */
+"password" = "passord";
+
 /* Register Domain - Domain contact information field Phone */
 "phone number" = "telefonnummer";
 
@@ -4810,6 +5265,27 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Used when the response doesn't have a valid url to display */
 "unknown url" = "ukjent url";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "Beste visninger noensinne";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Innlegg";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Kommentarer";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Liker";
+
+/* Title of today widget */
+"widget.today.title" = "I dag";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Visninger";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Besøkere";
 
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "vil være utilgjengelig i fremtiden.";
@@ -4834,6 +5310,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'My Sites' tab. */
 "wordpress, sites, site, blogs, blog" = "wordpress, sider, side, blogger, blogg";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Logg inn med Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Domener";

--- a/WordPress/Resources/nl.lproj/Localizable.strings
+++ b/WordPress/Resources/nl.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Translation-Revision-Date: 2025-05-09 11:28:29+0000 */
+/* Translation-Revision-Date: 2025-03-07 07:46:43+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
 /* Generator: GlotPress/4.0.1 */
 /* Language: nl */
@@ -98,6 +98,9 @@
 
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "%1$@ van %2$@ op je site";
+
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "%1$@ van %2$@ gebruikt op je site";
 
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ biljard";
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Zonder titel)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(Geen titel)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*Johan Brandt* antwoordde op je bericht";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "Een \"meer\" knop bevat een dropdown met sharing knoppen";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "Een WordPress.com-account is gekoppeld aan je winkel-inloggegevens. Om door te gaan sturen wij je een verificatielink naar het bovenstaande e-mailadres.";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "Een bestand bevat een kwaadaardig codepatroon";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "Een titel voor de site";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "Er is een geldig e-mailadres vereist om een verificatielink te mailen. Ga terug naar het vorige scherm en voer een geldig e-mailadres in.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "Een verificatiecode bevat alleen getallen.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "ACTIEF";
@@ -334,9 +349,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* My Profile 'About me' label */
 "About Me" = "Over mij";
-
-/* Link to About screen for Jetpack for iOS */
-"About Reader for iOS" = "Over Reader voor iOS";
 
 /* Link to About screen for WordPress for iOS */
 "About WordPress" = "Over WordPress";
@@ -525,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "Na %@";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "Uitlijning";
@@ -588,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "Toegestane IP-adressen";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "Bijna klaar. Voer de verificatiecode in van je authenticatie-app.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Alt-tekst";
@@ -600,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "Alternatively, you can flatten the content by ungrouping the block.";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "Je kunt ook het wachtwoord voor dit account invoeren.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "Anders:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "Verzend altijd crashlogs";
@@ -621,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "Een actieve internetverbinding is vereist om activiteiten te bekijken";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "Een werkende internetverbinding is nodig om abonnementen te bekijken";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -671,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "Jaarlijkse site statistieken";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "Anoniem";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "Antwoord";
 
@@ -692,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "Weergave";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "Apple authenticatie mislukt.\nZorg dat je ingelogd bent bij iCloud met een Apple ID die twee-factor-authenticatie gebruikt.";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "Past de instelling toe";
@@ -778,6 +811,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "Authenticatie mislukt";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "Authenticatiecode";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "Authenticatie vereist voor host: %@";
@@ -888,6 +925,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "Reageer als eerste";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Laat als eerste een reactie achter.";
 
 /* Beauty site intent topic */
 "Beauty" = "Schoonheid";
@@ -1024,12 +1064,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button to copy post text" = "Knop om berichttekst te kopiëren";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "Als je doorgaat, ga je akkoord met onze _algemene voorwaarden_.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "Door dit domein te registreren, ga je akkoord met onze <a>algemene voorwaarden<\/a>.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "Door Jetpack in te stellen ga je akkoord met onze\n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "Door aan te melden, ga je akkoord met onze _algemene voorwaarden_.";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "AANPASSEN";
@@ -1043,6 +1089,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "Toegang tot camera nodig om inlogcodes te scannen";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Kan link niet aanvragen";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "Kan een lege pagina niet publiceren";
 
@@ -1052,6 +1101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1061,6 +1111,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1079,6 +1130,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1106,6 +1158,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "Annuleren...";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "Kan geen toegang krijgen tot de site op dit adres. Controleer je sleutel en probeer het nogmaals.";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "kun je niet kiezen? Je kunt op elk moment het thema veranderen.";
 
@@ -1113,7 +1168,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Bijschrift";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Voorzichtig!";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1122,7 +1178,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Categorieën";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Categorie";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1171,6 +1228,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "Bekijk onze beste tips voor meer weergaven en bezoekers";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "Controleer je e-mail op dit apparaat!";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Controleer je e-mail op dit apparaat en tik op de link in de e-mail die je ontvangen hebt van WordPress.com.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "Controleer je e-mail op dit apparaat en tik op de link in de e-mail die je ontvangen hebt van WordPress.com.\n\nKan je de e-mail niet vinden? Controleer je spam map.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "Controleer je e-mail!";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "Controleer je netwerkverbinding en veeg omlaag om te vernieuwen.";
@@ -1267,6 +1336,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "Claim je gratis domein";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "Klassiek blog";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "Wis media cache apparaat";
 
@@ -1294,6 +1366,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Sluit";
 
@@ -1335,6 +1408,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "Kolommen instellingen";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Comics";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1386,6 +1462,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Reacties";
 
@@ -1453,12 +1530,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Verbonden accounts";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Verbonden maar...";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "Verbinden met %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Door te verbinden met %1$@ wordt de huidige verbinding vervangen door %2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Verbinden met WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Verbinden...";
@@ -1489,8 +1572,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "Neem contact op via %@";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "Inhouds-structuur\nBlokken: %1$li, Woorden: %2$li, Karakters: %3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1505,6 +1592,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Lees verder";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Doorgaan met Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Doorgaan met Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Ga verder met Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "Bijdragen";
@@ -1633,6 +1729,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "Maak";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Creëer account";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "Maak een lege pagina";
 
@@ -1653,6 +1752,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "Maak een bericht";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "Een site maken";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "Maak een tag";
@@ -1686,6 +1788,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "Huidig";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Huidig abonnement";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Huidig thema";
@@ -1788,6 +1893,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "Standaard categorie";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Standaard menu";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Standaard berichtformat";
@@ -1796,6 +1904,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "Standaardinstellingen voor nieuwe berichten";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Verwijderen";
@@ -1853,6 +1962,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "Details";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "Wilde je geen nieuw account aanmaken? Ga terug om je e-mailadres opnieuw in te voeren.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "Afmetingen";
 
@@ -1900,7 +2012,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "Discussie";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Afbreken";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1922,6 +2036,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "Domeinen";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "Heb je geen account? _Aanmelden_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2051,6 +2168,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "Downloads";
 
+/* Name for the status of a draft post. */
+"Draft" = "Concept";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Concepten";
 
@@ -2160,7 +2280,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "E-mailadres";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "E-mailadres";
 
 /* Notification Settings Channel */
@@ -2244,8 +2367,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Voer wachtwoord in";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "Vul het adres van de WordPress site in die je wilt verbinden.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Voer wachtwoord voor je WordPress.com account in.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Voer gebruikersnaam in";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "Voer je accountgegevens in voor %@.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "Voer je e-mailadres in om in te loggen of maak een WordPress.com account.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "Vul je bestaande site-adres in";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "Voer je wachtwoord in.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "Voer je server referenties in";
@@ -2408,6 +2551,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "Extern";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Mislukt";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "Meldingen als gelezen markeren mislukt";
 
@@ -2419,9 +2565,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Failed to insert media.\nTap for more info." = "Media invoegen is mislukt.\nTik voor meer informatie.";
-
-/* A message indicating that we couldn't load the user's settings. */
-"Failed to load settings" = "Instellingen niet geladen";
 
 /* No comment provided by engineer. */
 "Failed to save files.\nPlease tap for options." = "Opslaan van bestanden mislukt.\nTik voor opties.";
@@ -2437,6 +2580,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "Mode";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "Uitgelicht";
@@ -2495,6 +2641,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "Meer te weten komen";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Vind je site adres";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2517,6 +2666,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "Bezig met bedreigingen oplossen";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "Volgen";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "Volg conversatie";
@@ -2611,6 +2763,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "Genereer een nieuwe link";
 
+/* View title for initial auth views. */
+"Get Started" = "Hoe te starten";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "Krijg een login link via e-mail";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "Ga aan de slag! Reageer op berichten uit blogs die je volgt.";
 
@@ -2632,8 +2790,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "Raak geinspireerd";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Account informatie ophalen";
+
+/* Cancel */
+"Give Up" = "Opgeven";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "Probeer het door een paar blokken toe te voegen aan je bericht of pagina!";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "Ga naar Reader";
@@ -2644,6 +2811,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "Ga naar iOS instellingen";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Aanmelden met Google mislukt.";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2718,6 +2888,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "Hulp icoon";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Verborgen";
+
 /* Title of a button used to collapse a group */
 "Hide" = "Verbergen";
 
@@ -2786,6 +2959,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "Updaten van icoon mislukt";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "Als je de e-mail niet kunt vinden, controleer dan de spamfolder of de prullenbak van je inbox";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "Als je doorgaat met een Apple of Google account en je hebt nog geen WordPress.com account, dan maak je een account aan en ga je akkoord met onze _algemene voorwaarden_.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "Als je %1$@ verwijdert, kan deze gebruiker deze site niet meer openen. Alle inhoud die door %2$@ is gemaakt blijft op de site staan.";
@@ -2861,6 +3040,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "Bevat wp-config.php en alle niet WordPress bestanden";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Gebruikersnaam of wachtwoord onjuist. Probeer nogmaals je inloggegevens in te voeren.";
 
 /* Title for a threat */
 "Infected core file" = "Geïnfecteerd core-bestand";
@@ -2962,6 +3144,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "Introductie van blog meldingen";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "Ongeldig e-mailadres";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "Ongeldig site-adres";
 
@@ -2979,6 +3164,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "Ongeldige URL. Audiobestand niet gevonden.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "Ongeldige URL. Controleer je sleutel en probeer het nogmaals.";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "Ongeldige URL. Voer een geldige URL in.";
@@ -3000,6 +3188,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "Mensen uitnodigen";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "Het lijkt erop dat deze gebruikersnaam\/dit wachtwoord niet aan deze site is gekoppeld.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "Het lijkt erop dat je een onjuist wachtwoord hebt ingevoerd. Wil je het nog eens proberen?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "Het is tijd om te bloggen op %@!";
@@ -3228,7 +3422,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "Regelhoogte";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Link";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3290,6 +3485,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "Mensen laden...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Abonnement wordt geladen...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Plannen worden geladen...";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "Plugin laden ...";
 
@@ -3322,7 +3523,10 @@ translators: %s: Block name e.g. \"Image block\" */
    Suggestions loading message
    Text displayed in HUD while a media item is being loaded.
    Text displayed while loading time zones */
-"Loading..." = "Aan het laden...";
+"Loading..." = "Laden...";
+
+/* Status for Media object that is only exists locally. */
+"Local" = "Lokaal";
 
 /* Local Services site intent topic */
 "Local Services" = "Plaatselijke diensten";
@@ -3330,15 +3534,26 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "Lokale wijzigingen";
 
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Locatie";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Locatiediensten moet worden ingeschakeld voordat WordPress je huidige locatie kan toevoegen. Schakel locatiediensten in vanuit je Instellingen-app.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Locatie onbekend";
+
 /* No comment provided by engineer. */
 "Lock icon" = "Slot icoon";
 
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Log bestanden op creëer datum";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Inloggen";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3348,17 +3563,33 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of a button for signing in. */
 "Log in" = "Login";
 
-/* LogOut confirmation text, whenever there are no local changes */
-"Log out of Jetpack?" = "Uitloggen bij Jetpack?";
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Inloggen mislukt. Probeer het nogmaals.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "Log in of meld je aan bij WordPress.com";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Login met je WordPress.com account die je gebruikt hebt om verbinding met Jetpack te maken.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "Login op je WordPress.com account met je e-mailadres.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "Log in met je WordPress.com gebruikersnaam en wachtwoord.";
 
 /* LogOut confirmation text, whenever there are no local changes */
-"Log out of Reader?" = "Uitloggen uit reader?";
+"Log out of Jetpack?" = "Uitloggen bij Jetpack?";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of WordPress?" = "Uitloggen van WordPress?";
 
 /* Login Request Expired */
 "Login Request Expired" = "Aanmeldingsverzoek is verlopen";
+
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "Log in met het wachtwoord van je account";
 
 /* No comment provided by engineer. */
 "Logs" = "Logs";
@@ -3368,6 +3599,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Het lijkt er op dat Jetpack is geïnstalleerd op je site. Gefeliciteerd!\nLogin met je WordPress.com inloggegevens om statistieken en meldingen in te schakelen.";
+
+/* Title of a button. */
+"Lost your password?" = "Wachtwoord vergeten?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "Mail (standaard)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Hoofdnavigatie";
@@ -3515,6 +3752,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "Bericht";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "Verschillende kwetsbaarheden";
 
@@ -3610,6 +3850,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "Mijn site";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "Mijn sites in WordPress";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "Mijn toptien cafés";
 
@@ -3649,8 +3892,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Hulp nodig?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "Hulp nodig in het vinden van je site adres?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "Hulp nodig?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Meer hulp nodig?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "Heeft update nodig";
@@ -3679,6 +3929,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "Nieuw bericht";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Nieuw item";
+
 /* Placeholder text for password field */
 "New password" = "Nieuw wachtwoord";
 
@@ -3696,7 +3949,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "Nieuws";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Volgende";
 
 /* Accessibility label for the next notification button */
@@ -3732,6 +3987,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "Geen voorbeeld URL beschikbaar";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "Geen titel";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "Geen activiteiten beschikbaar";
 
@@ -3764,7 +4022,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "Nog geen reacties";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "Geen verbinding";
 
@@ -3913,6 +4172,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "Niet nu";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "Kan je de e-mail niet vinden? Controleer je spam-map of ongewenste e-mail.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "Opmerking:";
 
@@ -3976,7 +4238,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Genummerde lijst";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -4033,7 +4300,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "Oeps";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Oeps!";
 
 /* No comment provided by engineer. */
@@ -4048,7 +4316,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "Open Jetpack Security instellingen";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Open e-mail";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Open Instellingen";
 
 /* No comment provided by engineer. */
@@ -4066,6 +4339,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "Link openen in een nieuw venster\/tab";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "Open abonnement-instellingen voor het bericht";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "Open de ik-sectie";
 
@@ -4080,6 +4356,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "Optioneel: vul een aangepast bericht in van maximaal %1$d karakters wat met je uitnodiging verstuurd wordt.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "Of";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "Of kies een andere vorm van authenticatie.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "Of login door _je site-adres in te voeren_.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "Log in met de magische link";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Geordende lijst";
@@ -4128,7 +4416,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "Padding";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Pagina";
 
@@ -4161,8 +4450,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "Ouderschap";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Wachtwoord";
 
@@ -4179,8 +4471,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "Plak het blok na";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "In afwachting";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Afwachting van de moderatie";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4211,6 +4507,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "Kies een gebruikersnaam";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Abonnementen";
+
 /* User action to play a video on the editor. */
 "Play video" = "Speel video";
 
@@ -4240,6 +4540,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "Zorg ervoor dat de blok-editor ingeschakeld is op je site. Indien niet ingeschakeld, zal het niet laden.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "Vul een compleet site-adres in, zoals voorbeeld.nl.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "Een site-adres invoeren.";
@@ -4274,11 +4577,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "Voer een geldig adres in";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "Vul een geldig e-mailadres in voor een WordPress.com account.";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Geef een geldig e-mailadres op.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "Voer een geldig telefoonnummer in";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Vul het wachtwoord voor je WordPress.com account in om met je Apple ID in te loggen.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Voer alsjeblieft je gegevens in";
@@ -4286,8 +4595,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Vul je e-mailadres in.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Vul aub alle velden in";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Open de WordPress app, login op WordPress.com en controleer of je minimaal één site hebt, probeer dan opnieuw.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "Log uit voordat je verbinding maakt met een andere WordPress.com-site";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "Probeer later opnieuw";
@@ -4355,7 +4670,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "Populaire talen";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Publiceer";
 
@@ -4476,6 +4792,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "Privacybericht voor gebruikers in Californie";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Prive";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "\"Probleem bij het weergeven van het blok\" \nTap to attempt block recovery.";
 
@@ -4490,6 +4809,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "Probleem bij het aanschaffen van je domein. Probeer het nog eens.";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Als je doorgaat worden alle WordPress.com gegevens van dit apparaat verwijderd en alle lokaal opgeslagen concepten gewist. Alles wat je op je WordPress.com blog(s) hebt opgeslagen blijft bewaard.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Projecten";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "Opdracht overgeslagen";
@@ -4507,13 +4832,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "Publicatiedatum";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Direct publiceren";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "Publiceer pagina op:";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "Publiceer bericht op:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Gepubliceerd";
 
@@ -4715,7 +5044,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "Reactie";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Antwoordtekst";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "Antwoord aan %1$@";
 
 /* An explaination of a setting. */
@@ -4744,6 +5078,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "Herstel datumbereik filter";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Je wachtwoord opnieuw instellen";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Afmeting wijzigen en bijsnijden";
@@ -4801,6 +5138,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "Probeer alles opnieuw";
 
+/* No comment provided by engineer. */
+"Retry?" = "Opnieuw?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "Terug naar bericht";
 
@@ -4830,6 +5170,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "Rol";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "Sms verzonden";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "STATUS";
 
@@ -4841,6 +5184,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4907,7 +5251,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "Bestanden scannen";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Gepland";
 
 /* No comment provided by engineer. */
@@ -5047,6 +5392,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "Selecteert dit onderwerp als het doel van je site.";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Stuur link";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "Link per e-mail verzenden";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "Logbericht verzenden";
 
@@ -5055,6 +5406,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "Testcrash verzenden";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "Link voor e-mailverificatie verzenden";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "Stuur meldingen via e-mail";
@@ -5101,11 +5455,11 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Message to show when setting save failed */
 "Settings update failed" = "Bijwerken van instellingen mislukt";
 
-/* Title for a button that recommends the app to others */
-"Share Jetpack with a friend" = "Deel Jetpack met een vriend";
+/* Spoken accessibility label */
+"Share" = "Delen";
 
 /* Title for a button that recommends the app to others */
-"Share Reader with a friend" = "Reader delen met een vriend";
+"Share Jetpack with a friend" = "Deel Jetpack met een vriend";
 
 /* Title for a button that recommends the app to others */
 "Share WordPress with a friend" = "Deel WordPress met een vriend";
@@ -5156,6 +5510,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "Toon Reblog knop";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "Toon wachtwoord";
+
 /* No comment provided by engineer. */
 "Show post content" = "Toon bericht inhoud";
 
@@ -5167,6 +5525,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "Statistieken tonen voor:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "Getoond";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Wordt openbaar getoond als je reageert op blogs.";
@@ -5182,6 +5543,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "Geeft het bericht weer";
+
+/* View title during the sign up process. */
+"Sign Up" = "Aanmelden";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "Inloggen met site-inloggegevens";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Aanmelden";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Inschrijven op WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Inschrijven met e-mail";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "Aangezien je een gratis abonnement gebruikt, zie je een beperkt aantal gebeurtenissen in je activiteitenlogboek.";
@@ -5220,6 +5596,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Prestaties voor de site";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Site-adres";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "Site-adres moet minimaal 4 karakters zijn.";
@@ -5304,7 +5683,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Site adressen moeten ook letters bevatten!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Sorry, dat e-mailadres is al in gebruik!";
 
 /* No comment provided by engineer. */
@@ -5364,6 +5743,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "Spam";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "Versnel je site";
@@ -5389,6 +5771,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "Staat";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "Statische homepage";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5419,6 +5804,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "Doorstrepen";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Stub";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "Inzenden voor beoordeling";
@@ -5509,7 +5897,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "Tablet";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Tag";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5644,6 +6033,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Servicevoorwaarden";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Testimonials";
+
 /* Title of a button style */
 "Text Only" = "Enkel tekst";
 
@@ -5653,8 +6045,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "De tekstopmaak besturingen bevinden zich in de werkbalk boven het toetsenbord tijdens het bewerken van een tekstblok";
 
+/* Button title */
+"Text me a code instead" = "SMS een code naar me toe";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "Stuur me een code via sms";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Bedankt voor het kiezen van %1$@ door %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "Dat blijkt geen geldige verificatiecode.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "Dat lijkt geen WordPress-site te zijn.";
@@ -5676,6 +6077,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "De Facebook verbinding kan geen pagina's vinden. Publiceren kan niet verbinden met Facebook profielen, alleen met gepubliceerde pagina's.";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "Het Google account \"%@\" komt niet overeen met een account op WordPress.com";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "De internetverbinding is offline.";
@@ -5715,6 +6119,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "De afbeelding kon niet aan de mediabibliotheek toegevoegd worden.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "De Internet verbinding is offline.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "Soorten sites die gemaakt kunnen worden";
@@ -5758,6 +6165,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "De site op %1$@ gebruikt WordPress %2$@. Wij raden aan om te updaten naar de laatste versie, of minimaal %3$@";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "De site op dit adres is geen WordPress site. Om door ons verbinding te kunnen maken, moet de site WordPress gebruiken.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "Verwijderen van site mislukt.";
 
@@ -5799,6 +6210,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "Er is een onverwachte fout opgetreden bij het bewerken van je reactie";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "Er is een onverwachte fout opgetreden bij het laden van de reacties.";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "Er is een onverwachte fout opgetreden bij het registreren van je domein";
 
@@ -5807,6 +6221,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "Er is een onverwachte fout opgetreden bij het bijwerken van je meldingsinstellingen";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "Er is een onverwachte fout opgetreden bij het updaten van je reactie";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "Er was een onverwachte fout.";
@@ -5828,6 +6245,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "Er is een probleem opgetreden bij het communiceren met de site.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "Er was een probleem met het verbinden naar WordPress.com. Log opnieuw in.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "Er is een probleem opgetreden met de weergave van dit bericht.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "Er is een probleem opgetreden bij het laden van je gegevens. Vernieuw je pagina om het opnieuw te proberen.";
 
@@ -5837,12 +6260,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "Er is een probleem opgetreden bij het opslaan van wijzigingen aan deelbeheer.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "Er is een probleem opgetreden bij het ophalen van je locatie. Probeer het later opnieuw.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "Er is een fout opgetreden tijdens het wijzigen van het wachtwoord";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "Er is iets fout gegaan tijdens laden activiteiten";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "Er is een fout opgetreden bij het laden van abonnementen";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "Er is een fout opgetreden bij het laden van plugins";
@@ -5855,6 +6284,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "Er is een fout opgetreden bij het laden van de geschiedenis";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "Er is een fout opgetreden bij het laden van het abonnement";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "Er is een fout opgetreden bij het laden van de scan geschiedenis";
@@ -5903,6 +6335,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "Dit domein is niet beschikbaar";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "Dit e-mailadres is niet geregistreerd op WordPress.com.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "Dit bestand is te groot om te uploaden naar je site of ondersteunt deze media-indeling niet.";
@@ -5983,6 +6418,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "Tijdzone";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "De tijd is om, maar maak je geen zorgen, jouw beveiliging is van het hoogste belang. Probeer het nog eens!";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "Tips om WordPress.com optimaal te benutten.";
 
@@ -5996,6 +6434,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "Om verder te gaan, vul je e-mailadres en naam in.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "Om een nieuw WordPress.com account te maken, vul jouw e-mailadres in.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "Installeer de Jetpack plugin om nuttige meldingen van je WordPress site op je telefoon te ontvangen.";
 
@@ -6004,6 +6445,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "Om plugins te installeren, moet er een aangepast domein aan je site zijn gekoppeld.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "Om verder te gaan met dit Apple ID, meld je eerst aan met je WordPress.com wachtwoord. Dit wordt maar één keer gevraagd.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "Om verder te gaan met dit Google account, meld je eerst aan met je WordPress.com wachtwoord. Dit wordt maar één keer gevraagd.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "Om een blok te verwijderen, selecteer je het blok en klik je op de drie stippen rechts onderaan het blok om de instellingen te zien. Kies van daaruit de optie om het blok te verwijderen.";
@@ -6078,7 +6525,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "Prullenmand";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "Verwijderd";
 
@@ -6092,6 +6540,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "Uitproberen en aanpassen";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Probeer opnieuw";
@@ -6117,6 +6566,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "Probeer de nieuwe blok-editor";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Probeer met ander e-mailadres";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Probeer met het site-adres";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "Meldingen uitschakelen";
@@ -6159,6 +6614,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "GEBRUIKSFUNCTIES";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "Verbinding niet mogelijk";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "Kan berichten niet laden";
@@ -6208,6 +6666,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Niet mogelijk video af te spelen";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Kan geen WordPress site lezen op deze URL. Tik op 'Hulp nodig?' om de veelgestelde vragen te bekijken.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Kan je site niet terugzetten";
 
@@ -6234,6 +6695,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "Niet kunnen uploaden 1 bericht, 1 bestand";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "Niet mogelijk om e-mailadres te verifiëren. Probeer het later opnieuw.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "Kan Jetpack-instellingen voor site niet bezoeken";
@@ -6378,7 +6842,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Uploaden mislukt";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Geüpload";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6396,7 +6861,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Thema's uploaden";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Uploaden";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6411,18 +6877,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "Gebruik";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "Beveiligingssleutel";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "Gebruik blok-editor";
 
 /* No comment provided by engineer. */
 "Use icon button" = "Gebruik icoon knop";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "Gebruik je wachtwoord om je aan te melden";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Gebruikersnaam";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6437,6 +6912,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Gebruikers";
+
+/* two factor code placeholder */
+"Verification code" = "Verificatiecode";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "Verificatie e-mail verzonden, controleer je inbox.";
@@ -6569,8 +7047,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "WP-content folder";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Wachten tot Google klaar is...";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "Wachten op verbinding";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "Wachten op beveiligingssleutel";
+
+/* View title during the Google auth process. */
+"Waiting..." = "Wachten...";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6610,6 +7098,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "Er was een probleem bij het laden van gegevens";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "We hebben een link per e-mail gestuurd naar %@. Controleer je mail app en tik op de link om in te loggen.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "We hebben zojuist een magische link verstuurd naar";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "We hebben met succes een back-up gemaakt van je site vanaf %@";
 
@@ -6619,14 +7113,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "We gebruiken ook andere tracking-tools, waaronder een aantal van derden. Bekijk meer informatie over deze tools en hoe je ze kunt beheren.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "We konden je op dit moment geen e-mail sturen. Probeer het later nogmaals.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Wij sturen een e-mail als er bedreigingen gevonden zijn. In de tussentijd kan je je site gewoon blijven gebruiken, je kan ook terugkomen om de voortgang controleren.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "We sturen je een e-mail met een magische link waarmee je onmiddellijk kunt inloggen, zonder wachtwoord. Nooit meer moeite doen!";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "We sturen je een inschrijf link per e-mail om je nieuwe WordPress.com account aan te maken.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "We sturen je een melding bij nieuwe volgers, reacties en vind-ik-leuks.";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "We brengen je op de hoogte als je nieuwe volgers, reacties en vind-ik-leuks krijgt. Wil je pushberichten toestaan?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "We zullen dit e-mailadres gebruiken om je nieuwe WordPress account aan te maken.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "We zijn een downloadbare back-up van je site aan het maken van %1$@.";
@@ -6637,6 +7143,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "We zijn hard aan het werk om deze bedreigingen op de achtergrond te verhelpen. In de tussentijd kan je je site gewoon blijven gebruiken, je kan op elk moment de voortgang bekijken.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "We kunnen geen verbinding maken met de Jetpack-site via die URL. Neem contact op voor hulp.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "We zetten je site terug naar %1$@.";
 
@@ -6645,6 +7154,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "We hebben je ook een link naar je bestand gemaild.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "We hebben je een inschrijf link gestuurd om je nieuwe WordPress.com account aan te maken. Controleer je e-mail op dit apparaat en tik op de link in de e-mail die je van WordPress.com ontvangt.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6671,6 +7183,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "Wekelijks overzicht: %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "Welkom bij Jetpack";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Welkom bij WordPress";
 
 /* A message title */
 "Welcome to the Reader" = "Welkom bij de Reader";
@@ -6715,6 +7233,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "Wat is Gravatar?";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "Wat is WordPress.com?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "Wat is een blok?";
 
@@ -6731,10 +7252,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "What's New in Jetpack" = "Wat is er nieuw in Jetpack";
 
 /* Opens the What's New / Feature Announcement modal */
-"What's New in Reader" = "Nieuw in reader";
-
-/* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "Wat is er nieuw in WordPress";
+
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "Wat is het adres van mijn site?";
 
 /* Select the site's intent. Title */
 "What's your website about?" = "Waar gaat je site over?";
@@ -6748,6 +7269,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "Wanneer je wijzigingen aan je site aanbrengt, kun je hier je activiteitengeschiedenis bekijken.";
 
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Er ging iets mis en we konden je niet inloggen. Probeer nogmaals!";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "Oeps, er is iets fout gegaan. Probeer het nog eens!";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "Oeps, het lijkt erop dat die beveiligingssleutel niet geldig is. Probeer het opnieuw met een andere";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Dat is geen geldige twee-factor verificatiecode. Controleer de code en probeer nogmaals!";
+
 /* No comment provided by engineer. */
 "Width Settings" = "Breedte instellingen";
 
@@ -6760,17 +7293,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "WordPress app-instellingen";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "WordPress apps - Apps voor elk scherm";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "WordPress blog";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "WordPress ondersteuning";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "WordPress mediabibliotheek";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "WordPress melding-instellingen";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "WordPress meldingen";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "WordPress plugins";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "WordPress profiel";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "WordPress Reader";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "WordPress site details";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "WordPress thema's";
@@ -6781,17 +7335,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "WordPress multisites worden niet ondersteund";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress heeft toestemming nodig om toegang te krijgen tot de huidige locatie van je apparaat om deze toe te kunnen voegen aan je bericht. Update je privacyinstellingen.";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "WordPress root";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "WordPress versie te oud";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "WordPress versie te oud. De site op %1$@ gebruikt WordPress %2$@. We raden aan bij te werken naar de nieuwste versie of minimaal %3$@";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "WordPress.com account";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "WordPress.com-abonnementen";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "WordPress.com thema's";
@@ -6822,6 +7385,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "Schrijf bericht";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "Schrijf een antwoord";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "Schrijf een reactie...";
 
 /* Title for the writing section in site settings screen */
@@ -6835,6 +7401,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Y-as positie";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "Jaar";
@@ -6919,6 +7488,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Displayed when the user views trashed in the posts list and there are no posts */
 "You don't have any trashed posts" = "Je hebt geen berichten in de prullenbak";
 
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"You don't have permission to view this private blog." = "Je hebt geen toestemming om dit privéblog te bekijken.";
+
 /* Description for the first domain purchased with a paid plan. */
 "You have a free one-year domain registration with your plan." = "Je hebt een gratis eenjarige domeinregistratie met je abonnement";
 
@@ -6934,7 +7506,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "Je hebt geen herinneringen ingesteld.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Je hebt de wijzigingen niet opgeslagen.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -7021,9 +7594,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Help text that describes how the password should be. It appears while editing the password */
 "Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ & )." = "Je wachtwoord moet minstens zes karakters lang zijn. Om het sterker te maken, gebruik hoofd- en kleine letters, getallen en symbolen zoals ! \" ? $ % ^ & ).";
 
-/* Message of Export Content confirmation alert */
-"Your posts, pages, and settings will be mailed to the account's email address." = "Je berichten, pagina's en instellingen worden naar het e-mailadres van de account gemaild.";
-
 /* Message of Export Content confirmation alert; substitution is user's email address */
 "Your posts, pages, and settings will be mailed to you at %@." = "Je berichten, pagina's en instellingen worden naar je gemaild via %@.";
 
@@ -7032,6 +7602,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "Je zoekopdracht bevat tekens die niet worden ondersteund door domeinen van WordPress.com. Je kunt de volgende tekens gebruiken: A-Z, a-z, 0-9.";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "Je site-adres verschijnt in de balk boven aan het scherm wanneer je je site bezoekt in Safari.";
 
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "Je site wordt al beschermd door VaultPress. Hieronder staat een link naar je VaultPress-dashboard.";
@@ -7111,17 +7684,23 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility identifier for an 'Add Comment' button */
 "addCommentButton.accessibilityIdentifity" = "Reactie toevoegen";
 
-/* Error message when user cancels login */
-"addSite.selfHosted.cancelled" = "Login is geannuleerd";
+/* Error message shown a URL does not point to an existing site. */
+"addSite.restApiNotAvailable" = "De site op dit adres is geen WordPress site. Om er verbinding mee te kunnen maken, moet de site gebruikmaken van WordPress.";
+
+/* Error message shown when an receiving an invalid application-password authentication result from a self-hosted WordPress site */
+"addSite.selfHosted.authenticationFailed" = "Kan niet inloggen met applicatie wachtwoord authenticatie.";
 
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "Voer het adres van de WordPress site in die je wil verbinden.";
 
+/* Error message when user input is not a WordPress site */
+"addSite.selfHosted.invalidUrl" = "Het siteadres is niet geldig.";
+
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "Kan de site details van WordPress niet laden";
 
-/* Error message when user signs in with an unexpected usern. The first argument is the expected username */
-"addSite.selfHosted.mismatchUser" = "Aanmelden met de ingelogde gebruiker. Gebruikersnaam: %@";
+/* Error message shown when application-password authentication is disabled on a self-hosted WordPress site */
+"addSite.selfHosted.noLoginUrlFound" = "Toegang autorisatie met applicatie wachtwoord moet ingeschakeld zijn op de WordPress site.";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "Kan de WordPress site niet opslaan, probeer het later opnieuw.";
@@ -7129,17 +7708,14 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "Zelf gehoste site toevoegen";
 
-/* Error message when XML-RPC is disabled on the WordPress site. The first argument is detailed error message */
-"addSite.selfHosted.xmlrpcDisabled" = "Kan geen verbinding maken met de WordPress site. XML-RPC is mogelijk uitgeschakeld op de server. Neem contact op met je hostingprovider om dit probleem op te lossen.";
+/* Error message when an unknown error occurred when adding a self-hosted site */
+"addSite.selfHosted.unknownError" = "Er is iets fout gegaan. Probeer het nog eens.";
 
 /* Age between dates equaling one hour. */
 "an hour" = "een uur";
 
 /* This is the string we display when prompting the user to review the Jetpack app */
 "appRatings.jetpack.prompt" = "Wat vind je van Jetpack?";
-
-/* This is the string we display when prompting the user to review the Reader app */
-"appRatings.reader.prompt" = "Wat vind je van Reader?";
 
 /* This is the string we display when prompting the user to review the WordPress app */
 "appRatings.wordpress.prompt" = "Wat vind je van WordPress?";
@@ -7843,6 +8419,10 @@ Example: Reply to Pamela Nguyen */
 /* A name of the ID field (it's a technical field, has to be short, displayed below everything else) */
 "entityMetadataFooterView.id" = "ID";
 
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "voorbeeld.nl";
+
 /* Accept button title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackAccept" = "Feedback verzenden";
 
@@ -7854,9 +8434,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackTitle" = "Deel je feedback";
-
-/* Communicates the future removal of the option to disable the experimental editor, displayed beneath the experimental features list */
-"experimentalFeatures.editorNote" = "De experimentele blok-editor wordt de standaard in een toekomstige release en de mogelijkheid om deze uit te schakelen wordt verwijderd.";
 
 /* The title for the experimental features list */
 "experimentalFeaturesList.heading" = "Experimentele functies";
@@ -7903,8 +8480,14 @@ Example: Reply to Pamela Nguyen */
 /* A footer retry button */
 "general.pagingFooterView.retry" = "Opnieuw proberen";
 
+/* Error message format when REST API returns an error response. The first argument is error message. */
+"generic.error.rest-api-error" = "Je site heeft een fout reactie verzonden: %@";
+
 /* A generic title for an error */
 "generic.error.title" = "Fout";
+
+/* Error message when failing to parse API responses */
+"generic.error.unparsableResponse" = "Je site heeft een reactie verzonden die de app niet kon parsen";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "Stel je blogging herinneringen in";
@@ -8076,42 +8659,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title of the Jetpack powered overlay. */
 "jetpack.branding.overlay.title" = "WordPress is completer met Jetpack";
-
-/* Title for the button that starts the Jetpack connection process */
-"jetpack.connection.connect.button" = "Je site koppelen";
-
-/* Error message shown when WordPress.com authentication fails */
-"jetpack.connection.error.authentication" = "Ongeldig WordPress.com account";
-
-/* Error message shown when a connection step is attempted in an invalid order */
-"jetpack.connection.error.context" = "Deze stap is nog niet klaar";
-
-/* Title for the retry button shown when a connection step fails */
-"jetpack.connection.retry.button" = "Opnieuw proberen";
-
-/* Status message when a connection step is pending */
-"jetpack.connection.stage.pending" = "Wachten om te beginnen";
-
-/* Status message when a connection step is in progress */
-"jetpack.connection.stage.processing" = "Aan de gang...";
-
-/* Status message when a connection step is completed successfully */
-"jetpack.connection.stage.success" = "Afgerond";
-
-/* Title for the finalization step in Jetpack connection flow */
-"jetpack.connection.step.finalize.title" = "Verbinding afronden";
-
-/* Title for the install step in Jetpack connection flow */
-"jetpack.connection.step.install.title" = "Jetpack installeren";
-
-/* Title for the login step in Jetpack connection flow */
-"jetpack.connection.step.login.title" = "Login bij WordPress.com";
-
-/* Title for the site connection step in Jetpack connection flow */
-"jetpack.connection.step.site.title" = "Verbinding maken met je site";
-
-/* Title for the user connection step in Jetpack connection flow */
-"jetpack.connection.step.user.title" = "Verbinding maken met je WordPress.com account";
 
 /* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
 "jetpack.fullscreen.overlay.early.switch.title" = "Schakel over naar de nieuwe Jetpack-app";
@@ -8332,41 +8879,11 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "Je hebt geen toestemming om dit privéblog te bekijken.";
 
-/* Button to dismiss the re-authentication view */
-"login.appPasswordReAuth.cancelButton" = "Annuleren";
-
-/* Description explaining why the user needs to re-authenticate */
-"login.appPasswordReAuth.description" = "Het toepassingswachtwoord dat aan de app is toegewezen, bestaat niet meer in je profiel.\nOpnieuw aanmelden om een nieuw toepassingswachtwoord voor de app aan te maken.";
-
-/* Button to start the re-authentication process */
-"login.appPasswordReAuth.signInButton" = "Aanmelden";
-
-/* Title shown when the application password is invalid */
-"login.appPasswordReAuth.title" = "Ongeldig applicatie wachtwoord";
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "Voer de verificatiecode in van je authenticatie app voor je WordPress.com account.";
 
 /* Indicating that referrer was marked as spam */
 "marked as spam" = "gemarkeerd als spam";
-
-/* Button title when verification link sending failed */
-"me.verifyEmail.button.retry" = "Probeer het opnieuw";
-
-/* Button title to send verification link */
-"me.verifyEmail.button.send" = "E-mail opnieuw verzenden";
-
-/* Button title while verification link is being sent */
-"me.verifyEmail.button.sending" = "Bezig met verzenden...";
-
-/* Button title after verification link is sent */
-"me.verifyEmail.button.sent" = "E-mail verzonden";
-
-/* Message for email verification card */
-"me.verifyEmail.message.noEmail" = "Verifieer je e-mail om je account te beveiligen en toegang te krijgen tot meer functies.\nKijk in je inbox voor de bevestigings e-mail, of klik op '%@' om een nieuwe te ontvangen..";
-
-/* Message for email verification card with email address */
-"me.verifyEmail.message.withEmail" = "Verifieer je e-mail om je account te beveiligen en toegang te krijgen tot meer functies.\nKijk in je inbox op %1$@ voor de bevestigings e-mail, of klik op '%2$@' om een nieuwe te ontvangen.";
-
-/* Title for email verification card */
-"me.verifyEmail.title" = "Verifieer je e-mail";
 
 /* Me tab menu items */
 "meMenu.submitFeedback" = "Verzend feedback";
@@ -8809,6 +9326,9 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "Hoofdpagina";
 
+/* No comment provided by engineer. */
+"password" = "wachtwoord";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "Kaarten kunnen verschillende inhoud weergeven, afhankelijk van wat er op je site gebeurt. We zijn bezig meer kaarten en beheermogelijkheden te creëren.";
 
@@ -8913,9 +9433,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Message shown while loading plugin details */
 "pluginDetails.loading" = "Plugin informatie aan het laden...";
-
-/* Placeholder message shown when a plugin has no description */
-"pluginDetails.noDescription" = "Deze plugin heeft geen beschrijving gegeven.";
 
 /* Title of the changelog section in plugin details */
 "pluginDetails.section.changelog" = "Changelog";
@@ -9205,6 +9722,30 @@ Example: Reply to Pamela Nguyen */
 /* An alert message explaning that by changing the visibility to private, the post will be published immediately to your site */
 "postSettings.warningPostWillBePublishedAlertMessage" = "Door de zichtbaarheid te wijzigen naar 'Privé', wordt het bericht onmiddellijk gepubliceerd.";
 
+/* Localized post type: `Page` */
+"postType.page" = "pagina";
+
+/* Localized post type: `Post` */
+"postType.post" = "bericht";
+
+/* Details for a 'Private' privacy setting */
+"postVisibility.private.details" = "Alleen zichtbaar voor beheerders en redacteuren van de site";
+
+/* Title for a 'Private' privacy setting */
+"postVisibility.private.title" = "Privé";
+
+/* Details for a 'Password Protected' privacy setting */
+"postVisibility.protected.details" = "Zichtbaar voor iedereen maar vereist een wachtwoord";
+
+/* Title for a 'Password Protected' privacy setting */
+"postVisibility.protected.title" = "Beschermd met een wachtwoord";
+
+/* Details for a 'Public' (default) privacy setting */
+"postVisibility.public.details" = "Zichtbaar voor iedereen";
+
+/* Title for a 'Public' (default) privacy setting */
+"postVisibility.public.title" = "Publiek";
+
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Annuleren";
 
@@ -9425,18 +9966,6 @@ Tapping on this row allows the user to edit the sharing message. */
 /* Title for the success view when the user has successfully logged in */
 "qrLoginVerifyAuthorization.completedInstructions.title" = "Je bent ingelogd!";
 
-/* No comment provided by engineer. */
-"reachability-utils.alert.cancel" = "OK";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.retry" = "Opnieuw?";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.title" = "Geen verbinding";
-
-/* Message of error prompt shown when no internet connection is available */
-"reachability-utils.alert.utils" = "De Internet verbinding is offline.";
-
 /* Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog. */
 "reader.blocked.blog.message" = "De blog %@ verschijnt niet langer in je Reader. Tik om ongedaan te maken.";
 
@@ -9473,26 +10002,8 @@ Tapping on this row allows the user to edit the sharing message. */
 /* A shared button title for Reader */
 "reader.button.unsubscribe" = "Uitschrijven";
 
-/* Button title. Follow the comments on a post. */
-"reader.comments.buttonFollow" = "Volg";
-
 /* Informational message, should be short. */
 "reader.comments.commentsClosed" = "Reacties gesloten";
-
-/* Empty state view title */
-"reader.comments.emptyStateTitle" = "Laat als eerste een reactie achter.";
-
-/* Empty state view title */
-"reader.comments.errorLoadingComments" = "Er is een onverwachte fout opgetreden bij het laden van de reacties.";
-
-/* VoiceOver hint */
-"reader.comments.followingSettingAccessibilityIdentifier" = "Meldingsinstellingen voor het bericht openen";
-
-/* Error message that informs reader comments from a private blog cannot be fetched. */
-"reader.comments.noPermissionToViewPrivateBlog" = "Je hebt geen toestemming om deze privéblog te bekijken.";
-
-/* Navigation title */
-"reader.comments.title" = "Reacties";
 
 /* Accessibility hint to inform that the author section can be tapped to see posts from the site. */
 "reader.detail.header.authorInfo.a11y.hint" = "Bekijkt berichten van de site";
@@ -9570,23 +10081,8 @@ but tapping on this button will remove their like from the post. */
 /* Screen header details */
 "reader.following.header.details" = "Blijf op de hoogte van de blogs waarop je bent geabonneerd.";
 
-/* Empty state view */
-"reader.following.lists.emptyTitle" = "Lijsten leeg";
-
-/* Screen header details */
-"reader.home.header.details" = "Blijf op de hoogte van de blogs waarop je bent geabonneerd.";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.home.title" = "Home";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.library.title" = "Bibliotheek";
-
 /* Used in multiple contexts, usually as a screen title */
 "reader.likes.title" = "Vind-ik-leuks";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.lists.title" = "Lijsten";
 
 /* Reader logged-out screen details */
 "reader.loggedOut.details" = "Meld je aan met een WordPress.com account om je favoriete blogs te volgen";
@@ -9829,8 +10325,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title of a Reader tab showing Posts matching a user's search query */
 "reader.search.tab.posts" = "Berichten";
 
-/* Title of the Reader's search feature
-   Used in multiple contexts, usually as a screen title */
+/* Title of the Reader's search feature */
 "reader.search.title" = "Zoeken";
 
 /* Screen title. Reader select interests title label text. */
@@ -9856,6 +10351,21 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Reader select interests title label text */
 "reader.select.tags.title" = "Ontdek en volg blogs waar je van houdt";
+
+/* Reader sidebar menu item */
+"reader.sidebar.discover" = "Ontdek";
+
+/* Reader sidebar menu item */
+"reader.sidebar.likes" = "Vind-ik-leuks";
+
+/* Reader sidebar menu item */
+"reader.sidebar.recent" = "Recent";
+
+/* Reader sidebar menu item */
+"reader.sidebar.saved" = "Opgeslagen";
+
+/* Reader sidebar menu item */
+"reader.sidebar.search" = "Zoeken";
 
 /* Reader sidebar section title */
 "reader.sidebar.section.favorites.title" = "Favorieten";
@@ -9905,7 +10415,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Number of subscriptions on a site (singular) */
 "reader.subscriptions.subscriptionsSingular" = "%@ abonnee";
 
-/* Used in multiple contexts, usually as a screen title */
+/* Navigation bar title */
 "reader.subscriptions.title" = "Abonnementen";
 
 /* A suggestion of topics the user might want to subscribe to */
@@ -9947,29 +10457,11 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Verb. Button title. The user is following a tag. */
 "reader.tags.following.button.title" = "Volgend";
 
-/* Used in multiple contexts, usually as a screen title */
-"reader.tags.title" = "Tags";
-
 /* Accessibility label for unsubscribing from a tag */
 "reader.tags.unfollow.accessibility.label" = "Ontvolg %@";
 
 /* Field title */
 "reader.userProfile.site" = "Site";
-
-/* Reader Welcome screen login button */
-"reader.welcome.continueText" = "Doorgaan met WordPress.com";
-
-/* Reader Welcome screen */
-"reader.welcome.subtitle" = "Word lid van de grootste blogcommunity";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.discover" = "Ontdek";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.me" = "Ik";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.notifications" = "Meldingen";
 
 /* Spoken accessibility label */
 "readerDetail.backButton.accessibilityLabel" = "Terug";
@@ -10247,14 +10739,10 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Message shown when there are no inactive plugins on the site */
 "site.plugins.empty.inactive" = "Geen inactieve plugins";
 
-/* The plugin fillter option for displaying active plugins */
-"site.plugins.filter.option.active" = "Actief";
-
-/* The plugin fillter option for displaying all plugins */
+/* The plugin fillter option for displaying active plugins
+   The plugin fillter option for displaying all plugins
+   The plugin fillter option for displaying inactive plugins */
 "site.plugins.filter.option.all" = "Alles";
-
-/* The plugin fillter option for displaying inactive plugins */
-"site.plugins.filter.option.inactive" = "Inactief";
 
 /* Title of the plugin filter picker */
 "site.plugins.filter.title" = "Filteren";
@@ -10806,9 +11294,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* View title for Help & Support page. */
 "support.title" = "Help";
 
-/* Subject of new Zendesk ticket. */
-"support.zendesk.readerAppTicketSubject" = "Reader voor iOS ondersteuning";
-
 /* Title for placeholder in Tenor picker */
 "tenor.welcomeMessage" = "Zoek gratis GIF's om toe te voegen aan je mediabibliotheek!";
 
@@ -10957,8 +11442,119 @@ Feel free to replace it with other bracket types that you think looks better for
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "Status";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "Alle berichten en meeste weergaven";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "Alle weergaven";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "Alle weergaven en bezoekers";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "Best bekeken ooit";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "Meeste weergaven";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "Kan statistieken sinds het begin niet laden.";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "Maak een site aan of voeg er een toe om de statistieken sinds het begin te zien.";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Berichten";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "Blijf op de hoogte met de activiteit allertijden op je WordPress site.";
+
+/* Title of all time widget */
+"widget.alltime.title" = "Allertijden";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "Log in bij WordPress om de statistieken allertijden te zien.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "Log in bij Jetpack om de statistieken allertijden te zien.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "Log in bij Jetpack om de statistieken van deze week te zien.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "Log in bij Jetpack om de statistieken van vandaag te zien.";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "Alle weergaven";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "Aantal weergaven vandaag";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "Kan de statistieken van deze week niet laden.";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "Maak een site aan of voeg er een toe om de statistieken van deze week te zien.";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "Blijf op de hoogte met de activiteit van deze week op je WordPress site.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "Deze week";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "Log in bij WordPress om de statistieken van deze week te zien.";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Reacties";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "Statistieken zullen naar de Jetpack-app worden verplaatst. Overstappen is gratis en duurt maar een minuut.";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Vind-ik-leuks";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "Kan site statistieken niet laden.";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "Kan de statistieken van vandaag niet laden.";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "Maak een site aan of voeg er een toe om de statistieken van vandaag te zien.";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "Blijf op de hoogte van de activiteiten van vandaag op je WordPress site.";
+
+/* Title of today widget */
+"widget.today.title" = "Vandaag";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "Log in bij WordPress om de statistieken van vandaag te zien.";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "Weergave is niet beschikbaar";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Weergaven";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Bezoekers";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "Likes en comments van vandaag";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "Weergaven van vandaag";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "Weergaven en bezoekers van vandaag";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "is in de toekomst niet meer beschikbaar.";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "Een nieuwe site starten?";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "wordpress, help, ondersteuning, faq, vragen, debug, logs, helpcentrum, contact";
@@ -10983,6 +11579,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Error message that describes an unknown error had occured */
 "wordpress-api.error.unknown" = "Er ging iets fout, probeer het later nog eens.";
+
+/* Error message when failing to find selected media file on the user's device. */
+"wordpress.api.upload.media.fileNotFound" = "Kan het mediabestand niet vinden op het apparaat";
 
 /* Jetpack Plugin Modal on WordPress primary button title */
 "wordpress.jetpack.plugin.modal.primary.button.title" = "Schakel over naar de Jetpack app";
@@ -11029,21 +11628,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Error message when user signs in with an unexpected email address. The first argument is the expected email address */
 "wpComLogin.error.mismatchedEmail" = "Meld je aan met e-mailadres %@";
 
-/* Message shown when user denies WordPress.com login, offering option to try with different account */
-"wpComLogin.loginDenied.message" = "Je kunt je aanmelden met een ander account als je een ander account nodig hebt. Tikken op \"%@\" om te beginnen.";
-
-/* Title of alert shown when user cancels WordPress.com login */
-"wpComLogin.loginDenied.title" = "Login geannuleerd";
-
-/* Button title for signing in with a different WordPress.com account */
-"wpComLogin.loginDenied.useDifferentAccount" = "Ander account gebruiken";
-
-/* Button title to log out the current WordPress.com account */
-"wpcom.token.alert.button.logout" = "Uitloggen";
-
-/* Button title to Sign In to WordPress.com */
-"wpcom.token.alert.button.signin" = "Aanmelden";
-
 /* Message title to be displayed when the user needs to re-authenticate their WordPress.com account. */
 "wpcom.token.fix.signin" = "Aanmelden bij WordPress.com";
 
@@ -11058,6 +11642,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "Niet ondersteunde bijlage";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Inloggen met Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Domeinen";

--- a/WordPress/Resources/pl.lproj/Localizable.strings
+++ b/WordPress/Resources/pl.lproj/Localizable.strings
@@ -74,6 +74,9 @@
 /* Empty Post Title */
 "(No Title)" = "(Brak tytułu)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(brak tytułu)";
+
 /* Indicates a video will be resized to Full HD 1920x1080 when uploaded. */
 "1080p" = "1080p";
 
@@ -89,8 +92,14 @@
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "Przycisk „Więcej” zawiera rozwijaną listę, która wyświetla przyciski udostępniania";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "Konto WordPress.com jest połączone z poświadczeniami twojego sklepu. Aby kontynuować, wyślemy odnośnik weryfikacyjny na powyższy adres e-mail.";
+
 /* Message of the alert indicating that a tag with that name already exists. The placeholder is the name of the tag */
 "A tag named '%@' already exists." = "Tag '%@' już istnieje.";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "Poprawny adres e-mail jest wymagany by przesłać odnośnik potwierdzający. Proszę wrócić do poprzedniego ekranu i wprowadzić poprawny adres e-mail.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "WŁĄCZONE";
@@ -173,6 +182,9 @@
 /* A short description of the comment like sharing setting. */
 "Allow all comments to be Liked by you and your readers" = "Pozwól, aby wszystkie komentarze były możliwie do polubienia przez ciebie i odwiedzających";
 
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "Alternatywnie możesz wprowadzić hasło do tego konta.";
+
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "Zawsze wysyłaj dziennik zdarzeń awarii";
 
@@ -193,6 +205,9 @@
 
 /* A failure reason for when the error that occured wasn't able to be determined. */
 "An unknown error occurred." = "Wystąpił nieznany błąd.";
+
+/* the comment has an anonymous author. */
+"Anonymous" = "Anonim";
 
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "Odpowiedz";
@@ -237,6 +252,10 @@
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "Nieudane uwierzytelnianie";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "Kod autentykacji";
 
 /* Author label.
    Label for list of stats by content author.
@@ -336,6 +355,9 @@
 /* Accessibility label for taking an image or video with the camera on formatting toolbar. */
 "Camera" = "Aparat";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Nie możesz zażądać odnośnika";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "Nie można opublikować pustej strony";
 
@@ -345,6 +367,7 @@
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -354,6 +377,7 @@
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -372,6 +396,7 @@
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -385,17 +410,22 @@
 /* Share extension dialog dismiss button label - displayed when user is missing a login token. */
 "Cancel sharing" = "Anuluj udostępnianie";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "Nie można uzyskać dostępu do witryny pod tym adresem. Sprawdź dokładnie i spróbuj ponownie.";
+
 /* Image caption field label (for editing)
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Podpis";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Ostrożnie!";
 
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Kategorie";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Kategoria";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -413,6 +443,9 @@
 
 /* Title of alert when getting purchases fails */
 "Check Purchases Error" = "Błąd sprawdzania zakupów";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "Sprawdź pocztę e-mail na tym urządzeniu!";
 
 /* Overlay message displayed while checking if site has premium purchases */
 "Checking purchases…" = "Sprawdzanie zakupów…";
@@ -450,6 +483,9 @@
 /* No comment provided by engineer. */
 "Choose video" = "Wybierz film";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "Klasyczny blog";
+
 /* No comment provided by engineer. */
 "Clear Old Activity Logs" = "Wyczyść stare wpisy z dziennika aktywności";
 
@@ -462,6 +498,7 @@
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Zamknij";
 
@@ -476,6 +513,9 @@
 
 /* No comment provided by engineer. */
 "Columns Settings" = "Ustawienia kolumn";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Komiksy";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -493,6 +533,7 @@
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Komentarze";
 
@@ -540,6 +581,9 @@
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Łączenie %1$@ zostanie zastąpione przez %2$@.";
 
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Łączenie z WordPress.com";
+
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Łączenie…";
 
@@ -565,6 +609,9 @@
 /* Button label for contacting support
    Title of a button. A call to action to contact support for assistance. */
 "Contact support" = "Kontakt z pomocą techniczną";
+
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "Struktura treści\nBloki: %1$li, słowa: %2$li, znaki: %3$li";
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Czytaj dalej";
@@ -612,6 +659,9 @@
 /* Accessibility label for create floating action button */
 "Create" = "Utwórz";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Stwórz konto";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "Utwórz pustą stronę";
 
@@ -630,6 +680,9 @@
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "Utwórz wpis";
 
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "Utwórz witrynę";
+
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "Utwórz tag";
 
@@ -644,6 +697,9 @@
 
 /* No comment provided by engineer. */
 "Current" = "Obecnie";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Aktualny plan";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Bieżący motyw";
@@ -667,7 +723,11 @@
 /* Action title. Noun. Opens the user's WordPress.com dashboard in an external browser. */
 "Dashboard" = "Kokplt";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Domyślne menu";
+
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Usuń";
@@ -724,7 +784,9 @@
    Title for the Discussion Settings Screen */
 "Discussion" = "Dyskusja";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Odrzuć";
 
 /* Display Name label text.
@@ -777,6 +839,9 @@
 
 /* translators: accessibility text (hint for switches) */
 "Double tap to toggle setting" = "Stuknij dwukrotnie aby przełączyć ustawienie";
+
+/* Name for the status of a draft post. */
+"Draft" = "Szkic";
 
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Szkice";
@@ -842,7 +907,10 @@
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "Adres e-mail";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "Adres e-mail";
 
 /* Notification Settings Channel */
@@ -872,6 +940,9 @@
 
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Wpisz nazwę użytkownika";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "Wprowadź dane swojego konta dla %@.";
 
 /* Generic error alert title
    Generic popup title for any type of error. */
@@ -905,8 +976,14 @@
 /* Overlay message displayed while starting content export */
 "Exporting content…" = "Eksportowanie zawartości…";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Niepowodzenie";
+
 /* Fashion site intent topic */
 "Fashion" = "Moda";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Text displayed while fetching themes */
 "Fetching Themes..." = "Pobieranie motywów…";
@@ -935,6 +1012,9 @@
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "Dowiedz się wiecej";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Znajdź adres swojej witryny";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -942,6 +1022,9 @@
 
 /* Fitness & Exercise site intent topic */
 "Fitness & Exercise" = "Fitness i ćwiczenia";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "Obserwuj";
 
 /* Label for number of followers. */
 "Followers" = "Obserwujący";
@@ -987,6 +1070,15 @@
 
 /* Title of the second alert preparing users to grant permission for us to send them push notifications. */
 "Get your notifications faster" = "Szybciej otrzymuj powiadomienia";
+
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Pobieranie informacji o koncie";
+
+/* Cancel */
+"Give Up" = "Poddaj się";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
@@ -1050,6 +1142,9 @@
 /* No comment provided by engineer. */
 "Help icon" = "Ikonka pomocy";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Ukryty";
+
 /* Title of a button used to collapse a group */
 "Hide" = "Ukryj";
 
@@ -1080,6 +1175,9 @@
 /* Title of a button style */
 "Icon Only" = "Tylko ikonka";
 
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "Jeśli nie można znaleźć wiadomości e-mail, proszę sprawdzić foldery: śmieci i spam";
+
 /* Hint for image description on image settings. */
 "Image Description" = "Opis obrazka";
 
@@ -1088,6 +1186,9 @@
 
 /* Hint for image title on image settings. */
 "Image title" = "Tytuł obrazka";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Błędny login lub hasło. Spróbuj ponownie.";
 
 /* Default button title used in media picker to insert media (photos / videos) into a post.
    Label action for inserting a link on the editor */
@@ -1141,8 +1242,14 @@
 /* The Jetpack view title used while the is installing */
 "Installing Jetpack" = "Zainstaluj Jetpack";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "Nieprawidłowy adres e-mail";
+
 /* No comment provided by engineer. */
 "Invalid URL." = "Nieprawidłowy adres URL";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "Nieprawidłowy adres URL. Sprawdź dokładnie i spróbuj ponownie.";
 
 /* No comment provided by engineer. */
 "Invalid username" = "Nieprawidłowa nazwa użytkownika";
@@ -1255,7 +1362,8 @@
    Today's Stats 'Likes' label */
 "Likes" = "Polubienia";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Odnośnik";
 
 /* Link copied to clipboard notice title */
@@ -1285,12 +1393,26 @@
    Text displayed while loading time zones */
 "Loading..." = "Wczytywanie…";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Lokalny";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Lokalizacja";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Możliwość lokalizacji musi zostać włączona zanim będzie można dodać swoją lokalizację w aplikacji WordPress. Proszę włączyć usługi lokalizacyjne w ustawieniach.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Nieznana lokalizacja";
+
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Loguj pliki po dacie utworzenia";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Zaloguj się";
 
 /* Button for confirming logging out from WordPress.com account
@@ -1300,6 +1422,12 @@
 /* Title of a button for signing in. */
 "Log in" = "Zaloguj się";
 
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Nie udało się zalogować. Proszę spróbować ponownie.";
+
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "Zaloguj się hasłem do konta";
+
 /* No comment provided by engineer. */
 "Logs" = "Dziennik zdarzeń";
 
@@ -1308,6 +1436,9 @@
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Wygląda na to że masz zainstalowany Jetpack na swojej stronie. Gratulujemy! Zaloguj się używając swojej nazwy użytkownika i hasła z WordPress.com żeby włączyć Statystyki i Powiadomienia.";
+
+/* Title of a button. */
+"Lost your password?" = "Nie pamiętasz hasła?";
 
 /* Button leading to a screen where users can manage their installed plugins
    Screen title, where users can see all their installed plugins.
@@ -1358,6 +1489,9 @@
 /* Menus placeholder text for the name field of a menu with no name. */
 "Menu Name" = "Nazwa menu";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Action button to display more available options
    Label for the More Options area in post settings. Should use the same translation as core WP. */
 "More Options" = "Więcej opcji";
@@ -1394,6 +1528,9 @@
    Title of My Site tab */
 "My Site" = "Moja witryna";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "Moje witryny na WordPress";
+
 /* No comment provided by engineer. */
 "Navigates to custom color picker" = "Przechodzi do wyboru koloru";
 
@@ -1418,6 +1555,9 @@
 /* New Post 3D Touch Shortcut */
 "New Post" = "Nowy wpis";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Nowa pozycja";
+
 /* Noun. The title of an item in a list. */
 "New posts" = "Nowe wpisy";
 
@@ -1428,7 +1568,9 @@
 "Newest first" = "Najnowsze na początku";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Następne";
 
 /* Label for a cancel button */
@@ -1446,6 +1588,9 @@
 /* Menus selection title for setting a location to not use a menu. */
 "No Menu" = "Brak menu";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "Bez tytułu";
+
 /* A short message that informs the user no sites could be loaded in the share extension. */
 "No available sites" = "Brak dostępnych witryn";
 
@@ -1457,7 +1602,8 @@
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "Brak komentarzy";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "Brak połączenia";
 
@@ -1510,7 +1656,12 @@
 /* No comment provided by engineer. */
 "Number of columns" = "Liczba kolumn";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -1555,7 +1706,8 @@
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "Otwórz ustawienia zabezpieczeń Jetpacka";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Otwórz ustawienia";
 
 /* No comment provided by engineer. */
@@ -1563,6 +1715,9 @@
 
 /* No comment provided by engineer. */
 "Open link in a browser" = "Otwórz odnośnik w przeglądarce";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "Lub zaloguj się za pomocą magicznego odnośnika";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Lista uporządkowana";
@@ -1580,7 +1735,8 @@
 /* No comment provided by engineer. */
 "Padding" = "Dopełnienie";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Strona";
 
@@ -1598,8 +1754,11 @@
 /* Title for selecting parent category of a category */
 "Parent Category" = "Kategoria nadrzędna";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Hasło";
 
@@ -1610,8 +1769,12 @@
 "Paste block after" = "Wklej blok po";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Oczekujące";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Oczekuje na przegląd";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -1626,6 +1789,10 @@
 
 /* Photography site intent topic */
 "Photography" = "Fotografia";
+
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Plany";
 
 /* Suggestion to add content before trying to publish post or page */
 "Please add some content before trying to publish." = "Przed opublikowaniem proszę dodać jakąś treść.";
@@ -1645,7 +1812,7 @@
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid Last Name" = "Proszę wprowadzić poprawne nazwisko";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Proszę wprowadzić prawidłowy adres e-mail.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
@@ -1653,6 +1820,9 @@
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Wprowadź swoje dane";
+
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Proszę uzupełnić wszystkie pola";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "Proszę spróbować ponownie później";
@@ -1677,7 +1847,8 @@
 /* Section title for Popular Languages */
 "Popular languages" = "Popularne języki";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Wpis";
 
@@ -1735,8 +1906,14 @@
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "Nota o ochronie prywatności dla użytkowników z Kalifornii";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Prywatny";
+
 /* Error message title informing the user that reader content could not be loaded. */
 "Problem loading content" = "Wystąpił problem z wczytywaniem treści";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Projekty";
 
 /* Label for the publish (verb) button. Tapping publishes a draft post.
    Publish post action on share extension site picker screen.
@@ -1746,7 +1923,11 @@
 /* Label for the publish date button. */
 "Publish Date" = "Data publikacji";
 
-/* Period Stats 'Published' header
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Opublikuj natychmiast";
+
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Opublikowano";
 
@@ -1846,6 +2027,9 @@
 /* Settings: Comments Approval settings */
 "Require users to log in" = "Wymagaj od użytkowników zalogowania się";
 
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Resetuj hasło";
+
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Zmień wielkość lub przytnij";
 
@@ -1871,8 +2055,14 @@
    User action to retry media upload. */
 "Retry" = "Ponów";
 
+/* No comment provided by engineer. */
+"Retry?" = "Ponowić?";
+
 /* Right alignment for an image. Should be the same as in core WP. */
 "Right" = "Do prawej";
+
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS został wysłany";
 
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "STATUS";
@@ -1882,6 +2072,7 @@
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -1900,7 +2091,8 @@
 /* Button title that triggers a scan */
 "Scan Now" = "Skanuj teraz";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Zaplanowano";
 
 /* Title of Stats section that shows search engine referrer traffic. */
@@ -1928,17 +2120,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Selected: Default" = "Wybrano: domyślne";
 
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "Wyślij odnośnik w wiadomości e-mail";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "Wyślij treść dziennika zdarzeń";
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "Wyślij testowy raport awarii";
 
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "Wyślij wiadomość e-mail z odnośnikiem weryfikacyjnym";
+
 /* Link to plugin's Settings
    Section title
    Title for screen that allows configuration of your blog/site settings.
    Title for the Jetpack Security Settings Screen */
 "Settings" = "Ustawienia";
+
+/* Spoken accessibility label */
+"Share" = "Podziel się";
 
 /* Title for a button that recommends the app to others */
 "Share Jetpack with a friend" = "Udostępnij Jetpack znajomemu";
@@ -1974,6 +2175,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Show post content" = "Pokaż treść wpisu";
 
+/* View title during the sign up process. */
+"Sign Up" = "Zarejestruj się";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "Zaloguj się przy użyciu poświadczeń witryny";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Załóż konto";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Zarejestruj się na WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Zarejestruj się używając e-maila";
+
 /* Header for a single site, shown in Notification user profile. */
 "Site" = "Witryna";
 
@@ -1984,6 +2200,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Label for site title blog setting
    Title for screen that show site title editor */
 "Site Title" = "Tytuł witryny";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Adres witryny";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "Adres witryny musi zawierać co najmniej 4 znaki.";
@@ -2027,7 +2246,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Nazwa witryny musi składać się także z liter!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Podany adres e-mail jest już używany!";
 
 /* No comment provided by engineer. */
@@ -2069,6 +2288,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "Spam";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "Przyspiesz swoją witrynę";
@@ -2085,6 +2307,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Start writing…" = "Rozpocznij pisanie...";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "Statyczna strona główna";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -2118,7 +2343,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Theme Support action title */
 "Support" = "Wsparcie";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Tag";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -2197,6 +2423,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Message for when the certificate for the server is invalid. The %@ placeholder will be replaced the a host name, received from the API. */
 "The certificate for this server is invalid. You might be connecting to a server that is pretending to be “%@” which could put your confidential information at risk.\n\nWould you like to trust the certificate anyway?" = "Certyfikat tego serwera jest nieprawidłowy. Być może łączysz się z serwerem, który podszywa się pod “%@”, co może być zagrożeniem dla twoich prywatnych informacji.";
 
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "Prawdopodobnie utracono połączenie z internetem.";
+
 /* No comment provided by engineer. */
 "The site address must be shorter than 64 characters." = "Adres witryny internetowej musi mieć mniej niż 64 znaki.";
 
@@ -2217,11 +2446,20 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of Themes browser page */
 "Themes" = "Motywy";
 
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "Wystąpił nieoczekiwany błąd podczas aktualizowania komentarza";
+
 /* Generic error alert message */
 "There has been an unexpected error." = "Wystąpił niespodziewany błąd.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "Wystąpił problem podczas połączenie z WordPress.com. Proszę zalogować się ponownie.";
+
 /* Error message informing the user that there was a problem clearing the block on site preventing its posts from displaying in the reader. */
 "There was a problem removing the block for specified site." = "Wystąpił problem podczas usuwania blokady witryny.";
+
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "Wystąpił problem podczas próby uzyskania lokalizacji. Proszę spróbować ponownie później.";
 
 /* A description informing the user in order to proceed with this feature we will need camera permissions, and how to enable it. */
 "This app needs permission to access the Camera to scan login codes, tap on the Open Settings button to enable it." = "Aplikacja potrzebuje pozwolenia na dostęp do aparatu w celu skanowania kodów logowania. Dotknij przycisku Otwórz ustawienia, aby go włączyć.";
@@ -2254,6 +2492,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text for Report Crashes setting */
 "To help us improve the app’s performance and fix the occasional bug, enable automatic crash reports." = "By pomóc nam w usprawnieniu aplikacji i usunięciu okazjonalnych błędów, aktywuj automatyczne raportowanie o błędach.";
 
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "Aby kontynuować z identyfikatorem Apple, zaloguj się najpierw, podając swoje hasło do WordPressa. Prosimy o to jednorazowo.";
+
 /* Comments Today Section Header
    Insights 'Today' header
    Notifications Today Section Header */
@@ -2277,6 +2518,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "Spróbuj i dostosuj";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Spróbuj ponownie";
@@ -2311,6 +2553,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* URL text field placeholder */
 "URL" = "Adres URL";
+
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Nie znaleziono witryny WordPressa pod adresem URL. Kliknij 'Potrzebujesz pomocy?', żeby zobaczyć najczęściej zadawane pytania.";
 
 /* Error informing the user that their homepage settings could not be updated */
 "Unable to update homepage settings" = "Nie udało się aktualizować ustawień strony głównej";
@@ -2375,10 +2620,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Nie powiodło się przesyłanie";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Wysłano";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Przesyłanie";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -2387,12 +2634,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "Użyj";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "Użyj hasła, aby się zalogować";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Nazwa użytkownika";
 
 /* No comment provided by engineer. */
@@ -2401,6 +2654,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Użytkownicy";
+
+/* two factor code placeholder */
+"Verification code" = "Kod weryfikacyjny";
 
 /* Description for the version label in the What's new page. */
 "Version " = "Wersja ";
@@ -2476,6 +2732,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Action title. Noun. Opens the user's WordPress Admin in an external browser. */
 "WP Admin" = "WP Admin";
 
+/* View title during the Google auth process. */
+"Waiting..." = "Oczekuję…";
+
 /* No comment provided by engineer. */
 "Warning message" = "Wiadomość ostrzeżenia";
 
@@ -2484,6 +2743,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "Mieliśmy problem z ładowaniem danych";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "Właśnie wysłaliśmy magiczny odnośnik do";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "Dostaniesz od nas maila z magicznym odnośnikiem do założenia konta w witrynie WordPress.com.";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "Użyjemy podanego adresu e-mail do stworzenia konta na WordPress.com.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Wysłaliśmy odnośnik, za pomocą którego utworzysz nowe konto na WordPress.com. Sprawdź pocztę na tym urządzeniu, i stuknij odnośnik w wiadomości e-mail, którą otrzymasz od WordPress.com";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -2495,8 +2766,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Writing Settings: Weeks starts on */
 "Week starts on" = "Tydzień zaczyna się od";
 
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "Witamy w Jetpacku!";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Witamy w WordPress";
+
 /* A message title */
 "Welcome to the Reader" = "Witamy w czytniku";
+
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "Co to jest WordPress.com?";
 
 /* Title of section that contains plugins' change log */
 "What's New" = "Co nowego?";
@@ -2516,14 +2796,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "Blog WordPress";
 
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "Profil WordPress";
+
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress wymaga uprawnień do pobrania informacji o aktualnej lokalizacji urządzenia, by dodać ją do wpisu. Proszę zaktulizować ustawienia prywatności.";
+
 /* No comment provided by engineer. */
 "WordPress version too old" = "Wersja WordPressa jest za stara";
+
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Używana przez Ciebie wersja Wordpressa jest zbyt przestarzała. Strona %1$@ używa wersji %2$@. Rekomendujemy uaktualnienie do najnowszej wersji lub chociażby do %3$@";
 
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "Konto WordPress.com";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "WordPress.com Plany";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "Motywy WordPress.com";
@@ -2560,7 +2852,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "Nie ustawiono żadnych przypomnień.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Masz niezapisane zmiany.";
 
 /* Error message informing the user that being logged into a WordPress.com account is required. */
@@ -2640,6 +2933,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for more button in dashboard quick start card. */
 "ellipsisButton.AccessibilityLabel" = "Więcej";
+
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "example.com";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "Ustaw przypomnienia o blogowaniu";
@@ -2902,6 +3199,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dismiss button title. */
 "noResultsViewController.dismissButton" = "Odrzuć";
 
+/* No comment provided by engineer. */
+"password" = "hasło";
+
 /* Register Domain - Domain contact information field Phone */
 "phone number" = "numer telefonu";
 
@@ -3060,6 +3360,39 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Verb. Dismiss the web view screen. */
 "webKit.button.dismiss" = "Odrzuć";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Wpisy";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "By zobaczyć wszystkie statystyki, zaloguj się do WordPressa.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "Zaloguj się do Jetpacka, aby zobaczyć wszystkie statystyki.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "Zaloguj się do Jetpacka, aby zobaczyć statystyki z tego tygodnia.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "Zaloguj się do Jetpacka, aby zobaczyć dzisiejsze statystyki.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "Bieżący tydzień";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Komentarze";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Polubienia";
+
+/* Title of today widget */
+"widget.today.title" = "Dzisiaj";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Wyświetlenia";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Odwiedzający";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Domeny";

--- a/WordPress/Resources/pt-BR.lproj/Localizable.strings
+++ b/WordPress/Resources/pt-BR.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "%1$@ de %2$@ em seu site";
 
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "%1$@ de %2$@ usados em seu site";
+
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ quatrilhões";
 
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Sem título)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(sem título)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*Johann Brandt* respondeu à sua publicação";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "Um botão \"mais\" contém uma lista suspensa que mostra botões de compartilhamento";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "Uma conta do WordPress.com está conectada às credenciais da sua loja. Para continuar, enviaremos um link de verificação para o endereço de e-mail acima.";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "Um arquivo contém um padrão de código malicioso";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "Um título para o site";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "É necessário um endereço de e-mail válido para enviar um link de autenticação. Retorne para a tela anterior e forneça um endereço de e-mail válido.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "Um código de verificação só contém números.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "ATIVO";
@@ -522,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "Após %s";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "Alinhamento";
@@ -585,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "Endereços IP permitidos";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "Quase pronto! Informe o código de verificação do seu aplicativo de autenticação.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Texto alternativo";
@@ -597,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "Se preferir, desagrupe o bloco para nivelar o conteúdo.";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "Se preferir, insira a senha para esta conta.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "Ou:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "Sempre enviar resumo de falhas";
@@ -618,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "É necessária uma conexão à internet para ver as atividades";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "É necessário estar conectado a internet para visualizar os planos.";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -668,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "Estatísticas anual do site";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "Anônimo";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "Responder";
 
@@ -689,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "Aparência";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "A autenticação com a Apple falhou.\nCertifique-se de que está conectado ao iCloud com um Apple ID que usa autenticação de dois fatores.";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "Aplicar configurações";
@@ -775,6 +811,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "Falha na autenticação";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "Código de autenticação";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "Autenticação requerida pelo host: %@";
@@ -885,6 +925,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "Seja o primeiro a comentar";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Seja o primeiro a fazer um comentário.";
 
 /* Beauty site intent topic */
 "Beauty" = "Beleza";
@@ -1021,12 +1064,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button to copy post text" = "Botão para copiar o texto do post";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "Ao continuar, você concorda com os nossos _Termos de Serviço_.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "Ao registrar um domínio, você concorda com nossos <a>termos e condições<\/a>.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "Ao configurar o Jetpack, você concorda com nossos\n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "Ao cadastrar-se, você concorda com os nossos _Termos de serviço_.";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "Personalizar";
@@ -1040,6 +1089,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "Necessário acesso à câmera para verificar os códigos de login";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Não pode requisitar link";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "Não é possível publicar uma página sem conteúdo";
 
@@ -1049,6 +1101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1058,6 +1111,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1076,6 +1130,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1103,6 +1158,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "Cancelando...";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "Não é possível acessar o site com este endereço. Verifique novamente e tente outra vez.";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Não consegue decidir? Você pode mudar o tema a qualquer momento.";
 
@@ -1110,7 +1168,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Legenda";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Cuidado!";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1119,7 +1178,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Categorias";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Categoria";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1168,6 +1228,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "Confira nossas principais dicas para aumentar suas visualizações e tráfego";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "Verifique seu e-mail neste dispositivo.";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Verifique seu e-mail neste dispositivo e toque no link que você recebeu do WordPress.com.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "Verifique o e-mail neste dispositivo e clique no link enviado pelo WordPress.com.\n\nNão encontrou o e-mail? Dê uma olhada na caixa de Spam.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "Verifique seu e-mail.";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "Verifique sua conexão com a internet e arraste para atualizar.";
@@ -1264,6 +1336,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "Resgatar seu domínio gratuito";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "Blog clássico";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "Liberar cache de arquivos do dispositivo";
 
@@ -1291,6 +1366,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Fechar";
 
@@ -1332,6 +1408,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "Configurações de colunas";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "HQs";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1383,6 +1462,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Comentários";
 
@@ -1450,12 +1530,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Contas conectadas";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Conectado, mas...";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "Conectando %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Conectar com %1$@ irá substituir a conexão atual com a conta %2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Conectando com WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Conectando...";
@@ -1486,8 +1572,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "Entre em contato em %@";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "Estrutura do conteúdo\nBlocos: %1$li, Palavras: %2$li, Caracteres: %3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1502,6 +1592,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Continuar lendo";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Continuar com Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Continuar com Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Prosseguindo with Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "Contribuir";
@@ -1630,6 +1729,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "Criar";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Criar conta";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "Criar uma página vazia";
 
@@ -1650,6 +1752,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "Criar um post";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "Criar um site";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "Criar uma tag";
@@ -1683,6 +1788,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "Atual";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Plano atual";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Tema atual";
@@ -1785,6 +1893,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "Categoria padrão";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Menu padrão";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Formato de post padrão";
@@ -1793,6 +1904,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "Padrões para novos posts";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Excluir";
@@ -1850,6 +1962,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "Detalhes";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "Não queria criar uma conta nova? Volte para redigitar seu endereço de e-mail.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "Dimensões";
 
@@ -1897,7 +2012,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "Discussão";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Dispensar";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1919,6 +2036,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "Domínios";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "Não tem uma conta? _Cadastre-se_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2048,6 +2168,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "Downloads";
 
+/* Name for the status of a draft post. */
+"Draft" = "Rascunho";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Rascunhos";
 
@@ -2157,7 +2280,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "Endereço de e-mail";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "Endereço de e-mail";
 
 /* Notification Settings Channel */
@@ -2241,8 +2367,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Digite a senha";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "Digite o endereço do site WordPress que você deseja conectar.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Digite a senha da sua conta no WordPress.com.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Digite o nome de usuário";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "Digite as informações da conta de %@.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "Digite seu endereço de e-mail para acessar ou criar uma conta no WordPress.com.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "Digite o endereço de seu site";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "Digitar sua senha.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "Insira as credenciais do servidor";
@@ -2405,6 +2551,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "Externo";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Falhou";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "Erro ao marcar todas as notificações como lidas";
 
@@ -2431,6 +2580,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "Moda";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "Em destaque";
@@ -2489,6 +2641,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "Saiba mais";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Encontrar um endereço para seu site";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2511,6 +2666,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "Corrigindo ameaças";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "Seguir";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "Seguir conversa";
@@ -2605,6 +2763,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "Gerar novo link";
 
+/* View title for initial auth views. */
+"Get Started" = "Comece agora";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "Receber um link de acesso por e-mail";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "Mexa-se! Comente em posts de blogs que você segue.";
 
@@ -2626,8 +2790,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "Inspirando-se";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Obtendo informações da conta";
+
+/* Cancel */
+"Give Up" = "Desistir";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "Experimente adicionar alguns blocos ao seu post ou à sua página!";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "Ir para o Leitor";
@@ -2638,6 +2811,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "Ir para configurações do iOS";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "O cadastro com o Google falhou.";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2712,6 +2888,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "Ícone de ajuda";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Oculto";
+
 /* Title of a button used to collapse a group */
 "Hide" = "Ocultar";
 
@@ -2780,6 +2959,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "A atualização do ícone falhou";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "Caso você não encontre o e-mail, verifique seu lixo eletrônico ou spam";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "Se você continuar com o Google ou Apple e ainda não tiver uma conta no WordPress.com, você criará uma conta e concordará com nossos _Termos de Serviços_.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "Se remover %1$@, este usuário não poderá mais acessar este site, mas todo o conteúdo criado por %2$@ será mantido.";
@@ -2855,6 +3040,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "Inclui wp-config.php e qualquer arquivo que não seja do WordPress";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Nome de usuário ou senha incorretos. Tente digitar seus dados de login novamente.";
 
 /* Title for a threat */
 "Infected core file" = "Arquivo do núcleo infectado";
@@ -2956,6 +3144,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "Apresentamos as sugestões de publicação";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "Endereço de e-mail inválido";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "Endereço do site inválido";
 
@@ -2973,6 +3164,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "URL inválido. Arquivo de áudio não encontrado.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "URL inválido. Verifique novamente e tente outra vez.";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "URL inválido. Digite um URL válido.";
@@ -2994,6 +3188,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "Convidar pessoas";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "Parece que esse usuário\/senha não está associado a esse site.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "Parece que você digitou com uma senha incorreta. Quer tentar novamente?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "Está na hora de publicar em %@!";
@@ -3222,7 +3422,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "Altura da linha";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Link";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3284,6 +3485,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "Carregando pessoas...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Carregando o plano...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Carregando planos....";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "Carregando o plugin...";
 
@@ -3318,11 +3525,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "Carregando...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Local";
+
 /* Local Services site intent topic */
 "Local Services" = "Serviços locais";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "Alterações locais";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Localização ";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Os Serviços de Localização precisam ser ativados antes para o WordPress poder adicionar sua localização atual. Por favor, ative os Serviços de Localização em Configurações.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Local desconhecido";
 
 /* No comment provided by engineer. */
 "Lock icon" = "Ícone de bloqueio";
@@ -3330,9 +3549,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Arquivos de log por data de criação";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Fazer login";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3341,6 +3562,22 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title of a button for signing in. */
 "Log in" = "Acessar";
+
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Falha ao tentar fazer login. Tente novamente.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "Faça login ou se registre no WordPress.com";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Acesse a conta do WordPress.com usada para se conectar ao Jetpack.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "Acesse sua conta do WordPress.com com seu endereço de e-mail.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "Faça login com seu nome de usuário e sua senha do WordPress.com.";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of Jetpack?" = "Sair do Jetpack?";
@@ -3351,6 +3588,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Login Request Expired */
 "Login Request Expired" = "Solicitação de login expirada";
 
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "Fazer login com a senha da conta";
+
 /* No comment provided by engineer. */
 "Logs" = "Logs";
 
@@ -3359,6 +3599,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Parece que o Jetpack está configurado em seu site. Parabéns!\nAcesse com suas credenciais WordPress.com para ativar as estatísticas e notificações.";
+
+/* Title of a button. */
+"Lost your password?" = "Esqueceu sua senha?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "Mail (Padrão)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Navegação principal";
@@ -3506,6 +3752,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "Mensagem";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "Diversas vulnerabilidades";
 
@@ -3601,6 +3850,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "Meu site";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "Meus sites em WordPress";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "Minhas 10 cafeterias preferidas";
 
@@ -3640,8 +3892,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Precisa de ajuda?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "Precisa de ajuda para encontrar o endereço do seu site?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "Precisa de ajuda?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Precisa de ajuda?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "Precisa de atualização";
@@ -3670,6 +3929,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "Novo post";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Novo item";
+
 /* Placeholder text for password field */
 "New password" = "Nova senha";
 
@@ -3687,7 +3949,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "Notícias";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Próximo";
 
 /* Accessibility label for the next notification button */
@@ -3723,6 +3987,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "Não há pré-visualização disponível. ";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "Sem título";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "Nenhuma atividade disponível";
 
@@ -3755,7 +4022,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "Nenhum comentário";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "Sem conexão";
 
@@ -3904,6 +4172,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "Agora não";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "Não está vendo o e-mail? Verifique sua pasta de spam ou lixo eletrônico.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "Nota:";
 
@@ -3967,7 +4238,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Lista numerada";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -4024,7 +4300,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "Ops";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Opa!";
 
 /* No comment provided by engineer. */
@@ -4039,7 +4316,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "Abrir configurações do Jetpack Security";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Abrir o Mail";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Abrir configurações";
 
 /* No comment provided by engineer. */
@@ -4057,6 +4339,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "Abrir o link em uma nova janela";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "Abrir configurações de inscrição do post";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "Abrir a tela Eu";
 
@@ -4071,6 +4356,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "Opcional: digite uma mensagem personalizada com até %1$d caracteres para enviar com seu convite.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "Ou";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "Você também pode escolher outra forma de autenticação.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "Ou acesse  _informando o endereço do seu site_.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "Ou fazer login pelo link mágico";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Lista ordenada";
@@ -4119,7 +4416,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "Recuo";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Página";
 
@@ -4152,8 +4450,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "Criação de filhos";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Senha";
 
@@ -4170,8 +4471,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "Colar bloco após";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Pendente";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Revisão pendente";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4202,6 +4507,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "Escolha seu nome de usuário";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Planos";
+
 /* User action to play a video on the editor. */
 "Play video" = "Reproduzir vídeo";
 
@@ -4231,6 +4540,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "Confirme que o editor de blocos está ativo em seu site. Caso não esteja ativo, ele não será carregado.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "Digite um endereço completo de site como exemplo.com.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "Entre o endereço de um site.";
@@ -4265,11 +4577,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "Digite um endereço válido";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "Insira um endereço de e-mail válido de uma conta do WordPress.com.";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Digite um endereço de e-mail válido.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "Digite um número de telefone válido";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Digite a senha de sua conta do WordPress.com para acessar com a ID da Apple.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Entre com suas credenciais";
@@ -4277,8 +4595,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Digite seu endereço de e-mail.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Por favor, preencha todos os campos";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Abra o aplicativo do WordPress, acesse sua conta do WordPress.com, assegure-se de que você tem pelo menos um site e, então, tente novamente.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "Faça logout antes de se conectar a um site diferente do WordPress.com";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "Tente novamente mais tarde";
@@ -4346,7 +4670,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "Idiomas populares ";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Post";
 
@@ -4467,6 +4792,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "Aviso de privacidade para usuários na Califórnia";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Privado";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "Problema ao exibir o bloco. \nToque para tentar restaurá-lo.";
 
@@ -4481,6 +4809,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "Houve um problema ao tentar comprar seu domínio. Tente novamente.";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Continuar irá remover todos os dados WordPress.com deste serviço e excluirá qualquer rascunho localmente salvo. Você não perderá qualquer coisa já salva em seu(s) blog(s) WordPress.com.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Projetos";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "Sugestão ignorada";
@@ -4498,13 +4832,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "Data de publicação";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Publicar imediatamente";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "Publicar página em:";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "Publicar post em:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Publicado";
 
@@ -4706,7 +5044,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "Responder";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Texto de resposta";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "Responder para %1$@";
 
 /* An explaination of a setting. */
@@ -4735,6 +5078,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "Redefine o filtro de intervalo de data";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Redefinir sua senha";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Redimensionar e cortar";
@@ -4792,6 +5138,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "Tentar todas novamente";
 
+/* No comment provided by engineer. */
+"Retry?" = "Tentar novamente?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "Voltar para o post";
 
@@ -4821,6 +5170,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "Função";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS enviado";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "Status";
 
@@ -4832,6 +5184,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4898,7 +5251,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "Examinando arquivos";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Agendado";
 
 /* No comment provided by engineer. */
@@ -5038,6 +5392,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "Seleciona este tópico como o assunto de seu site.";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Enviar link";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "Enviar link por e-mail";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "Enviar mensagem com resumo";
 
@@ -5046,6 +5406,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "Enviar um teste de falha";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "Enviar link de verificação de e-mail";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "Enviar notificações por e-mail";
@@ -5091,6 +5454,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message to show when setting save failed */
 "Settings update failed" = "A atualização das configurações falhou";
+
+/* Spoken accessibility label */
+"Share" = "Compartilhar";
 
 /* Title for a button that recommends the app to others */
 "Share Jetpack with a friend" = "Compartilhe o Jetpack com amigos";
@@ -5144,6 +5510,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "Mostrar botão reblogar";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "Mostrar senha";
+
 /* No comment provided by engineer. */
 "Show post content" = "Mostrar conteúdo do post";
 
@@ -5155,6 +5525,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "Mostrando estatísticas de:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "Mostrando senha";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Exibido publicamente quando você comenta em blogs.";
@@ -5170,6 +5543,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "Mostra os posts";
+
+/* View title during the sign up process. */
+"Sign Up" = "Registrar-se";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "Fazer login com as credenciais do site";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Registre-se";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Cadastrar no WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Cadastrar com e-mail";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "Como você está usando o plano gratuito, você verá eventos limitados em suas atividades.";
@@ -5208,6 +5596,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Conquistas do site";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Endereço do site";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "O endereço do site deve ter pelo menos 4 caracteres.";
@@ -5292,7 +5683,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Desculpe, endereços de sites devem conter letras também!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Esse endereço de e-mail já está sendo usado!";
 
 /* No comment provided by engineer. */
@@ -5352,6 +5743,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "Spam";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "Acelere seu site";
@@ -5377,6 +5771,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "Estado";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "Página inicial estática";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5407,6 +5804,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "Riscado";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Apenas local";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "Enviar para revisão";
@@ -5497,7 +5897,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "Tablet";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Tag";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5632,6 +6033,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Termos de serviço";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Testemunhos";
+
 /* Title of a button style */
 "Text Only" = "Apenas texto";
 
@@ -5641,8 +6045,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "Os controles de formatação de texto estão posicionados na barra de ferramentas acima do teclado ao editar um bloco de texto";
 
+/* Button title */
+"Text me a code instead" = "Envie-me o código por SMS";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "Enviar código por SMS";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Obrigado por escolher %1$@ de %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "Isto não parece ser um código de verificação válido.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "Esse site não parece ser um site WordPress.";
@@ -5664,6 +6077,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "A conexão com o Facebook não conseguiu encontrar nenhuma página. A publicidade não consegue se conectar aos perfis do Facebook, apenas às páginas publicadas.";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "A conta do Google \"%@\" não corresponde à nenhuma conta do WordPress.com";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "A conexão com a internet parece estar offline.";
@@ -5703,6 +6119,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "Não foi possível adicionar a imagem à biblioteca de mídia.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "A conexão de internet parece estar offline.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "Tipos de sites que podem ser criados";
@@ -5746,6 +6165,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "O site em %1$@ usa o WordPress %2$@. Recomendamos atualizar para a última versão, ou pelo menos a %3$@ ";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "O site publicado nesse endereço não é um site WordPress. Para que possamos nos conectar a ele, é necessário que o site tenha sido feito com WordPress.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "Não foi possível excluir o site.";
 
@@ -5787,6 +6210,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "Ocorreu um erro inesperado ao editar o comentário";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "Ocorreu um erro ao carregar os comentários.";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "Houve um erro inesperado ao registrar seu domínio";
 
@@ -5795,6 +6221,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "Ocorreu um erro inesperado durante a tentativa de atualizar suas Configurações de notificação";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "Ocorreu um erro inesperado ao atualizar seu comentário";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "Ocorreu um erro inesperado.";
@@ -5816,6 +6245,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "Ocorreu um problema na comunicação com o site.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "Ocorreu um problema ao conectar com o WordPress.com. Por favor, faça login novamente.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "Houve um problema exibindo este post.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "Ocorreu um problema ao carregar seus dados. Atualize a página para tentar novamente.";
 
@@ -5825,12 +6260,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "Ocorreu um erro ao salvar as alterações do gerenciador de compartilhamento.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "Ocorreu um erro ao tentar acessar sua localização. Por favor, tente novamente mais tarde.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "Ocorreu um erro ao alterar a senha";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "Houve um erro ao carregar as atividades";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "Ocorreu um erro ao carregar os planos";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "Ocorreu um erro ao carregar os plugins";
@@ -5843,6 +6284,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "Houve um erro ao carregar o histórico";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "Houve um erro ao carregar o plano";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "Ocorreu um erro ao carregar o histórico da varredura.";
@@ -5891,6 +6335,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "Este domínio não está disponível";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "Este endereço de e-mail não está registrado no WordPress.com.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "Este arquivo é muito grande para ser enviado para o seu site ou este formato de mídia não é suportado por ele.";
@@ -5971,6 +6418,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "Fuso horário";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "Acabou o tempo, mas não se preocupe, nossa prioridade é sua segurança. Tente novamente.";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "Dicas para aproveitar o máximo do WordPress.com";
 
@@ -5984,6 +6434,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "Digite seu endereço de e-mail e nome para continuar.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "Para criar sua nova conta WordPress.com, digite seu endereço de e-mail.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "Para receber notificações úteis de seu site WordPress em seu dispositivo, é necessário instalar o plugin Jetpack.";
 
@@ -5992,6 +6445,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "Para instalar plugins, é necessário ter um domínio personalizado associado ao seu site.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "Para continuar usando esta conta da Apple, primeiro faça login com a sua senha do WordPress.com. Isto só será solicitado uma vez.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "Para continuar usando esta conta do Google, primeiro faça login com a sua senha do WordPress.com. Isto só será solicitado uma vez.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "Para remover um bloco, selecione o bloco e clique nos três pontos no canto inferior direito do bloco para ver as configurações. A partir daí, escolha a opção de remover o bloco.";
@@ -6066,7 +6525,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "Lixeira";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "Na lixeira";
 
@@ -6080,6 +6540,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "Experimentar e personalizar";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Tente novamente";
@@ -6105,6 +6566,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "Experimente o novo editor de blocos";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Tentar com outro e-mail";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Tentar com o endereço do site";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "Desativar sugestões";
@@ -6147,6 +6614,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "USA";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "Não foi possível conectar";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "Não foi possível carregar os posts";
@@ -6196,6 +6666,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Não foi possível reproduzir o vídeo";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Não foi possível ler o site WordPress nesse URL. Toque em 'Precisa de mais ajuda?' para ver as perguntas frequentes.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Não foi possível restaurar o site";
 
@@ -6222,6 +6695,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "Não foi possível enviar um post e um arquivo";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "Não foi possível verificar o endereço de e-mail. Tente novamente mais tarde.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "Não foi possível visitar as configurações do Jetpack do site";
@@ -6366,7 +6842,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Falha ao carregar";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Enviado";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6384,7 +6861,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Temas enviados";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Fazendo upload";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6399,18 +6877,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "Usar";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "Usar uma chave de segurança";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "Usar o editor de blocos";
 
 /* No comment provided by engineer. */
 "Use icon button" = "Usar ícone de botão";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "Usar senha para fazer login";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Nome de usuário";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6425,6 +6912,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Usuários";
+
+/* two factor code placeholder */
+"Verification code" = "Código de verificação";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "E-mail de verificação enviado, confira sua caixa de entrada.";
@@ -6557,8 +7047,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "O diretório wp-content";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Esperando o Google para concluir...";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "Aguardando conexão";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "Aguardando chave de segurança";
+
+/* View title during the Google auth process. */
+"Waiting..." = "Aguardando...";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6598,6 +7098,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "Tivemos problemas ao carregar os dados";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "Enviamos um link para o e-mail %@. Confira seu aplicativo de e-mail e acesse o link para fazer login.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "Acabamos de enviar um link mágico para";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "O backup do seu site foi criado com sucesso para %@";
 
@@ -6607,14 +7113,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "Nós usamos outras ferramentas de acompanhamento, inclusive algumas de terceiros. Leia mais sobre elas e como controlá-las.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "Não foi possível enviar um e-mail para você no momento. Tente novamente mais tarde.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Enviaremos um e-mail se forem encontradas ameaças à segurança. Enquanto isso, fique à vontade para continuar a usar seu site normalmente. Você pode verificar o progresso a qualquer momento.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "Vamos enviar para você um link mágico que fará seu login na hora, sem precisar de senha. Chega de catar milho no teclado!";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "Enviaremos um link por e-mail para criar sua nova conta no WordPress.com.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "Nós te avisaremos assim que você receber seguidores, comentários e curtidas.";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "Nós te avisaremos quando você tiver novos seguidores, comentários e curtidas. Gostaria de permitir as notificações?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "Usaremos este endereço de e-mail para criar sua nova conta no WordPress.com.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "Estamos criando um backup do seu site para %1$@.";
@@ -6625,6 +7143,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Vamos corrigir essas ameaças enquanto você faz outras coisas. Enquanto isso, sinta-se à vontade para continuar usando o site normalmente. Você pode conferir o progresso a qualquer momento.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "Não conseguimos conectar ao site do Jetpack com esse URL. Entre em contato para ajudarmos.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "Estamos restaurando o seu site para %1$@.";
 
@@ -6633,6 +7154,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "Nós também enviamos um e-mail com um link para seu arquivo.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Nós enviamos um link de cadastro por e-mail para criar sua nova conta no WordPress.com. Verifique sua caixa de e-mails neste dispositivo e clique no link enviado pelo WordPress.com.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6659,6 +7183,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "Resumo semanal: %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "Desejamos boas-vindas ao Jetpack";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Bem-vindo ao WordPress";
 
 /* A message title */
 "Welcome to the Reader" = "Bem-vindo(a) ao leitor";
@@ -6703,6 +7233,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "O que é o Gravatar?";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "O que é o WordPress.com?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "O que é um bloco?";
 
@@ -6721,6 +7254,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "O que há de novo no WordPress";
 
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "O que é o endereço do meu site?";
+
 /* Select the site's intent. Title */
 "What's your website about?" = "Qual o propósito do seu site?";
 
@@ -6732,6 +7268,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "Assim que você fizer alterações no site, você poderá ver o histórico de atividades aqui.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Oops, não conseguimos realizar seu login. Tente novamente!";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "Ops, ocorreu um erro. Tente novamente.";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "Ops, parece que essa chave de segurança não é válida. Selecione outra e tente novamente";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Ooops, este não é um código de verificação em duas etapas válido. Confira o código e tente novamente!";
 
 /* No comment provided by engineer. */
 "Width Settings" = "Configurações de largura";
@@ -6745,17 +7293,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "Configurações do aplicativo WordPress";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "Apps do WordPress - Apps para qualquer tela";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "Blog do WordPress";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "Ajuda do WordPress";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "Biblioteca de mídia do WordPress";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "Configurações de notificações do WordPress";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "Notificações do WordPress";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "Plugins WordPress";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "Perfil do WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "Leitor do WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "Detalhes do site WordPress";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "Temas WordPress";
@@ -6766,17 +7335,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "WordPress multisites não é suportado";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "O WordPress precisa de sua permissão para acessar a localização atual de seu dispositivo para adiconá-la a seu post. Por favor, revise seus ajustes de privacidade.";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "Raiz do WordPress";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "Versão do WordPress muito antiga";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Versão muito antiga do WordPress. O site em %1$@ usa o WordPress %2$@. Recomendamos a atualização para a última versão ou pelo menos, a versão %3$@.";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "Conta no WordPress.com";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "Planos do WordPress.com";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "Temas WordPress.com";
@@ -6807,6 +7385,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "Escrever post";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "Escreva uma resposta";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "Escreva uma resposta…";
 
 /* Title for the writing section in site settings screen */
@@ -6820,6 +7401,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Posição eixo Y";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "Ano";
@@ -6904,6 +7488,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Displayed when the user views trashed in the posts list and there are no posts */
 "You don't have any trashed posts" = "Você não possui nenhum post na lixeira";
 
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"You don't have permission to view this private blog." = "Você não tem permissão para ver este blog privado.";
+
 /* Description for the first domain purchased with a paid plan. */
 "You have a free one-year domain registration with your plan." = "Você tem um registro de domínio gratuito por um ano no seu plano.";
 
@@ -6919,7 +7506,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "Não há nenhum lembrete configurado.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Você tem alterações não salvas.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -7015,6 +7603,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "Sua pesquisa inclui caracteres não permitidos em domínios do WordPress.com. São permitidos os seguintes caracteres: A–Z, a–z, 0–9.";
 
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "O endereço do seu site é exibido na barra superior quando visitado no Safari.";
+
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "Seu site já está protegido pelo VaultPress. Você pode encontrar um link para o painel do VaultPress abaixo.";
 
@@ -7093,17 +7684,32 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility identifier for an 'Add Comment' button */
 "addCommentButton.accessibilityIdentifity" = "Adicionar comentário";
 
+/* Error message shown a URL does not point to an existing site. */
+"addSite.restApiNotAvailable" = "Este endereço não pertence a um site WordPress. O site precisa usar o WordPress para realizarmos a conexão.";
+
+/* Error message shown when an receiving an invalid application-password authentication result from a self-hosted WordPress site */
+"addSite.selfHosted.authenticationFailed" = "Não foi possível fazer login usando a autenticação por senha de aplicativo.";
+
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "Digite o endereço do site WordPress ao qual você deseja conectar.";
 
+/* Error message when user input is not a WordPress site */
+"addSite.selfHosted.invalidUrl" = "O endereço do site não é válido.";
+
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "Não foi possível carregar os detalhes do site";
+
+/* Error message shown when application-password authentication is disabled on a self-hosted WordPress site */
+"addSite.selfHosted.noLoginUrlFound" = "A autenticação por senha de aplicativo precisa estar ativada no site.";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "Não foi possível salvar o site, tente novamente mais tarde.";
 
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "Adicionar site auto-hospedado";
+
+/* Error message when an unknown error occurred when adding a self-hosted site */
+"addSite.selfHosted.unknownError" = "Ocorreu um erro. Tente novamente.";
 
 /* Age between dates equaling one hour. */
 "an hour" = "uma hora";
@@ -7813,6 +8419,10 @@ Example: Reply to Pamela Nguyen */
 /* A name of the ID field (it's a technical field, has to be short, displayed below everything else) */
 "entityMetadataFooterView.id" = "ID";
 
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "exemplo.com";
+
 /* Accept button title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackAccept" = "Enviar comentários";
 
@@ -7870,8 +8480,14 @@ Example: Reply to Pamela Nguyen */
 /* A footer retry button */
 "general.pagingFooterView.retry" = "Tentar novamente";
 
+/* Error message format when REST API returns an error response. The first argument is error message. */
+"generic.error.rest-api-error" = "Seu site enviou uma resposta com um erro: %@";
+
 /* A generic title for an error */
 "generic.error.title" = "Erro";
+
+/* Error message when failing to parse API responses */
+"generic.error.unparsableResponse" = "Seu site enviou uma resposta que o aplicativo não pôde analisar";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "Configurar lembretes para publicação";
@@ -8262,6 +8878,9 @@ Example: Reply to Pamela Nguyen */
 
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "Você não tem permissão para ver este blog privado.";
+
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "Digite o código de verificação do aplicativo de autenticação para a sua conta do WordPress.com.";
 
 /* Indicating that referrer was marked as spam */
 "marked as spam" = "marcado como spam";
@@ -8707,6 +9326,9 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "Página principal";
 
+/* No comment provided by engineer. */
+"password" = "senha";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "Os cartões podem mostrar conteúdo diferente dependendo do que está acontecendo em seu site. Estamos trabalhando em mais cartões e controles.";
 
@@ -9099,6 +9721,30 @@ Example: Reply to Pamela Nguyen */
 
 /* An alert message explaning that by changing the visibility to private, the post will be published immediately to your site */
 "postSettings.warningPostWillBePublishedAlertMessage" = "Ao mudar a visibilidade para \"Privado\", o post será publicado imediatamente";
+
+/* Localized post type: `Page` */
+"postType.page" = "página";
+
+/* Localized post type: `Post` */
+"postType.post" = "post";
+
+/* Details for a 'Private' privacy setting */
+"postVisibility.private.details" = "Visível apenas para administradores e editores do site";
+
+/* Title for a 'Private' privacy setting */
+"postVisibility.private.title" = "Privado";
+
+/* Details for a 'Password Protected' privacy setting */
+"postVisibility.protected.details" = "Visível para todos, mas requer uma senha";
+
+/* Title for a 'Password Protected' privacy setting */
+"postVisibility.protected.title" = "Protegido por senha";
+
+/* Details for a 'Public' (default) privacy setting */
+"postVisibility.public.details" = "Visível para todos";
+
+/* Title for a 'Public' (default) privacy setting */
+"postVisibility.public.title" = "Público";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Cancelar";
@@ -9679,8 +10325,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title of a Reader tab showing Posts matching a user's search query */
 "reader.search.tab.posts" = "Posts";
 
-/* Title of the Reader's search feature
-   Used in multiple contexts, usually as a screen title */
+/* Title of the Reader's search feature */
 "reader.search.title" = "Pesquisa";
 
 /* Screen title. Reader select interests title label text. */
@@ -9706,6 +10351,21 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Reader select interests title label text */
 "reader.select.tags.title" = "Descubra e siga blogs que você ama";
+
+/* Reader sidebar menu item */
+"reader.sidebar.discover" = "Explorar";
+
+/* Reader sidebar menu item */
+"reader.sidebar.likes" = "Curtidas";
+
+/* Reader sidebar menu item */
+"reader.sidebar.recent" = "Recentes";
+
+/* Reader sidebar menu item */
+"reader.sidebar.saved" = "Salvos";
+
+/* Reader sidebar menu item */
+"reader.sidebar.search" = "Pesquisar";
 
 /* Reader sidebar section title */
 "reader.sidebar.section.favorites.title" = "Favoritos";
@@ -9755,7 +10415,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Number of subscriptions on a site (singular) */
 "reader.subscriptions.subscriptionsSingular" = "%@ assinante";
 
-/* Used in multiple contexts, usually as a screen title */
+/* Navigation bar title */
 "reader.subscriptions.title" = "Assinaturas";
 
 /* A suggestion of topics the user might want to subscribe to */
@@ -10079,7 +10739,9 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Message shown when there are no inactive plugins on the site */
 "site.plugins.empty.inactive" = "Nenhum plugin inativo";
 
-/* The plugin fillter option for displaying all plugins */
+/* The plugin fillter option for displaying active plugins
+   The plugin fillter option for displaying all plugins
+   The plugin fillter option for displaying inactive plugins */
 "site.plugins.filter.option.all" = "Tudo";
 
 /* Title of the plugin filter picker */
@@ -10780,8 +11442,119 @@ Feel free to replace it with other bracket types that you think looks better for
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "Status";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "Todos posts e mais visualizados";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "Todas as visualizações";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "Todas as visualizações e visitantes";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "Melhores visualizações";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "Mais visualizados";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "Não foi possível carregar todas as estatísticas.";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "Crie ou adicione um site para ver todas as estatísticas.";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Posts";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "Fique por dentro de todas as atividades no seu site WordPress.";
+
+/* Title of all time widget */
+"widget.alltime.title" = "Total";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "Faça login no WordPress para ver todas as estatísticas.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "Faça login no Jetpack para ver todas as estatísticas.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "Faça login no Jetpack para ver as estatísticas desta semana.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "Faça login no Jetpack para ver as estatísticas de hoje.";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "Todas as visualizações";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "Visualizações do dia";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "Não foi possível carregar as estatísticas desta semana.";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "Crie ou adicione um site para ver as estatísticas desta semana.";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "Fique por dentro das atividades semanais no seu site WordPress.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "Esta semana";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "Faça login no WordPress para ver as estatísticas desta semana.";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Comentários";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "As estatísticas migraram para o aplicativo Jetpack. A troca é gratuita e leva apenas um minuto.";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Curtidas";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "Não foi possível carregar as estatísticas do site.";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "Não foi possível carregar as estatísticas do hoje.";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "Crie ou adicione um site para ver as estatísticas de hoje.";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "Fique por dentro das atividades diárias no seu site WordPress.";
+
+/* Title of today widget */
+"widget.today.title" = "Hoje";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "Faça login no WordPress para ver as estatísticas de hoje.";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "Visualização indisponível";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Visualizações";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Visitantes";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "Curtidas e comentários do dia";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "Visualizações do dia";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "Visualizações e visitantes do dia";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "ficará indisponível no futuro.";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "Quer começar um novo site?";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "wordpress, ajuda, suporte, faq, perguntas frequentes, questões, debug, depuração, logs, registros de atividades, central de ajuda, contato";
@@ -10806,6 +11579,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Error message that describes an unknown error had occured */
 "wordpress-api.error.unknown" = "Ocorreu um erro. Tente novamente mais tarde.";
+
+/* Error message when failing to find selected media file on the user's device. */
+"wordpress.api.upload.media.fileNotFound" = "Não é possível localizar o arquivo de mídia no dispositivo";
 
 /* Jetpack Plugin Modal on WordPress primary button title */
 "wordpress.jetpack.plugin.modal.primary.button.title" = "Mudar para o aplicativo do Jetpack";
@@ -10866,6 +11642,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "Anexo incompatível";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Acessar com o Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Domínios";

--- a/WordPress/Resources/pt.lproj/Localizable.strings
+++ b/WordPress/Resources/pt.lproj/Localizable.strings
@@ -59,6 +59,9 @@
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Sem título)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(sem título)";
+
 /* Menus button text for adding a new menu to a site. */
 "+ Add new menu" = "+ Adicionar novo menu";
 
@@ -79,6 +82,12 @@
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "Um título para o site";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "É necessário um endereço de email válido para onde enviar uma ligação de autenticação. Por favor volte ao ecrã anterior e insira um endereço de email válido.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "O código de verificação só deverá conter números.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "ACTIVO";
@@ -181,6 +190,9 @@
    Label for the alt for a media asset (image) */
 "Alt Text" = "Texto alternativo (Alt)";
 
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "É necessária uma ligação à Internet para ver os planos";
+
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
 "An active internet connection is required to view plugins" = "É necessária uma ligação à Internet para ver os plugins";
@@ -211,6 +223,9 @@
 
 /* Error message shown when a media upload fails for unknown reason and the user should try again. */
 "An unknown error occurred. Please try again." = "Ocorreu um erro desconhecido. Por favor, tente de novo.";
+
+/* the comment has an anonymous author. */
+"Anonymous" = "Anónimo";
 
 /* App Settings Title
    Link to App Settings section
@@ -289,6 +304,9 @@
    Previous web page */
 "Back" = "Voltar";
 
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Seja o primeiro a deixar um comentário.";
+
 /* Accessibility label for block quote button on formatting toolbar.
    Discoverability title for block quote keyboard shortcut. */
 "Block Quote" = "Citação";
@@ -315,6 +333,9 @@
 /* Title for a list of different button styles. */
 "Button Style" = "Estilo de botão";
 
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "Ao registar-se, concorda com os nossos _Termos de Serviço_.";
+
 /* Label for size of media while it's being calculated. */
 "Calculating..." = "A calcular...";
 
@@ -324,6 +345,7 @@
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -333,6 +355,7 @@
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -351,6 +374,7 @@
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -376,13 +400,15 @@
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Legenda";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Cuidado!";
 
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Categorias";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Categoria";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -421,6 +447,7 @@
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Fechar";
 
@@ -458,6 +485,7 @@
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Comentários";
 
@@ -507,9 +535,15 @@
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Contas ligadas";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Ligado, mas...";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "A ligar %@";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "A ligar ao WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "A ligar...";
@@ -538,6 +572,7 @@
 
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -578,6 +613,9 @@
 /* Register Domain - Address information field Country Code */
 "Country Code" = "Código do país";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Criar uma conta";
+
 /* Button for selecting the current page template.
    Title for button to make a page with the contents of the selected layout */
 "Create Page" = "Criar página";
@@ -592,6 +630,9 @@
 
 /* No comment provided by engineer. */
 "Current" = "Actual";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Plano actual";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Tema actual";
@@ -618,6 +659,9 @@
    Title for selecting a default category for a post */
 "Default Category" = "Categoria por omissão";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Menu por omissão";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Formato de artigo por omissão";
@@ -626,6 +670,7 @@
 "Defaults for New Posts" = "Por omissão para novos artigos";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Eliminar";
@@ -699,7 +744,9 @@
    Title for the Discussion Settings Screen */
 "Discussion" = "Discussão";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Ignorar";
 
 /* Display Name label text.
@@ -725,6 +772,9 @@
 
 /* Voiceover accessibility hint informing the user they can double tap a modal alert to dismiss it */
 "Double tap to dismiss" = "Duplo toque para ignorar";
+
+/* Name for the status of a draft post. */
+"Draft" = "Rascunho";
 
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Rascunhos";
@@ -769,7 +819,10 @@
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "Endereço de email";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "Endereço de email";
 
 /* Notification Settings Channel */
@@ -786,6 +839,9 @@
 
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Insira a senha";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Insira a senha da sua conta WordPress.com.";
 
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Insira o nome de utilizador";
@@ -831,6 +887,9 @@
 /* Overlay message displayed while starting content export */
 "Exporting content…" = "A exportar conteúdo...";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Falhou";
+
 /* Label for the Featured Image area in post settings. */
 "Featured Image" = "Imagem de destaque";
 
@@ -863,6 +922,9 @@
    User's First Name */
 "First Name" = "Nome";
 
+/* Button title. Follow the comments on a post. */
+"Follow" = "Seguir";
+
 /* User role badge */
 "Follower" = "Seguidor";
 
@@ -886,6 +948,12 @@
 
 /* Title for the general section in site settings screen */
 "General" = "Geral";
+
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "A obter informações da conta";
+
+/* Cancel */
+"Give Up" = "Desistir";
 
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
@@ -942,6 +1010,9 @@
    Title of the 'Help & Support' screen within the 'Me' tab - used for spotlight indexing on iOS. */
 "Help & Support" = "Ajuda e suporte";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Invisível";
+
 /* No comment provided by engineer. */
 "Hide keyboard" = "Esconder teclado";
 
@@ -994,6 +1065,9 @@
 
 /* Describes a standard *.wordpress.com site domain */
 "Included with Site" = "Incluído no site";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Nome de utilizador ou senha incorrectos. Por favor insira os seus dados de novo.";
 
 /* Default button title used in media picker to insert media (photos / videos) into a post.
    Label action for inserting a link on the editor */
@@ -1124,7 +1198,8 @@
 /* VoiceOver accessibility hint, informing the user the button can be used to like a comment */
 "Likes the Comment." = "Gosta do comentário.";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Ligação";
 
 /* Menus title label when editing a menu item as a link. */
@@ -1153,6 +1228,12 @@
 /* Menus label text displayed while menus are loading */
 "Loading Menus..." = "A carregar menus...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "A carregar plano...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "A carregar planos...";
+
 /* Text displayed while loading plugins for a site */
 "Loading Plugins..." = "A carregar plugins...";
 
@@ -1166,12 +1247,26 @@
    Text displayed while loading time zones */
 "Loading..." = "A carregar...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Local";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Localização";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "O serviço de localização tem que estar activado para que o WordPress possa adicionar a sua localização. Por favor active os Serviços de localização nas definições do iOS.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Localização desconhecida";
+
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Ficheiros de relatório por data de criação.";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Iniciar sessão";
 
 /* Button for confirming logging out from WordPress.com account
@@ -1181,6 +1276,9 @@
 /* Title of a button for signing in. */
 "Log in" = "Iniciar sessão";
 
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Falhou ao iniciar sessão. Por favor tente de novo.";
+
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of WordPress?" = "Terminar sessão do WordPress?";
 
@@ -1189,6 +1287,9 @@
 
 /* No comment provided by engineer. */
 "Logs" = "Relatórios";
+
+/* Title of a button. */
+"Lost your password?" = "Esqueceu-se da senha?";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Navegação principal";
@@ -1294,8 +1395,14 @@
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Necessita de ajuda?";
 
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Precisa de mais ajuda?";
+
 /* New Post 3D Touch Shortcut */
 "New Post" = "Novo artigo";
+
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Novo item";
 
 /* Screen title, where users can see the newest plugins */
 "Newest" = "Mais recentes";
@@ -1304,7 +1411,9 @@
 "Newest first" = "Mais recentes primeiro";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Seguinte";
 
 /* Accessibility label for the next notification button */
@@ -1336,7 +1445,8 @@
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "Sem comentários";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "Sem ligação";
 
@@ -1407,7 +1517,12 @@
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Lista numerada";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -1443,13 +1558,19 @@
    Title for the view when there's an error loading time zones */
 "Oops" = "Ups";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Ups!";
 
 /* Opens iOS's Device Settings for WordPress App */
 "Open Device Settings" = "Abrir definições do dispositivo";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Abrir Mail";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Abrir definições";
 
 /* No comment provided by engineer. */
@@ -1499,7 +1620,8 @@
 /* Register Domain - Phone number section header title */
 "PHONE" = "TELEFONE";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Página";
 
@@ -1516,14 +1638,21 @@
 /* Title for selecting parent category of a category */
 "Parent Category" = "Categoria superior";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Senha";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Pendente";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Pendente de revisão";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -1538,6 +1667,10 @@
 
 /* Accessibility label for selecting an image or video from the device's photo library on formatting toolbar. */
 "Photo Library" = "Biblioteca de fotografias";
+
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Planos";
 
 /* User action to play a video on the editor. */
 "Play video" = "Reproduzir vídeo";
@@ -1554,7 +1687,7 @@
 /* No comment provided by engineer. */
 "Please enter a username." = "Por favor insira um nome de utilizador.";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Por favor insira um endereço de email válido.";
 
 /* Popup message to ask for user credentials (fields shown below). */
@@ -1562,6 +1695,9 @@
 
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Por favor insira um endereço de email.";
+
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Por favor preencha todos os campos";
 
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Por favor inicie a aplicação WordPress, inicie sessão em WordPress.com, verifique se tem pelo menos um site e tente de novo.";
@@ -1586,7 +1722,8 @@
 /* Section title for Popular Languages */
 "Popular languages" = "Idiomas populares";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Publicar";
 
@@ -1657,12 +1794,22 @@
    Privacy Settings Title */
 "Privacy Settings" = "Definições de privacidade";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Privada";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Projectos";
+
 /* Label for the publish (verb) button. Tapping publishes a draft post.
    Publish post action on share extension site picker screen.
    Section title for the publish table section in the blog details screen */
 "Publish" = "Publicar";
 
-/* Period Stats 'Published' header
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Publicar imediatamente";
+
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Publicado";
 
@@ -1751,6 +1898,9 @@
    Verb. Button title. Reply to a comment. */
 "Reply" = "Responder";
 
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Texto de resposta";
+
 /* Settings: Comments Approval settings */
 "Require name and email" = "É necessário nome e email";
 
@@ -1791,6 +1941,9 @@
    User action to retry media upload. */
 "Retry" = "Tentar de novo";
 
+/* No comment provided by engineer. */
+"Retry?" = "Tentar de novo?";
+
 /* Cancels a pending Email Change */
 "Revert Pending Change" = "Reverter alteração pendente";
 
@@ -1805,8 +1958,12 @@
    User's Role */
 "Role" = "Papel";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS enviado";
+
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -1816,7 +1973,8 @@
 /* Menus save button title while it is saving a Menu. */
 "Saving..." = "A guardar...";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Agendado";
 
 /* Title of Stats section that shows search engine referrer traffic. */
@@ -1837,6 +1995,9 @@
 /* Accessibility label for selecting paragraph style button on formatting toolbar. */
 "Select paragraph style" = "Seleccione o estilo do parágrafo";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Enviar ligação";
+
 /* Settings: Sending Pingbacks */
 "Send Pingbacks" = "Enviar pingbacks";
 
@@ -1851,6 +2012,9 @@
 
 /* Message to show when setting save failed */
 "Settings update failed" = "Falhou ao actualizar opções";
+
+/* Spoken accessibility label */
+"Share" = "Partilhar";
 
 /* Aztec's Text Placeholder
    Share Extension Content Body Text Placeholder */
@@ -1876,6 +2040,15 @@
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Mostrado publicamente quando comenta em sites.";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Registar";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Registar em WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Registar com email";
 
 /* Title for the Language Picker View */
 "Site Language" = "Idioma do site";
@@ -1926,7 +2099,7 @@
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Desculpe mas o endereço do site também tem de incluir letras!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Desculpe mas esse endereço de email já está a ser utilizado!";
 
 /* No comment provided by engineer. */
@@ -2016,7 +2189,8 @@
 /* Switches the Editor to Rich Text Mode */
 "Switch to Visual Mode" = "Mudar para modo visual";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Etiqueta";
 
 /* Label for tagline blog setting
@@ -2042,11 +2216,17 @@
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Termos do serviço";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Testemunhos";
+
 /* Title of a button style */
 "Text Only" = "Apenas texto";
 
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Obrigado por escolher o %1$@ de %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "Este não parece ser um código de verificação válido.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "Não parece ser um site WordPress.";
@@ -2071,6 +2251,9 @@
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "Não foi possível adicionar a imagem à biblioteca multimédia.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "Parece não existir conexão à internet.";
 
 /* Footer Text displayed in Blog Language Settings View */
 "The language in which this site is primarily written." = "O idioma principal do site.";
@@ -2113,6 +2296,15 @@
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "Ocorreu um erro inesperado ao editar o seu comentário";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "Ocorreu um erro inesperado ao carregar os comentários.";
+
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "Ocorreu um problema ao ligar a WordPress.com. Por favor inicie sessão de novo.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "Ocorreu um problema ao mostrar este artigo.";
+
 /* Error message informing the user that there was a problem clearing the block on site preventing its posts from displaying in the reader. */
 "There was a problem removing the block for specified site." = "Ocorreu um problema ao remover o bloco do site especificado.";
 
@@ -2122,8 +2314,14 @@
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "Ocorreu um erro ao carregar actividades";
 
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "Ocorreu um erro ao carregar planos";
+
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "Ocorreu um erro ao carregar os plugins";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "Ocorreu um erro ao carregar o plano";
 
 /* Error message when time zones can't be loaded */
 "There was an error loading time zones" = "Ocorreu um erro ao carregar os fusos horários";
@@ -2133,6 +2331,9 @@
 
 /* An error message display if the users device does not have a camera input available */
 "This app needs permission to access the Camera to capture new media, please change the privacy settings if you wish to allow this." = "WordPress precisa de autorização para aceder à câmara do seu dispositivo para poder adicionar fotos e vídeos aos seus artigos. Por favor, actualize as suas definições de privacidade.";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "Este endereço de email não está registado em WordPress.com.";
 
 /* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
 "This media item has been deleted." = "Este item multimédia foi eliminado.";
@@ -2164,6 +2365,9 @@
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "Para continuar por favor insira um endereço de email e um nome.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "Para criar uma nova conta em WordPress.com, por favor insira um endereço de email.";
+
 /* Comments Today Section Header
    Insights 'Today' header
    Notifications Today Section Header */
@@ -2186,7 +2390,8 @@
    Trashes the comment */
 "Trash" = "Lixo";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "No lixo";
 
@@ -2197,6 +2402,7 @@
 "Try & Customize" = "Tentar e personalizar";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Tentar de novo";
@@ -2207,6 +2413,12 @@
    Button that lets users try to reload the plugin directory after loading failure
    Re-load the history again. It appears if the loading call fails. */
 "Try again" = "Tentar de novo";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Tente com outro email";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Tente com o endereço do site";
 
 /* Title of button that displays the app's Twitter profile */
 "Twitter" = "Twitter";
@@ -2223,6 +2435,9 @@
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "UTILIZA";
 
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "Não é possível ligar";
+
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "Não foi possível carregar os conteúdos";
 
@@ -2237,6 +2452,9 @@
 
 /* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
 "Unable to save media item." = "Não é possível guardar o item multimédia.";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "Não foi possível verificar o endereço de email. Por favor tente mais tarde.";
 
 /* Error reason to display when the writing of a image to a file fails */
 "Unable to write image to file" = "Não foi possível guardar o ficheiro de imagem";
@@ -2308,13 +2526,15 @@
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "O carregamento falhou.";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Carregado";
 
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Temas carregados";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "A carregar";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -2324,11 +2544,14 @@
 "Use" = "Usar";
 
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Nome de utilizador";
 
 /* Setting: indicates if Mentions will be notified */
@@ -2340,6 +2563,9 @@
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Utilizadores";
+
+/* two factor code placeholder */
+"Verification code" = "Código de verificação";
 
 /* Push Authentication Alert Title */
 "Verify Log In" = "Verificar sessão";
@@ -2415,6 +2641,9 @@
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "Ocorreram problemas ao carregar dados";
 
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "Será enviada uma ligação para inicio de sessão automático, sem precisar de senha.";
+
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
 "Web Address" = "Endereço web";
@@ -2422,8 +2651,14 @@
 /* The title of the option group for editing an image's size, alignment, etc. on the image details screen. */
 "Web Display Settings" = "Definições de visualização web";
 
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Bemvindo ao Wordpress!";
+
 /* A message title */
 "Welcome to the Reader" = "Bem-vindo ao Leitor";
+
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "Qual é o endereço do meu site?";
 
 /* Help text when editing email address */
 "Will not be publicly displayed." = "Não será mostrado ao público.";
@@ -2434,14 +2669,26 @@
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "Site WordPress";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "Ajuda do WordPress";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "Notificações do WordPress";
+
 /* No comment provided by engineer. */
 "WordPress version too old" = "Versão do WordPress demasiado antiga";
+
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "A versão do WordPress é muito antiga. O site em %1$@ usa WordPress %2$@. Recomendamos que seja actualizado para a versão mais recente, ou pelo menos para a versão %3$@";
 
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "Conta do WordPress.com";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "Planos de WordPress.com";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "Temas de WordPress.com";
@@ -2487,7 +2734,8 @@
 /* Warning displayed before logging out. The %d placeholder will contain the number of local posts (PLURAL!) */
 "You have changes to %d posts that haven’t been uploaded to your site. Logging out now will delete those changes. Log out anyway?" = "Tem alterações feitas em %d artigos que ainda não foram carregados para o seu site. Ao terminar a sessão agora estas alterações são eliminadas. Quer terminar sessão na mesma?";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Tem alterações por guardar.";
 
 /* Error message informing the user that being logged into a WordPress.com account is required. */
@@ -2538,8 +2786,29 @@
 /* Used when the response doesn't have a valid url to display */
 "unknown url" = "URL desconhecido";
 
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Conteúdos";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Comentários";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Gostos";
+
+/* Title of today widget */
+"widget.today.title" = "Hoje";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Visualizações";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Visitantes";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "irá estar indisponível de futuro.";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Iniciar sessão com o Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Domínios";

--- a/WordPress/Resources/ro.lproj/Localizable.strings
+++ b/WordPress/Resources/ro.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Translation-Revision-Date: 2025-05-10 20:15:42+0000 */
+/* Translation-Revision-Date: 2025-03-19 19:27:15+0000 */
 /* Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n == 0 || n % 100 >= 2 && n % 100 <= 19) ? 1 : 2); */
 /* Generator: GlotPress/4.0.1 */
 /* Language: ro */
@@ -98,6 +98,9 @@
 
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "%1$@ din %2$@ pe site-ul tău";
+
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "%1$@ din %2$@ folosiți pe site-ul tău";
 
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ cvadrilioane";
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Fără titlu)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(fără titlu)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*Johan Brandt* a răspuns la articolul tău";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "Un buton \"mai mult\" conține o listă desfășurată care afișează butoane de partajare";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "Am conectat un cont WordPress.com la datele de conectare ale magazinului tău. Pentru a continua, îți vom trimite o legătură de verificare la adresa de email de mai sus.";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "Un fișier conține un model de cod care poate crea vulnerabilități";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "Un titlu pentru site";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "Este necesară o adresă email validă pentru trimite prin email o legătură de autentificare. Te rog revino la ecranul anterior și furnizează o adresă email validă.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "Un cod de verificare va conține numai cifre.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "ACTIVĂ";
@@ -334,9 +349,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* My Profile 'About me' label */
 "About Me" = "Despre mine";
-
-/* Link to About screen for Jetpack for iOS */
-"About Reader for iOS" = "Despre Cititor pentru iOS";
 
 /* Link to About screen for WordPress for iOS */
 "About WordPress" = "Despre WordPress";
@@ -525,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "După %@";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "Aliniere";
@@ -588,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "Adrese IP permise în lista";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "Aproape gata! Te rog să introduci codul de verificare din aplicația Authenticator.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Text alternativ";
@@ -600,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "Ca alternativă, poți să aplatizezi conținutul prin anularea grupării blocurilor.";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "Ca alternativă, poți să introduci parola pentru acest cont.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "Alternativ:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "Trimite întotdeauna jurnalele de erori fatale";
@@ -621,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "Pentru a vedea activitățile, ai nevoie de o conexiune activă la internet";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "Pentru a vizualiza planurile, ai nevoie de o conexiune activă la internet";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -671,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "Statistici anuale site";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "Anonim";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "Răspunde";
 
@@ -692,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "Apariție";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "Autentificarea Apple a eșuat.\nTe rog asigură-te că ești conectat la iCloud cu un ID Apple care folosește autentificarea pe două niveluri.";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "Aplică setarea";
@@ -779,6 +812,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "Autentificarea a eșuat";
 
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "Cod de autentificare";
+
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "Autentificare necesară pentru gazda: %@";
 
@@ -789,7 +826,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Author" = "Autor";
 
 /* Voiceover description of a button that allows the user to filter posts by author. */
-"Author Filter" = "Filtru pentru autori";
+"Author Filter" = "Filtru după autor";
 
 /* Label for comments by author
    Period Stats 'Authors' header */
@@ -888,6 +925,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "Fii primul care comentează";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Fii primul care lasă un comentariu.";
 
 /* Beauty site intent topic */
 "Beauty" = "Frumusețe";
@@ -1024,12 +1064,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button to copy post text" = "Buton pentru a copia textul articolului";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "Dacă continui, ești de acord cu _Termenii noștri de utilizare ai serviciului_.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "Prin înregistrarea acestui domeniu ești de acord cu\n<a>termenii&nbsp;și&nbsp;condițiile<\/a>.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "Prin inițializarea Jetpack ești de acord cu\n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "Prin înregistrare, ești de acord cu _Termenii noștri de utilizare ai serviciului_.";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "PERSONALIZEAZĂ";
@@ -1043,6 +1089,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "Pentru a scana codurile de autentificare, trebuie să dai acces la aparatul foto";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Nu poți solicita legătură";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "Nu pot publica o pagină goală";
 
@@ -1052,6 +1101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1061,6 +1111,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1079,6 +1130,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1106,6 +1158,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "Anulez...";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "Nu pot să accesez site-ul la această adresă. Te rog verifică încă o dată și încearcă din nou.";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Nu te poți decide? Poți să schimbi tema oricând.";
 
@@ -1113,7 +1168,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Text asociat";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Atenție!";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1122,7 +1178,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Categorii";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Categorie";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1171,6 +1228,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "Vezi sfaturile noastre importante pentru a mări numărul de vizualizări și a-ți crește traficul";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "Verifică-ți emailul primit pe acest dispozitiv!";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Verifică emailurile primite pe acest dispozitiv și atinge legătura din emailul primit de la WordPress.com.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "Verifică pe acest dispozitiv emailurile primite și atinge legătura din emailul primit de la WordPress.com.\n\nNu ai găsit emailul? Caută-l și în dosarul Spam sau Junk.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "Verifică-ți emailul!";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "Verifică dacă ai conexiune la internet și reîmprospătează pagina.";
@@ -1267,6 +1336,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "Revendică-ți domeniul gratuit";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "Blog clasic";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "Șterge cache-ul fișierelor media din dispozitiv";
 
@@ -1294,6 +1366,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Închidere";
 
@@ -1335,6 +1408,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "Setări coloane";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Benzi desenate";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1386,6 +1462,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Comentarii";
 
@@ -1453,12 +1530,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Conturi conectate";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Conectat dar...";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "Conectare cu %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Conectarea la %1$@ va înlocui actuala conectare la %2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Se conectează la WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Conectare...";
@@ -1489,8 +1572,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "Contactează-ne la %@";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "Structură conținut\nBlocuri: %1$li; cuvinte: %2$li; caractere: %3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1505,6 +1592,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Citește în continuare";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Continuă cu Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Continuă cu Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Continui cu Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "Contribuie";
@@ -1633,6 +1729,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "Creează";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Creează un cont";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "Creează o pagină goală";
 
@@ -1653,6 +1752,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "Creează un articol";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "Creează un site";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "Creează o etichetă";
@@ -1686,6 +1788,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "Curent";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Planul curent";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Temă curentă";
@@ -1788,6 +1893,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "Categorie implicită";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Meniu implicit";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Format implicit pentru articole";
@@ -1796,6 +1904,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "Implicite pentru articole noi";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Ștergre";
@@ -1853,6 +1962,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "Detalii";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "Nu ai vrut să creezi un cont nou? Mergi înapoi și reintrodu adresa ta de email.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "Dimensiuni";
 
@@ -1900,7 +2012,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "Discuție";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Refuză";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1922,6 +2036,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "Domenii";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "Nu ai un cont? _Sign up_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2051,6 +2168,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "Descărcări";
 
+/* Name for the status of a draft post. */
+"Draft" = "Ciornă";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Ciorne";
 
@@ -2160,7 +2280,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "Adresă email";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "Adresă email";
 
 /* Notification Settings Channel */
@@ -2244,8 +2367,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Introdu parola";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "Introdu adresa site-ului WordPress pe care vrei să-l conectezi.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Introdu parola pentru contul tău WordPress.com.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Introdu numele de utilizator";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "Introdu informațiile contului pentru %@.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "Introdu adresa ta de email pentru a te autentifica sau creează un cont WordPress.com.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "Introdu adresa site-ului tău de acum";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "În schimb, introdu parola.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "Introdu datele de conectare la server";
@@ -2408,6 +2551,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "Extern";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Eșuat";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "Marcarea notificărilor ca citite a eșuat";
 
@@ -2419,9 +2565,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Failed to insert media.\nTap for more info." = "Inserarea elementului media a eșuat.\nAtinge pentru mai multe informații.";
-
-/* A message indicating that we couldn't load the user's settings. */
-"Failed to load settings" = "Încărcarea setărilor a eșuat";
 
 /* No comment provided by engineer. */
 "Failed to save files.\nPlease tap for options." = "Salvarea fișierelor a eșuat.\nTe rog atinge pentru opțiuni.";
@@ -2437,6 +2580,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "Modă";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "Reprezentative";
@@ -2495,6 +2641,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "Află mai multe";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Găsește adresa site-ului";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2517,6 +2666,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "Înlătur amenințările...";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "Urmărire";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "Urmărește conversația";
@@ -2611,6 +2763,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "Generează o legătură nouă";
 
+/* View title for initial auth views. */
+"Get Started" = "Începe";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "Primești o legătură de autentificare prin email";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "Fii activ! Comentează la articole de pe blogurile pe care le urmărești.";
 
@@ -2632,8 +2790,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "Inspiră-te";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Preiau informațiile contului";
+
+/* Cancel */
+"Give Up" = "Renunț";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "Încearcă-le, adaugă câteva blocuri în articolele sau paginile tale!";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "Du-te la Cititor";
@@ -2644,6 +2811,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "Mergi la setările iOS";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Înregistrarea pe Google a eșuat.";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2718,6 +2888,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "Icon pentru ajutor";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Ascuns";
+
 /* Title of a button used to collapse a group */
 "Hide" = "Ascunde";
 
@@ -2786,6 +2959,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "Actualizare icon eșuată";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "Dacă nu ai găsit emailul, te rog să verifici și dosarele Junk și Spam";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "Dacă continui cu Apple sau Google și nu ai deja un cont WordPress.com, îți creezi un cont și ești de acord cu _Termenii de utilizare ai serviciului_ nostru.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "Dacă %1$@ este înlăturat, el nu va mai putea accesa acest site, dar întregul conținut creat de %2$@ va rămâne pe site.";
@@ -2861,6 +3040,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "Include wp-config.php și toate fișierele care nu sunt din WordPress";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Nume utilizator incorect sau parolă incorectă. Te rog încearcă să-ți introduci din nou detaliile de autentificare.";
 
 /* Title for a threat */
 "Infected core file" = "Fișier din nucleu infectat";
@@ -2962,6 +3144,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "Îți prezentăm îndemnurile pentru publicare";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "Adresa de email nu este validă";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "Adresa site-ului este invalidă";
 
@@ -2979,6 +3164,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "URL-ul nu este valid. Nu am găsit fișierul audio.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "URL-ul nu este valid. Te rog verifică încă o dată și încearcă din nou.";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "URL-ul nu este valid. Te rog să introduci un URL valid.";
@@ -3000,6 +3188,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "Invită persoane";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "Se pare că acest nume de utilizator nu este asociat sau această parolă nu este asociată cu acest site.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "Se pare că ai introdus o parolă incorectă. Vrei s-o mai încerci odată?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "Azi trebuie să publici pe %@!";
@@ -3228,7 +3422,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "Înălțime linie";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Legătură";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3290,6 +3485,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "Încarc People...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Se încarcă planul...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Încărcare planuri...";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "Încarc modulul...";
 
@@ -3324,11 +3525,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "Încarc...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Local";
+
 /* Local Services site intent topic */
 "Local Services" = "Servicii locale";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "Schimbări locale";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Locație";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Serviciile de localizare trebuie validate înainte ca WordPress să poată adăuga locația ta curentă. Te rog validează Serviciile de localizare din aplicația Setări.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Locație necunoscută";
 
 /* No comment provided by engineer. */
 "Lock icon" = "Icon blocare";
@@ -3336,9 +3549,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Fișierele de jurnalizare după data creării";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Autentificare";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3348,17 +3563,33 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of a button for signing in. */
 "Log in" = "Autentificare";
 
-/* LogOut confirmation text, whenever there are no local changes */
-"Log out of Jetpack?" = "Te dezautentifici de pe Jetpack?";
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Autentificarea a eșuat. Te rog încearcă din nou.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "Autentifică-te în WordPress.com sau înregistrează-te";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Autentifică-te în contul WordPress.com pe care l-ai folosit pentru a conecta Jetpack.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "Autentifică-te în contul tău WordPress.com cu adresa de email.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "Autentifică-te cu numele de utilizator și parola WordPress.com.";
 
 /* LogOut confirmation text, whenever there are no local changes */
-"Log out of Reader?" = "Te dezautentifici din Cititor?";
+"Log out of Jetpack?" = "Te dezautentifici de pe Jetpack?";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of WordPress?" = "Te dezautentifici de pe WordPress?";
 
 /* Login Request Expired */
 "Login Request Expired" = "Autentificare cerută expirată";
+
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "Autentifică-te cu parola contului";
 
 /* No comment provided by engineer. */
 "Logs" = "Jurnale";
@@ -3368,6 +3599,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Se pare că ai inițializat Jetpack pe site-ul tău. Felicitări! Autentifică-te pe WordPress.com cu datele tale de conectare pentru a activa statisticile și notificările.";
+
+/* Title of a button. */
+"Lost your password?" = "Ai uitat parola?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "Mail (implicit)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Navigare principală";
@@ -3515,6 +3752,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "Mesaj";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "Vulnerabilități diverse";
 
@@ -3610,6 +3850,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "Site-ul meu";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "Site-urile mele în WordPress";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "Primele zece cafenele, pe gustul meu";
 
@@ -3649,8 +3892,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Ai nevoie de ajutor?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "Ai nevoie de ajutor ca să-ți găsești adresa site-ului?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "Ai nevoie de ajutor?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Ai nevoie de mai mult ajutor?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "Necesită actualizare";
@@ -3679,6 +3929,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "Articol nou";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Element nou";
+
 /* Placeholder text for password field */
 "New password" = "Parolă nouă";
 
@@ -3696,7 +3949,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "Știri";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Următorul";
 
 /* Accessibility label for the next notification button */
@@ -3732,6 +3987,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "Nu este disponibil un URL de previzualizare";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "Fără titlu";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "Nu sunt disponibile activități";
 
@@ -3764,7 +4022,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "Niciun comentariu până acum";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "Nu ai conexiune";
 
@@ -3913,6 +4172,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "Nu acum";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "Nu ai găsit emailul? Uită-te și în dosarele Spam sau Junk.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "Notă:";
 
@@ -3976,7 +4238,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Listă numerotată";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -4033,7 +4300,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "Hopa";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Hopa!";
 
 /* No comment provided by engineer. */
@@ -4048,7 +4316,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "Deschide setările Securitate Jetpack";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "DESCHIDE CORESPONDENȚA";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Deschide setările";
 
 /* No comment provided by engineer. */
@@ -4066,6 +4339,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "Deschide legătură într-o fereastră\/filă nouă";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "Deschide setările de abonare pentru articol";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "Deschide secțiunea Eu";
 
@@ -4080,6 +4356,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "Opțional: introdu un mesaj personalizat care să conțină până la %1$d de caractere pentru a fi trimis împreună cu invitația ta.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "Sau";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "Sau alege o alt tip de autentificare.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "Sau autentifică-te prin _introducerea adresei site-ului tău_.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "Sau autentifică-te cu legătura magică";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Listă ordonată";
@@ -4128,7 +4416,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "Distanțare";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Pagină";
 
@@ -4161,8 +4450,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "Creșterea și educarea copiilor";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Parolă";
 
@@ -4170,7 +4462,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Password (optional)" = "Parolă (opțional)";
 
 /* Loader title displayed by the loading view while the password is changed successfully */
-"Password changed successfully" = "Am schimbat cu succes parola";
+"Password changed successfully" = "Parolă schimbată cu succes";
 
 /* No comment provided by engineer. */
 "Paste URL" = "Plasează URL-ul";
@@ -4179,8 +4471,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "Plasează blocul după";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "În așteptare";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "În curs de revizuire";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4211,6 +4507,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "Alege numele de utilizator";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Planuri";
+
 /* User action to play a video on the editor. */
 "Play video" = "Rulează videoul";
 
@@ -4240,6 +4540,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "Te rog asigură-te că editorul de blocuri este activat pe site-ul tău. Dacă nu este activat, el nu se va încărca.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "Te rog introdu adresa completă a site-ului web, adică exemplu.com.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "Te rog introdu o adresă de site.";
@@ -4274,11 +4577,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "Te rog introdu o adresă validă";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "Te rog introdu o adresă de email validă pentru un cont WordPress.com.";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Te rog să introduci o adresă de email validă.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "Te rog să introduci un număr valid de telefon";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Te rog introdu parola pentru contul tău WordPress.com pentru a te autentifica cu ID-ul Apple.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Te rog să-ți introduci datele de conectare";
@@ -4286,8 +4595,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Te rog să introduci adresa ta de email.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Te rog să completezi toate câmpurile";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Te rog lansează aplicația WordPress, autentifică-te în WordPress.com și asigură-te că ai cel puțin un site, apoi încearcă din nou.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "Te rog dezautentifică-te înainte de a te conecta la un alt site WordPress.com";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "Te rog să încerci din nou mai târziu";
@@ -4355,7 +4670,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "Limbi populare";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Articol";
 
@@ -4476,6 +4792,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "Notificări de confidențialitate pentru utilizatorii din California";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Privat";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "Este o problemă la afișarea blocului. \nAtinge pentru a încerca recuperarea blocului.";
 
@@ -4490,6 +4809,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "Problemă la achiziția domeniului tău. Te rog încearcă din nou.";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Continuând se vor îndepărta toate datele WordPress.com de pe acest dispozitiv și se vor șterge toate ciornele salvate local. Nu vei pierde nimic din ce a fost deja salvat pe blogul\/blogurile tale WordPress.com.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Proiecte";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "Am omis îndemnul";
@@ -4507,13 +4832,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "Data publicării";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Publică imediat";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "Publică pagina pe:";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "Publică articolul pe:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Publicat";
 
@@ -4715,7 +5044,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "Răspunde";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Text pentru răspuns";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "Răspunde-i lui %1$@";
 
 /* An explaination of a setting. */
@@ -4744,6 +5078,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "Resetează filtrul pentru interval de timp";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Resetează-ți parola";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Redimensionare și decupare";
@@ -4801,6 +5138,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "Reîncearcă-le pe toate";
 
+/* No comment provided by engineer. */
+"Retry?" = "Reîncerci?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "Revino la articol";
 
@@ -4830,6 +5170,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "Rol";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS trimis";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "STARE";
 
@@ -4841,6 +5184,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4907,7 +5251,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "Scanez fișierele";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Programat";
 
 /* No comment provided by engineer. */
@@ -5047,6 +5392,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "Selectează acest subiect ca un scop pentru site-ul tău.";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Trimite legătura";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "Trimite legătura prin email";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "Trimite un mesaj la jurnalizare";
 
@@ -5055,6 +5406,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "Trimite erorile fatale la testare";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "Trimite legătura de verificare prin email";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "Trimite notificări prin email";
@@ -5101,11 +5455,11 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Message to show when setting save failed */
 "Settings update failed" = "Actualizarea setărilor a eșuat";
 
-/* Title for a button that recommends the app to others */
-"Share Jetpack with a friend" = "Împărtășește Jetpack cu un prieten";
+/* Spoken accessibility label */
+"Share" = "Partajează";
 
 /* Title for a button that recommends the app to others */
-"Share Reader with a friend" = "Partajează Cititor unui prieten";
+"Share Jetpack with a friend" = "Împărtășește Jetpack cu un prieten";
 
 /* Title for a button that recommends the app to others */
 "Share WordPress with a friend" = "Împărtășește WordPress cu un prieten";
@@ -5156,6 +5510,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "Arată butonul de reblogare";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "Arată parola";
+
 /* No comment provided by engineer. */
 "Show post content" = "Arată conținutul articolului";
 
@@ -5167,6 +5525,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "Arăt statisticile pentru:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "Vizibilă";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Arată public când comentezi pe bloguri.";
@@ -5182,6 +5543,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "Arată articolul";
+
+/* View title during the sign up process. */
+"Sign Up" = "Înregistrare";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "Autentifică-te cu datele de conectare ale site-ului";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Înregistrare";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Înregistrează-te la WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Înregistrare prin email";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "Deoarece ai un plan gratuit, vei vedea numai anumite evenimente în jurnalul de activități.";
@@ -5220,6 +5596,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Realizări site";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Adresă site";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "Adresa site-ului trebuie să aibă cel puțin 4 caractere.";
@@ -5304,7 +5683,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Regret, adresele de site-uri trebuie să conțină și litere!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Regret, acea adresă de email este deja folosită!";
 
 /* No comment provided by engineer. */
@@ -5364,6 +5743,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "Spam";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "Accelerează-ți site-ul";
@@ -5389,6 +5771,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "Județ (provincie, stat)";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "Prima pagină statică";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5419,6 +5804,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "Barare";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Schiță";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "Trimite pentru verificare";
@@ -5509,7 +5897,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "Tabletă";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Etichetă";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5644,6 +6033,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Termenii de funcționare a serviciului";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Testimoniale";
+
 /* Title of a button style */
 "Text Only" = "Numai text";
 
@@ -5653,8 +6045,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "Când editezi un bloc Text, comenzile pentru formatarea textului se află în bara de unelte poziționată deasupra tastaturii.";
 
+/* Button title */
+"Text me a code instead" = "În schimb, trimite-mi un mesaj text cu un cod";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "Trimite-mi un cod prin SMS";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Mulțumim pentru că ai ales %1$@ de %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "Aceasta nu pare a fi un cod de verificare valid.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "Nu arată ca un site WordPress.";
@@ -5677,8 +6078,11 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "Conexiunea Facebook nu găsește nicio pagină. Publicitatea nu se poate conecta la profilurile Facebook, ci numai la pagini Facebook publicate.";
 
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "Contul Google „%@” nu se potrivește cu niciun cont de pe WordPress.com";
+
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
-"The Internet connection appears to be offline." = "Conexiunea la internet pare să fie offline.";
+"The Internet connection appears to be offline." = "Conexiunea la internet pare să fie oprită.";
 
 /* Message informing the user that the site title can only be changed by an administrator user. */
 "The Site Title can only be changed by a user with the administrator role." = "Titlul site-ului poate fi modificat numai de un utilizator cu rolul de administrator.";
@@ -5715,6 +6119,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "Imaginea nu a putut fi adăugată în Biblioteca media.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "Conexiunea la internet pare să fie decuplată.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "Tipurile de site care pot fi create";
@@ -5758,6 +6165,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Site-ul %1$@ folosește WordPress %2$@. Îți recomandăm să actualizezi la ultima versiune sau cel puțin la %3$@";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "Site-ul de la această adresă nu este un site WordPress. Pentru a-l putea conecta, site-ul trebuie să folosească WordPress.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "Site-ul nu a putut fi șters.";
 
@@ -5799,6 +6210,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "A fost o eroare neașteptată în timpul editării comentariului tău";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "A apărut o eroare neașteptată în timpul încărcării comentariilor.";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "A fost o eroare neașteptată în timpul înregistrării domeniului tău";
 
@@ -5807,6 +6221,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "A apărut o eroare neașteptată în timpul actualizării setărilor pentru notificări";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "A apărut o eroare neașteptată în timpul actualizării comentariului tău";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "A apărut o eroare neașteptată.";
@@ -5828,6 +6245,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "A fost o problemă de comunicare cu site-ul.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "A fost o problemă de conectare la WordPress.com. Te rog autentifică-te din nou.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "A fost o problemă la afișarea acestui articol.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "A fost o problemă la încărcarea datelor tale, reîmprospătează pagina pentru a încerca din nou.";
 
@@ -5837,12 +6260,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "A apărut o problemă la salvarea modificărilor gestiunii partajării.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "A apărut o problemă când am încercat să accesăm locația ta. Te rog încearcă din nou.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "A fost o eroare la schimbarea parolei";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "A fost o eroare la încărcarea activităților";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "A fost o eroare la încărcarea planurilor";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "A fost o eroare la încărcarea modulelor";
@@ -5855,6 +6284,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "A fost o eroare la încărcarea istoricului";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "A fost o eroare la încărcarea planului";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "A fost o eroare la încărcarea istoricului scanărilor";
@@ -5903,6 +6335,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "Acest domeniu nu este disponibil";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "Această adresă de email nu este înregistrată pe WordPress.com.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "Acest fișier este prea mare pentru a fi încărcat pe site-ul tău sau nu suportă acest format în media.";
@@ -5983,6 +6418,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "Fus orar";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "Timpul a expirat, dar nu îți face griji, securitatea ta este prioritatea noastră. Te rog să încerci din nou.";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "Sfaturi pentru a folosi la maxim WordPress.com.";
 
@@ -5996,6 +6434,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "Pentru a continua te rog introdu adresa ta de email și numele.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "Pentru a-ți crea un cont WordPress.com nou, te rog introdu adresa ta de email.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "Pentru a primi notificări utile pe telefon de la site-ul tău WordPress, va trebui să instalezi modulul Jetpack.";
 
@@ -6004,6 +6445,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "Pentru a instala module, trebuie să ai un domeniu personalizat asociat cu site-ul tău.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "Pentru a continua cu acest ID Apple, mai întâi te rog să te autentifici cu parola WordPress.com. Acest lucru va fi cerut o singură dată.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "Pentru a continua cu acest cont Google, mai întâi te rog să te autentifici cu parola WordPress.com. Acest lucru va fi cerut o singură dată.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "Pentru a înlătura un bloc, selectează blocul și dă clic pe cele trei puncte din dreaptă jos a blocului pentru a vizualiza setările. Acolo, alege opțiunea de a înlătura blocul.";
@@ -6078,7 +6525,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "Coș de gunoi";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "Aruncate la gunoi";
 
@@ -6092,6 +6540,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "Încearcă și personalizează";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Încearcă din nou";
@@ -6117,6 +6566,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "Încearcă noul Editor de blocuri";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Încearcă cu un alt email";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Încearcă cu adresa site-ului";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "Oprește îndemnurile";
@@ -6159,6 +6614,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "UTILIZĂRI";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "Nu mă pot conecta";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "Nu pot încărca articole";
@@ -6208,6 +6666,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Nu pot rula videoul";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Nu pot să găsesc site-ul WordPress la acel URL. Atinge „Ai nevoi de mai mult ajutor?” pentru a vedea Întrebări frecvente.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Nu pot să restaurez site-ul";
 
@@ -6234,6 +6695,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "Nu pot încărca un articol, un fișier";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "Nu pot verifica adresa de email. Te rog reîncearcă mai târziu.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "Nu pot să vizitez setările Jetpack pentru site";
@@ -6378,7 +6842,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Încărcarea a eșuat";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Încărcat";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6396,7 +6861,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Teme încărcate";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Încarc";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6411,18 +6877,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "Folosește";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "Folosește o cheie de securitate";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "Folosește editorul de blocuri";
 
 /* No comment provided by engineer. */
 "Use icon button" = "Folosește butonul icon";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "Folosește parola pentru autentificare";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Nume utilizator";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6437,6 +6912,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Utilizatori";
+
+/* two factor code placeholder */
+"Verification code" = "Cod de verificare";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "Email de confirmare trimis, verifică-ți emailurile primite.";
@@ -6569,8 +7047,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "Directorul wp-content";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Aștept să finalizeze Google...";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "Aștept conexiunea";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "Aștept cheia de securitate";
+
+/* View title during the Google auth process. */
+"Waiting..." = "Așteaptă...";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6610,6 +7098,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "Am avut probleme cu încărcarea datelor";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "Tocmai am trimis o legătură la %@. Te rog vezi emailul primit și atinge legătura pentru a te autentifica.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "Tocmai am trimis o legătură magică la";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "Am creat cu succes o copie de siguranță a site-ului tău la %@";
 
@@ -6619,14 +7113,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "Folosim și alte instrumente de urmărire, inclusiv unele de la terți. Citește despre ele și despre cum le controlăm.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "N-am putut să-ți trimitem un email acum. Te rog reîncearcă mai târziu.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Îți vom trimite un email dacă găsim amenințări de securitate. Între timp îți poți folosi site-ul așa cum o faci de obicei și poți vedea oricând desfășurarea procesului de scanare.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "Îți vom trimite prin email o legătură magică care te va autentifica instantaneu, fără nicio parolă. Nu te mai chinui să tastezi!";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "Îți vom trimite prin email o legătură de înregistrare pentru a-ți crea noul cont WordPress.com.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "Te vom notifica când ai urmăritori noi, primești comentarii și aprecieri.";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "Te vom notifica când ai urmăritori, comentarii și aprecieri noi. Vrei să activezi notificările imediate?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "Vom folosi această adresă de email pentru a-ți crea noul cont WordPress.com.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "Creăm o copie de siguranță a site-ului tău la %1$@, care poate fi descărcată.";
@@ -6637,6 +7143,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Lucrăm din greu (în fundal) pentru înlăturarea acestor amenințări. Între timp, îți poți folosi site-ul așa cum o faci de obicei și poți vedea oricând progresul făcut.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "Nu putem să ne conectăm la site-ul Jetpack la acel URL. Contactează-ne pentru asistență.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "Îți restaurăm site-ul înapoi la %1$@.";
 
@@ -6645,6 +7154,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "De asemenea, ți-am trimis prin email o legătură la fișierul tău.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Ți-am trimis prin email o legătură de înregistrare pentru a-ți crea noul cont WordPress.com. Verifică emailurile primite pe acest dispozitiv și atinge legătura din emailul primit de la WordPress.com.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6671,6 +7183,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "Rezumat săptămânal: %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "Bine ai venit la Jetpack";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Bine ai venit la WordPress";
 
 /* A message title */
 "Welcome to the Reader" = "Bine ai venit în cititor";
@@ -6715,6 +7233,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "Ce este Gravatar?";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "Ce este WordPress.com?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "Ce este un bloc?";
 
@@ -6731,10 +7252,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "What's New in Jetpack" = "Care sunt noutățile din Jetpack";
 
 /* Opens the What's New / Feature Announcement modal */
-"What's New in Reader" = "Care sunt noutățile în Cititor";
-
-/* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "Care sunt noutățile în WordPress";
+
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "Care este adresa site-ului meu?";
 
 /* Select the site's intent. Title */
 "What's your website about?" = "Despre ce este site-ul tău web?";
@@ -6748,6 +7269,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "Când faci modificări pe site-ul tău, aici vei putea vedea istoricul activităților.";
 
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Hopa, ceva a mers prost și nu te-am putut autentifica. Te rog reîncearcă!";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "Ceva nu a mers bine. Te rog să încerci din nou.";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "Această cheie de securitate nu pare a fi validă. Te rog să încerci din nou cu alta";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Hopa, acesta nu este un cod valid de verificare cu doi-factori. Verifică-ți din nou codul și reîncearcă!";
+
 /* No comment provided by engineer. */
 "Width Settings" = "Setări lățime";
 
@@ -6760,17 +7293,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "Setări aplicații WordPress";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "Aplicații WordPress - aplicații pentru orice tip de ecran";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "Blog WordPress ";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "Ajutor WordPress";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "Bibliotecă Media WordPress";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "Setări notificări WordPress";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "Notificări WordPress";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "Module WordPress";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "Profil WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "Cititor WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "Detalii site WordPress";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "Teme WordPress";
@@ -6781,17 +7335,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "Instalările WordPress multi-site nu sunt acceptate";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress are nevoie de permisiunea de a accesa locația curentă de pe dispozitivul tău pentru a o adăuga articolului. Te rog actualizează setările tale de confidențialitate.";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "Rădăcină WordPress";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "Versiune de WordPress prea veche";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Versiunea WordPress este prea veche. Site-ul %1$@ folosește WordPress %2$@. Îți recomandăm să actualizezi la ultima versiune sau cel puțin la %3$@";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "Cont WordPress.com";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "Planuri WordPress.com";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "Teme WordPress.com";
@@ -6822,6 +7385,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "Scrie un articol";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "Scrie un răspuns";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "Scrie un răspuns...";
 
 /* Title for the writing section in site settings screen */
@@ -6835,6 +7401,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Poziție pe axa Y";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "An";
@@ -6919,6 +7488,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Displayed when the user views trashed in the posts list and there are no posts */
 "You don't have any trashed posts" = "Nu ai niciun articol aruncat la gunoi";
 
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"You don't have permission to view this private blog." = "Nu ai permisiunea să vezi acest blog privat.";
+
 /* Description for the first domain purchased with a paid plan. */
 "You have a free one-year domain registration with your plan." = "În planul tău ai o înregistrare gratuită pentru un domeniu în primul an.";
 
@@ -6934,7 +7506,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "Nu ai setat nicio reamintire.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Ai modificări nesalvate.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -7021,9 +7594,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Help text that describes how the password should be. It appears while editing the password */
 "Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ & )." = "Parola ar trebui să aibă cel puțin șase caractere. Pentru a o face mai puternică, folosește majuscule și minuscule, cifre și simboluri, cum ar fi ! \" ? $ % ^ &amp; ).";
 
-/* Message of Export Content confirmation alert */
-"Your posts, pages, and settings will be mailed to the account's email address." = "Articolele, paginile și setările tale vor fi trimise prin email la adresa de email a contului.";
-
 /* Message of Export Content confirmation alert; substitution is user's email address */
 "Your posts, pages, and settings will be mailed to you at %@." = "Articolele, paginile și setările ți se vor trimite prin email la %@.";
 
@@ -7032,6 +7602,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "Căutarea ta include caractere care nu sunt acceptate în domeniile WordPress.com. Sunt permise următoarele caractere: A–Z, a–z, 0–9.";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "Când îți vizitezi site-ul în Safari, adresa site-ului tău apare în bara din partea de sus a ecranului.";
 
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "Site-ul este deja protejat de VaultPress. Mai jos găsești o legătură la panoul de control VaultPress.";
@@ -7111,17 +7684,23 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility identifier for an 'Add Comment' button */
 "addCommentButton.accessibilityIdentifity" = "Adaugă un comentariu";
 
-/* Error message when user cancels login */
-"addSite.selfHosted.cancelled" = "Autentificarea a fost anulată";
+/* Error message shown a URL does not point to an existing site. */
+"addSite.restApiNotAvailable" = "Site-ul de la această adresă nu este un site WordPress. Pentru a-l putea conecta, site-ul trebuie să folosească WordPress.";
+
+/* Error message shown when an receiving an invalid application-password authentication result from a self-hosted WordPress site */
+"addSite.selfHosted.authenticationFailed" = "Nu mă pot autentifica folosind autentificarea în Parole pentru aplicații.";
 
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "Introdu adresa site-ului WordPress pe care vrei să-l conectezi.";
 
+/* Error message when user input is not a WordPress site */
+"addSite.selfHosted.invalidUrl" = "Adresa site-ului nu este validă.";
+
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "Nu am putut să încarc detaliile despre site-ul WordPress";
 
-/* Error message when user signs in with an unexpected usern. The first argument is the expected username */
-"addSite.selfHosted.mismatchUser" = "Te rog să te autentifici cu utilizatorul pentru autentificare. Nume utilizator: %@";
+/* Error message shown when application-password authentication is disabled on a self-hosted WordPress site */
+"addSite.selfHosted.noLoginUrlFound" = "Autentificarea în Parole pentru aplicații trebuie să fie activată pe site-ul WordPress.";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "Nu pot să salvez site-ul WordPress, te rog să reîncerci mai târziu.";
@@ -7129,17 +7708,14 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "Adaugă un site auto-găzduit";
 
-/* Error message when XML-RPC is disabled on the WordPress site. The first argument is detailed error message */
-"addSite.selfHosted.xmlrpcDisabled" = "Nu am putut face conexiunea la site-ul WordPress. Probabil metodele XML-RPC au fost dezactivate pe server. Te rog să contactezi furnizorul tău de găzduire pentru a rezolva această problemă.";
+/* Error message when an unknown error occurred when adding a self-hosted site */
+"addSite.selfHosted.unknownError" = "Ceva nu a mers bine. Te rog să încerci din nou.";
 
 /* Age between dates equaling one hour. */
 "an hour" = "o oră";
 
 /* This is the string we display when prompting the user to review the Jetpack app */
 "appRatings.jetpack.prompt" = "Ce părere ai despre Jetpack?";
-
-/* This is the string we display when prompting the user to review the Reader app */
-"appRatings.reader.prompt" = "Ce părere ai despre Cititor?";
 
 /* This is the string we display when prompting the user to review the WordPress app */
 "appRatings.wordpress.prompt" = "Ce părere ai despre WordPress?";
@@ -7843,6 +8419,10 @@ Example: Reply to Pamela Nguyen */
 /* A name of the ID field (it's a technical field, has to be short, displayed below everything else) */
 "entityMetadataFooterView.id" = "ID";
 
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "exemplu.com";
+
 /* Accept button title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackAccept" = "Trimite-ne impresii";
 
@@ -7854,9 +8434,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackTitle" = "Spune-ne părerea";
-
-/* Communicates the future removal of the option to disable the experimental editor, displayed beneath the experimental features list */
-"experimentalFeatures.editorNote" = "Editorul de blocuri experimental va deveni implicit într-o versiune viitoare și posibilitatea de a-l dezactiva va fi înlăturată.";
 
 /* The title for the experimental features list */
 "experimentalFeaturesList.heading" = "Funcționalități experimentale";
@@ -7903,8 +8480,14 @@ Example: Reply to Pamela Nguyen */
 /* A footer retry button */
 "general.pagingFooterView.retry" = "Reîncearcă";
 
+/* Error message format when REST API returns an error response. The first argument is error message. */
+"generic.error.rest-api-error" = "Site-ul tău a trimis un răspuns cu eroare: %@";
+
 /* A generic title for an error */
 "generic.error.title" = "Eroare";
+
+/* Error message when failing to parse API responses */
+"generic.error.unparsableResponse" = "Site-ul tău a trimis un răspuns pe care aplicația nu l-a putut interpreta";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "Setează reamintirile pentru publicare";
@@ -8076,42 +8659,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title of the Jetpack powered overlay. */
 "jetpack.branding.overlay.title" = "WordPress este mai bun cu Jetpack";
-
-/* Title for the button that starts the Jetpack connection process */
-"jetpack.connection.connect.button" = "Conectează-ți site-ul";
-
-/* Error message shown when WordPress.com authentication fails */
-"jetpack.connection.error.authentication" = "Contul WordPress.com nu este valid";
-
-/* Error message shown when a connection step is attempted in an invalid order */
-"jetpack.connection.error.context" = "Acest pas nu este încă gata";
-
-/* Title for the retry button shown when a connection step fails */
-"jetpack.connection.retry.button" = "Reîncearcă";
-
-/* Status message when a connection step is pending */
-"jetpack.connection.stage.pending" = "Aștept să înceapă";
-
-/* Status message when a connection step is in progress */
-"jetpack.connection.stage.processing" = "În desfășurare...";
-
-/* Status message when a connection step is completed successfully */
-"jetpack.connection.stage.success" = "Finalizată";
-
-/* Title for the finalization step in Jetpack connection flow */
-"jetpack.connection.step.finalize.title" = "Finalizează conexiunea";
-
-/* Title for the install step in Jetpack connection flow */
-"jetpack.connection.step.install.title" = "Instalează Jetpack";
-
-/* Title for the login step in Jetpack connection flow */
-"jetpack.connection.step.login.title" = "Autentifică-te în WordPress.com";
-
-/* Title for the site connection step in Jetpack connection flow */
-"jetpack.connection.step.site.title" = "Conectează-te la site";
-
-/* Title for the user connection step in Jetpack connection flow */
-"jetpack.connection.step.user.title" = "Conectează-ți contul WordPress.com";
 
 /* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
 "jetpack.fullscreen.overlay.early.switch.title" = "Comută la noua aplicație Jetpack";
@@ -8332,41 +8879,11 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "Nu ai permisiunea să vezi acest blog privat.";
 
-/* Button to dismiss the re-authentication view */
-"login.appPasswordReAuth.cancelButton" = "Anulează";
-
-/* Description explaining why the user needs to re-authenticate */
-"login.appPasswordReAuth.description" = "Parola pentru aplicație care a fost atribuită nu mai există în profilul tău.\nTe rog să te autentifici din nou pentru a crea o parolă nouă pentru aplicație.";
-
-/* Button to start the re-authentication process */
-"login.appPasswordReAuth.signInButton" = "Autentificare";
-
-/* Title shown when the application password is invalid */
-"login.appPasswordReAuth.title" = "Parola pentru aplicația nu este validă";
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "Te rog să introduci codul de verificare din aplicația de autentificare pentru contul tău WordPress.com.";
 
 /* Indicating that referrer was marked as spam */
 "marked as spam" = "marcat ca spam";
-
-/* Button title when verification link sending failed */
-"me.verifyEmail.button.retry" = "Încearcă din nou";
-
-/* Button title to send verification link */
-"me.verifyEmail.button.send" = "Retrimite emailul";
-
-/* Button title while verification link is being sent */
-"me.verifyEmail.button.sending" = "Trimit...";
-
-/* Button title after verification link is sent */
-"me.verifyEmail.button.sent" = "Am trimis emailul";
-
-/* Message for email verification card */
-"me.verifyEmail.message.noEmail" = "Confirmă-ți adresa de email pentru a-ți securiza contul și a accesa mai multe funcționalități.\nVerifică emailurile primite și caută emailul de confirmare sau dă clic pe „%@” pentru a primi unul nou.";
-
-/* Message for email verification card with email address */
-"me.verifyEmail.message.withEmail" = "Confirmă-ți adresa de email pentru a-ți securiza contul și a accesa mai multe funcționalități.\nVerifică emailurile primite la %1$@ și caută emailul de confirmare sau dă clic pe „%2$@” pentru a primi unul nou.";
-
-/* Title for email verification card */
-"me.verifyEmail.title" = "Confirmă-ți adresa de email";
 
 /* Me tab menu items */
 "meMenu.submitFeedback" = "Trimite-ne impresii";
@@ -8809,6 +9326,9 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "Pagină părinte";
 
+/* No comment provided by engineer. */
+"password" = "parolă";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "Cartușele pot să afișeze conținut diferit în funcție de ceea ce se întâmplă pe site-ul tău. Lucrăm la mai multe cartușe și comenzi.";
 
@@ -8913,9 +9433,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Message shown while loading plugin details */
 "pluginDetails.loading" = "Încarc informațiile despre modul...";
-
-/* Placeholder message shown when a plugin has no description */
-"pluginDetails.noDescription" = "Acest modul nu a oferit nicio descriere.";
 
 /* Title of the changelog section in plugin details */
 "pluginDetails.section.changelog" = "Istoric modificări";
@@ -9205,6 +9722,30 @@ Example: Reply to Pamela Nguyen */
 /* An alert message explaning that by changing the visibility to private, the post will be published immediately to your site */
 "postSettings.warningPostWillBePublishedAlertMessage" = "Dacă schimbi vizibilitatea în „Privat”, articolul va fi publicat imediat";
 
+/* Localized post type: `Page` */
+"postType.page" = "pagină";
+
+/* Localized post type: `Post` */
+"postType.post" = "articol";
+
+/* Details for a 'Private' privacy setting */
+"postVisibility.private.details" = "Vizibil numai pentru administratorii și editorii site-ului";
+
+/* Title for a 'Private' privacy setting */
+"postVisibility.private.title" = "Privat";
+
+/* Details for a 'Password Protected' privacy setting */
+"postVisibility.protected.details" = "Vizibil pentru toată lumea, dar necesită o parolă";
+
+/* Title for a 'Password Protected' privacy setting */
+"postVisibility.protected.title" = "Protejat cu parolă";
+
+/* Details for a 'Public' (default) privacy setting */
+"postVisibility.public.details" = "Vizibil pentru toată lumea";
+
+/* Title for a 'Public' (default) privacy setting */
+"postVisibility.public.title" = "Public";
+
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Anulează";
 
@@ -9425,18 +9966,6 @@ Tapping on this row allows the user to edit the sharing message. */
 /* Title for the success view when the user has successfully logged in */
 "qrLoginVerifyAuthorization.completedInstructions.title" = "Ești autentificat!";
 
-/* No comment provided by engineer. */
-"reachability-utils.alert.cancel" = "OK";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.retry" = "Reîncerci?";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.title" = "Nu ai conexiune";
-
-/* Message of error prompt shown when no internet connection is available */
-"reachability-utils.alert.utils" = "Conexiunea la internet pare să fie offline.";
-
 /* Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog. */
 "reader.blocked.blog.message" = "Blogul %@ nu va mai apărea în Cititor. Atinge pentru a reveni.";
 
@@ -9473,26 +10002,8 @@ Tapping on this row allows the user to edit the sharing message. */
 /* A shared button title for Reader */
 "reader.button.unsubscribe" = "Dezabonează-te";
 
-/* Button title. Follow the comments on a post. */
-"reader.comments.buttonFollow" = "Urmărește";
-
 /* Informational message, should be short. */
 "reader.comments.commentsClosed" = "Comentariile sunt închise";
-
-/* Empty state view title */
-"reader.comments.emptyStateTitle" = "Fii primul care lasă un comentariu.";
-
-/* Empty state view title */
-"reader.comments.errorLoadingComments" = "A apărut o eroare neașteptată în timpul încărcării comentariilor.";
-
-/* VoiceOver hint */
-"reader.comments.followingSettingAccessibilityIdentifier" = "Deschide setările de notificare pentru articol";
-
-/* Error message that informs reader comments from a private blog cannot be fetched. */
-"reader.comments.noPermissionToViewPrivateBlog" = "Nu ai permisiunea să vezi acest blog privat.";
-
-/* Navigation title */
-"reader.comments.title" = "Comentarii";
 
 /* Accessibility hint to inform that the author section can be tapped to see posts from the site. */
 "reader.detail.header.authorInfo.a11y.hint" = "Vezi articolele de pe site";
@@ -9570,23 +10081,8 @@ but tapping on this button will remove their like from the post. */
 /* Screen header details */
 "reader.following.header.details" = "Ești la curent cu blogurile la care te-ai abonat.";
 
-/* Empty state view */
-"reader.following.lists.emptyTitle" = "Liste goale";
-
-/* Screen header details */
-"reader.home.header.details" = "Ești la curent cu blogurile la care te-ai abonat.";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.home.title" = "Prima pagină";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.library.title" = "Bibliotecă";
-
 /* Used in multiple contexts, usually as a screen title */
 "reader.likes.title" = "Aprecieri";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.lists.title" = "Liste";
 
 /* Reader logged-out screen details */
 "reader.loggedOut.details" = "Autentifică-te cu un cont WordPress.com ca să urmărești blogurile preferate";
@@ -9829,8 +10325,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title of a Reader tab showing Posts matching a user's search query */
 "reader.search.tab.posts" = "Articole";
 
-/* Title of the Reader's search feature
-   Used in multiple contexts, usually as a screen title */
+/* Title of the Reader's search feature */
 "reader.search.title" = "Caută";
 
 /* Screen title. Reader select interests title label text. */
@@ -9856,6 +10351,21 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Reader select interests title label text */
 "reader.select.tags.title" = "Descoperi și urmărești blogurile care îți plac";
+
+/* Reader sidebar menu item */
+"reader.sidebar.discover" = "Descoperă";
+
+/* Reader sidebar menu item */
+"reader.sidebar.likes" = "Aprecieri";
+
+/* Reader sidebar menu item */
+"reader.sidebar.recent" = "Recente";
+
+/* Reader sidebar menu item */
+"reader.sidebar.saved" = "Salvate";
+
+/* Reader sidebar menu item */
+"reader.sidebar.search" = "Caută";
 
 /* Reader sidebar section title */
 "reader.sidebar.section.favorites.title" = "Preferate";
@@ -9905,7 +10415,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Number of subscriptions on a site (singular) */
 "reader.subscriptions.subscriptionsSingular" = "%@ abonat";
 
-/* Used in multiple contexts, usually as a screen title */
+/* Navigation bar title */
 "reader.subscriptions.title" = "Abonamente";
 
 /* A suggestion of topics the user might want to subscribe to */
@@ -9947,29 +10457,11 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Verb. Button title. The user is following a tag. */
 "reader.tags.following.button.title" = "Urmărești";
 
-/* Used in multiple contexts, usually as a screen title */
-"reader.tags.title" = "Etichete";
-
 /* Accessibility label for unsubscribing from a tag */
 "reader.tags.unfollow.accessibility.label" = "Anulează urmărirea %@";
 
 /* Field title */
 "reader.userProfile.site" = "Site";
-
-/* Reader Welcome screen login button */
-"reader.welcome.continueText" = "Continuă cu WordPress.com";
-
-/* Reader Welcome screen */
-"reader.welcome.subtitle" = "Alătură-te celei mai mari comunități pentru blogging";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.discover" = "Descoperă";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.me" = "Eu";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.notifications" = "Notificări";
 
 /* Spoken accessibility label */
 "readerDetail.backButton.accessibilityLabel" = "Înapoi";
@@ -10247,14 +10739,10 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Message shown when there are no inactive plugins on the site */
 "site.plugins.empty.inactive" = "Nu ai module inactive";
 
-/* The plugin fillter option for displaying active plugins */
-"site.plugins.filter.option.active" = "Active";
-
-/* The plugin fillter option for displaying all plugins */
+/* The plugin fillter option for displaying active plugins
+   The plugin fillter option for displaying all plugins
+   The plugin fillter option for displaying inactive plugins */
 "site.plugins.filter.option.all" = "Toate";
-
-/* The plugin fillter option for displaying inactive plugins */
-"site.plugins.filter.option.inactive" = "Inactive";
 
 /* Title of the plugin filter picker */
 "site.plugins.filter.title" = "Filtrează";
@@ -10806,9 +11294,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* View title for Help & Support page. */
 "support.title" = "Ajutor";
 
-/* Subject of new Zendesk ticket. */
-"support.zendesk.readerAppTicketSubject" = "Suport Cititor pentru iOS";
-
 /* Title for placeholder in Tenor picker */
 "tenor.welcomeMessage" = "Caută pentru a găsi imagini GIF pe care să le adaugi în biblioteca ta Media!";
 
@@ -10957,8 +11442,119 @@ Feel free to replace it with other bracket types that you think looks better for
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "Stare";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "Total general articole și cele mai multe vizualizări";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "Total general vizualizări";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "Total general vizualizări și vizitatori";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "Cele mai multe vizualizări";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "Cele mai multe vizualizări";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "Nu pot încărca statisticile de la început.";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "Creează sau adaugă un site pentru a vedea statisticile de la început.";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Articole";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "Ești la curent cu toate activitățile pe site-ul tău WordPress.";
+
+/* Title of all time widget */
+"widget.alltime.title" = "Total general";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "Autentifică-te în WordPress pentru a vedea toate statisticile.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "Autentifică-te în Jetpack pentru a vedea toate statisticile.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "Autentifică-te în Jetpack pentru a vedea statisticile din această săptămână.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "Autentifică-te în Jetpack pentru a vedea statisticile de azi.";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "Total general vizualizări";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "Vizualizări azi";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "Nu pot încărca statisticile pentru această săptămână.";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "Creează sau adaugă un site pentru a vedea statisticile din această săptămână.";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "Ești la curent cu activitățile din această săptămână pe site-ul tău WordPress.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "Săptămâna aceasta";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "Autentifică-te în WordPress pentru a vedea statisticile din această săptămână.";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Comentarii";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "Statisticile s-au mutat în aplicația Jetpack. Comutarea este gratuită și durează doar un minut.";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Aprecieri";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "Nu pot să încarc statisticile site-ului.";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "Nu pot încărca statisticile de astăzi.";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "Creează sau adaugă un site pentru a vedea statisticile de astăzi.";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "Ești la curent cu activitățile de azi pe site-ul tău WordPress.";
+
+/* Title of today widget */
+"widget.today.title" = "Azi";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "Autentifică-te în WordPress pentru a vedea statisticile de azi.";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "Vizualizarea nu este disponibilă";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Vizualizări";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Vizitatori";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "Aprecierile și comentariile de azi";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "Vizualizările de azi";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "Vizualizările și vizitatorii de azi";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "va fi indisponibil în viitor.";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "Începi un site nou?";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "wordpress, ajutor, suport, întrebări frecvente, întrebări, depanare, jurnale, centru de ajutor, contact";
@@ -10983,6 +11579,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Error message that describes an unknown error had occured */
 "wordpress-api.error.unknown" = "Ceva nu a mers bine, te rog să reîncerci mai târziu.";
+
+/* Error message when failing to find selected media file on the user's device. */
+"wordpress.api.upload.media.fileNotFound" = "Nu pot să localizez fișierul media pe dispozitiv";
 
 /* Jetpack Plugin Modal on WordPress primary button title */
 "wordpress.jetpack.plugin.modal.primary.button.title" = "Comută la aplicația Jetpack";
@@ -11029,21 +11628,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Error message when user signs in with an unexpected email address. The first argument is the expected email address */
 "wpComLogin.error.mismatchedEmail" = "Te rog să te autentifici cu adresa de email %@";
 
-/* Message shown when user denies WordPress.com login, offering option to try with different account */
-"wpComLogin.loginDenied.message" = "Poți să te autentifici cu un alt cont dacă ai nevoie de unul diferit. Apasă pe „%@” pentru a începe.";
-
-/* Title of alert shown when user cancels WordPress.com login */
-"wpComLogin.loginDenied.title" = "Autentificarea este anulată";
-
-/* Button title for signing in with a different WordPress.com account */
-"wpComLogin.loginDenied.useDifferentAccount" = "Folosește un alt cont";
-
-/* Button title to log out the current WordPress.com account */
-"wpcom.token.alert.button.logout" = "Dezautentificare";
-
-/* Button title to Sign In to WordPress.com */
-"wpcom.token.alert.button.signin" = "Autentificare";
-
 /* Message title to be displayed when the user needs to re-authenticate their WordPress.com account. */
 "wpcom.token.fix.signin" = "Autentificare la WordPress.com";
 
@@ -11058,6 +11642,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "Atașamentul nu este acceptat";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Autentifică-te cu Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Domenii";

--- a/WordPress/Resources/ru.lproj/Localizable.strings
+++ b/WordPress/Resources/ru.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Translation-Revision-Date: 2025-05-13 15:54:08+0000 */
+/* Translation-Revision-Date: 2025-03-12 10:54:08+0000 */
 /* Plural-Forms: nplurals=3; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2); */
 /* Generator: GlotPress/4.0.1 */
 /* Language: ru */
@@ -98,6 +98,9 @@
 
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "%1$@ из %2$@ на вашем сайте";
+
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "Используется %1$@ из %2$@";
 
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ квадриллион(-ов)";
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Без названия)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(без заголовка)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*Александр Петров* ответил на вашу запись";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "При нажатии на кнопку «Ещё» открывается список кнопок «Поделиться»";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "Учётная запись WordPress.com подключена к вашим учётным данным магазина. Чтобы продолжить, перейдите по ссылке для подтверждения, которую мы отправили на указанный адрес электронной почты.";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "Файл содержит элемент вредоносного кода";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "Название сайта";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "Чтобы отправить ссылку для аутентификации, необходим действительный адрес эл. почты. Вернитесь на предыдущий экран и укажите действительный адрес эл. почты.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "Код проверки будет содержать только цифры.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "АКТИВНО";
@@ -334,9 +349,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* My Profile 'About me' label */
 "About Me" = "Обо мне";
-
-/* Link to About screen for Jetpack for iOS */
-"About Reader for iOS" = "О приложении «Читалка» для iOS";
 
 /* Link to About screen for WordPress for iOS */
 "About WordPress" = "О WordPress";
@@ -525,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "После %@";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "Выравнивание";
@@ -588,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "Разрешённые IP-адреса";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "Почти готово! Введите проверочный код из приложения Authenticator.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Атрибут alt";
@@ -600,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "Альтернативно вы можете сгладить содержимое, разгруппировав блок.";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "В качестве альтернативы можно ввести пароль для этой учётной записи.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "Альтернативно:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "Всегда отсылать отчеты о падениях";
@@ -621,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "Требуется работающее подключение к интернет чтобы просматривать активность";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "Для просмотра тарифных планов требуется подключение к Интернету.";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -671,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "Статистика сайта за год";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "Аноним";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "Ответ";
 
@@ -692,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "Внешний вид";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "Ошибка авторизации в Apple.\nУбедитесь что вы вошли в iCloud с Apple ID использующим 2 факторную авторизацию.";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "Применить настройку";
@@ -778,6 +811,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "Сбой аутентификации";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "Код авторизации";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "Необходима авторизация для доступа к узлу: %@";
@@ -888,6 +925,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "Будьте первым, кто оставит комментарий";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Ваш комментарий будет первым.";
 
 /* Beauty site intent topic */
 "Beauty" = "Красота";
@@ -1024,12 +1064,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button to copy post text" = "Кнопка для копирования текста записи";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "Продолжив, вы соглашаетесь с нашими _Правилами пользования_.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "Регистрируя этот домен, вы соглашаетесь с нашими <a>Правилами&nbsp;и&nbsp;условиями<\/a>.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "Устанавливая Jetpack, вы принимаете наши\n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "Регистрируясь вы соглашаетесь с нашими _Правилами пользования_.";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "НАСТРОИТЬ";
@@ -1043,6 +1089,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "Для сканирования кодов на вход нужен доступ к камере";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Не удаётся запросить ссылку.";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "Нельзя опубликовать пустую страницу";
 
@@ -1052,6 +1101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1061,6 +1111,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1079,6 +1130,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1106,6 +1158,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "Отмена...";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "Невозможно открыть сайт по этому адресу. Проверьте данные и повторите попытку.";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Не можете выбрать? Изменить тему можно в любой момент.";
 
@@ -1113,7 +1168,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Подпись";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Осторожно!";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1122,7 +1178,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Рубрики";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Рубрика";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1171,6 +1228,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "Прочитайте советы по повышению просмотров и посещаемости";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "Проверьте электронную почту на этом устройстве!";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Проверьте почту на этом устройстве и нажмите ссылку в письме от WordPress.com.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "Проверьте вашу почту и нажмите на ссылку в сообщении полученном от\nWordPress.com\n\nНе нашли сообщение ? Поищите в спаме.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "Проверьте ваш адрес email!";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "Проверьте подключение к Интернету и проведите пальцем, чтобы обновить экран.";
@@ -1267,6 +1336,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "Получите свой домен бесплатно";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "Классический блог";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "Очистить мультимедиа кеш устройства";
 
@@ -1294,6 +1366,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Закрыть";
 
@@ -1335,6 +1408,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "Настройки столбцов";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Комиксы";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1386,6 +1462,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Комментарии";
 
@@ -1453,12 +1530,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Подключенные учетные записи";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Подключено, но...";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "Подключение к %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "При подключении %1$@ будет выполнено отключение %2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Идёт подключение к WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Подключение...";
@@ -1489,8 +1572,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "Свяжитесь с нами, написав на %@";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "Структура содержимого\nБлоки: %1$li, Слова: %2$li, Символы: %3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1505,6 +1592,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Читать дальше";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Продолжить с Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Продолжить с Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Продолжение через Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "Участвовать";
@@ -1633,6 +1729,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "Создать";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Создать учётную запись";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "Создать пустую страницу";
 
@@ -1653,6 +1752,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "Создать запись";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "Создать сайт";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "Создать метку";
@@ -1686,6 +1788,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "Текущий";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Текущий тарифный план";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Текущая тема";
@@ -1788,6 +1893,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "Основная рубрика";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Меню по умолчанию";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Основной формат записей";
@@ -1796,6 +1904,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "Параметры по умолчанию для новых записей";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Удалить";
@@ -1853,6 +1962,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "Подробности";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "Не планировали создание новой учётной записи? Перейдите назад и введите ваш адрес email.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "Размеры";
 
@@ -1900,7 +2012,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "Обсуждение";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Игнорировать";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1922,6 +2036,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "Домены";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "Нет учетной записи? _Зарегистрироваться_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2051,6 +2168,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "Загрузки";
 
+/* Name for the status of a draft post. */
+"Draft" = "Черновик";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Черновики";
 
@@ -2160,7 +2280,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "Адрес электронной почты";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "Адрес e-mail";
 
 /* Notification Settings Channel */
@@ -2244,8 +2367,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Введите пароль";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "Введите адрес сайта WordPress, к которому требуется подключиться.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Введите пароль вашей учетной записи WordPress.com.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Введите имя пользователя";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "Введите данные вашей учётной записи для %@.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "Введите ваш адрес электронной почты чтобы войти или создать учётную запись WordPress.com.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "Введите адрес вашего сайта";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "Введите пароль.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "введите учётные данные сервера";
@@ -2408,6 +2551,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "Внешний";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Произошла ошибка";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "Ошибка отметки всех уведомлений как прочитанных";
 
@@ -2419,9 +2565,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Failed to insert media.\nTap for more info." = "Не удалось вставить медиафайл.\nКоснитесь, чтобы получить больше информации.";
-
-/* A message indicating that we couldn't load the user's settings. */
-"Failed to load settings" = "Не удалось загрузить настройки";
 
 /* No comment provided by engineer. */
 "Failed to save files.\nPlease tap for options." = "Невозможно сохранить файлы.\nНажмите для выбора вариантов.";
@@ -2437,6 +2580,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "Мода";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "Рекомендуемые";
@@ -2495,6 +2641,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "Узнать больше";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Найдите адрес вашего сайта";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2517,6 +2666,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "Устранение угроз";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "Наблюдать";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "Подписаться на беседу";
@@ -2611,6 +2763,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "Сгенерировать новую ссылку";
 
+/* View title for initial auth views. */
+"Get Started" = "Вперёд!";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "Получить ссылку для входа по email";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "Будьте активны! Оставляйте комментарии в блогах, на которые вы подписаны.";
 
@@ -2632,8 +2790,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "Вдохновляйтесь";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Получение информации об учетной записи";
+
+/* Cancel */
+"Give Up" = "Не отправлять";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "Попробуйте, добавив несколько блоков в запись или страницу!";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "Перейти к Чтиву";
@@ -2644,6 +2811,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "Перейти в раздел настроек iOS";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Регистрация в Google не удалась.";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2718,6 +2888,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "Значок справки";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Скрыто";
+
 /* Title of a button used to collapse a group */
 "Hide" = "Скрыть";
 
@@ -2786,6 +2959,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "Не удалось обновить значок";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "Если не удаётся найти письмо, проверьте папку спама или нежелательной почты.";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "Если вы продолжите работу с учетной записью Apple или Google, не имея учётной записи WordPress.com, вы создадите учётную запись и примете наши _Условия обслуживания_.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "Если вы удалите %1$@, он больше не сможет посещать этот сайт, но всё содержимое, созданное %2$@, останется на сайте.";
@@ -2861,6 +3040,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "Включает wp-config.php и все файлы не принадлежащие WordPress";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Неправильное имя пользователя или пароль. Попробуйте ввести учётные данные ещё раз.";
 
 /* Title for a threat */
 "Infected core file" = "Заражение файла ядра";
@@ -2962,6 +3144,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "Представляем подсказки для ведения блога";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "Недействительный email адрес";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "Неверный адрес сайта";
 
@@ -2979,6 +3164,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "Неверный URL. Аудиофайл не найден.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "Неверный URL. Пожалуйста перепроверьте и попытку позднее";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "Неверный URL, укажите корректный URL.";
@@ -3000,6 +3188,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "Пригласить людей";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "Похоже, введённое имя пользователя или пароль не связаны с этим сайтом.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "Похоже, вы ввели неправильный пароль. Хотите попытаться ещё раз?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "Самое время написать в блог на %@!";
@@ -3228,7 +3422,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "Высота строки";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Ссылка";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3290,6 +3485,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "Загрузка информации о людях...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Загрузка тарифного плана...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Загрузка тарифный план...";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "Загрузка плагина...";
 
@@ -3324,11 +3525,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "Загрузка...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Черновики";
+
 /* Local Services site intent topic */
 "Local Services" = "Местные услуги";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "Локальные изменения";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Местоположение";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Чтобы добавить данные о местоположении к записям WordPress, необходимо включить службы определения местоположения в настройках.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Местоположение неизвестно";
 
 /* No comment provided by engineer. */
 "Lock icon" = "Значок блокировки";
@@ -3336,9 +3549,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Файлы журнала по дате создания";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Войти";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3348,17 +3563,33 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of a button for signing in. */
 "Log in" = "Войти";
 
-/* LogOut confirmation text, whenever there are no local changes */
-"Log out of Jetpack?" = "Выйти из Jetpack?";
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Не удалось выполнить вход. Повторите попытку.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "Войти или зарегистрироваться с WordPress.com";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Войдите в учетную запись WordPress.com, через которую подключен Jetpack.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "Войдите в учётную запись WordPress.com с вашим email адресом.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "Войдите, указав имя пользователя WordPress.com и пароль.";
 
 /* LogOut confirmation text, whenever there are no local changes */
-"Log out of Reader?" = "Выйти из «Читалки»?";
+"Log out of Jetpack?" = "Выйти из Jetpack?";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of WordPress?" = "Выйти из WordPress?";
 
 /* Login Request Expired */
 "Login Request Expired" = "Срок действия запроса истёк";
+
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "Войти с помощью пароля";
 
 /* No comment provided by engineer. */
 "Logs" = "Логи";
@@ -3368,6 +3599,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Похоже, на вашем сайте настроен Jetpack. Поздравляем!\nВойдите в систему с использованием ваших учетных данных на WordPress.com ниже, чтобы включить статистику и уведомления. ";
+
+/* Title of a button. */
+"Lost your password?" = "Забыли пароль?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "Mail (по умолчанию)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Меню навигации";
@@ -3515,6 +3752,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "Сообщение";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "Прочие уязвимости";
 
@@ -3610,6 +3850,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "Мой сайт";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "Мои сайты WordPress";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "Мой выбор лучших 10 кафе";
 
@@ -3649,8 +3892,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Нужна помощь?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "Как найти адрес своего сайта?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "Нужна помощь?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Нужна дополнительная помощь?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "Требует обновления";
@@ -3679,6 +3929,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "Новая запись";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Новый элемент";
+
 /* Placeholder text for password field */
 "New password" = "Новый пароль";
 
@@ -3696,7 +3949,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "Новости";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Далее";
 
 /* Accessibility label for the next notification button */
@@ -3732,6 +3987,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "URL предварительного просмотра недоступен";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "Нет названия";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "Пока нет активности";
 
@@ -3764,7 +4022,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "Комментариев пока нет";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "Нет подключения";
 
@@ -3913,6 +4172,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "Не сейчас";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "Не нашли письмо? Загляните в папку со спамом.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "Примечание:";
 
@@ -3976,7 +4238,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Нумерованный список";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "ОК";
@@ -4033,7 +4300,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "Ой";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Ой!";
 
 /* No comment provided by engineer. */
@@ -4048,7 +4316,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "Открыть настройки безопасности Jetpack";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Открыть почту";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Открыть «Настройки»";
 
 /* No comment provided by engineer. */
@@ -4066,6 +4339,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "Открыть ссылку в новом окне (на новой вкладке)";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "Открыть настройки подписки для записи";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "Открыть мой профиль";
 
@@ -4080,6 +4356,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "Не обязательно: введите пользовательское сообщение до %1$d символов, оно будет послано вместе с вашим приглашением.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "или";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "Или выберите иную форму авторизации.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "Или войдите с _адресом вашего сайта_.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "или войдите по специальной ссылке";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Упорядоченный список";
@@ -4128,7 +4416,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "Отступ";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Страница";
 
@@ -4161,8 +4450,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "Воспитание детей";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Пароль";
 
@@ -4179,8 +4471,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "Вставить блок после";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Ожидает проверки";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Ожидает проверки";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4211,6 +4507,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "Выберите имя пользователя";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Тарифные планы";
+
 /* User action to play a video on the editor. */
 "Play video" = "Воспроизвести видео";
 
@@ -4240,6 +4540,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "Убедитесь что у вас на сайте включен редактор блоков. Если он не включен, то он и не загрузится.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "Введите полный адрес вебсайта, например example.com.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "Пожалуйста, введите адрес сайта.";
@@ -4274,11 +4577,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "Введите правильный адрес";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "Введите действительный адрес email для учетной записи WordPress.com.";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Пожалуйста, введите корректный адрес e-mail.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "Пожалуйста, введите правильный номер телефона";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Введите пароль учётной записи WordPress.com, чтобы войти с вашим Apple ID.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Пожалуйста, введите ваши учётные данные";
@@ -4286,8 +4595,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Пожауйста, введите ваш адрес email.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Пожалуйста, заполните все поля";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Пожалуйста, запустите приложение WordPress, войдите в учетную запись WordPress.com, убедитесь что у вас есть хотя бы один сайт, затем попробуйте еще раз.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "Пожалуйста, выйдите перед тем, как подключиться к другому сайту wordpress.com";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "Попробуйте позже";
@@ -4355,7 +4670,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "Популярные языки";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Запись";
 
@@ -4476,6 +4792,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "Уведомление о конфиденциальности для жителей Калифорнии";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Личное";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "Проблема с отображением блока. \nНажмите, чтобы попытаться восстановить блок.";
 
@@ -4490,6 +4809,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "Возникла проблема регистрации домена. Попробуйте еще раз.";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Если вы продолжите, с вашего устройства будут удалены все данные WordPress.com и сохранённые локально черновики. Всё, что уже сохранено на ваших блогах WordPress.com, не пропадёт.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Проекты";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "Подсказка закрыта";
@@ -4507,13 +4832,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "Дата публикации";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Опубликовать немедленно";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "Опубликовать страницу на:";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "Опубликовать запись на:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Опубликовано";
 
@@ -4715,7 +5044,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "Ответить";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Текст ответа";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "Ответить на %1$@";
 
 /* An explaination of a setting. */
@@ -4744,6 +5078,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "Сброс фильтра диапазона дат";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Сбросить пароль";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Изменить размер и обрезать";
@@ -4801,6 +5138,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "Попробовать снова для всех";
 
+/* No comment provided by engineer. */
+"Retry?" = "Повторить?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "Вернуться к записи";
 
@@ -4830,6 +5170,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "Роль";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS отправлено";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "СТАТУС";
 
@@ -4841,6 +5184,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4907,7 +5251,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "Проверка файлов";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Запланировано";
 
 /* No comment provided by engineer. */
@@ -5047,6 +5392,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "Эта тема будет указывать на то, для чего создан ваш сайт.";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Отправить ссылку";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "Прислать ссылку по электронной почте";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "Отправить тестовое сообщение в журнал";
 
@@ -5055,6 +5406,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "Отправить тестовое сообщение о падении";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "Отправить ссылку для подтверждения по email";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "Отправлять уведомления по электронной почте";
@@ -5101,11 +5455,11 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Message to show when setting save failed */
 "Settings update failed" = "Не удалось обновить настройки";
 
-/* Title for a button that recommends the app to others */
-"Share Jetpack with a friend" = "Поделитесь Jetpack с друзьями";
+/* Spoken accessibility label */
+"Share" = "Поделиться";
 
 /* Title for a button that recommends the app to others */
-"Share Reader with a friend" = "Поделиться ссылкой на «Читалку»";
+"Share Jetpack with a friend" = "Поделитесь Jetpack с друзьями";
 
 /* Title for a button that recommends the app to others */
 "Share WordPress with a friend" = "Поделитесь WordPress с друзьями";
@@ -5156,6 +5510,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "Показывать кнопку «Перепост»";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "Показать пароль";
+
 /* No comment provided by engineer. */
 "Show post content" = "Показать содержимое записи";
 
@@ -5167,6 +5525,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "Показ статистики для:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "Показано";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Отображается для всех пользователей, когда вы добавляете комментарии к блогам.";
@@ -5182,6 +5543,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "Показать запись.";
+
+/* View title during the sign up process. */
+"Sign Up" = "Регистрация";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "Войти с учетными данными сайта";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Регистрация";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Зарегистрироваться на WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Зарегистрироваться с адресом Email";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "Для бесплатного тарифа доступно ограниченное количество записей журнала активности.";
@@ -5220,6 +5596,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Достижения сайта";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Адрес сайта";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "Адрес сайта должен содержать не менее 4 символов.";
@@ -5304,7 +5683,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Извините, адрес сайта должен содержать также и буквы!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Извините, этот адрес e-mail уже используется!";
 
 /* No comment provided by engineer. */
@@ -5364,6 +5743,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "Спам";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "Ускорьте ваш сайт";
@@ -5389,6 +5771,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "Округ\/Область";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "Статическая главная страница";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5419,6 +5804,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "Перечёркнутый";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Заглушка";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "Отправить на утверждение";
@@ -5509,7 +5897,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "Планшет";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Метка";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5644,6 +6033,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Условия сервиса";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Отзывы";
+
 /* Title of a button style */
 "Text Only" = "Только текст";
 
@@ -5653,8 +6045,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "Элементы управления форматированием текста расположены на панели инструментов над клавиатурой при редактировании текстового блока";
 
+/* Button title */
+"Text me a code instead" = "Пришлите мне сообщение с кодом";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "Прислать код по SMS";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Благодарим вас за выбор темы %1$@ от %2$@!";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "Это не похоже на правильный код проверки.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "Скорее всего, этот сайт размещён не на WordPress.";
@@ -5676,6 +6077,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "Подключение к Facebook не может обнаружить страниц, Publicize не может использовать профили Facebook, только страницы.";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "Учетная запись Google \"%@\" не соответствует ни одной учетной записи WordPress.com";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "Похоже, что нет связи с Интернетом.";
@@ -5715,6 +6119,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "Невозможно добавить изображение в «Библиотеку медиафайлов».";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "Интернет-соединение недоступно.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "Типы сайтов для создания";
@@ -5758,6 +6165,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Сайт по адресу %1$@ использует WordPress %2$@. Рекомендуем обновить его до текущей версии или хотя бы до %3$@";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "Сайт по этому адресу не является сайтом на WordPress. Мы не можем подключиться к нему.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "Не удалось удалить сайт.";
 
@@ -5799,6 +6210,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "При изменении вашего комментария произошла непредвиденная ошибка.";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "Возникла непредвиденная ошибка при загрузке комментариев.";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "Возникла неожиданная ошибка при регистрации вашего домена";
 
@@ -5807,6 +6221,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "При обновлении настроек уведомлений произошла неожиданная ошибка.";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "При изменении вашего комментария произошла непредвиденная ошибка.";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "Возникла неожиданная ошибка.";
@@ -5828,6 +6245,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "Возникла проблема при подключении к сайту.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "При подключении к WordPress.com произошла ошибка. Войдите заново.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "При размещении этой записи произошла ошибка.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "Возникла проблема с загрузкой ваших данных, обновите страницу, чтобы попробовать еще раз.";
 
@@ -5837,12 +6260,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "При сохранении измененных параметров отправки данных произошла ошибка.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "При доступе к данным о вашем местоположении произошла ошибка. Повторите попытку позже.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "Возникла ошибка при смене пароля";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "Возникла ошибка загрузки канала активности";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "При загрузке тарифных планов произошла ошибка.";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "Возникла ошибка при загрузке плагинов";
@@ -5855,6 +6284,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "Возникла ошибка загрузки истории";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "При загрузке тарифного плана произошла ошибка.";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "Возникла ошибка загрузки истории проверок";
@@ -5903,6 +6335,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "Этот домен недоступен";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "Этот адрес электронной почты не зарегистрирован на WordPress.com.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "Файл очень большой для загрузки на ваш сайт или медиаформат не поддерживается.";
@@ -5983,6 +6418,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "Часовой пояс";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "Время вышло, но не волнуйтесь, ваша безопасность — наш приоритет. Пожалуйста, попробуйте еще раз!";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "Советы по максимально эффективному использованию WordPress.com.";
 
@@ -5996,6 +6434,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "Для продолжения введите ваш адрес email и имя.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "Для создания новой учетной записи WordPress.com, пожалуйста, введите ваш адрес эл.почты.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "Для использования уведомлений от WordPress на вашем устройстве вам нужно установить плагин Jetpack.";
 
@@ -6004,6 +6445,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "Для установки плагинов вам требуется собственный домен привязаный к вашему сайту.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "Чтобы войти через эту учетную запись Apple ID, пожалуйста войдите сначала с паролем WordPress.com. Это запрашивается только один раз.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "Чтобы войти через эту учетную запись Google, пожалуйста войдите сначала с паролем WordPress.com. Это запрашивается только один раз.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "Чтобы удалить блок, выберите блок и щелкните три точки в правом нижнем углу блока, чтобы просмотреть настройки. Оттуда выберите вариант удаления блока.";
@@ -6078,7 +6525,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "В корзину";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "В корзине";
 
@@ -6092,6 +6540,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "Попробовать и настроить";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Попробуйте еще раз.";
@@ -6117,6 +6566,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "Попробуйте редактор блоков";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Попробуйте с другим email";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Попробуйте с адресом сайта";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "Отключить подсказки";
@@ -6159,6 +6614,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "ВАРИАНТЫ ИСПОЛЬЗОВАНИЯ";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "Невозможно подключиться";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "Не удалось загрузить записи";
@@ -6208,6 +6666,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Невозможно вопроизвести видео";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Не удалось найти веб-сайт WordPress по этому URL-адресу. Нажмите кнопку «Нужна помощь?», чтобы просмотреть ответы на часто задаваемые вопросы.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Не удалось восстановить сайт";
 
@@ -6234,6 +6695,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "Невозможно загрузить 1 запись, 1 файл";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "Невозможно проверить ваш электронный адрес. Попробуйте позже еще раз.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "Не удается посетить настройки Jetpack для сайта";
@@ -6378,7 +6842,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Ошибка загрузки";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Загружено";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6396,7 +6861,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Загруженные темы";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Загрузка";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6411,18 +6877,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "Использовать";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "Использовать ключ безопасности";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "Использовать редактор блоков";
 
 /* No comment provided by engineer. */
 "Use icon button" = "Использовать кнопку со значком";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "Войти с паролем";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Имя пользователя";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6437,6 +6912,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Пользователи";
+
+/* two factor code placeholder */
+"Verification code" = "Проверочный код";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "Письмо для подтверждения выслано, проверьте почту.";
@@ -6569,8 +7047,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "Папка wp-content";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Ожидание Google...";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "Ожидание подключения";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "Ожидание ключа безопасности";
+
+/* View title during the Google auth process. */
+"Waiting..." = "Ожидайте...";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6610,6 +7098,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "Не удалось загрузить данные.";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "Мы только что отправили ссылку на %@. Проверьте вашу почту в приложении и нажмите на ссылку, чтобы войти.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "Только что мы отправили специальную ссылку на";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "Мы создали резервную копию вашего сайта на %@";
 
@@ -6619,14 +7113,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "Мы используем другие инструменты отслеживания, включая и инструменты третьих сторон. Прочитайте о них и как их контролировать.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "Мы не смогли отправить вам сообщение по эл.почте. Попробуйте еще раз позже.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Если будут обнаружены угрозы безопасности, вы получите сообщение на эл. почту. Вы можете продолжать работу со своим сайтом как обычно — прогресс сканирования можно проверить в любое удобное время.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "Мы отправим вам волшебную ссылку, по которой вы сможете сразу войти в систему без использования пароля. Не нужно больше тыкать по клавиатуре!";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "Мы пришлём вам ссылку для создания учётной записи WordPress.com.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "Мы уведомим вас о новых подписчиках, комментариях и отметках \"нравится\".";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "Мы уведомим вас о подписчиках, комментариях, \"лайках\". Хотите разрешить push-уведомления?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "Этот адрес эл.почты будет использован для создания новой учётной записи WordPress.com.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "Создается резервная копия вашего сайта на %1$@.";
@@ -6637,6 +7143,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Мы сейчас стараемся исправить эти угрозы в фоновом режиме, вы можете продолжать использовать ваш сайт как обычно, проверить состояние вы сможете в любое время.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "Не удалось подключиться к сайту Jetpack по этому URL-адресу. Свяжитесь с нами, если потребуется помощь.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "Выполняется откат к состоянию сайта на %1$@.";
 
@@ -6645,6 +7154,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "Мы также отправили вам ссылку на файл по email.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Мы отослали вам ссылку для создания учётной записи WordPress.com. Проверьте почту на вашем устройстве и нажмите на ссылку, полученную с WordPress.com.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6671,6 +7183,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "За неделю: %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "Jetpack приветствует вас!";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Добро пожаловать в WordPress";
 
 /* A message title */
 "Welcome to the Reader" = "Добро пожаловать в раздел «Чтиво».";
@@ -6715,6 +7233,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "Что такое Gravatar?";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "Что такое WordPress.com?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "Что такое блок?";
 
@@ -6731,10 +7252,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "What's New in Jetpack" = "Что нового в Jetpack";
 
 /* Opens the What's New / Feature Announcement modal */
-"What's New in Reader" = "Что нового в «Читалке»";
-
-/* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "Что нового в WordPress";
+
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "Какой адрес у моего сайта?";
 
 /* Select the site's intent. Title */
 "What's your website about?" = "О чём ваш веб-сайт?";
@@ -6748,6 +7269,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "При внесении изменений на сайт вы можете увидеть историю активности здесь.";
 
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Произошла ошибка: не удалось выполнить вход. Повторите попытку.";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "Что-то пошло не так. Пожалуйста, попробуйте еще раз!";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "Ой, кажется, этот ключ безопасности недействителен. Пожалуйста, попробуйте еще раз с другим";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Проверочный код для двухфакторной аутентификации недействителен. Проверьте код и повторите попытку.";
+
 /* No comment provided by engineer. */
 "Width Settings" = "Настройки ширины";
 
@@ -6760,17 +7293,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "Настройки приложения WordPress";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "Приложения WordPress - приложения для любого экрана";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "Блог на WordPress";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "Справка по WordPress";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "Библиотека медиафайлов WordPress";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "Настройки уведомлений WordPress";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "Уведомления WordPress";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "Плагины WordPress";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "Профиль WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "Чтиво WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "Подробности о сайте WordPress";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "Темы WordPress";
@@ -6781,17 +7335,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "Мультисайтовые системы WordPress не поддерживаются";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "Сайту WordPress требуется доступ к данным о местоположении вашего устройства, чтобы добавить их к записи. Обновите настройки конфиденциальности.";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "Корневая папка WordPress";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "Слишком старая версия WordPress";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Слишком старая версия WordPress. Веб-сайт по адресу %1$@ использует WordPress %2$@. Рекомендуем обновить его до текущей версии или хотя бы до версии %3$@.";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "Учетная запись WordPress.com";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "Тарифные планы WordPress.com";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "Темы WordPress.com";
@@ -6822,6 +7385,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "Написать запись";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "Написать ответ";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "Написать ответ.";
 
 /* Title for the writing section in site settings screen */
@@ -6835,6 +7401,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Позиция по оси Y";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "Год";
@@ -6919,6 +7488,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Displayed when the user views trashed in the posts list and there are no posts */
 "You don't have any trashed posts" = "У вас нет записей в корзине";
 
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"You don't have permission to view this private blog." = "У вас нет разрешения на доступ к этому закрытому блогу.";
+
 /* Description for the first domain purchased with a paid plan. */
 "You have a free one-year domain registration with your plan." = "На вашем тарифе возможно зарегистрировать бесплатно домен сроком на 1 год.";
 
@@ -6934,7 +7506,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "Напоминания не установлены.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "У вас есть несохранённые изменения.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -7021,9 +7594,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Help text that describes how the password should be. It appears while editing the password */
 "Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ & )." = "Ваш пароль должен быть не менее 6 символов, для усиления безопасности используйте разный регистр букв, цифры и  символы типа ! \" ? $ % ^ & ).";
 
-/* Message of Export Content confirmation alert */
-"Your posts, pages, and settings will be mailed to the account's email address." = "Ваши записи, страницы и настройки будут отправлены по адресу электронной почты учётной записи.";
-
 /* Message of Export Content confirmation alert; substitution is user's email address */
 "Your posts, pages, and settings will be mailed to you at %@." = "Ваши записи, страницы и настройки будут отправлены вам по электронной почте %@.";
 
@@ -7032,6 +7602,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "Ваш поисковый запрос включает символы, не поддерживаемые в домене WordPress.com. Разрешены следующие символы: A–Z, a–z, 0–9.";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "При открытии сайта в браузере Safari его адрес отображается в строке в верхней части экрана.";
 
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "Ваш сайт уже защищён VaultPress. Ниже вы можете найти ссылку на консоль VaultPress.";
@@ -7111,17 +7684,23 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility identifier for an 'Add Comment' button */
 "addCommentButton.accessibilityIdentifity" = "Добавить комментарий";
 
-/* Error message when user cancels login */
-"addSite.selfHosted.cancelled" = "Вход отменён";
+/* Error message shown a URL does not point to an existing site. */
+"addSite.restApiNotAvailable" = "Сайт по этому адресу не имеет отношения к WordPress. Для того чтобы мы могли выполнить подключение к сайту, он должен работать на WordPress.";
+
+/* Error message shown when an receiving an invalid application-password authentication result from a self-hosted WordPress site */
+"addSite.selfHosted.authenticationFailed" = "Не удалось выполнить вход при помощи аутентификации по паролю приложения.";
 
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "Введите адрес сайта WordPress, к которому требуется подключиться.";
 
+/* Error message when user input is not a WordPress site */
+"addSite.selfHosted.invalidUrl" = "Адрес сайта недействителен.";
+
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "Не удалось загрузить подробные данные сайта WordPress";
 
-/* Error message when user signs in with an unexpected usern. The first argument is the expected username */
-"addSite.selfHosted.mismatchUser" = "Войдите с учётными данными пользователя, выполнившего вход. Имя пользователя: %@";
+/* Error message shown when application-password authentication is disabled on a self-hosted WordPress site */
+"addSite.selfHosted.noLoginUrlFound" = "Необходимо включить аутентификацию по паролю приложения на сайте WordPress.";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "Не удалось сохранить сайт WordPress, повторите попытку позднее.";
@@ -7129,17 +7708,14 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "Добавить автономный веб-сайт";
 
-/* Error message when XML-RPC is disabled on the WordPress site. The first argument is detailed error message */
-"addSite.selfHosted.xmlrpcDisabled" = "Не удалось подключиться к сайту WordPress. XML-RPC мог быть отключён на сервере. Свяжитесь с поставщиком услуг хостинга, чтобы решить эту проблему.";
+/* Error message when an unknown error occurred when adding a self-hosted site */
+"addSite.selfHosted.unknownError" = "Что-то пошло не так. Повторите попытку.";
 
 /* Age between dates equaling one hour. */
 "an hour" = "час";
 
 /* This is the string we display when prompting the user to review the Jetpack app */
 "appRatings.jetpack.prompt" = "Каково ваше мнение о Jetpack?";
-
-/* This is the string we display when prompting the user to review the Reader app */
-"appRatings.reader.prompt" = "Что вы думаете о «Читалке»?";
 
 /* This is the string we display when prompting the user to review the WordPress app */
 "appRatings.wordpress.prompt" = "Каково ваше мнение о WordPress?";
@@ -7354,9 +7930,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Action shown in a bottom notice to dismiss it. */
 "blogDashboard.dismiss" = "Закрыть";
-
-/* Context menu button title */
-"blogHeader.actionVisitSite" = "Перейти на сайт";
 
 /* Badge title in site list */
 "blogList.siteBadge.staging" = "Предварительная версия";
@@ -7840,8 +8413,9 @@ Example: Reply to Pamela Nguyen */
 /* Shared empty state view */
 "emptyStateView.noSearchResult.title" = "Нет результатов";
 
-/* A name of the ID field (it's a technical field, has to be short, displayed below everything else) */
-"entityMetadataFooterView.id" = "ID";
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "example.com";
 
 /* Accept button title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackAccept" = "Отправить отзыв";
@@ -7854,9 +8428,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackTitle" = "Отправить отзыв";
-
-/* Communicates the future removal of the option to disable the experimental editor, displayed beneath the experimental features list */
-"experimentalFeatures.editorNote" = "Экспериментальный редактор блоков станет редактором блоков по умолчанию в следующей версии, и его нельзя будет отключить.";
 
 /* The title for the experimental features list */
 "experimentalFeaturesList.heading" = "Экспериментальные функции";
@@ -7903,8 +8474,14 @@ Example: Reply to Pamela Nguyen */
 /* A footer retry button */
 "general.pagingFooterView.retry" = "Повторить";
 
+/* Error message format when REST API returns an error response. The first argument is error message. */
+"generic.error.rest-api-error" = "Ваш сайт отправил ошибочный ответ: %@";
+
 /* A generic title for an error */
 "generic.error.title" = "Ошибка";
+
+/* Error message when failing to parse API responses */
+"generic.error.unparsableResponse" = "Ваш сайт отправил ответ, который приложение не смогло обработать";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "Установить напоминания о блогинге";
@@ -8076,42 +8653,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title of the Jetpack powered overlay. */
 "jetpack.branding.overlay.title" = "WordPress будет гораздо лучше с Jetpack";
-
-/* Title for the button that starts the Jetpack connection process */
-"jetpack.connection.connect.button" = "Подключить ваш сайт";
-
-/* Error message shown when WordPress.com authentication fails */
-"jetpack.connection.error.authentication" = "Неверная учётная запись WordPress.com";
-
-/* Error message shown when a connection step is attempted in an invalid order */
-"jetpack.connection.error.context" = "Этот этап ещё не готов";
-
-/* Title for the retry button shown when a connection step fails */
-"jetpack.connection.retry.button" = "Повторить";
-
-/* Status message when a connection step is pending */
-"jetpack.connection.stage.pending" = "Ожидается запуск";
-
-/* Status message when a connection step is in progress */
-"jetpack.connection.stage.processing" = "Выполняется…";
-
-/* Status message when a connection step is completed successfully */
-"jetpack.connection.stage.success" = "Завершено";
-
-/* Title for the finalization step in Jetpack connection flow */
-"jetpack.connection.step.finalize.title" = "Завершить подключение";
-
-/* Title for the install step in Jetpack connection flow */
-"jetpack.connection.step.install.title" = "Установить Jetpack";
-
-/* Title for the login step in Jetpack connection flow */
-"jetpack.connection.step.login.title" = "Войти на WordPress.com";
-
-/* Title for the site connection step in Jetpack connection flow */
-"jetpack.connection.step.site.title" = "Подключить ваш сайт";
-
-/* Title for the user connection step in Jetpack connection flow */
-"jetpack.connection.step.user.title" = "Подключить учётную запись WordPress.com";
 
 /* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
 "jetpack.fullscreen.overlay.early.switch.title" = "Перейти в новое приложение Jetpack";
@@ -8332,41 +8873,11 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "У вас нет разрешения на доступ к этому закрытому блогу.";
 
-/* Button to dismiss the re-authentication view */
-"login.appPasswordReAuth.cancelButton" = "Отмена";
-
-/* Description explaining why the user needs to re-authenticate */
-"login.appPasswordReAuth.description" = "Назначенный пароль приложения сброшен в вашем профиле.\nВойдите снова, чтобы создать новый пароль приложения.";
-
-/* Button to start the re-authentication process */
-"login.appPasswordReAuth.signInButton" = "Войти";
-
-/* Title shown when the application password is invalid */
-"login.appPasswordReAuth.title" = "Неверный пароль приложения";
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "Введите проверочный код вашей учётной записи WordPress.com из приложения аутентификации.";
 
 /* Indicating that referrer was marked as spam */
 "marked as spam" = "отмечено как спам";
-
-/* Button title when verification link sending failed */
-"me.verifyEmail.button.retry" = "Повторить попытку";
-
-/* Button title to send verification link */
-"me.verifyEmail.button.send" = "Отправить письмо ещё раз";
-
-/* Button title while verification link is being sent */
-"me.verifyEmail.button.sending" = "Отправка…";
-
-/* Button title after verification link is sent */
-"me.verifyEmail.button.sent" = "Письмо отправлено";
-
-/* Message for email verification card */
-"me.verifyEmail.message.noEmail" = "Подтвердите адрес электронной почты, чтобы защитить свою учётную запись и получить доступ к дополнительным функциям.\nПроверьте почту, чтобы открыть письмо с подтверждением, или нажмите «%@», чтобы получить новое.";
-
-/* Message for email verification card with email address */
-"me.verifyEmail.message.withEmail" = "Подтвердите адрес электронной почты, чтобы защитить свою учётную запись и получить доступ к дополнительным функциям.\nПроверьте почту по адресу %1$@, чтобы открыть письмо с подтверждением, или нажмите «%2$@», чтобы получить новое.";
-
-/* Title for email verification card */
-"me.verifyEmail.title" = "Подтвердить адрес электронной почты";
 
 /* Me tab menu items */
 "meMenu.submitFeedback" = "Отправьте отзыв";
@@ -8469,9 +8980,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Bottom toolbar title in the selection mode */
 "mediaLibrary.toolbarSelectItemsPrompt" = "Выбрать элементы";
-
-/* A name of the action in the context menu */
-"mediaPicker.imagePlayground" = "Песочница изображений";
 
 /* Message for alert when access to camera is not granted */
 "mediaPicker.noCameraAccessMessage" = "Этому приложению необходим доступ к камере для получения новых медиаданных. Если вы хотите разрешить доступ, измените настройки конфиденциальности.";
@@ -8809,6 +9317,9 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "Родительская страница";
 
+/* No comment provided by engineer. */
+"password" = "пароль";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "Содержимое карточек может быть разным и зависит от активности на сайте. Скоро станет доступно больше карточек и элементов управления.";
 
@@ -8914,9 +9425,6 @@ Example: Reply to Pamela Nguyen */
 /* Message shown while loading plugin details */
 "pluginDetails.loading" = "Загрузка сведений о плагине…";
 
-/* Placeholder message shown when a plugin has no description */
-"pluginDetails.noDescription" = "Отсутствует описание плагина.";
-
 /* Title of the changelog section in plugin details */
 "pluginDetails.section.changelog" = "Журнал изменений";
 
@@ -8925,9 +9433,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title of the details section in plugin details */
 "pluginDetails.section.details" = "Сведения";
-
-/* Title of the FAQ section in plugin details */
-"pluginDetails.section.faq" = "FAQ";
 
 /* Title of the installation section in plugin details */
 "pluginDetails.section.installation" = "Установка";
@@ -9205,6 +9710,30 @@ Example: Reply to Pamela Nguyen */
 /* An alert message explaning that by changing the visibility to private, the post will be published immediately to your site */
 "postSettings.warningPostWillBePublishedAlertMessage" = "Если статус будет изменен на «Закрытый», запись будет сразу же опубликована";
 
+/* Localized post type: `Page` */
+"postType.page" = "страница";
+
+/* Localized post type: `Post` */
+"postType.post" = "запись";
+
+/* Details for a 'Private' privacy setting */
+"postVisibility.private.details" = "Видна только администраторам и редакторам";
+
+/* Title for a 'Private' privacy setting */
+"postVisibility.private.title" = "Закрытая";
+
+/* Details for a 'Password Protected' privacy setting */
+"postVisibility.protected.details" = "Общедоступная, но требует ввода пароля";
+
+/* Title for a 'Password Protected' privacy setting */
+"postVisibility.protected.title" = "Защищено паролем";
+
+/* Details for a 'Public' (default) privacy setting */
+"postVisibility.public.details" = "Видна всем";
+
+/* Title for a 'Public' (default) privacy setting */
+"postVisibility.public.title" = "Публичная";
+
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Отмена";
 
@@ -9425,18 +9954,6 @@ Tapping on this row allows the user to edit the sharing message. */
 /* Title for the success view when the user has successfully logged in */
 "qrLoginVerifyAuthorization.completedInstructions.title" = "Вход выполнен!";
 
-/* No comment provided by engineer. */
-"reachability-utils.alert.cancel" = "ОК";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.retry" = "Повторить?";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.title" = "Нет соединения";
-
-/* Message of error prompt shown when no internet connection is available */
-"reachability-utils.alert.utils" = "Похоже, нет подключения к Интернету.";
-
 /* Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog. */
 "reader.blocked.blog.message" = "Блог %@ больше не будет отображаться в приложении «Чтиво». Нажмите, чтобы отменить действие.";
 
@@ -9473,23 +9990,8 @@ Tapping on this row allows the user to edit the sharing message. */
 /* A shared button title for Reader */
 "reader.button.unsubscribe" = "Отменить подписку";
 
-/* Button title. Follow the comments on a post. */
-"reader.comments.buttonFollow" = "Подписаться";
-
 /* Informational message, should be short. */
 "reader.comments.commentsClosed" = "Комментарии закрыты";
-
-/* Empty state view title */
-"reader.comments.emptyStateTitle" = "Оставьте комментарий первым.";
-
-/* Empty state view title */
-"reader.comments.errorLoadingComments" = "Возникла непредвиденная ошибка при загрузке комментариев.";
-
-/* VoiceOver hint */
-"reader.comments.followingSettingAccessibilityIdentifier" = "Открыть настройки уведомлений записи";
-
-/* Error message that informs reader comments from a private blog cannot be fetched. */
-"reader.comments.noPermissionToViewPrivateBlog" = "У вас нет разрешения на доступ к этому закрытому блогу.";
 
 /* Accessibility hint to inform that the author section can be tapped to see posts from the site. */
 "reader.detail.header.authorInfo.a11y.hint" = "Просмотр записей с сайта";
@@ -9567,23 +10069,8 @@ but tapping on this button will remove their like from the post. */
 /* Screen header details */
 "reader.following.header.details" = "Будьте в курсе обновлений в блогах, на которые вы подписаны.";
 
-/* Empty state view */
-"reader.following.lists.emptyTitle" = "Списки пусты";
-
-/* Screen header details */
-"reader.home.header.details" = "Будьте в курсе обновлений в блогах, на которые вы подписаны.";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.home.title" = "Главная";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.library.title" = "Библиотека";
-
 /* Used in multiple contexts, usually as a screen title */
 "reader.likes.title" = "Отметки «Нравится»";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.lists.title" = "Списки";
 
 /* Reader logged-out screen details */
 "reader.loggedOut.details" = "Войдите с данными вашей учётной записи WordPress.com, чтобы подписываться на любимые блоги";
@@ -9826,8 +10313,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title of a Reader tab showing Posts matching a user's search query */
 "reader.search.tab.posts" = "Записи";
 
-/* Title of the Reader's search feature
-   Used in multiple contexts, usually as a screen title */
+/* Title of the Reader's search feature */
 "reader.search.title" = "Поиск";
 
 /* Screen title. Reader select interests title label text. */
@@ -9854,6 +10340,21 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Reader select interests title label text */
 "reader.select.tags.title" = "Найдите блоги, которые вам понравятся, и подпишитесь на них";
 
+/* Reader sidebar menu item */
+"reader.sidebar.discover" = "Раздел «Поиск»";
+
+/* Reader sidebar menu item */
+"reader.sidebar.likes" = "Отметки «Нравится»";
+
+/* Reader sidebar menu item */
+"reader.sidebar.recent" = "Недавние";
+
+/* Reader sidebar menu item */
+"reader.sidebar.saved" = "Сохранено";
+
+/* Reader sidebar menu item */
+"reader.sidebar.search" = "Поиск";
+
 /* Reader sidebar section title */
 "reader.sidebar.section.favorites.title" = "Избранное";
 
@@ -9862,9 +10363,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Reader sidebar section title */
 "reader.sidebar.section.organization.title" = "Организация";
-
-/* Reader sidebar section title */
-"reader.sidebar.section.subscriptions.title" = "Подписки";
 
 /* Reader sidebar button */
 "reader.sidebar.section.tags.addTag" = "Добавить метку";
@@ -9902,7 +10400,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Number of subscriptions on a site (singular) */
 "reader.subscriptions.subscriptionsSingular" = "%@ подписчик";
 
-/* Used in multiple contexts, usually as a screen title */
+/* Navigation bar title */
 "reader.subscriptions.title" = "Подписки";
 
 /* A suggestion of topics the user might want to subscribe to */
@@ -9944,29 +10442,11 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Verb. Button title. The user is following a tag. */
 "reader.tags.following.button.title" = "Подписки";
 
-/* Used in multiple contexts, usually as a screen title */
-"reader.tags.title" = "Метки";
-
 /* Accessibility label for unsubscribing from a tag */
 "reader.tags.unfollow.accessibility.label" = "Отписаться от %@";
 
 /* Field title */
 "reader.userProfile.site" = "Сайт";
-
-/* Reader Welcome screen login button */
-"reader.welcome.continueText" = "Продолжить с WordPress.com";
-
-/* Reader Welcome screen */
-"reader.welcome.subtitle" = "Присоединяйтесь к крупнейшему сообществу блогеров";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.discover" = "Новое";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.me" = "Я";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.notifications" = "Уведомления";
 
 /* Spoken accessibility label */
 "readerDetail.backButton.accessibilityLabel" = "Назад";
@@ -10244,14 +10724,10 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Message shown when there are no inactive plugins on the site */
 "site.plugins.empty.inactive" = "Нет неактивных плагинов";
 
-/* The plugin fillter option for displaying active plugins */
-"site.plugins.filter.option.active" = "Активно";
-
-/* The plugin fillter option for displaying all plugins */
+/* The plugin fillter option for displaying active plugins
+   The plugin fillter option for displaying all plugins
+   The plugin fillter option for displaying inactive plugins */
 "site.plugins.filter.option.all" = "Все";
-
-/* The plugin fillter option for displaying inactive plugins */
-"site.plugins.filter.option.inactive" = "Неактивно";
 
 /* Title of the plugin filter picker */
 "site.plugins.filter.title" = "Фильтр";
@@ -10803,9 +11279,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* View title for Help & Support page. */
 "support.title" = "Справка";
 
-/* Subject of new Zendesk ticket. */
-"support.zendesk.readerAppTicketSubject" = "Поддержка «Читалки» в iOS";
-
 /* Title for placeholder in Tenor picker */
 "tenor.welcomeMessage" = "Найдите GIF-изображения и добавьте их в вашу Библиотеку файлов!";
 
@@ -10954,8 +11427,119 @@ Feel free to replace it with other bracket types that you think looks better for
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "Статус";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "Записи за все время, максимум просмотров";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "Просмотры за всё время";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "Просмотры за всё время и посетители";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "Максимальное число просмотров за всё время";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "Наиболее просматриваемые";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "Не удалось загрузить статистику сайта.";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "Создайте или добавьте сайт, чтобы увидеть статистику за все время.";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Записи";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "Будьте в курсе всех действий на вашем сайте WordPress.";
+
+/* Title of all time widget */
+"widget.alltime.title" = "За всё время";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "Войдите в WordPress для просмотра статистики за всё время.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "Войдите в Jetpack для просмотра статистики за всё время.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "Войдите в Jetpack для просмотра статистики за неделю.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "Войдите в Jetpack для просмотра статистики за сегодняшний день.";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "Просмотры за всё время";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "Просмотров сегодня";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "Не удалось загрузить статистику за неделю.";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "Создайте или добавьте сайт, чтобы увидеть статистику за неделю.";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "Будьте в курсе всех действий на вашем сайте WordPress за эту неделю.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "На этой неделе";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "Войдите в WordPress для просмотра статистики за неделю.";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Комментарии";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "Статистика переместилась в приложение Jetpack. Переключение бесплатно и займет всего минуту.";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "\"Нравится\"";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "Не удалось загрузить статистику сайта.";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "Не удалось загрузить статистику за сегодня.";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "Создайте или добавьте сайт, чтобы увидеть сегодняшнюю статистику.";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "Будьте в курсе всех действий за сегодня на вашем сайте WordPress.";
+
+/* Title of today widget */
+"widget.today.title" = "Cегодня";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "Войдите в WordPress для просмотра статистики за сегодняшний день.";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "Просмотр недоступен";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Просмотры";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Посетители";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "Отметки \"нравится\" за сегодня и комментарии";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "Просмотры за сегодня";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "Просмотры за сегодня и посетители";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "в будущем будет недоступен.";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "Запускаете новый сайт?";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "wordpress, помощь, поддержка, faq, вопросы, отладка, журналы, центр справки, контакт";
@@ -10980,6 +11564,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Error message that describes an unknown error had occured */
 "wordpress-api.error.unknown" = "Что-то пошло не так, пожалуйста, повторите попытку позже.";
+
+/* Error message when failing to find selected media file on the user's device. */
+"wordpress.api.upload.media.fileNotFound" = "Не удалось найти медиафайл на устройстве";
 
 /* Jetpack Plugin Modal on WordPress primary button title */
 "wordpress.jetpack.plugin.modal.primary.button.title" = "Перейти в приложение Jetpack";
@@ -11026,21 +11613,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Error message when user signs in with an unexpected email address. The first argument is the expected email address */
 "wpComLogin.error.mismatchedEmail" = "Войдите по адресу электронной почты %@";
 
-/* Message shown when user denies WordPress.com login, offering option to try with different account */
-"wpComLogin.loginDenied.message" = "Если нужно, вы можете войти с другой учётной записью. Нажмите «%@», чтобы начать.";
-
-/* Title of alert shown when user cancels WordPress.com login */
-"wpComLogin.loginDenied.title" = "Вход отменён";
-
-/* Button title for signing in with a different WordPress.com account */
-"wpComLogin.loginDenied.useDifferentAccount" = "Использовать другую учётную запись";
-
-/* Button title to log out the current WordPress.com account */
-"wpcom.token.alert.button.logout" = "Выйти";
-
-/* Button title to Sign In to WordPress.com */
-"wpcom.token.alert.button.signin" = "Войти";
-
 /* Message title to be displayed when the user needs to re-authenticate their WordPress.com account. */
 "wpcom.token.fix.signin" = "Войти в WordPress.com";
 
@@ -11055,6 +11627,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "Вложение не поддерживается";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Войти через Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Домены";

--- a/WordPress/Resources/sk.lproj/Localizable.strings
+++ b/WordPress/Resources/sk.lproj/Localizable.strings
@@ -92,6 +92,9 @@
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Bez názvu)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(bez názvu)";
+
 /* Menus button text for adding a new menu to a site. */
 "+ Add new menu" = "+ Pridať nové menu";
 
@@ -133,6 +136,12 @@
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "Názov stránky";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "Platná emailová adresa je dôležitá pre overenie a prepojenie. Vráťte sa na predchádzajúcu obrazovku a zadajte platný email.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "Overovací kód obsahuje len číslice.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "AKTÍVNA";
@@ -251,15 +260,24 @@
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "Zoznam povolených IP adries";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "Už to skoro je hotové! Prosím zadajte overovací kód z aplikácie overovania.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Alt Text";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "Prípadne:";
 
 /* Error message when loading failed because there's no connection */
 "An active internet connection is required" = "Vyžaduje sa aktívne internetové pripojenie";
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "Vyžaduje sa aktívne internetové pripojenie k náhľadu aktivít";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "Na zobrazenie paušálov je potrebné pripojenie k internetu";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -294,6 +312,9 @@
 
 /* Error message shown when a media upload fails for unknown reason and the user should try again. */
 "An unknown error occurred. Please try again." = "Vyskytla sa neznáma chyba. Prosím skúste to znova.";
+
+/* the comment has an anonymous author. */
+"Anonymous" = "Anonymný";
 
 /* App Settings Title
    Link to App Settings section
@@ -402,6 +423,9 @@
    Previous web page */
 "Back" = "Späť";
 
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Buďte prvý, kto napíše komentár.";
+
 /* Accessibility label for block quote button on formatting toolbar.
    Discoverability title for block quote keyboard shortcut. */
 "Block Quote" = "Blok citácie";
@@ -438,15 +462,22 @@
 /* Title for a list of different button styles. */
 "Button Style" = "Štýl tlačidiel";
 
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "Prihlásením súhlasíte s našimi _Podmienkami poskytovania služby_.";
+
 /* Label for size of media while it's being calculated. */
 "Calculating..." = "Prepočítava sa...";
 
 /* Accessibility label for taking an image or video with the camera on formatting toolbar. */
 "Camera" = "Fotoaparát";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Nieje možné načítať adresu";
+
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -456,6 +487,7 @@
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -474,6 +506,7 @@
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -502,13 +535,15 @@
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Titulok";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Pozor!";
 
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Kategórie";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Kategória";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -567,6 +602,7 @@
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Zavrieť";
 
@@ -587,6 +623,9 @@
 
 /* Label for switch to turn on/off sending app usage data */
 "Collect information" = "Zbierať informácie";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Komiks";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -610,6 +649,7 @@
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Komentáre";
 
@@ -662,12 +702,18 @@
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Prepojené účty";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Pripojené ale...";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "Pripájam %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Pripojovanie k %1$@ nahradí aktuálne spojenie k %2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Pripájanie sa na WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Pripájam...";
@@ -700,6 +746,7 @@
 
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -767,6 +814,9 @@
    Register Domain - Domain contact information field Country */
 "Country" = "Krajina";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Vytvoriť účet";
+
 /* Button to progress to the next step
    Site creation. Step 1. Screen title
    Title for the button to progress with creating the site with the selected design. */
@@ -783,6 +833,9 @@
 
 /* No comment provided by engineer. */
 "Current" = "Súčasné";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Súčasný paušál";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Aktuálna téma";
@@ -822,6 +875,9 @@
    Title for selecting a default category for a post */
 "Default Category" = "Predvolená kategória";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Základné menu";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Predvolený formát článku";
@@ -830,6 +886,7 @@
 "Defaults for New Posts" = "Základné pre nové príspevky";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Odstrániť";
@@ -909,7 +966,9 @@
    Title for the Discussion Settings Screen */
 "Discussion" = "Diskusia";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Zrušiť";
 
 /* Display Name label text.
@@ -919,6 +978,9 @@
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "Domény";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "Ešte nemáš účet? _Zaregistruj sa_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -935,6 +997,9 @@
 
 /* Voiceover accessibility hint informing the user they can double tap a modal alert to dismiss it */
 "Double tap to dismiss" = "Dvojklikom odmietnete";
+
+/* Name for the status of a draft post. */
+"Draft" = "Koncept";
 
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Koncepty";
@@ -985,7 +1050,10 @@
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "E-mailová adresa";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "E-mailová adresa";
 
 /* Notification Settings Channel */
@@ -1024,8 +1092,15 @@
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Vložte heslo";
 
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Zadajte heslo pre svoj účet WordPress.com.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Vložte prihlasovacie meno";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "Vpíšte svoje heslo.";
 
 /* Generic error alert title
    Generic popup title for any type of error. */
@@ -1113,6 +1188,9 @@
 /* Section title for the external table section in the blog details screen */
 "External" = "Externý";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Neúspešné";
+
 /* Error message to show to use when media insertion on a post fails */
 "Failed to insert media.\n Please tap for options." = "Chyba pri nahrávaní súboru.\nKliknutím otvoríte nastavenia.";
 
@@ -1154,6 +1232,9 @@
    User's First Name */
 "First Name" = "Krstné meno";
 
+/* Button title. Follow the comments on a post. */
+"Follow" = "Odoberať";
+
 /* User role badge */
 "Follower" = "Odberateľ";
 
@@ -1190,12 +1271,21 @@
 /* Displayed in the Notifications Tab as a message, when the Follow Filter shows no notifications */
 "Get noticed: comment on posts you've read." = "Dostávať upozornenia: pri pridaní komentára v článku ktorý ste prečítali.";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Získať informácie o účte";
+
+/* Cancel */
+"Give Up" = "Vzdať sa";
+
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "Prejsť na čítačku";
 
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "Prejsť do iOS nastavení";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Zlyhalo prihlásie do Google.";
 
 /* This is the text we display to the user after they've indicated they like the app */
 "Great!\n We love to hear from happy users \n😁" = "Vynikajúco!\n Radi počujeme o šťastných používateľoch. \n😁";
@@ -1250,6 +1340,9 @@
    Open editor help options
    Title of the 'Help & Support' screen within the 'Me' tab - used for spotlight indexing on iOS. */
 "Help & Support" = "Pomoc a podpora";
+
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Skrytý";
 
 /* Title of a button used to collapse a group */
 "Hide" = "Skryť";
@@ -1327,6 +1420,9 @@
 /* Describes a standard *.wordpress.com site domain */
 "Included with Site" = "Súčasťou stránky";
 
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Nesprávne užívateľské meno alebo heslo. Skúste to znovu a zadajte vaše prihlasovacie údaje.";
+
 /* WordPress.com Community Footer Text */
 "Information on WordPress.com courses and events (online & in-person)." = "Informácie o kurzoch a udalostiach tímu WordPress.com (online a osobne).";
 
@@ -1375,6 +1471,9 @@
 /* Message displayed in an alert when user tries to install a first plugin on their site. */
 "Installing the first plugin on your site can take up to 1 minute. During this time you won’t be able to make changes to your site." = "Inštaluje sa prvý plugin na webovej stránke. Môže to trvať 1 minútu. Počas tohto času, nebudete môcť vykonávať zmeny na webovej stránke.";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "Neplatná e-mailová adresa.";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "Neplatná adresa webovej stránky";
 
@@ -1398,6 +1497,12 @@
 
 /* Send Person Invite */
 "Invite" = "Pozvať";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "Zdá sa, že toto používateľské meno\/heslo nie je priradené k tejto webovej stránke.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "Zdá sa, že ste zadali nesprávne heslo. Chcete to skúsiť znovu?";
 
 /* Accessibility label for italic button on formatting toolbar.
    Discoverability title for italic formatting keyboard shortcut. */
@@ -1491,7 +1596,8 @@
 /* VoiceOver accessibility hint, informing the user the button can be used to like a comment */
 "Likes the Comment." = "Komentár sa páči.";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Odkaz";
 
 /* Menus title label when editing a menu item as a link. */
@@ -1529,6 +1635,12 @@
 /* Menus label text displayed while menus are loading */
 "Loading Menus..." = "Načítanie menu...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Načítava sa paušál...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Nahrávajú sa plány...";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "Načítava sa plugin ...";
 
@@ -1551,15 +1663,29 @@
    Text displayed while loading time zones */
 "Loading..." = "Nahráva sa...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Miestne";
+
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "Miestne zmeny";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Poloha";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Lokalizačné služby musia byť povolené predtým, ako WordPress môže pridať svoju aktuálnu polohu. Povoľte Lokalizačné služby v nastaveniach aplikácie.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Neznáma poloha";
 
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Súbory denníka podľa dátumu vytvorenia";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Prihlásiť sa";
 
 /* Button for confirming logging out from WordPress.com account
@@ -1568,6 +1694,12 @@
 
 /* Title of a button for signing in. */
 "Log in" = "Prihlásiť";
+
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Prihlásenie zlyhalo. Prosím skúste to znova.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Prihláste sa do účtu WordPress.com, ktorý používate na pripojenie k Jetpack.";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of WordPress?" = "Odhlásiť sa z WordPress?";
@@ -1580,6 +1712,9 @@
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Zdá sa, že na vašej webovej stránke máte nastavený Jetpack. Gratulujeme! Prihláste sa s poverením WordPress.com a zapnite Štatistika a Upozornenia.";
+
+/* Title of a button. */
+"Lost your password?" = "Zabudli ste heslo?";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Hlavná navigácia";
@@ -1712,6 +1847,9 @@
    Title of My Site tab */
 "My Site" = "Moja webová stránka";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "Moja webová stránka je vo WordPress";
+
 /* Accessibility label for the Email text field.
    Header for a comment author's name, shown when editing a comment.
    Name text field placeholder */
@@ -1723,8 +1861,15 @@
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Potrebujete pomoc?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "Potrebujete pomoc pri hľadaní adresy vašej webovej stránky?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "Potrebujete pomoc?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Potrebujete ďalšiu pomoc?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "Potrebná aktualizácia";
@@ -1744,6 +1889,9 @@
 /* New Post 3D Touch Shortcut */
 "New Post" = "Nový článok";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Nová položka";
+
 /* Noun. The title of an item in a list. */
 "New posts" = "Nové príspevky";
 
@@ -1754,7 +1902,9 @@
 "Newest first" = "Najnovšie prvé";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Ďalší";
 
 /* Accessibility label for the next notification button */
@@ -1784,6 +1934,9 @@
 /* Menus name field text when no menu is selected. */
 "No Menu Selected" = "Žiadne menu nieje vybrané";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "Bez názvu";
+
 /* Title for the view when there aren't any Activities to display in the Activity Log */
 "No activity yet" = "Zatiaľ žiadna aktivita";
 
@@ -1798,7 +1951,8 @@
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "Žiadne komentáre";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "Žiadne spojenie";
 
@@ -1903,7 +2057,12 @@
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Očíslovaný zoznam";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -1939,13 +2098,19 @@
    Title for the view when there's an error loading time zones */
 "Oops" = "Oops";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Ojoj!";
 
 /* Opens iOS's Device Settings for WordPress App */
 "Open Device Settings" = "Otvoriť nastavenia zariadenia";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Otvoriť Mail";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Otvoriť nastavenia";
 
 /* No comment provided by engineer. */
@@ -1992,7 +2157,8 @@
    Other Sites Notification Settings Title */
 "Other Sites" = "Ďalšie webové stránky";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Stránka";
 
@@ -2009,14 +2175,21 @@
 /* Title for selecting parent category of a category */
 "Parent Category" = "Nadradená kategória";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Heslo";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Čakajúce";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Čakajúce na kontrolu";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -2037,6 +2210,10 @@
 
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "Vyberte užívateľské meno";
+
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Paušály";
 
 /* User action to play a video on the editor. */
 "Play video" = "Prehrať video";
@@ -2062,7 +2239,7 @@
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "Zadajte platnú e-mailovú adresu";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Vložte platnú e-mailovú adresu.";
 
 /* Popup message to ask for user credentials (fields shown below). */
@@ -2070,6 +2247,9 @@
 
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Prosím, zadajte svoju e-mailovú adresu.";
+
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Vyplňte prosím všetky polia";
 
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Prosím spusťte aplikáciu WordPress, prihláste sa do WordPress.com a uistite sa, že máte aspoň jednu webovú stránku, potom skúste znovu.";
@@ -2103,7 +2283,8 @@
 /* Section title for Popular Languages */
 "Popular languages" = "Populárne jazyky";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Článok";
 
@@ -2182,15 +2363,28 @@
    Privacy Settings Title */
 "Privacy Settings" = "Nastavenia súkromia";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Súkromné";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Proces odstráni všetky údaje WordPress.com z tohto zariadenia a zmaže všetky uložené koncepty. Neprídete o nič, čo ste už uložili na blogu WordPress.com.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Projekty";
+
 /* Label for the publish (verb) button. Tapping publishes a draft post.
    Publish post action on share extension site picker screen.
    Section title for the publish table section in the blog details screen */
 "Publish" = "Zverejniť";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Zverejniť okamžite";
+
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "Zverejniť člábok na:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Zverejnené";
 
@@ -2302,6 +2496,9 @@
    Verb. Button title. Reply to a comment. */
 "Reply" = "Odpovedať";
 
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Text odpovede";
+
 /* An explaination of a setting. */
 "Require manual approval for comments that include more than this number of links." = "Vyžadovať schválenie pre komentáre, ktoré obsahujú viacej než tento počet odkazov.";
 
@@ -2354,6 +2551,9 @@
 /* User action to retry all failed media uploads. */
 "Retry all" = "Zopakovať všetko";
 
+/* No comment provided by engineer. */
+"Retry?" = "Obnoviť?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "Návrat na príspevok";
 
@@ -2371,8 +2571,12 @@
    User's Role */
 "Role" = "Rola";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS odoslaná";
+
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -2403,7 +2607,8 @@
 /* Menus save button title while it is saving a Menu. */
 "Saving..." = "Ukladá sa...";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Naplánované";
 
 /* Title of Stats section that shows search engine referrer traffic. */
@@ -2455,6 +2660,9 @@
 /* Menus alert message for alerting the user to unsaved changes while trying to select a different menu. */
 "Selecting a different menu will discard changes you've made to the current menu. Are you sure you want to continue?" = "Pokiaľ vyberiete iné menu, zahodíte si tak zmeny, ktoré ste urobili v aktuálnom menu. Určite chcete pokračovať?";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Poslať odkaz";
+
 /* Settings: Sending Pingbacks */
 "Send Pingbacks" = "Odosielať pingbacky";
 
@@ -2493,6 +2701,9 @@
 
 /* Message to show when setting save failed */
 "Settings update failed" = "Aktualizácia nastavení zlyhala";
+
+/* Spoken accessibility label */
+"Share" = "Zdieľať";
 
 /* Informational text for Collect Information setting */
 "Share information with our analytics tool about your use of services while logged in to your WordPress.com account." = "Zdieľajte informácie o vašom používaní služieb s našim analytickýcm nástrojom, pokým sa prihlasujete do svojho účtu na WordPress.com. ";
@@ -2534,6 +2745,15 @@
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Zobraziť verejne keď komentujete blogy.";
 
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Registrácia";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Prihláste sa na WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Prihláste sa cez E-mail";
+
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "Keďže máte bezplatný plán, v logu aktivít uvidíte obmedzené udalosti.";
 
@@ -2550,6 +2770,9 @@
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Výsledky webovej stránky";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Adresa webovej stránky";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "Adresa webovej stránky musí mať aspoň 4 písmená.";
@@ -2601,7 +2824,7 @@
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Adresa webovej stránky musia obsahovať písmená.";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Táto e-mailová adresa sa už používa!";
 
 /* No comment provided by engineer. */
@@ -2696,6 +2919,9 @@
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "Preškrtnutie ";
 
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Zástup";
+
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "Odoslať ku kontrole";
 
@@ -2746,7 +2972,8 @@
 /* Title for the app appearance setting (light / dark mode) that uses the system default value */
 "System default" = "Podľa systému";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Značka";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -2784,14 +3011,23 @@
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Zmluvné podmienky";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Recenzie";
+
 /* Title of a button style */
 "Text Only" = "Len text";
 
 /* No comment provided by engineer. */
 "Text color" = "Farba textu";
 
+/* Button title */
+"Text me a code instead" = "Radšej mi pošlite kód";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Ďakujeme, že používate %1$@ od %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "Zdá sa, že overovací kód je neplatný.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "Vyzerá to tak, že toto nieje stránka WordPress.";
@@ -2825,6 +3061,9 @@
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "Obrázok sa nepodarilo pridať do knižnice.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "Internetové pripojenie vyzerá nedostupné.";
 
 /* Footer Text displayed in Blog Language Settings View */
 "The language in which this site is primarily written." = "Jazyk v ktorom je tento web primárne napísaný.";
@@ -2882,11 +3121,17 @@
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "Vyskytla sa neočakávaná chyba počas úpravy vášho komentáru";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "Došlo k neočakávanej chybe pri načítavaní komentárov.";
+
 /* Invite Failed Message */
 "There has been an unexpected error while sending your Invitation" = "Došlo k neočakávanej chybe pri odosielaní pozvánky";
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "Vyskytla sa neočakávaná chyba počas aktualizácie nastavení upozornení";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "Nastala neočakávaná chyba pri aktualizovaní vášho komentáru";
 
 /* Displayed when there's a pending Email Change. The variable is the new email address. */
 "There is a pending change of your email to %@. Please check your inbox for a confirmation link." = "Existuje čakajúca zmena e-mailu na %@. Skontrolujte vašu schránku a vyhľadajte potvrdzovací odkaz.";
@@ -2902,17 +3147,32 @@
 /* Error message informing the user that there was a problem blocking posts from a site from their reader. */
 "There was a problem blocking posts from the specified site." = "Vyskytol sa problém s blokovaním príspevkov na tejto webovej stránke. ";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "Pri pripájaní na Wordpress.com nastala chyba. Prihláste sa znova.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "Došlo k chybe pri zobrazení tohto príspevku.";
+
 /* Error message informing the user that there was a problem clearing the block on site preventing its posts from displaying in the reader. */
 "There was a problem removing the block for specified site." = "Nastal problém pri odstraňovaní bloku z určenej webovej stránky,";
 
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "Došlo k chybe pri ukladaní zmien v nastaveniach zdieľania.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "Došlo k chybe pri pokuse načítať vašu polohu. Skúste to znovu pozdejšie.";
+
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "Došlo k chybe pri načítavaní aktivít";
 
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "Došlo k chybe pri načítaní paušálov";
+
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "Došlo k chybe pri načítavaní pluginov";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "Pri načítavaní stránky sa vyskytla chyba.";
 
 /* Text displayed when there is a failure loading the plugin */
 "There was an error loading this plugin" = "Pri načítavaní tohto pluginu sa vyskytla chyba";
@@ -2931,6 +3191,9 @@
 
 /* An error message display if the users device does not have a camera input available */
 "This app needs permission to access the Camera to capture new media, please change the privacy settings if you wish to allow this." = "Táto aplikácia potrebuje povolenie na prístup do fotoaparátu na zachytenie nových súborov, prosím zmeňte nastavenia súkromia, pokiaľ si prajete jeho prijatie.";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "Táto e-mailová adresa nie je registrovaná na WordPress.com.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "Súbor je príliš veľký, aby sa načítal na weboú stránku alebo jeho formát nie je podporovaný.";
@@ -2982,6 +3245,12 @@
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "Ak chcete pokračovať, zadajte svoju e-mailovú adresu a meno.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "Prosím zadajte svoju e-mailovú adresu na vytvorenie nového účtu WordPress.com.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "Prosím, prihláste sa pomocou hesla na WordPress.com a pokračujte s účtou Google. Prihlásite sa iba raz.";
+
 /* Comments Today Section Header
    Insights 'Today' header
    Notifications Today Section Header */
@@ -3017,7 +3286,8 @@
    Trashes the comment */
 "Trash" = "Kôš";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "Odstránené ";
 
@@ -3028,6 +3298,7 @@
 "Try & Customize" = "Vyskúšať a prispôsobiť";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Skúsiť znova";
@@ -3038,6 +3309,12 @@
    Button that lets users try to reload the plugin directory after loading failure
    Re-load the history again. It appears if the loading call fails. */
 "Try again" = "Pokus zopakujte";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Skúste s iným e-mailom";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Skúste s adresou webovej stránky";
 
 /* Title of button that displays the app's Twitter profile */
 "Twitter" = "Twitter";
@@ -3057,6 +3334,9 @@
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "USES";
 
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "Nedá sa pripojiť";
+
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "Nepodarilo sa načítať články";
 
@@ -3075,6 +3355,9 @@
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Nepodarilo sa prehrať video";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Nenašla sa webová stránka WordPress na tejto URL adrese. Ťuknite \"Potrebujete pomoc?\" na zobrazenie FAQ.";
+
 /* Text displayed when a site restore fails. */
 "Unable to restore your site, please try again later or contact support." = "Nepodarilo sa obnoviť webovú stránku, prosím pokus zopakujte alebo kontaktujte podporu.";
 
@@ -3092,6 +3375,9 @@
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "Nepodarilo sa nahrať 1 článok, 1 súbor";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "Nepodarilo sa overiť e-mailovú adresu. Prosím skúste neskôr.";
 
 /* Error reason to display when the writing of a image to a file fails */
 "Unable to write image to file" = "Nedalo sa zapísať obrázok k súboru";
@@ -3173,7 +3459,8 @@
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Nahrávanie zlyhalo";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Nahraté";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -3191,7 +3478,8 @@
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Nahrané témy";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Nahráva sa";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -3201,11 +3489,14 @@
 "Use" = "Použiť";
 
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Používateľské meno";
 
 /* Setting: indicates if Mentions will be notified */
@@ -3217,6 +3508,9 @@
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Používatelia";
+
+/* two factor code placeholder */
+"Verification code" = "Overovací kód";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "Odoslali sme overovací e-mail, prosím skontrolujte si doručenú poštu.";
@@ -3301,6 +3595,9 @@
 /* Action title. Noun. Opens the user's WordPress Admin in an external browser. */
 "WP Admin" = "WP Admin";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Čaká sa na Google, kým dokončí...";
+
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
    Title for Jetpack Restore Warning screen */
@@ -3318,6 +3615,12 @@
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "Používame ďalšie nástroje na sledovanie, vrátane niektorých od tretích strán. Prečítajte si o nich a o možnostiach ako ich ovládať.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "Nepodarilo sa nám odoslať e-mail. Prosím, skúste ešte raz neskôr. ";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "Cez e-mail vám pošleme zázračný odkaz, ktorý vás prihlási okamžite, bez potreby zadávania hesla. Už žiadne vyťukávanie!";
+
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "Upozorníme vás, keď získate nových odberateľov, komentáre a lajky.";
 
@@ -3326,6 +3629,9 @@
 
 /* Title of progress label displayed when a first plugin on a site is almost done installing. */
 "We're doing the final setup—almost done…" = "Vykonávame posledné nastavenia - sme skoro hotoví ... ";
+
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "Nepodarilo sa nám pripojiť na webovú stránku Jetpack z tejto URL adresy. Kontaktujte pre pomoc. ";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -3349,6 +3655,9 @@
 /* Title of section that contains plugins' change log */
 "What's New" = "Čo je nové";
 
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "Aká je adresa mojej webovej stránky?";
+
 /* Text rendered at the bottom of the Discussion Moderation Keys editor */
 "When a comment contains any of these words in its content, name, URL, e-mail or IP, it will be held in the moderation queue. You can enter partial words, so \"press\" will match \"WordPress\"." = "Pokiaľ komentár obsahuje akékoľvek z týchto slov vo svojom obsahu, mene, URL, e-mailu, alebo IP, tento komentár bude pozdržaný a skontrolovaný moderátorom. Môžete taktiež zadať časti slov, takže napríklad podmienke \"press\" bude odpovedať \"WordPress\".";
 
@@ -3358,29 +3667,65 @@
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "V prípade, že spravíte zmeny na webovej stránke, uvidíte ich v histórii aktivít.";
 
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Hups, niečo sa pokazilo a nepodarilo sa nám prihlásiť vás. Prosím, skúste ešte raz!";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Hups, dvojfaktorový overovací kód nie je platný. Skontrolujte kód a skúste ešte raz!";
+
 /* Help text when editing email address */
 "Will not be publicly displayed." = "Táto adresa nebude zverejnená.";
 
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "Nastavenia aplikácie WordPress";
+
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "WordPress Blog";
+
+/* Siri Suggestion to open Support */
+"WordPress Help" = "Pomoc WordPress";
 
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "Knižnica médií WordPress";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "Nastavenia upozornení WordPress";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "Upozornenie WordPress";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "Profil WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "Čítačka WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "Detaily webovej stránky WordPress";
+
 /* Subject of new Zendesk ticket. */
 "WordPress for iOS Support" = "Podpora pre WordPress pre iOS";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress potrebuje oprávnenie pre prístup aktuálnej polohy Vášho zariadenia pre jej pridanie do Vášho článku. Prosím aktualizujte Vaše nastavenia súkromia.";
+
 /* No comment provided by engineer. */
 "WordPress version too old" = "Verzia WordPress je príliš stará";
+
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Verzia WordPress je príliš stará. Na webe %1$@ používate WordPress vo verzií %2$@. Odporúčame aktualizáciu na najnovšiu verziu, alebo aspoň na %3$@";
 
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "Účet WordPress.com";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "WordPress.com paušály";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "Témy WordPress.com";
@@ -3463,7 +3808,8 @@
 /* Warning displayed before logging out. The %d placeholder will contain the number of local posts (PLURAL!) */
 "You have changes to %d posts that haven’t been uploaded to your site. Logging out now will delete those changes. Log out anyway?" = "Máte zmeny v %d príspevkoch, ktoré neboli nahrané na vašu webovú stránku. Ak sa teraz odhlásite, budú tieto zmeny zmazané. Chcete sa napriek tomu odhlásiť?";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Máte neuložené zmeny.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -3513,6 +3859,9 @@
 /* Text displayed when a site restore takes too long. */
 "Your restore is taking longer than usual, please check again in a few minutes." = "Obnovenie trvá dlhšie ako obvykle, prosím skontrolujte o niekoľko minút.  ";
 
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "Adresa webovej stránky sa zobrazí na hornom paneli obrazovky, keď navštívite webovú stránku cez Safari.";
+
 /* Title of a message displayed when a site has finished rewinding */
 "Your site has been succesfully restored" = "Vaša webová stránka bola úspešne obnovená";
 
@@ -3558,6 +3907,24 @@
 /* Used when the response doesn't have a valid url to display */
 "unknown url" = "neznáma url adresa";
 
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Články";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Komentáre";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Likes";
+
+/* Title of today widget */
+"widget.today.title" = "Dnes";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Zobrazenia";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Návštevníci";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "v budúcnosti nebude k dispozícii.";
 
@@ -3581,6 +3948,9 @@
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'My Sites' tab. */
 "wordpress, sites, site, blogs, blog" = "wordpress, webové stránky, webová stránka, blogy, blog";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Prihláste sa cez Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Domény";

--- a/WordPress/Resources/sq.lproj/Localizable.strings
+++ b/WordPress/Resources/sq.lproj/Localizable.strings
@@ -99,6 +99,9 @@
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "%1$@ nga %2$@ gjithsej në sajtin tuaj";
 
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "%1$@ nga %2$@ gjithsej të përdorur në sajtin tuaj";
+
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ kuadrilion";
 
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Pa titull)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(pa titull)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "<b>Durim Cerova<\/b> iu përgjigj postimit tuaj";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "Një buton “Më tepër” përmban një menu hapmbyll që shfaq butona ndarjesh me të tjerët";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "Me kredencialet tuaja për shitoren ka të përshoqëruar një llogari WordPress.com. Që të vazhdohet, do të dërgojmë një lidhje verifikimi te adresa email më sipër.";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "Një kartelë përmban rregullsi kodi dashakeq";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "Titull për këtë sajt";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "Lypse të adresë email e vlefshme, për postimin e një lidhje mirëfilltësimi. Ju lutemi, kthehuni te skena e mëparshme dhe jepni një adresë email të vlefshme.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "Një kod verifikimi do të përmbajë vetëm numra.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "AKTIVE";
@@ -522,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "Pas %@";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "Drejtim";
@@ -585,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "Adresa IP të shënuara si të lejuara";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "Thuajse arritëm! Ju lutemi, jepni kodin e verifikimit prej aplikacionit tuaj Authenticator.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Tekst Alternativ";
@@ -597,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "Ndryshe, mund ta sheshoni lëndën duke hequr bllokun nga grupi.";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "Ndryshe, mund të jepni fjalëkalimin për këtë llogari.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "Ndryshe:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "Dërgo Përherë Regjistrime Vithisjesh";
@@ -618,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "Që të shihni veprimtari lypse një lidhje internet aktive";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "Që të shihni planet lypse një lidhje internet aktive";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -668,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "Statistika Vjetore Sajti";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "I paemër";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "Përgjigjuni";
 
@@ -689,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "Dukje";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "Mirëfilltësimi Apple dështoi.\nJu lutemi, sigurohuni se keni bërë hyrjen te llogaria juaj iCloud me një Apple ID që përdor mirëfilltësim dyfaktorësh.";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "Aplikon rregullimin";
@@ -775,6 +811,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "Mirëfilltësimi Dështoi";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "Kod mirëfilltësimi";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "Lypset mirëfilltësim për strehën: %@";
@@ -885,6 +925,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "Bëhuni i pari që komenton";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Bëhuni i pari që lë një koment.";
 
 /* Beauty site intent topic */
 "Beauty" = "Bukuri";
@@ -1018,12 +1061,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button to copy post text" = "Buton për “Kopjo tekst postimi”";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "Duke vazhduar, pajtoheni me _Termat tona të Shërbimit_.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "Duke regjistruar këtë përkatësi, pajtoheni me <a>Termat&nbsp;dhe&nbsp;Kushtet<\/a> tona.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "Duke ujdisur Jetpack-un, pajtoheni me\n%@ tona";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "Duke u regjistruar, pajtoheni me _Kushtet tona të Shërbimit_.";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "PËRSHTATENI";
@@ -1037,6 +1086,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "Për skanim kode hyrjesh lypsen leje mbi kamerën";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "S’Kërkohet Dot Lidhje";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "S’botohet dot një faqe e zbrazët";
 
@@ -1046,6 +1098,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1055,6 +1108,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1073,6 +1127,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1100,6 +1155,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "Po anulohet …";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "S’kapet dot sajt në këtë adresë. Ju lutemi, rikontrollojeni dhe riprovoni.";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "S’e ndani dot mendjen? Temën mund ta ndryshoni kurdo.";
 
@@ -1107,7 +1165,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Legjendë";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Kujdes!";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1116,7 +1175,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Kategori";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Kategori";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1165,6 +1225,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "Shihni ndihmëzat tona kryesuese për shtim të parjeve dhe trafikut";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "Shihni email-in tuaj në këtë pajisje!";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Kontrolloni email-in tuaj te kjo pajisje dhe prekni lidhjen te email-i që merrni prej WordPress.com-i.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "Hapeni email-et në këtë pajisje dhe prekni lidhjen te email-i që morët nga WordPress.com.\n\nS’e shihni email-in? Shihni te dosja Të padëshiruar ose Të pavlera.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "Kontrolloni email-in tuaj!";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "Kontrolloni lidhjen tuaj internet dhe tërhiqeni që të rifreskohet.";
@@ -1261,6 +1333,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "Kërkoni përkatësinë tuaj falas";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "Blog Klasik";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "Pastro Fshehtinë Medie Pajisjeje";
 
@@ -1288,6 +1363,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Mbylle";
 
@@ -1329,6 +1405,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "Rregullime Shtyllash";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Tregime me Figura";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1380,6 +1459,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Komente";
 
@@ -1447,12 +1527,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Llogari të Lidhura";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "U lidhët, Por…";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "Po bëhet lidhja me %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Lidhja e %1$@ do të zëvendësojë lidhjen ekzistuese me %2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Po lidhjet me WordPress.com-in";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Po bëhet lidhja…";
@@ -1483,8 +1569,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "Lidhuni me ne te %@";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "Strukturë Lënde\nBlloqe: %1$li, Fjalë: %2$li, Shenja: %3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1499,6 +1589,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Vazhdoni me leximin";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Vazhdo me Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Vazhdoni me Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Po vazhdohet me Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "Kontribuoni";
@@ -1627,6 +1726,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "Krijoje";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Krijo Llogarinë";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "Krijo Faqe të Zbrazët";
 
@@ -1647,6 +1749,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "Krijoni një Postim";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "Krijoni një Sajt";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "Krijoni një Etiketë";
@@ -1677,6 +1782,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "I tanishmi";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Plani i Tanishëm";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Tema e Tanishme";
@@ -1779,6 +1887,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "Kategori Parazgjedhje";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Menu Parazgjedhje";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Format Parazgjedhje Postimesh";
@@ -1787,6 +1898,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "Parazgjedhje për Postime të Reja";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Fshije";
@@ -1844,6 +1956,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "Hollësi";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "S’e kishit fjalën për të krijuar një llogari të re? Shkoni mbrapsht, që të rijepni adresën tuaj email.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "Përmasa";
 
@@ -1891,7 +2006,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "Diskutim";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Hidhe tej";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1913,6 +2030,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "Përkatësi";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "S’keni llogari? _Regjistrohuni_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2042,6 +2162,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "Shkarkime";
 
+/* Name for the status of a draft post. */
+"Draft" = "Skicë";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Skica";
 
@@ -2151,7 +2274,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "Adresë Email";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "Adresë email";
 
 /* Notification Settings Channel */
@@ -2235,8 +2361,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Jepni fjalëkalim";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "Jepni adresën e sajtit WordPress te i cili do të donit të lidheshit.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Jepni fjalëkalimin për llogarinë tuaj WordPress.com.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Jepni emër përdoruesi";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "Jepni hollësi të llogarisë tuaj për %@.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "Që të bëni hyrjen ose të krijoni një llogari te WordPress.com, jepni adresën tuaj email.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "Jepni adresën e sajtit tuaj ekzistues";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "Në vend të kësaj, jepni fjalëkalimin tuaj.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "Jepni kredencialet tuaja për në shërbyes";
@@ -2399,6 +2545,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "E jashtme";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Dështoi";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "S’u arrit t’u vihej shenjë Njoftimeve si të lexuara";
 
@@ -2425,6 +2574,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "Modë";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "Të zgjedhura";
@@ -2483,6 +2635,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "Shihni më tepër";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Gjeni adresën e sajtit tuaj";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2502,6 +2657,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "Zgjidhje Kërcënimesh";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "Ndiqeni";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "Ndiqe Bisedën";
@@ -2596,6 +2754,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "Prodho lidhje të re";
 
+/* View title for initial auth views. */
+"Get Started" = "Fillojani";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "Merrni me email një lidhje hyrjeje";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "Aktivizohuni! Komentoni në postime prej blogjesh që ndiqni.";
 
@@ -2617,8 +2781,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "Frymëzohuni";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Po merren hollësi llogarie";
+
+/* Cancel */
+"Give Up" = "Lëre Fare";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "Provojeni, duke shtuar ca blloqe te postimi ose faqja juaj!";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "Kaloni te Lexuesi";
@@ -2629,6 +2802,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "Shkoni te Rregullimet për iOS";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Hyrja në llogarinë Google dështoi.";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2703,6 +2879,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "Ikonë ndihme";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Të fshehura";
+
 /* Title of a button used to collapse a group */
 "Hide" = "Fshihe";
 
@@ -2771,6 +2950,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "Përditësimi i ikonës dështoi";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "Nëse s’e gjeni dot email-in, ju lutemi, shihni te dosja juaj Hedhurina, ose ajo Të padëshiruar";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "Nëse vazhdoni me Google apo Apple dhe s’keni ende një llogari WordPress.com, po krijoni një llogari dhe pajtoheni me _Kushtet tona të Shërbimit_.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "Nëse e hiqni %1$@, ky përdorues s’do të jetë më në gjendje të hyjë në këtë sajt, por çfarëdo lënde që është krijuar prej %2$@ do të mbesë në sajt.";
@@ -2846,6 +3031,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "Përfshin wp-config.php dhe çfarëdo kartelash jo WordPress";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Emër përdoruesi ose fjalëkalim i pasaktë. Ju lutemi, provoni të rijepni hollësitë tuaja për hyrjen.";
 
 /* Title for a threat */
 "Infected core file" = "Kartelë bazë e infektuar";
@@ -2947,6 +3135,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "Ju Paraqesim Cytje Blogimi";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "Adresë Email e Pavlefshme";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "Adresë Sajti e Pavlefshme";
 
@@ -2964,6 +3155,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "URL e pavlefshme. S’u gjet kartelë audio.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "URL e pavlefshme. Ju lutemi, rikontrollojeni dhe riprovoni.";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "URL e pavlefshme. Ju lutemi, jepni një URL të vlefshme.";
@@ -2985,6 +3179,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "Ftoni Njerëz";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "Duket sikur ky emër përdoruesi\/fjalëkalim s’është i përshoqëruar me këtë sajt.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "Duket se keni dhënë një fjalëkalim të pasaktë. Doni ta provoni edhe një herë?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "Është koha të blogoni te %@!";
@@ -3213,7 +3413,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "Lartësi Rreshti";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Lidhje për te";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3275,6 +3476,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "Po ngarkohen Persona…";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Po ngarkohet Plani…";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Po ngarkohen Plane…";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "Po ngarkohet Shtojca…";
 
@@ -3309,11 +3516,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "Po ngarkohet…";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Vendor";
+
 /* Local Services site intent topic */
 "Local Services" = "Shërbime Vendore";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "Ndryshime vendore";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Vendndodhje";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Shërbimet e Vendeve duhet të aktivizohen përpara se WordPress-i të mund të shtojë vendin tuaj të tanishëm. Ju lutemi, aktivizoni Shërbime Vendesh që nga aplikacioni Rregullime.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Vendndodhje e panjohur";
 
 /* No comment provided by engineer. */
 "Lock icon" = "Ikonë kyçjeje";
@@ -3321,9 +3540,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Kartela Regjistër Sipas Datash Krijimi";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Hyni";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3332,6 +3553,22 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title of a button for signing in. */
 "Log in" = "Hyni";
+
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Hyrja dështoi. Ju lutemi, riprovoni.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "Hyni ose regjistrohuni me WordPress.com";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Bëni hyrjen te llogaria WordPress.com që përdorët për t’ia përshoqëruar Jetpack-ut.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "Bëni hyrjen te llogaria juaj në WordPress.com përmes adresës tuaj email.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "Hyni me emrin tuaj të përdoruesit dhe fjalëkalimin për te WordPress.com.";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of Jetpack?" = "Të dilet nga Jetpack-u?";
@@ -3342,6 +3579,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Login Request Expired */
 "Login Request Expired" = "Kërkesa Për Hyrje Skadoi";
 
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "Hyrje me fjalëkalim llogarie";
+
 /* No comment provided by engineer. */
 "Logs" = "Regjistra";
 
@@ -3350,6 +3590,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Duket se keni të rregulluar Jetpack-un në sajtin tuaj. Ju lumtë! Bëni hyrjen me kredencialet tuaja për te WordPress.com, që të aktivizoni Statistika dhe Njoftime.";
+
+/* Title of a button. */
+"Lost your password?" = "Humbët fjalëkalimin tuaj?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "Mail (Parazgjedhje)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Lëvizjet Kryesore";
@@ -3497,6 +3743,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "Mesazh";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "Cenueshmëri të ndryshme";
 
@@ -3592,6 +3841,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "Sajti Im";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "Sajtet e Mi në WordPress";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "Dhjetë Kafehanet e Mia Më të Mira";
 
@@ -3631,8 +3883,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Ju Duhet Ndihmë?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "Ju duhet ndihmë për gjetjen e adresës së sajtit tuaj?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "Ju duhet ndihmë?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Ju duhet më tepër ndihmë?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "Lyp Përditësim";
@@ -3661,6 +3920,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "Postim i Ri";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Element i ri";
+
 /* Placeholder text for password field */
 "New password" = "Fjalëkalim i ri";
 
@@ -3678,7 +3940,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "Lajme";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Pasuesi";
 
 /* Accessibility label for the next notification button */
@@ -3714,6 +3978,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "S’ka URL Paraparje";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "Pa Titull";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "S’ka veprimtari të gatshme";
 
@@ -3746,7 +4013,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "Ende pa komente";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "S'ka lidhje";
 
@@ -3895,6 +4163,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "Jo tani";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "S’e shihni email-in? Shihni te dosja juaj Të padëshiruar ose Të pavlerë.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "Shënim:";
 
@@ -3958,7 +4229,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Listë Me Numra";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -4015,7 +4291,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "Hëm";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Hëm!";
 
 /* No comment provided by engineer. */
@@ -4030,7 +4307,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "Hapni Rregullime Sigurie Jetpack-u";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Hap Postën";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Hap Rregullimet";
 
 /* No comment provided by engineer. */
@@ -4048,6 +4330,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "Hape lidhjen në dritare\/skedë të re";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "Hapni rregullime pajtimi për postimin";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "Hap Ndarjen Unë";
 
@@ -4062,6 +4347,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "Opsionale: Jepni një mesazh vetjak deri në %1$d shenja, që të dërgohet me ftesën tuaj.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "Ose";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "Ose zgjidhni një tjetër metodë mirëfilltësimi.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "Ose hyni _duke dhënë adresën e sajtit tuaj_.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "Ose hyni me lidhje magjike";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Listë e Renditur";
@@ -4110,7 +4407,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "Zbutje";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Faqe";
 
@@ -4140,8 +4438,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting parent category of a category */
 "Parent Category" = "Kategori Mëmë";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Fjalëkalim";
 
@@ -4158,8 +4459,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "Ngjite bllokun pas";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Pezull";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Në pritje të shqyrtimit";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4190,6 +4495,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "Zgjidhni emër përdoruesi";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Plane";
+
 /* User action to play a video on the editor. */
 "Play video" = "Luaje videon";
 
@@ -4219,6 +4528,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "Ju lutemi, garantoni që përpunuesi me blloqe të jetë aktivizuar në sajtin tuaj. Nëse s’është aktivizuar, s’do të ngarkohet.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "Ju lutemi, jepni një adresë të plotë sajti, bie fjala, example.com.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "Ju lutemi, jepni një adresë sajti.";
@@ -4253,11 +4565,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "Ju lutemi, jepni një adresë të vlefshme";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "Ju lutemi, jepni një adresë email të vlefshme për një llogari WordPress.com.";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Ju lutemi, jepni një adresë email të vlefshme.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "Ju lutemi, jepni një numër telefoni të vlefshëm";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Ju lutemi, jepni fjalëkalimin për llogarinë tuaj te WordPress.com që të bëhet hyrja me ID-në tuaj Apple.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Ju lutemi, jepni kredencialet tuaja";
@@ -4265,8 +4583,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Ju lutemi, jepni adresën tuaj email.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Ju lutemi, plotësoni krejt fushat";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Ju lutemi, nisni aplikacionin WordPress, bëni hyrjen te WordPress.com dhe sigurohuni që keni të paktën një sajt, mandej riprovoni.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "Ju lutemi, përpara se të lidheni te një sajt tjetër wordpress.com, dilni nga llogaria";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "Ju lutemi, riprovoni më vonë";
@@ -4334,7 +4658,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "Gjuhë popullore";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Postim";
 
@@ -4455,6 +4780,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "Shënim mbi privatësinë për përdorues në Kalifornia";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Privat";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "Problem me shfaqje blloku. \nPrekeni që të provohet rikthim blloku.";
 
@@ -4469,6 +4797,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "Problem gjatë blerjes së përkatësisë tuaj. Ju lutemi, riprovoni.";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Ecja më tej do të shkaktojë heqjen e krejt të dhënave WordPress.com prej këtij shërbimi, dhe do të fshijë çfarëdo skicash të ruajtura lokalisht. S’do të humbni gjë nga sa është ruajtur tashmë te blogu apo blogjet tuaj në WordPress.com.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Projekte";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "U anashkalua cytje";
@@ -4486,13 +4820,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "Datë Botimi";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Botoje Menjëherë";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "Botojeni faqen në:";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "Botojeni postimin në:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "U botua";
 
@@ -4694,7 +5032,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "Përgjigjiuni";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Tekst Përgjigjeje";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "Përgjigje për %1$@";
 
 /* An explaination of a setting. */
@@ -4723,6 +5066,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "Zero filtër Interval Datash";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Ricaktoni fjalëkalimi tuaj";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Ripërmasojeni & Qetheni";
@@ -4780,6 +5126,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "Riprovoji krejt";
 
+/* No comment provided by engineer. */
+"Retry?" = "Të riprovohet?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "Kthehu te postim";
 
@@ -4809,6 +5158,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "Rol";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "U dërgua Me SMS";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "GJENDJE";
 
@@ -4820,6 +5172,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4886,7 +5239,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "Po skanohen kartelat";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Vënë në plan";
 
 /* No comment provided by engineer. */
@@ -5026,6 +5380,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "Përzgjedh këtë temë si e synuara për sajtin tuaj.";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Dërgoje Lidhjen";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "Dërgoje Lidhjen me Email";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "Dërgo Mesazh Regjistri";
 
@@ -5034,6 +5394,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "Dërgo Provë Vithisjeje";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "Dërgo lidhje verifikimi email-i";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "Dërgo njoftime me email";
@@ -5079,6 +5442,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message to show when setting save failed */
 "Settings update failed" = "Përditësimi i rregullimeve dështoi";
+
+/* Spoken accessibility label */
+"Share" = "Ndajeni me të tjerët";
 
 /* Title for a button that recommends the app to others */
 "Share Jetpack with a friend" = "Jepjani WordPress-in një shoku";
@@ -5132,6 +5498,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "Shfaq buton Riblogimesh";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "Shfaqe fjalëkalimin";
+
 /* No comment provided by engineer. */
 "Show post content" = "Shfaq lëndë postimi";
 
@@ -5143,6 +5513,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "Po shfaqen statistika për:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "I shfaqur";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "E shfaqur publikisht kur komentoni në blogje.";
@@ -5158,6 +5531,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "Shfaq postimin";
+
+/* View title during the sign up process. */
+"Sign Up" = "Regjistrohuni";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "Hyni me kredenciale sajti";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Regjistrohuni";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Regjistrohuni te WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Regjistrohuni me Email";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "Meqë jeni nën një plan falas, te Regjistri juaj i Veprimtarisë do të shihni veprimtari të kufizuara.";
@@ -5196,6 +5584,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Arritje sajti";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Adresë sajti";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "Adresa e sajtit duhet të jetë e pakta 4 shenja.";
@@ -5277,7 +5668,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Na ndjeni, emrat e sajteve duhet të përmbajnë edhe shkronja!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Na ndjeni, ajo adresë email është tashmë në përdorim!";
 
 /* No comment provided by engineer. */
@@ -5337,6 +5728,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "I padëshiruar";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "Përshpejtoni funksionimin e sajtit tuaj";
@@ -5362,6 +5756,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "Shtet";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "Faqe Hyrëse Statike";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5392,6 +5789,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "Hequrvije";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Stub";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "Parashtrojeni për Shqyrtim";
@@ -5482,7 +5882,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "Tablet";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Etiketë";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5617,6 +6018,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Kushte Shërbimi";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Përshtypje";
+
 /* Title of a button style */
 "Text Only" = "Vetëm Tekst";
 
@@ -5626,8 +6030,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "Kontrollet për formatim teksti gjenden brenda panelit të vendosur mbi tastierën, kur përpunohet një bllok teksti";
 
+/* Button title */
+"Text me a code instead" = "Më mirë më dërgoni kod me tekst";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "Dërgomëni një kod përmes SMS-je";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Faleminderit që zgjodhët %1$@ nga %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "Ky s’duket të jetë kod verifikimi i vlefshëm.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "Ky s’duket si sajt WordPress.";
@@ -5649,6 +6062,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "Lidhja Facebook s’gjen dot ndonjë Faqe. Publicize s’mund të lidhet me Profile Facebook, vetëm me Faqe të botuara.";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "Llogaria Google \"%@\" s’ka përputhje me ndonjë llogari te WordPress.com";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "Lidhja Internet duket se është jashtë linje.";
@@ -5688,6 +6104,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "Figura s’u shtua dot te Mediateka.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "Lidhja internet duket se është jashtë linje.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "Llojet e sajteve që mund të krijohen";
@@ -5731,6 +6150,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Sajti te %1$@ përdor %2$@. Këshillojmë ta përditësoni me versionin më të ri, ose të paktën %3$@";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "Sajti në këtë adresë s’është sajt WordPress. Që të lidhemi me të, sajti duhet të përdorë WordPress.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "Sajti s’u fshi dot.";
 
@@ -5772,6 +6195,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "Pati një gabim të papritur teksa përpunohej komenti juaj";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "Pati një gabim të papritur teksa ngarkoheshin komente.";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "Pati një gabim të papritur teksa regjistrohej përkatësia juaj";
 
@@ -5780,6 +6206,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "Pati një gabim të papritur teksa përditësoheshin Rregullimet tuaja për Njoftime";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "Pati një gabim të papritur teksa përditësohej komenti juaj";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "Pati një gabim të papritur.";
@@ -5801,6 +6230,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "Pati një problem komunikimi me sajtin.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "Pati një problem gjatë lidhjes me WordPress.com-in. Ju lutemi, ribëni hyrjen.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "Pati një problem me shfaqjen e këtij postimi.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "Pati një problem me ngarkimin e të dhënave tuaja, rifreskoni faqen tuaj që të riprovoni.";
 
@@ -5810,12 +6245,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "Pati një gabim me ruajtjen e ndryshimeve te administrimi i ndarjeve me të tjerët.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "Pati një gabim teksa bëheshin përpjekje për të hyrë te vendi juaj. Ju lutemi, riprovoni më vonë.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "Pati një gabim në ndryshimin e fjalëkalimit";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "Pati një gabim në ngarkim veprimtarish";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "Pati një gabim në ngarkim planesh";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "Pati një gabim në ngarkim shtojcash";
@@ -5828,6 +6269,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "Pati një gabim në ngarkimin e historikut";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "Pati një gabim në ngarkimin e planit";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "Pati një gabim në ngarkimin e historikut të kontrolleve";
@@ -5876,6 +6320,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "Kjo përkatësi s’është e lirë";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "Kjo adresë email s’është e regjistruar në WordPress.com.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "Kartela është shumë e madhe për t’u ngarkuar te sajti juaj ose ky format mediash nuk mbulohet.";
@@ -5956,6 +6403,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "Zonë Kohore";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "Po mbaron koha, por mos u bëni merak, siguria juaj është përparësia jonë. Ju lutemi, riprovoni!";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "Këshilla për të përfituar maksimumin nga WordPress.com.";
 
@@ -5969,6 +6419,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "Që të vazhdohet, jepni adresën tuaj email dhe emrin.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "Që të krijoni llogarinë tuaj të re WordPress.com, ju lutemi, jepni adresën tuaj email.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "Që të merrni në telefonin tuaj njoftime të dobishme nga sajti juaj WordPress, do t’ju duhet të instaloni shtojcën Jetpack-un.";
 
@@ -5977,6 +6430,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "Që të instaloni shtojca, lypset të keni një përkatësi vetjake përshoqëruar sajtit tuaj.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "Që të vazhdohet me këtë Apple ID, ju lutemi, së pari bëni hyrjen me fjalëkalimin tuaj për te WordPress.com. Kjo do t’ju kërkohet vetëm një herë.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "Që të vazhdohet me këtë llogari Google, ju lutemi, së pari bëni hyrjen me fjalëkalimin tuaj për te WordPress.com. Kjo do t’ju kërkohet vetëm një herë.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "Që të hiqni një bllok, përzgjidhni bllokun dhe klikoni tre pikat poshtë djathtas bllokut që të shihni rregullimet. Prej andej, zgjidhni mundësinë për heqjen e bllokut.";
@@ -6051,7 +6510,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "Në hedhurina";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "Shpënë te Hedhurinat";
 
@@ -6065,6 +6525,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "Provojeni & Përshtateni";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Riprovoni";
@@ -6090,6 +6551,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "Provoni Përpunuesin e ri me Blloqe";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Provoni me një tjetër email";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Provoni me këtë adresë sajti";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "Çaktivizo cytjet";
@@ -6132,6 +6599,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "PËRDORIME";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "S’arrihet të Lidhet";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "S’arrihet të Ngarkohen Postime";
@@ -6181,6 +6651,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "S’arrihet të luhet videoja";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "S’arrihet të lexohet sajti WordPress tek ajo URL. Prekni “Ju duhet Ndihmë?” që të shihni PBR.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "S’arrihet të rikthehet sajti juaj";
 
@@ -6207,6 +6680,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "S’arrihet të ngarkohet 1 postim, 1 kartelë";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "S’u arrit të verifikohej adresa email. Ju lutemi, riprovoni më vonë.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "S’arrihet të vizitohen rregullime Jetpack për sajtin";
@@ -6351,7 +6827,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Ngarkimi dështoi";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "U ngarkua";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6369,7 +6846,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Tema të ngarkuara";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Po ngarkohet";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6384,18 +6862,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "Përdore";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "Përdorni një kyç sigurie";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "Përdorni përpunuesin me blloqe";
 
 /* No comment provided by engineer. */
 "Use icon button" = "Përdor buton ikone";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "Përdorni fjalëkalimin për hyrje";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Emër përdoruesi";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6410,6 +6897,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Përdorues";
+
+/* two factor code placeholder */
+"Verification code" = "Kod verifikimi";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "Email-i i verifikimit u dërgua, kontrolloni mesazhet e marrë.";
@@ -6542,8 +7032,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "Drejtoria WP-content";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Po pritet që të mbarojë punë Google…";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "Po pritet për lidhje";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "Po pritet për kyç sigurie";
+
+/* View title during the Google auth process. */
+"Waiting..." = "Po pritet…";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6583,6 +7083,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "Patëm probleme në ngarkim të dhënash";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "Sapo dërguam me email një lidhje te %@. Ju lutemi, kontrolloni te aplikacioni juaj për email-e dhe prekni lidhjen që të bëni hyrjen.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "Sapo dërguam një lidhje magjike te";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "Krijuam me sukses një kopjeruajtje të sajtit tuaj, siç qe më %1$@";
 
@@ -6592,14 +7098,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "Përdorim mjete të tjera gjurmimi, përfshi disa të tillë nga palë të treta. Lexoni rreth tyre dhe se si t’i mbani nën kontroll.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "S’qemë në gjendje t’ju dërgonim një email këtë herë. Ju lutemi, riprovoni më vonë.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Do t’ju dërgojmë një email, nëse gjenden kërcënime sigurie. Ndërkohë, mos ngurroni të përdorni sajtin tuaj si normalisht, ecurinë mund ta rikontrolloni kur të doni.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "Do t’ju dërgojmë me email një lidhje magjike që do t’ju fusë menjëherë, pa qenë nevoja për fjalëkalim. Mjaft më me shtypje me dy gishta!";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "Për të krijuar llogarinë tuaj të re WordPress.com, do t’ju dërgojmë me email një lidhje regjistrimi.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "Do t’ju njoftojmë kur të ketë ndjekës, komente dhe pëlqime të reja.";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "Do t’ju njoftojmë për ndjekës të rinj, komente dhe pëlqime. Do të donit të lejohen njoftime <em>push<\/em>?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "Këtë adresë email do ta përdorim për të krijuar llogarinë tuaj të re WordPress.com.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "Po krijojmë një kopjeruajtje të shkarkueshme të sajtit tuaj prej %1$@.";
@@ -6610,6 +7128,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Po punojmë fort për t’i zgjidhur këto kërcënime në prapaskenë. Ndërkohë mos ngurroni të vazhdoni ta përdorni sajtin tuaj si normalisht, ecurinë këtu mund ta kontrolloni në çfarëdo kohe.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "S’qemë në gjendje të lidheshim me sajtin Jetpack te ajo URL.  Për asistencë, lidhuni me ne.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "Po e rikthejmë sajtin tuaj te %1$@.";
 
@@ -6618,6 +7139,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "Ju dërguam gjithashtu me email një lidhje për te kartela juaj.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Ju dërguam me email një lidhje regjistrimi për të krijuar llogarinë tuaj të re WordPress.com. Kontrolloni email-et në këtë pajisje dhe prekni lidhjen te email-i i ardhur nga WordPress.com.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6644,6 +7168,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "Përmbledhje Javore: %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "Mirë se vini te Jetpack-u";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Mirë se vini në WordPress";
 
 /* A message title */
 "Welcome to the Reader" = "Mirë se vini te Lexuesi";
@@ -6688,6 +7218,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "Ç’është Gravatar-i?";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "Ç’është WordPress.com?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "Ç’është një bllok?";
 
@@ -6706,6 +7239,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "Ç’ka të Re në WordPress";
 
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "Cila është adresa e sajtit tim?";
+
 /* Select the site's intent. Title */
 "What's your website about?" = "Për çfarë është sajti juaj?";
 
@@ -6717,6 +7253,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "Kur bëni ndryshime te sajti juaj, këtu do të jeni në gjendje të shihni historikun e veprimtarisë tuaj.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Hëm, diç shkoi ters dhe s’bëmë dot futjen tuaj. Ju lutemi, riprovoni!";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "Hëm, diç shkoi ters. Ju lutemi, riprovoni!";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "Oh, ai kyç sigurie nuk duket i vlefshëm. Ju lutemi, riprovoni me një tjetër";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Hëm, ky s’është kod i vlefshëm mirëfilltësimi dyfaktorësh. Kontrolloni sërish kodin tuaj dhe riprovoni!";
 
 /* No comment provided by engineer. */
 "Width Settings" = "Rregullime Gjerësie";
@@ -6730,17 +7278,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "Rregullime Aplikacioni WordPress";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "Aplikacione WordPress - Aplikacioni për çfarëdo ekrani";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "Blog WordPress";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "Ndihmë WordPress";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "Mediatekë WordPress";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "Rregullime Njoftimesh WordPress";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "Njoftime WordPress";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "Shtojca WordPress";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "Profil WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "Lexues WordPress";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "Hollësi Sajti WordPress";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "Tema WordPress";
@@ -6751,17 +7320,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "Instalimet shumësajtëshe WordPress nuk mbulohen";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress-i lyp leje që të hyjë te vendi i tanishëm i pajisjes tuaj, që të mund t’ia shtojë atë postimit tuaj. Ju lutemi, përditësoni rregullimet tuaja për privatësinë.";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "Rrënjë WordPress-i";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "Version WordPress-i shumë i vjetër";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Version WordPress-i shumë i vjetër. Sajti te %1$@ përdor WordPress %2$@. Këshillojmë ta përditësoni me versionin më të ri, ose të paktën %3$@";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "Llogari WordPress.com";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "Plane WordPress.com";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "Tema WordPress.com";
@@ -6792,6 +7370,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "Shkruani Postim";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "Shkruani një përgjigje";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "Shkruani një përgjigje…";
 
 /* Title for the writing section in site settings screen */
@@ -6805,6 +7386,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Pozicion në boshtin Y";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "Vit";
@@ -6889,6 +7473,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Displayed when the user views trashed in the posts list and there are no posts */
 "You don't have any trashed posts" = "S’keni postime të shpëna te hedhurinat";
 
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"You don't have permission to view this private blog." = "S’keni leje të shihni këtë blog privat.";
+
 /* Description for the first domain purchased with a paid plan. */
 "You have a free one-year domain registration with your plan." = "Me planin tuaj keni të përfshirë një regjistrim përkatësie falas për një vit.";
 
@@ -6904,7 +7491,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "S’keni të ujdisur kujtues.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Keni ndryshime të paruajtura.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -7000,6 +7588,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "Kërkimi juaj përmban shenja të pambuluara në përkatësi WordPress.com. Lejohen shenjat vijuese: A–Z, a–z, 0–9.";
 
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "Adresa e sajtit tuaj shfaqet te shtylla në krye të skenës, kur vizitoni sajtin tuaj nën Safari.";
+
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "Sajti juaj mbrohet tashmë nga VaultPress. Më poshtë mund të gjeni një lidhje për te pulti juaj VaultPress.";
 
@@ -7078,17 +7669,32 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility identifier for an 'Add Comment' button */
 "addCommentButton.accessibilityIdentifity" = "Shtoni Koment";
 
+/* Error message shown a URL does not point to an existing site. */
+"addSite.restApiNotAvailable" = "Sajti në këtë adresë s’është sajt WordPress. Që të lidhemi me të, sajti duhet të përdorë WordPress.";
+
+/* Error message shown when an receiving an invalid application-password authentication result from a self-hosted WordPress site */
+"addSite.selfHosted.authenticationFailed" = "S’bëhet do hyrja duke përdorur mirëfilltësim me Fjalëkalim Aplikacion.";
+
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "Jepni adresën e sajtit WordPress te i cili do të donit të lidheshit.";
 
+/* Error message when user input is not a WordPress site */
+"addSite.selfHosted.invalidUrl" = "Kjo adresë sajti s’është e vlefshme.";
+
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "S’ngarkohen dot hollësi sajti WordPress";
+
+/* Error message shown when application-password authentication is disabled on a self-hosted WordPress site */
+"addSite.selfHosted.noLoginUrlFound" = "Te sajti WordPress lypset të aktivizohet mirëfilltësimi me Fjalëkalim Aplikacioni.";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "S’mund të ruhet sajti WordPress, ju lutemi, riprovoni më vonë.";
 
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "Shtoni Sajt të Vetëstrehuar";
+
+/* Error message when an unknown error occurred when adding a self-hosted site */
+"addSite.selfHosted.unknownError" = "Diç shkoi ters. Ju lutemi, riprovoni.";
 
 /* Age between dates equaling one hour. */
 "an hour" = "një orë";
@@ -7795,6 +8401,10 @@ Example: Reply to Pamela Nguyen */
 /* A name of the ID field (it's a technical field, has to be short, displayed below everything else) */
 "entityMetadataFooterView.id" = "ID";
 
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "example.com";
+
 /* Accept button title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackAccept" = "Dërgoni përshtypje";
 
@@ -7849,8 +8459,14 @@ Example: Reply to Pamela Nguyen */
 /* A footer retry button */
 "general.pagingFooterView.retry" = "Riprovoni";
 
+/* Error message format when REST API returns an error response. The first argument is error message. */
+"generic.error.rest-api-error" = "Sajti juaj dërgoi një përgjigje për gabim: %@";
+
 /* A generic title for an error */
 "generic.error.title" = "Gabim";
+
+/* Error message when failing to parse API responses */
+"generic.error.unparsableResponse" = "Sajti juaj dërgoi një përgjigje që aplikacioni s’e përpunoi dot";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "Ujdisni kujtues blogimi";
@@ -8241,6 +8857,9 @@ Example: Reply to Pamela Nguyen */
 
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "S’keni leje të shihni këtë blog privat.";
+
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "Ju lutemi, jepni kodin e verifikimit për llogarinë tuaj WordPress.com prej aplikacionit tuaj të mirëfilltësimeve.";
 
 /* Indicating that referrer was marked as spam */
 "marked as spam" = "iu vu shenjë si i padëshiruar";
@@ -8683,6 +9302,9 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "Faqe Mëmë";
 
+/* No comment provided by engineer. */
+"password" = "fjalëkalim";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "Kartat mund të shfaqin lëndë të ndryshme, në varësi të çka ndodh në sajtin tuaj. Po punojmë për më tepër karta dhe kontrolle.";
 
@@ -9072,6 +9694,30 @@ Example: Reply to Pamela Nguyen */
 
 /* An alert message explaning that by changing the visibility to private, the post will be published immediately to your site */
 "postSettings.warningPostWillBePublishedAlertMessage" = "Duke ndryshuar dukshmërinë në “Private”, postimi do të botohet menjëherë";
+
+/* Localized post type: `Page` */
+"postType.page" = "faqe";
+
+/* Localized post type: `Post` */
+"postType.post" = "postim";
+
+/* Details for a 'Private' privacy setting */
+"postVisibility.private.details" = "I dukshëm vetëm për përgjegjës sajti dhe redaktorë";
+
+/* Title for a 'Private' privacy setting */
+"postVisibility.private.title" = "Privat";
+
+/* Details for a 'Password Protected' privacy setting */
+"postVisibility.protected.details" = "I dukshëm për këdo, por lyp fjalëkalim";
+
+/* Title for a 'Password Protected' privacy setting */
+"postVisibility.protected.title" = "Mbrojtur me fjalëkalim";
+
+/* Details for a 'Public' (default) privacy setting */
+"postVisibility.public.details" = "I dukshëm për këdo";
+
+/* Title for a 'Public' (default) privacy setting */
+"postVisibility.public.title" = "Publik";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Anuloje";
@@ -9652,8 +10298,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title of a Reader tab showing Posts matching a user's search query */
 "reader.search.tab.posts" = "Postime";
 
-/* Title of the Reader's search feature
-   Used in multiple contexts, usually as a screen title */
+/* Title of the Reader's search feature */
 "reader.search.title" = "Kërko";
 
 /* Screen title. Reader select interests title label text. */
@@ -9679,6 +10324,21 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Reader select interests title label text */
 "reader.select.tags.title" = "Zbuloni dhe ndiqni blogje që keni për zemër";
+
+/* Reader sidebar menu item */
+"reader.sidebar.discover" = "Zbuloni";
+
+/* Reader sidebar menu item */
+"reader.sidebar.likes" = "Pëlqime";
+
+/* Reader sidebar menu item */
+"reader.sidebar.recent" = "Së fundi";
+
+/* Reader sidebar menu item */
+"reader.sidebar.saved" = "U ruajt";
+
+/* Reader sidebar menu item */
+"reader.sidebar.search" = "Kërko";
 
 /* Reader sidebar section title */
 "reader.sidebar.section.favorites.title" = "Të parapëlqyer";
@@ -9728,7 +10388,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Number of subscriptions on a site (singular) */
 "reader.subscriptions.subscriptionsSingular" = "%@ pajtimtar";
 
-/* Used in multiple contexts, usually as a screen title */
+/* Navigation bar title */
 "reader.subscriptions.title" = "Pajtime";
 
 /* A suggestion of topics the user might want to subscribe to */
@@ -10052,7 +10712,9 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Message shown when there are no inactive plugins on the site */
 "site.plugins.empty.inactive" = "S’ka shtojca joaktive";
 
-/* The plugin fillter option for displaying all plugins */
+/* The plugin fillter option for displaying active plugins
+   The plugin fillter option for displaying all plugins
+   The plugin fillter option for displaying inactive plugins */
 "site.plugins.filter.option.all" = "Krejt";
 
 /* Title of the plugin filter picker */
@@ -10753,8 +11415,119 @@ Feel free to replace it with other bracket types that you think looks better for
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "Gjendje";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "Postime & Më të Parët e Krejt Kohës";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "Parje Gjatë Krejt Kohës";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "Parje & Vizitorë Gjatë Gjithë Kohës";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "Parjet më të mira ndonjëherë";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "Shumica e Parjeve";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "S’arrihet të ngarkohen statistika të krejt kohës.";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "Që të shihni statistika të krejt kohës, krijoni, ose shtoni një sajt.";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Postime";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "Jini i përditësuar me veprimtarinë gjithë kohën në sajtin tuaj WordPress.";
+
+/* Title of all time widget */
+"widget.alltime.title" = "Tërë Kohën";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "Bëni hyrjen në WordPress, që të shihni statistikat për krejt kohën.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "Që të shihni statistikat për krejt kohën, hyni në llogarinë tuaj Jetpcak.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "Që të shihni statistikat e kësaj jave, hyni në llogarinë tuaj Jetpcak.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "Që të shihni statistikat për sot, hyni në llogarinë tuaj Jetpack.";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "Parje Gjatë Krejt Kohës";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "Parje Sot";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "S’arrihet të ngarkohen statistika të kësaj jave.";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "Që të shihni statistika të kësaj jave, krijoni, ose shtoni një sajt.";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "Jini i përditësuar me veprimtarinë e kësaj jave në sajtin tuaj WordPress.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "Këtë Javë";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "Bëni hyrjen në WordPress, që të shihni statistikat e kësaj jave.";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Komente";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "Statistikat kanë kaluar te aplikacioni Jetpack. Kalimi në të është falas dhe ha vetëm një minutë.";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Pëlqime";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "S’arrihen të ngarkohen statistika sajti.";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "S’arrihen të ngarkohen statistika të sotme.";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "Që të shihni statistika të sotmet, krijoni, ose shtoni një sajt.";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "Jini i përditësuar me veprimtarinë e sotme në sajtin tuaj WordPress.";
+
+/* Title of today widget */
+"widget.today.title" = "Sot";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "Që të shihni statistikat për sot, bëni hyrjen te WordPress-i.";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "Parje jo e passhme";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Parje";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Vizitorë";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "Pëlqime & Komente Sot";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "Parje Sot";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "Parje & Vizitorë Sot";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "s’do të jetë më i passhëm në të ardhmen.";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "Po filloni një sajt të ri?";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "wordpress, ndihmë, asistencë, PBR, pyetje, diagnostikim, regjistra, qendër ndihme, kontakt";
@@ -10779,6 +11552,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Error message that describes an unknown error had occured */
 "wordpress-api.error.unknown" = "Diç shkoi ters, ju lutemi, riprovoni më vonë.";
+
+/* Error message when failing to find selected media file on the user's device. */
+"wordpress.api.upload.media.fileNotFound" = "S’lokalizohet dot kartela media te pajisja";
 
 /* Jetpack Plugin Modal on WordPress primary button title */
 "wordpress.jetpack.plugin.modal.primary.button.title" = "Kaloni te aplikacioni Jetpack";
@@ -10839,6 +11615,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "Bashkëngjitje e pambuluar";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} të Bëni hyrjen me Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Përkatësi";

--- a/WordPress/Resources/sv.lproj/Localizable.strings
+++ b/WordPress/Resources/sv.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Translation-Revision-Date: 2025-05-13 11:54:08+0000 */
+/* Translation-Revision-Date: 2025-03-22 10:01:32+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
 /* Generator: GlotPress/4.0.1 */
 /* Language: sv_SE */
@@ -98,6 +98,9 @@
 
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "%1$@ av %2$@ på din webbplats";
+
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "Din webbplats använder %1$@ av tillgängliga %2$@";
 
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ biljard";
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Utan rubrik)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(ingen rubrik)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*Erik S* svarade på ditt inlägg";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "Knappen ”mer” innehåller en rullgardinsmeny som visar delningsknappar";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "Ett WordPress.com-konto är kopplat till dina butiksautentiseringsuppgifter. Vi kommer att skicka en verifieringslänk till e-postadressen ovan.";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "En fil innehåller ett skadligt kodmönster";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "En rubrik för webbplatsen";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "Det krävs en giltig e-postadress för att skicka en autentiseringslänk. Gå tillbaka till föregående sida och ange en giltig e‑postadress.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "Verifieringskoden innehåller endast siffror.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "AKTIV";
@@ -334,9 +349,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* My Profile 'About me' label */
 "About Me" = "Om mig";
-
-/* Link to About screen for Jetpack for iOS */
-"About Reader for iOS" = "Om läsaren för iOS";
 
 /* Link to About screen for WordPress for iOS */
 "About WordPress" = "Om WordPress";
@@ -525,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "Efter %@";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "Justering";
@@ -588,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "Tillåtna IP-adresser";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "Nästan klart! Skriv in verifieringskoden från din autentiserings-app.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Alt-text";
@@ -600,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "Alternativt kan du platta ut innehållet genom att avgruppera blocket.";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "Alternativt kan du ange lösenordet för detta konto.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "Alternativt:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "Skicka alltid kraschloggar";
@@ -621,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "För att kunna se aktiviteter krävs en aktiv internetanslutning";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "En aktiv internetanslutning krävs för att kunna visa paket";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -671,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "Årstatistik för webbplatsen";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "Anonym";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "Svar";
 
@@ -692,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "Utseende";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "Autentisering via Apple-ID misslyckades.\nSe till att du är inloggad till iCloud med ett Apple-ID som använder tvåfaktorsautentisering.";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "Tillämpar inställningen";
@@ -778,6 +811,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "Autentiseringen misslyckades";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "Autentiseringskod";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "Autentisering krävs för server: %@";
@@ -888,6 +925,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "Bli först att kommentera";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "Bli först med att skriva en kommentar.";
 
 /* Beauty site intent topic */
 "Beauty" = "Skönhet";
@@ -1024,12 +1064,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button to copy post text" = "Knapp för att kopiera inläggstext";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "Genom att fortsätta samtycker du till våra _användarvillkor_.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "När du registrerar denna domän samtycker du till våra <a>villkor<\/a>.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "Genom att konfigurera Jetpack accepterar du våra\n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "Genom att registrera dig godkänner du våra _användarvillkor_.";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "ANPASSA";
@@ -1043,6 +1089,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "För att skanna inloggningskoder krävs åtkomst till kameran";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Kan inte begära länk";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "Det går inte att publicera en tom sida";
 
@@ -1052,6 +1101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1061,6 +1111,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1079,6 +1130,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1106,6 +1158,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "Avbryter …";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "Det går inte komma åt webbplatsen på den här adressen. Dubbelkolla och försök igen.";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Kan du inte bestämma dig? Du kan byta tema när som helst.";
 
@@ -1113,7 +1168,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Bildtext";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Var försiktig!";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1122,7 +1178,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Kategorier";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Kategori";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1171,6 +1228,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "Kolla in våra bästa tips för fler sidvisningar och mer trafik";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "Kontrollera din e-post på denna enhet!";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Öppna e-posten på din enhet och tryck på länken i meddelandet du fått från WordPress.com.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "Kontrollera din e-post på den här enheten och tryck på länken du just fått i ett meddelande från WordPress.com.\n\nOm du inte hittar e-postmeddelandet kan du kolla om det hamnat bland skräpposten.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "Kolla din e-post!";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "Kontrollera din internetanslutning och dra för att uppdatera.";
@@ -1267,6 +1336,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "Gör anspråk på din gratisdomän";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "Klassisk blogg";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "Töm enhetens cache-minne för mediafiler";
 
@@ -1294,6 +1366,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Stäng";
 
@@ -1335,6 +1408,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "Kolumninställningar";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Serier";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1386,6 +1462,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Kommentarer";
 
@@ -1453,12 +1530,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Anslutna konton";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Ansluten men …";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "Ansluter %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "Anslutning av %1$@ kommer att ersätta den befintliga anslutningen till %2$@.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "Ansluter till WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Ansluter …";
@@ -1489,8 +1572,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "Kontakta oss på %@";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "Innehållsstruktur\nBlock: %1$li, Ord: %2$li, Tecken: %3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1505,6 +1592,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Fortsätt läsa";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Fortsätt med Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Fortsätt med Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Fortsätter med Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "Bidra";
@@ -1633,6 +1729,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "Skapa";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Skapa konto";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "Skapa en tom sida";
 
@@ -1653,6 +1752,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "Skapa ett inlägg";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "Skapa en webbplats";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "Skapa en etikett";
@@ -1686,6 +1788,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "Nuvarande";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Nuvarande paket";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Nuvarande tema";
@@ -1788,6 +1893,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "Standardkategori";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Standardmeny";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Standardformat för inlägg";
@@ -1796,6 +1904,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "Standard för nya inlägg";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Kasta i papperskorgen";
@@ -1853,6 +1962,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "Detaljer";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "Vill du inte registrera ett nytt konto? Gå tillbaka för att mata in e-postadressen igen.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "Storlekar";
 
@@ -1900,7 +2012,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "Diskussion";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Avfärda";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1922,6 +2036,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "Domäner";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "Har du inget konto? _Registrera dig_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2051,6 +2168,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "Nedladdningar";
 
+/* Name for the status of a draft post. */
+"Draft" = "Utkast";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Utkast";
 
@@ -2160,7 +2280,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "E-postadress";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "E-postadress";
 
 /* Notification Settings Channel */
@@ -2244,8 +2367,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Ange lösenord";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "Skriv in adressen för den WordPress-webbplats du vill ansluta.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Ange lösenordet för ditt konto på WordPress.com.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Ange användarnamn";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "Ange din kontoinformation för %@.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "Ange din e-postadress för att logga in eller registrera ett konto hos WordPress.com.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "Ange din befintliga webbplatsadress";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "Skriv in ditt lösenord istället.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "Ange dina inloggningsuppgifter till servern";
@@ -2408,6 +2551,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "Externt";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Misslyckades";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "Lyckades inte markera aviseringarna som lästa";
 
@@ -2419,9 +2565,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Failed to insert media.\nTap for more info." = "Misslyckades att infoga media.\nTryck för mer information.";
-
-/* A message indicating that we couldn't load the user's settings. */
-"Failed to load settings" = "Misslyckades att ladda inställningar";
 
 /* No comment provided by engineer. */
 "Failed to save files.\nPlease tap for options." = "Kunde inte spara filerna.\nTryck för att visa alternativ.";
@@ -2437,6 +2580,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "Mode";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "Utvalda";
@@ -2495,6 +2641,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "Ta reda på mer";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Hitta adressen till din webbplats";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2517,6 +2666,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "Åtgärdar hot";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "Följ";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "Följer denna konversation";
@@ -2611,6 +2763,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "Generera ny länk";
 
+/* View title for initial auth views. */
+"Get Started" = "Kom igång";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "Få en länk för inloggning via e-post";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "Aktivera dig! Kommentera inlägg från bloggar du följer.";
 
@@ -2632,8 +2790,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "Låt dig inspireras";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Hämtar kontoinformation";
+
+/* Cancel */
+"Give Up" = "Ge upp";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "Prova nu direkt genom att lägga till några block i ditt inlägg eller din sida!";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "Gå till läsare";
@@ -2644,6 +2811,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "Gå till iOS-inställningar";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Registrering via Google misslyckades.";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2718,6 +2888,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "Hjälpikon";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Dold";
+
 /* Title of a button used to collapse a group */
 "Hide" = "Dölj";
 
@@ -2786,6 +2959,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "Uppladdning av ikon misslyckades";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "Kolla i mappen för skräppost om du inte hittar meddelandet.";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "Om du går vidare med alternativet Apple eller Google och inte redan har ett konto hos WordPress.com innebär detta att du härmed registrerar ett konto och att du samtycker till våra _användarvillkor_.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "Om du tar bort %1$@ kommer användaren inte längre att ha åtkomst till den här webbplatsen, men allt innehåll som skapats av %2$@ kommer att finnas kvar på.";
@@ -2861,6 +3040,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "Innehåller wp-config.php och eventuella filer som inte hör till WordPress";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Felaktigt användarnamn eller lösenord. Försök ange dina inloggningsdetaljer igen.";
 
 /* Title for a threat */
 "Infected core file" = "Infekterad fil i WordPress-kärnan";
@@ -2962,6 +3144,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "Introducerar bloggningsförslag";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "Ogiltig e-postadress";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "Ogiltig adress till webbplatsen";
 
@@ -2979,6 +3164,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "Ogiltig URL. Ljudfil hittades inte.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "Ogiltig URL. Dubbelkolla och försök igen.";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "Ogiltig URL. Ange en giltig URL.";
@@ -3000,6 +3188,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "Bjud in personer";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "Detta användarnamn och lösenord verkar inte fungera på denna webbplats.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "Du verkar ha skrivit fel lösenord. Vill du försöka en gång till?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "Det är dags att blogga på %@!";
@@ -3228,7 +3422,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "Radhöjd";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Länk";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3290,6 +3485,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "Laddar in personer …";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Laddar in paket …";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Laddar in paket …";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "Laddar tillägg…";
 
@@ -3324,11 +3525,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "Laddar in …";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Lokalt";
+
 /* Local Services site intent topic */
 "Local Services" = "Lokala tjänster";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "Lokala ändringar";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Plats";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Platstjänster måste aktiveras innan WordPress kan lägga till din aktuella plats. Vänligen aktivera Platstjänster via appen Inställningar.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Geografisk plats okänd";
 
 /* No comment provided by engineer. */
 "Lock icon" = "Låsikon";
@@ -3336,9 +3549,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Loggfiler sorterade på datum";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Logga in";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3348,17 +3563,33 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of a button for signing in. */
 "Log in" = "Logga in";
 
-/* LogOut confirmation text, whenever there are no local changes */
-"Log out of Jetpack?" = "Logga ut från Jetpack?";
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Inloggning misslyckades. Försök igen.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "Logga in eller registrera dig hos WordPress.com";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Logga in till det WordPress.com-konto du använde när du anslöt Jetpack.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "Logga in till ditt konto hos WordPress.com med din e-postadress.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "Logga in med ditt användarnamn och lösenord för WordPress.com.";
 
 /* LogOut confirmation text, whenever there are no local changes */
-"Log out of Reader?" = "Logga ut från läsaren?";
+"Log out of Jetpack?" = "Logga ut från Jetpack?";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of WordPress?" = "Logga ut från WordPress?";
 
 /* Login Request Expired */
 "Login Request Expired" = "Inloggningsbegäran har löpt ut";
+
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "Logga in med kontolösenord";
 
 /* No comment provided by engineer. */
 "Logs" = "Loggar";
@@ -3368,6 +3599,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Det verkar som att du har Jetpack installerat på din webbplats. Grattis!\nLogga in med dina användaruppgifter från WordPress.com för att kunna se din statistik och dina notiser.";
+
+/* Title of a button. */
+"Lost your password?" = "Glömt ditt lösenord?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "E-post (standardval)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Huvudnavigering";
@@ -3515,6 +3752,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "Meddelande";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "Övrig typ av sårbarhet";
 
@@ -3610,6 +3850,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "Min webbplats";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "Mina WordPress-webbplatser";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "Mina tio favoritcaféer";
 
@@ -3649,8 +3892,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Behöver du hjälp?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "Behöver du hjälp att hitta adressen till din webbplats?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "Behöver du hjälp?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Behöver du mer hjälp?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "Uppdatering finns";
@@ -3679,6 +3929,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "Nytt inlägg";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Nytt objekt";
+
 /* Placeholder text for password field */
 "New password" = "Nytt lösenord";
 
@@ -3696,7 +3949,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "Nyheter";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Nästa";
 
 /* Accessibility label for the next notification button */
@@ -3732,6 +3987,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "Ingen förhandsgransknings-URL tillgänglig.";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "Ingen rubrik";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "Inga aktiviteter tillgängliga";
 
@@ -3764,7 +4022,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "Inga kommentarer än";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "Ingen anslutning";
 
@@ -3913,6 +4172,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "Inte nu";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "Hittar du inte meddelandet? Kolla i mappen för skräppost eller reklam.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "Observera:";
 
@@ -3976,7 +4238,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Numrerad lista";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -4033,7 +4300,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "Hoppsan";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Hoppsan!";
 
 /* No comment provided by engineer. */
@@ -4048,7 +4316,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "Öppna säkerhetsinställningarna för Jetpack";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "Öppna Mail";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Öppna inställningar";
 
 /* No comment provided by engineer. */
@@ -4066,6 +4339,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "Öppna länken i nytt fönster\/ny flik";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "Öppna inläggets prenumerationsinställningar";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "Öppna sektionen om mig";
 
@@ -4080,6 +4356,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "Valfritt: Ange ett eget meddelande på högst %1$d tecken som skickas tillsammans med din inbjudan.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "eller";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "Eller välj en annan form av autentisering.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "Eller logga in genom att _skriva in adressen till din webbplats_.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "Eller logga in med magisk länk";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Sorterad lista";
@@ -4128,7 +4416,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "Padding";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Sida";
 
@@ -4161,8 +4450,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "Föräldraskap";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Lösenord";
 
@@ -4179,8 +4471,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "Infoga blocket efter";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Inväntar granskning";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Inväntar granskning";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4211,6 +4507,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "Välj användarnamn";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Paket";
+
 /* User action to play a video on the editor. */
 "Play video" = "Spela video";
 
@@ -4240,6 +4540,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "Se till att blockredigeraren är aktiverad på din webbplats. Om den inte är aktiverad kan den inte laddas in.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "Ange den fullständiga adressen till en webbplats, t.ex. example.com.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "Ange en webbplatsadress.";
@@ -4274,11 +4577,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "Ange en giltig adress";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "Ange en giltig e-postadress för ett WordPress.com-konto.";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Ange en giltig e-postadress.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "Ange ett giltigt telefonnummer";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Ange lösenordet för ditt konto hos WordPress.com eller logga in med ditt Apple-ID.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Ange dina användaruppgifter";
@@ -4286,8 +4595,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Skriv in din e-postadress.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Fyll i alla fälten";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Starta WordPress-appen, logga in på WordPress.com och se till att du har minst en webbplats där, och försök sedan igen.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "Logga ut innan du ansluter till någon annan webbplats på wordpress.com";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "Försök igen senare";
@@ -4355,7 +4670,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "Populära språk";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Skicka";
 
@@ -4476,6 +4792,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "Integritetsnotis för användare i Kalifornien";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Privat";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "Problem med att visa block. \nTryck för att försöka med blockåterställning.";
 
@@ -4490,6 +4809,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "Problem att köpa din domän. Försök igen.";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "Om du fortsätter kommer all lokal WordPress.com-data tas bort från denna enhet och eventuella lokala utkast kommer tas bort. Du kommer inte förlora någonting som redan har sparats på WordPress.com.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Projekt";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "Förslaget hoppades över";
@@ -4507,13 +4832,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "Publiceringsdatum";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Publicera direkt";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "Publicera sidan på:";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "Publicerar inlägget den:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Publicerat";
 
@@ -4715,7 +5044,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "Svara";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Svarstext";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "Svar till %1$@";
 
 /* An explaination of a setting. */
@@ -4744,6 +5078,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "Återställ filtret för datumintervall";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Återställ ditt lösenord";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Ändra storlek och beskär";
@@ -4801,6 +5138,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "Försök igen med alla";
 
+/* No comment provided by engineer. */
+"Retry?" = "Försök igen?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "Återgå till inlägget";
 
@@ -4830,6 +5170,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "Roll";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS skickat";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "STATUS";
 
@@ -4841,6 +5184,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4907,7 +5251,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "Skannar filer";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Schemalagd";
 
 /* No comment provided by engineer. */
@@ -5047,6 +5392,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "Väljer detta ämne som syftet med din webbplats.";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Skicka länk";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "Skicka länk via e-post";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "Skicka ett loggmeddelande";
 
@@ -5055,6 +5406,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "Skicka en testkrasch";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "Skicka länk för e-postverifiering";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "Skicka notifieringar via e-post";
@@ -5101,11 +5455,11 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Message to show when setting save failed */
 "Settings update failed" = "Kunde inte uppdatera inställningarna";
 
-/* Title for a button that recommends the app to others */
-"Share Jetpack with a friend" = "Dela Jetpack med en vän";
+/* Spoken accessibility label */
+"Share" = "Dela";
 
 /* Title for a button that recommends the app to others */
-"Share Reader with a friend" = "Dela läsare med en vän";
+"Share Jetpack with a friend" = "Dela Jetpack med en vän";
 
 /* Title for a button that recommends the app to others */
 "Share WordPress with a friend" = "Dela WordPress med en vän";
@@ -5156,6 +5510,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "Visa Reblogga-knappen";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "Visa lösenord";
+
 /* No comment provided by engineer. */
 "Show post content" = "Visa inläggets innehåll";
 
@@ -5167,6 +5525,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "Visar statistik för:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "Visat";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Visas offentligt när du kommenterar på bloggar.";
@@ -5182,6 +5543,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "Visar inlägget";
+
+/* View title during the sign up process. */
+"Sign Up" = "Skapa konto";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "Logga in med uppgifterna för webbplatsen";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Registrering";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Registrera dig på WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Registrera dig med hjälp av e-postadress";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "Eftersom du använder ett gratispaket kommer du endast att se begränsade händelser i din aktivitetslogg.";
@@ -5220,6 +5596,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Webbplats-troféer";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Webbplatsadress";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "Adressen till webbplatsen måste bestå av minst 4 bokstäver.";
@@ -5304,7 +5683,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "En adress till en webbplats måste även innehålla bokstäver!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Den e-postadressen har redan använts!";
 
 /* No comment provided by engineer. */
@@ -5364,6 +5743,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "Skräppost";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "Snabba upp din webbplats";
@@ -5389,6 +5771,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "Stat";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "Statisk startsida";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5419,6 +5804,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "Överstrykning";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Påbörjat";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "Spara som väntande";
@@ -5509,7 +5897,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "Surfplatta";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Etikett";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5644,6 +6033,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Användarvillkor";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Omdömen";
+
 /* Title of a button style */
 "Text Only" = "Endast text";
 
@@ -5653,8 +6045,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "Medan man redigerar ett textblock finns verktygen för textformatering finns i verktygsfältet ovanför tangentbordet ";
 
+/* Button title */
+"Text me a code instead" = "Skicka mig en kod via SMS i stället";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "Skicka mig en kod via SMS";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Tack för att du väljer %1$@ från %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "Det där ser inte ut som någon giltig verifieringskod.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "Det där ser inte ut som en WordPress-webbplats.";
@@ -5676,6 +6077,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "Facebook-anslutningen kan inte hitta några sidor. Offentliggör kan inte ansluta till Facebook-profiler, endast publicerade sidor.";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "Google-kontot ”%@” matchar inte något konto på WordPress.com";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "Du verkar inte vara uppkopplad mot Internet.";
@@ -5715,6 +6119,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "Bilden kunde inte läggas till i mediabiblioteket.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "Kan inte ansluta till Internet.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "De typer av webbplatser som kan skapas";
@@ -5758,6 +6165,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Webbplatsen %1$@ använder WordPress %2$@. Vi rekommenderar att du uppdaterar till den senaste versionen, dock allra minst %3$@.";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "Webbplatsen på den angivna adressen använder inte WordPress. För att du ska kunna ansluta en webbplats behöver den använda WordPress.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "Webbplatsen kunde inte raderas.";
 
@@ -5799,6 +6210,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "Ett oväntat fel inträffade vid redigering av kommentaren";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "Ett oväntat fel inträffade när kommentarerna lästes in.";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "Ett oväntat fel inträffade när din domän skulle registreras";
 
@@ -5807,6 +6221,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "Ett oväntat fel uppstod vid uppdateringen av dina notisinställningar";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "Ett oväntat fel inträffade när din kommentar skulle uppdateras";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "Det har blivit ett oväntat fel.";
@@ -5828,6 +6245,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "Det var ett problem att kommunicera med webbplatsen.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "Ett fel uppstod vid anslutning till WordPress.com. Var vänlig logga in igen.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "Kunde inte visa detta inlägg.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "Det gick inte att hämta in dina uppgifter. Försök igen genom att ladda om sidan.";
 
@@ -5837,12 +6260,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "Det uppstod ett problem när ändringarna i delningshanteringen skulle sparas.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "Ett problem uppstod med åtkomsten till din plats. Försök igen senare.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "Ett fel inträffade när lösenordet skulle ändras";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "Ett fel inträffade när aktiviteter skulle läsas in";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "Ett fel uppstod vid laddningen av paket";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "Ett fel inträffade när tilläggen lästes in";
@@ -5855,6 +6284,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "Ett fel inträffade när historiken skulle laddas in";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "Det uppstod ett fel när paketet laddades.";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "Ett fel inträffade när genomsökningshistoriken skulle laddas in";
@@ -5903,6 +6335,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "Denna domän är inte tillgänglig";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "Denna e-postadress är inte registrerad på WordPress.com.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "Filen är för stor för att laddas upp till din webbplats, eller så saknas stöd för detta mediaformat.";
@@ -5983,6 +6418,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "Tidszon";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "Tiden är ute, men oroa dig inte, din säkerhet är vår prioritet. Försök igen!";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "Tips för att få ut så mycket som möjligt av WordPress.com.";
 
@@ -5996,6 +6434,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "Skriv in din e-postadress och ditt namn för att fortsätta.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "Fyll i din e-postadress för att skapa ditt nya WordPress.com-konto.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "För att kunna få hjälpsamma notiser till din telefon från din WordPress-webbplats behöver du installera tillägget Jetpack.";
 
@@ -6004,6 +6445,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "För att installera tillägg behöver en anpassad domän kopplad till din webbplats.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "Om du vill använda detta Apple-ID behöver du först logga in med ditt lösenord för WordPress.com. Det behöver du endast göra en gång.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "För att fortsätta med detta Google-konto måste du först logga in med ditt lösenord för WordPress.com. Detta behövs bara en gång.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "Ta bort ett block genom att markera blocket och klicka på de tre punkterna i blockets nedre högra hörn för att visa inställningarna. Där väljer du sedan alternativet att ta bort blocket.";
@@ -6078,7 +6525,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "Släng";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "Borttagen";
 
@@ -6092,6 +6540,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "Testa och anpassa";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Försök igen";
@@ -6117,6 +6566,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "Prova den nya blockredigeraren";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Prova med en annan e-postadress";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Prova med webbplatsens adress";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "Stäng av förslag";
@@ -6159,6 +6614,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "ANVÄNDER";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "Kan inte ansluta";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "Kunde inte ladda inlägg";
@@ -6208,6 +6666,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Det går inte att spela video";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Kunde inte läsa WordPress-webbplatsen på denna URL. Tryck på ”Behöver du mer hjälp?” för att visa vanliga frågorna.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Kan inte återställa din webbplats";
 
@@ -6234,6 +6695,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "Det gick inte att ladda upp 1 inlägg och 1 fil";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "Kunde inte verifiera e-postadressen. Försök igen senare.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "Det gick inte att besöka Jetpack-inställningar för webbplatsen";
@@ -6378,7 +6842,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Uppladdning misslyckades";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Uppladdad";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6396,7 +6861,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Uppladdade teman";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Laddar upp";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6411,18 +6877,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "Använd";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "Använd en säkerhetsnyckel";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "Använd blockredigeraren";
 
 /* No comment provided by engineer. */
 "Use icon button" = "Använd ikonknapp";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "Använd lösenord för att logga in";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Användarnamn";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6437,6 +6912,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Användare";
+
+/* two factor code placeholder */
+"Verification code" = "Verifieringskod";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "E-postmeddelande för verifiering har skickats. Kolla inkorgen.";
@@ -6569,8 +7047,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "Katalogen wp-content";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Väntar på att Google ska bli klara …";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "Väntar på anslutning";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "Väntar på säkerhetsnyckel";
+
+/* View title during the Google auth process. */
+"Waiting..." = "Väntar…";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6610,6 +7098,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "Vi hade problem med att ladda data";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "Vi har just skickat en länk via e-post till %@. Kolla din e-post och tryck på länken för att logga in.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "Vi har precis skickat en magisk länk till";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "Vi har skapat en säkerhetskopia av din webbplats per %1$@.";
 
@@ -6619,14 +7113,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "Vi använder andra spårningsverktyg, inklusive verktyg från utomstående parter. Läs om dessa och hur vi kontrollerar dem.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "Vi lyckades inte skicka dig något e-postmeddelande just nu. Försök igen senare.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Vi skickar ett e-postmeddelande till dig om säkerhetshot hittas. Under tiden kan du använda din webbplats som du brukar göra. Du kan även när som helst kontrollera genomsökningens status.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "Vi e-postar dig en magisk länk som låter dig logga in direkt utan något lösenord. Inget mer stök och bök!";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "Vi kommer att skicka e-post med en registreringslänk som låter dig skapa ett nytt WordPress.com-konto.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "Vi kommer att informera dig när du får nya följare, kommentarer och gillanden.";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "Vi informerar dig när du får nya följare, kommentarer och gilla-märkningar. Vill du tillåta push-notiser?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "Vi använder den här e-postadressen för att skapa ditt nya WordPress.com-konto.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "Vi håller på att skapa en nedladdningsbar säkerhetskopia av din webbplats från %1$@.";
@@ -6637,6 +7143,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Vi arbetar intensivt med att rätta dessa hot i bakgrunden. Under tiden kan du fortsätta att använda din webbplats som vanligt. Du kan när som helst kolla hur arbetet fortskrider.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "Vi kan inte ansluta till Jetpack-webbplatsen på denna URL. Kontakta oss och be om hjälp.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "Vi håller på att återställa din webbplats till innehållet från %1$@.";
 
@@ -6645,6 +7154,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "Vi har även skickat e-post med länken till din fil.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Vi har skickat en registreringslänk som låter dig skapa ditt nya konto hos WordPress.com. Öppna e-posten på din enhet och tryck på länken i meddelandet du fått från WordPress.com.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6671,6 +7183,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "Veckosammanfattning: %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "Välkommen till Jetpack";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "Välkommen till WordPress";
 
 /* A message title */
 "Welcome to the Reader" = "Välkommen till Läsaren";
@@ -6715,6 +7233,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "Vad är Gravatar?";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "Vad är WordPress.com?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "Vad är ett block?";
 
@@ -6731,10 +7252,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "What's New in Jetpack" = "Vad som är nytt i Jetpack";
 
 /* Opens the What's New / Feature Announcement modal */
-"What's New in Reader" = "Vad som är nytt i läsaren";
-
-/* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "Nyheter i WordPress";
+
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "Vilken adress har min webbplats?";
 
 /* Select the site's intent. Title */
 "What's your website about?" = "Vad handlar din webbplats om?";
@@ -6748,6 +7269,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "När du ändrar saker på din webbplats kommer du att kunna se din åtgärdshistorik här.";
 
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Ojdå. Något blev fel. Vi lyckades inte logga in dig. Försök igen!";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "Hoppsan, något gick fel. Försök igen!";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "Hoppsan, den säkerhetsnyckeln verkar inte vara giltig. Försök igen med en annan";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Ojdå. Den där var ingen giltig bekräftelsekod för tvåfaktorautentisering. Dubbelkolla koden och försök en gång till!";
+
 /* No comment provided by engineer. */
 "Width Settings" = "Breddinställningar";
 
@@ -6760,17 +7293,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "App-inställningar för WordPress";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "WordPress-appar – appar för alla skärmtyper";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "WordPress-blogg";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "WordPress-hjälp";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "WordPress mediabibliotek";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "Inställningar för WordPress-aviseringar";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "WordPress-aviseringar";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "WordPress-tillägg";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "WordPress-profil";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "WordPress-läsare";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "Uppgifter om WordPress-webbplatsen";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "WordPress-teman";
@@ -6781,17 +7335,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "WordPress multisite stöds inte";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress behöver tillåtelse för åtkomst till din enhets aktuella plats för att kunna lägga till den i ditt inlägg. Uppdatera dina integritetsinställningar.";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "WordPress-rot";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "WordPress-versionen är för gammal";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "WordPress-versionen är för gammal. Webbplatsen %1$@ använder WordPress %2$@. Vi rekommenderar att du uppdaterar till den senaste versionen, dock allra minst %3$@.";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "WordPress.com-konto";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "WordPress.com-paket";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "WordPress.com-teman";
@@ -6822,6 +7385,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "Skriv inlägg";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "Skriv ett svar";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "Skriv ett svar …";
 
 /* Title for the writing section in site settings screen */
@@ -6835,6 +7401,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Läge på Y-axeln";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "År";
@@ -6919,6 +7488,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Displayed when the user views trashed in the posts list and there are no posts */
 "You don't have any trashed posts" = "Du har inte några inlägg i papperskorgen";
 
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"You don't have permission to view this private blog." = "Du har inte behörighet att visa den här privata bloggen.";
+
 /* Description for the first domain purchased with a paid plan. */
 "You have a free one-year domain registration with your plan." = "Ditt paket inkluderar en gratis domännamnsregistrering i ett år.";
 
@@ -6934,7 +7506,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "Du har inga påminnelser inställda.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Du har osparade ändringar.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -7021,9 +7594,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Help text that describes how the password should be. It appears while editing the password */
 "Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ & )." = "Ditt lösenord bör vara minst sex tecken långt. Det blir mer svårgissat om du använder en blandning av stora och små bokstäver, siffror och symboler, såsom ! \" ? $ % ^ & ).";
 
-/* Message of Export Content confirmation alert */
-"Your posts, pages, and settings will be mailed to the account's email address." = "Dina inlägg, sidor och inställningar kommer att skickas till kontots e-postadress.";
-
 /* Message of Export Content confirmation alert; substitution is user's email address */
 "Your posts, pages, and settings will be mailed to you at %@." = "Dina inlägg, sidor och inställningar kommer att skickas till dig på adressen %@.";
 
@@ -7032,6 +7602,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "Din sökning innehåller tecken som inte stöds i WordPress.com-domäner. Följande tecken är tillåtna: A–Z, a–z, 0–9.";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "Din webbplatsadress visas i listen längst upp på skärmen när du besöker din webbplats i Safari.";
 
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "Din webbplats är redan skyddad av VaultPress. Du kan hitta en länk till din adminpanel för VaultPress nedan.";
@@ -7111,17 +7684,23 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility identifier for an 'Add Comment' button */
 "addCommentButton.accessibilityIdentifity" = "Lägg till kommentar";
 
-/* Error message when user cancels login */
-"addSite.selfHosted.cancelled" = "Inloggningen har avbrutits";
+/* Error message shown a URL does not point to an existing site. */
+"addSite.restApiNotAvailable" = "Webbplatsen på denna adress är inte en WordPress-webbplats. För att vi ska kunna ansluta till den måste webbplatsen använda WordPress.";
+
+/* Error message shown when an receiving an invalid application-password authentication result from a self-hosted WordPress site */
+"addSite.selfHosted.authenticationFailed" = "Kan inte logga in med Applikationslösenord-autentisering.";
 
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "Ange adressen till WordPress-webbplatsen du vill ansluta.";
 
+/* Error message when user input is not a WordPress site */
+"addSite.selfHosted.invalidUrl" = "Webbplatsadressen är inte giltig.";
+
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "Kan inte ladda WordPress-webbplatsens detaljer";
 
-/* Error message when user signs in with an unexpected usern. The first argument is the expected username */
-"addSite.selfHosted.mismatchUser" = "Logga in med den inloggade användaren. Användarnamn: %@";
+/* Error message shown when application-password authentication is disabled on a self-hosted WordPress site */
+"addSite.selfHosted.noLoginUrlFound" = "Applikationslösenord-autentisering måste vara aktiverat på WordPress-webbplatsen.";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "Kan inte spara WordPress-webbplatsen, försök igen senare.";
@@ -7129,17 +7708,14 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "Lägg till webbplats på egen server";
 
-/* Error message when XML-RPC is disabled on the WordPress site. The first argument is detailed error message */
-"addSite.selfHosted.xmlrpcDisabled" = "Det gick inte att ansluta till WordPress-webbplatsen. XML-RPC kan ha inaktiverats på servern. Kontakta ditt webbhotell för att lösa detta problem.";
+/* Error message when an unknown error occurred when adding a self-hosted site */
+"addSite.selfHosted.unknownError" = "Något gick fel. Försök igen.";
 
 /* Age between dates equaling one hour. */
 "an hour" = "en timme";
 
 /* This is the string we display when prompting the user to review the Jetpack app */
 "appRatings.jetpack.prompt" = "Vad tycker du om Jetpack?";
-
-/* This is the string we display when prompting the user to review the Reader app */
-"appRatings.reader.prompt" = "Vad tycker du om läsaren?";
 
 /* This is the string we display when prompting the user to review the WordPress app */
 "appRatings.wordpress.prompt" = "Vad tycker du om WordPress?";
@@ -7843,6 +8419,10 @@ Example: Reply to Pamela Nguyen */
 /* A name of the ID field (it's a technical field, has to be short, displayed below everything else) */
 "entityMetadataFooterView.id" = "ID";
 
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "example.com";
+
 /* Accept button title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackAccept" = "Skicka feedback";
 
@@ -7854,9 +8434,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackTitle" = "Dela feedback";
-
-/* Communicates the future removal of the option to disable the experimental editor, displayed beneath the experimental features list */
-"experimentalFeatures.editorNote" = "Den experimentella blockredigeraren kommer att bli standard i en framtida version och möjligheten att inaktivera den kommer att tas bort.";
 
 /* The title for the experimental features list */
 "experimentalFeaturesList.heading" = "Experimentella funktioner";
@@ -7903,8 +8480,14 @@ Example: Reply to Pamela Nguyen */
 /* A footer retry button */
 "general.pagingFooterView.retry" = "Försök igen";
 
+/* Error message format when REST API returns an error response. The first argument is error message. */
+"generic.error.rest-api-error" = "Din webbplats skickade ett felsvar: %@";
+
 /* A generic title for an error */
 "generic.error.title" = "Fel";
+
+/* Error message when failing to parse API responses */
+"generic.error.unparsableResponse" = "Din webbplats skickade ett svar som appen inte kunde analysera";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "Ställ in bloggningspåminnelser";
@@ -8076,42 +8659,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title of the Jetpack powered overlay. */
 "jetpack.branding.overlay.title" = "WordPress är bättre med Jetpack";
-
-/* Title for the button that starts the Jetpack connection process */
-"jetpack.connection.connect.button" = "Anslut din webbplats";
-
-/* Error message shown when WordPress.com authentication fails */
-"jetpack.connection.error.authentication" = "Ogiltigt WordPress.com-konto";
-
-/* Error message shown when a connection step is attempted in an invalid order */
-"jetpack.connection.error.context" = "Detta steg är inte klart än";
-
-/* Title for the retry button shown when a connection step fails */
-"jetpack.connection.retry.button" = "Försök igen";
-
-/* Status message when a connection step is pending */
-"jetpack.connection.stage.pending" = "Väntar på att starta";
-
-/* Status message when a connection step is in progress */
-"jetpack.connection.stage.processing" = "Pågår …";
-
-/* Status message when a connection step is completed successfully */
-"jetpack.connection.stage.success" = "Slutförd";
-
-/* Title for the finalization step in Jetpack connection flow */
-"jetpack.connection.step.finalize.title" = "Slutför anslutning";
-
-/* Title for the install step in Jetpack connection flow */
-"jetpack.connection.step.install.title" = "Installera Jetpack";
-
-/* Title for the login step in Jetpack connection flow */
-"jetpack.connection.step.login.title" = "Logga in på WordPress.com";
-
-/* Title for the site connection step in Jetpack connection flow */
-"jetpack.connection.step.site.title" = "Anslut till din webbplats";
-
-/* Title for the user connection step in Jetpack connection flow */
-"jetpack.connection.step.user.title" = "Anslut till ditt WordPress.com-konto";
 
 /* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
 "jetpack.fullscreen.overlay.early.switch.title" = "Byt till den nya Jetpack-appen";
@@ -8332,41 +8879,11 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "Du har inte behörighet att visa den här privata bloggen.";
 
-/* Button to dismiss the re-authentication view */
-"login.appPasswordReAuth.cancelButton" = "Avbryt";
-
-/* Description explaining why the user needs to re-authenticate */
-"login.appPasswordReAuth.description" = "Applikationslösenordet som tilldelats appen finns inte längre i din profil.\nLogga in igen för att skapa ett nytt applikationslösenord som appen kan använda.";
-
-/* Button to start the re-authentication process */
-"login.appPasswordReAuth.signInButton" = "Logga in";
-
-/* Title shown when the application password is invalid */
-"login.appPasswordReAuth.title" = "Ogiltigt applikationslösenord";
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "Ange verifieringskoden från din autentiseringsapp för ditt WordPress.com-konto.";
 
 /* Indicating that referrer was marked as spam */
 "marked as spam" = "markerad som skräppost";
-
-/* Button title when verification link sending failed */
-"me.verifyEmail.button.retry" = "Försök igen";
-
-/* Button title to send verification link */
-"me.verifyEmail.button.send" = "Skicka e-post igen";
-
-/* Button title while verification link is being sent */
-"me.verifyEmail.button.sending" = "Skickar …";
-
-/* Button title after verification link is sent */
-"me.verifyEmail.button.sent" = "E-post skickad";
-
-/* Message for email verification card */
-"me.verifyEmail.message.noEmail" = "Verifiera din e-postadress för att säkra ditt konto och få åtkomst till fler funktioner.\nKontrollera din inkorg för att se bekräftelsemeddelandet, eller klicka på \"%@\" för att få ett nytt.";
-
-/* Message for email verification card with email address */
-"me.verifyEmail.message.withEmail" = "Verifiera din e-postadress för att säkra ditt konto och få åtkomst till fler funktioner.\nKontrollera din inkorg på %1$@ för att se bekräftelsemeddelandet, eller klicka på ”%2$@” för att få ett nytt.";
-
-/* Title for email verification card */
-"me.verifyEmail.title" = "Verifiera din e-post";
 
 /* Me tab menu items */
 "meMenu.submitFeedback" = "Skicka feedback";
@@ -8809,6 +9326,9 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "Överordnad sida";
 
+/* No comment provided by engineer. */
+"password" = "lösenord";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "Kort kan visa olika innehåll beroende på vad som händer på din webbplats. Vi arbetar på fler kort och kontroller.";
 
@@ -8913,9 +9433,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Message shown while loading plugin details */
 "pluginDetails.loading" = "Laddar tilläggsinformation…";
-
-/* Placeholder message shown when a plugin has no description */
-"pluginDetails.noDescription" = "Detta tillägg har inte angett någon beskrivning.";
 
 /* Title of the changelog section in plugin details */
 "pluginDetails.section.changelog" = "Ändringslogg";
@@ -9205,6 +9722,30 @@ Example: Reply to Pamela Nguyen */
 /* An alert message explaning that by changing the visibility to private, the post will be published immediately to your site */
 "postSettings.warningPostWillBePublishedAlertMessage" = "Om synligheten ändras till \"Privat\" kommer inlägget att publiceras omedelbart";
 
+/* Localized post type: `Page` */
+"postType.page" = "sida";
+
+/* Localized post type: `Post` */
+"postType.post" = "inlägg";
+
+/* Details for a 'Private' privacy setting */
+"postVisibility.private.details" = "Endast synlig för webbplatsadministratörer och redigerare.";
+
+/* Title for a 'Private' privacy setting */
+"postVisibility.private.title" = "Privat";
+
+/* Details for a 'Password Protected' privacy setting */
+"postVisibility.protected.details" = "Synlig för alla men kräver ett lösenord";
+
+/* Title for a 'Password Protected' privacy setting */
+"postVisibility.protected.title" = "Lösenordsskyddat";
+
+/* Details for a 'Public' (default) privacy setting */
+"postVisibility.public.details" = "Synligt för alla";
+
+/* Title for a 'Public' (default) privacy setting */
+"postVisibility.public.title" = "Offentlig";
+
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Avbryt";
 
@@ -9425,18 +9966,6 @@ Tapping on this row allows the user to edit the sharing message. */
 /* Title for the success view when the user has successfully logged in */
 "qrLoginVerifyAuthorization.completedInstructions.title" = "Du är inloggad!";
 
-/* No comment provided by engineer. */
-"reachability-utils.alert.cancel" = "OK";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.retry" = "Försök igen?";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.title" = "Ingen anslutning";
-
-/* Message of error prompt shown when no internet connection is available */
-"reachability-utils.alert.utils" = "Kan inte ansluta till Internet.";
-
 /* Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog. */
 "reader.blocked.blog.message" = "Bloggen %@ kommer inte längre att visas i läsaren. Tryck här för att ångra åtgärden.";
 
@@ -9473,26 +10002,8 @@ Tapping on this row allows the user to edit the sharing message. */
 /* A shared button title for Reader */
 "reader.button.unsubscribe" = "Avsluta prenumeration";
 
-/* Button title. Follow the comments on a post. */
-"reader.comments.buttonFollow" = "Följ";
-
 /* Informational message, should be short. */
 "reader.comments.commentsClosed" = "Kommentarer stängda";
-
-/* Empty state view title */
-"reader.comments.emptyStateTitle" = "Bli först med att skriva en kommentar.";
-
-/* Empty state view title */
-"reader.comments.errorLoadingComments" = "Ett oväntat fel inträffade när kommentarerna lästes in.";
-
-/* VoiceOver hint */
-"reader.comments.followingSettingAccessibilityIdentifier" = "Öppna inläggets aviseringsinställningar";
-
-/* Error message that informs reader comments from a private blog cannot be fetched. */
-"reader.comments.noPermissionToViewPrivateBlog" = "Du har inte behörighet att visa denna privata blogg.";
-
-/* Navigation title */
-"reader.comments.title" = "Kommentarer";
 
 /* Accessibility hint to inform that the author section can be tapped to see posts from the site. */
 "reader.detail.header.authorInfo.a11y.hint" = "Visar inlägg från webbplatsen";
@@ -9570,23 +10081,8 @@ but tapping on this button will remove their like from the post. */
 /* Screen header details */
 "reader.following.header.details" = "Håll dig uppdaterad med de bloggar som du prenumererar på.";
 
-/* Empty state view */
-"reader.following.lists.emptyTitle" = "Listor tomma";
-
-/* Screen header details */
-"reader.home.header.details" = "Håll dig uppdaterad med de bloggar som du prenumererar på.";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.home.title" = "Hem";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.library.title" = "Bibliotek";
-
 /* Used in multiple contexts, usually as a screen title */
 "reader.likes.title" = "Gillamarkeringar";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.lists.title" = "Listor";
 
 /* Reader logged-out screen details */
 "reader.loggedOut.details" = "Logga in med ett WordPress.com-konto för att följa dina favoritbloggar";
@@ -9829,8 +10325,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title of a Reader tab showing Posts matching a user's search query */
 "reader.search.tab.posts" = "Inlägg";
 
-/* Title of the Reader's search feature
-   Used in multiple contexts, usually as a screen title */
+/* Title of the Reader's search feature */
 "reader.search.title" = "Sök";
 
 /* Screen title. Reader select interests title label text. */
@@ -9856,6 +10351,21 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Reader select interests title label text */
 "reader.select.tags.title" = "Upptäck och följ bloggar du gillar";
+
+/* Reader sidebar menu item */
+"reader.sidebar.discover" = "Upptäck";
+
+/* Reader sidebar menu item */
+"reader.sidebar.likes" = "Gillamarkeringar";
+
+/* Reader sidebar menu item */
+"reader.sidebar.recent" = "Senaste";
+
+/* Reader sidebar menu item */
+"reader.sidebar.saved" = "Sparat";
+
+/* Reader sidebar menu item */
+"reader.sidebar.search" = "Sök";
 
 /* Reader sidebar section title */
 "reader.sidebar.section.favorites.title" = "Favoriter";
@@ -9905,7 +10415,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Number of subscriptions on a site (singular) */
 "reader.subscriptions.subscriptionsSingular" = "%@ prenumerant";
 
-/* Used in multiple contexts, usually as a screen title */
+/* Navigation bar title */
 "reader.subscriptions.title" = "Prenumerationer";
 
 /* A suggestion of topics the user might want to subscribe to */
@@ -9947,29 +10457,11 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Verb. Button title. The user is following a tag. */
 "reader.tags.following.button.title" = "Följer";
 
-/* Used in multiple contexts, usually as a screen title */
-"reader.tags.title" = "Etiketter";
-
 /* Accessibility label for unsubscribing from a tag */
 "reader.tags.unfollow.accessibility.label" = "Sluta följa %@";
 
 /* Field title */
 "reader.userProfile.site" = "Webbplats";
-
-/* Reader Welcome screen login button */
-"reader.welcome.continueText" = "Fortsätt med WordPress.com";
-
-/* Reader Welcome screen */
-"reader.welcome.subtitle" = "Gå med i den största bloggcommunityn";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.discover" = "Upptäck";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.me" = "Jag";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.notifications" = "Aviseringar";
 
 /* Spoken accessibility label */
 "readerDetail.backButton.accessibilityLabel" = "Tillbaka";
@@ -10247,14 +10739,10 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Message shown when there are no inactive plugins on the site */
 "site.plugins.empty.inactive" = "Inga inaktiva tillägg";
 
-/* The plugin fillter option for displaying active plugins */
-"site.plugins.filter.option.active" = "Aktivt";
-
-/* The plugin fillter option for displaying all plugins */
+/* The plugin fillter option for displaying active plugins
+   The plugin fillter option for displaying all plugins
+   The plugin fillter option for displaying inactive plugins */
 "site.plugins.filter.option.all" = "Alla";
-
-/* The plugin fillter option for displaying inactive plugins */
-"site.plugins.filter.option.inactive" = "Inaktivt";
 
 /* Title of the plugin filter picker */
 "site.plugins.filter.title" = "Filtrera";
@@ -10806,9 +11294,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* View title for Help & Support page. */
 "support.title" = "Hjälp";
 
-/* Subject of new Zendesk ticket. */
-"support.zendesk.readerAppTicketSubject" = "Läsare för iOS-support";
-
 /* Title for placeholder in Tenor picker */
 "tenor.welcomeMessage" = "Leta efter GIF-filer att lägga till i ditt mediabibliotek!";
 
@@ -10957,8 +11442,119 @@ Feel free to replace it with other bracket types that you think looks better for
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "Status";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "Alla inlägg och flest visningar";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "Alla visningar";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "Alla visningar och besökare";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "Flest visningar någonsin";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "Flest visningar";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "Kan inte ladda statistik sedan starten.";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "Skapa eller lägg till en webbplats för att se statistik sedan starten.";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Inlägg";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "Håll dig uppdaterad om statistiken sedan starten för din WordPress-webbplats.";
+
+/* Title of all time widget */
+"widget.alltime.title" = "Sedan starten";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "Logga in i WordPress för att se statistik sedan starten.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "Logga in på Jetpack för att se statistik sedan starten.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "Logga in på Jetpack för att se veckans statistik.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "Logga in på Jetpack för att se dagens statistik.";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "Alla visningar";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "Visningar idag";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "Kan inte ladda denna veckas statistik.";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "Skapa eller lägg till en webbplats för att se denna veckas statistik.";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "Håll dig uppdaterad om veckans statistik för din WordPress-webbplats.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "Denna vecka";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "Logga in i WordPress för att se veckans statistik.";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Kommentarer";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "Statistik har flyttat till Jetpack-appen. Att byta är gratis och tar bara en minut.";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Gillamarkeringar";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "Kan inte ladda webbplatsstatistik.";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "Det gick inte att ladda dagens statistik.";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "Skapa eller lägg till en webbplats för att se dagens statistik.";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "Håll dig uppdaterad om statistiken för idag för din WordPress-webbplats.";
+
+/* Title of today widget */
+"widget.today.title" = "Idag";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "Logga in i WordPress för att se statistiken för idag.";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "Vyn är inte tillgänglig";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Visningar";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Besökare";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "Dagens gillamarkeringar och kommentarer";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "Dagens visningar";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "Dagens visningar och besökare";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "kommer inte att kunna nås i fortsättningen.";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "Ska du starta en ny webbplats?";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "wordpress, hjälp, support, faq, vanliga frågor, felsökning, loggar, kontakt";
@@ -10983,6 +11579,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Error message that describes an unknown error had occured */
 "wordpress-api.error.unknown" = "Något gick fel, försök igen senare.";
+
+/* Error message when failing to find selected media file on the user's device. */
+"wordpress.api.upload.media.fileNotFound" = "Kan inte hitta mediafilen på enheten";
 
 /* Jetpack Plugin Modal on WordPress primary button title */
 "wordpress.jetpack.plugin.modal.primary.button.title" = "Byt till Jetpack-appen";
@@ -11029,21 +11628,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Error message when user signs in with an unexpected email address. The first argument is the expected email address */
 "wpComLogin.error.mismatchedEmail" = "Logga in med e-postadress %@";
 
-/* Message shown when user denies WordPress.com login, offering option to try with different account */
-"wpComLogin.loginDenied.message" = "Du kan logga in med ett annat konto om det behövs. Tryck på ”%@” för att börja.";
-
-/* Title of alert shown when user cancels WordPress.com login */
-"wpComLogin.loginDenied.title" = "Inloggning avbruten";
-
-/* Button title for signing in with a different WordPress.com account */
-"wpComLogin.loginDenied.useDifferentAccount" = "Använd annat konto";
-
-/* Button title to log out the current WordPress.com account */
-"wpcom.token.alert.button.logout" = "Logga ut";
-
-/* Button title to Sign In to WordPress.com */
-"wpcom.token.alert.button.signin" = "Logga in";
-
 /* Message title to be displayed when the user needs to re-authenticate their WordPress.com account. */
 "wpcom.token.fix.signin" = "Logga in på WordPress.com";
 
@@ -11058,6 +11642,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "Bilagan stöds ej";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Logga in med Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Domännamn";

--- a/WordPress/Resources/th.lproj/Localizable.strings
+++ b/WordPress/Resources/th.lproj/Localizable.strings
@@ -38,6 +38,9 @@
 /* Empty Post Title */
 "(No Title)" = "(ไม่มีหัวข้อ)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(ไม่มีหัวข้อ)";
+
 /* Placeholder text for the title of a site */
 "A title for the site" = "หัวข้อสำหรับเว็บไซต์";
 
@@ -92,6 +95,9 @@
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Alt Text";
+
+/* the comment has an anonymous author. */
+"Anonymous" = "นิรนาม";
 
 /* The title of the app appearance settings screen */
 "Appearance" = "รูปแบบ";
@@ -164,6 +170,7 @@
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -173,6 +180,7 @@
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -191,6 +199,7 @@
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -208,7 +217,8 @@
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "คำอธิบาย";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "ควรระวัง";
 
 /* Label for the categories field. Should be the same as WP core. */
@@ -229,6 +239,7 @@
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "ปิด";
 
@@ -257,6 +268,7 @@
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "ความเห็น";
 
@@ -281,6 +293,9 @@
 /* Verb. Title for Jetpack Restore confirm button. */
 "Confirm" = "ยืนยัน";
 
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "กำลังเชื่อมต่อไปยัง  WordPress.com";
+
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "อ่านเพิ่มเติม";
 
@@ -302,6 +317,9 @@
 /* Label for list of countries.
    Register Domain - Domain contact information field Country */
 "Country" = "ประเทศ";
+
+/* The button title text for creating a new account. */
+"Create Account" = "สร้างบัญชี";
 
 /* Button to progress to the next step
    Site creation. Step 1. Screen title
@@ -336,6 +354,7 @@
 "Defaults for New Posts" = "ค่าเริ่มต้นสำหรับเรื่องใหม่";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "ลบ";
@@ -374,7 +393,9 @@
    Title for the Discussion Settings Screen */
 "Discussion" = "การสนทนา";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "ยกเลิก";
 
 /* Display Name label text.
@@ -394,6 +415,9 @@
    Title for button that will dismiss this view
    Title for the button that will dismiss this view. */
 "Done" = "เสร็จแล้ว";
+
+/* Name for the status of a draft post. */
+"Draft" = "โครงเรื่อง";
 
 /* Editing GIF alert default action button.
    Edits a Comment
@@ -451,6 +475,9 @@
 /* Placeholder text for the tagline of a site */
 "Explain what this site is about." = "อธิบายว่าเว็บนี้เกี่ยวกับอะไร";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "ล้มเหลว";
+
 /* Label for the Featured Image area in post settings. */
 "Featured Image" = "รูปภาพพิเศษ";
 
@@ -471,6 +498,9 @@
    User's First Name */
 "First Name" = "ชื่อ";
 
+/* Button title. Follow the comments on a post. */
+"Follow" = "ติดตาม";
+
 /* User role badge */
 "Follower" = "ผู้ติดตาม";
 
@@ -489,6 +519,12 @@
 /* Title for the general section in site settings screen */
 "General" = "ทั่วไป";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "ได้รับข้อมูลบัญชี";
+
+/* Cancel */
+"Give Up" = "ยอมแพ้";
+
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "ไปที่การตั้งค่า iOS";
@@ -504,6 +540,9 @@
    Open editor help options
    Title of the 'Help & Support' screen within the 'Me' tab - used for spotlight indexing on iOS. */
 "Help & Support" = "ช่วยเหลือและสนับสนุน";
+
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "ซ่อน";
 
 /* No comment provided by engineer. */
 "Hide keyboard" = "ซ่อนคีย์บอร์ด";
@@ -603,7 +642,8 @@
 /* Setting: indicates if Replies to your comments will be notified */
 "Likes on my posts" = "ความชื่นชอบบนเรื่องของฉัน";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "ลิงก์";
 
 /* Link name field placeholder */
@@ -627,12 +667,20 @@
    Text displayed while loading time zones */
 "Loading..." = "กำลังโหลด...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "บนเครื่อง";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "ไม่ทราบที่อยู่";
+
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "ไฟล์ log โดยวันที่สร้างขึ้น";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "เข้าสู่ระบบ";
 
 /* Login Request Expired */
@@ -640,6 +688,9 @@
 
 /* No comment provided by engineer. */
 "Logs" = "log";
+
+/* Title of a button. */
+"Lost your password?" = "จำรหัสผ่านไม่ได้?";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "เมนูนำทางหลัก";
@@ -715,7 +766,9 @@
 "Newest first" = "เรียงตามใหม่สุดก่อน";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "ต่อไป";
 
 /* Label for a cancel button */
@@ -778,7 +831,12 @@
 /* Notifications tab bar item accessibility label, unread notifications state */
 "Notifications Unread" = "คำเตือนที่ยังไม่ได้อ่าน";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "ตกลง";
@@ -801,10 +859,12 @@
 /* Sort Order */
 "Oldest first" = "เรียงตามเก่าสุดก่อน";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "โอ๊ะ";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "การตั้งค่าแบบเปิด";
 
 /* No comment provided by engineer. */
@@ -851,14 +911,21 @@
 /* Title for selecting parent category of a category */
 "Parent Category" = "หมวดหมู่หลัก";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "รหัสผ่าน";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "รอตรวจสอบ";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "รอคอยการตรวจสอบ";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -880,11 +947,14 @@
 /* No comment provided by engineer. */
 "Please enter a username." = "กรุณาใส่ชื่อผู้ใช้";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "โปรดใส่ที่อยู่อีเมล์ที่ใช้งานได้";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "โปรดใส่การรับรองของคุณ";
+
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "กรุณากรอกข้อมูลในช่องทั้งหมด";
 
 /* No comment provided by engineer. */
 "Please try entering your login details again." = "กรุณาลองใส่ข้อมูลเข้าสู่ระบบของคุณอีกครั้ง";
@@ -893,7 +963,8 @@
    Screen title, where users can see the most popular plugins */
 "Popular" = "ยอดนิยม";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "เรื่อง";
 
@@ -931,12 +1002,22 @@
 /* Title of button that displays the App's privacy policy */
 "Privacy Policy" = "นโยบายความเป็นส่วนตัว";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "ส่วนตัว";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "การทำต่อจะลบข้อมูล WordPress.com ทั้งหมดออกจาอุปกรณ์  และลบฉบับร่างที่บันทึกในอุปกรณ์ด้วย  แต่คุณไม่ได้เสียอะไรเพราะว่าทั้งหมดถูกบันทึกไปที่บล็อก WordPress.com ของคุณแล้ว";
+
 /* Label for the publish (verb) button. Tapping publishes a draft post.
    Publish post action on share extension site picker screen.
    Section title for the publish table section in the blog details screen */
 "Publish" = "เผยแพร่";
 
-/* Period Stats 'Published' header
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "เผยแพร่ทันที";
+
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "เผยแพร่แล้ว";
 
@@ -1025,11 +1106,18 @@
    User action to retry media upload. */
 "Retry" = "ลองใหม่";
 
+/* No comment provided by engineer. */
+"Retry?" = "ลองใหม่?";
+
 /* Right alignment for an image. Should be the same as in core WP. */
 "Right" = "ขวา";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "ส่ง SMS";
+
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -1039,7 +1127,8 @@
 /* Menus save button title while it is saving a Menu. */
 "Saving..." = "กำลังบันทึก...";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "เข้าตารางเวลาแล้ว";
 
 /* Title of Stats section that shows search engine referrer traffic. */
@@ -1071,6 +1160,9 @@
 
 /* Message to show when setting save failed */
 "Settings update failed" = "อัปเดตการตั้งค่าล้มเหลว";
+
+/* Spoken accessibility label */
+"Share" = "แบ่งปัน";
 
 /* Aztec's Text Placeholder
    Share Extension Content Body Text Placeholder */
@@ -1112,7 +1204,7 @@
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "ขอโทษครับ  ที่อยู่เว็บต้องมีตัวอักษรด้วย";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "ขอโทษครับ  แต่ที่อยู่อีเมล์นี้ถูกใช้ไปแล้ว";
 
 /* No comment provided by engineer. */
@@ -1233,6 +1325,9 @@
 /* Message for when the certificate for the server is invalid. The %@ placeholder will be replaced the a host name, received from the API. */
 "The certificate for this server is invalid. You might be connecting to a server that is pretending to be “%@” which could put your confidential information at risk.\n\nWould you like to trust the certificate anyway?" = "การรับรองสำหรับเซิร์ฟเวอร์นี้ใช้งานไม่ได้ คุณอาจจะเชื่อมต่อกับเซิร์ฟเวอร์ที่แกล้งทำเป็น “%@” ซึ่งสามารถทำให้ข้อความความลับของคุณอยู่ในความเสี่ยง\n\nคุณต้องการที่จะเชื่อมั่นการรับรองนี้อยู่หรือไม่?";
 
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "การเชื่อมต่ออินเตอร์เนตเหมือนว่าปิดใช้งานอยู่";
+
 /* WordPress.com Push Authentication Expired message */
 "The login request has expired. Log in to WordPress.com to try again." = "คำขอร้องเข้าสู่ระบบหมดอายุ  ให้คุณเข้าสู่ระบบ WordPress.com แล้วลองอีกครั้ง";
 
@@ -1261,6 +1356,9 @@
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "มีความผิดพลาดที่ไม่ได้คาดคิดในระหว่างการอัปเดตการตั้งค่าการเตือนของคุณ";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "มีความผิดพลาดเหนือความคาดหมายในขณะอัปเดตความเห็นของคุณ";
 
 /* Error message informing the user that there was a problem blocking posts from a site from their reader. */
 "There was a problem blocking posts from the specified site." = "มีปัญหาในการปิดกั้นเรื่องจากเว็บที่กำหนด";
@@ -1304,7 +1402,8 @@
    Trashes the comment */
 "Trash" = "ถังขยะ";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "ย้ายไปถังขยะแล้ว";
 
@@ -1315,6 +1414,7 @@
 "Try & Customize" = "ทดลองและปรับแต่ง";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "ลองใหม่อีกครั้ง";
@@ -1380,21 +1480,26 @@
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "การอัปโหลดล้มเหลว";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "อัปโหลดแล้ว";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "กำลังอัปโหลด";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
 "Uploading media" = "การอัปโหลดไฟล์สื่อ";
 
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "ชื่อผู้ใช้";
 
 /* Setting: indicates if Mentions will be notified */
@@ -1452,6 +1557,9 @@
 /* The title of the option group for editing an image's size, alignment, etc. on the image details screen. */
 "Web Display Settings" = "การตั้งค่าการแสดงผลเว็บ";
 
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "ยินดีต้อนรับสู่เวิร์ดเพรส";
+
 /* Title displayed in the Notification Settings for WordPress.com */
 "We’ll always send important emails regarding your account, but you can get some helpful extras, too." = "เรามักจะส่งอีเมลสำคัญเกี่ยวกับบัญชีของคุณ  แต่คุณสามารถได้ข้อมูลที่มีประโยชน์อย่างอื่นด้วย";
 
@@ -1502,7 +1610,8 @@
 /* No comment provided by engineer. */
 "You cannot use that email address to signup. We are having problems with them blocking some of our email. Please use another email provider." = "คุณไม่สามารถใช้ที่อยู่อีเมล์นั้นในการลงทะเบียนได้  เรามีปัญหากับระบบของพวกเขาที่ปิดกั้นอีเมล์บางส่วนของเรา  โปรดใช้เมล์ของผู้ให้บริการอีเมล์อื่น";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "คุณมีการเปลี่ยนแปลงที่ยังไม่ได้บันทึก";
 
 /* Error message informing the user that being logged into a WordPress.com account is required. */
@@ -1534,4 +1643,22 @@
 
 /* Later today */
 "later today" = "ภายหลังในวันนี้";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "เรื่อง";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "ความเห็น";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "ชื่นชอบ";
+
+/* Title of today widget */
+"widget.today.title" = "วันนี้";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "การดู";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "ผู้เยี่ยมชม";
 

--- a/WordPress/Resources/tr.lproj/Localizable.strings
+++ b/WordPress/Resources/tr.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Translation-Revision-Date: 2025-05-13 13:54:07+0000 */
+/* Translation-Revision-Date: 2025-03-14 00:41:38+0000 */
 /* Plural-Forms: nplurals=2; plural=n > 1; */
 /* Generator: GlotPress/4.0.1 */
 /* Language: tr */
@@ -98,6 +98,9 @@
 
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "Sitenizde %2$@ alanın %1$@ kadarı";
+
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "Sitenizde %2$@ alanın %1$@ kadarı kullanılıyor";
 
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ katrilyon";
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Adlandırılmamış)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(başlıksız)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*Johan Brandt* yazınıza yanıt verdi";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "\"Diğer\" düğmesine tıklandığında paylaşım araçlarını görüntüleyen bir menü açılır";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "Bir WordPress.com hesabı mağaza kimlik bilgilerinizle ilişkilendirildi. İlerlemek için yukarıdaki e-posta adresine bir doğrulama bağlantısı göndereceğiz.";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "Bir dosyada kötü amaçlı bir kod modeli var";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "Sitenin başlığı";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "Kimlik doğrulama bağlantısının gönderilebilmesi için geçerli bir e-posta adresi gereklidir. Geçerli bir e-posta adresi yazmak için lütfen önceki ekrana dönün.";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "Doğrulama kodunda yalnızca rakamlar olmalıdır.";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "ETKİN";
@@ -522,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "%@ ögesinden sonra";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "Hizalama";
@@ -585,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "İzin verilen IP adresleri";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "Neredeyse bitiyor! Lütfen doğrulama uygulamanızdan alacağınız kodu yazın.";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "Alternatif metin";
@@ -597,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "Alternatif olarak blok gruplamasını kaldırarak içeriği düzleştirebilirsiniz.";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "Alternatif olarak, bu hesabın parolasını yazabilirsiniz.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "Alternatif olarak:";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "Kilitlenme günlükleri her zaman gönderilsin";
@@ -618,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "Etkinlikleri görüntülemek için etkin bir internet bağlantısı gereklidir";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "Paketleri görüntüleyebilmek için etkin bir İnternet bağlantısı gereklidir";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -668,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "Yıllık site istatistikleri";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "Anonim";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "Yanıt";
 
@@ -689,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "Görünüm";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "Apple ID doğrulanamadı.\nLütfen iCloud oturumunuzu iki adımlı doğrulama kullanan bir Apple ID ile açtığınızdan emin olun.";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "Ayarı uygular";
@@ -775,6 +811,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "Doğrulanamadı";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "Kimlik doğrulama kodu";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "Şu sunucu için doğrulama gerekli: %@";
@@ -885,6 +925,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "İlk yorumu siz yapın";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "İlk yorumu siz yapın.";
 
 /* Beauty site intent topic */
 "Beauty" = "Güzellik";
@@ -1021,12 +1064,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button to copy post text" = "Gönderi metnini kopyalama düğmesi";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "İlerleyerek _hizmet koşullarını_ kabul etmiş olursunuz.";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "Bu etki alanını kaydederek <a>Hüküm ve koşullar<\/a> metnini kabul etmiş olursunuz.";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "Jetpack kurarak %@ metnimizi\nkabul etmiş olursunuz";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "Hesap açarak _hizmet koşulları_ metnimizi kabul etmiş olursunuz.";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "ÖZELLEŞTİR";
@@ -1040,6 +1089,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "Oturum açma kodlarını taramak için kameraya erişme izni gereklidir";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "Bağlantı istenemedi";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "Boş bir sayfa yayınlanamaz";
 
@@ -1049,6 +1101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1058,6 +1111,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1076,6 +1130,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1103,6 +1158,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "İptal ediliyor...";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "Bu adresten siteye erişilemiyor. Lütfen kontrol edip yeniden deneyin.";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Karar veremiyor musunuz? Temayı istediğiniz zaman değiştirebilirsiniz.";
 
@@ -1110,7 +1168,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "Alt yazı";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "Dikkatli olun!";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1119,7 +1178,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "Kategoriler";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "Kategori";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1168,6 +1228,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "Görüntülemelerinizi ve trafiğinizi artırmak için ipuçlarımıza göz atın";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "Bu aygıttan e-postanızı kontrol edin!";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "E-postanıza bu aygıtta bakın ve WordPress.com tarafından gönderilen e-postadaki bağlantıya dokunun.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "Bu aygıttan e-postanızı denetleyin ve WordPress.com tarafından gönderilen e-postadaki bağlantıya dokunun..\n\nE-postayı görmüyor musunuz? İstenmeyen veya önemsiz e-posta klasörünüze bakın.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "E-postanıza bakın!";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "İnternet bağlantınızı denetleyip yenilemek için çekin.";
@@ -1264,6 +1336,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "Ücretsiz etki alanınızı kullanın";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "Klasik blog";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "Aygıtın ortam ön belleğini temizle";
 
@@ -1291,6 +1366,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "Kapat";
 
@@ -1332,6 +1408,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "Sütun ayarları";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "Çizgi romanlar";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1383,6 +1462,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "Yorumlar";
 
@@ -1450,12 +1530,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Bağlı hesaplar";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Bağlantı kuruldu ancak…";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "%@ bağlantısı kuruluyor";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "%1$@ bağlantısını kurmak var olan bağlantıyı %2$@ olarak değiştirir.";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "WordPress.com sitesi ile bağlantı kuruluyor";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Bağlantı kuruluyor...";
@@ -1486,8 +1572,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "Bizimle %@ üzerinden görüşün";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "İçerik yapısı\nBloklar: %1$li, Sözcükler: %2$li, Karakterler: %3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1502,6 +1592,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Okumayı sürdür";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Apple ile ilerle";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Google ile ilerle";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Apple ile ilerleniyor";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "Katkıda bulunun";
@@ -1630,6 +1729,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "Oluştur";
 
+/* The button title text for creating a new account. */
+"Create Account" = "Hesap aç";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "Boş sayfa oluştur";
 
@@ -1650,6 +1752,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "Bir yazı oluştur";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "Bir site oluştur";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "Bir etiket oluştur";
@@ -1683,6 +1788,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "Geçerli";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "Geçerli paket";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Geçerli tema";
@@ -1785,6 +1893,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "Varsayılan kategori";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "Varsayılan menü";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Varsayılan yazı biçimi";
@@ -1793,6 +1904,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "Yeni yazı varsayılanları";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "Sil";
@@ -1850,6 +1962,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "Ayrıntılar";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "Yeni bir hesap açmak istemediniz mi? E-posta adresinizi yeniden yazmak için geri dönün.";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "Boyutlar";
 
@@ -1897,7 +2012,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "Tartışma";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "Yok say";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1919,6 +2036,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "Etki alanları";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "Hesabınız yok mu? _Hesap açın_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2048,6 +2168,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "İndirmeler";
 
+/* Name for the status of a draft post. */
+"Draft" = "Taslak";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "Taslaklar";
 
@@ -2157,7 +2280,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "E-posta adresi";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "E-posta adresi";
 
 /* Notification Settings Channel */
@@ -2241,8 +2367,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Parolayı yazın";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "Bağlanmak istediğiniz WordPress sitesinin adresini yazın.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "WordPress.com hesabınızın parolasını yazın.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Kullanıcı adını yazın";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "%@ için hesap bilgilerinizi yazın.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "Oturum açmak ya da bir WordPress.com hesabı oluşturmak için e-posta adresinizi yazın.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "Var olan site adresinizi yazın";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "Bunun yerine parolanızı yazın.";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "Sunucu kimlik doğrulama bilgilerinizi yazın";
@@ -2405,6 +2551,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "Dış";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "Tamamlanamadı";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "Bildirim okundu olarak işaretlenemedi";
 
@@ -2416,9 +2565,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Failed to insert media.\nTap for more info." = "Ortam eklenemedi.\nAyrıntılı bilgi almak için dokunun.";
-
-/* A message indicating that we couldn't load the user's settings. */
-"Failed to load settings" = "Ayarlar yüklenemedi";
 
 /* No comment provided by engineer. */
 "Failed to save files.\nPlease tap for options." = "Dosyalar kaydedilemedi.\nSeçenekler için dokunun.";
@@ -2434,6 +2580,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "Moda";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "Öne çıkarılmış";
@@ -2492,6 +2641,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "Ayrıntılı bilgi alın";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Site adresinizi bulun";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2514,6 +2666,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "Tehditler düzeltiliyor";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "Takip et";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "Yazışmayı takip et";
@@ -2608,6 +2763,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "Yeni bağlantı oluştur";
 
+/* View title for initial auth views. */
+"Get Started" = "Haydi başlayalım";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "E-posta ile bir oturum açma bağlantısı alın";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "Etkin olun! Takip ettiğiniz bloglardaki yazılara yorum yapın.";
 
@@ -2629,8 +2790,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "İlham alma";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "Hesap bilgileri alınıyor";
+
+/* Cancel */
+"Give Up" = "Vazgeç";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "Yazınıza veya sayfanıza birkaç blok ekleyerek deneyin!";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "Okuyucuya git";
@@ -2641,6 +2811,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "iOS ayarlarına git";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Google oturumu açılamadı.";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2715,6 +2888,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "Yardım simgesi";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "Gizli";
+
 /* Title of a button used to collapse a group */
 "Hide" = "Gizle";
 
@@ -2783,6 +2959,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "Simge güncellenemedi";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "E-postayı bulamıyorsanız, önemsiz veya istenmeyen klasörlerine de bakın";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "Apple veya Google ile ilerlerseniz ve bir WordPress.com hesabınız yoksa, bir hesap oluşturarak _Hizmet koşullarımızı_ kabul etmiş olursunuz.";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "%1$@ kullanıcısını kaldırırsanız artık bu siteye erişemez. Ancak %2$@ tarafından oluşturulmuş içerikler sitede kalmayı sürdürecek.";
@@ -2858,6 +3040,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "Wp-config php ve WordPress paketinde olmayan tüm dosyaları içerir";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "Kullanıcı adı ya da parola yanlış. Lütfen oturum açma bilgilerinizi yazarak yeniden deneyin.";
 
 /* Title for a threat */
 "Infected core file" = "Etkilenmiş temel dosya";
@@ -2959,6 +3144,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "Blog istemleriyle tanışın";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "E-posta adresi geçersiz.";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "Site adresi geçersiz";
 
@@ -2976,6 +3164,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "Adres geçersiz. Ses dosyası bulunamadı.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "Adres geçersiz. Lütfen kontrol edip yeniden deneyin.";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "Adres geçersiz. Lütfen geçerli bir adres yazın.";
@@ -2997,6 +3188,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "İnsanları davet edin";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "Bu kullanıcı adı\/parola bu siteyle ilişkili değil gibi görünüyor.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "Yanlış bir parola yazmışsınız gibi görünüyor. Yeniden denemek ister misiniz?";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "%@ için blog yazma zamanı!";
@@ -3225,7 +3422,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "Satır yüksekliği";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "Bağlantı";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3287,6 +3485,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "Kişiler yükleniyor...";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "Paket yükleniyor...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "Paketler yükleniyor...";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "Eklenti yükleniyor...";
 
@@ -3321,11 +3525,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "Yükleniyor...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "Yerel";
+
 /* Local Services site intent topic */
 "Local Services" = "Yerel hizmetler";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "Yerel değişiklikler";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "Konum";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "Geçerli konumunuzu eklemeden önce konum servisleri açılmalıdır. Lütfen Ayarlar uygulamasından Konum Servislerini açın.";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "Konum bilinmiyor";
 
 /* No comment provided by engineer. */
 "Lock icon" = "Kilit simgesi";
@@ -3333,9 +3549,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "Oluşturulma tarihine göre günlük dosyaları";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "Oturum aç";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3345,17 +3563,33 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of a button for signing in. */
 "Log in" = "Oturum aç";
 
-/* LogOut confirmation text, whenever there are no local changes */
-"Log out of Jetpack?" = "Jetpack oturumu kapatılsın mı?";
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "Oturum açılamadı. Lütfen yeniden deneyin.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "WordPress.com oturumu ya da hesabı açın";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Jetpack bağlantısı kurmak için kullandığınız WordPress.com hesabıyla oturum açın.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "E-posta adresinizle WordPress.com hesabınızda oturum açın.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "WordPress.com kullanıcı adınız ve parolanız ile oturum açın.";
 
 /* LogOut confirmation text, whenever there are no local changes */
-"Log out of Reader?" = "Okuyucunun oturumu kapatılsın mı?";
+"Log out of Jetpack?" = "Jetpack oturumu kapatılsın mı?";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of WordPress?" = "WordPress oturumu kapatılsın mı?";
 
 /* Login Request Expired */
 "Login Request Expired" = "Oturum açma isteğinin süresi dolmuş";
+
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "Hesap parolası ile oturum açın";
 
 /* No comment provided by engineer. */
 "Logs" = "Günlükler";
@@ -3365,6 +3599,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Görünüşe göre sitenizde Jetpack kurulu. Tebrikler! İstatistikleri ve bildirimleri etkinleştirmek için WordPress.com hesabınızla oturum açın.";
+
+/* Title of a button. */
+"Lost your password?" = "Parolanızı mı unuttunuz?";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "Mail (varsayılan)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Ana gezinme";
@@ -3512,6 +3752,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "İleti";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "Diğer güvenlik açığı";
 
@@ -3607,6 +3850,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "Benim sitem";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "WordPress sitelerim";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "En sevdiğim on kafe";
 
@@ -3646,8 +3892,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Yardım mı gerekli?";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "Sitenizin adresini bulmanız için yardım mı gerekli?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "Yardım mı gerekli?";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "Daha fazla yardım mı gerekli?";
 
 /* Describes a status of a plugin */
 "Needs Update" = "Güncellenmesi gerekli";
@@ -3676,6 +3929,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "Yeni yazı";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "Yeni öge";
+
 /* Placeholder text for password field */
 "New password" = "Yeni parola";
 
@@ -3693,7 +3949,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "Haberler";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "Sonraki";
 
 /* Accessibility label for the next notification button */
@@ -3729,6 +3987,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "Kullanılabilecek bir ön izleme adresi yok";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "Başlık yok";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "Herhangi bir etkinlik yok";
 
@@ -3761,7 +4022,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "Henüz bir yorum yok";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "Bağlantı yok";
 
@@ -3910,6 +4172,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "Şimdi değil";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "E-postayı görmüyor musunuz? İstenmeyen e-posta klasörünüze bakın.";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "Not:";
 
@@ -3973,7 +4238,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Numaralı liste";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "Tamam";
@@ -4030,7 +4300,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "Kusura bakmayın";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "Sorun çıktı!";
 
 /* No comment provided by engineer. */
@@ -4045,7 +4316,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "Jetpack güvenlik ayarlarını açın";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "E-postayı aç";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "Ayarları aç";
 
 /* No comment provided by engineer. */
@@ -4063,6 +4339,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "Bağlantıyı yeni pencerede\/sekmede aç";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "Yazının abonelik ayarlarını açın";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "Ben bölümünü aç";
 
@@ -4077,6 +4356,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "İsteğe bağlı: Davetinizle gönderilecek en fazla %1$d karakter uzunluğunda özel bir ileti yazın.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "Veya";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "Farklı bir doğrulama biçimi de seçebilirsiniz.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "Ya da _site adresinizi yazarak_ oturum açın.";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "Veya sihirli bağlantı ile oturum açın";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Sıralı liste";
@@ -4125,7 +4416,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "İç kenar boşluğu";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Sayfa";
 
@@ -4158,8 +4450,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "Ebeveynlik";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Parola";
 
@@ -4176,8 +4471,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "Bloğu arkasına yapıştır";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "Bekliyor";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "Değerlendirilmeyi bekliyor";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4208,6 +4507,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "Kullanıcı adı seçin";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "Paketler";
+
 /* User action to play a video on the editor. */
 "Play video" = "Videoyu oynat";
 
@@ -4237,6 +4540,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "Lütfen sitenizde blok düzenleyicinin etkinleştirildiğinden emin olun. Etkinleştirilmemişse yüklenmez.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "Lütfen ornek.com gibi eksiksiz bir site adresi yazın.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "Lütfen bir site adresi yazın.";
@@ -4271,11 +4577,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "Lütfen geçerli bir adres yazın";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "Lütfen bir WordPress.com hesabı için geçerli bir e-posta adresi yazın.";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Lütfen geçerli bir e-posta adresi yazın.";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "Lütfen geçerli bir telefon numarası yazın";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Lütfen Apple ID ile oturum açmak için WordPress.com hesabınızın parolasını yazın.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Lütfen oturum açma bilgilerinizi yazın";
@@ -4283,8 +4595,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "Lütfen e-posta adresinizi yazın.";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "Lütfen tüm alanları doldurun";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Lütfen WordPress uygulamasını açın, WordPress.com oturumu açın ve en azından bir sitenizin olduğundan emin olduktan sonra yeniden deneyin.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "Farklı bir wordpress.com sitesine bağlanmadan önce lütfen oturumunuzu kapatın";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "Lütfen bir süre sonra yeniden deneyin";
@@ -4352,7 +4670,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "Yaygın kullanılan diller";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Yazı";
 
@@ -4473,6 +4792,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "Californiya kullanıcıları için gizlilik notu";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "Özel";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "Blok görüntülenirken bir sorun çıktı \nBloğu kurtarmayı denemek için dokunun.";
 
@@ -4487,6 +4809,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "Etki alanınız satın alınırken sorun çıktı. Lütfen yeniden deneyin.";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "İlerlerseniz bu aygıttaki tüm WordPress.com verileri ve tüm yerel taslaklarınız silinecek. WordPress.com blogunuza\/bloglarınıza kaydedilmiş olan verileri kaybetmeyeceksiniz.";
+
+/* Menu item label for linking a project page. */
+"Projects" = "Projeler";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "İstem atlandı";
@@ -4504,13 +4832,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "Yayınlanma Tarihi";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "Hemen yayınla";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "Sayfayı şurada yayınla:";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "Yazıyı şurada yayınla:";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "Yayınlanmış";
 
@@ -4712,7 +5044,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "Yanıtla";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "Yanıt metni";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "%1$@ için yanıt verin";
 
 /* An explaination of a setting. */
@@ -4741,6 +5078,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "Tarih aralığı süzgecini sıfırla";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Parolanızı sıfırlayın";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Boyutlandır ve kırp";
@@ -4798,6 +5138,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "Tümünü yeniden dene";
 
+/* No comment provided by engineer. */
+"Retry?" = "Yeniden denensin mi?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "Yazıya dön";
 
@@ -4827,6 +5170,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "Rol";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "SMS gönderildi";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "DURUM";
 
@@ -4838,6 +5184,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4904,7 +5251,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "Dosyalar taranıyor";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Zamanlandı";
 
 /* No comment provided by engineer. */
@@ -5044,6 +5392,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "Bu konuyu sitenizin amacı olarak seçer.";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "Bağlantı gönder";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "E-posta ile bağlantı gönder";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "Günlük iletisi gönder";
 
@@ -5052,6 +5406,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "Deneme çökmesi gönder";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "E-posta doğrulama bağlantısı gönder";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "Bildirimler e-posta ile gönderilsin";
@@ -5098,11 +5455,11 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Message to show when setting save failed */
 "Settings update failed" = "Ayarlar güncellenemedi";
 
-/* Title for a button that recommends the app to others */
-"Share Jetpack with a friend" = "Jetpack uygulamasını arkadaşınızla paylaşın";
+/* Spoken accessibility label */
+"Share" = "Paylaş";
 
 /* Title for a button that recommends the app to others */
-"Share Reader with a friend" = "Okuyucuyu bir arkadaşınızla paylaşın";
+"Share Jetpack with a friend" = "Jetpack uygulamasını arkadaşınızla paylaşın";
 
 /* Title for a button that recommends the app to others */
 "Share WordPress with a friend" = "WordPress'i bir arkadaşınızla paylaşın";
@@ -5153,6 +5510,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "Yeniden blogla düğmesi görüntülensin";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "Parolayı görüntüle";
+
 /* No comment provided by engineer. */
 "Show post content" = "Yazı içeriği görüntülensin";
 
@@ -5164,6 +5525,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "Şunun için istatistikler gösteriliyor:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "Görüntülenen";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Bloglara yaptığınız yorumlar herkese açık olarak görüntülenir.";
@@ -5179,6 +5543,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "Yazıyı görüntüler";
+
+/* View title during the sign up process. */
+"Sign Up" = "Hesap aç";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "Site kimlik bilgileriyle oturum açın";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Hesap aç";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "WordPress.com hesabı açın";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "E-posta ile hesap aç";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "Ücretsiz plan kullandığınız için etkinlik kaydınızda göreceğiniz etkinlikler sınırlı olacak.";
@@ -5217,6 +5596,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Site başarıları";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Site adresi";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "Site adresiniz en az dört karakter uzunluğunda olmalı.";
@@ -5301,7 +5683,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "Kusura bakmayın. Site adreslerinde harfler de bulunmalıdır!";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "Kusura bakmayın. Bu e-posta adresi zaten kullanılıyor!";
 
 /* No comment provided by engineer. */
@@ -5361,6 +5743,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "İstenmeyen";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "Sitenizi hızlandırın";
@@ -5386,6 +5771,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "İl";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "Sabit giriş sayfası";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5416,6 +5804,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "Üstü çizili";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Yerel";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "Değerlendirilmek üzere gönder";
@@ -5506,7 +5897,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "Tablet";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "Etiket";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5641,6 +6033,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Hizmet koşulları";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "Görüşler";
+
 /* Title of a button style */
 "Text Only" = "Yalnızca metin";
 
@@ -5650,8 +6045,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "Bir metin bloğu düzenlenirken, metin biçimlendirme denetimleri klavyenin üzerindeki araç çubuğunda bulunur";
 
+/* Button title */
+"Text me a code instead" = "Kodu mesaj olarak gönder";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "Bana SMS ile kod gönder";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "%2$@ tarafından hazırlanan %1$@ temasını seçtiğiniz için teşekkürler";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "Bu kod, geçerli bir doğrulama kodu gibi görünmüyor.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "Bu bir WordPress sitesine benzemiyor.";
@@ -5673,6 +6077,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "Facebook bağlantısı herhangi bir sayfa bulamadı. Publicize, Facebook Profillerine bağlanamaz, yalnızca yayınlanan sayfalara bağlanır.";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "\"%@\" Google hesabı, WordPress.com üzerindeki bir hesapla eşleşmiyor";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "Internet bağlantınız çevrim dışı görünüyor.";
@@ -5712,6 +6119,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "Görsel ortam kitaplığına eklenemedi.";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "Internet bağlantınız çevrim dışı görünüyor.";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "Oluşturulabilecek site türleri";
@@ -5755,6 +6165,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "%1$@ sitesi WordPress %2$@ kullanıyor. Güncel sürüme ya da en azından %3$@ sürümüne yükseltmenizi öneririz";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "Bu adresteki site bir WordPress sitesi değil. Bağlanabilmemiz için sitenin WordPress kullanması gerekir.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "Site silinemedi.";
 
@@ -5796,6 +6210,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "Yorumunuz düzenlenirken beklenmeyen bir sorun çıktı";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "Yorumlar yüklenirken beklenmeyen bir sorun çıktı.";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "Etki alanınız kaydedilirken beklenmeyen bir sorun çıktı";
 
@@ -5804,6 +6221,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "Bildirim ayarlarınız güncellenirken beklenmeyen bir sorun çıktı";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "Yorumunuz güncellenirken beklenmeyen bir sorun çıktı";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "Beklenmedik bir sorun çıktı.";
@@ -5825,6 +6245,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "Siteyle iletişim kurulurken bir sorun çıktı.";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "WordPress.com sitesi ile bağlantı kurulurken bir sorun çıktı. Lütfen yeniden oturum açın.";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "Bu yazıyı görüntülenirken bir sorun çıktı.";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "Verileriniz yüklenirken bir sorun çıktı. Sayfanızı yenileyip yeniden deneyin.";
 
@@ -5834,12 +6260,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "Paylaşım yönetiminde değişiklikler kaydedilirken bir sorun çıktı.";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "Konumunuza erişilirken bir sorun çıktı. Lütfen bir süre sonra yeniden deneyin.";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "Parolanız değiştirilirken sorun çıktı";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "Etkinlikler yüklenirken bir sorun çıktı";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "Paketler yüklenirken bir sorun çıktı";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "Eklentiler yüklenirken bir sorun çıktı";
@@ -5852,6 +6284,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "Geçmiş yüklenirken bir hata oluştu";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "Paket yüklenirken bir sorun çıktı";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "Tarama geçmişi yüklenirken bir sorun çıktı";
@@ -5900,6 +6335,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "Bu etki alanı kullanılamaz";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "Bu e-posta adresi WordPress.com üzerinde kayıtlı değil.";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "Bu dosya sitenize yüklenemeyecek kadar büyük ya da bu ortam biçimi desteklenmiyor.";
@@ -5980,6 +6418,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "Saat dilimi";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "Süre doldu, ancak endişelenmenize gerek yok. Güvenliğiniz önceliğimizdir. Lütfen yeniden deneyin!";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "WordPress.com üzerinden en fazlasını almak için ipuçları.";
 
@@ -5993,6 +6434,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "İlerlemek için lütfen e-posta adresinizi ve adınızı yazın.";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "Yeni WordPress.com hesabınızı açmak için lütfen e-posta adresinizi yazın.";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "WordPress sitenizden yararlı bildirimler almak için telefonunuza Jetpack eklentisini kurmalısınız.";
 
@@ -6001,6 +6445,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "Eklentileri yüklemek için, sitenizle ilişkilendirilmiş bir özel alan adına sahip olmalısınız.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "Bu Apple ID ile ilerlemek için lütfen önce WordPress.com parolanızla oturum açın. Bu yalnızca bir kez sorulur.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "Bu Google hesabı ile ilerlemek için lütfen önce WordPress.com parolanızla oturum açın. Bu yalnızca bir kez sorulacak.";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "Bir bloğu kaldırmak için bloğu seçin ve bloğun sağ alt tarafındaki üç noktaya tıklayıp ayarları görüntüleyin. Oradan bloğu kaldırma üzerine dokunun.";
@@ -6075,7 +6525,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "Çöp";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "Çöpe atıldı";
 
@@ -6089,6 +6540,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "Dene ve özelleştir";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "Yeniden deneyin";
@@ -6114,6 +6566,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "Yeni blok düzenleyiciyi deneyin";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Başka bir e-posta ile deneyin";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Site adresi ile deneyin";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "İstemleri kapat";
@@ -6156,6 +6614,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "KULLANIM";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "Bağlantı kurulamadı";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "Yazılar yüklenemedi";
@@ -6205,6 +6666,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Video oynatılamıyor";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Belirtilen adresteki WordPress sitesi okunamadı. 'Daha fazla yardım mı gerekli?' düğmesine tıklayarak SSS bölümüne bakabilirsiniz.";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Siteniz geri yüklenemedi";
 
@@ -6231,6 +6695,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "1 yazı, 1 dosya yüklenemedi";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "E-posta adresi doğrulanamadı. Lütfen bir süre sonra yeniden deneyin.";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "Sitenin Jetpack ayarları ziyaret edilemedi";
@@ -6375,7 +6842,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Yüklenemedi";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "Yüklendi";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6393,7 +6861,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Yüklenmiş temalar";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "Yükleniyor";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6408,18 +6877,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "Kullan";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "Bir güvenlik anahtarı kullanın";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "Blok düzenleyiciyi kullan";
 
 /* No comment provided by engineer. */
 "Use icon button" = "Simge düğmesini kullan";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "Oturum açmak için parolayı kullanın";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "Kullanıcı adı";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6434,6 +6912,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "Kullanıcılar";
+
+/* two factor code placeholder */
+"Verification code" = "Doğrulama kodu";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "Doğrulama e-postası gönderildi, gelen kutunuza bakın.";
@@ -6566,8 +7047,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "WP-content klasörü";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Tamamlanması için Google bekleniyor…";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "Bağlantı kurulması bekleniyor";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "Güvenlik anahtarı bekleniyor";
+
+/* View title during the Google auth process. */
+"Waiting..." = "Bekliyor...";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6607,6 +7098,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "Veriler yüklenirken sorun çıktı";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "%@ adresine bir e-posta gönderdik. Lütfen e-posta uygulamanıza bakın ve oturum açmak için bağlantıya dokunun.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "Az önce size sihirli bir bağlantı gönderdik";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "%@ zamanında sitenizin yedeği oluşturuldu";
 
@@ -6616,14 +7113,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "Üçüncü tarafların da sahibi olduğu çeşitli izleme araçları kullanıyoruz. Bunlar ve nasıl kontrol edilecekleri hakkında bilgi alın.";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "Size şu anda bir e-posta gönderemedik. Lütfen bir süre sonra yeniden deneyin.";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Güvenlik tehditleri bulunursa size e-posta gönderilir. Bu arada sitenizi normal şekilde kullanmayı sürdürebilir, istediğiniz zaman dönüp taramanın durumuna bakabilirsiniz.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "Size e-posta ile, anında oturum açmanızı sağlayacak ve parola gerektirmeyen sihirli bir bağlantı göndereceğiz. Artık tek tek yazmanız gerekmiyor!";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "Yeni WordPress.com hesabınızı oluşturmanız için size e-postayla bir hesap açma bağlantısı göndereceğiz.";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "Takipçi, yorum ve beğeni aldığınızda sizi bilgilendireceğiz.";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "Yorum, beğeni ve yeni takipçi aldığınızda sizi bilgilendireceğiz. Anlık bildirimlere izin vermek istiyor musunuz?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "Bu e-posta adresini yeni WordPress.com hesabınızı açmak için kullanacağız.";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "%1$@ üzerinden sitenizin indirilebilir bir yedeği oluşturuluyor.";
@@ -6634,6 +7143,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Arka planda bu tehditleri düzeltmek için çok çalışıyoruz. Bu arada sitenizi normal bir şekilde kullanmayı sürdürebilirsiniz. İlerlemeyi istediğiniz zaman denetleyebilirsiniz.";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "Bu adresteki Jetpack sitesi ile bağlantı kuramadık. Yardım almak için bizimle görüşün.";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "Siteniz %1$@ zamanına döndürülüyor.";
 
@@ -6642,6 +7154,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "Ayrıca dosyanızın bağlantısı da e-posta ile size gönderildi.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Yeni WordPress.com hesabınızı oluşturmanız için size e-postayla bir hesap açma bağlantısı gönderdik. E-postanıza bu aygıtta bakın ve WordPress.com tarafından gönderilen e-postadaki bağlantıya dokunun.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6668,6 +7183,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "Haftalık özet: %@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "Jetpack uygulamasına hoş geldiniz";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "WordPress kullanmaya hoş geldiniz";
 
 /* A message title */
 "Welcome to the Reader" = "Okuyucuya hoş geldiniz";
@@ -6712,6 +7233,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "Gravatar nedir?";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "WordPress.com nedir?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "Blok nedir?";
 
@@ -6728,10 +7252,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "What's New in Jetpack" = "Jetpack yenilikleri";
 
 /* Opens the What's New / Feature Announcement modal */
-"What's New in Reader" = "Okuyucudaki Yenilikler";
-
-/* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "WordPress yenilikleri";
+
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "Sitemin adresi ne?";
 
 /* Select the site's intent. Title */
 "What's your website about?" = "Siteniz ne hakkında?";
@@ -6745,6 +7269,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "Sitenizde değişiklik yaptığınızda etkinlik geçmişinizi burada görebileceksiniz.";
 
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Ne yazık ki bir sorun çıktı ve oturumunuzu açamadık. Lütfen yeniden deneyin!";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "Ne yazık ki, bir sorun çıktı. Lütfen yeniden deneyin!";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "Ne yazık ki, bu güvenlik anahtarı geçersiz gibi görünüyor. Lütfen farklı bir anahtarla yeniden deneyin";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Hayır, bu geçerli bir iki adımlı doğrulama kodu değil. Kodunuzu iki kere kontrol edip yeniden deneyin!";
+
 /* No comment provided by engineer. */
 "Width Settings" = "Genişlik ayarları";
 
@@ -6757,17 +7293,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "WordPress uygulama ayarları";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "WordPress uygulamaları - Her ekran için uygulamalar";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "WordPress bloğu";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "WordPress yardımı";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "WordPress ortam kitaplığı";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "WordPress bildirim ayarları";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "WordPress bildirimleri";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "WordPress eklentileri";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "WordPress profili";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "WordPress okuyucusu";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "WordPress sitesi bilgileri";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "WordPress temaları";
@@ -6778,17 +7335,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "WordPress çoklu siteleri desteklenmez";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress geçerli yazıya konum bilgilerini ekleyebilmek için aygıtınızın konumuna erişme iznine gerek duyuyor. Lütfen gizlilik ayarlarınızı güncelleyin.";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "WordPress kök klasörü";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "WordPress sürümünüz çok eski";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "WordPress sürümü çok eski. %1$@ adresindeki site WordPress %2$@ sürümünü kullanıyor. Son sürüme ya da en azından %3$@ sürümüne yükseltmenizi öneririz";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "WordPress.com hesabı";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "WordPress.com paketleri";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "WordPress.com temaları";
@@ -6819,6 +7385,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "Yazı yaz";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "Yanıt yazın";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "Yanıt yazın…";
 
 /* Title for the writing section in site settings screen */
@@ -6832,6 +7401,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Y ekseni konumu";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
 
 /* 'This Year' label for the the year. */
 "Year" = "Yıl";
@@ -6916,6 +7488,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Displayed when the user views trashed in the posts list and there are no posts */
 "You don't have any trashed posts" = "Herhangi bir silinmiş yazınız yok";
 
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"You don't have permission to view this private blog." = "Bu özel blogu görüntülemek için izniniz yok.";
+
 /* Description for the first domain purchased with a paid plan. */
 "You have a free one-year domain registration with your plan." = "Paketinizde ücretsiz bir yıllık etki alanı kaydı var.";
 
@@ -6931,7 +7506,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "Ayarlanmış bir hatırlatıcınız yok.";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Kaydedilmemiş değişiklikleriniz var.";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -7018,9 +7594,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Help text that describes how the password should be. It appears while editing the password */
 "Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ & )." = "Parolanız en az altı karakter uzunluğunda olmalıdır. Zorlaştırmak için, büyük harf, küçük harf, sayı ve ! \"? $% ^ &) gibi karakterler kullanın.";
 
-/* Message of Export Content confirmation alert */
-"Your posts, pages, and settings will be mailed to the account's email address." = "Gönderileriniz, sayfalarınız ve ayarlarınız hesabın e-posta adresine e-posta ile gönderilecek.";
-
 /* Message of Export Content confirmation alert; substitution is user's email address */
 "Your posts, pages, and settings will be mailed to you at %@." = "Yazılarınız, sayfalarınız ve ayarlarınız %@ adresine e-posta ile gönderilecek.";
 
@@ -7029,6 +7602,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "Aramanız, WordPress.com alan adlarında desteklenmeyen karakterler içeriyor. Aşağıdaki karakterlere izin verilir: A–Z, a–z, 0–9.";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "Sitenizin adresi, sitenizi Safari ile ziyaret ettiğinizde üstte görüntülenir.";
 
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "Siteniz zaten VaultPress tarafından korunuyor. Aşağıda VaultPress panonuzun bağlantısını bulabilirsiniz.";
@@ -7108,17 +7684,23 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility identifier for an 'Add Comment' button */
 "addCommentButton.accessibilityIdentifity" = "Yorum Ekle";
 
-/* Error message when user cancels login */
-"addSite.selfHosted.cancelled" = "Oturum açma iptal edildi";
+/* Error message shown a URL does not point to an existing site. */
+"addSite.restApiNotAvailable" = "Bu adresteki site bir WordPress sitesi değil. Siteyle bağlantı kurabilmemiz için sitede WordPress kullanılmalıdır.";
+
+/* Error message shown when an receiving an invalid application-password authentication result from a self-hosted WordPress site */
+"addSite.selfHosted.authenticationFailed" = "Uygulama Şifresi doğrulaması kullanılarak oturum açılamıyor.";
 
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "Bağlanmak istediğiniz WordPress sitesinin adresini girin.";
 
+/* Error message when user input is not a WordPress site */
+"addSite.selfHosted.invalidUrl" = "Site adresi geçerli değil.";
+
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "WordPress sitesi ayrıntıları yüklenemiyor";
 
-/* Error message when user signs in with an unexpected usern. The first argument is the expected username */
-"addSite.selfHosted.mismatchUser" = "Lütfen oturum açmış bir kullanıcı ile giriş yapın. Kullanıcı adı: %@";
+/* Error message shown when application-password authentication is disabled on a self-hosted WordPress site */
+"addSite.selfHosted.noLoginUrlFound" = "Uygulama Şifresi doğrulamasının WordPress sitesinde etkinleştirilmesi gerekiyor.";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "WordPress sitesi kaydedilemiyor, lütfen daha sonra tekrar deneyin.";
@@ -7126,17 +7708,14 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "Kullanıcı Tarafından Barındırılan Site Ekleyin";
 
-/* Error message when XML-RPC is disabled on the WordPress site. The first argument is detailed error message */
-"addSite.selfHosted.xmlrpcDisabled" = "WordPress sitesine bağlanılamadı. XML-RPC sunucuda devre dışı bırakılmış olabilir. Bu sorunu çözmek için lütfen barındırma sağlayıcınızla iletişime geçin.";
+/* Error message when an unknown error occurred when adding a self-hosted site */
+"addSite.selfHosted.unknownError" = "Bir sorun oluştu. Lütfen tekrar deneyin.";
 
 /* Age between dates equaling one hour. */
 "an hour" = "bir saat";
 
 /* This is the string we display when prompting the user to review the Jetpack app */
 "appRatings.jetpack.prompt" = "Jetpack hakkında ne düşünüyorsunuz?";
-
-/* This is the string we display when prompting the user to review the Reader app */
-"appRatings.reader.prompt" = "Okuyucu hakkında ne düşünüyorsunuz?";
 
 /* This is the string we display when prompting the user to review the WordPress app */
 "appRatings.wordpress.prompt" = "WordPress hakkında ne düşünüyorsunuz?";
@@ -7840,6 +8419,10 @@ Example: Reply to Pamela Nguyen */
 /* A name of the ID field (it's a technical field, has to be short, displayed below everything else) */
 "entityMetadataFooterView.id" = "Kimlik";
 
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "ornek.com";
+
 /* Accept button title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackAccept" = "Geri bildirim gönder";
 
@@ -7851,9 +8434,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackTitle" = "Görüşlerinizi Paylaşın";
-
-/* Communicates the future removal of the option to disable the experimental editor, displayed beneath the experimental features list */
-"experimentalFeatures.editorNote" = "Deneysel Blok Düzenleyici gelecekteki bir sürümde varsayılan olacak ve bunu devre dışı bırakma özelliği kaldırılacak.";
 
 /* The title for the experimental features list */
 "experimentalFeaturesList.heading" = "Deneysel İşlevler";
@@ -7900,8 +8480,14 @@ Example: Reply to Pamela Nguyen */
 /* A footer retry button */
 "general.pagingFooterView.retry" = "Yeniden dene";
 
+/* Error message format when REST API returns an error response. The first argument is error message. */
+"generic.error.rest-api-error" = "Siteniz bir hata yanıtı gönderdi: %@";
+
 /* A generic title for an error */
 "generic.error.title" = "Hata";
+
+/* Error message when failing to parse API responses */
+"generic.error.unparsableResponse" = "Siteniz, uygulamanın ayrıştıramadığı bir yanıt gönderdi";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "Blog hatırlatıcıları ayarlayın";
@@ -8073,42 +8659,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title of the Jetpack powered overlay. */
 "jetpack.branding.overlay.title" = "WordPress, Jetpack ile daha iyi";
-
-/* Title for the button that starts the Jetpack connection process */
-"jetpack.connection.connect.button" = "Sitenizi bağlayın";
-
-/* Error message shown when WordPress.com authentication fails */
-"jetpack.connection.error.authentication" = "Geçersiz WordPress.com Hesabı";
-
-/* Error message shown when a connection step is attempted in an invalid order */
-"jetpack.connection.error.context" = "Bu adım henüz hazır değil";
-
-/* Title for the retry button shown when a connection step fails */
-"jetpack.connection.retry.button" = "Tekrar dene";
-
-/* Status message when a connection step is pending */
-"jetpack.connection.stage.pending" = "Başlaması bekleniyor";
-
-/* Status message when a connection step is in progress */
-"jetpack.connection.stage.processing" = "Devam ediyor...";
-
-/* Status message when a connection step is completed successfully */
-"jetpack.connection.stage.success" = "Tamamlandı";
-
-/* Title for the finalization step in Jetpack connection flow */
-"jetpack.connection.step.finalize.title" = "Bağlantıyı Sonlandırın";
-
-/* Title for the install step in Jetpack connection flow */
-"jetpack.connection.step.install.title" = "Jetpack'i yükleyin";
-
-/* Title for the login step in Jetpack connection flow */
-"jetpack.connection.step.login.title" = "WordPress.com’da oturum açın";
-
-/* Title for the site connection step in Jetpack connection flow */
-"jetpack.connection.step.site.title" = "Sitenize bağlanın";
-
-/* Title for the user connection step in Jetpack connection flow */
-"jetpack.connection.step.user.title" = "WordPress.com hesabınıza bağlanın";
 
 /* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
 "jetpack.fullscreen.overlay.early.switch.title" = "Yeni Jetpack uygulamasına geçin";
@@ -8329,41 +8879,11 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "Bu özel blogu görüntülemek için izniniz yok.";
 
-/* Button to dismiss the re-authentication view */
-"login.appPasswordReAuth.cancelButton" = "İptal Et";
-
-/* Description explaining why the user needs to re-authenticate */
-"login.appPasswordReAuth.description" = "Uygulamaya atanan uygulama parolası artık profilinizde yok.\nUygulamanın kullanacağı yeni bir uygulama şifresi oluşturmak için lütfen tekrar oturum açın.";
-
-/* Button to start the re-authentication process */
-"login.appPasswordReAuth.signInButton" = "Oturum Aç";
-
-/* Title shown when the application password is invalid */
-"login.appPasswordReAuth.title" = "Geçersiz uygulama şifresi";
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "Lütfen kimlik doğrulayıcı uygulamanızdaki WordPress.com doğrulama kodunu girin.";
 
 /* Indicating that referrer was marked as spam */
 "marked as spam" = "istenmeyen olarak işaretlendi";
-
-/* Button title when verification link sending failed */
-"me.verifyEmail.button.retry" = "Yeniden Dene";
-
-/* Button title to send verification link */
-"me.verifyEmail.button.send" = "E-postayı tekrar gönder";
-
-/* Button title while verification link is being sent */
-"me.verifyEmail.button.sending" = "Gönderiliyor...";
-
-/* Button title after verification link is sent */
-"me.verifyEmail.button.sent" = "E-posta gönderildi";
-
-/* Message for email verification card */
-"me.verifyEmail.message.noEmail" = "Hesabınızın güvenliğini sağlamak ve daha fazla özelliğe erişmek için e-postanızı doğrulayın.\nOnay e-postası için gelen kutunuzu kontrol edin veya yeni bir e-posta almak için '%@' öğesine tıklayın.";
-
-/* Message for email verification card with email address */
-"me.verifyEmail.message.withEmail" = "Hesabınızın güvenliğini sağlamak ve daha fazla özelliğe erişmek için e-postanızı doğrulayın.\nOnay e-postası için %1$@ adresinden gelen kutunuzu kontrol edin veya yeni bir e-posta almak için '%2$@' öğesine tıklayın.";
-
-/* Title for email verification card */
-"me.verifyEmail.title" = "E-posta Adresinizi Doğrulayın";
 
 /* Me tab menu items */
 "meMenu.submitFeedback" = "Geri bildirim gönder";
@@ -8806,6 +9326,9 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "Üst Sayfa";
 
+/* No comment provided by engineer. */
+"password" = "parola";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "Sitenizde olanlara göre kartlar farklı içerikler görüntüleyebilir. Daha fazla kart ve kontrol üzerinde çalışıyoruz.";
 
@@ -8910,9 +9433,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Message shown while loading plugin details */
 "pluginDetails.loading" = "Eklenti bilgileri yükleniyor...";
-
-/* Placeholder message shown when a plugin has no description */
-"pluginDetails.noDescription" = "Bu eklenti herhangi bir açıklama sağlamadı.";
 
 /* Title of the changelog section in plugin details */
 "pluginDetails.section.changelog" = "Değişiklik Günlüğü";
@@ -9202,6 +9722,30 @@ Example: Reply to Pamela Nguyen */
 /* An alert message explaning that by changing the visibility to private, the post will be published immediately to your site */
 "postSettings.warningPostWillBePublishedAlertMessage" = "Görünürlüğü \"Özel\" olarak değiştirdiğinizde gönderi hemen yayımlanır";
 
+/* Localized post type: `Page` */
+"postType.page" = "sayfa";
+
+/* Localized post type: `Post` */
+"postType.post" = "gönderi";
+
+/* Details for a 'Private' privacy setting */
+"postVisibility.private.details" = "Yalnızca site yöneticileri ve düzenleyicileri tarafından görülebilir";
+
+/* Title for a 'Private' privacy setting */
+"postVisibility.private.title" = "Gizli";
+
+/* Details for a 'Password Protected' privacy setting */
+"postVisibility.protected.details" = "Herkes tarafından görülebilir ancak şifre gerektirir";
+
+/* Title for a 'Password Protected' privacy setting */
+"postVisibility.protected.title" = "Şifre korumalı";
+
+/* Details for a 'Public' (default) privacy setting */
+"postVisibility.public.details" = "Herkes tarafından görülebilir";
+
+/* Title for a 'Public' (default) privacy setting */
+"postVisibility.public.title" = "Herkese açık";
+
 /* Button cancel */
 "postVisibilityPicker.cancel" = "İptal Et";
 
@@ -9422,18 +9966,6 @@ Tapping on this row allows the user to edit the sharing message. */
 /* Title for the success view when the user has successfully logged in */
 "qrLoginVerifyAuthorization.completedInstructions.title" = "Oturum açtınız!";
 
-/* No comment provided by engineer. */
-"reachability-utils.alert.cancel" = "Tamam";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.retry" = "Tekrar denensin mi?";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.title" = "Bağlantı yok";
-
-/* Message of error prompt shown when no internet connection is available */
-"reachability-utils.alert.utils" = "İnternet bağlantısı çevrimdışı gibi duruyor.";
-
 /* Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog. */
 "reader.blocked.blog.message" = "%@ bloğu artık okuyucunuzda görüntülenmeyecek. Geri almak için dokunun.";
 
@@ -9470,26 +10002,8 @@ Tapping on this row allows the user to edit the sharing message. */
 /* A shared button title for Reader */
 "reader.button.unsubscribe" = "Takip Etmeyi Bırak";
 
-/* Button title. Follow the comments on a post. */
-"reader.comments.buttonFollow" = "Takip et";
-
 /* Informational message, should be short. */
 "reader.comments.commentsClosed" = "Yorumlar Kapalı";
-
-/* Empty state view title */
-"reader.comments.emptyStateTitle" = "Yorum yapan ilk kişi olun.";
-
-/* Empty state view title */
-"reader.comments.errorLoadingComments" = "Yorumlar yüklenirken beklenmeyen bir hata oluştu.";
-
-/* VoiceOver hint */
-"reader.comments.followingSettingAccessibilityIdentifier" = "Gönderi için bildirim ayarlarını açın";
-
-/* Error message that informs reader comments from a private blog cannot be fetched. */
-"reader.comments.noPermissionToViewPrivateBlog" = "Bu özel blogu görüntülemek için izniniz yok.";
-
-/* Navigation title */
-"reader.comments.title" = "Yorumlar";
 
 /* Accessibility hint to inform that the author section can be tapped to see posts from the site. */
 "reader.detail.header.authorInfo.a11y.hint" = "Sitedeki yazıları görüntüler";
@@ -9567,23 +10081,8 @@ but tapping on this button will remove their like from the post. */
 /* Screen header details */
 "reader.following.header.details" = "Abone olduğunuz bloglarla ilgili güncel gelişmelerden haberdar olun.";
 
-/* Empty state view */
-"reader.following.lists.emptyTitle" = "Listeler Boş";
-
-/* Screen header details */
-"reader.home.header.details" = "Abone olduğunuz bloglarla ilgili güncel gelişmelerden haberdar olun.";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.home.title" = "Ana Sayfa";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.library.title" = "Kütüphane";
-
 /* Used in multiple contexts, usually as a screen title */
 "reader.likes.title" = "Beğeniler";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.lists.title" = "Listeler";
 
 /* Reader logged-out screen details */
 "reader.loggedOut.details" = "Favori bloglarınızı takip etmek için WordPress.com hesabıyla oturum açın";
@@ -9826,8 +10325,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title of a Reader tab showing Posts matching a user's search query */
 "reader.search.tab.posts" = "Gönderiler";
 
-/* Title of the Reader's search feature
-   Used in multiple contexts, usually as a screen title */
+/* Title of the Reader's search feature */
 "reader.search.title" = "Arama";
 
 /* Screen title. Reader select interests title label text. */
@@ -9853,6 +10351,21 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Reader select interests title label text */
 "reader.select.tags.title" = "Sevdiğiniz blogları keşfedin ve takip edin";
+
+/* Reader sidebar menu item */
+"reader.sidebar.discover" = "Keşfet";
+
+/* Reader sidebar menu item */
+"reader.sidebar.likes" = "Beğeniler";
+
+/* Reader sidebar menu item */
+"reader.sidebar.recent" = "Son";
+
+/* Reader sidebar menu item */
+"reader.sidebar.saved" = "Kaydedildi";
+
+/* Reader sidebar menu item */
+"reader.sidebar.search" = "Ara";
 
 /* Reader sidebar section title */
 "reader.sidebar.section.favorites.title" = "Favoriler";
@@ -9902,7 +10415,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Number of subscriptions on a site (singular) */
 "reader.subscriptions.subscriptionsSingular" = "%@ abone";
 
-/* Used in multiple contexts, usually as a screen title */
+/* Navigation bar title */
 "reader.subscriptions.title" = "Abonelikler";
 
 /* A suggestion of topics the user might want to subscribe to */
@@ -9944,26 +10457,11 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Verb. Button title. The user is following a tag. */
 "reader.tags.following.button.title" = "Takip ediliyor";
 
-/* Used in multiple contexts, usually as a screen title */
-"reader.tags.title" = "Etiketler";
-
 /* Accessibility label for unsubscribing from a tag */
 "reader.tags.unfollow.accessibility.label" = "%@ takibini bırak";
 
 /* Field title */
 "reader.userProfile.site" = "Site";
-
-/* Reader Welcome screen login button */
-"reader.welcome.continueText" = "WordPress.com ile devam et";
-
-/* Reader Welcome screen */
-"reader.welcome.subtitle" = "En büyük blog topluluğuna katılın";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.me" = "Ben";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.notifications" = "Bildirimler";
 
 /* Spoken accessibility label */
 "readerDetail.backButton.accessibilityLabel" = "Geri";
@@ -10241,14 +10739,10 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Message shown when there are no inactive plugins on the site */
 "site.plugins.empty.inactive" = "Etkin olmayan eklenti yok";
 
-/* The plugin fillter option for displaying active plugins */
-"site.plugins.filter.option.active" = "Etkin";
-
-/* The plugin fillter option for displaying all plugins */
+/* The plugin fillter option for displaying active plugins
+   The plugin fillter option for displaying all plugins
+   The plugin fillter option for displaying inactive plugins */
 "site.plugins.filter.option.all" = "Tümü";
-
-/* The plugin fillter option for displaying inactive plugins */
-"site.plugins.filter.option.inactive" = "Etkin değil";
 
 /* Title of the plugin filter picker */
 "site.plugins.filter.title" = "Filtrele";
@@ -10948,8 +11442,119 @@ Feel free to replace it with other bracket types that you think looks better for
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "Durum";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "Tüm zamanlarda görüntülemeler ve en çok beğenmeler";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "Tüm zamanlarda görüntülemeler";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "Tüm zamanlarda görüntülemeler ve ziyaretçiler";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "Şimdiye kadar en iyi görüntülemeler";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "En çok görüntüleme";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "Tüm zamanların istatistikleri yüklenemiyor.";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "Tüm zamanların istatistiklerini görmek için bir site oluşturun veya ekleyin.";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "Yazılar";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "WordPress sitenizdeki tüm etkinliklerden haberdar olun.";
+
+/* Title of all time widget */
+"widget.alltime.title" = "Tüm zamanlar";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "Tüm zamanlara ait istatistikleri görmek için WordPress oturumu açın.";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "Tüm zamanların istatistiklerini görüntülemek için Jetpack oturumu açın.";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "Bu haftanın istatistiklerini görüntülemek için Jetpack oturumu açın.";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "Bugünün istatistiklerini görüntülemek için Jetpack oturumu açın.";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "Tüm zamanlarda görüntülemeler";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "Bugünkü görüntülemeler";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "Bu haftanın istatistikleri yüklenemedi.";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "Bu haftanın istatistiklerini görmek için bir site oluşturun veya ekleyin.";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "WordPress sitenizde bu haftaki etkinliklerden haberdar olun.";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "Bu hafta";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "Bu haftanın istatistiklerini görmek için WordPress oturumu açın.";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "Yorumlar";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "İstatistikler Jetpack uygulamasına taşındı. Geçiş ücretsizdir ve yalnızca bir dakika sürer.";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "Beğeniler";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "Site istatistikleri yüklenemedi.";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "Bugünün istatistikleri yüklenemedi.";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "Bugünün istatistiklerini görmek için bir site oluşturun veya ekleyin.";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "WordPress sitenizde bugünkü etkinliklerden haberdar olun.";
+
+/* Title of today widget */
+"widget.today.title" = "Bugün";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "Bugünün istatistiklerini görmek için WordPress oturumu açın.";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "Görünüm kullanılamıyor";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "Görüntülemeler";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "Ziyaretçiler";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "Bugünkü beğeniler ve yorumlar";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "Bugünkü görüntülemeler";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "Bugünkü görüntülemeler ve ziyaretçiler";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "gelecekte kullanılamayacak.";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "Yeni site mi başlatıyorsunuz?";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "wordpress, yardım, destek, sss, sorular, debug, hata ayıklama, logs, günlük kayıtları, yardım merkezi, iletişim";
@@ -10974,6 +11579,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Error message that describes an unknown error had occured */
 "wordpress-api.error.unknown" = "Bir sorun çıktı. Lütfen bir süre sonra yeniden deneyin.";
+
+/* Error message when failing to find selected media file on the user's device. */
+"wordpress.api.upload.media.fileNotFound" = "Cihazdaki ortam dosyası bulunamıyor";
 
 /* Jetpack Plugin Modal on WordPress primary button title */
 "wordpress.jetpack.plugin.modal.primary.button.title" = "Jetpack uygulamasına geç";
@@ -11020,21 +11628,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Error message when user signs in with an unexpected email address. The first argument is the expected email address */
 "wpComLogin.error.mismatchedEmail" = "Lütfen %@ e-posta adresiyle oturum açın";
 
-/* Message shown when user denies WordPress.com login, offering option to try with different account */
-"wpComLogin.loginDenied.message" = "Farklı bir hesaba ihtiyacınız varsa farklı bir hesapla oturum açabilirsiniz. Başlamak için \"%@\" öğesine dokunun.";
-
-/* Title of alert shown when user cancels WordPress.com login */
-"wpComLogin.loginDenied.title" = "Giriş İptal Edildi";
-
-/* Button title for signing in with a different WordPress.com account */
-"wpComLogin.loginDenied.useDifferentAccount" = "Farklı Hesap Kullan";
-
-/* Button title to log out the current WordPress.com account */
-"wpcom.token.alert.button.logout" = "Oturumu kapat";
-
-/* Button title to Sign In to WordPress.com */
-"wpcom.token.alert.button.signin" = "Oturum Aç";
-
 /* Message title to be displayed when the user needs to re-authenticate their WordPress.com account. */
 "wpcom.token.fix.signin" = "WordPress.com'da oturum aç";
 
@@ -11049,6 +11642,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "Desteklenmeyen ek dosyası";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Google ile oturum aç.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Etki alanları";

--- a/WordPress/Resources/zh-Hans.lproj/Localizable.strings
+++ b/WordPress/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Translation-Revision-Date: 2025-05-13 09:54:09+0000 */
+/* Translation-Revision-Date: 2025-03-11 09:54:08+0000 */
 /* Plural-Forms: nplurals=1; plural=0; */
 /* Generator: GlotPress/4.0.1 */
 /* Language: zh_CN */
@@ -98,6 +98,9 @@
 
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "你的网站%2$@中的%1$@ ";
+
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "你的网站已使用%2$@中的%1$@";
 
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ 千的五次方";
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "（无标题）";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(无标题)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*\"约翰-勃兰特 \"回应了您的文章。";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "“更多”按钮包含显示共享按钮的下拉菜单";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "WordPress.com 账户已关联您的商店凭据。 要继续，我们将向上述电子邮件地址发送一个验证链接。";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "一个包含恶意代码模式的文件";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "站点标题";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "必须提供有效电子邮件地址才能发送身份验证链接。请返回上一屏幕并提供有效电子邮件地址。";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "验证码将仅包含数字。";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "活动";
@@ -334,9 +349,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* My Profile 'About me' label */
 "About Me" = "关于我";
-
-/* Link to About screen for Jetpack for iOS */
-"About Reader for iOS" = "关于 iOS 版阅读器";
 
 /* Link to About screen for WordPress for iOS */
 "About WordPress" = "关于 WordPress";
@@ -525,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "在 %@ 之后";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "对齐方式";
@@ -588,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "已加入允许列表的 IP 地址";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "马上就好！请输入验证器应用程序中的验证码。";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "替代文本";
@@ -600,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "或者，您也可以取消区块分组，以使内容扁平化。";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "此外，您也可以输入此账户的密码。";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "其他方式：";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "始终发送崩溃日志";
@@ -621,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "需要有效的互联网连接才能查看活动";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "必须连接互联网才能查看套餐";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -671,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "年度站点统计信息";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "匿名";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "回复";
 
@@ -692,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "外观";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "Apple 验证失败。\n请确保通过使用双因素验证的 Apple ID 登录 iCloud。";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "使用此设置";
@@ -778,6 +811,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "验证失败";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "验证码";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "需要对主机进行验证：%@";
@@ -888,6 +925,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "成为第一个发表评论的用户";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "率先发表评论。";
 
 /* Beauty site intent topic */
 "Beauty" = "美容";
@@ -1024,12 +1064,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button to copy post text" = "点击此按钮即可复制文章文本";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "继续即表示您同意我们的_服务条款_。";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "注册此域即表示，您同意我们的<a>条款和条件<\/a>。";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "通过设置Jetpack，您同意遵守我们的使用条款\n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "注册即表示您同意我们的_服务条款_。";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "定制";
@@ -1043,6 +1089,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "扫描登录代码需要相机访问权限";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "无法请求链接";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "不能发布空页";
 
@@ -1052,6 +1101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1061,6 +1111,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1079,6 +1130,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1106,6 +1158,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "正在取消...";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "无法访问此地址的站点。 请仔细检查，然后重试。";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "决定不了？ 您可以随时更改主题。";
 
@@ -1113,7 +1168,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "标题";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "小心！";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1122,7 +1178,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "分类目录";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "分类";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1171,6 +1228,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "查看我们的重要贴士，增加您的阅读量和流量";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "检查此设备上的电子邮件！";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "请在此设备上查看电子邮件，并轻点您从 WordPress.com 收到的电子邮件中的链接。";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "在此设备上检查您的电子邮件，然后点击从WordPress.com收到的电子邮件中的链接。\n\n看不到电子邮件？ 检查您的垃圾邮件文件夹。";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "请查看电子邮件！";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "请检查您的网络连接是否正常，然后刷新。";
@@ -1267,6 +1336,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "声明您的免费域";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "经典博客";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "清除设备媒体缓存";
 
@@ -1294,6 +1366,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "关闭";
 
@@ -1335,6 +1408,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "列设置";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "漫画";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1386,6 +1462,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "评论";
 
@@ -1453,12 +1530,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "已连接账户";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "已连接，但是…";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "正在连接 %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "连接 %1$@ 将取代 %2$@ 的现有连接。";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "正在连接 WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "正在连接...";
@@ -1489,8 +1572,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "请通过 %@ 与我们联系";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "内容结构\n区块：%1$li，字词：%2$li，字符：%3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1505,6 +1592,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "继续阅读";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "继续使用 Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "继续使用 Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "继续使用 Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "贡献";
@@ -1633,6 +1729,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "创建";
 
+/* The button title text for creating a new account. */
+"Create Account" = "创建账户";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "创建空白页面";
 
@@ -1653,6 +1752,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "撰写文章";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "创建站点";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "创建标签";
@@ -1686,6 +1788,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "当前";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "当前套餐";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "当前主题";
@@ -1788,6 +1893,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "默认分类";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "默认菜单";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "默认文章形式";
@@ -1796,6 +1904,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "新文章的默认设置";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "删除";
@@ -1853,6 +1962,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "详情";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "不打算创建新账户？ 返回以重新输入您的电子邮件地址。";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "尺寸";
 
@@ -1900,7 +2012,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "讨论";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "关闭";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1922,6 +2036,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "域";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "还没有账户？_注册_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2051,6 +2168,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "下载";
 
+/* Name for the status of a draft post. */
+"Draft" = "草稿";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "草稿";
 
@@ -2160,7 +2280,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "E-mail 地址";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "电子邮件地址";
 
 /* Notification Settings Channel */
@@ -2244,8 +2367,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "输入密码";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "输入您要连接的 WordPress 站点的地址。";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "输入您的 WordPress.com 账户的密码。";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "输入用户名";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "输入您的 %@ 账户信息。";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "输入您的电子邮件地址以登录或创建 WordPress.com 账户。";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "输入您的现有站点地址";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "改为输入密码。";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "输入您的服务器凭据";
@@ -2408,6 +2551,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "外部";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "失败";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "未能将通知标为已读";
 
@@ -2419,9 +2565,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Failed to insert media.\nTap for more info." = "未能插入媒体。\n点按获取更多信息。";
-
-/* A message indicating that we couldn't load the user's settings. */
-"Failed to load settings" = "无法加载设置";
 
 /* No comment provided by engineer. */
 "Failed to save files.\nPlease tap for options." = "无法保存文件。\n请轻点以查看选项。";
@@ -2437,6 +2580,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "时尚";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "精选插件";
@@ -2495,6 +2641,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "了解更多";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "找到您的站点地址";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2517,6 +2666,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "修复威胁";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "关注";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "关注对话";
@@ -2611,6 +2763,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "生成新链接";
 
+/* View title for initial auth views. */
+"Get Started" = "开始";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "通过电子邮件获取登录链接";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "活跃起来吧！积极评论您关注的博客中的文章。";
 
@@ -2632,8 +2790,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "受到启发";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "获取账户信息";
+
+/* Cancel */
+"Give Up" = "放弃";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "将一些区块添加到您的博文或页面，试试看吧！";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "转到“阅读器”";
@@ -2644,6 +2811,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "转至“iOS 设置”";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Google 注册失败。";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2718,6 +2888,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "“帮助”图标";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "隐藏";
+
 /* Title of a button used to collapse a group */
 "Hide" = "隐藏";
 
@@ -2786,6 +2959,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "图标更新失败";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "如果您找不到该电子邮件，请检查您的垃圾邮件文件夹";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "如果您继续使用 Apple 或 Google，并且还没有 WordPress.com 账户，则需要创建一个账户，并同意我们的_服务条款_。";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "删除 %1$@ 后，此用户将无法再访问此站点，但是 %2$@ 创建的所有内容仍会保留在此站点上。";
@@ -2861,6 +3040,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "包括wp-config php和所有非WordPress文件";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "用户名或密码有误。请尝试再次输入您的登录详细信息。";
 
 /* Title for a threat */
 "Infected core file" = "已被感染的核心文件";
@@ -2962,6 +3144,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "隆重推出博客提示功能";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "无效的电子邮箱地址";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "无效站点地址";
 
@@ -2979,6 +3164,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "无效的URL。找不到音频文件。";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "URL 无效。 请仔细检查，然后重试。";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "无效 URL。请输入有效 URL。";
@@ -3000,6 +3188,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "邀请用户";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "此用户名\/密码可能与该站点无关。";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "您可能输入了错误的密码。是否想重试？";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "在 %@ 上发布博客的时间到了！";
@@ -3228,7 +3422,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "行高";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "链接";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3290,6 +3485,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "正在加载人员信息…";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "正在加载套餐...";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "正在加载套餐...";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "正在加载插件...";
 
@@ -3324,11 +3525,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "正在载入...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "本地";
+
 /* Local Services site intent topic */
 "Local Services" = "本地服务";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "本地更改";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "位置";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "必须启用“位置服务”，WordPress 才能添加您的当前位置。请在“设置”应用程序中启用“位置服务”。";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "位置未知";
 
 /* No comment provided by engineer. */
 "Lock icon" = "锁形图标";
@@ -3336,9 +3549,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "日志文件 按创建日期排序";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "登录";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3348,17 +3563,33 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of a button for signing in. */
 "Log in" = "登录";
 
-/* LogOut confirmation text, whenever there are no local changes */
-"Log out of Jetpack?" = "从Jetpack注销登录？";
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "登录失败，请重试。";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "使用 WordPress.com 登录或注册";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "登录关联 Jetpack 时使用的 WordPress.com 账户。";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "使用您的电子邮件地址登录 WordPress.com 账户。";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "使用您的 WordPress.com 用户名和密码登录。";
 
 /* LogOut confirmation text, whenever there are no local changes */
-"Log out of Reader?" = "注销阅读器？";
+"Log out of Jetpack?" = "从Jetpack注销登录？";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of WordPress?" = "注销 WordPress？";
 
 /* Login Request Expired */
 "Login Request Expired" = "登录请求已过期";
+
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "使用账户密码登录";
 
 /* No comment provided by engineer. */
 "Logs" = "日志";
@@ -3368,6 +3599,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "似乎您已在站点上设置 Jetpack。恭喜！使用下方的 WordPress.com 凭据登录，以启用“统计数据”与“通知”功能。";
+
+/* Title of a button. */
+"Lost your password?" = "忘记密码？";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "Mail（默认）";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "主要导航";
@@ -3515,6 +3752,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "邮件";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "其他漏洞";
 
@@ -3610,6 +3850,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "我的站点";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "我的 WordPress 站点";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "我的十大咖啡馆";
 
@@ -3649,8 +3892,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "需要帮助？";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "查找站点地址时需要帮助？";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "需要帮助？";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "需要更多帮助？";
 
 /* Describes a status of a plugin */
 "Needs Update" = "需要更新";
@@ -3679,6 +3929,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "新建文章";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "新建项目";
+
 /* Placeholder text for password field */
 "New password" = "新密码";
 
@@ -3696,7 +3949,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "新闻";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "继续";
 
 /* Accessibility label for the next notification button */
@@ -3732,6 +3987,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "没有可用预览 URL";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "无标题";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "无可用的活动";
 
@@ -3764,7 +4022,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "暂无评论";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "没有连接";
 
@@ -3913,6 +4172,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "现在不行";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "没有看到电子邮件？ 请检查您的垃圾邮件文件夹。";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "注意：";
 
@@ -3976,7 +4238,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "编号列表";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "好";
@@ -4033,7 +4300,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "出错啦";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "糟糕！";
 
 /* No comment provided by engineer. */
@@ -4048,7 +4316,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "打开 Jetpack Security 设置";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "打开邮件";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "打开设置";
 
 /* No comment provided by engineer. */
@@ -4066,6 +4339,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "在新窗口\/选项卡中打开链接";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "打开此文章的订阅设置";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "打开“我”部分";
 
@@ -4080,6 +4356,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "可选：输入一条最多包含 %1$d 个字符的自定义消息，与您的邀请一起发送。";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "或";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "或者选择另一种身份验证形式。";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "或通过 _输入您的站点地址_ 登录。";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "或者通过免密链接登录";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "有序列表";
@@ -4128,7 +4416,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "内边距";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "页面";
 
@@ -4161,8 +4450,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "育儿";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "密码";
 
@@ -4179,8 +4471,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "在以下位置后粘贴区块";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "待审";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "等待复审";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4211,6 +4507,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "选择用户名";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "套餐";
+
 /* User action to play a video on the editor. */
 "Play video" = "播放视频";
 
@@ -4240,6 +4540,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "请确保您的站点已开启区块编辑器。 如果没有开启，将不会加载。";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "请输入完整网址（如 example.com）。";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "请输入站点地址。";
@@ -4274,11 +4577,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "请输入有效的地址";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "请为 WordPress.com 账户输入有效的电子邮箱地址。";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "请输入一个合法的 E-mail 地址。";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "请输入有效的电话号码";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "请输入您的 WordPress.com 账户密码，以使用 Apple ID 登录。";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "请输入你的验证信息";
@@ -4286,8 +4595,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "请输入您的电子邮件地址。";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "请填写所有表单项";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "请启动 WordPress 应用程序，登录 WordPress.com 并确保您至少有一个站点，然后重试。";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "在连接到其他 wordpress.com 站点前请先注销";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "请稍后重试";
@@ -4355,7 +4670,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "热门语言";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "发布";
 
@@ -4476,6 +4792,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "面向加州用户的隐私声明";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "私密";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "显示区块时出现问题。 \n点击尝试恢复区块。";
 
@@ -4490,6 +4809,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "购买您的域时遇到问题。请重试。";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "继续当前操作会将所有 WordPress.com 数据从此设备中移除，并删除本地保存的所有草稿。您不会丢失已保存在 WordPress.com 博客中的任何内容。";
+
+/* Menu item label for linking a project page. */
+"Projects" = "项目";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "已跳过提示";
@@ -4507,13 +4832,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "发布日期";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "立即发布";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "在以下网站发布页面：";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "在以下站点发布文章：";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "已发布";
 
@@ -4715,7 +5044,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "回复";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "回复文本";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "回复 %1$@";
 
 /* An explaination of a setting. */
@@ -4744,6 +5078,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "重置日期范围过滤器";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "重置密码";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "调整大小和裁剪";
@@ -4801,6 +5138,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "全部重试";
 
+/* No comment provided by engineer. */
+"Retry?" = "重试?";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "返回文章";
 
@@ -4830,6 +5170,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "身份";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "短信已发送";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "状态";
 
@@ -4841,6 +5184,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4907,7 +5251,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "正在扫描文件";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "已定时";
 
 /* No comment provided by engineer. */
@@ -5047,6 +5392,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "将此主题选作站点意图。";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "发送链接";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "通过电子邮件发送链接";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "发送日志信息";
 
@@ -5055,6 +5406,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "发送测试崩溃";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "发送电子邮件验证链接";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "通过电子邮件发送通知";
@@ -5101,11 +5455,11 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Message to show when setting save failed */
 "Settings update failed" = "“设置”更新失败";
 
-/* Title for a button that recommends the app to others */
-"Share Jetpack with a friend" = "与朋友分享 Jetpack";
+/* Spoken accessibility label */
+"Share" = "分享";
 
 /* Title for a button that recommends the app to others */
-"Share Reader with a friend" = "与好友共享阅读器";
+"Share Jetpack with a friend" = "与朋友分享 Jetpack";
 
 /* Title for a button that recommends the app to others */
 "Share WordPress with a friend" = "将 WordPress 与您的朋友分享";
@@ -5156,6 +5510,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "显示转载按钮";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "显示密码";
+
 /* No comment provided by engineer. */
 "Show post content" = "显示文章内容";
 
@@ -5167,6 +5525,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "显示以下文章统计数据：";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "已显示";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "公开显示您对博客作出的评论。";
@@ -5182,6 +5543,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "显示文章";
+
+/* View title during the sign up process. */
+"Sign Up" = "注册";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "使用站点凭据登录";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "注册";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "注册 WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "使用电子邮件注册";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "由于您使用的是免费套餐，因此您的活动日志中显示有限的事件。";
@@ -5220,6 +5596,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "站点成就";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "站点地址";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "站点地址至少要包含 4 个字符。";
@@ -5304,7 +5683,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "抱歉，站点地址必须包含字母！";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "抱歉，这个 E-mail 地址已经占用了！";
 
 /* No comment provided by engineer. */
@@ -5364,6 +5743,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "垃圾评论";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "加快站点加载速度";
@@ -5389,6 +5771,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "州\/省\/自治区\/直辖市";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "静态主页";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5419,6 +5804,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "删除线";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "存根";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "提交以待审核";
@@ -5509,7 +5897,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "平板电脑";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "标签";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5644,6 +6033,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "使用条款";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "褒奖";
+
 /* Title of a button style */
 "Text Only" = "仅显示文字";
 
@@ -5653,8 +6045,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "编辑文本区块时，文本格式控件位于键盘上方的工具栏内";
 
+/* Button title */
+"Text me a code instead" = "通过短信向我发送代码";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "通过短信将代码发送给我";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "感谢选择 %2$@ 提供的 %1$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "验证码好像无效。";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "这不像是 WordPress 站点。";
@@ -5676,6 +6077,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "Facebook 连接无法找到任何页面。Publicize 无法连接到 Facebook 个人资料，只能连接到已发布的页面。";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "Google 账户“%@”与 WordPress.com 上的任何账户均不匹配";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "未连接网络。";
@@ -5715,6 +6119,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "无法将图片添加到媒体库。";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "似乎您没有联网。";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "可以创建的站点类型";
@@ -5758,6 +6165,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "这个网站%1$@使用WordPress%2$@。我们推荐升级到最新版本，或者%3$@以上版本";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "此地址下的站点不是 WordPress 站点。站点必须使用 WordPress，我们才能建立连接。";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "无法删除该站点。";
 
@@ -5799,6 +6210,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "编辑您的评论时出现意外错误";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "加载评论时出现意外错误。";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "注册您的域时出现意外错误";
 
@@ -5807,6 +6221,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "更新“通知设置”时发生意外错误";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "更新您的评论时出现意外错误";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "发生意外错误。";
@@ -5828,6 +6245,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "与站点通信时出现问题。";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "连接到 WordPress.com 时出现问题。请重新登录。";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "显示该文章时出现问题。";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "加载数据时出现问题，请刷新页面以重试。";
 
@@ -5837,12 +6260,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "在保存对共享管理的更改时出错。";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "尝试访问您的位置时出错。请稍后重试。";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "修改密码时出错";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "加载活动时出现错误";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "加载套餐时出错。";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "加载插件时出错";
@@ -5855,6 +6284,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "加载历史记录时出错";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "加载套餐时出错";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "加载扫描历史记录时出错";
@@ -5903,6 +6335,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "此域不可用";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "此电子邮件地址并未在 WordPress.com 上注册。";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "此文件过大，无法上传至您的站点，或您的站点不支持此媒体格式。";
@@ -5983,6 +6418,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "时区";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "时间到了，请别担心，我们会优先保证您的安全。 请重试！";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "有关畅享 WordPress.com 的提示。";
 
@@ -5996,6 +6434,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "请输入您的电子邮件地址和名称以继续。";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "要创建新的 WordPress.com 账户，请输入您的电子邮件地址。";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "为了在您的手机上获取来自您的WordPress网站的通知，您需要首先安装Jetpack插件。";
 
@@ -6004,6 +6445,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "要安装插件，您需要拥有一个与您的站点相关联的自定义域。";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "要继续使用此 Apple ID，请先使用您的 WordPress.com 密码登录。 此要求只会出现一次。";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "要继续使用此 Google 账户，请先使用您的 WordPress.com 密码登录。此要求只会出现一次。";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "要移除某个区块，请选中该区块，然后点击该区块右上角的三个点，以查看设置。 从该处，选择用于移除区块的选项。";
@@ -6078,7 +6525,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "移到回收站";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "已放入回收站";
 
@@ -6092,6 +6540,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "尝试与定制";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "重试";
@@ -6117,6 +6566,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "试试新的区块编辑器";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "试试其他电子邮件地址";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "试试站点地址";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "关闭提示";
@@ -6159,6 +6614,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "使用";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "无法连接";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "无法加载文章";
@@ -6208,6 +6666,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "无法播放视频";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "无法通过该 URL 读取 WordPress 网站。 轻点“需要更多帮助？”可查看常见问题解答。";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "无法恢复您的站点";
 
@@ -6234,6 +6695,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "无法上传 1 篇文章、1 个文件";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "无法验证电子邮件地址。请稍后重试。";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "无法访问您站点的Jetpack设置";
@@ -6378,7 +6842,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "上传失败";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "已上传";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6396,7 +6861,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "已上传的主题";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "正在上传";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6411,18 +6877,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "使用";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "使用安全密钥";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "使用区块编辑器";
 
 /* No comment provided by engineer. */
 "Use icon button" = "使用图标按钮";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "使用密码登录";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "用户名";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6437,6 +6912,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "用户";
+
+/* two factor code placeholder */
+"Verification code" = "验证码";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "已发送验证电子邮件，请查看您的收件箱。";
@@ -6569,8 +7047,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "WP-content 目录";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "正在等待 Google 完成…";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "正在等待连接";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "正在等待安全密钥插入";
+
+/* View title during the Google auth process. */
+"Waiting..." = "正在等待…";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6610,6 +7098,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "加载数据时出现问题";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "我们刚刚通过电子邮件向 %@ 发送了一个链接。请查看您的邮箱应用程序，点击链接登录。";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "我们刚刚发送了一个免密链接至";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "我们已成功在 %@ 前为您的站点创建备份";
 
@@ -6619,14 +7113,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "我们使用其他跟踪工具，其中包括来自第三方的工具。了解这些工具及其使用方法。";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "此时，我们无法向您发送电子邮件。请稍后重试。";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "如果发现安全威胁，我们会给您发送电子邮件。 在此期间，您可以继续正常使用您的站点，您可以随时查看进度。";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "我们将通过电子邮件向您发送一个神奇链接，利用它您无需密码即可立即登录。无需再输入密码了！";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "我们将通过电子邮件向您发送注册链接，供您创建新的 WordPress.com 账户。";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "当您获得粉丝、评论和赞时，我们将通知您。";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "当您获得新的粉丝、评论和赞时，我们将通知您。 是否希望接收推送通知？";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "我们将使用此电子邮件地址创建您的新 WordPress.com 账户。";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "我们正在为您的站点创建 %1$@ 时点的可下载备份。";
@@ -6637,6 +7143,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "我们正在后台努力修复这些威胁。 在此期间，您可以继续正常使用您的站点，您可以随时查看进度。";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "我们无法连接到该 URL 指向的 Jetpack 站点。请联系我们获取帮助。";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "我们正在恢复您的网站至 %1$@ 时的样子";
 
@@ -6645,6 +7154,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "我们还通过电子邮件向您发送了文件链接。";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "我们已通过电子邮件向您发送了注册链接，供您创建新的 WordPress.com 账户。 请在此设备上查看电子邮件，并轻点您从 WordPress.com 收到的电子邮件中的链接。";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6671,6 +7183,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "每周综述：%@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "欢迎使用 Jetpack";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "欢迎来到 WordPress";
 
 /* A message title */
 "Welcome to the Reader" = "欢迎使用阅读器";
@@ -6715,6 +7233,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "什么是 Gravatar？";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "什么是 WordPress.com?";
+
 /* No comment provided by engineer. */
 "What is a block?" = "什么是区块？";
 
@@ -6731,10 +7252,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "What's New in Jetpack" = "Jetpack 的新变化";
 
 /* Opens the What's New / Feature Announcement modal */
-"What's New in Reader" = "阅读器的新功能";
-
-/* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "WordPress 的新变化";
+
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "我的站点地址是什么？";
 
 /* Select the site's intent. Title */
 "What's your website about?" = "您的网站是关于什么的？";
@@ -6748,6 +7269,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "在对站点进行更改时，您可在此处查看您的活动历史记录。";
 
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "糟糕，出问题了，您无法登录。请重试！";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "糟糕，出错了。 请重试！";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "糟糕，安全密钥似乎无效。 请换个密钥再试一次";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "糟糕，双因素验证码无效。请仔细检查代码，然后重试！";
+
 /* No comment provided by engineer. */
 "Width Settings" = "宽度设置";
 
@@ -6760,17 +7293,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "WordPress 应用程序设置";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "WordPress App——适用于任何屏幕的App";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "WordPress 博客";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "WordPress 帮助";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "WordPress 媒体库";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "WordPress 通知设置";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "WordPress 通知";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "WordPress 插件";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "WordPress 个人资料";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "WordPress 阅读器";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "WordPress 站点详细信息";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "WordPress 主题";
@@ -6781,17 +7335,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "不支持WordPress多站点。";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress 必须获得访问设备当前位置的权限才能将其添加到您的文章。请更新您的隐私设置。";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "WordPress 根";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "WordPress版本过旧";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "WordPress 版本过旧。%1$@ 上的站点采用 WordPress %2$@。我们建议更新至最新版本或至少更新为 %3$@";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "WordPress.com 账户";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "WordPress.com 套餐";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "WordPress.com 主题";
@@ -6822,6 +7385,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "写文章";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "写回复";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "写回复…";
 
 /* Title for the writing section in site settings screen */
@@ -6835,6 +7401,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Y轴位置";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo 邮箱";
 
 /* 'This Year' label for the the year. */
 "Year" = "年";
@@ -6919,6 +7488,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Displayed when the user views trashed in the posts list and there are no posts */
 "You don't have any trashed posts" = "您没有任何已放入垃圾桶的文章";
 
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"You don't have permission to view this private blog." = "您无权查看此私人博客。";
+
 /* Description for the first domain purchased with a paid plan. */
 "You have a free one-year domain registration with your plan." = "您的套餐中包括为期一年的免费域名注册。";
 
@@ -6934,7 +7506,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "您没有设置提醒。";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "尚有未保存的更改。";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -7021,9 +7594,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Help text that describes how the password should be. It appears while editing the password */
 "Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ & )." = "密码不得少于 6 个字符。要提高密码强度，请使用大小写字母、数字和 ! \" ? $ % ^ & ) 等符号。";
 
-/* Message of Export Content confirmation alert */
-"Your posts, pages, and settings will be mailed to the account's email address." = "系统会将您的文章、页面和设置发送到该账户的电子邮件地址。";
-
 /* Message of Export Content confirmation alert; substitution is user's email address */
 "Your posts, pages, and settings will be mailed to you at %@." = "文章、页面和设置将通过邮件发送给您（地址为：%@）。";
 
@@ -7032,6 +7602,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "您的搜索中包含 WordPress.com 域名不支持的字符。 允许使用以下字符：A–Z、a–z、0–9。";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "在您使用 Safari 访问自己的站点时，站点地址显示在屏幕顶部的地址栏中。";
 
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "您的站点已受 VaultPress 保护。 您可以在下面找到指向您的 VaultPress 仪表盘的链接。";
@@ -7111,17 +7684,23 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility identifier for an 'Add Comment' button */
 "addCommentButton.accessibilityIdentifity" = "添加评论";
 
-/* Error message when user cancels login */
-"addSite.selfHosted.cancelled" = "登录已取消";
+/* Error message shown a URL does not point to an existing site. */
+"addSite.restApiNotAvailable" = "此地址下的站点不是 WordPress 站点。 站点必须使用 WordPress，我们才能建立连接。";
+
+/* Error message shown when an receiving an invalid application-password authentication result from a self-hosted WordPress site */
+"addSite.selfHosted.authenticationFailed" = "无法使用应用程序密码验证登录。";
 
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "输入您要连接的 WordPress 站点的地址。";
 
+/* Error message when user input is not a WordPress site */
+"addSite.selfHosted.invalidUrl" = "该站点地址无效。";
+
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "无法加载 WordPress 站点详细信息";
 
-/* Error message when user signs in with an unexpected usern. The first argument is the expected username */
-"addSite.selfHosted.mismatchUser" = "请使用已登录的用户登录。 用户名：%@";
+/* Error message shown when application-password authentication is disabled on a self-hosted WordPress site */
+"addSite.selfHosted.noLoginUrlFound" = "需要在 WordPress 站点上启用应用程序密码验证。";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "无法保存 WordPress 站点，请稍后再试。";
@@ -7129,17 +7708,14 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "添加自托管站点";
 
-/* Error message when XML-RPC is disabled on the WordPress site. The first argument is detailed error message */
-"addSite.selfHosted.xmlrpcDisabled" = "无法关联 WordPress 站点。 服务器可能已禁用 XML-RPC。 请联系您的托管服务提供商以解决此问题。";
+/* Error message when an unknown error occurred when adding a self-hosted site */
+"addSite.selfHosted.unknownError" = "出错了。 请重试。";
 
 /* Age between dates equaling one hour. */
 "an hour" = "一小时";
 
 /* This is the string we display when prompting the user to review the Jetpack app */
 "appRatings.jetpack.prompt" = "您认为 Jetpack 怎么样？";
-
-/* This is the string we display when prompting the user to review the Reader app */
-"appRatings.reader.prompt" = "您对阅读器作何评价？";
 
 /* This is the string we display when prompting the user to review the WordPress app */
 "appRatings.wordpress.prompt" = "您认为 WordPress 怎么样？";
@@ -7843,6 +8419,10 @@ Example: Reply to Pamela Nguyen */
 /* A name of the ID field (it's a technical field, has to be short, displayed below everything else) */
 "entityMetadataFooterView.id" = "ID";
 
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "example.com";
+
 /* Accept button title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackAccept" = "发送反馈";
 
@@ -7854,9 +8434,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackTitle" = "分享反馈";
-
-/* Communicates the future removal of the option to disable the experimental editor, displayed beneath the experimental features list */
-"experimentalFeatures.editorNote" = "实验性区块编辑器将在今后的版本中成为默认设置，并且将无法禁用。";
 
 /* The title for the experimental features list */
 "experimentalFeaturesList.heading" = "实验性功能";
@@ -7903,8 +8480,14 @@ Example: Reply to Pamela Nguyen */
 /* A footer retry button */
 "general.pagingFooterView.retry" = "重试";
 
+/* Error message format when REST API returns an error response. The first argument is error message. */
+"generic.error.rest-api-error" = "您的站点发送了错误响应：%@";
+
 /* A generic title for an error */
 "generic.error.title" = "错误";
+
+/* Error message when failing to parse API responses */
+"generic.error.unparsableResponse" = "您的站点发送了应用程序无法解析的响应";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "设置博客发布提醒";
@@ -8076,42 +8659,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title of the Jetpack powered overlay. */
 "jetpack.branding.overlay.title" = "安装 Jetpack 的 WordPress 性能更优";
-
-/* Title for the button that starts the Jetpack connection process */
-"jetpack.connection.connect.button" = "关联您的站点";
-
-/* Error message shown when WordPress.com authentication fails */
-"jetpack.connection.error.authentication" = "WordPress.com 账户无效";
-
-/* Error message shown when a connection step is attempted in an invalid order */
-"jetpack.connection.error.context" = "此步骤尚未准备就绪";
-
-/* Title for the retry button shown when a connection step fails */
-"jetpack.connection.retry.button" = "重试";
-
-/* Status message when a connection step is pending */
-"jetpack.connection.stage.pending" = "正在等待开始";
-
-/* Status message when a connection step is in progress */
-"jetpack.connection.stage.processing" = "进行中...";
-
-/* Status message when a connection step is completed successfully */
-"jetpack.connection.stage.success" = "已完成";
-
-/* Title for the finalization step in Jetpack connection flow */
-"jetpack.connection.step.finalize.title" = "完成连接";
-
-/* Title for the install step in Jetpack connection flow */
-"jetpack.connection.step.install.title" = "安装 Jetpack";
-
-/* Title for the login step in Jetpack connection flow */
-"jetpack.connection.step.login.title" = "登录 WordPress.com";
-
-/* Title for the site connection step in Jetpack connection flow */
-"jetpack.connection.step.site.title" = "关联您的站点";
-
-/* Title for the user connection step in Jetpack connection flow */
-"jetpack.connection.step.user.title" = "关联您的 WordPress.com 账户";
 
 /* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
 "jetpack.fullscreen.overlay.early.switch.title" = "切换到新版 Jetpack 应用";
@@ -8332,41 +8879,11 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "您无权查看此私人博客。";
 
-/* Button to dismiss the re-authentication view */
-"login.appPasswordReAuth.cancelButton" = "取消";
-
-/* Description explaining why the user needs to re-authenticate */
-"login.appPasswordReAuth.description" = "该应用程序关联的密码已从您的个人资料中删除。\n请重新登录，为该应用程序创建新的专用密码。";
-
-/* Button to start the re-authentication process */
-"login.appPasswordReAuth.signInButton" = "登录";
-
-/* Title shown when the application password is invalid */
-"login.appPasswordReAuth.title" = "应用程序密码无效";
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "请输入您的身份验证应用程序中的 WordPress.com 账户验证码。";
 
 /* Indicating that referrer was marked as spam */
 "marked as spam" = "标记为垃圾内容";
-
-/* Button title when verification link sending failed */
-"me.verifyEmail.button.retry" = "重试";
-
-/* Button title to send verification link */
-"me.verifyEmail.button.send" = "重发电子邮件";
-
-/* Button title while verification link is being sent */
-"me.verifyEmail.button.sending" = "正在发送...";
-
-/* Button title after verification link is sent */
-"me.verifyEmail.button.sent" = "电子邮件已发送";
-
-/* Message for email verification card */
-"me.verifyEmail.message.noEmail" = "验证您的电子邮件地址，以确保您的账户安全并使用更多功能。\n请在您的收件箱中查看确认电子邮件，或点击“%@”以获取新的确认电子邮件。";
-
-/* Message for email verification card with email address */
-"me.verifyEmail.message.withEmail" = "验证您的电子邮件地址，以确保您的账户安全并使用更多功能。\n请在您的 %1$@ 收件箱中查看确认电子邮件，或点击“%2$@”以获取新的确认电子邮件。";
-
-/* Title for email verification card */
-"me.verifyEmail.title" = "验证您的电子邮件地址";
 
 /* Me tab menu items */
 "meMenu.submitFeedback" = "发送反馈";
@@ -8469,9 +8986,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Bottom toolbar title in the selection mode */
 "mediaLibrary.toolbarSelectItemsPrompt" = "选择项目";
-
-/* A name of the action in the context menu */
-"mediaPicker.imagePlayground" = "图像游乐场";
 
 /* Message for alert when access to camera is not granted */
 "mediaPicker.noCameraAccessMessage" = "此应用程序需要获取照相机的访问权限，才可以拍摄新媒体。如要允许此操作，请更改隐私设置。";
@@ -8809,6 +9323,9 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "父页面";
 
+/* No comment provided by engineer. */
+"password" = "密码";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "卡片可能会显示不同的内容，具体取决于您站点上的情况。 我们正在开发更多卡片和控件。";
 
@@ -8913,9 +9430,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Message shown while loading plugin details */
 "pluginDetails.loading" = "正在加载插件信息...";
-
-/* Placeholder message shown when a plugin has no description */
-"pluginDetails.noDescription" = "此插件未提供任何描述。";
 
 /* Title of the changelog section in plugin details */
 "pluginDetails.section.changelog" = "变更日志";
@@ -9205,6 +9719,30 @@ Example: Reply to Pamela Nguyen */
 /* An alert message explaning that by changing the visibility to private, the post will be published immediately to your site */
 "postSettings.warningPostWillBePublishedAlertMessage" = "将可见性更改为“私人”即会立即发布此文章";
 
+/* Localized post type: `Page` */
+"postType.page" = "页面";
+
+/* Localized post type: `Post` */
+"postType.post" = "文章";
+
+/* Details for a 'Private' privacy setting */
+"postVisibility.private.details" = "仅站点管理员和编辑可见";
+
+/* Title for a 'Private' privacy setting */
+"postVisibility.private.title" = "私人";
+
+/* Details for a 'Password Protected' privacy setting */
+"postVisibility.protected.details" = "所有人可见，但需要密码";
+
+/* Title for a 'Password Protected' privacy setting */
+"postVisibility.protected.title" = "受密码保护";
+
+/* Details for a 'Public' (default) privacy setting */
+"postVisibility.public.details" = "所有人可见";
+
+/* Title for a 'Public' (default) privacy setting */
+"postVisibility.public.title" = "公开";
+
 /* Button cancel */
 "postVisibilityPicker.cancel" = "取消";
 
@@ -9425,18 +9963,6 @@ Tapping on this row allows the user to edit the sharing message. */
 /* Title for the success view when the user has successfully logged in */
 "qrLoginVerifyAuthorization.completedInstructions.title" = "您已登录！";
 
-/* No comment provided by engineer. */
-"reachability-utils.alert.cancel" = "确定";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.retry" = "重试？";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.title" = "无连接";
-
-/* Message of error prompt shown when no internet connection is available */
-"reachability-utils.alert.utils" = "网络连接似乎已断开。";
-
 /* Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog. */
 "reader.blocked.blog.message" = "博客 %@ 将不再显示在您的阅读器中。 轻点以撤消。";
 
@@ -9473,26 +9999,8 @@ Tapping on this row allows the user to edit the sharing message. */
 /* A shared button title for Reader */
 "reader.button.unsubscribe" = "退订";
 
-/* Button title. Follow the comments on a post. */
-"reader.comments.buttonFollow" = "关注";
-
 /* Informational message, should be short. */
 "reader.comments.commentsClosed" = "评论已关闭";
-
-/* Empty state view title */
-"reader.comments.emptyStateTitle" = "率先发表评论。";
-
-/* Empty state view title */
-"reader.comments.errorLoadingComments" = "加载评论时出现意外错误。";
-
-/* VoiceOver hint */
-"reader.comments.followingSettingAccessibilityIdentifier" = "打开此文章的通知设置";
-
-/* Error message that informs reader comments from a private blog cannot be fetched. */
-"reader.comments.noPermissionToViewPrivateBlog" = "您无权查看此私人博客。";
-
-/* Navigation title */
-"reader.comments.title" = "评论";
 
 /* Accessibility hint to inform that the author section can be tapped to see posts from the site. */
 "reader.detail.header.authorInfo.a11y.hint" = "查看站点中的文章";
@@ -9570,23 +10078,8 @@ but tapping on this button will remove their like from the post. */
 /* Screen header details */
 "reader.following.header.details" = "时刻关注您订阅的博客。";
 
-/* Empty state view */
-"reader.following.lists.emptyTitle" = "列表为空";
-
-/* Screen header details */
-"reader.home.header.details" = "时刻关注您订阅的博客。";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.home.title" = "主页";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.library.title" = "媒体库";
-
 /* Used in multiple contexts, usually as a screen title */
 "reader.likes.title" = "点赞数";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.lists.title" = "列表";
 
 /* Reader logged-out screen details */
 "reader.loggedOut.details" = "使用 WordPress.com 账户登录，以关注您喜爱的博客";
@@ -9829,8 +10322,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title of a Reader tab showing Posts matching a user's search query */
 "reader.search.tab.posts" = "文章";
 
-/* Title of the Reader's search feature
-   Used in multiple contexts, usually as a screen title */
+/* Title of the Reader's search feature */
 "reader.search.title" = "搜索";
 
 /* Screen title. Reader select interests title label text. */
@@ -9856,6 +10348,21 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Reader select interests title label text */
 "reader.select.tags.title" = "发现并关注您喜欢的博客";
+
+/* Reader sidebar menu item */
+"reader.sidebar.discover" = "发现";
+
+/* Reader sidebar menu item */
+"reader.sidebar.likes" = "点赞数";
+
+/* Reader sidebar menu item */
+"reader.sidebar.recent" = "最近";
+
+/* Reader sidebar menu item */
+"reader.sidebar.saved" = "已保存";
+
+/* Reader sidebar menu item */
+"reader.sidebar.search" = "搜索";
 
 /* Reader sidebar section title */
 "reader.sidebar.section.favorites.title" = "收藏夹";
@@ -9905,7 +10412,7 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Number of subscriptions on a site (singular) */
 "reader.subscriptions.subscriptionsSingular" = "%@ 位订阅者";
 
-/* Used in multiple contexts, usually as a screen title */
+/* Navigation bar title */
 "reader.subscriptions.title" = "订阅";
 
 /* A suggestion of topics the user might want to subscribe to */
@@ -9947,35 +10454,17 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Verb. Button title. The user is following a tag. */
 "reader.tags.following.button.title" = "已关注";
 
-/* Used in multiple contexts, usually as a screen title */
-"reader.tags.title" = "标签";
-
 /* Accessibility label for unsubscribing from a tag */
 "reader.tags.unfollow.accessibility.label" = "取消关注 %@";
 
 /* Field title */
 "reader.userProfile.site" = "站点";
 
-/* Reader Welcome screen login button */
-"reader.welcome.continueText" = "继续使用 WordPress.com";
-
-/* Reader Welcome screen */
-"reader.welcome.subtitle" = "加入最大的博客社区";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.me" = "我";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.notifications" = "通知";
-
 /* Spoken accessibility label */
 "readerDetail.backButton.accessibilityLabel" = "返回";
 
 /* Spoken accessibility label */
 "readerDetail.dismissButton.accessibilityLabel" = "忽略";
-
-/* Spoken accessibility label for the Reading Preferences menu. */
-"readerDetail.displaySettingButton.displaySettingsLabel" = "阅读偏好";
 
 /* Section title for global related posts. */
 "readerDetail.globalPostsSection.accessibilityLabel" = "有关 WordPress.com 的更多信息";
@@ -10244,14 +10733,10 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Message shown when there are no inactive plugins on the site */
 "site.plugins.empty.inactive" = "没有未激活的插件";
 
-/* The plugin fillter option for displaying active plugins */
-"site.plugins.filter.option.active" = "已启用";
-
-/* The plugin fillter option for displaying all plugins */
+/* The plugin fillter option for displaying active plugins
+   The plugin fillter option for displaying all plugins
+   The plugin fillter option for displaying inactive plugins */
 "site.plugins.filter.option.all" = "全部";
-
-/* The plugin fillter option for displaying inactive plugins */
-"site.plugins.filter.option.inactive" = "未启用";
 
 /* Title of the plugin filter picker */
 "site.plugins.filter.title" = "筛选";
@@ -10951,8 +11436,119 @@ Feel free to replace it with other bracket types that you think looks better for
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "状态";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "历年文章数和浏览次数之最";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "历年浏览次数";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "历年浏览次数和访客人数";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "最受欢迎的文章";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "浏览次数之最";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "无法加载所有时间的统计信息。";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "创建或添加站点以查看所有时间的统计信息。";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "文章";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "在您的WordPress网站上了解全部时间活动更新。";
+
+/* Title of all time widget */
+"widget.alltime.title" = "全部时间";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "登录WordPress以查看全部时间统计数据。";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "登录 Jetpack，查看所有时间的统计信息。";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "登录 Jetpack，查看本周的统计信息。";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "登录 Jetpack，查看今天的统计信息。";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "历年浏览次数";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "今日浏览次数";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "无法加载本周的统计信息。";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "创建或添加站点以查看本周的统计信息。";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "在您的WordPress网站上了解本周活动更新。";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "本周";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "登录WordPress以查看本周统计数据。";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "评论";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "统计信息功能已转移至 Jetpack 应用。您可以免费切换，并且只需 1 分钟即可完成。";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "赞";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "无法加载站点统计信息。";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "无法加载今天的统计信息。";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "创建或添加站点以查看今天的统计信息。";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "在您的WordPress网站上了解今日活动。";
+
+/* Title of today widget */
+"widget.today.title" = "今日";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "登录WordPress以查看今日统计数据。";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "视图是不可用的";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "查看数";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "访客数";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "今日点赞数和评论数";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "今日浏览次数";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "今日浏览次数和访客人数";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "今后将无法再访问。";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "创建新站点？";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "wordpress, help, support, faq, questions, debug, logs, help center, contact wordpress, 帮助, 支持, 常见问题, 问题, 调试, 日志, 帮助中心, 联系";
@@ -10977,6 +11573,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Error message that describes an unknown error had occured */
 "wordpress-api.error.unknown" = "出错了，请稍后重试。";
+
+/* Error message when failing to find selected media file on the user's device. */
+"wordpress.api.upload.media.fileNotFound" = "无法在设备上找到媒体文件";
 
 /* Jetpack Plugin Modal on WordPress primary button title */
 "wordpress.jetpack.plugin.modal.primary.button.title" = "切换到 Jetpack 应用";
@@ -11023,21 +11622,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Error message when user signs in with an unexpected email address. The first argument is the expected email address */
 "wpComLogin.error.mismatchedEmail" = "请使用电子邮件地址 %@ 登录";
 
-/* Message shown when user denies WordPress.com login, offering option to try with different account */
-"wpComLogin.loginDenied.message" = "如有需要，您可以使用其他账户登录。 轻点“%@”以开始。";
-
-/* Title of alert shown when user cancels WordPress.com login */
-"wpComLogin.loginDenied.title" = "登录已取消";
-
-/* Button title for signing in with a different WordPress.com account */
-"wpComLogin.loginDenied.useDifferentAccount" = "使用其他账户";
-
-/* Button title to log out the current WordPress.com account */
-"wpcom.token.alert.button.logout" = "注销";
-
-/* Button title to Sign In to WordPress.com */
-"wpcom.token.alert.button.signin" = "登录";
-
 /* Message title to be displayed when the user needs to re-authenticate their WordPress.com account. */
 "wpcom.token.fix.signin" = "登录 WordPress.com";
 
@@ -11052,6 +11636,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "不受支持的附件";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} 使用 Google 登录。";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "•域";

--- a/WordPress/Resources/zh-Hant.lproj/Localizable.strings
+++ b/WordPress/Resources/zh-Hant.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-/* Translation-Revision-Date: 2025-05-14 07:10:17+0000 */
+/* Translation-Revision-Date: 2025-03-11 15:54:08+0000 */
 /* Plural-Forms: nplurals=1; plural=0; */
 /* Generator: GlotPress/4.0.1 */
 /* Language: zh_TW */
@@ -98,6 +98,9 @@
 
 /* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
 "%@ of %@ on your site" = "你的網站 %2$@ 中的 %1$@";
+
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB used on your site. */
+"%@ of %@ used on your site" = "你的網站已使用 %2$@ 中的 %1$@";
 
 /* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
 "%@ quadrillion" = "%@ 拍";
@@ -236,6 +239,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(未命名)";
 
+/* Lets a user know that a local draft does not have a title. */
+"(no title)" = "(無標題)";
+
 /* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
 "*Johann Brandt* responded to your post" = "*Johan Brandt* 已回應你的文章";
 
@@ -308,6 +314,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "一個「更多」按鈕包含顯示分享按鈕的下拉式選單";
 
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "WordPress.com 帳號已連結至你的商店憑證。 若要繼續操作，我們會傳送驗證連結到上方電子郵件地址。";
+
 /* Title for a threat */
 "A file contains a malicious code pattern" = "檔案包含惡意程式碼模式";
 
@@ -316,6 +325,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "網站標題";
+
+/* An error message. */
+"A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "需要有效的電子郵件地址才能傳送驗證連結。請返回上一個畫面，並提供有效的電子郵件地址。";
+
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "驗證碼僅包含數字。";
 
 /* Label for active Theme browser cell */
 "ACTIVE" = "使用中";
@@ -334,9 +349,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* My Profile 'About me' label */
 "About Me" = "關於我";
-
-/* Link to About screen for Jetpack for iOS */
-"About Reader for iOS" = "關於 iOS 版閱讀器";
 
 /* Link to About screen for WordPress for iOS */
 "About WordPress" = "關於 WordPress";
@@ -525,6 +537,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "%@之後";
 
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
+
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "對齊";
@@ -588,6 +603,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Jetpack Settings: Allowlisted IP addresses */
 "Allowlisted IP addresses" = "在允許清單中的 IP 位址";
 
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "快完成了！請輸入驗證器應用程式上的驗證碼。";
+
 /* Image alt attribute option title.
    Label for the alt for a media asset (image) */
 "Alt Text" = "替代文字";
@@ -600,6 +618,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: Alternative option included in a warning related to having blocks deeply nested. */
 "Alternatively, you can flatten the content by ungrouping the block." = "或者，你可以取消區塊群組來簡化內容。";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "或者你也可以輸入此帳號的密碼。";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "替代作法：";
 
 /* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
 "Always Send Crash Logs" = "一律傳送故障記錄";
@@ -621,6 +645,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Error message shown when trying to view the Activity Log feature and there is no internet connection. */
 "An active internet connection is required to view activities" = "需要有效的網際網路連線才能檢視活動";
+
+/* An error message shown when there is no internet connection. */
+"An active internet connection is required to view plans" = "需要有效的網際網路連線才能檢視方案";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
@@ -671,6 +698,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Insights 'This Year' details view header */
 "Annual Site Stats" = "年度網站統計";
 
+/* the comment has an anonymous author. */
+"Anonymous" = "匿名";
+
 /* Verb. Opens the editor to answer the blogging prompt. */
 "Answer" = "答案";
 
@@ -692,6 +722,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* The title of the app appearance settings screen */
 "Appearance" = "外觀";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "Apple 驗證失敗。\n請確認你已透過 Apple ID 使用兩步驟驗證登入 iCloud。";
 
 /* No comment provided by engineer. */
 "Applies the setting" = "套用此設定";
@@ -778,6 +811,10 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for the error view when the authentication failed for any reason */
 "Authentication Failed" = "驗證失敗";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "驗證碼";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "主機需要的驗證：%@";
@@ -888,6 +925,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the post details page when there are no comments. */
 "Be the first to comment" = "成為第一位留言的人";
+
+/* Message shown encouraging the user to leave a comment on a post in the reader. */
+"Be the first to leave a comment." = "當第一個留言的人。";
 
 /* Beauty site intent topic */
 "Beauty" = "美妝";
@@ -1024,12 +1064,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Button to copy post text" = "複製文章文字的按鈕";
 
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "繼續操作即代表你同意我們的_服務條款_。";
+
 /* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
 "By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "註冊此網域，即表示你同意我們的<a>條款與條件<\/a>。";
 
 /* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
 . Also there is a placeholder %@ which is: Terms and Conditions */
 "By setting up Jetpack you agree to our\n%@" = "設定 Jetpack 即代表你同意我們的\n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "註冊即代表你同意我們的「服務條款」。";
 
 /* No comment provided by engineer. */
 "CUSTOMIZE" = "自訂";
@@ -1043,6 +1089,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
 "Camera access needed to scan login codes" = "需要相機存取權限才能掃描登入碼";
 
+/* Title of an alert letting the user know */
+"Can Not Request Link" = "無法要求連結";
+
 /* Alert message that is shown when trying to publish empty page */
 "Can't publish an empty page" = "無法發表空白的頁面";
 
@@ -1052,6 +1101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
    Button title, cancel fixing all threats
+   Button title. Tapping it cancels the login flow.
    Cancel Action
    Cancel action on share extension editor screen.
    Cancel action on the app extension category picker screen.
@@ -1061,6 +1111,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Cancel action title
    Cancel button
    Cancel button label
+   Cancel button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Cancel button.
    Cancel button. Site creation modal popover.
    Cancel copying link to comment button title
@@ -1079,6 +1130,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Menus cancel button for deleting a menu.
    Menus cancel button within text bar while editing items.
    Menus: Cancel button title for canceling an edited menu item.
+   Option to cancel the email app selection when logging in with magic links
    Title for cancel action. Dismisses the action sheet.
    Title of a button that dismisses the permissions alert
    Title. Title of a cancel button. Tapping disnisses an alert.
@@ -1106,6 +1158,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "正在取消…";
 
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "無法使用此地址存取網站。 請重新檢查，然後再試一次。";
+
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "下不了決定嗎？ 你可以隨時變更佈景主題。";
 
@@ -1113,7 +1168,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Noun. Label for the caption for a media asset (image / video) */
 "Caption" = "媒體說明文字";
 
-/* Alert title. */
+/* Alert title.
+   Title for the warning shown to the user when he refuses to re-login when the authToken is missing. */
 "Careful!" = "請小心！";
 
 /* Example prompt for the Prompts card in Feature Introduction. */
@@ -1122,7 +1178,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for the categories field. Should be the same as WP core. */
 "Categories" = "分類";
 
-/* Category menu item in share extension. */
+/* Category menu item in share extension.
+   Menu item label for linking a specific category. */
 "Category" = "分類";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -1171,6 +1228,18 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
 "Check out our top tips to increase your views and traffic" = "查看我們的頂尖秘訣，瞭解如何增加瀏覽次數和流量";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "在此裝置查看你的電子郵件！";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "請使用此裝置查看電子郵件，並點選 WordPress.com 所傳送電子郵件中的連結。";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "請使用此裝置查看電子郵件，並點選 WordPress.com 所傳送電子郵件中的連結。\n\n沒看到電子郵件嗎？ 請檢查你的「垃圾郵件」資料夾。";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "請檢查你的電子郵件！";
 
 /* Subtitle shown on the dashboard when it fails to load */
 "Check your internet connection and pull to refresh." = "請檢查你的網際網路連線，並拖動以重新整理。";
@@ -1267,6 +1336,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "索取你的免費網域";
 
+/* Name of setting configured when a site uses a list of blog posts as its homepage */
+"Classic Blog" = "傳統網誌";
+
 /* Label for button that clears all media cache. */
 "Clear Device Media Cache" = "清除裝置媒體快取";
 
@@ -1294,6 +1366,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Action button to close edior and cancel changes or insertion of post
    Action button to close the editor
+   Dismiss the current view
    Dismisses the current screen */
 "Close" = "關閉";
 
@@ -1335,6 +1408,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Columns Settings" = "欄位設定";
+
+/* Menu item label for linking a comic page. */
+"Comics" = "漫畫";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -1386,6 +1462,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comment Sections
    Text for the 'comment' button when there are multiple comments
    Title for the Blog's Comments Section View
+   Title of the reader's comments screen
    Today's Stats 'Comments' label */
 "Comments" = "留言";
 
@@ -1453,12 +1530,18 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "已連結的帳號";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "已連線，但是…";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "現正連結至 %@";
 
 /* Informs the user of consequences of chooseing a new account to connect to publicize.  The %@ characters are placeholders for account names. */
 "Connecting %@ will replace the existing connection to %@." = "連結 %1$@ 後，將會取代 %2$@ 的現有連結。";
+
+/* No comment provided by engineer. */
+"Connecting to WordPress.com" = "正在連線至 WordPress.com";
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "正在連結...";
@@ -1489,8 +1572,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
 "Contact us at %@" = "透過 %@ 聯絡我們";
 
+/* Displays the number of blocks, words and characters in text */
+"Content Structure\nBlocks: %li, Words: %li, Characters: %li" = "內容結構\n區塊：%1$li、文字：%2$li、字元：%3$li";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
+   The button title text when there is a next step for logging in or signing up.
    The default Jetpack view button title
    The primary button title in the migration welcome and notifications screens.
    Title for the continue button in the What's New page.
@@ -1505,6 +1592,15 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "繼續閱讀";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "繼續使用 Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "繼續使用 Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "繼續使用 Apple";
 
 /* Title of button that displays the WordPress.org contributor page */
 "Contribute" = "參與";
@@ -1633,6 +1729,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for create floating action button */
 "Create" = "建立";
 
+/* The button title text for creating a new account. */
+"Create Account" = "建立帳號";
+
 /* Title for button to make a blank page */
 "Create Blank Page" = "建立空白頁面";
 
@@ -1653,6 +1752,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
 "Create a Post" = "建立文章";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "建立網站";
 
 /* Title of the button in the placeholder for an empty list of blog tags. */
 "Create a Tag" = "建立標籤";
@@ -1686,6 +1788,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Current" = "目前記錄";
+
+/* Label title. Refers to the current WordPress.com plan for a user's site. */
+"Current Plan" = "目前方案";
 
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "目前佈景主題";
@@ -1788,6 +1893,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for selecting a default category for a post */
 "Default Category" = "預設類別";
 
+/* Menu name for the defaut menu that is automatically generated. */
+"Default Menu" = "預設選單";
+
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "預設文章格式";
@@ -1796,6 +1904,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Defaults for New Posts" = "新文章預設值";
 
 /* Delete
+   Delete button title for the warning shown to the user when he refuses to re-login when the authToken is missing.
    Title for button that permanently deletes a media item (photo / video)
    Title of the trash confirmation alert. */
 "Delete" = "刪除";
@@ -1853,6 +1962,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Theme Details action title */
 "Details" = "詳細資料";
 
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "並不是想要建立新帳號嗎？ 返回並重新輸入電子郵件地址。";
+
 /* Label for the dimensions in pixels for a media asset (image / video) */
 "Dimensions" = "尺寸";
 
@@ -1900,7 +2012,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title for the Discussion Settings Screen */
 "Discussion" = "討論";
 
-/* No comment provided by engineer. */
+/* Accessibility label for the transparent space above the login dialog which acts as a button to dismiss the dialog.
+   Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog.
+   Dismiss a view. Verb */
 "Dismiss" = "關閉";
 
 /* Accessibility hint for the continue button in the Feature Announcements screen. */
@@ -1922,6 +2036,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "網域";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "還沒有帳號？_註冊_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -2051,6 +2168,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Label for number of file downloads. */
 "Downloads" = "下載";
 
+/* Name for the status of a draft post. */
+"Draft" = "草稿";
+
 /* Title of the drafts filter.  This filter shows a list of draft posts. */
 "Drafts" = "草稿";
 
@@ -2157,7 +2277,10 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "電子郵件地址";
 
-/* Describes the email address section in the comment detail screen. */
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
 "Email address" = "電子郵件地址";
 
 /* Notification Settings Channel */
@@ -2241,8 +2364,28 @@ translators: %s: Block name e.g. \"Image block\" */
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "輸入密碼";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "請輸入要連結的 WordPress 網站位址。";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "請輸入 WordPress.com 帳號的密碼。";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "輸入使用者名稱";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "請輸入你的 %@ 帳號資訊。";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "請輸入你的電子郵件地址以登入或建立 WordPress.com 帳號。";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "輸入你現有的網址";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "請改為輸入你的密碼。";
 
 /* Error message displayed when site credentials aren't configured. */
 "Enter your server credentials" = "輸入伺服器憑證";
@@ -2405,6 +2548,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Section title for the external table section in the blog details screen */
 "External" = "外部";
 
+/* Status for Media object that is failed upload or export. */
+"Failed" = "失敗";
+
 /* Message for mark all as read success notice */
 "Failed marking Notifications as read" = "無法將全部通知標示為已讀";
 
@@ -2416,9 +2562,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Failed to insert media.\nTap for more info." = "無法插入媒體。\n點選以瞭解更多資訊。";
-
-/* A message indicating that we couldn't load the user's settings. */
-"Failed to load settings" = "無法載入設定";
 
 /* No comment provided by engineer. */
 "Failed to save files.\nPlease tap for options." = "存檔失敗。\n請點選以顯示選項。";
@@ -2434,6 +2577,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Fashion site intent topic */
 "Fashion" = "時尚";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
 "Featured" = "精選";
@@ -2492,6 +2638,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "瞭解更多";
 
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "尋找你的網站位址";
+
 /* My Profile first name label
    Register Domain - Domain contact information field First name
    User's First Name */
@@ -2514,6 +2663,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Subtitle displayed while the server is fixing threats */
 "Fixing Threats" = "正在修正威脅";
+
+/* Button title. Follow the comments on a post. */
+"Follow" = "關注";
 
 /* Button title. Follow the comments on a post. */
 "Follow Conversation" = "關注討論";
@@ -2608,6 +2760,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title. A call to action to generate a new invite link. */
 "Generate new link" = "產生新連結";
 
+/* View title for initial auth views. */
+"Get Started" = "開始使用";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "透過電子郵件取得登入連結";
+
 /* Displayed in the Notifications Tab as a message, when there are no notifications */
 "Get active! Comment on posts from blogs you follow." = "動起來吧！在關注的網誌文章上留言。";
 
@@ -2629,8 +2787,17 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post title used in the login prologue screens. */
 "Getting Inspired" = "激發靈感";
 
+/* Alerts the user that wpcom account information is being retrieved. */
+"Getting account information" = "取得帳號資訊";
+
+/* Cancel */
+"Give Up" = "放棄";
+
 /* No comment provided by engineer. */
 "Give it a try by adding a few blocks to your post or page!" = "馬上嘗試為你的文章或頁面新增幾個區塊！";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
 
 /* Displayed in the Notifications Tab as a button title, when there are no notifications */
 "Go to Reader" = "前往讀取器";
@@ -2641,6 +2808,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "前往 iOS 設定";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Google 註冊失敗。";
 
 /* Button title on the blogging prompt's feature introduction view to dismiss the view.
    Title for the continue button in the dashboard's custom What's New page. */
@@ -2715,6 +2885,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Help icon" = "說明圖示";
 
+/* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
+"Hidden" = "隱藏";
+
 /* Title of a button used to collapse a group */
 "Hide" = "隱藏";
 
@@ -2783,6 +2956,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message to show when site icon update failed */
 "Icon update failed" = "圖示更新失敗";
+
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "若找不到此封電子郵件，請檢查你的垃圾郵件資料夾";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "如果你繼續使用 Apple 或 Google 操作且尚未擁有 WordPress.com 帳號，即表示你正在建立帳號，並同意我們的_服務條款_。";
 
 /* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
 "If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "若移除 %1$@，該使用者將無法再存取此網站，但 %2$@ 建立的所有內容仍會保留在網站上。";
@@ -2858,6 +3037,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Downloadable/Restorable items: general section footer text */
 "Includes wp-config.php and any non WordPress files" = "包括 wp-config.php 以及任何非 WordPress 檔案";
+
+/* An error message shown when a user signed in with incorrect credentials. */
+"Incorrect username or password. Please try entering your login details again." = "錯誤的使用者名稱或密碼。請再次嘗試輸入你的登入詳細資料。";
 
 /* Title for a threat */
 "Infected core file" = "受感染的核心檔案";
@@ -2959,6 +3141,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title displayed on the feature introduction view. */
 "Introducing Blogging Prompts" = "網誌提示簡介";
 
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "無效的電子郵件地址";
+
 /* No comment provided by engineer. */
 "Invalid Site Address" = "無效的網站位址";
 
@@ -2976,6 +3161,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Invalid URL. Audio file not found." = "無效網址。 找不到音訊檔案。";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "URL 無效。 請重新檢查，然後再試一次。";
 
 /* No comment provided by engineer. */
 "Invalid URL. Please enter a valid URL." = "無效網址。 請輸入正確的網址。";
@@ -2997,6 +3185,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Invite People Title */
 "Invite People" = "邀請他人";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "使用者名稱\/密碼似乎不適用於這個網站。";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "輸入的密碼似乎有誤。是否要再試一次？";
 
 /* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
 "It's time to blog on %@!" = "該在 %@ 新增網誌內容了！";
@@ -3225,7 +3419,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Line Height" = "行高";
 
-/* Label for link title in Clicks stat. */
+/* Label for link title in Clicks stat.
+   Menu item label for linking a custom source URL. */
 "Link" = "連結";
 
 /* Menus title label when editing a menu item as a link. */
@@ -3287,6 +3482,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Text displayed while loading site People. */
 "Loading People..." = "正在載入人員…";
 
+/* Text displayed while loading plans details */
+"Loading Plan..." = "正在載入方案…";
+
+/* Text displayed while loading plans details */
+"Loading Plans..." = "正在載入方案...";
+
 /* Text displayed while loading an specific plugin */
 "Loading Plugin..." = "正在載入外掛程式...";
 
@@ -3321,11 +3522,23 @@ translators: %s: Block name e.g. \"Image block\" */
    Text displayed while loading time zones */
 "Loading..." = "正在載入...";
 
+/* Status for Media object that is only exists locally. */
+"Local" = "本機";
+
 /* Local Services site intent topic */
 "Local Services" = "當地服務";
 
 /* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
 "Local changes" = "本機變更";
+
+/* Title for alert when a generic error happened when trying to find the location of the device */
+"Location" = "位置";
+
+/* Explaining to the user that location services need to be enable in order to geotag a post. */
+"Location Services must be enabled before WordPress can add your current location. Please enable Location Services from the Settings app." = "若要讓 Wordpress 新增你目前的位置，你必須啟用「定位服務」。請在「設定」應用程式中啟用「定位服務」。";
+
+/* Used when geo-tagging posts, if the geo-tagging failed. */
+"Location unknown" = "未知的位置";
 
 /* No comment provided by engineer. */
 "Lock icon" = "鎖定圖示";
@@ -3333,9 +3546,11 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Log Files By Created Date" = "依建立日期排列記錄檔案";
 
-/* Label for logging in to WordPress.com account
+/* Button title.  Tapping takes the user to the login form.
+   Label for logging in to WordPress.com account
    Log In 3D Touch Shortcut
-   Log In button label. */
+   Log In button label.
+   View title during the log in process. */
 "Log In" = "登入";
 
 /* Button for confirming logging out from WordPress.com account
@@ -3345,17 +3560,33 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of a button for signing in. */
 "Log in" = "登入";
 
-/* LogOut confirmation text, whenever there are no local changes */
-"Log out of Jetpack?" = "是否登出 Jetpack？";
+/* A generic error message for a failed log in. */
+"Log in failed. Please try again." = "登入失敗，請再試一次。";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "登入或註冊 WordPress.com";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "請登入你用來連結 Jetpack 的 WordPress.com 帳號。";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "使用電子郵件地址登入 WordPress.com 帳號。";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "請使用你的 WordPress.com 使用者名稱和密碼登入。";
 
 /* LogOut confirmation text, whenever there are no local changes */
-"Log out of Reader?" = "確定要登出閱讀器嗎？";
+"Log out of Jetpack?" = "是否登出 Jetpack？";
 
 /* LogOut confirmation text, whenever there are no local changes */
 "Log out of WordPress?" = "是否要登出 WordPress？";
 
 /* Login Request Expired */
 "Login Request Expired" = "登入要求已到期";
+
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "使用帳號密碼登入";
 
 /* No comment provided by engineer. */
 "Logs" = "記錄";
@@ -3365,6 +3596,12 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message asking the user to sign into Jetpack with WordPress.com credentials */
 "Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "你似乎已在網站上設定 Jetpack。恭喜！使用 WordPress.com 憑證登入，以啟用「統計與通知」。";
+
+/* Title of a button. */
+"Lost your password?" = "忘記密碼？";
+
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "郵件 (預設)";
 
 /* No comment provided by engineer. */
 "Main Navigation" = "主導覽";
@@ -3512,6 +3749,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Label for the share message field on the post settings. */
 "Message" = "訊息";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
 /* Summary description for a threat */
 "Miscellaneous vulnerability" = "其他安全漏洞";
 
@@ -3607,6 +3847,9 @@ translators: %s: Block name e.g. \"Image block\" */
    Title of My Site tab */
 "My Site" = "我的網站";
 
+/* Siri Suggestion to open My Sites */
+"My Sites in WordPress" = "我在 WordPress 的網站";
+
 /* Example post title used in the login prologue screens. */
 "My Top Ten Cafes" = "我最愛的十家咖啡館";
 
@@ -3646,8 +3889,15 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "需要協助？";
 
-/* The secondary button title in the migration welcome screen */
+/* A button title. */
+"Need help finding your site address?" = "需要幫你找網站位址嗎？";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
 "Need help?" = "需要協助？";
+
+/* Title of the more help button on alert helping users understand their site address */
+"Need more help?" = "需要更多協助嗎？";
 
 /* Describes a status of a plugin */
 "Needs Update" = "需要更新";
@@ -3676,6 +3926,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* New Post 3D Touch Shortcut */
 "New Post" = "新增文章";
 
+/* Menu item title text used as default when creating a new menu item. */
+"New item" = "新增項目";
+
 /* Placeholder text for password field */
 "New password" = "新密碼";
 
@@ -3693,7 +3946,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "News" = "新聞";
 
 /* Next action on comment moderation snackbar.
-   Next action on share extension editor screen. */
+   Next action on share extension editor screen.
+   Title of a button.
+   Title of a button. The text should be capitalized. */
 "Next" = "下一篇";
 
 /* Accessibility label for the next notification button */
@@ -3729,6 +3984,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* missing preview URL for blog post preview */
 "No Preview URL available" = "沒有可用的預覽網址";
 
+/* Label used for posts without a title in spotlight search. */
+"No Title" = "無標題";
+
 /* Title for the view when there aren't any Activities Types to display in the Activity Log Types picker */
 "No activities available" = "無活動";
 
@@ -3761,7 +4019,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Displayed when there are no comments in the Comments views. */
 "No comments yet" = "尚無回應";
 
-/* Displayed during Site Creation, when searching for Verticals and the network is unavailable.
+/* An error message title shown when there is no internet connection.
+   Displayed during Site Creation, when searching for Verticals and the network is unavailable.
    Title for the error view when there's no connection */
 "No connection" = "沒有連線";
 
@@ -3910,6 +4169,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
 "Not now" = "現在不要";
 
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "沒看到電子郵件？ 請檢查你的「垃圾郵件」資料夾。";
+
 /* Label for the note displayed in the Feature Introduction view. */
 "Note:" = "注意：";
 
@@ -3973,7 +4235,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "編號清單";
 
-/* Menus: button title for finishing editing of a menu item.
+/* Alert dismissal title
+   Button title. An acknowledgement of the message displayed in a prompt.
+   Dismisses the alert
+   Menus: button title for finishing editing of a menu item.
+   Ok button for dismissing alert helping users understand their site address
+   OK button title for the warning shown to the user when the app realizes there should be an auth token but there isn't one.
    OK Button title shown in alert informing users about the Reader Save for Later feature.
    Title of a button that dismisses a prompt */
 "OK" = "OK";
@@ -4030,7 +4297,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Title for the view when there's an error loading time zones */
 "Oops" = "噢噢";
 
-/* An informal exclaimation meaning `something went wrong`. */
+/* An informal exclaimation meaning `something went wrong`.
+   Title for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
 "Oops!" = "糟糕！";
 
 /* No comment provided by engineer. */
@@ -4045,7 +4313,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Open Jetpack Security settings" = "開啟 Jetpack Security 設定";
 
-/* Title of a button that opens the apps settings in the system Settings.app */
+/* The button title text for opening the user's preferred email app.
+   Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
+"Open Mail" = "開啟郵件";
+
+/* Go to the settings app
+   Title of a button that opens the apps settings in the system Settings.app */
 "Open Settings" = "開啟設定";
 
 /* No comment provided by engineer. */
@@ -4063,6 +4336,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "在新視窗或分頁中開啟連結";
 
+/* VoiceOver hint. Informs the user that the button allows the user to access post subscription settings. */
+"Open subscription settings for the post" = "開啟文章的訂閱設定";
+
 /* Accessibility hint the Me button in My Site. */
 "Open the Me Section" = "開啟「我」畫面";
 
@@ -4077,6 +4353,18 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
 "Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "選填：輸入自訂訊息 (上限 %1$d 個字元)，連同你的邀請一併傳送。";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "或者";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "或選擇其他驗證方式。";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "或輸入網站位址登入。";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "或使用神奇連結登入";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "已排序清單";
@@ -4125,7 +4413,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* No comment provided by engineer. */
 "Padding" = "邊框間距";
 
-/* Noun. Type of content being selected is a blog page
+/* Menu item label for linking a page.
+   Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "網頁";
 
@@ -4158,8 +4447,11 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Parenting site intent topic */
 "Parenting" = "育兒";
 
-/* Label for entering password in password field
+/* Accessibility label for the password text field in the self-hosted login page.
+   Label for entering password in password field
    Login dialog password placeholder
+   Password placeholder
+   Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "密碼";
 
@@ -4176,8 +4468,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Paste block after" = "將區塊貼在以下物件後方：";
 
 /* Button title for Pending comment state.
+   Status for Media object that is being processed locally.
    Title of pending Comments filter. */
 "Pending" = "待審核";
+
+/* Name for the status of a post pending review. */
+"Pending review" = "等待複審";
 
 /* Noun. Title of the people management feature.
    Noun. Title. Links to the people management feature.
@@ -4208,6 +4504,10 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for selecting a new username in the site creation flow. */
 "Pick username" = "挑選使用者名稱";
 
+/* Action title. Noun. Links to a blog's Plans screen.
+   Title for the plan selector */
+"Plans" = "方案";
+
 /* User action to play a video on the editor. */
 "Play video" = "播放影片";
 
@@ -4237,6 +4537,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
 "Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "請確認你的網站已啟用區塊編輯器。 若未啟用將不會載入區塊編輯器。";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "請輸入完整的網站位址，例如 example.com。";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "請輸入網站位址。";
@@ -4271,11 +4574,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid address" = "請輸入有效的地址";
 
-/* No comment provided by engineer. */
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "請輸入可用於 WordPress.com 帳號的有效電子郵件地址";
+
+/* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "請輸入有效的電子郵件位址";
 
 /* Register Domain - Domain contact information validation error message for an input field */
 "Please enter a valid phone number" = "請輸入有效的電話號碼";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "請輸入 WordPress.com 帳戶的密碼，以便使用 Apple ID 登入。";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "請輸入你的密碼";
@@ -4283,8 +4592,14 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Instructions for alert asking for email. */
 "Please enter your email address." = "請輸入你的電子郵件地址。";
 
+/* A short prompt asking the user to properly fill out all login fields. */
+"Please fill out all the fields" = "請填寫所有欄位";
+
 /* Share extension dialog text  - displayed when user is missing a login token. */
 "Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "請啟動 WordPress 應用程式，登入 WordPress.com，並確定你至少有一個網站，然後重試一次。";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "請先登出再連結至另一個 WordPress.com 網站";
 
 /* Used on an error alert to prompt the user to try again */
 "Please try again later" = "請稍後再試一次";
@@ -4349,7 +4664,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Section title for Popular Languages */
 "Popular languages" = "熱門語言";
 
-/* Noun. Type of content being selected is a blog post
+/* Menu item label for linking a post.
+   Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "張貼";
 
@@ -4470,6 +4786,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Link to the CCPA privacy notice for residents of California. */
 "Privacy notice for California users" = "加州使用者的隱私權聲明";
 
+/* Name for the status of a post that is marked private. */
+"Private" = "私密";
+
 /* No comment provided by engineer. */
 "Problem displaying block. \nTap to attempt block recovery." = "顯示區塊時發生問題 \nTap to attempt block recovery.";
 
@@ -4484,6 +4803,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Register Domain - error displayed when there's a problem when purchasing the domain. */
 "Problem purchasing your domain. Please try again." = "購買網域時發生問題。請再試一次。";
+
+/* Message for the warning shown to the user when he refuses to re-login when the authToken is missing. */
+"Proceeding will remove all WordPress.com data from this device, and delete any locally saved drafts. You will not lose anything already saved to your WordPress.com blog(s)." = "若繼續操作，將移除此裝置上的所有 WordPress.com 資料，並刪除儲存在本機的任何草稿。已儲存在 WordPress.com 網誌上的內容不會遺失。";
+
+/* Menu item label for linking a project page. */
+"Projects" = "專案";
 
 /* Title of the notification presented when a prompt is skipped */
 "Prompt skipped" = "已略過提示";
@@ -4501,13 +4826,17 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Label for the publish date button. */
 "Publish Date" = "發表日期";
 
+/* A short phrase indicating a post is due to be immedately published. */
+"Publish Immediately" = "立刻發佈";
+
 /* Text displayed in the share extension's summary view. It describes the publish page action. */
 "Publish page on:" = "將頁面張貼在以下位置：";
 
 /* Text displayed in the share extension's summary view. It describes the publish post action. */
 "Publish post on:" = "文章發表位置：";
 
-/* Period Stats 'Published' header
+/* Name for the status of a published post.
+   Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
 "Published" = "已發佈";
 
@@ -4709,7 +5038,12 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Verb. Button title. Reply to a comment. */
 "Reply" = "回覆";
 
-/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+/* Notifications Reply Accessibility Identifier */
+"Reply Text" = "回覆文字";
+
+/* Placeholder text for replying to a comment. %1$@ is a placeholder for the comment author's name.
+   Placeholder text for the reply text field.%1$@ is a placeholder for the comment author.Example: Reply to Pamela Nguyen
+   Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
 "Reply to %1$@" = "回覆 %1$@";
 
 /* An explaination of a setting. */
@@ -4738,6 +5072,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Accessibility label for the reset date range button */
 "Reset Date Range filter" = "重設日期範圍篩選器";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "重設密碼";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "重新調整大小與裁切";
@@ -4795,6 +5132,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* User action to retry all failed media uploads. */
 "Retry all" = "全部重試";
 
+/* No comment provided by engineer. */
+"Retry?" = "重試？";
+
 /* Share extension error dialog cancel button text */
 "Return to post" = "返回文章";
 
@@ -4824,6 +5164,9 @@ translators: %s: Select control button label e.g. \"Button width\" */
    User's Role */
 "Role" = "角色";
 
+/* One Time Code has been sent via SMS */
+"SMS Sent" = "簡訊已傳送";
+
 /* Section title for the moderation section of the comment details screen. */
 "STATUS" = "狀態";
 
@@ -4835,6 +5178,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Menus save button title
    Save Action
+   Save button label (saving content, ex: Post, Page, Comment).
    Save draft post action on share extension site picker screen.
    Settings Text save button title
    Title for the button that will save the site icon
@@ -4901,7 +5245,8 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title for label when the actively scanning the users site */
 "Scanning files" = "掃瞄檔案";
 
-/* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
+/* Name for the status of a scheduled post
+   Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "已排程";
 
 /* No comment provided by engineer. */
@@ -5041,6 +5386,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility hint for a topic in the Site Creation intents view. */
 "Selects this topic as the intent for your site." = "選取此主題作為你的網站用途。";
 
+/* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
+"Send Link" = "傳送連結";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "以電子郵件傳送連結";
+
 /* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
 "Send Log Message" = "傳送記錄訊息";
 
@@ -5049,6 +5400,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
 "Send Test Crash" = "傳送故障測試";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "傳送電子郵件驗證連結";
 
 /* Jetpack Monitor Settings: Send notifications by email */
 "Send notifications by email" = "以電子郵件傳送通知";
@@ -5095,11 +5449,11 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Message to show when setting save failed */
 "Settings update failed" = "設定更新失敗";
 
-/* Title for a button that recommends the app to others */
-"Share Jetpack with a friend" = "與親友分享 Jetpack";
+/* Spoken accessibility label */
+"Share" = "分享";
 
 /* Title for a button that recommends the app to others */
-"Share Reader with a friend" = "與好友分享閱讀器";
+"Share Jetpack with a friend" = "與親友分享 Jetpack";
 
 /* Title for a button that recommends the app to others */
 "Share WordPress with a friend" = "向朋友推薦 WordPress";
@@ -5150,6 +5504,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "顯示轉發按鈕";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "顯示密碼";
+
 /* No comment provided by engineer. */
 "Show post content" = "顯示文章內容";
 
@@ -5161,6 +5519,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Label on Post Stats view indicating which post the stats are for. */
 "Showing stats for:" = "顯示以下統計資料：";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "顯示";
 
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "當你在網誌中留言時會公開顯示。";
@@ -5176,6 +5537,21 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint for a match/mention on a post notification. */
 "Shows the post" = "顯示文章";
+
+/* View title during the sign up process. */
+"Sign Up" = "註冊";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "使用網站憑證登入";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "註冊";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "註冊 WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "透過電子郵件註冊";
 
 /* Text displayed as a footer of a table view with Activities when user is on a free plan */
 "Since you're on a free plan, you'll see limited events in your Activity Log." = "由於你使用免費方案，你將無法在活動記錄中查看所有活動。";
@@ -5214,6 +5590,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "網站成就";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "網站位址";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "網站位址至少必須為 4 個字元。";
@@ -5298,7 +5677,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Sorry, site addresses must have letters too!" = "很抱歉，網站位址也必須包含字母！";
 
-/* No comment provided by engineer. */
+/* Error message displayed when the entered email is not available. */
 "Sorry, that email address is already being used!" = "很抱歉，已有人使用該電子郵件地址！";
 
 /* No comment provided by engineer. */
@@ -5358,6 +5737,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title of spam Comments filter. */
 "Spam" = "垃圾迴響";
 
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
 /* Label for selecting the Speed up your site Settings section
    Title for the Speed up your site Settings Screen */
 "Speed up your site" = "加快網站的速度";
@@ -5383,6 +5765,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Register Domain - Domain Address field State */
 "State" = "州";
+
+/* Name of setting configured when a site uses a static page as its homepage */
+"Static Homepage" = "靜態首頁";
 
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
@@ -5413,6 +5798,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Discoverability title for strikethrough formatting keyboard shortcut. */
 "Strikethrough" = "刪除線";
+
+/* Status for Media object that is only has the mediaID locally. */
+"Stub" = "Stub";
 
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "送交審查";
@@ -5503,7 +5891,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the tablet web preview */
 "Tablet" = "平板電腦";
 
-/* Section header for tag name in Tag Details View. */
+/* Menu item label for linking a specific tag.
+   Section header for tag name in Tag Details View. */
 "Tag" = "標籤";
 
 /* Title of the alert indicating that a tag with that name already exists. */
@@ -5638,6 +6027,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "服務條款";
 
+/* Menu item label for linking a testimonial post. */
+"Testimonials" = "證言";
+
 /* Title of a button style */
 "Text Only" = "只顯示文字";
 
@@ -5647,8 +6039,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "編輯文字區塊時，文字格式控制項就在鍵盤上方的工具列中";
 
+/* Button title */
+"Text me a code instead" = "請改用簡訊傳送驗證碼給我";
+
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "透過簡訊向我傳送驗證碼";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "感謝你選擇 %2$@ 設計的 %1$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "該驗證碼似乎無效。";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "這似乎不是 WordPress 網站。";
@@ -5670,6 +6071,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
 "The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "Facebook 連結找不到任何頁面。Publicize 無法連結至 Facebook 個人檔案，只能連結至已發表的頁面。";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "沒有任何與 Google 帳號「%@」匹配的 WordPress.com 帳號";
 
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "看來網際網路連線狀態為離線。";
@@ -5709,6 +6113,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Message shown when an image failed to load while trying to add it to the Media library. */
 "The image could not be added to the Media Library." = "無法將圖片新增到媒體庫。";
+
+/* Message of error prompt shown when a user tries to perform an action without an internet connection. */
+"The internet connection appears to be offline." = "網路似乎斷線囉！";
 
 /* Accessibility hint for list */
 "The kinds of sites that can be created" = "可建立的網站類型";
@@ -5752,6 +6159,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "網誌 %1$@ 使用 WordPress 版本 %2$@。我們建議升級至最新版本，至少使用 %3$@ 以上的版本。";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "此地址的網站不是 WordPress 網站。該網站必須使用 WordPress，我們才能與其連結。";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "網站無法刪除。";
 
@@ -5793,6 +6204,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "編輯你的留言時發生未預期的錯誤";
 
+/* Message shown when comments for a post can not be loaded. */
+"There has been an unexpected error while loading the comments." = "載入留言時發生未預期的錯誤。";
+
 /* Register domain - Error message displayed whenever registering domain fails unexpectedly */
 "There has been an unexpected error while registering your domain" = "註冊網域時發生未預期的錯誤";
 
@@ -5801,6 +6215,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "更新你的通知設定時發生意外錯誤";
+
+/* Displayed whenever a Comment Update Fails */
+"There has been an unexpected error while updating your comment" = "更新你的留言時發生未預期的錯誤";
 
 /* Generic error alert message */
 "There has been an unexpected error." = "發生未預期的錯誤。";
@@ -5822,6 +6239,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A general error message shown to the user when there was an API communication failure. */
 "There was a problem communicating with the site." = "與網站通訊時發生問題。";
 
+/* Message for the warning shown to the user when the app realizes there should be an auth token but there isn't one. */
+"There was a problem connecting to WordPress.com. Please log in again." = "連線到 WordPress.com 時發生問題。請重新登入。";
+
+/* A short error message letting the user know about a problem displaying a post. */
+"There was a problem displaying this post." = "顯示此文章時發生問題。";
+
 /* The loading view subtitle displayed when an error occurred */
 "There was a problem loading your data, refresh your page to try again." = "載入資料時發生問題，請重新整理網頁並重試。";
 
@@ -5831,12 +6254,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "儲存分享管理的變更時發生問題。";
 
+/* Explaining to the user there was an error trying to obtain the current location of the user. */
+"There was a problem when trying to access your location. Please try again later." = "嘗試存取你的位置時發生問題。請稍後再試一次。";
+
 /* Text displayed when there is a failure changing the password.
    Text displayed when there is a failure loading the history. */
 "There was an error changing the password" = "變更密碼時發生錯誤";
 
 /* Text displayed when there is a failure loading the activity feed */
 "There was an error loading activities" = "載入活動時發生錯誤";
+
+/* Text displayed when there is a failure loading the plan list */
+"There was an error loading plans" = "載入方案時發生錯誤";
 
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "載入外掛程式時發生錯誤";
@@ -5849,6 +6278,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Text displayed when there is a failure loading the history. */
 "There was an error loading the history" = "載入記錄時發生錯誤";
+
+/* Text displayed when there is a failure loading the plan details */
+"There was an error loading the plan" = "載入此方案時發生錯誤";
 
 /* Text displayed when there is a failure loading the history feed */
 "There was an error loading the scan history" = "載入掃瞄記錄時發生錯誤";
@@ -5897,6 +6329,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Notifies the user that the a domain matching the search term wasn't returned in the results */
 "This domain is unavailable" = "此網域不可使用";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "這個電子郵件地址沒有在 WordPress.com 上註冊。";
 
 /* Message to show to user when media upload failed because server doesn't support media type */
 "This file is too large to upload to your site or it does not support this media format." = "由於檔案太大，或你的網站不支援此媒體格式，因此無法上傳此檔案至網站。";
@@ -5977,6 +6412,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Title for the time zone selector */
 "Time Zone" = "時區";
 
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "優惠已到期，但別擔心，你的安全是我們的第一要務。 請再試一次！";
+
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "讓 WordPress.com 發揮最大功效的秘訣。";
 
@@ -5990,6 +6428,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Instructions for alert asking for email and name. */
 "To continue please enter your email address and name." = "若要繼續，請輸入你的電子郵件地址和姓名。";
 
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "若要建立新的 WordPress.com 帳號，請輸入你的電子郵件地址。";
+
 /* Message asking the user if they want to set up Jetpack from notifications */
 "To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "若要在手機上獲得來自你 WordPress 網站的實用通知，必須安裝 Jetpack 外掛程式。";
 
@@ -5998,6 +6439,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Install Plugin dialog text. */
 "To install plugins, you need to have a custom domain associated with your site." = "若要安裝外掛程式，你的自訂網域必須與你的網站建立關聯。";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "若要繼續使用這個 Apple ID，請先使用你的 WordPress.com 密碼登入。 系統只會要求你進行此操作一次。";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "若要繼續使用這個 Google 帳號，請先使用你的 WordPress.com 密碼登入。系統只會向你要求一次。";
 
 /* No comment provided by engineer. */
 "To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "若要移除區塊，請選取區塊，並按一下區塊右下角的三個點以檢視設定。 在設定中選擇移除區塊的選項。";
@@ -6072,7 +6519,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Trashes the comment */
 "Trash" = "移至回收桶";
 
-/* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
+/* Name for the status of a trashed post
+   Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "已移至垃圾桶";
 
@@ -6086,6 +6534,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Try & Customize" = "試用與自訂";
 
 /* Retries an Action
+   Retry
    Try Again. Action
    Try to load the list of interests again. */
 "Try Again" = "再試一次";
@@ -6111,6 +6560,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
 "Try the new Block Editor" = "試用全新的區塊編輯器";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "請嘗試使用其他電子郵件登入";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "請嘗試使用網站位址登入";
 
 /* Destructive menu title to remove the prompt card from the dashboard. */
 "Turn off prompts" = "關閉提示";
@@ -6153,6 +6608,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "USES";
+
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "無法連線";
 
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "無法載入文章";
@@ -6202,6 +6660,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "無法播放影片";
 
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "無法透過該 URL 讀取 WordPress 網站。 點選「需要更多說明？」即可檢視常見問題。";
+
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "無法還原網站";
 
@@ -6228,6 +6689,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Alert displayed to the user when a single post and 1 file has failed to upload. */
 "Unable to upload 1 post, 1 file" = "無法上傳 1 篇文章、1 個檔案";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "無法驗證電子郵件地址。請稍後再試一次。";
 
 /* Message displayed when visiting the Jetpack settings page fails. */
 "Unable to visit Jetpack settings for site" = "無法前往網站的 Jetpack 設定";
@@ -6372,7 +6836,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "上傳失敗";
 
-/* Label for the date a media asset (image / video) was uploaded */
+/* Label for the date a media asset (image / video) was uploaded
+   Status for Media object that is uploaded and sync with server. */
 "Uploaded" = "已上傳";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
@@ -6390,7 +6855,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "已上傳的布景主題";
 
-/* \"Uploading\" Status text */
+/* \"Uploading\" Status text
+   Status for Media object that is being uploaded. */
 "Uploading" = "正在上傳";
 
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
@@ -6405,18 +6871,27 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Use the current image */
 "Use" = "使用";
 
+/* The button's title text to use a security key. */
+"Use a security key" = "使用安全性金鑰";
+
 /* Option to enable the block editor for new posts */
 "Use block editor" = "使用區塊編輯器";
 
 /* No comment provided by engineer. */
 "Use icon button" = "使用圖示按鈕";
 
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "使用密碼登入";
+
 /* A placeholder for the twitter username
+   Accessibility label for the username text field in the self-hosted login page.
    Account Settings Username label
    Label for entering username in the username field
    Login dialog username placeholder
+   Placeholder for the username textfield.
    The header and main title
-   Username label text. */
+   Username label text.
+   Username placeholder */
 "Username" = "使用者名稱";
 
 /* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
@@ -6431,6 +6906,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Blog Users
    Noun. Title. Links to the user management feature. */
 "Users" = "使用者";
+
+/* two factor code placeholder */
+"Verification code" = "驗證碼";
 
 /* Message shown when a verification email was re-sent succesfully */
 "Verification email sent, check your inbox." = "驗證電子郵件已傳送，請查看收件匣";
@@ -6563,8 +7041,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Downloadable/Restorable items: WP-content directory */
 "WP-content directory" = "WP 內容目錄";
 
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "正在等待 Google 完成…";
+
 /* No comment provided by engineer. */
 "Waiting for connection" = "正在等待連線";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "正在等候安全性金鑰";
+
+/* View title during the Google auth process. */
+"Waiting..." = "等待中…";
 
 /* Editing GIF alert title.
    Noun. Title for Jetpack Restore warning.
@@ -6601,6 +7089,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "載入資料時遇到問題";
 
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "我們剛將連結以電子郵件傳送至 %@。請檢查你的電子郵件應用程式，並點選連結以登入。";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "我們剛將神奇連結傳送至：";
+
 /* Message displayed when a backup has finished */
 "We successfully created a backup of your site as of %@" = "我們已成功建立截至 %@ 為止的網站備份";
 
@@ -6610,14 +7104,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Informational text about link to other tracking tools */
 "We use other tracking tools, including some from third parties. Read about these and how to control them." = "我們會使用其他的追蹤工具，包括由第三方所提供的追蹤工具。瞭解相關資訊及其控制方式。";
 
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "我們目前無法寄送電子郵件給你。請稍後再試一次。";
+
 /* Description for label when the actively scanning the users site */
 "We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "如果發現安全性威脅，我們會傳送電子郵件給你。 這段時間你可以照常使用網站，也可以隨時回來檢視掃瞄進度。";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "我們會寄給你一個神奇的連結，讓你馬上就能登入，無須輸入密碼。不用再敲著兩隻手指打字了！";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "我們會透過電子郵件傳送註冊連結給你，使用此連結即可建立新的 WordPress.com 帳號。";
 
 /* This is the string we display when asking the user to approve push notifications */
 "We'll notify you when you get followers, comments, and likes." = "我們會在你收到關注、留言和按讚時通知你。";
 
 /* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
 "We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "我們會在你收到關注、留言和按讚時通知你。 是否要允許推播通知？";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "我們會使用這個電子郵件地址，為你建立全新的 WordPress.com 帳號。";
 
 /* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
 "We're creating a downloadable backup of your site from %1$@." = "我們正透過 %1$@ 建立你的網站的可下載備份。";
@@ -6628,6 +7134,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Detail text display informing the user that we're fixing threats */
 "We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "我們正努力在背景修正此威脅。 這段時間你可以照常使用網站，也可以隨時回來檢視掃瞄進度。";
 
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "我們無法用此 URL 連上 Jetpack 網站。如需協助，請與我們聯絡。";
+
 /* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
 "We're restoring your site back to %1$@." = "我們正在將你的網站還原至 %1$@。";
 
@@ -6636,6 +7145,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
 "We've also emailed you a link to your file." = "我們也已將檔案連結透過電子郵件傳送給你。";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "我們已透過電子郵件傳送註冊連結給你，使用此連結即可建立新的 WordPress.com 帳號。 請使用此裝置查看電子郵件，並點選 WordPress.com 所傳送電子郵件中的連結。";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -6662,6 +7174,12 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
 "Weekly Roundup: %@" = "每週綜合整理：%@";
+
+/* Post Signup Interstitial Title Text for Jetpack iOS */
+"Welcome to Jetpack" = "歡迎使用 Jetpack";
+
+/* Post Signup Interstitial Title Text for WordPress iOS */
+"Welcome to WordPress" = "歡迎來到 WordPress";
 
 /* A message title */
 "Welcome to the Reader" = "歡迎使用讀取器";
@@ -6706,6 +7224,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* This is a link that takes the user to the external Gravatar website */
 "What is Gravatar?" = "什麼是 Gravatar？";
 
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "什麼是 WordPress.com？";
+
 /* No comment provided by engineer. */
 "What is a block?" = "什麼是區塊？";
 
@@ -6722,10 +7243,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "What's New in Jetpack" = "Jetpack 的新功能";
 
 /* Opens the What's New / Feature Announcement modal */
-"What's New in Reader" = "閱讀器新功能";
-
-/* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "WordPress 新功能";
+
+/* Title of alert helping users understand their site address */
+"What's my site address?" = "我的網站位址是？";
 
 /* Select the site's intent. Title */
 "What's your website about?" = "你的網站主題為何？";
@@ -6739,6 +7260,18 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text display when the view when there aren't any Activities to display in the Activity Log */
 "When you make changes to your site you'll be able to see your activity history here." = "當你變更自己的網站內容時，即可在此查看你的活動記錄。";
 
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "糟糕，發生了點錯誤，我們無法將你登入。請再試一次！";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "糟糕，出狀況了。 請再試一次！";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "糟糕，安全性金鑰似乎不是有效的。 請使用另一組金鑰再試一次";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "糟糕，此雙重驗證碼無效。請再次檢查你的驗證碼，然後再試一次！";
+
 /* No comment provided by engineer. */
 "Width Settings" = "寬度設定";
 
@@ -6751,17 +7284,38 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
 
+/* Siri Suggestion to open App Settings */
+"WordPress App Settings" = "WordPress 應用程式設定";
+
 /* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
 "WordPress Apps - Apps for any screen" = "WordPress 應用程式 - 適用任何螢幕";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "WordPress 網誌";
 
+/* Siri Suggestion to open Support */
+"WordPress Help" = "WordPress 說明";
+
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "WordPress 媒體庫";
 
+/* Siri Suggestion to open Notification Settings */
+"WordPress Notification Settings" = "WordPress 通知設定";
+
+/* Siri Suggestion to open Notifications */
+"WordPress Notifications" = "WordPress 通知";
+
 /* Downloadable/Restorable items: WordPress Plugins */
 "WordPress Plugins" = "WordPress 外掛程式";
+
+/* Siri Suggestion to open Me tab */
+"WordPress Profile" = "WordPress 個人檔案";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Reader" = "WordPress 讀取器";
+
+/* Siri Suggestion to open My Sites */
+"WordPress Site Details" = "WordPress 網站詳細資料";
 
 /* Downloadable/Restorable items: WordPress Themes */
 "WordPress Themes" = "WordPress 佈景主題";
@@ -6772,17 +7326,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for label when the user's site is a multisite. */
 "WordPress multisites are not supported" = "不支援 WordPress 多站台";
 
+/* Explaining to the user why the app needs access to the device location. */
+"WordPress needs permission to access your device's current location in order to add it to your post. Please update your privacy settings." = "WordPress 需要取得你的同意以存取裝置目前的位置，並將其新增到你的文章。請更新你的隱私設定。";
+
 /* Downloadable/Restorable items: WordPress root */
 "WordPress root" = "WordPress 根目錄";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "WordPress 版本過舊";
 
+/* No comment provided by engineer. */
+"WordPress version too old. The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "WordPress 版本過舊。網址為 %1$@ 的網站使用 WordPress %2$@。建議更新至最新版本，或至少更新至 %3$@";
+
 /* Label for WordPress.com followers */
 "WordPress.com" = "WordPress.com";
 
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "WordPress.com 帳號";
+
+/* Title for the Plans list header */
+"WordPress.com Plans" = "WordPress.com 方案";
 
 /* Title for the WordPress.com themes section, should be the same as in Calypso */
 "WordPress.com Themes" = "WordPress.com 佈景主題";
@@ -6813,6 +7376,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Write Post" = "撰寫文章";
 
 /* Placeholder text for inline compose view */
+"Write a reply" = "撰寫回覆";
+
+/* Placeholder text for inline compose view */
 "Write a reply…" = "撰寫回應…";
 
 /* Title for the writing section in site settings screen */
@@ -6826,6 +7392,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* No comment provided by engineer. */
 "Y-Axis Position" = "Y 軸位置";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo奇摩電子信箱";
 
 /* 'This Year' label for the the year. */
 "Year" = "年";
@@ -6910,6 +7479,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Displayed when the user views trashed in the posts list and there are no posts */
 "You don't have any trashed posts" = "你沒有任何已移至垃圾桶的文章";
 
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"You don't have permission to view this private blog." = "你沒有檢視此私人網誌的權限。";
+
 /* Description for the first domain purchased with a paid plan. */
 "You have a free one-year domain registration with your plan." = "你的方案已包含一年免費網域註冊。";
 
@@ -6925,7 +7497,8 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
 "You have no reminders set." = "你目前並未設定任何提醒。";
 
-/* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
+/* Show when clicking cancel on a comment text box and you didn't save your changes.
+   Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "您有新設定尚未儲存。";
 
 /* Displayed when the user views published pages in the pages list and there are no pages */
@@ -7012,9 +7585,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Help text that describes how the password should be. It appears while editing the password */
 "Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ & )." = "密碼必須至少包含 6 個字元。若要提升密碼強度，可使用大小寫字母、數字，以及 ! \" ? $ % ^ & ) 等符號。";
 
-/* Message of Export Content confirmation alert */
-"Your posts, pages, and settings will be mailed to the account's email address." = "系統會將你的文章、頁面與設定傳送至此帳號的電子郵件地址。";
-
 /* Message of Export Content confirmation alert; substitution is user's email address */
 "Your posts, pages, and settings will be mailed to you at %@." = "我們會將你的文章、網頁與設定透過電子郵件傳送至 %@。";
 
@@ -7023,6 +7593,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* This is shown to the user when their domain search query contains invalid characters. */
 "Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "你的搜尋包含 WordPress.com 網域不支援的字元。 允許使用以下字元：A–Z、a–z、0–9。";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "當你使用 Safari 造訪自己的網站時，網站位址會顯示在畫面上方的網址列中。";
 
 /* Description for label when the user has a site with VaultPress. */
 "Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "你的網站已受 VaultPress 保護 按下方連結即可前往你的 VaultPress 儀表板。";
@@ -7102,17 +7675,23 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility identifier for an 'Add Comment' button */
 "addCommentButton.accessibilityIdentifity" = "新增留言";
 
-/* Error message when user cancels login */
-"addSite.selfHosted.cancelled" = "登入已取消";
+/* Error message shown a URL does not point to an existing site. */
+"addSite.restApiNotAvailable" = "此地址的網站不是 WordPress 網站。 網站必須使用 WordPress，以利連結作業。";
+
+/* Error message shown when an receiving an invalid application-password authentication result from a self-hosted WordPress site */
+"addSite.selfHosted.authenticationFailed" = "無法透過應用程式密碼驗證登入。";
 
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "請輸入要連結的 WordPress 網站位址。";
 
+/* Error message when user input is not a WordPress site */
+"addSite.selfHosted.invalidUrl" = "網站位址無效。";
+
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "無法載入 WordPress 網站詳細資料";
 
-/* Error message when user signs in with an unexpected usern. The first argument is the expected username */
-"addSite.selfHosted.mismatchUser" = "請以目前登入的使用者身分登入。 使用者名稱：%@";
+/* Error message shown when application-password authentication is disabled on a self-hosted WordPress site */
+"addSite.selfHosted.noLoginUrlFound" = "請在 WordPress 網站啟用應用程式密碼驗證。";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "無法儲存 WordPress 網站，請稍後再試一次。";
@@ -7120,17 +7699,14 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "新增自助託管網站";
 
-/* Error message when XML-RPC is disabled on the WordPress site. The first argument is detailed error message */
-"addSite.selfHosted.xmlrpcDisabled" = "無法連結 WordPress 網站。 伺服器上的 XML-RPC 可能已停用。 請聯絡主機服務提供者以解決問題。";
+/* Error message when an unknown error occurred when adding a self-hosted site */
+"addSite.selfHosted.unknownError" = "發生錯誤。 請再試一次。";
 
 /* Age between dates equaling one hour. */
 "an hour" = "一小時";
 
 /* This is the string we display when prompting the user to review the Jetpack app */
 "appRatings.jetpack.prompt" = "你覺得 Jetpack 如何？";
-
-/* This is the string we display when prompting the user to review the Reader app */
-"appRatings.reader.prompt" = "你覺得閱讀器如何？";
 
 /* This is the string we display when prompting the user to review the WordPress app */
 "appRatings.wordpress.prompt" = "你覺得 WordPress 如何？";
@@ -7825,6 +8401,10 @@ Example: Reply to Pamela Nguyen */
 /* Shared empty state view */
 "emptyStateView.noSearchResult.title" = "沒有結果";
 
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "example.com";
+
 /* Accept button title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackAccept" = "傳送意見";
 
@@ -7836,9 +8416,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackTitle" = "分享意見";
-
-/* Communicates the future removal of the option to disable the experimental editor, displayed beneath the experimental features list */
-"experimentalFeatures.editorNote" = "試用版區塊編輯器將在未來版本中成為預設選項，屆時將無法停用。";
 
 /* The title for the experimental features list */
 "experimentalFeaturesList.heading" = "實驗性功能";
@@ -7885,8 +8462,14 @@ Example: Reply to Pamela Nguyen */
 /* A footer retry button */
 "general.pagingFooterView.retry" = "重試";
 
+/* Error message format when REST API returns an error response. The first argument is error message. */
+"generic.error.rest-api-error" = "你的網站傳送了錯誤回應：%@";
+
 /* A generic title for an error */
 "generic.error.title" = "錯誤";
+
+/* Error message when failing to parse API responses */
+"generic.error.unparsableResponse" = "你的網站傳送了應用程式無法解析的回應";
 
 /* Title for button that will open up the blogging reminders screen. */
 "growAudienceCell.bloggingReminders.actionButton" = "設定網誌提醒";
@@ -8058,42 +8641,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Title of the Jetpack powered overlay. */
 "jetpack.branding.overlay.title" = "WordPress 搭配 Jetpack 效果更加";
-
-/* Title for the button that starts the Jetpack connection process */
-"jetpack.connection.connect.button" = "連結你的網站";
-
-/* Error message shown when WordPress.com authentication fails */
-"jetpack.connection.error.authentication" = "無效的 WordPress.com 帳號";
-
-/* Error message shown when a connection step is attempted in an invalid order */
-"jetpack.connection.error.context" = "此步驟尚未準備就緒";
-
-/* Title for the retry button shown when a connection step fails */
-"jetpack.connection.retry.button" = "重試";
-
-/* Status message when a connection step is pending */
-"jetpack.connection.stage.pending" = "等待開始";
-
-/* Status message when a connection step is in progress */
-"jetpack.connection.stage.processing" = "進行中...";
-
-/* Status message when a connection step is completed successfully */
-"jetpack.connection.stage.success" = "已完成";
-
-/* Title for the finalization step in Jetpack connection flow */
-"jetpack.connection.step.finalize.title" = "完成連線";
-
-/* Title for the install step in Jetpack connection flow */
-"jetpack.connection.step.install.title" = "安裝 Jetpack";
-
-/* Title for the login step in Jetpack connection flow */
-"jetpack.connection.step.login.title" = "登入 WordPress.com";
-
-/* Title for the site connection step in Jetpack connection flow */
-"jetpack.connection.step.site.title" = "連結至網站";
-
-/* Title for the user connection step in Jetpack connection flow */
-"jetpack.connection.step.user.title" = "連結你的 WordPress.com 帳號";
 
 /* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
 "jetpack.fullscreen.overlay.early.switch.title" = "切換至全新 Jetpack 應用程式";
@@ -8314,41 +8861,11 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "你沒有檢視此私人網誌的權限。";
 
-/* Button to dismiss the re-authentication view */
-"login.appPasswordReAuth.cancelButton" = "取消";
-
-/* Description explaining why the user needs to re-authenticate */
-"login.appPasswordReAuth.description" = "指派給應用程式的這組密碼已不在你的個人檔案。\n請重新登入，為應用程式建立新的密碼。";
-
-/* Button to start the re-authentication process */
-"login.appPasswordReAuth.signInButton" = "登入";
-
-/* Title shown when the application password is invalid */
-"login.appPasswordReAuth.title" = "無效的應用程式密碼";
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "請輸入驗證器應用程式的 WordPress.com 帳號驗證碼。";
 
 /* Indicating that referrer was marked as spam */
 "marked as spam" = "已標示為垃圾訊息";
-
-/* Button title when verification link sending failed */
-"me.verifyEmail.button.retry" = "請再試一次";
-
-/* Button title to send verification link */
-"me.verifyEmail.button.send" = "重新傳送電子郵件";
-
-/* Button title while verification link is being sent */
-"me.verifyEmail.button.sending" = "正在傳送...";
-
-/* Button title after verification link is sent */
-"me.verifyEmail.button.sent" = "電子郵件已寄出！";
-
-/* Message for email verification card */
-"me.verifyEmail.message.noEmail" = "請驗證你的電子郵件地址，以保護帳號並使用更多功能。\n請前往收件匣查看確認郵件，或按一下「%@」重新傳送。";
-
-/* Message for email verification card with email address */
-"me.verifyEmail.message.withEmail" = "請驗證你的電子郵件地址，以保護帳號並使用更多功能。\n請前往 %1$@ 查看確認郵件，或按一下「%2$@」重新傳送。";
-
-/* Title for email verification card */
-"me.verifyEmail.title" = "驗證你的電子郵件地址";
 
 /* Me tab menu items */
 "meMenu.submitFeedback" = "傳送意見回饋";
@@ -8791,6 +9308,9 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "上層頁面";
 
+/* No comment provided by engineer. */
+"password" = "密碼";
+
 /* Section footer displayed below the list of toggles */
 "personalizeHome.cardsSectionFooter" = "資訊卡可根據網站活動顯示不同內容。 我們正在開發更多資訊卡和控制功能。";
 
@@ -8895,9 +9415,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Message shown while loading plugin details */
 "pluginDetails.loading" = "正在載入外掛程式資訊...";
-
-/* Placeholder message shown when a plugin has no description */
-"pluginDetails.noDescription" = "這個外掛程式未提供任何說明。";
 
 /* Title of the changelog section in plugin details */
 "pluginDetails.section.changelog" = "變更記錄";
@@ -9187,6 +9704,30 @@ Example: Reply to Pamela Nguyen */
 /* An alert message explaning that by changing the visibility to private, the post will be published immediately to your site */
 "postSettings.warningPostWillBePublishedAlertMessage" = "在你將可見度變更為「私密」後，系統就會立刻發表文章";
 
+/* Localized post type: `Page` */
+"postType.page" = "頁面";
+
+/* Localized post type: `Post` */
+"postType.post" = "文章";
+
+/* Details for a 'Private' privacy setting */
+"postVisibility.private.details" = "僅網站管理員及編輯者可檢視";
+
+/* Title for a 'Private' privacy setting */
+"postVisibility.private.title" = "私人";
+
+/* Details for a 'Password Protected' privacy setting */
+"postVisibility.protected.details" = "所有人都可檢視但需要密碼";
+
+/* Title for a 'Password Protected' privacy setting */
+"postVisibility.protected.title" = "受密碼保護";
+
+/* Details for a 'Public' (default) privacy setting */
+"postVisibility.public.details" = "所有人都能檢視";
+
+/* Title for a 'Public' (default) privacy setting */
+"postVisibility.public.title" = "公開";
+
 /* Button cancel */
 "postVisibilityPicker.cancel" = "取消";
 
@@ -9404,18 +9945,6 @@ Tapping on this row allows the user to edit the sharing message. */
 /* Title for the success view when the user has successfully logged in */
 "qrLoginVerifyAuthorization.completedInstructions.title" = "你已登入！";
 
-/* No comment provided by engineer. */
-"reachability-utils.alert.cancel" = "確定";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.retry" = "要重試嗎？";
-
-/* No comment provided by engineer. */
-"reachability-utils.alert.title" = "沒有連線";
-
-/* Message of error prompt shown when no internet connection is available */
-"reachability-utils.alert.utils" = "網際網路連線似乎已中斷。";
-
 /* Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog. */
 "reader.blocked.blog.message" = "網誌「%@」將不再顯示於你的讀取器中。 點選以復原。";
 
@@ -9452,26 +9981,8 @@ Tapping on this row allows the user to edit the sharing message. */
 /* A shared button title for Reader */
 "reader.button.unsubscribe" = "取消訂閱";
 
-/* Button title. Follow the comments on a post. */
-"reader.comments.buttonFollow" = "追蹤";
-
 /* Informational message, should be short. */
 "reader.comments.commentsClosed" = "留言已關閉";
-
-/* Empty state view title */
-"reader.comments.emptyStateTitle" = "留下第一則留言。";
-
-/* Empty state view title */
-"reader.comments.errorLoadingComments" = "載入留言時發生未預期的錯誤。";
-
-/* VoiceOver hint */
-"reader.comments.followingSettingAccessibilityIdentifier" = "開啟文章的通知設定";
-
-/* Error message that informs reader comments from a private blog cannot be fetched. */
-"reader.comments.noPermissionToViewPrivateBlog" = "你沒有這個私人網誌的檢視權限。";
-
-/* Navigation title */
-"reader.comments.title" = "留言";
 
 /* Accessibility hint to inform that the author section can be tapped to see posts from the site. */
 "reader.detail.header.authorInfo.a11y.hint" = "檢視網站的文章";
@@ -9549,23 +10060,8 @@ but tapping on this button will remove their like from the post. */
 /* Screen header details */
 "reader.following.header.details" = "掌握訂閱網誌的最新動態。";
 
-/* Empty state view */
-"reader.following.lists.emptyTitle" = "清單沒有內容";
-
-/* Screen header details */
-"reader.home.header.details" = "隨時掌握你訂閱的網誌最新動態。";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.home.title" = "首頁";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.library.title" = "媒體庫";
-
 /* Used in multiple contexts, usually as a screen title */
 "reader.likes.title" = "讚";
-
-/* Used in multiple contexts, usually as a screen title */
-"reader.lists.title" = "清單";
 
 /* Reader logged-out screen details */
 "reader.loggedOut.details" = "使用 a WordPress.com 帳號登入並追蹤你喜愛的網誌";
@@ -9799,8 +10295,7 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Title of a Reader tab showing Posts matching a user's search query */
 "reader.search.tab.posts" = "文章";
 
-/* Title of the Reader's search feature
-   Used in multiple contexts, usually as a screen title */
+/* Title of the Reader's search feature */
 "reader.search.title" = "搜尋";
 
 /* Screen title. Reader select interests title label text. */
@@ -9826,6 +10321,21 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Reader select interests title label text */
 "reader.select.tags.title" = "探索並關注你喜愛的網誌";
+
+/* Reader sidebar menu item */
+"reader.sidebar.discover" = "探索";
+
+/* Reader sidebar menu item */
+"reader.sidebar.likes" = "讚";
+
+/* Reader sidebar menu item */
+"reader.sidebar.recent" = "近期";
+
+/* Reader sidebar menu item */
+"reader.sidebar.saved" = "已儲存";
+
+/* Reader sidebar menu item */
+"reader.sidebar.search" = "搜尋";
 
 /* Reader sidebar section title */
 "reader.sidebar.section.favorites.title" = "我的最愛";
@@ -9872,7 +10382,7 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Number of subscriptions on a site (singular) */
 "reader.subscriptions.subscriptionsSingular" = "%@ 位訂閱者";
 
-/* Used in multiple contexts, usually as a screen title */
+/* Navigation bar title */
 "reader.subscriptions.title" = "訂閱";
 
 /* A suggestion of topics the user might want to subscribe to */
@@ -9914,26 +10424,11 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Verb. Button title. The user is following a tag. */
 "reader.tags.following.button.title" = "正在追蹤";
 
-/* Used in multiple contexts, usually as a screen title */
-"reader.tags.title" = "標籤";
-
 /* Accessibility label for unsubscribing from a tag */
 "reader.tags.unfollow.accessibility.label" = "停止追蹤 %@";
 
 /* Field title */
 "reader.userProfile.site" = "網站";
-
-/* Reader Welcome screen login button */
-"reader.welcome.continueText" = "繼續使用 WordPress.com";
-
-/* Reader Welcome screen */
-"reader.welcome.subtitle" = "加入最大的網誌社群";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.me" = "我";
-
-/* Reader app primary navigation tab bar */
-"readerApp.tabBar.notifications" = "通知";
 
 /* Spoken accessibility label */
 "readerDetail.backButton.accessibilityLabel" = "返回";
@@ -10208,14 +10703,10 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Message shown when there are no inactive plugins on the site */
 "site.plugins.empty.inactive" = "沒有閒置的外掛程式";
 
-/* The plugin fillter option for displaying active plugins */
-"site.plugins.filter.option.active" = "已啟用";
-
-/* The plugin fillter option for displaying all plugins */
+/* The plugin fillter option for displaying active plugins
+   The plugin fillter option for displaying all plugins
+   The plugin fillter option for displaying inactive plugins */
 "site.plugins.filter.option.all" = "全部";
-
-/* The plugin fillter option for displaying inactive plugins */
-"site.plugins.filter.option.inactive" = "未啟用";
 
 /* Title of the plugin filter picker */
 "site.plugins.filter.title" = "篩選";
@@ -10909,8 +11400,119 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* A title for the filter on the PHP logs screen */
 "webServerLogs.filterStatus" = "狀態";
 
+/* Preview title of all-time posts and most views widget */
+"widget.allTimePostViews.previewTitle" = "有史以來的文章數與最高瀏覽數";
+
+/* Preview title of all-time views widget */
+"widget.allTimeViews.previewTitle" = "有史以來的瀏覽次數";
+
+/* Preview title of all-time views and visitors widget */
+"widget.allTimeViewsVisitors.previewTitle" = "有史以來的瀏覽次數與訪客數";
+
+/* Title of best views ever label in all time widget */
+"widget.alltime.bestviews.label" = "最高記錄的瀏覽次數";
+
+/* Title of the label which displays the number of the most daily views the site has ever had. Keep the translation as short as possible. */
+"widget.alltime.bestviewsshort.label" = "最高瀏覽數";
+
+/* Title of the no data view in all time widget */
+"widget.alltime.nodata.view.title" = "無法載入所有時間的統計資料。";
+
+/* Title of the no site view in all time widget */
+"widget.alltime.nosite.view.title" = "建立或新增網站以查看所有時間的統計資料。";
+
+/* Title of posts label in all time widget */
+"widget.alltime.posts.label" = "文章";
+
+/* Description of all time widget in the preview */
+"widget.alltime.preview.description" = "隨時掌握 WordPress 網站上的所有活動。";
+
+/* Title of all time widget */
+"widget.alltime.title" = "開站以來";
+
+/* Title of the unconfigured view in all time widget */
+"widget.alltime.unconfigured.view.title" = "登入 WordPress 查看所有統計資料。";
+
+/* Title of the unconfigured view in all time widget */
+"widget.jetpack.alltime.unconfigured.view.title" = "登入 Jetpack 以查看所有統計資料。";
+
+/* Title of the unconfigured view in this week widget */
+"widget.jetpack.thisweek.unconfigured.view.title" = "登入 Jetpack 以查看本週的統計資料。";
+
+/* Title of the unconfigured view in today widget */
+"widget.jetpack.today.unconfigured.view.title" = "登入 Jetpack 以查看今日的統計資料。";
+
+/* Title of the one-liner information consist of views field and all time date range in lock screen all time views widget */
+"widget.lockscreen.alltimeview.label" = "有史以來的瀏覽次數";
+
+/* Title of the one-liner information consist of views field and today date range in lock screen today views widget */
+"widget.lockscreen.todayview.label" = "本日瀏覽次數";
+
+/* Title of the no data view in this week widget */
+"widget.thisweek.nodata.view.title" = "無法載入本週統計資料。";
+
+/* Title of the no site view in this week widget */
+"widget.thisweek.nosite.view.title" = "建立或新增網站以查看本週統計資料。";
+
+/* Description of all time widget in the preview */
+"widget.thisweek.preview.description" = "隨時掌握本週 WordPress 網站上的活動。";
+
+/* Title of this week widget */
+"widget.thisweek.title" = "本週";
+
+/* Title of the unconfigured view in this week widget */
+"widget.thisweek.unconfigured.view.title" = "登入 WordPress 查看本週的統計資料。";
+
+/* Title of comments label in today widget */
+"widget.today.comments.label" = "留言";
+
+/* Title of the disabled view in today widget */
+"widget.today.disabled.view.title" = "統計資料已移至 Jetpack 應用程式。你可以免費切換，只需一分鐘就能完成。";
+
+/* Title of likes label in today widget */
+"widget.today.likes.label" = "按讚數";
+
+/* Fallback title of the no data view in the stats widget */
+"widget.today.nodata.view.fallbackTitle" = "無法載入網站統計資料。";
+
+/* Title of the no data view in today widget */
+"widget.today.nodata.view.title" = "無法載入本日統計資料。";
+
+/* Title of the no site view in today widget */
+"widget.today.nosite.view.title" = "建立或新增網站以查看本日統計資料。";
+
+/* Description of today widget in the preview */
+"widget.today.preview.description" = "隨時掌握今天 WordPress 網站上的活動。";
+
+/* Title of today widget */
+"widget.today.title" = "今天";
+
+/* Title of the unconfigured view in today widget */
+"widget.today.unconfigured.view.title" = "登入 WordPress 查看今天的統計資料。";
+
+/* Error message to show if a widget view is unavailable */
+"widget.today.view.unavailable.title" = "無法檢視";
+
+/* Title of views label in today widget */
+"widget.today.views.label" = "點閱數";
+
+/* Title of visitors label in today widget */
+"widget.today.visitors.label" = "訪客";
+
+/* Preview title of today's likes and commnets widget */
+"widget.todayLikesComments.previewTitle" = "本日按讚數與留言數";
+
+/* Preview title of today's views widget */
+"widget.todayViews.previewTitle" = "本日瀏覽次數";
+
+/* Preview title of today's views and visitors widget */
+"widget.todayViewsVisitors.previewTitle" = "本日瀏覽次數與訪客";
+
 /* Second part of delete screen title stating [the site] will be unavailable in the future. */
 "will be unavailable in the future." = "日後將無法使用。";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "是否建立新網站？";
 
 /* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
 "wordpress, help, support, faq, questions, debug, logs, help center, contact" = "wordpress, 說明, 支援, 常見問題集, 問題, 除錯, 記錄, 說明中心, 聯絡";
@@ -10935,6 +11537,9 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Error message that describes an unknown error had occured */
 "wordpress-api.error.unknown" = "發生錯誤，請稍後再試一次。";
+
+/* Error message when failing to find selected media file on the user's device. */
+"wordpress.api.upload.media.fileNotFound" = "找不到裝置的媒體檔案位置";
 
 /* Jetpack Plugin Modal on WordPress primary button title */
 "wordpress.jetpack.plugin.modal.primary.button.title" = "切換至 Jetpack 應用程式";
@@ -10981,21 +11586,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Error message when user signs in with an unexpected email address. The first argument is the expected email address */
 "wpComLogin.error.mismatchedEmail" = "請使用電子郵件地址 %@ 登入";
 
-/* Message shown when user denies WordPress.com login, offering option to try with different account */
-"wpComLogin.loginDenied.message" = "如果你需要使用其他帳號，可以選擇以不同帳號登入。 點選「%@」開始使用。";
-
-/* Title of alert shown when user cancels WordPress.com login */
-"wpComLogin.loginDenied.title" = "登入已取消";
-
-/* Button title for signing in with a different WordPress.com account */
-"wpComLogin.loginDenied.useDifferentAccount" = "使用其他帳號";
-
-/* Button title to log out the current WordPress.com account */
-"wpcom.token.alert.button.logout" = "登出";
-
-/* Button title to Sign In to WordPress.com */
-"wpcom.token.alert.button.signin" = "登入";
-
 /* Message title to be displayed when the user needs to re-authenticate their WordPress.com account. */
 "wpcom.token.fix.signin" = "登入 WordPress.com";
 
@@ -11010,6 +11600,9 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Managing Zendesk attachments */
 "zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "不支援的附件";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} 透過 Google 登入。";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "•網域";

--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -191,7 +191,7 @@ platform :ios do
       paths: [
         'WordPress/',
         'Modules/Sources/',
-        'WordPressAuthenticator/Sources/',
+        'Sources/WordPressAuthenticator',
         gutenberg_path,
         *REMOTE_SWIFT_PACKAGES_TO_LOCALIZE.map { |name| File.join(derived_data_path, 'SourcePackages', 'checkouts', name, 'Sources') }
       ],


### PR DESCRIPTION
Fixes localization by adjusting the search paths, re-generating the localization file, and reverting the downloaded changes.

After this PR lands, we'll need to upload the changes to GlotPress, then re-run the `download_localized_strings_and_metadata` lane