### PR TITLE
Post Settings: StandardForm

### DIFF
--- a/Modules/Sources/DesignSystem/Foundation/AppColor.swift
+++ b/Modules/Sources/DesignSystem/Foundation/AppColor.swift
@@ -147,12 +147,18 @@ extension UIAppColor {
     public static let prologueBackground = UIColor(light: blue(.shade0), dark: .systemBackground)
 
     public static let switchStyle: SwitchToggleStyle = SwitchToggleStyle(tint: Color(UIAppColor.primary))
+
+    public static let secondaryBackground = UIColor(
+        light: CSColor.Gray.shade(.shade0),
+        dark: CSColor.Gray.shade(.shade100)
+    )
 }
 
 public enum AppColor {
     public static var tint: Color { Color(UIAppColor.tint) }
     public static var primary: Color { Color(UIAppColor.primary) }
     public static var secondary: Color { Color(UIAppColor.secondary) }
+    public static var secondaryBackground: Color { Color(UIAppColor.secondaryBackground) }
 }
 
 private extension UIColor {

--- a/Modules/Sources/WordPressUI/Views/StandardForm/StandardForm.swift
+++ b/Modules/Sources/WordPressUI/Views/StandardForm/StandardForm.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+import DesignSystem
+
+/// A standard WordPress form with cards.
+public struct StandardForm<Content: View>: View {
+    @ViewBuilder public  let content: () -> Content
+
+    public init(@ViewBuilder content: @escaping () -> Content) {
+        self.content = content
+    }
+
+    public var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 24) {
+                content()
+            }
+            .padding()
+        }
+        .textFieldStyle(.roundedBorder)
+        .background(AppColor.secondaryBackground)
+    }
+}

--- a/Modules/Sources/WordPressUI/Views/StandardForm/StandardFormRow.swift
+++ b/Modules/Sources/WordPressUI/Views/StandardForm/StandardFormRow.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+import DesignSystem
+
+/// A reusable info row component that displays a title and customizable content.
+/// Commonly used within cards or forms to display editable fields.
+public struct StandardFormRow<Content: View>: View {
+    let title: String
+    @ViewBuilder let content: () -> Content
+
+    public init(_ title: String, @ViewBuilder content: @escaping () -> Content) {
+        self.title = title
+        self.content = content
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.subheadline.weight(.medium))
+                .lineLimit(1)
+            content()
+                .font(.subheadline.weight(.regular))
+                .foregroundStyle(AppColor.secondary)
+                .lineLimit(1)
+        }
+    }
+}

--- a/Modules/Sources/WordPressUI/Views/StandardForm/StandardFormSection.swift
+++ b/Modules/Sources/WordPressUI/Views/StandardForm/StandardFormSection.swift
@@ -1,0 +1,43 @@
+import SwiftUI
+
+/// A reusable card view component that provides a consistent container style
+/// with optional title and customizable content.
+public struct StandardFormSection<Content: View>: View {
+    let title: String?
+    @ViewBuilder let content: () -> Content
+
+    public init(_ title: String? = nil, @ViewBuilder content: @escaping () -> Content) {
+        self.title = title
+        self.content = content
+    }
+
+    public var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            if let title {
+                Text(title.uppercased())
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            content()
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+        .background(Color(.systemBackground))
+        .clipShape(RoundedRectangle(cornerRadius: 8))
+        .overlay(
+            RoundedRectangle(cornerRadius: 8)
+                .stroke(Color(.separator), lineWidth: 0.5)
+        )
+    }
+}
+
+#Preview("With Title") {
+    StandardFormSection("Section Title") {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Card Content")
+            Text("More content here")
+                .foregroundStyle(.secondary)
+        }
+    }
+    .padding()
+}

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -37,7 +37,7 @@ private struct PostSettingsView: View {
     @State private var isShowingDiscardChangesAlert = false
 
     var body: some View {
-        Form {
+        StandardForm {
             form
         }
         .opacity(viewModel.isSaving ? 0.6 : 1.0)
@@ -98,13 +98,9 @@ private struct PostSettingsView: View {
 
     @ViewBuilder
     private var form: some View {
-        Section(header: Text(Strings.moreOptionsHeader)) {
-            HStack {
-                Text(Strings.slugLabel)
-                Spacer()
+        StandardFormSection(Strings.moreOptionsHeader) {
+            StandardFormRow(Strings.slugLabel) {
                 TextField(Strings.slugPlaceholder, text: $viewModel.settings.slug)
-                    .textFieldStyle(.plain)
-                    .multilineTextAlignment(.trailing)
                     .textInputAutocapitalization(.never)
                     .disableAutocorrection(true)
             }


### PR DESCRIPTION
Add basic components for representing WordPress-style forms: `StandardForm`, `StandardFormRow`, `StandardFormSection`. Integrate them in the existing test "Slug" field.

<img width="320" alt="Screenshot 2025-06-25 at 7 24 02 PM" src="https://github.com/user-attachments/assets/0c36ffa9-84c3-4303-9ccd-1f1526058483" />