### PR TITLE
Only lookup local post when quering with "wp_jp_foreign_id"

### DIFF
--- a/Sources/WordPressData/Objective-C/PostHelper.m
+++ b/Sources/WordPressData/Objective-C/PostHelper.m
@@ -182,7 +182,7 @@
         if (post == nil) {
             NSUUID *foreignID = remotePost.foreignID;
             if (foreignID != nil) {
-                post = [blog lookupPostWithForeignID:foreignID inContext:context];
+                post = [blog lookupLocalPostWithForeignID:foreignID inContext:context];
             }
         }
         if (!post) {

--- a/Sources/WordPressData/Swift/Blog+Post.swift
+++ b/Sources/WordPressData/Swift/Blog+Post.swift
@@ -35,10 +35,10 @@ extension Blog {
     ///
     /// - Parameter foreignID: The foreign ID associated with the post; used to deduplicate new posts.
     /// - Returns: The `AbstractPost` associated with the given foreign ID.
-    @objc(lookupPostWithForeignID:inContext:)
-    public func lookupPost(withForeignID foreignID: UUID, in context: NSManagedObjectContext) -> AbstractPost? {
+    @objc(lookupLocalPostWithForeignID:inContext:)
+    public func lookupLocalPost(withForeignID foreignID: UUID, in context: NSManagedObjectContext) -> AbstractPost? {
         let request = NSFetchRequest<AbstractPost>(entityName: NSStringFromClass(AbstractPost.self))
-        request.predicate = NSPredicate(format: "blog = %@ AND original = NULL AND \(#keyPath(AbstractPost.foreignID)) == %@", self, foreignID as NSUUID)
+        request.predicate = NSPredicate(format: "blog = %@ AND original = NULL AND (postID = NULL OR postID <= 0) AND \(#keyPath(AbstractPost.foreignID)) == %@", self, foreignID as NSUUID)
         request.fetchLimit = 1
         return (try? context.fetch(request))?.first
     }


### PR DESCRIPTION
## Description

The `wp_jp_foreign_id` is introduced to associate local posts with posts in the WordPress site. In that process, we should only look up _local_ posts. This PR adds a condition to only query local posts.

`wp_jp_foreign_id` is asavednot a unique id. Multiple posts may have the same "foreign id". I'm not exactly sure how to do that, but I think it's possible that some plugins have a feature to copy/duplicate a post which copies the post's custom fields too.

## Testing instructions
Verify no regression on this issue: pe7hp4-N2-p2#comment-322

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->