### PR TITLE
Fix #23025: Avoid unnecessary copying files

### DIFF
--- a/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
+++ b/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
@@ -35,7 +35,10 @@ final class ItemProviderMediaExporter: MediaExporter {
         }
 
         // `MediaImageExporter` doesn't support GIF, so it requires special handling.
-        func processGIF(at url: URL) throws {
+        func processGIF(at original: URL) throws {
+            let url = try self.mediaFileManager.makeLocalMediaURL(withFilename: original.lastPathComponent, fileExtension: original.pathExtension)
+            try FileManager.default.copyItem(at: original, to: url)
+
             let pixelSize = url.pixelSize
             let media = MediaExport(url: url, fileSize: url.fileSize, width: pixelSize.width, height: pixelSize.height, duration: nil)
             let exportProgress = Progress(totalUnitCount: 1)
@@ -67,15 +70,18 @@ final class ItemProviderMediaExporter: MediaExporter {
 
             // Retaining `self` on purpose.
             do {
-                let copyURL = try self.mediaFileManager.makeLocalMediaURL(withFilename: url.lastPathComponent, fileExtension: url.pathExtension)
-                try FileManager.default.copyItem(at: url, to: copyURL)
-
+                // Pre-copying the file at `url` using `mediaFileManager` caused the issue
+                // https://github.com/wordpress-mobile/WordPress-iOS/issues/23025.
+                //
+                // The image and video process functions create new files based on the file at `url`, which means they
+                // don't need to copy the file at `url`, they just need to read it.
+                // We'll let the individual process to decide whether to copy the file at `url` or not.
                 if self.hasConformingType(.gif) {
-                    try processGIF(at: copyURL)
+                    try processGIF(at: url)
                 } else if self.hasConformingType(.image) {
-                    try processImage(at: copyURL)
+                    try processImage(at: url)
                 } else if self.hasConformingType(.movie) || self.hasConformingType(.video) {
-                    try processVideo(at: copyURL)
+                    try processVideo(at: url)
                 } else {
                     onError(ExportError.unsupportedContentType)
                 }


### PR DESCRIPTION
## Description
In the process of uploading an image from the Photos app, there are two places that creates file using `mediaFileManager`, with the same filename and at the same directory.
1. Copying the selected image file, which is in a temp directory, to the app's "local media directory". That's done by the code that's moved in this commit.
2. Creating a new image based on the selected image file, for the purpose of removing some exif data.

Since these two operations creates the same file at the same directory, the second copy creates a file with "-1" suffix, which is uploaded to the site's media library. That's the root cause of why there is a "-1" in the title of uploaded images.

## Testing instructions

Verify the issue is fixed, on WP.com sites and self-hosted sites.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
