### PR TITLE
Use ActivityLogsView to show Backups

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1aecad5b79a89459675bbe1705ca2f091cedc0a3874c3ce3e07aef3d60f2b061",
+  "originHash" : "fa035de2741e39c23eaba17409869db3ebef935eb88585d1f08d5dc2497e6d7d",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -390,7 +390,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/WordPressKit-iOS",
       "state" : {
-        "revision" : "30dadcab01a980eb16976340c1e9e8a9527ddc05"
+        "revision" : "ae3961ce89ac0c43a90e88d4963a04aa92008443"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(
             url: "https://github.com/wordpress-mobile/WordPressKit-iOS",
-            revision: "30dadcab01a980eb16976340c1e9e8a9527ddc05" // see wpios-edition branch
+            revision: "ae3961ce89ac0c43a90e88d4963a04aa92008443" // see wpios-edition branch
         ),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.

--- a/WordPress/Classes/ViewRelated/Activity/Details/ActivityLogDetailsView.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Details/ActivityLogDetailsView.swift
@@ -14,11 +14,11 @@ struct ActivityLogDetailsView: View {
         ScrollView {
             VStack(spacing: 24) {
                 ActivityHeaderView(activity: activity)
-                if let actor = activity.actor {
-                    makeActorCard(for: actor)
-                }
                 if activity.isRewindable {
                     restoreSiteCard
+                }
+                if let actor = activity.actor {
+                    makeActorCard(for: actor)
                 }
             }
             .padding()

--- a/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsMenu.swift
+++ b/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsMenu.swift
@@ -13,7 +13,9 @@ struct ActivityLogsMenu: View {
         Menu {
             Section {
                 dateFilters
-                activityTypeFilter
+                if !viewModel.isBackupMode {
+                    activityTypeFilter
+                }
                 if !viewModel.parameters.isEmpty {
                     resetFiltersButton
                 }

--- a/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsView.swift
+++ b/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsView.swift
@@ -65,10 +65,8 @@ private struct ActivityLogsListView: View {
             await viewModel.refresh()
         }
         .toolbar {
-            if !viewModel.isBackupMode {
-                ToolbarItem(placement: .navigationBarTrailing) {
-                    ActivityLogsMenu(viewModel: viewModel)
-                }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                ActivityLogsMenu(viewModel: viewModel)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsView.swift
+++ b/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsView.swift
@@ -6,14 +6,20 @@ struct ActivityLogsView: View {
     @ObservedObject var viewModel: ActivityLogsViewModel
 
     var body: some View {
-        Group {
+        let content = Group {
             if !viewModel.searchText.isEmpty {
                 ActivityLogsSearchView(viewModel: viewModel)
             } else {
                 ActivityLogsListView(viewModel: viewModel)
             }
         }
-        .searchable(text: $viewModel.searchText)
+        .navigationTitle(viewModel.isBackupMode ? Strings.backupsTitle : Strings.activityTitle)
+
+        if viewModel.isBackupMode {
+            content
+        } else {
+            content.searchable(text: $viewModel.searchText)
+        }
     }
 }
 
@@ -38,7 +44,11 @@ private struct ActivityLogsListView: View {
         .overlay {
             if let response = viewModel.response {
                 if response.isEmpty {
-                    EmptyStateView(Strings.empty, systemImage: "archivebox")
+                    EmptyStateView(
+                        viewModel.isBackupMode ? Strings.emptyBackups : Strings.empty,
+                        systemImage: "archivebox",
+                        description: viewModel.isBackupMode ? Strings.emptyBackupsSubtitle : nil
+                    )
                 }
             } else if viewModel.isLoading {
                 ProgressView()
@@ -55,8 +65,10 @@ private struct ActivityLogsListView: View {
             await viewModel.refresh()
         }
         .toolbar {
-            ToolbarItem(placement: .navigationBarTrailing) {
-                ActivityLogsMenu(viewModel: viewModel)
+            if !viewModel.isBackupMode {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    ActivityLogsMenu(viewModel: viewModel)
+                }
             }
         }
     }
@@ -127,4 +139,8 @@ private struct ActivityLogsPaginatedForEach: View {
 private enum Strings {
     static let empty = NSLocalizedString("activityLogs.empty", value: "No Activity", comment: "Empty state message for activity logs")
     static let freePlanNotice = NSLocalizedString("activityLogs.freePlan.notice", value: "Since you're on a free plan, you'll see limited events in your Activity Log.", comment: "Notice shown to free plan users about limited activity log events")
+    static let activityTitle = NSLocalizedString("activityLogs.title", value: "Activity", comment: "Title for activity logs screen")
+    static let backupsTitle = NSLocalizedString("backups.title", value: "Backups", comment: "Title for backups screen")
+    static let emptyBackups = NSLocalizedString("backups.empty.title", value: "Your first backup will be ready soon", comment: "Title for the view when there aren't any Backups to display")
+    static let emptyBackupsSubtitle = NSLocalizedString("backups.empty.subtitle", value: "Your first backup will appear here within 24 hours and you will receive a notification once the backup has been completed", comment: "Text displayed in the view when there aren't any Backups to display")
 }

--- a/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsViewController.swift
@@ -6,10 +6,10 @@ import WordPressKit
 final class ActivityLogsViewController: UIHostingController<AnyView> {
     private let viewModel: ActivityLogsViewModel
 
-    init(blog: Blog) {
-        self.viewModel = ActivityLogsViewModel(blog: blog)
+    init(blog: Blog, isBackupMode: Bool = false) {
+        self.viewModel = ActivityLogsViewModel(blog: blog, isBackupMode: isBackupMode)
         super.init(rootView: AnyView(ActivityLogsView(viewModel: viewModel)))
-        self.title = Strings.title
+        self.title = isBackupMode ? Strings.backupsTitle : Strings.activityTitle
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -18,5 +18,6 @@ final class ActivityLogsViewController: UIHostingController<AnyView> {
 }
 
 private enum Strings {
-    static let title = NSLocalizedString("activity.logs.title", value: "Activity", comment: "Title for the activity logs screen")
+    static let activityTitle = NSLocalizedString("activity.logs.title", value: "Activity", comment: "Title for the activity logs screen")
+    static let backupsTitle = NSLocalizedString("backups.title", value: "Backups", comment: "Title for the backups screen")
 }

--- a/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsViewModel.swift
@@ -8,6 +8,7 @@ typealias ActivityLogsPaginatedResponse = DataViewPaginatedResponse<ActivityLogR
 @MainActor
 final class ActivityLogsViewModel: ObservableObject {
     let blog: Blog
+    let isBackupMode: Bool
 
     @Published var searchText = ""
     @Published var parameters = GetActivityLogsParameters() {
@@ -27,8 +28,9 @@ final class ActivityLogsViewModel: ObservableObject {
         blog.isHostedAtWPcom && !blog.hasPaidPlan
     }
 
-    init(blog: Blog) {
+    init(blog: Blog, isBackupMode: Bool = false) {
         self.blog = blog
+        self.isBackupMode = isBackupMode
     }
 
     func onAppear() {
@@ -83,19 +85,22 @@ final class ActivityLogsViewModel: ObservableObject {
     }
 
     private func makeResponse(searchText: String?, parameters: GetActivityLogsParameters) async throws -> ActivityLogsPaginatedResponse {
-        try await ActivityLogsPaginatedResponse { [blog] offset in
+        try await ActivityLogsPaginatedResponse { [blog, isBackupMode] offset in
             guard let siteID = blog.dotComID?.intValue,
                   let api = blog.wordPressComRestApi else {
                 throw NSError(domain: "ActivityLogs", code: 0, userInfo: [NSLocalizedDescriptionKey: SharedStrings.Error.generic])
             }
             let service = ActivityServiceRemote(wordPressComRestApi: api)
             let offset = offset ?? 0
+            let pageSize = 32
+
             let (activities, hasMore) = try await service.getActivities(
                 siteID: siteID,
                 offset: offset,
-                pageSize: 32,
+                pageSize: pageSize,
                 searchText: searchText,
-                parameters: parameters
+                parameters: parameters,
+                rewindable: isBackupMode ? true : nil
             )
             let viewModels = await makeViewModels(for: activities)
             return ActivityLogsPaginatedResponse.Page(
@@ -142,7 +147,7 @@ struct GetActivityLogsParameters: Hashable {
 }
 
 private extension ActivityServiceRemote {
-    func getActivities(siteID: Int, offset: Int, pageSize: Int, searchText: String? = nil, parameters: GetActivityLogsParameters = .init()) async throws -> ([Activity], hasMore: Bool) {
+    func getActivities(siteID: Int, offset: Int, pageSize: Int, searchText: String? = nil, parameters: GetActivityLogsParameters = .init(), rewindable: Bool? = nil) async throws -> ([Activity], hasMore: Bool) {
         return try await withCheckedThrowingContinuation { continuation in
             getActivityForSite(
                 siteID,
@@ -151,6 +156,7 @@ private extension ActivityServiceRemote {
                 after: parameters.startDate,
                 before: parameters.endDate,
                 group: Array(parameters.activityTypes),
+                rewindable: rewindable,
                 searchText: searchText
             ) { activities, hasMore in
                 continuation.resume(returning: (activities, hasMore))

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
@@ -182,10 +182,21 @@ extension BlogDetailsViewController {
     }
 
     @objc public func showBackup() {
-        guard let backupListVC = BackupListViewController.withJPBannerForBlog(blog) else {
-            return wpAssertionFailure("failed to instantiate")
+        let controller: UIViewController
+
+        if FeatureFlag.dataViews.enabled {
+            controller = ActivityLogsViewController(blog: blog, isBackupMode: true)
+            controller.navigationItem.largeTitleDisplayMode = .never
+        } else {
+            guard let backupListVC = BackupListViewController.withJPBannerForBlog(blog) else {
+                return wpAssertionFailure("failed to instantiate")
+            }
+            controller = backupListVC
         }
-        presentationDelegate?.presentBlogDetailsViewController(backupListVC)
+
+        presentationDelegate?.presentBlogDetailsViewController(controller)
+
+        WPAnalytics.track(.backupListOpened)
     }
 
     @objc public func showThemes() {


### PR DESCRIPTION
- Use `ActivityLogsView` to show Backups
- Dependency: https://github.com/wordpress-mobile/WordPressKit-iOS/pull/839 (added `rewindable` support)

The only missing piece currently is how we track backup/restore status in the case you dismiss the restore flow – will address in the future PRs.