### PR TITLE
Copy the exported file to a temporary dir instead of the local Media dir

### DIFF
--- a/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
+++ b/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
@@ -13,8 +13,29 @@ final class ItemProviderMediaExporter: MediaExporter {
         self.provider = provider
     }
 
-    func export(onCompletion: @escaping (MediaExport) -> Void, onError: @escaping (MediaExportError) -> Void) -> Progress {
+    func export(onCompletion originalOnCompletion: @escaping (MediaExport) -> Void, onError originalOnError: @escaping (MediaExportError) -> Void) -> Progress {
         let progress = Progress.discreteProgress(totalUnitCount: MediaExportProgressUnits.done)
+        let onCompletion: (MediaExport) -> Void
+        let onError: (MediaExportError) -> Void
+
+        // Create a temporary directory to hold the exported file from the `NSItemProvider` instance.
+        let tempDir = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        do {
+            try FileManager.default.createDirectory(at: tempDir, withIntermediateDirectories: true)
+
+            // Delete the temporary directory after we are done with the exported file.
+            onCompletion = {
+                try? FileManager.default.removeItem(at: tempDir)
+                originalOnCompletion($0)
+            }
+            onError = {
+                try? FileManager.default.removeItem(at: tempDir)
+                originalOnError($0)
+            }
+        } catch {
+            originalOnError(MediaExportSystemError.failedWith(systemError: error))
+            return progress
+        }
 
         // It's important to use the `MediaImageExporter` because it strips the
         // GPS data and performs other image manipulations before the upload.
@@ -67,7 +88,7 @@ final class ItemProviderMediaExporter: MediaExporter {
 
             // Retaining `self` on purpose.
             do {
-                let copyURL = try self.mediaFileManager.makeLocalMediaURL(withFilename: url.lastPathComponent, fileExtension: url.pathExtension)
+                let copyURL = tempDir.appendingPathComponent(url.lastPathComponent)
                 try FileManager.default.copyItem(at: url, to: copyURL)
 
                 if self.hasConformingType(.gif) {

--- a/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
+++ b/WordPress/Classes/Utility/Media/ItemProviderMediaExporter.swift
@@ -56,7 +56,10 @@ final class ItemProviderMediaExporter: MediaExporter {
         }
 
         // `MediaImageExporter` doesn't support GIF, so it requires special handling.
-        func processGIF(at url: URL) throws {
+        func processGIF(at original: URL) throws {
+            let url = try self.mediaFileManager.makeLocalMediaURL(withFilename: original.lastPathComponent, fileExtension: original.pathExtension)
+            try FileManager.default.copyItem(at: original, to: url)
+
             let pixelSize = url.pixelSize
             let media = MediaExport(url: url, fileSize: url.fileSize, width: pixelSize.width, height: pixelSize.height, duration: nil)
             let exportProgress = Progress(totalUnitCount: 1)
@@ -91,6 +94,8 @@ final class ItemProviderMediaExporter: MediaExporter {
                 let copyURL = tempDir.appendingPathComponent(url.lastPathComponent)
                 try FileManager.default.copyItem(at: url, to: copyURL)
 
+                // The "process" functions are responsible for making sure the end result file
+                // (the one passed to `onCompletion` block) is located in the local Media library dir (`mediaFileManager`).
                 if self.hasConformingType(.gif) {
                     try processGIF(at: copyURL)
                 } else if self.hasConformingType(.image) {


### PR DESCRIPTION
## Description

Fix #23025. This PR supersedes #24570, to address the issue raised in https://github.com/wordpress-mobile/WordPress-iOS/pull/24570#discussion_r2136074822.

## Testing instructions

Verify that issue #23025 is fixed on WP.com sites and self-hosted sites.

Verify that photos, GIFs, and videos can be uploaded.

<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
