### PR TITLE
Update icons for filters in DataViews

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsMenu.swift
+++ b/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsMenu.swift
@@ -2,7 +2,7 @@ import SwiftUI
 import WordPressKit
 import WordPressShared
 
-struct ActivityLogsMenu: View {
+struct ActivityLogsFiltersMenu: View {
     @ObservedObject var viewModel: ActivityLogsViewModel
 
     @State private var isShowingActivityTypePicker = false
@@ -21,7 +21,7 @@ struct ActivityLogsMenu: View {
                 }
             }
         } label: {
-            Image(systemName: "ellipsis")
+            Image(systemName: "line.3.horizontal.decrease.circle")
         }
         .sheet(isPresented: $isShowingActivityTypePicker) {
             NavigationView {

--- a/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsView.swift
+++ b/WordPress/Classes/ViewRelated/Activity/List/ActivityLogsView.swift
@@ -74,7 +74,7 @@ private struct ActivityLogsListView: View {
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
-                ActivityLogsMenu(viewModel: viewModel)
+                ActivityLogsFiltersMenu(viewModel: viewModel)
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/Subscribers/List/SubscribersMenu.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Subscribers/List/SubscribersMenu.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-struct SubscribersMenu: View {
+struct SubscribersFiltersMenu: View {
     @ObservedObject var viewModel: SubscribersViewModel
 
     var body: some View {
@@ -14,7 +14,7 @@ struct SubscribersMenu: View {
                 Text("\(Strings.subscribers) \(count)")
             }
         } label: {
-            Image(systemName: "ellipsis.circle")
+            Image(systemName: "line.3.horizontal.decrease.circle")
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Subscribers/List/SubscribersView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Subscribers/List/SubscribersView.swift
@@ -73,7 +73,7 @@ private struct SubscribersListView: View {
                 } label: {
                     Image(systemName: "plus")
                 }
-                SubscribersMenu(viewModel: viewModel)
+                SubscribersFiltersMenu(viewModel: viewModel)
             }
         }
         .sheet(isPresented: $isShowingInviteView) {


### PR DESCRIPTION
Let's use a separate "Filters" icon for all DataViews and use it consistently across screens. With a standard place for filters, it will be clear if the screen has filters (and sorting options) or not or where to find them. It will also show the total number of items if available. 

<img width="320" alt="Screenshot 2025-06-20 at 12 30 01 PM" src="https://github.com/user-attachments/assets/9b6ef71c-cc68-4f09-a3a6-0253e31af125" />
<img width="320" alt="Screenshot 2025-06-20 at 12 29 53 PM" src="https://github.com/user-attachments/assets/e9856b37-045d-4777-ba6d-f3d7a1923e07" />
