### PR TITLE
Add error handling for post likes

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -139,8 +139,10 @@ class ReaderDetailToolbar: UIView, NibLoadable {
             self?.trackArticleDetailsLikedOrUnliked()
         }, failure: { [weak self] (error: Error?) in
             self?.trackArticleDetailsLikedOrUnliked()
-            if let anError = error {
-                DDLogError("Error (un)liking post: \(anError.localizedDescription)")
+            if let error {
+                DDLogError("Error (un)liking post: \(error.localizedDescription)")
+                Notice(error: error).post()
+                UINotificationFeedbackGenerator().notificationOccurred(.error)
             }
         })
     }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-460/the-app-doesnt-let-me-like-posts by adding missing error handling: notice + haptics.

https://github.com/user-attachments/assets/b54b5a05-8685-492b-b663-35812f6c8873

