### PR TITLE
Post Settings: Save Infrastructure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ WordPress-iOS uses a modular architecture with the main app and separate Swift p
 - Follow Swift API Design Guidelines
 - Use strict access control modifiers where possible
 - Use four spaces (not tabs)
-- When you add an empty line, don't any spaces to it 
+- Lines should not have trailing whitespace 
 - Follow the standard formatting practices enforced by SwiftLint
 - Don't create `body` for `View` that are too long
 - Use semantics text sizes like `.headline`

--- a/Sources/WordPressData/Swift/AbstractPost.swift
+++ b/Sources/WordPressData/Swift/AbstractPost.swift
@@ -28,6 +28,15 @@ public extension AbstractPost {
 
     private static let deprecatedStatuses: Set<AbstractPostRemoteStatus> = [.pushing, .failed, .local, .sync, .pushingMedia, .autoSaved]
 
+    /// Creates an array of tags by parsing a comma-separate list of tags.
+    static func makeTags(from tags: String) -> [String] {
+        tags
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .components(separatedBy: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
     // MARK: - Status
 
     /// Returns `true` is the post has one of the given statuses.

--- a/WordPress/Classes/Services/PostRepository+Helpers.swift
+++ b/WordPress/Classes/Services/PostRepository+Helpers.swift
@@ -26,7 +26,7 @@ extension RemotePostCreateParameters {
         case let post as Post:
             format = post.postFormat
             isSticky = post.isStickyPost
-            tags = makeTags(from: post.tags ?? "")
+            tags = AbstractPost.makeTags(from: post.tags ?? "")
             categoryIDs = (post.categories ?? []).compactMap {
                 $0.categoryID?.intValue
             }
@@ -43,14 +43,6 @@ extension RemotePostCreateParameters {
             break
         }
     }
-}
-
-private func makeTags(from tags: String) -> [String] {
-    tags
-        .trimmingCharacters(in: .whitespacesAndNewlines)
-        .components(separatedBy: ",")
-        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-        .filter { !$0.isEmpty }
 }
 
 public extension RemotePostUpdateParameters {

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -12,7 +12,7 @@ extension PostEditor {
         }
         // Use the new SwiftUI-based Post Settings
         let viewModel = PostSettingsViewModel(post: post)
-        viewModel.onSaveTapped = { [weak self] in
+        viewModel.onEditorPostSaved = { [weak self] in
             self?.editorContentWasUpdated()
             self?.navigationController?.dismiss(animated: true)
         }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -6,6 +6,7 @@ import SwiftUI
 
 extension PostEditor {
 
+    @MainActor
     func displayPostSettings() {
         guard FeatureFlag.postSettingsV2.enabled else {
             return showDeprecatedPostSettings()

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
@@ -1,6 +1,7 @@
 import Foundation
 import WordPressData
 import WordPressKit
+import WordPressShared
 
 /// A plain data structure representing the subset of post/page settings that can be edited in PostSettingsView.
 /// Used for change tracking and to separate UI state from Core Data objects.
@@ -11,13 +12,13 @@ struct PostSettings: Hashable {
     var publishDate: Date?
     var password: String?
     var authorID: Int?
-    var categoryIDs: Set<Int>
-    var tags: String
+    var categoryIDs: Set<Int> = []
+    var tags: [String] = []
     var featuredImageID: Int?
 
     // MARK: - Post-specific
     var postFormat: String?
-    var isStickyPost: Bool
+    var isStickyPost = false
 
     // MARK: - Page-specific
     var parentPageID: Int?
@@ -26,34 +27,26 @@ struct PostSettings: Hashable {
 
     /// Creates PostSettings from an AbstractPost instance.
     init(from post: AbstractPost) {
-        self.excerpt = post.mt_excerpt ?? ""
-        self.slug = post.wp_slug ?? ""
+        excerpt = post.mt_excerpt ?? ""
+        slug = post.wp_slug ?? ""
+        status = post.status ?? .draft
+        publishDate = post.dateCreated
+        password = post.password
+        authorID = post.authorID?.intValue
+        featuredImageID = post.featuredImage?.mediaID?.intValue
 
-        self.status = post.status ?? .draft
-        self.publishDate = post.dateCreated
-        self.password = post.password
-
-        self.authorID = post.authorID?.intValue
-
-        // Extract category IDs
-        if let post = post as? Post {
-            self.categoryIDs = Set((post.categories ?? []).compactMap { $0.categoryID?.intValue })
-            self.tags = post.tags ?? ""
-            self.postFormat = post.postFormat
-            self.isStickyPost = post.isStickyPost
-        } else {
-            self.categoryIDs = []
-            self.tags = ""
-            self.postFormat = nil
-            self.isStickyPost = false
-        }
-
-        self.featuredImageID = post.featuredImage?.mediaID?.intValue
-
-        if let page = post as? Page {
-            self.parentPageID = page.parentID?.intValue
-        } else {
-            self.parentPageID = nil
+        switch post {
+        case let post as Post:
+            postFormat = post.postFormat
+            isStickyPost = post.isStickyPost
+            tags = AbstractPost.makeTags(from: post.tags ?? "")
+            categoryIDs = Set((post.categories ?? []).compactMap {
+                $0.categoryID?.intValue
+            })
+        case let page as Page:
+            parentPageID = page.parentID?.intValue
+        default:
+            wpAssertionFailure("unsupported post type", userInfo: ["post_type": String(describing: type(of: post))])
         }
     }
 
@@ -62,68 +55,10 @@ struct PostSettings: Hashable {
     /// Applies the settings to an AbstractPost instance.
     /// Only updates properties that have actually changed.
     func apply(to post: AbstractPost) {
-        // More Options
-        if post.mt_excerpt != excerpt {
-            post.mt_excerpt = excerpt
-        }
         if post.wp_slug != slug {
             post.wp_slug = slug
         }
-
-        // Publishing
-        if post.status != status {
-            post.status = status
-        }
-        if post.dateCreated != publishDate {
-            post.dateCreated = publishDate
-        }
-        if post.password != password {
-            post.password = password
-        }
-
-        // Author
-        if let authorID, post.authorID?.intValue != authorID {
-            post.authorID = NSNumber(value: authorID)
-        }
-
-        // Featured Image
-        if let featuredImageID {
-            if post.featuredImage?.mediaID?.intValue != featuredImageID {
-                // Note: Setting featured image requires fetching the Media object
-                // This would typically be handled by the view model
-            }
-        } else if post.featuredImage != nil {
-            post.featuredImage = nil
-        }
-
-        // Post-specific properties
-        if let post = post as? Post {
-            // Categories - only update if changed
-            let currentCategoryIDs = Set((post.categories ?? []).compactMap { $0.categoryID?.intValue })
-            if currentCategoryIDs != categoryIDs {
-                // Note: Updating categories requires fetching PostCategory objects
-                // This would typically be handled by the view model
-            }
-
-            if post.tags != tags {
-                post.tags = tags
-            }
-
-            if let postFormat, post.postFormat != postFormat {
-                post.postFormat = postFormat
-            }
-
-            if post.isStickyPost != isStickyPost {
-                post.isStickyPost = isStickyPost
-            }
-        }
-
-        // Page-specific properties
-        if let page = post as? Page {
-            if page.parentID?.intValue != parentPageID {
-                page.parentID = parentPageID.map { NSNumber(value: $0) }
-            }
-        }
+        // TODO: implement it for the remaining fields
     }
 
     // MARK: - Diff Generation
@@ -131,65 +66,10 @@ struct PostSettings: Hashable {
     /// Creates RemotePostUpdateParameters representing the changes from the original settings.
     func makeUpdateParameters(from original: PostSettings) -> RemotePostUpdateParameters {
         var parameters = RemotePostUpdateParameters()
-
-        // More Options
-        if excerpt != original.excerpt {
-            parameters.excerpt = excerpt
-        }
         if slug != original.slug {
             parameters.slug = slug
         }
-
-        // Publishing
-        if status != original.status {
-            parameters.status = status.rawValue
-        }
-        if publishDate != original.publishDate {
-            parameters.date = publishDate
-        }
-        if password != original.password {
-            parameters.password = password
-        }
-
-        // Author
-        if authorID != original.authorID {
-            parameters.authorID = authorID
-        }
-
-        // Featured Image
-        if featuredImageID != original.featuredImageID {
-            parameters.featuredImageID = featuredImageID
-        }
-
-        // Post-specific
-        if postFormat != original.postFormat {
-            parameters.format = postFormat
-        }
-        if isStickyPost != original.isStickyPost {
-            parameters.isSticky = isStickyPost
-        }
-        if tags != original.tags {
-            parameters.tags = makeTags(from: tags)
-        }
-        if categoryIDs != original.categoryIDs {
-            parameters.categoryIDs = Array(categoryIDs)
-        }
-
-        // Page-specific
-        if parentPageID != original.parentPageID {
-            parameters.parentPageID = parentPageID
-        }
-
+        // TODO: implement it for the remaining field
         return parameters
     }
-}
-
-// MARK: - Private Helpers
-
-private func makeTags(from tags: String) -> [String] {
-    tags
-        .trimmingCharacters(in: .whitespacesAndNewlines)
-        .components(separatedBy: ",")
-        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-        .filter { !$0.isEmpty }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
@@ -1,0 +1,259 @@
+import Foundation
+import WordPressData
+import WordPressKit
+
+/// A plain data structure representing the subset of post/page settings that can be edited in PostSettingsView.
+/// Used for change tracking and to separate UI state from Core Data objects.
+struct PostSettings: Hashable {
+    // MARK: - More Options
+    var excerpt: String
+    var slug: String
+
+    // MARK: - Publishing
+    var status: String
+    var publishDate: Date?
+    var password: String?
+
+    // MARK: - Author
+    var authorID: Int?
+
+    // MARK: - Taxonomies
+    var categoryIDs: Set<Int>
+    var tags: String
+
+    // MARK: - Media
+    var featuredImageID: Int?
+
+    // MARK: - Post-specific
+    var postFormat: String?
+    var isStickyPost: Bool
+
+    // MARK: - Page-specific
+    var parentPageID: Int?
+
+    // MARK: - Social
+    var publicizeMessage: String?
+    var disabledPublicizeConnectionIDs: Set<NSNumber>
+
+    // MARK: - Initialization
+
+    /// Creates PostSettings from an AbstractPost instance.
+    init(from post: AbstractPost) {
+        self.excerpt = post.mt_excerpt ?? ""
+        self.slug = post.wp_slug ?? ""
+
+        self.status = post.status ?? PostStatusDraft
+        self.publishDate = post.dateCreated
+        self.password = post.password
+
+        self.authorID = post.authorID?.intValue
+
+        // Extract category IDs
+        if let post = post as? Post {
+            self.categoryIDs = Set((post.categories ?? []).compactMap { $0.categoryID?.intValue })
+            self.tags = post.tags ?? ""
+            self.postFormat = post.postFormat
+            self.isStickyPost = post.isStickyPost
+        } else {
+            self.categoryIDs = []
+            self.tags = ""
+            self.postFormat = nil
+            self.isStickyPost = false
+        }
+
+        self.featuredImageID = post.featuredImage?.mediaID?.intValue
+
+        if let page = post as? Page {
+            self.parentPageID = page.parentID?.intValue
+        } else {
+            self.parentPageID = nil
+        }
+
+        // Social settings
+        if let post = post as? Post {
+            self.publicizeMessage = post.publicizeMessage
+            self.disabledPublicizeConnectionIDs = post.disabledPublicizeConnectionIDs()
+        } else {
+            self.publicizeMessage = nil
+            self.disabledPublicizeConnectionIDs = []
+        }
+    }
+
+    // MARK: - Applying Changes
+
+    /// Applies the settings to an AbstractPost instance.
+    /// Only updates properties that have actually changed.
+    func apply(to post: AbstractPost) {
+        // More Options
+        if post.mt_excerpt != excerpt {
+            post.mt_excerpt = excerpt
+        }
+        if post.wp_slug != slug {
+            post.wp_slug = slug
+        }
+
+        // Publishing
+        if post.status != status {
+            post.status = status
+        }
+        if post.dateCreated != publishDate {
+            post.dateCreated = publishDate
+        }
+        if post.password != password {
+            post.password = password
+        }
+
+        // Author
+        if let authorID, post.authorID?.intValue != authorID {
+            post.authorID = NSNumber(value: authorID)
+        }
+
+        // Featured Image
+        if let featuredImageID {
+            if post.featuredImage?.mediaID?.intValue != featuredImageID {
+                // Note: Setting featured image requires fetching the Media object
+                // This would typically be handled by the view model
+            }
+        } else if post.featuredImage != nil {
+            post.featuredImage = nil
+        }
+
+        // Post-specific properties
+        if let post = post as? Post {
+            // Categories - only update if changed
+            let currentCategoryIDs = Set((post.categories ?? []).compactMap { $0.categoryID?.intValue })
+            if currentCategoryIDs != categoryIDs {
+                // Note: Updating categories requires fetching PostCategory objects
+                // This would typically be handled by the view model
+            }
+
+            if post.tags != tags {
+                post.tags = tags
+            }
+
+            if let postFormat, post.postFormat != postFormat {
+                post.postFormat = postFormat
+            }
+
+            if post.isStickyPost != isStickyPost {
+                post.isStickyPost = isStickyPost
+            }
+
+            // Social settings
+            if post.publicizeMessage != publicizeMessage {
+                post.publicizeMessage = publicizeMessage
+            }
+
+            // Update disabled connections
+            let currentDisabledIDs = post.disabledPublicizeConnectionIDs()
+            if currentDisabledIDs != disabledPublicizeConnectionIDs {
+                // Remove all current disabled connections
+                for connectionID in currentDisabledIDs {
+                    post.enablePublicizeConnection(with: connectionID)
+                }
+                // Add new disabled connections
+                for connectionID in disabledPublicizeConnectionIDs {
+                    post.disablePublicizeConnection(with: connectionID)
+                }
+            }
+        }
+
+        // Page-specific properties
+        if let page = post as? Page {
+            if page.parentID?.intValue != parentPageID {
+                page.parentID = parentPageID.map { NSNumber(value: $0) }
+            }
+        }
+    }
+
+    // MARK: - Diff Generation
+
+    /// Creates RemotePostUpdateParameters representing the changes from the original settings.
+    func makeUpdateParameters(from original: PostSettings) -> RemotePostUpdateParameters {
+        var parameters = RemotePostUpdateParameters()
+
+        // More Options
+        if excerpt != original.excerpt {
+            parameters.excerpt = excerpt
+        }
+        if slug != original.slug {
+            parameters.slug = slug
+        }
+
+        // Publishing
+        if status != original.status {
+            parameters.status = status
+        }
+        if publishDate != original.publishDate {
+            parameters.date = publishDate
+        }
+        if password != original.password {
+            parameters.password = password
+        }
+
+        // Author
+        if authorID != original.authorID {
+            parameters.authorID = authorID
+        }
+
+        // Featured Image
+        if featuredImageID != original.featuredImageID {
+            parameters.featuredImageID = featuredImageID
+        }
+
+        // Post-specific
+        if postFormat != original.postFormat {
+            parameters.format = postFormat
+        }
+        if isStickyPost != original.isStickyPost {
+            parameters.isSticky = isStickyPost
+        }
+        if tags != original.tags {
+            parameters.tags = makeTags(from: tags)
+        }
+        if categoryIDs != original.categoryIDs {
+            parameters.categoryIDs = Array(categoryIDs)
+        }
+
+        // Page-specific
+        if parentPageID != original.parentPageID {
+            parameters.parentPageID = parentPageID
+        }
+
+        // Note: Social settings (publicize) are typically handled via metadata,
+        // which would require additional implementation
+
+        return parameters
+    }
+}
+
+// MARK: - Private Helpers
+
+private func makeTags(from tags: String) -> [String] {
+    tags
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+        .components(separatedBy: ",")
+        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+        .filter { !$0.isEmpty }
+}
+
+// MARK: - Post Extensions
+
+private extension Post {
+    /// Returns the set of disabled publicize connection IDs.
+    func disabledPublicizeConnectionIDs() -> Set<NSNumber> {
+        var disabledIDs = Set<NSNumber>()
+
+        // Get all available connections
+        if let connections = blog.connections as? Set<PublicizeConnection> {
+            for connection in connections {
+                if let keyringID = connection.keyringConnectionID,
+                   publicizeConnectionDisabledForKeyringID(keyringID) {
+                    disabledIDs.insert(keyringID)
+                }
+            }
+        }
+
+        return disabledIDs
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
@@ -14,8 +14,6 @@ struct PostSettings: Hashable {
     var categoryIDs: Set<Int>
     var tags: String
     var featuredImageID: Int?
-    var publicizeMessage: String?
-    var disabledPublicizeConnectionIDs: Set<NSNumber>
 
     // MARK: - Post-specific
     var postFormat: String?
@@ -57,15 +55,6 @@ struct PostSettings: Hashable {
         } else {
             self.parentPageID = nil
         }
-
-        // Social settings
-        if let post = post as? Post {
-            self.publicizeMessage = post.publicizeMessage
-            self.disabledPublicizeConnectionIDs = post.disabledPublicizeConnectionIDs()
-        } else {
-            self.publicizeMessage = nil
-            self.disabledPublicizeConnectionIDs = []
-        }
     }
 
     // MARK: - Applying Changes
@@ -83,7 +72,7 @@ struct PostSettings: Hashable {
 
         // Publishing
         if post.status != status {
-            post.status = status.rawValue
+            post.status = status
         }
         if post.dateCreated != publishDate {
             post.dateCreated = publishDate
@@ -126,24 +115,6 @@ struct PostSettings: Hashable {
 
             if post.isStickyPost != isStickyPost {
                 post.isStickyPost = isStickyPost
-            }
-
-            // Social settings
-            if post.publicizeMessage != publicizeMessage {
-                post.publicizeMessage = publicizeMessage
-            }
-
-            // Update disabled connections
-            let currentDisabledIDs = post.disabledPublicizeConnectionIDs()
-            if currentDisabledIDs != disabledPublicizeConnectionIDs {
-                // Remove all current disabled connections
-                for connectionID in currentDisabledIDs {
-                    post.enablePublicizeConnection(with: connectionID)
-                }
-                // Add new disabled connections
-                for connectionID in disabledPublicizeConnectionIDs {
-                    post.disablePublicizeConnection(with: connectionID)
-                }
             }
         }
 
@@ -209,9 +180,6 @@ struct PostSettings: Hashable {
             parameters.parentPageID = parentPageID
         }
 
-        // Note: Social settings (publicize) are typically handled via metadata,
-        // which would require additional implementation
-
         return parameters
     }
 }
@@ -224,25 +192,4 @@ private func makeTags(from tags: String) -> [String] {
         .components(separatedBy: ",")
         .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
         .filter { !$0.isEmpty }
-}
-
-// MARK: - Post Extensions
-
-private extension Post {
-    /// Returns the set of disabled publicize connection IDs.
-    func disabledPublicizeConnectionIDs() -> Set<NSNumber> {
-        var disabledIDs = Set<NSNumber>()
-
-        // Get all available connections
-        if let connections = blog.connections as? Set<PublicizeConnection> {
-            for connection in connections {
-                if let keyringID = connection.keyringConnectionID,
-                   publicizeConnectionDisabledForKeyringID(keyringID) {
-                    disabledIDs.insert(keyringID)
-                }
-            }
-        }
-
-        return disabledIDs
-    }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
@@ -5,24 +5,17 @@ import WordPressKit
 /// A plain data structure representing the subset of post/page settings that can be edited in PostSettingsView.
 /// Used for change tracking and to separate UI state from Core Data objects.
 struct PostSettings: Hashable {
-    // MARK: - More Options
     var excerpt: String
     var slug: String
-
-    // MARK: - Publishing
-    var status: String
+    var status: BasePost.Status
     var publishDate: Date?
     var password: String?
-
-    // MARK: - Author
     var authorID: Int?
-
-    // MARK: - Taxonomies
     var categoryIDs: Set<Int>
     var tags: String
-
-    // MARK: - Media
     var featuredImageID: Int?
+    var publicizeMessage: String?
+    var disabledPublicizeConnectionIDs: Set<NSNumber>
 
     // MARK: - Post-specific
     var postFormat: String?
@@ -31,10 +24,6 @@ struct PostSettings: Hashable {
     // MARK: - Page-specific
     var parentPageID: Int?
 
-    // MARK: - Social
-    var publicizeMessage: String?
-    var disabledPublicizeConnectionIDs: Set<NSNumber>
-
     // MARK: - Initialization
 
     /// Creates PostSettings from an AbstractPost instance.
@@ -42,7 +31,7 @@ struct PostSettings: Hashable {
         self.excerpt = post.mt_excerpt ?? ""
         self.slug = post.wp_slug ?? ""
 
-        self.status = post.status ?? PostStatusDraft
+        self.status = post.status ?? .draft
         self.publishDate = post.dateCreated
         self.password = post.password
 
@@ -94,7 +83,7 @@ struct PostSettings: Hashable {
 
         // Publishing
         if post.status != status {
-            post.status = status
+            post.status = status.rawValue
         }
         if post.dateCreated != publishDate {
             post.dateCreated = publishDate
@@ -182,7 +171,7 @@ struct PostSettings: Hashable {
 
         // Publishing
         if status != original.status {
-            parameters.status = status
+            parameters.status = status.rawValue
         }
         if publishDate != original.publishDate {
             parameters.date = publishDate

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -31,6 +31,7 @@ final class NewPostSettingsViewController: UIHostingController<PostSettingsView>
     }
 }
 
+@MainActor
 struct PostSettingsView: View {
     @ObservedObject var viewModel: PostSettingsViewModel
     @State private var isShowingDiscardChangesAlert = false
@@ -56,11 +57,20 @@ struct PostSettingsView: View {
                 if viewModel.isSaving {
                     ProgressView()
                 } else {
-                    Button(SharedStrings.Button.save) {
-                        viewModel.buttonSaveTapped()
+                    Group {
+                        if viewModel.isStandalone {
+                            Button(SharedStrings.Button.save) {
+                                viewModel.buttonSaveTapped()
+                            }
+                            .buttonStyle(.borderedProminent)
+                            .buttonBorderShape(.capsule)
+                        } else {
+                            Button(SharedStrings.Button.done) {
+                                viewModel.buttonSaveTapped()
+                            }
+                            .fontWeight(.medium)
+                        }
                     }
-                    .buttonStyle(.borderedProminent)
-                    .buttonBorderShape(.capsule)
                     .disabled(!viewModel.hasChanges)
                     .tint(AppColor.tint)
                 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -74,8 +74,8 @@ struct PostSettingsView: View {
                 dismiss()
             }
         }
-        .alert(viewModel.deletedAlertTitle, isPresented: $viewModel.showingDeletedAlert) {
-            Button(Strings.okButton) {
+        .alert(viewModel.deletedAlertTitle, isPresented: $viewModel.isShowingDeletedAlert) {
+            Button(SharedStrings.Button.ok) {
                 dismiss()
             }
         } message: {
@@ -101,23 +101,5 @@ private enum Strings {
         "postSettings.slug.placeholder",
         value: "Enter slug",
         comment: "Placeholder text for the slug field"
-    )
-    
-    static let cancelButton = NSLocalizedString(
-        "postSettings.button.cancel",
-        value: "Cancel",
-        comment: "Cancel button in the Post Settings screen"
-    )
-    
-    static let saveButton = NSLocalizedString(
-        "postSettings.button.save",
-        value: "Save",
-        comment: "Save button in the Post Settings screen"
-    )
-    
-    static let okButton = NSLocalizedString(
-        "postSettings.button.ok",
-        value: "OK",
-        comment: "OK button in post settings alerts"
     )
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -4,6 +4,7 @@ import Combine
 import WordPressData
 import WordPressKit
 import WordPressShared
+import WordPressUI
 import SwiftUI
 
 final class NewPostSettingsViewController: UIHostingController<PostSettingsView> {
@@ -19,6 +20,10 @@ final class NewPostSettingsViewController: UIHostingController<PostSettingsView>
         super.viewDidLoad()
 
         title = viewModel.navigationTitle
+
+        viewModel.onDismiss = { [weak self] in
+            self?.presentingViewController?.dismiss(animated: true)
+        }
     }
 
     @preconcurrency required dynamic init?(coder aDecoder: NSCoder) {
@@ -28,58 +33,70 @@ final class NewPostSettingsViewController: UIHostingController<PostSettingsView>
 
 struct PostSettingsView: View {
     @ObservedObject var viewModel: PostSettingsViewModel
-    @Environment(\.dismiss) private var dismiss
+    @State private var isShowingDiscardChangesAlert = false
 
     var body: some View {
-        ZStack {
-            Form {
-                Section(header: Text(Strings.moreOptionsHeader)) {
-                    HStack {
-                        Text(Strings.slugLabel)
-                        Spacer()
-                        TextField(Strings.slugPlaceholder, text: $viewModel.settings.slug)
-                            .textFieldStyle(.plain)
-                            .multilineTextAlignment(.trailing)
-                            .textInputAutocapitalization(.never)
-                            .disableAutocorrection(true)
-                    }
-                }
-            }
-            .opacity(viewModel.isSaving ? 0.6 : 1.0)
-            .disabled(viewModel.isSaving)
+        Form {
+            form
         }
+        .opacity(viewModel.isSaving ? 0.6 : 1.0)
+        .disabled(viewModel.isSaving)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
                 Button(SharedStrings.Button.cancel) {
-                    viewModel.cancel()
+                    if viewModel.hasChanges {
+                        isShowingDiscardChangesAlert = true
+                    } else {
+                        viewModel.buttonCancelTapped()
+                    }
                 }
+                .tint(AppColor.tint)
             }
             ToolbarItem(placement: .navigationBarTrailing) {
                 if viewModel.isSaving {
                     ProgressView()
                 } else {
                     Button(SharedStrings.Button.save) {
-                        Task {
-                            await viewModel.save()
-                        }
+                        viewModel.buttonSaveTapped()
                     }
                     .buttonStyle(.borderedProminent)
                     .disabled(!viewModel.hasChanges)
+                    .tint(AppColor.tint)
                 }
             }
         }
         .interactiveDismissDisabled(viewModel.isSaving || viewModel.hasChanges)
-        .onAppear {
-            viewModel.onDismiss = {
-                dismiss()
-            }
-        }
         .alert(viewModel.deletedAlertTitle, isPresented: $viewModel.isShowingDeletedAlert) {
             Button(SharedStrings.Button.ok) {
-                dismiss()
+                viewModel.onDismiss?()
             }
         } message: {
             Text(viewModel.deletedAlertMessage)
+        }
+        .confirmationDialog(Strings.discardChangesTitle, isPresented: $isShowingDiscardChangesAlert) {
+            Button(Strings.discardChangesButton, role: .destructive) {
+                viewModel.buttonCancelTapped()
+            }
+            Button(SharedStrings.Button.cancel, role: .cancel) {
+                // Do nothing - continue editing
+            }
+        } message: {
+            Text(Strings.discardChangesMessage)
+        }
+    }
+
+    @ViewBuilder
+    private var form: some View {
+        Section(header: Text(Strings.moreOptionsHeader)) {
+            HStack {
+                Text(Strings.slugLabel)
+                Spacer()
+                TextField(Strings.slugPlaceholder, text: $viewModel.settings.slug)
+                    .textFieldStyle(.plain)
+                    .multilineTextAlignment(.trailing)
+                    .textInputAutocapitalization(.never)
+                    .disableAutocorrection(true)
+            }
         }
     }
 }
@@ -101,5 +118,23 @@ private enum Strings {
         "postSettings.slug.placeholder",
         value: "Enter slug",
         comment: "Placeholder text for the slug field"
+    )
+
+    static let discardChangesTitle = NSLocalizedString(
+        "postSettings.discardChanges.title",
+        value: "Discard Changes?",
+        comment: "Title for the discard changes confirmation dialog"
+    )
+
+    static let discardChangesMessage = NSLocalizedString(
+        "postSettings.discardChanges.message",
+        value: "You have unsaved changes. Are you sure you want to discard them?",
+        comment: "Message for the discard changes confirmation dialog"
+    )
+
+    static let discardChangesButton = NSLocalizedString(
+        "postSettings.discardChanges.button",
+        value: "Discard Changes",
+        comment: "Button to confirm discarding changes"
     )
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -14,7 +14,7 @@ final class NewPostSettingsViewController: UIHostingController<PostSettingsView>
         let postSettingsView = PostSettingsView(viewModel: viewModel)
         super.init(rootView: postSettingsView)
     }
-    
+
     override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -90,13 +90,13 @@ private enum Strings {
         value: "More Options",
         comment: "Section header for More Options in Post Settings"
     )
-    
+
     static let slugLabel = NSLocalizedString(
         "postSettings.slug.label",
         value: "Slug",
         comment: "Label for the slug field. Should be the same as WP core."
     )
-    
+
     static let slugPlaceholder = NSLocalizedString(
         "postSettings.slug.placeholder",
         value: "Enter slug",

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -50,7 +50,7 @@ struct PostSettingsView: View {
         }
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {
-                Button(Strings.cancelButton) {
+                Button(SharedStrings.Button.cancel) {
                     viewModel.cancel()
                 }
             }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -32,7 +32,7 @@ final class NewPostSettingsViewController: UIHostingController<PostSettingsView>
 }
 
 @MainActor
-struct PostSettingsView: View {
+private struct PostSettingsView: View {
     @ObservedObject var viewModel: PostSettingsViewModel
     @State private var isShowingDiscardChangesAlert = false
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -60,6 +60,7 @@ struct PostSettingsView: View {
                         viewModel.buttonSaveTapped()
                     }
                     .buttonStyle(.borderedProminent)
+                    .buttonBorderShape(.capsule)
                     .disabled(!viewModel.hasChanges)
                     .tint(AppColor.tint)
                 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -58,7 +58,7 @@ struct PostSettingsView: View {
                 if viewModel.isSaving {
                     ProgressView()
                 } else {
-                    Button(Strings.saveButton) {
+                    Button(SharedStrings.Button.save) {
                         Task {
                             await viewModel.save()
                         }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -1,5 +1,6 @@
 import UIKit
 import CoreData
+import Combine
 import WordPressData
 import WordPressKit
 import WordPressShared
@@ -8,20 +9,16 @@ import SwiftUI
 final class NewPostSettingsViewController: UIHostingController<PostSettingsView> {
     private let viewModel: PostSettingsViewModel
 
-    /// Shows a "Post Settings" screen that can be used outside of the "Post Editor".
-    ///
-    /// - note: Creates a revisions for editing automatically.
-    static func showStandaloneEditor(for post: AbstractPost, from presentingVC: UIViewController) {
-        let revision = post.createRevision()
-        let viewModel = PostSettingsViewModel(post: revision)
-        let postSettingsVC = NewPostSettingsViewController(viewModel: viewModel)
-        let navigation = UINavigationController(rootViewController: postSettingsVC)
-        presentingVC.present(navigation, animated: true)
-    }
-
     init(viewModel: PostSettingsViewModel) {
         self.viewModel = viewModel
-        super.init(rootView: PostSettingsView(viewModel: viewModel))
+        let postSettingsView = PostSettingsView(viewModel: viewModel)
+        super.init(rootView: postSettingsView)
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        title = viewModel.navigationTitle
     }
 
     @preconcurrency required dynamic init?(coder aDecoder: NSCoder) {
@@ -31,8 +28,96 @@ final class NewPostSettingsViewController: UIHostingController<PostSettingsView>
 
 struct PostSettingsView: View {
     @ObservedObject var viewModel: PostSettingsViewModel
+    @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        Text("Post Settings View")
+        ZStack {
+            Form {
+                Section(header: Text(Strings.moreOptionsHeader)) {
+                    HStack {
+                        Text(Strings.slugLabel)
+                        Spacer()
+                        TextField(Strings.slugPlaceholder, text: $viewModel.settings.slug)
+                            .textFieldStyle(.plain)
+                            .multilineTextAlignment(.trailing)
+                            .textInputAutocapitalization(.never)
+                            .disableAutocorrection(true)
+                    }
+                }
+            }
+            .opacity(viewModel.isSaving ? 0.6 : 1.0)
+            .disabled(viewModel.isSaving)
+        }
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(Strings.cancelButton) {
+                    viewModel.cancel()
+                }
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                if viewModel.isSaving {
+                    ProgressView()
+                } else {
+                    Button(Strings.saveButton) {
+                        Task {
+                            await viewModel.save()
+                        }
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(!viewModel.hasChanges)
+                }
+            }
+        }
+        .interactiveDismissDisabled(viewModel.isSaving || viewModel.hasChanges)
+        .onAppear {
+            viewModel.onDismiss = {
+                dismiss()
+            }
+        }
+        .alert(viewModel.deletedAlertTitle, isPresented: $viewModel.showingDeletedAlert) {
+            Button(Strings.okButton) {
+                dismiss()
+            }
+        } message: {
+            Text(viewModel.deletedAlertMessage)
+        }
     }
+}
+
+private enum Strings {
+    static let moreOptionsHeader = NSLocalizedString(
+        "postSettings.section.moreOptions",
+        value: "More Options",
+        comment: "Section header for More Options in Post Settings"
+    )
+    
+    static let slugLabel = NSLocalizedString(
+        "postSettings.slug.label",
+        value: "Slug",
+        comment: "Label for the slug field. Should be the same as WP core."
+    )
+    
+    static let slugPlaceholder = NSLocalizedString(
+        "postSettings.slug.placeholder",
+        value: "Enter slug",
+        comment: "Placeholder text for the slug field"
+    )
+    
+    static let cancelButton = NSLocalizedString(
+        "postSettings.button.cancel",
+        value: "Cancel",
+        comment: "Cancel button in the Post Settings screen"
+    )
+    
+    static let saveButton = NSLocalizedString(
+        "postSettings.button.save",
+        value: "Save",
+        comment: "Save button in the Post Settings screen"
+    )
+    
+    static let okButton = NSLocalizedString(
+        "postSettings.button.ok",
+        value: "OK",
+        comment: "OK button in post settings alerts"
+    )
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import WordPressData
 import WordPressKit
+import WordPressShared
 
 @MainActor
 final class PostSettingsViewModel: ObservableObject {
@@ -57,10 +58,10 @@ final class PostSettingsViewModel: ObservableObject {
             return
         }
 
-        guard !isStandalone else {
+        guard isStandalone else {
             // Apply settings and return to the editor
             settings.apply(to: post)
-            onDismiss?()
+            wpAssert(onEditorPostSaved != nil, "configuration missing")
             onEditorPostSaved?()
             return
         }
@@ -94,6 +95,18 @@ final class PostSettingsViewModel: ObservableObject {
 // MARK: - Localized Strings
 
 private enum Strings {
+    static let postSettingsTitle = NSLocalizedString(
+        "postSettings.navigationTitle.post",
+        value: "Post Settings",
+        comment: "The title of the Post Settings screen."
+    )
+
+    static let pageSettingsTitle = NSLocalizedString(
+        "postSettings.navigationTitle.page",
+        value: "Page Settings",
+        comment: "The title of the Page Settings screen."
+    )
+
     static let postDeletedTitle = NSLocalizedString(
         "postSettings.postDeleted.title",
         value: "Post Deleted",
@@ -116,17 +129,5 @@ private enum Strings {
         "postSettings.pageDeleted.message",
         value: "This page has been deleted and can no longer be saved.",
         comment: "Message when trying to save a deleted page"
-    )
-
-    static let postSettingsTitle = NSLocalizedString(
-        "postSettings.title.post",
-        value: "Post Settings",
-        comment: "The title of the Post Settings screen."
-    )
-
-    static let pageSettingsTitle = NSLocalizedString(
-        "postSettings.title.page",
-        value: "Page Settings",
-        comment: "The title of the Page Settings screen."
     )
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -53,7 +53,6 @@ final class PostSettingsViewModel: ObservableObject {
         // Check if the post still exists
         guard let context = post.managedObjectContext,
               let _ = try? context.existingObject(with: post.objectID) else {
-            isSaving = false
             isShowingDeletedAlert = true
             return
         }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -20,15 +20,15 @@ final class PostSettingsViewModel: ObservableObject {
     var navigationTitle: String {
         post is Page ? Strings.pageSettingsTitle : Strings.postSettingsTitle
     }
-    
+
     var deletedAlertTitle: String {
         post is Page ? Strings.pageDeletedTitle : Strings.postDeletedTitle
     }
-    
+
     var deletedAlertMessage: String {
         post is Page ? Strings.pageDeletedMessage : Strings.postDeletedMessage
     }
-    
+
     private let originalSettings: PostSettings
 
     var onDismiss: (() -> Void)?
@@ -46,7 +46,7 @@ final class PostSettingsViewModel: ObservableObject {
     func cancel() {
         onDismiss?()
     }
-    
+
     func save() async {
         // Check if the post still exists
         guard let context = post.managedObjectContext,
@@ -92,19 +92,19 @@ private enum Strings {
         value: "Post Deleted",
         comment: "Title of alert when trying to save a deleted post"
     )
-    
+
     static let pageDeletedTitle = NSLocalizedString(
         "postSettings.pageDeleted.title",
         value: "Page Deleted",
         comment: "Title of alert when trying to save a deleted page"
     )
-    
+
     static let postDeletedMessage = NSLocalizedString(
         "postSettings.postDeleted.message",
         value: "This post has been deleted and can no longer be saved.",
         comment: "Message when trying to save a deleted post"
     )
-    
+
     static let pageDeletedMessage = NSLocalizedString(
         "postSettings.pageDeleted.message",
         value: "This page has been deleted and can no longer be saved.",
@@ -116,7 +116,7 @@ private enum Strings {
         value: "Post Settings",
         comment: "The title of the Post Settings screen."
     )
-    
+
     static let pageSettingsTitle = NSLocalizedString(
         "postSettings.title.page",
         value: "Page Settings",

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -6,7 +6,7 @@ import WordPressShared
 @MainActor
 final class PostSettingsViewModel: ObservableObject {
     private let post: AbstractPost
-    private let isStandalone: Bool
+    let isStandalone: Bool
 
     @Published var settings: PostSettings {
         didSet {

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -44,11 +44,11 @@ final class PostSettingsViewModel: ObservableObject {
         self.originalSettings = initialSettings
     }
 
-    func cancel() {
+    func buttonCancelTapped() {
         onDismiss?()
     }
 
-    func save() async {
+    func buttonSaveTapped() {
         // Check if the post still exists
         guard let context = post.managedObjectContext,
               let _ = try? context.existingObject(with: post.objectID) else {
@@ -66,6 +66,12 @@ final class PostSettingsViewModel: ObservableObject {
         }
 
         isSaving = true
+        Task {
+            await actuallySave()
+        }
+    }
+
+    private func actuallySave() async {
         do {
             let coordinator = PostCoordinator.shared
             if coordinator.isSyncAllowed(for: post) {
@@ -83,7 +89,6 @@ final class PostSettingsViewModel: ObservableObject {
             // `PostCoordinator` handles errors by showing an alert when needed
         }
     }
-
 }
 
 // MARK: - Localized Strings

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -13,8 +13,8 @@ final class PostSettingsViewModel: ObservableObject {
         }
     }
 
-    @Published private (set) var isSaving = false
-    @Published private (set) var hasChanges = false
+    @Published private(set) var isSaving = false
+    @Published private(set) var hasChanges = false
     @Published var isShowingDeletedAlert = false
 
     var navigationTitle: String {
@@ -32,6 +32,7 @@ final class PostSettingsViewModel: ObservableObject {
     private let originalSettings: PostSettings
 
     var onDismiss: (() -> Void)?
+    var onEditorPostSaved: (() -> Void)?
 
     init(post: AbstractPost, isStandalone: Bool = false) {
         self.post = post
@@ -60,6 +61,7 @@ final class PostSettingsViewModel: ObservableObject {
             // Apply settings and return to the editor
             settings.apply(to: post)
             onDismiss?()
+            onEditorPostSaved?()
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -1,12 +1,131 @@
 import Foundation
 import WordPressData
+import WordPressKit
 
+@MainActor
 final class PostSettingsViewModel: ObservableObject {
-    let post: AbstractPost
+    private let post: AbstractPost
+    private let isStandalone: Bool
 
-    var onSaveTapped: (() -> Void)?
-
-    init(post: AbstractPost) {
-        self.post = post
+    @Published var settings: PostSettings {
+        didSet {
+            hasChanges = settings != originalSettings
+        }
     }
+
+    @Published private (set) var isSaving = false
+    @Published private (set) var hasChanges = false
+    @Published var showingDeletedAlert = false
+
+    var navigationTitle: String {
+        post is Page ? Strings.pageSettingsTitle : Strings.postSettingsTitle
+    }
+    
+    var deletedAlertTitle: String {
+        post is Page ? Strings.pageDeletedTitle : Strings.postDeletedTitle
+    }
+    
+    var deletedAlertMessage: String {
+        post is Page ? Strings.pageDeletedMessage : Strings.postDeletedMessage
+    }
+    
+    private let originalSettings: PostSettings
+
+    var onDismiss: (() -> Void)?
+
+    init(post: AbstractPost, isStandalone: Bool = false) {
+        self.post = post
+        self.isStandalone = isStandalone
+
+        // Initialize settings from the post
+        let initialSettings = PostSettings(from: post)
+        self.settings = initialSettings
+        self.originalSettings = initialSettings
+    }
+
+    func cancel() {
+        onDismiss?()
+    }
+    
+    func save() async {
+        // Check if the post still exists
+        guard let context = post.managedObjectContext,
+              let _ = try? context.existingObject(with: post.objectID) else {
+            isSaving = false
+            showingDeletedAlert = true
+            return
+        }
+
+        guard !isStandalone else {
+            // Apply settings and return to the editor
+            settings.apply(to: post)
+            onDismiss?()
+            return
+        }
+
+        isSaving = true
+        do {
+            let coordinator = PostCoordinator.shared
+            if coordinator.isSyncAllowed(for: post) {
+                // Apply settings to the post and mark for sync
+                settings.apply(to: post)
+                coordinator.setNeedsSync(for: post)
+            } else {
+                // When sync is not allowed, use the changes parameter
+                let changes = settings.makeUpdateParameters(from: originalSettings)
+                try await coordinator.save(post, changes: changes)
+            }
+            onDismiss?()
+        } catch {
+            isSaving = false
+            // `PostCoordinator` handles errors by showing an alert when needed
+        }
+    }
+
+}
+
+// MARK: - Localized Strings
+
+private enum Strings {
+    static let postDeletedTitle = NSLocalizedString(
+        "postSettings.postDeleted.title",
+        value: "Post Deleted",
+        comment: "Title of alert when trying to save a deleted post"
+    )
+    
+    static let pageDeletedTitle = NSLocalizedString(
+        "postSettings.pageDeleted.title",
+        value: "Page Deleted",
+        comment: "Title of alert when trying to save a deleted page"
+    )
+    
+    static let postDeletedMessage = NSLocalizedString(
+        "postSettings.postDeleted.message",
+        value: "This post has been deleted and can no longer be saved.",
+        comment: "Message when trying to save a deleted post"
+    )
+    
+    static let pageDeletedMessage = NSLocalizedString(
+        "postSettings.pageDeleted.message",
+        value: "This page has been deleted and can no longer be saved.",
+        comment: "Message when trying to save a deleted page"
+    )
+    
+    static let okButton = NSLocalizedString(
+        "postSettings.okButton",
+        value: "OK",
+        comment: "OK button in post settings alerts"
+    )
+    
+    static let postSettingsTitle = NSLocalizedString(
+        "postSettings.title.post",
+        value: "Post Settings",
+        comment: "The title of the Post Settings screen."
+    )
+    
+    static let pageSettingsTitle = NSLocalizedString(
+        "postSettings.title.page",
+        value: "Page Settings",
+        comment: "The title of the Page Settings screen."
+    )
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -15,7 +15,7 @@ final class PostSettingsViewModel: ObservableObject {
 
     @Published private (set) var isSaving = false
     @Published private (set) var hasChanges = false
-    @Published var showingDeletedAlert = false
+    @Published var isShowingDeletedAlert = false
 
     var navigationTitle: String {
         post is Page ? Strings.pageSettingsTitle : Strings.postSettingsTitle
@@ -52,7 +52,7 @@ final class PostSettingsViewModel: ObservableObject {
         guard let context = post.managedObjectContext,
               let _ = try? context.existingObject(with: post.objectID) else {
             isSaving = false
-            showingDeletedAlert = true
+            isShowingDeletedAlert = true
             return
         }
 
@@ -110,13 +110,7 @@ private enum Strings {
         value: "This page has been deleted and can no longer be saved.",
         comment: "Message when trying to save a deleted page"
     )
-    
-    static let okButton = NSLocalizedString(
-        "postSettings.okButton",
-        value: "OK",
-        comment: "OK button in post settings alerts"
-    )
-    
+
     static let postSettingsTitle = NSLocalizedString(
         "postSettings.title.post",
         value: "Post Settings",

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -18,7 +18,7 @@ extension PostSettingsViewController {
         }
     }
 
-    static func showStandaloneEditor(for post: AbstractPost, from presentingViewController: UIViewController) {
+    static func showStandaloneEditor(for post: AbstractPost, from presentingVC: UIViewController) {
         if FeatureFlag.postSettingsV2.enabled {
             let viewModel = PostSettingsViewModel(post: post, isStandalone: true)
             let postSettingsVC = NewPostSettingsViewController(viewModel: viewModel)
@@ -29,7 +29,7 @@ extension PostSettingsViewController {
             let viewController = PostSettingsViewController.make(for: revision)
             viewController.isStandalone = true
             let navigation = UINavigationController(rootViewController: viewController)
-            presentingViewController.present(navigation, animated: true)
+            presentingVC.present(navigation, animated: true)
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController+Swift.swift
@@ -20,7 +20,10 @@ extension PostSettingsViewController {
 
     static func showStandaloneEditor(for post: AbstractPost, from presentingViewController: UIViewController) {
         if FeatureFlag.postSettingsV2.enabled {
-            NewPostSettingsViewController.showStandaloneEditor(for: post, from: presentingViewController)
+            let viewModel = PostSettingsViewModel(post: post, isStandalone: true)
+            let postSettingsVC = NewPostSettingsViewController(viewModel: viewModel)
+            let navigation = UINavigationController(rootViewController: postSettingsVC)
+            presentingVC.present(navigation, animated: true)
         } else {
             let revision = post.createRevision()
             let viewController = PostSettingsViewController.make(for: revision)


### PR DESCRIPTION
## Summary

This PR introduces a new approach for savings and discarding changes in the "Post Settings" based not on Core Data, but on  a modern value-type architecture that improves reliability, testability, and performance.

In the previous implementation, this screen had a lot of complexity due to the fact that it was applying changes directly to the Core Data post entities. It had to create a local revision of a post. Then on "Cancel", it had to delete it and also make sure it gets deleted if the [app is terminated](https://github.com/wordpress-mobile/WordPress-iOS/blob/bcb3e07853d6ed13892a21ce399a37814e7821e0/WordPress/Classes/ViewRelated/Post/PostSettingsViewController%2BSwift.swift#L59) so we don't have unsaved changes in the store. It's just one example.

In the new version, we simply have this as a value type: `@Published var settings: PostSettings`. When the user taps "Cancel", there is nothing we need to do or worry about. It's also easier to check if there are any changes thanks to `Hashable`. You also no longer need to create or revert any post revisions.

The old version had mixed responsibilities with UI updates, Core Data management, and business logic. The new has clear separation between data (`PostSettings`), UI (`PostSettingsView`), and logic (`PostSettingsViewModel`).

## Recordings

I added a single temporary "slug" field for testing for now.

https://github.com/user-attachments/assets/60de4607-7c57-49d3-ad94-af5598a66b3f
https://github.com/user-attachments/assets/ee24e97e-ce1c-485a-bcdf-6f27df7f144b
