### PR TITLE
Make sure the configure secrets function is called before other code

### DIFF
--- a/WordPress/JetpackIntents/IntentHandler.swift
+++ b/WordPress/JetpackIntents/IntentHandler.swift
@@ -3,12 +3,12 @@ import BuildSettingsKit
 
 class IntentHandler: INExtension, SelectSiteIntentHandling {
 
-    let sitesDataProvider = SitesDataProvider()
+    let sitesDataProvider: SitesDataProvider
 
     override init() {
-        super.init()
-
         BuildSettings.configure(secrets: ApiCredentials.toSecrets())
+        sitesDataProvider = SitesDataProvider()
+        super.init()
     }
 
     // MARK: - INIntentHandlerProviding


### PR DESCRIPTION
## Description

Relate to https://github.com/wordpress-mobile/WordPress-iOS/pull/24565.

The `SitesDataProvider()`, which uses `Bundle.current`, is called before `IntentHandler.init`. Just need to update the code to ensure that the `BuildSettings.configure(secrets:)` is called before other code.

## Testing instructions

Verify this issue is fixed: https://linear.app/a8c/issue/CMM-523

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
