### PR TITLE
Remove TimeZoneObserver from SiteSettingsViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -70,13 +70,7 @@ extension SiteSettingsViewController {
             }
             return timezoneString
         }
-
-        // Fall back to GMT offset
-        if let gmtOffset = settings.gmtOffset {
-            return gmtOffset
-        }
-
-        return nil
+        return timezoneValue
     }
 
     var timezoneValue: String? {

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -1,20 +1,6 @@
 import Foundation
 import SwiftUI
-import WordPressFlux
 import WordPressShared
-
-// This is just a wrapper for the receipts, since Receipt isn't exposed to Obj-C
-@objc class TimeZoneObserver: NSObject {
-    let storeReceipt: Receipt
-    let queryReceipt: Receipt
-
-    init(onStateChange callback: @escaping (TimeZoneStoreState, TimeZoneStoreState) -> Void) {
-        let store = StoreContainer.shared.timezone
-        storeReceipt = store.onStateChange(callback)
-        queryReceipt = store.query(TimeZoneQuery())
-        super.init()
-    }
-}
 
 extension SiteSettingsViewController {
     // MARK: - General
@@ -66,37 +52,31 @@ extension SiteSettingsViewController {
 
     // MARK: - Timezone
 
-    @objc public func observeTimeZoneStore() {
-        timeZoneObserver = TimeZoneObserver() { [weak self] (oldState, newState) in
-            guard let controller = self else {
-                return
-            }
-            let oldLabel = controller.timezoneLabel(state: oldState)
-            let newLabel = controller.timezoneLabel(state: newState)
-            guard newLabel != oldLabel else {
-                return
-            }
-
-            // If this were ImmuTable-based, I'd reload the specific row
-            // But it could silently break if we change the order of rows in the future
-            // @koke 2018-01-17
-            controller.tableView.reloadData()
-        }
-    }
-
-    @objc public func timezoneLabel() -> String? {
-        return timezoneLabel(state: StoreContainer.shared.timezone.state)
-    }
-
-    func timezoneLabel(state: TimeZoneStoreState) -> String? {
+    func formattedTimezoneValue() -> String? {
         guard let settings = blog.settings else {
             return nil
         }
-        if let timezone = state.findTimezone(gmtOffset: settings.gmtOffset?.floatValue, timezoneString: settings.timezoneString) {
-            return timezone.label
-        } else {
-            return timezoneValue
+        if let timezoneString = settings.timezoneString?.nonEmptyString() {
+            // Try to get a localized name from the system
+            if let timeZone = TimeZone(identifier: timezoneString),
+               let name = timeZone.localizedName(for: .generic, locale: .current) {
+
+                let formatter = DateFormatter()
+                formatter.timeZone = timeZone
+                formatter.dateFormat = "ZZZZ"  // "GMT-05:00"
+                let offsetString = formatter.string(from: Date())
+
+                return "\(name) (\(offsetString))"
+            }
+            return timezoneString
         }
+
+        // Fall back to GMT offset
+        if let gmtOffset = settings.gmtOffset {
+            return gmtOffset
+        }
+
+        return nil
     }
 
     var timezoneValue: String? {
@@ -360,7 +340,7 @@ extension SiteSettingsViewController {
     private func configureCellForTimezone(_ cell: SettingTableViewCell) {
         cell.editable = blog.isAdmin
         cell.textLabel?.text = NSLocalizedString("Time Zone", comment: "Label for the timezone setting")
-        cell.textValue = timezoneLabel()
+        cell.textValue = formattedTimezoneValue()
     }
 
     // MARK: - Handling General Setting Cell Taps

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.h
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.h
@@ -2,7 +2,6 @@
 
 @class Blog;
 @class SettingTableViewCell;
-@class TimeZoneObserver;
 
 typedef NS_ENUM(NSInteger, SiteSettingsSection) {
     SiteSettingsSectionGeneral = 0,
@@ -21,7 +20,6 @@ typedef NS_ENUM(NSInteger, SiteSettingsSection) {
 @interface SiteSettingsViewController : UITableViewController
 
 @property (nonatomic, strong,  readonly) Blog *blog;
-@property (nonatomic, strong) TimeZoneObserver *timeZoneObserver;
 
 - (instancetype)initWithBlog:(Blog *)blog;
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -141,7 +141,6 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
     }
 
     [self refreshData];
-    [self observeTimeZoneStore];
 
     self.tableView.accessibilityIdentifier = @"siteSettingsTable";
 }


### PR DESCRIPTION
In the production version, the steps to display the timezone are the following:

- Show raw `blog.settings?.timezoneString?` (example `America/Los_Angeles`)
- Use `TimeZoneStore` (WordPressFlux) to fetch the list of timezones
- Find the selected one and display only the city name. (example: `Los Angeles`)

This results in a reload of the cells every time you open Site Settings.

The recommended way to show timezone is the following:

> For international users: Consider showing both local name and GMT offset

I updated the screen to do just that. It removed the complexity with `TimeZoneStore` usage, and remove the jump.

<img width="320" alt="Screenshot 2025-06-20 at 5 00 31 PM" src="https://github.com/user-attachments/assets/2e567c05-3ff5-47bb-83c1-59ab8781d025" />
