### PR TITLE
Show an card to prompt application password authentication

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2f50dc7601f992ac0e22d0e32a759ef5d14289c7cc5f8b887c46073f7d50391b",
+  "originHash" : "43fbce57dedae27ed83f0ebd59ff2f81e3f0deffd1a163762504793d8642905b",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -380,8 +380,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/wordpress-rs",
       "state" : {
-        "branch" : "alpha-20250520",
-        "revision" : "a1960ad79ecec20a8b18deda447f2f45630b14ce"
+        "branch" : "alpha-20250523",
+        "revision" : "ed3784376b8efd1eafcf85caa9055b1c3b1f80da"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
         ),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
-        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250520"),
+        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250523"),
         .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "fdfe788530bbff864ce7147b5a68608d7025e078"),
         .package(
             url: "https://github.com/Automattic/color-studio",

--- a/Sources/WordPressData/Swift/Blog+SelfHosted.swift
+++ b/Sources/WordPressData/Swift/Blog+SelfHosted.swift
@@ -189,10 +189,19 @@ public enum WordPressSite {
     case selfHosted(blogId: TaggedManagedObjectID<Blog>, apiRootURL: ParsedUrl, username: String, authToken: String)
 
     public init(blog: Blog) throws {
-        if let account = blog.account, let siteId = blog.dotComID?.intValue {
+        // Directly access the site content when available.
+        if let restApiRootURL = blog.restApiRootURL,
+           let restApiRootURL = try? ParsedUrl.parse(input: restApiRootURL),
+           let username = blog.username,
+           let authToken = try? blog.getApplicationToken() {
+            self = .selfHosted(blogId: TaggedManagedObjectID(blog), apiRootURL: restApiRootURL, username: username, authToken: authToken)
+        } else if let account = blog.account, let siteId = blog.dotComID?.intValue {
+            // When the site is added via a WP.com account, access the site via WP.com
             let authToken = try account.authToken ?? WPAccount.token(forUsername: account.username)
             self = .dotCom(siteId: siteId, authToken: authToken)
         } else {
+            // In theory, this branch should never run, because the two if statements above should have covered all paths.
+            // But we'll keep it here as the fallback.
             let url = try blog.restApiRootURL ?? blog.getUrl().appending(path: "wp-json").absoluteString
             let apiRootURL = try ParsedUrl.parse(input: url)
             self = .selfHosted(blogId: TaggedManagedObjectID(blog), apiRootURL: apiRootURL, username: try blog.getUsername(), authToken: try blog.getApplicationToken())

--- a/Sources/WordPressData/Swift/Blog+SelfHosted.swift
+++ b/Sources/WordPressData/Swift/Blog+SelfHosted.swift
@@ -183,9 +183,9 @@ public enum WordPressSite {
     case selfHosted(blogId: TaggedManagedObjectID<Blog>, apiRootURL: ParsedUrl, username: String, authToken: String)
 
     public init(blog: Blog) throws {
-        if let _ = blog.account {
-            // WP.com support is not ready yet.
-            throw NSError(domain: "WordPressAPI", code: 0)
+        if let account = blog.account, let siteId = blog.dotComID?.intValue {
+            let authToken = try account.authToken ?? WPAccount.token(forUsername: account.username)
+            self = .dotCom(siteId: siteId, authToken: authToken)
         } else {
             let url = try blog.restApiRootURL ?? blog.getUrl().appending(path: "wp-json").absoluteString
             let apiRootURL = try ParsedUrl.parse(input: url)

--- a/Sources/WordPressData/Swift/Blog+SelfHosted.swift
+++ b/Sources/WordPressData/Swift/Blog+SelfHosted.swift
@@ -20,12 +20,18 @@ public extension Blog {
         with details: WpApiApplicationPasswordDetails,
         restApiRootURL: URL,
         xmlrpcEndpointURL: URL,
+        blogID: TaggedManagedObjectID<Blog>?,
         in contextManager: ContextManager,
         using keychainImplementation: KeychainAccessible = KeychainUtils()
     ) async throws -> TaggedManagedObjectID<Blog> {
         try await contextManager.performAndSave { context in
-            let blog = Blog.lookup(username: details.userLogin, xmlrpc: xmlrpcEndpointURL.absoluteString, in: context)
-                ?? Blog.createBlankBlog(in: context)
+            let blog = if let blogID {
+                try context.existingObject(with: blogID)
+            } else {
+                Blog.lookup(username: details.userLogin, xmlrpc: xmlrpcEndpointURL.absoluteString, in: context)
+                    ?? Blog.createBlankBlog(in: context)
+            }
+
             blog.url = details.siteUrl
             blog.username = details.userLogin
             blog.restApiRootURL = restApiRootURL.absoluteString

--- a/Sources/WordPressData/Swift/Blog+SelfHosted.swift
+++ b/Sources/WordPressData/Swift/Blog+SelfHosted.swift
@@ -198,4 +198,23 @@ public enum WordPressSite {
             self = .selfHosted(blogId: TaggedManagedObjectID(blog), apiRootURL: apiRootURL, username: try blog.getUsername(), authToken: try blog.getApplicationToken())
         }
     }
+
+    public static func throughDotCom(blog: Blog) -> Self? {
+        guard
+            let account = blog.account,
+            let siteId = blog.dotComID?.intValue,
+            let authToken = try? account.authToken ?? WPAccount.token(forUsername: account.username)
+        else { return nil }
+
+        return .dotCom(siteId: siteId, authToken: authToken)
+    }
+
+    public func blog(in context: NSManagedObjectContext) throws -> Blog? {
+        switch self {
+        case let .dotCom(siteId, _):
+            return try Blog.lookup(withID: siteId, in: context)
+        case let .selfHosted(blogId, _, _ , _):
+            return try context.existingObject(with: blogId)
+        }
+    }
 }

--- a/Sources/WordPressData/Swift/Blog+SelfHosted.swift
+++ b/Sources/WordPressData/Swift/Blog+SelfHosted.swift
@@ -222,7 +222,7 @@ public enum WordPressSite {
         switch self {
         case let .dotCom(siteId, _):
             return try Blog.lookup(withID: siteId, in: context)
-        case let .selfHosted(blogId, _, _ , _):
+        case let .selfHosted(blogId, _, _, _):
             return try context.existingObject(with: blogId)
         }
     }

--- a/Tests/KeystoneTests/Tests/Models/Blog+RestAPITests.swift
+++ b/Tests/KeystoneTests/Tests/Models/Blog+RestAPITests.swift
@@ -19,6 +19,7 @@ final class Blog_RestAPITests: CoreDataTestCase {
             with: loginDetails,
             restApiRootURL: URL(string: "https://example.com/wp-json")!,
             xmlrpcEndpointURL: URL(string: "https://example.com/dir/xmlrpc.php")!,
+            blogID: nil,
             in: contextManager,
             using: testKeychain
         )

--- a/Tests/KeystoneTests/Tests/Services/CommentService+MorderationTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/CommentService+MorderationTests.swift
@@ -37,33 +37,14 @@ final class CommentService_MorderationTests: CoreDataTestCase {
         let commentService = CommentService(coreDataStack: contextManager)
 
         // Add a successful HTTP API call stub
-        stub(condition: isMethodPOST() && isPath("/wp/v2/sites/1/comments/3")) { _ in
+        stub(condition: isMethodPOST() && isPath("/rest/v1.1/sites/1/comments/3")) { _ in
             HTTPStubsResponse(
                 jsonObject: [
                     "id": 3,
                     "post": 2,
-                    "parent": 0,
-                    "author": 0,
-                    "author_name": "A WordPress Commenter",
-                    "author_email": "hello@example.com",
-                    "author_url": "https://wordpress.org/",
-                    "author_ip": "",
-                    "author_user_agent": "",
-                    "date": "2025-05-20T23:38:46",
-                    "date_gmt": "2025-05-20T23:38:46",
-                    "content": [
-                        "rendered": "<p>test comment</p>\n",
-                        "raw": "test comment"
-                    ],
-                    "link": "https://example.com/2025/05/20/hello-world/#comment-1",
                     "status": "approved",
                     "type": "comment",
-                    "author_avatar_urls": [
-                        "24": "https://secure.gravatar.com/avatar/123?s=24&d=mm&r=g",
-                        "48": "https://secure.gravatar.com/avatar/123?s=48&d=mm&r=g",
-                        "96": "https://secure.gravatar.com/avatar/123?s=96&d=mm&r=g"
-                    ],
-                    "meta": []
+                    "content": "<p>test comment</p>\n",
                 ] as [String: Any],
                 statusCode: 200,
                 headers: nil
@@ -88,38 +69,20 @@ final class CommentService_MorderationTests: CoreDataTestCase {
         let commentService = CommentService(coreDataStack: contextManager)
 
         // Add a successful HTTP API call stub
-        stub(condition: isMethodPOST() && isPath("/wp/v2/sites/1/comments/3")) { _ in
+        stub(condition: isMethodPOST() && isPath("/rest/v1.1/sites/1/comments/3")) { _ in
             HTTPStubsResponse(
                 jsonObject: [
                     "id": 3,
                     "post": 2,
-                    "parent": 0,
-                    "author": 0,
-                    "author_name": "A WordPress Commenter",
-                    "author_email": "hello@example.com",
-                    "author_url": "https://wordpress.org/",
-                    "author_ip": "",
-                    "author_user_agent": "",
-                    "date": "2025-05-20T23:38:46",
-                    "date_gmt": "2025-05-20T23:38:46",
-                    "content": [
-                        "rendered": "<p>test comment</p>\n",
-                        "raw": "test comment"
-                    ],
-                    "link": "https://example.com/2025/05/20/hello-world/#comment-1",
-                    "status": "hold",
+                    "status": "pending",
                     "type": "comment",
-                    "author_avatar_urls": [
-                        "24": "https://secure.gravatar.com/avatar/123?s=24&d=mm&r=g",
-                        "48": "https://secure.gravatar.com/avatar/123?s=48&d=mm&r=g",
-                        "96": "https://secure.gravatar.com/avatar/123?s=96&d=mm&r=g"
-                    ],
-                    "meta": []
+                    "content": "<p>test comment</p>\n",
                 ] as [String: Any],
                 statusCode: 200,
                 headers: nil
             )
         }
+
         // Call the moderation function and wait for it to complete
         waitUntil { done in
             commentService.unapproveComment(self.comment) {
@@ -138,38 +101,20 @@ final class CommentService_MorderationTests: CoreDataTestCase {
         let commentService = CommentService(coreDataStack: contextManager)
 
         // Add a successful HTTP API call stub
-        stub(condition: isMethodPOST() && isPath("/wp/v2/sites/1/comments/3")) { _ in
+        stub(condition: isMethodPOST() && isPath("/rest/v1.1/sites/1/comments/3")) { _ in
             HTTPStubsResponse(
                 jsonObject: [
                     "id": 3,
                     "post": 2,
-                    "parent": 0,
-                    "author": 0,
-                    "author_name": "A WordPress Commenter",
-                    "author_email": "hello@example.com",
-                    "author_url": "https://wordpress.org/",
-                    "author_ip": "",
-                    "author_user_agent": "",
-                    "date": "2025-05-20T23:38:46",
-                    "date_gmt": "2025-05-20T23:38:46",
-                    "content": [
-                        "rendered": "<p>test comment</p>\n",
-                        "raw": "test comment"
-                    ],
-                    "link": "https://example.com/2025/05/20/hello-world/#comment-1",
                     "status": "spam",
                     "type": "comment",
-                    "author_avatar_urls": [
-                        "24": "https://secure.gravatar.com/avatar/123?s=24&d=mm&r=g",
-                        "48": "https://secure.gravatar.com/avatar/123?s=48&d=mm&r=g",
-                        "96": "https://secure.gravatar.com/avatar/123?s=96&d=mm&r=g"
-                    ],
-                    "meta": []
+                    "content": "<p>test comment</p>\n",
                 ] as [String: Any],
                 statusCode: 200,
                 headers: nil
             )
         }
+
         // Call the moderation function and wait for it to complete
         waitUntil { done in
             commentService.spamComment(self.comment) {
@@ -188,38 +133,20 @@ final class CommentService_MorderationTests: CoreDataTestCase {
         let commentService = CommentService(coreDataStack: contextManager)
 
         // Add a successful HTTP API call stub
-        stub(condition: isMethodPOST() && isPath("/wp/v2/sites/1/comments/3")) { _ in
+        stub(condition: isMethodPOST() && isPath("/rest/v1.1/sites/1/comments/3")) { _ in
             HTTPStubsResponse(
                 jsonObject: [
                     "id": 3,
                     "post": 2,
-                    "parent": 0,
-                    "author": 0,
-                    "author_name": "A WordPress Commenter",
-                    "author_email": "hello@example.com",
-                    "author_url": "https://wordpress.org/",
-                    "author_ip": "",
-                    "author_user_agent": "",
-                    "date": "2025-05-20T23:38:46",
-                    "date_gmt": "2025-05-20T23:38:46",
-                    "content": [
-                        "rendered": "<p>test comment</p>\n",
-                        "raw": "test comment"
-                    ],
-                    "link": "https://example.com/2025/05/20/hello-world/#comment-1",
                     "status": "trash",
                     "type": "comment",
-                    "author_avatar_urls": [
-                        "24": "https://secure.gravatar.com/avatar/123?s=24&d=mm&r=g",
-                        "48": "https://secure.gravatar.com/avatar/123?s=48&d=mm&r=g",
-                        "96": "https://secure.gravatar.com/avatar/123?s=96&d=mm&r=g"
-                    ],
-                    "meta": []
+                    "content": "<p>test comment</p>\n",
                 ] as [String: Any],
                 statusCode: 200,
                 headers: nil
             )
         }
+
         // Call the moderation function and wait for it to complete
         waitUntil { done in
             commentService.trashComment(self.comment) {
@@ -238,37 +165,9 @@ final class CommentService_MorderationTests: CoreDataTestCase {
         let commentService = CommentService(coreDataStack: contextManager)
 
         // Add a successful HTTP API call stub
-        stub(condition: isMethodDELETE() && isPath("/wp/v2/sites/1/comments/3")) { _ in
+        stub(condition: isMethodPOST() && isPath("/rest/v1.1/sites/1/comments/3/delete")) { _ in
             HTTPStubsResponse(
-                jsonObject: [
-                    "deleted": true,
-                    "previous": [
-                        "id": 3,
-                        "post": 2,
-                        "parent": 0,
-                        "author": 0,
-                        "author_name": "A WordPress Commenter",
-                        "author_email": "hello@example.com",
-                        "author_url": "https://wordpress.org/",
-                        "author_ip": "",
-                        "author_user_agent": "",
-                        "date": "2025-05-20T23:38:46",
-                        "date_gmt": "2025-05-20T23:38:46",
-                        "content": [
-                            "rendered": "<p>test comment</p>\n",
-                            "raw": "test comment"
-                        ],
-                        "link": "https://example.com/2025/05/20/hello-world/#comment-1",
-                        "status": "approved",
-                        "type": "comment",
-                        "author_avatar_urls": [
-                            "24": "https://secure.gravatar.com/avatar/123?s=24&d=mm&r=g",
-                            "48": "https://secure.gravatar.com/avatar/123?s=48&d=mm&r=g",
-                            "96": "https://secure.gravatar.com/avatar/123?s=96&d=mm&r=g"
-                        ],
-                        "meta": []
-                    ]
-                ] as [String: Any],
+                jsonObject: [String: Any](),
                 statusCode: 200,
                 headers: nil
             )

--- a/Tests/KeystoneTests/Tests/Services/CommentService+MorderationTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/CommentService+MorderationTests.swift
@@ -37,14 +37,33 @@ final class CommentService_MorderationTests: CoreDataTestCase {
         let commentService = CommentService(coreDataStack: contextManager)
 
         // Add a successful HTTP API call stub
-        stub(condition: isMethodPOST() && isPath("/rest/v1.1/sites/1/comments/3")) { _ in
+        stub(condition: isMethodPOST() && isPath("/wp/v2/sites/1/comments/3")) { _ in
             HTTPStubsResponse(
                 jsonObject: [
                     "id": 3,
                     "post": 2,
+                    "parent": 0,
+                    "author": 0,
+                    "author_name": "A WordPress Commenter",
+                    "author_email": "hello@example.com",
+                    "author_url": "https://wordpress.org/",
+                    "author_ip": "",
+                    "author_user_agent": "",
+                    "date": "2025-05-20T23:38:46",
+                    "date_gmt": "2025-05-20T23:38:46",
+                    "content": [
+                        "rendered": "<p>test comment</p>\n",
+                        "raw": "test comment"
+                    ],
+                    "link": "https://example.com/2025/05/20/hello-world/#comment-1",
                     "status": "approved",
                     "type": "comment",
-                    "content": "<p>test comment</p>\n",
+                    "author_avatar_urls": [
+                        "24": "https://secure.gravatar.com/avatar/123?s=24&d=mm&r=g",
+                        "48": "https://secure.gravatar.com/avatar/123?s=48&d=mm&r=g",
+                        "96": "https://secure.gravatar.com/avatar/123?s=96&d=mm&r=g"
+                    ],
+                    "meta": []
                 ] as [String: Any],
                 statusCode: 200,
                 headers: nil
@@ -69,20 +88,38 @@ final class CommentService_MorderationTests: CoreDataTestCase {
         let commentService = CommentService(coreDataStack: contextManager)
 
         // Add a successful HTTP API call stub
-        stub(condition: isMethodPOST() && isPath("/rest/v1.1/sites/1/comments/3")) { _ in
+        stub(condition: isMethodPOST() && isPath("/wp/v2/sites/1/comments/3")) { _ in
             HTTPStubsResponse(
                 jsonObject: [
                     "id": 3,
                     "post": 2,
-                    "status": "pending",
+                    "parent": 0,
+                    "author": 0,
+                    "author_name": "A WordPress Commenter",
+                    "author_email": "hello@example.com",
+                    "author_url": "https://wordpress.org/",
+                    "author_ip": "",
+                    "author_user_agent": "",
+                    "date": "2025-05-20T23:38:46",
+                    "date_gmt": "2025-05-20T23:38:46",
+                    "content": [
+                        "rendered": "<p>test comment</p>\n",
+                        "raw": "test comment"
+                    ],
+                    "link": "https://example.com/2025/05/20/hello-world/#comment-1",
+                    "status": "hold",
                     "type": "comment",
-                    "content": "<p>test comment</p>\n",
+                    "author_avatar_urls": [
+                        "24": "https://secure.gravatar.com/avatar/123?s=24&d=mm&r=g",
+                        "48": "https://secure.gravatar.com/avatar/123?s=48&d=mm&r=g",
+                        "96": "https://secure.gravatar.com/avatar/123?s=96&d=mm&r=g"
+                    ],
+                    "meta": []
                 ] as [String: Any],
                 statusCode: 200,
                 headers: nil
             )
         }
-
         // Call the moderation function and wait for it to complete
         waitUntil { done in
             commentService.unapproveComment(self.comment) {
@@ -101,20 +138,38 @@ final class CommentService_MorderationTests: CoreDataTestCase {
         let commentService = CommentService(coreDataStack: contextManager)
 
         // Add a successful HTTP API call stub
-        stub(condition: isMethodPOST() && isPath("/rest/v1.1/sites/1/comments/3")) { _ in
+        stub(condition: isMethodPOST() && isPath("/wp/v2/sites/1/comments/3")) { _ in
             HTTPStubsResponse(
                 jsonObject: [
                     "id": 3,
                     "post": 2,
+                    "parent": 0,
+                    "author": 0,
+                    "author_name": "A WordPress Commenter",
+                    "author_email": "hello@example.com",
+                    "author_url": "https://wordpress.org/",
+                    "author_ip": "",
+                    "author_user_agent": "",
+                    "date": "2025-05-20T23:38:46",
+                    "date_gmt": "2025-05-20T23:38:46",
+                    "content": [
+                        "rendered": "<p>test comment</p>\n",
+                        "raw": "test comment"
+                    ],
+                    "link": "https://example.com/2025/05/20/hello-world/#comment-1",
                     "status": "spam",
                     "type": "comment",
-                    "content": "<p>test comment</p>\n",
+                    "author_avatar_urls": [
+                        "24": "https://secure.gravatar.com/avatar/123?s=24&d=mm&r=g",
+                        "48": "https://secure.gravatar.com/avatar/123?s=48&d=mm&r=g",
+                        "96": "https://secure.gravatar.com/avatar/123?s=96&d=mm&r=g"
+                    ],
+                    "meta": []
                 ] as [String: Any],
                 statusCode: 200,
                 headers: nil
             )
         }
-
         // Call the moderation function and wait for it to complete
         waitUntil { done in
             commentService.spamComment(self.comment) {
@@ -133,20 +188,38 @@ final class CommentService_MorderationTests: CoreDataTestCase {
         let commentService = CommentService(coreDataStack: contextManager)
 
         // Add a successful HTTP API call stub
-        stub(condition: isMethodPOST() && isPath("/rest/v1.1/sites/1/comments/3")) { _ in
+        stub(condition: isMethodPOST() && isPath("/wp/v2/sites/1/comments/3")) { _ in
             HTTPStubsResponse(
                 jsonObject: [
                     "id": 3,
                     "post": 2,
+                    "parent": 0,
+                    "author": 0,
+                    "author_name": "A WordPress Commenter",
+                    "author_email": "hello@example.com",
+                    "author_url": "https://wordpress.org/",
+                    "author_ip": "",
+                    "author_user_agent": "",
+                    "date": "2025-05-20T23:38:46",
+                    "date_gmt": "2025-05-20T23:38:46",
+                    "content": [
+                        "rendered": "<p>test comment</p>\n",
+                        "raw": "test comment"
+                    ],
+                    "link": "https://example.com/2025/05/20/hello-world/#comment-1",
                     "status": "trash",
                     "type": "comment",
-                    "content": "<p>test comment</p>\n",
+                    "author_avatar_urls": [
+                        "24": "https://secure.gravatar.com/avatar/123?s=24&d=mm&r=g",
+                        "48": "https://secure.gravatar.com/avatar/123?s=48&d=mm&r=g",
+                        "96": "https://secure.gravatar.com/avatar/123?s=96&d=mm&r=g"
+                    ],
+                    "meta": []
                 ] as [String: Any],
                 statusCode: 200,
                 headers: nil
             )
         }
-
         // Call the moderation function and wait for it to complete
         waitUntil { done in
             commentService.trashComment(self.comment) {
@@ -165,9 +238,37 @@ final class CommentService_MorderationTests: CoreDataTestCase {
         let commentService = CommentService(coreDataStack: contextManager)
 
         // Add a successful HTTP API call stub
-        stub(condition: isMethodPOST() && isPath("/rest/v1.1/sites/1/comments/3/delete")) { _ in
+        stub(condition: isMethodDELETE() && isPath("/wp/v2/sites/1/comments/3")) { _ in
             HTTPStubsResponse(
-                jsonObject: [String: Any](),
+                jsonObject: [
+                    "deleted": true,
+                    "previous": [
+                        "id": 3,
+                        "post": 2,
+                        "parent": 0,
+                        "author": 0,
+                        "author_name": "A WordPress Commenter",
+                        "author_email": "hello@example.com",
+                        "author_url": "https://wordpress.org/",
+                        "author_ip": "",
+                        "author_user_agent": "",
+                        "date": "2025-05-20T23:38:46",
+                        "date_gmt": "2025-05-20T23:38:46",
+                        "content": [
+                            "rendered": "<p>test comment</p>\n",
+                            "raw": "test comment"
+                        ],
+                        "link": "https://example.com/2025/05/20/hello-world/#comment-1",
+                        "status": "approved",
+                        "type": "comment",
+                        "author_avatar_urls": [
+                            "24": "https://secure.gravatar.com/avatar/123?s=24&d=mm&r=g",
+                            "48": "https://secure.gravatar.com/avatar/123?s=48&d=mm&r=g",
+                            "96": "https://secure.gravatar.com/avatar/123?s=96&d=mm&r=g"
+                        ],
+                        "meta": []
+                    ]
+                ] as [String: Any],
                 statusCode: 200,
                 headers: nil
             )

--- a/WordPress/Classes/Login/ApplicationPasswordReAuthenticationView.swift
+++ b/WordPress/Classes/Login/ApplicationPasswordReAuthenticationView.swift
@@ -37,7 +37,7 @@ struct ApplicationPasswordReAuthenticationView: View {
                                 .signIn(
                                     site: blog.getUrl().absoluteString,
                                     from: presenter,
-                                    context: .reauthentication(username: blog.getUsername())
+                                    context: .reauthentication(TaggedManagedObjectID(blog), username: blog.getUsername())
                                 )
 
                             // Automatically dismiss this view upon a successful re-authentication.

--- a/WordPress/Classes/Login/ApplicationPasswordRequiredView.swift
+++ b/WordPress/Classes/Login/ApplicationPasswordRequiredView.swift
@@ -45,7 +45,7 @@ struct ApplicationPasswordRequiredView<Content: View>: View {
         do {
             // Get an application password for the given site.
             let authenticator = SelfHostedSiteAuthenticator()
-            let blogID = try await authenticator.signIn(site: url, from: presenter, context: .reauthentication(username: blog.username))
+            let blogID = try await authenticator.signIn(site: url, from: presenter, context: .reauthentication(TaggedManagedObjectID(blog), username: blog.username))
 
             // Modify the `site` variable to display the intended feature.
             let blog = try ContextManager.shared.mainContext.existingObject(with: blogID)

--- a/WordPress/Classes/Login/SelfHostedSiteAuthenticator.swift
+++ b/WordPress/Classes/Login/SelfHostedSiteAuthenticator.swift
@@ -16,7 +16,16 @@ struct SelfHostedSiteAuthenticator {
         // Sign in to a self-hosted site. Using this context results in automatically reloading the app to display the site dashboard.
         case `default`
         // Sign in to a site that's alredy added to the app. This is typically used when the app needs to get a new application password.
-        case reauthentication(username: String?)
+        case reauthentication(TaggedManagedObjectID<Blog>, username: String?)
+
+        var blogID: TaggedManagedObjectID<Blog>? {
+            switch self {
+            case .default:
+                return nil
+            case let .reauthentication(blogID, _):
+                return blogID
+            }
+        }
     }
 
     private static let callbackURL = URL(string: "x-wordpress-app://login-callback")!
@@ -150,7 +159,7 @@ struct SelfHostedSiteAuthenticator {
             SVProgressHUD.dismiss()
         }
 
-        if case let .reauthentication(username) = context, let username, username != credentials.userLogin {
+        if case let .reauthentication(_, username) = context, let username, username != credentials.userLogin {
             throw .mismatchedUser(expectedUsername: username)
         }
 
@@ -165,7 +174,13 @@ struct SelfHostedSiteAuthenticator {
         // Only store the new site after credentials are validated.
         let blog: TaggedManagedObjectID<Blog>
         do {
-            blog = try await Blog.createRestApiBlog(with: credentials, restApiRootURL: apiRootURL, xmlrpcEndpointURL: xmlrpc, in: ContextManager.shared)
+            blog = try await Blog.createRestApiBlog(
+                with: credentials,
+                restApiRootURL: apiRootURL,
+                xmlrpcEndpointURL: xmlrpc,
+                blogID: context.blogID,
+                in: ContextManager.shared
+            )
         } catch {
             throw .savingSiteFailure
         }

--- a/WordPress/Classes/Login/SelfHostedSiteAuthenticator.swift
+++ b/WordPress/Classes/Login/SelfHostedSiteAuthenticator.swift
@@ -87,30 +87,32 @@ struct SelfHostedSiteAuthenticator {
 
     @MainActor
     func signIn(site: String, from viewController: UIViewController, context: SignInContext) async throws(SignInError) -> TaggedManagedObjectID<Blog> {
+        let details: AutoDiscoveryAttemptSuccess
         do {
-            let result = try await _signIn(site: site, from: viewController, context: context)
-            trackSuccess(url: site)
-            return result
+            details = try await internalClient.details(ofSite: site)
         } catch {
-            trackTypedError(error, url: site)
-            throw error
-        }
-    }
-
-    @MainActor
-    private func _signIn(site: String, from viewController: UIViewController, context: SignInContext) async throws(SignInError) -> TaggedManagedObjectID<Blog> {
-        do {
-            let (apiRootURL, credentials) = try await authenticate(site: site, from: viewController)
-            return try await handle(credentials: credentials, apiRootURL: apiRootURL, context: context)
-        } catch let error as SignInError {
-            throw error
-        } catch {
+            trackTypedError(.authentication(error), url: site)
             throw .authentication(error)
         }
+
+        return try await signIn(details: details, from: viewController, context: context)
     }
 
     @MainActor
-    private func authenticate(site: String, from viewController: UIViewController) async throws -> (apiRootURL: URL, credentials: WpApiApplicationPasswordDetails) {
+    func signIn(details: AutoDiscoveryAttemptSuccess, from viewController: UIViewController, context: SignInContext) async throws(SignInError) -> TaggedManagedObjectID<Blog> {
+        do {
+            let (apiRootURL, credentials) = try await authenticate(details: details, from: viewController)
+            let result = try await handle(credentials: credentials, apiRootURL: apiRootURL, context: context)
+            trackSuccess(url: details.parsedSiteUrl.url())
+            return result
+        } catch {
+            trackTypedError(error, url: details.parsedSiteUrl.url())
+            throw error
+        }
+    }
+
+    @MainActor
+    private func authenticate(details: AutoDiscoveryAttemptSuccess, from viewController: UIViewController) async throws(SignInError) -> (apiRootURL: URL, credentials: WpApiApplicationPasswordDetails) {
         let appId: WpUuid
         let appName: String
 
@@ -126,10 +128,13 @@ struct SelfHostedSiteAuthenticator {
         let timestamp = ISO8601DateFormatter.string(from: .now, timeZone: .current, formatOptions: .withInternetDateTime)
         let appNameValue = "\(appName) - \(deviceName) (\(timestamp))"
 
-        let details = try await internalClient.details(ofSite: site)
-        let loginURL = try details.loginURL(for: .init(id: appId, name: appNameValue, callbackUrl: SelfHostedSiteAuthenticator.callbackURL.absoluteString))
-        let callback = try await authorize(url: loginURL, callbackURL: SelfHostedSiteAuthenticator.callbackURL, from: viewController)
-        return (details.apiRootUrl.asURL(), try internalClient.credentials(from: callback))
+        do {
+            let loginURL = details.loginURL(for: .init(id: appId, name: appNameValue, callbackUrl: SelfHostedSiteAuthenticator.callbackURL.absoluteString))
+            let callback = try await authorize(url: loginURL, callbackURL: SelfHostedSiteAuthenticator.callbackURL, from: viewController)
+            return (details.apiRootUrl.asURL(), try internalClient.credentials(from: callback))
+        } catch {
+            throw .authentication(error)
+        }
     }
 
     @MainActor

--- a/WordPress/Classes/Services/CommentServiceRemoteFactory.swift
+++ b/WordPress/Classes/Services/CommentServiceRemoteFactory.swift
@@ -15,6 +15,7 @@ import WordPressKit
             return CommentServiceRemoteREST(wordPressComRestApi: api, siteID: dotComID)
         }
 
+        // The REST API does not have information about comment "likes". We'll continue to use WordPress.com API for now.
         if let site = try? WordPressSite(blog: blog) {
             return CommentServiceRemoteCoreRESTAPI(client: .init(site: site))
         }

--- a/WordPress/Classes/Services/CommentServiceRemoteFactory.swift
+++ b/WordPress/Classes/Services/CommentServiceRemoteFactory.swift
@@ -9,14 +9,14 @@ import WordPressKit
     /// - Parameter blog: A valid Blog object
     /// - Returns: A CommentServiceRemote instance
     @objc public func remote(blog: Blog) -> CommentServiceRemote? {
+        if let site = try? WordPressSite(blog: blog) {
+            return CommentServiceRemoteCoreRESTAPI(client: .init(site: site))
+        }
+
         if blog.supports(.wpComRESTAPI),
            let api = blog.wordPressComRestApi,
            let dotComID = blog.dotComID {
             return CommentServiceRemoteREST(wordPressComRestApi: api, siteID: dotComID)
-        }
-
-        if let site = try? WordPressSite(blog: blog) {
-            return CommentServiceRemoteCoreRESTAPI(client: .init(site: site))
         }
 
         if let api = blog.xmlrpcApi,

--- a/WordPress/Classes/Services/CommentServiceRemoteFactory.swift
+++ b/WordPress/Classes/Services/CommentServiceRemoteFactory.swift
@@ -9,14 +9,14 @@ import WordPressKit
     /// - Parameter blog: A valid Blog object
     /// - Returns: A CommentServiceRemote instance
     @objc public func remote(blog: Blog) -> CommentServiceRemote? {
-        if let site = try? WordPressSite(blog: blog) {
-            return CommentServiceRemoteCoreRESTAPI(client: .init(site: site))
-        }
-
         if blog.supports(.wpComRESTAPI),
            let api = blog.wordPressComRestApi,
            let dotComID = blog.dotComID {
             return CommentServiceRemoteREST(wordPressComRestApi: api, siteID: dotComID)
+        }
+
+        if let site = try? WordPressSite(blog: blog) {
+            return CommentServiceRemoteCoreRESTAPI(client: .init(site: site))
         }
 
         if let api = blog.xmlrpcApi,

--- a/WordPress/Classes/Services/MediaRepository.swift
+++ b/WordPress/Classes/Services/MediaRepository.swift
@@ -94,6 +94,9 @@ private extension MediaRepository {
             return MediaServiceRemoteREST(wordPressComRestApi: api, siteID: dotComID)
         }
 
+        // We use WordPress.com API for media management instead of WordPress core REST API to ensure
+        // compatibility with WordPress.com-specific features such as video upload restrictions
+        // and storage limits based on the site's plan.
         if let site = try? WordPressSite(blog: blog) {
             return MediaServiceRemoteCoreREST(client: .init(site: site))
         }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/ApplicationPasswordAuthenticationCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/ApplicationPasswordAuthenticationCard.swift
@@ -40,7 +40,6 @@ struct ApplicationPasswordAuthenticationCard: View {
     }
 }
 
-
 private enum Strings {
     static let newTitle = NSLocalizedString("application.password.new.title", value: "New: Application Passwords", comment: "Title for the new application passwords feature")
     static let description = NSLocalizedString("application.password.description", value: "You can now grant the app permission to use application passwords for quick and secure access to your site content.", comment: "Description for the application passwords feature")

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/ApplicationPasswordAuthenticationCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/ApplicationPasswordAuthenticationCard.swift
@@ -1,0 +1,48 @@
+import Foundation
+import WordPressUI
+import SwiftUI
+
+class ApplicationPasswordAuthenticationCardCell: UITableViewCell {
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+
+        let view = UIHostingView(view: ApplicationPasswordAuthenticationCard())
+        self.contentView.addSubview(view)
+        view.pinEdges()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+struct ApplicationPasswordAuthenticationCard: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 4) {
+                Image(systemName: "lock.circle.fill")
+                    .foregroundColor(.red)
+
+                Text(Strings.newTitle)
+                    .foregroundColor(.primary)
+            }
+            .font(.headline)
+
+            Text(Strings.description)
+                .font(.callout)
+                .foregroundColor(.primary)
+
+            Text(Strings.authorize)
+                .font(.callout.bold())
+                .foregroundStyle(Color.accentColor)
+        }
+        .padding()
+    }
+}
+
+
+private enum Strings {
+    static let newTitle = NSLocalizedString("application.password.new.title", value: "New: Application Passwords", comment: "Title for the new application passwords feature")
+    static let description = NSLocalizedString("application.password.description", value: "You can now grant the app permission to use application passwords for quick and secure access to your site content.", comment: "Description for the application passwords feature")
+    static let authorize = NSLocalizedString("application.password.authorize", value: "Authorize", comment: "Button label to authorize application passwords")
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/ApplicationPasswordAuthenticationCard.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/ApplicationPasswordAuthenticationCard.swift
@@ -2,7 +2,7 @@ import Foundation
 import WordPressUI
 import SwiftUI
 
-class ApplicationPasswordAuthenticationCardCell: UITableViewCell {
+public class ApplicationPasswordAuthenticationCardCell: UITableViewCell {
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
         super.init(style: style, reuseIdentifier: reuseIdentifier)
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.h
@@ -5,6 +5,7 @@
 @class CreateButtonCoordinator;
 @class IntrinsicTableView;
 @class MeViewController;
+@class ApplicationPasswordAuthenticationInfo;
 @protocol BlogDetailHeader;
 
 typedef NS_ENUM(NSUInteger, BlogDetailsSectionCategory) {
@@ -23,7 +24,8 @@ typedef NS_ENUM(NSUInteger, BlogDetailsSectionCategory) {
     BlogDetailsSectionCategorySotW2023Card,
     BlogDetailsSectionCategoryContent,
     BlogDetailsSectionCategoryTraffic,
-    BlogDetailsSectionCategoryMaintenance
+    BlogDetailsSectionCategoryMaintenance,
+    BlogDetailsSectionCategoryApplicationPasswordAuthentication
 };
 
 typedef NS_ENUM(NSUInteger, BlogDetailsSubsection) {
@@ -126,6 +128,10 @@ typedef NS_ENUM(NSUInteger, BlogDetailsSubsection) {
 
 /// A new display mode for the displaying it as part of the site menu.
 @property (nonatomic) BOOL isSidebarModeEnabled;
+
+/// When this property value is not nil, the view controller shows an "Application Passwords" to allow users to
+/// grant the app an application password.
+@property (nonatomic) ApplicationPasswordAuthenticationInfo *applicationPasswordAuthenticationInfo;
 
 @property (nonatomic, weak) UIViewController *presentedSiteSettingsViewController;
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -28,6 +28,7 @@ static NSString *const BlogDetailsMigrationSuccessCellIdentifier = @"BlogDetails
 static NSString *const BlogDetailsJetpackBrandingCardCellIdentifier = @"BlogDetailsJetpackBrandingCardCellIdentifier";
 static NSString *const BlogDetailsJetpackInstallCardCellIdentifier = @"BlogDetailsJetpackInstallCardCellIdentifier";
 static NSString *const BlogDetailsSotWCardCellIdentifier = @"BlogDetailsSotWCardCellIdentifier";
+static NSString *const BlogDetailsApplicationPasswordAuthenticationCardCellIdentifier = @"BlogDetailsApplicationPasswordAuthenticationCardCellIdentifier";
 
 CGFloat const BlogDetailGridiconSize = 24.0;
 CGFloat const BlogDetailGridiconAccessorySize = 17.0;
@@ -307,6 +308,7 @@ CGFloat const BlogDetailReminderSectionFooterHeight = 1.0;
     [self.tableView registerClass:[JetpackBrandingMenuCardCell class] forCellReuseIdentifier:BlogDetailsJetpackBrandingCardCellIdentifier];
     [self.tableView registerClass:[JetpackRemoteInstallTableViewCell class] forCellReuseIdentifier:BlogDetailsJetpackInstallCardCellIdentifier];
     [self.tableView registerClass:[SotWTableViewCell class] forCellReuseIdentifier:BlogDetailsSotWCardCellIdentifier];
+    [self.tableView registerClass:[ApplicationPasswordAuthenticationCardCell class] forCellReuseIdentifier:BlogDetailsApplicationPasswordAuthenticationCardCellIdentifier];
 
     self.tableView.cellLayoutMarginsFollowReadableWidth = YES;
 
@@ -345,6 +347,7 @@ CGFloat const BlogDetailReminderSectionFooterHeight = 1.0;
 
     [self reloadTableViewPreservingSelection];
     [self preloadBlogData];
+    [self checkApplicationPasswordEligibility];
 }
 
 - (void)viewDidAppear:(BOOL)animated
@@ -987,6 +990,10 @@ CGFloat const BlogDetailReminderSectionFooterHeight = 1.0;
         [marr addNullableObject:[self homeSectionViewModel]];
     }
 
+    if (self.applicationPasswordAuthenticationInfo != nil) {
+        [marr addNullableObject:[self applicationPasswordAuthenticationSectionViewModel]];
+    }
+
     if (ObjCBridge.isWordPress) {
         if ([self shouldAddJetpackSection]) {
             [marr addNullableObject:[self jetpackSectionViewModel]];
@@ -1474,6 +1481,15 @@ CGFloat const BlogDetailReminderSectionFooterHeight = 1.0;
     }
 }
 
+- (void)setApplicationPasswordAuthenticationInfo:(ApplicationPasswordAuthenticationInfo *)applicationPasswordAuthenticationInfo {
+    if (_applicationPasswordAuthenticationInfo != applicationPasswordAuthenticationInfo) {
+        _applicationPasswordAuthenticationInfo = applicationPasswordAuthenticationInfo;
+
+        [self configureTableViewData];
+        [self reloadTableViewPreservingSelection];
+    }
+}
+
 #pragma mark - Table view data source
 
 - (NSInteger)numberOfSectionsInTableView:(UITableView *)tableView
@@ -1535,6 +1551,10 @@ CGFloat const BlogDetailReminderSectionFooterHeight = 1.0;
         JetpackBrandingMenuCardCell *cell = [tableView dequeueReusableCellWithIdentifier:BlogDetailsJetpackBrandingCardCellIdentifier];
         [cell configureWithViewController:self];
         return cell;
+    }
+
+    if (section.category == BlogDetailsSectionCategoryApplicationPasswordAuthentication) {
+        return [tableView dequeueReusableCellWithIdentifier:BlogDetailsApplicationPasswordAuthenticationCardCellIdentifier];
     }
 
     BlogDetailsRow *row = [section.rows objectAtIndex:indexPath.row];


### PR DESCRIPTION
> [!Note]
>
> This PR touched quite a few areas. It might be easier to review this PR commit by commit.

## Description

This PR adds a card to the blog details screen to ask users to authenticate with application passwords. This card is only available when the "Application Passwords for self-hosted sites" feature flag/experimental feature is enabled.

Once an application password is authorized to the app, comments and media use it to talk directly to the site via REST API.

This card will show up on all self-hosted sites, with or without WP.com account. Here are a couple of recordings:

⬇️ **Site outside of WP.com**

https://github.com/user-attachments/assets/38161850-1329-4168-b7f8-51e7c0bd06fc.mp4

⬇️ **Sites within WP.com**

https://github.com/user-attachments/assets/748b3fc4-38e5-4014-ac00-a8176c10de7f.mp4


## Testing instructions

Enable the "Application Passwords for self-hosted sites" feature flag and test the new card on vanilla sites and sites that are connected to WP.com.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
