### PR TITLE
Cleanup Keystone and WordPressData Objective-C import

### DIFF
--- a/WordPress/Classes/Categories/Media+Extensions.h
+++ b/WordPress/Classes/Categories/Media+Extensions.h
@@ -1,11 +1,7 @@
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
 
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 @interface Media (Extensions)
 

--- a/WordPress/Classes/Categories/Media+Extensions.h
+++ b/WordPress/Classes/Categories/Media+Extensions.h
@@ -1,7 +1,11 @@
 #import <Foundation/Foundation.h>
 #import <AVFoundation/AVFoundation.h>
 
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 @interface Media (Extensions)
 

--- a/WordPress/Classes/Categories/Media+Extensions.m
+++ b/WordPress/Classes/Categories/Media+Extensions.m
@@ -2,12 +2,7 @@
 #import "MediaService.h"
 @import WordPressData;
 @import WordPressShared;
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @implementation Media (Extensions)
 
 - (NSError *)errorWithMessage:(NSString *)errorMessage {

--- a/WordPress/Classes/Categories/Media+Extensions.m
+++ b/WordPress/Classes/Categories/Media+Extensions.m
@@ -1,6 +1,10 @@
 #import "Media+Extensions.h"
 #import "MediaService.h"
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressShared;
 #ifdef KEYSTONE
 #import "Keystone-Swift.h"

--- a/WordPress/Classes/Categories/Media+Extensions.m
+++ b/WordPress/Classes/Categories/Media+Extensions.m
@@ -1,10 +1,6 @@
 #import "Media+Extensions.h"
 #import "MediaService.h"
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressShared;
 #ifdef KEYSTONE
 #import "Keystone-Swift.h"

--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -1,15 +1,11 @@
 #import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class WPAccount;
 @class RemoteUser;
+@protocol CoreDataStack;
 
 extern NSNotificationName const WPAccountEmailAndDefaultBlogUpdatedNotification;
 

--- a/WordPress/Classes/Services/AccountService.h
+++ b/WordPress/Classes/Services/AccountService.h
@@ -1,6 +1,10 @@
 #import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -5,12 +5,7 @@
 @import WordPressKit;
 @import WordPressShared;
 
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEmailAndDefaultBlogUpdatedNotification";
 
 @implementation AccountService

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -1,11 +1,7 @@
 #import "AccountService.h"
 #import "BlogService.h"
 
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressKit;
 @import WordPressShared;
 

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -1,7 +1,11 @@
 #import "AccountService.h"
 #import "BlogService.h"
 
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressKit;
 @import WordPressShared;
 

--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/Services/BlogService.h
+++ b/WordPress/Classes/Services/BlogService.h
@@ -1,9 +1,4 @@
 #import <Foundation/Foundation.h>
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -11,8 +6,10 @@ extern NSString *const WordPressMinimumVersion;
 extern NSString *const WPBlogUpdatedNotification;
 extern NSString *const WPBlogSettingsUpdatedNotification;
 
+@class Blog;
 @class WPAccount;
 @class SiteInfo;
+@protocol CoreDataStack;
 
 @interface BlogService : NSObject
 

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -3,11 +3,7 @@
 #import "WPError.h"
 #import "PostCategoryService.h"
 #import "CommentService.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 @import WordPressKit;
 @import WordPressShared;

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -8,11 +8,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressKit;
 @import WordPressShared;
 

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -8,7 +8,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressKit;
 @import WordPressShared;
 

--- a/WordPress/Classes/Services/CommentService.h
+++ b/WordPress/Classes/Services/CommentService.h
@@ -1,6 +1,10 @@
 #import <Foundation/Foundation.h>
 #import <WordPressKit/WordPressKit.h>
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/Services/CommentService.h
+++ b/WordPress/Classes/Services/CommentService.h
@@ -1,10 +1,5 @@
 #import <Foundation/Foundation.h>
 #import <WordPressKit/WordPressKit.h>
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -16,6 +11,7 @@ extern NSUInteger const WPTopLevelHierarchicalCommentsPerPage;
 @class BasePost;
 @class RemoteUser;
 @class CommentServiceRemoteFactory;
+@protocol CoreDataStack;
 
 @interface CommentService : NSObject
 

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -1,10 +1,6 @@
 #import "CommentService.h"
 #import "AccountService.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 
 @import WordPressShared;

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -5,11 +5,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 @import WordPressShared;
 

--- a/WordPress/Classes/Services/CommentService.m
+++ b/WordPress/Classes/Services/CommentService.m
@@ -5,7 +5,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 @import WordPressShared;
 

--- a/WordPress/Classes/Services/Facades/BlogSyncFacade.m
+++ b/WordPress/Classes/Services/Facades/BlogSyncFacade.m
@@ -7,11 +7,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 @import WordPressShared;
 @import NSObject_SafeExpectations;

--- a/WordPress/Classes/Services/Facades/BlogSyncFacade.m
+++ b/WordPress/Classes/Services/Facades/BlogSyncFacade.m
@@ -2,11 +2,7 @@
 #import "BlogService.h"
 #import "AccountService.h"
 #import "WPAppAnalytics.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 
 @import WordPressShared;

--- a/WordPress/Classes/Services/Facades/BlogSyncFacade.m
+++ b/WordPress/Classes/Services/Facades/BlogSyncFacade.m
@@ -7,7 +7,9 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, the modular import does not work.
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
 // @import WordPressData;
 #import <WordPressData/WordPressData.h>
 

--- a/WordPress/Classes/Services/MediaService.h
+++ b/WordPress/Classes/Services/MediaService.h
@@ -8,8 +8,6 @@
 
 @class Media;
 @class RemoteVideoPressVideo;
-@class Blog;
-@class AbstractPost;
 @protocol ExportableAsset;
 
 extern NSErrorDomain _Nonnull const MediaServiceErrorDomain;

--- a/WordPress/Classes/Services/MediaService.h
+++ b/WordPress/Classes/Services/MediaService.h
@@ -1,10 +1,6 @@
 #import <Foundation/Foundation.h>
 #import <Photos/Photos.h>
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 @class Media;
 @class RemoteVideoPressVideo;

--- a/WordPress/Classes/Services/MediaService.h
+++ b/WordPress/Classes/Services/MediaService.h
@@ -1,6 +1,10 @@
 #import <Foundation/Foundation.h>
 #import <Photos/Photos.h>
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 @class Media;
 @class RemoteVideoPressVideo;

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -1,11 +1,6 @@
 #import "MediaService.h"
 #import <MobileCoreServices/MobileCoreServices.h>
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressData;
 @import WordPressKit;
 @import WordPressUI;

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -6,11 +6,7 @@
 #import "WordPress-Swift.h"
 #endif
 
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressKit;
 @import WordPressUI;
 @import WordPressShared;

--- a/WordPress/Classes/Services/MediaService.m
+++ b/WordPress/Classes/Services/MediaService.m
@@ -6,7 +6,11 @@
 #import "WordPress-Swift.h"
 #endif
 
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressKit;
 @import WordPressUI;
 @import WordPressShared;

--- a/WordPress/Classes/Services/MenusService.h
+++ b/WordPress/Classes/Services/MenusService.h
@@ -1,5 +1,9 @@
 #import <CoreData/CoreData.h>
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/Services/MenusService.h
+++ b/WordPress/Classes/Services/MenusService.h
@@ -1,9 +1,5 @@
 #import <CoreData/CoreData.h>
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/Services/MenusService.h
+++ b/WordPress/Classes/Services/MenusService.h
@@ -7,11 +7,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class Blog;
-@class Menu;
-@class MenuLocation;
-@class MenuItem;
-
 typedef void(^MenusServiceSuccessBlock)(void);
 typedef void(^MenusServiceCreateOrUpdateMenuRequestSuccessBlock)(void);
 typedef void(^MenusServiceMenusRequestSuccessBlock)(NSArray<Menu *> * _Nullable menus);

--- a/WordPress/Classes/Services/MenusService.m
+++ b/WordPress/Classes/Services/MenusService.m
@@ -1,9 +1,5 @@
 #import "MenusService.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 @import WordPressKit;
 

--- a/WordPress/Classes/Services/MenusService.m
+++ b/WordPress/Classes/Services/MenusService.m
@@ -4,11 +4,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressKit;
 
 @implementation MenusService

--- a/WordPress/Classes/Services/MenusService.m
+++ b/WordPress/Classes/Services/MenusService.m
@@ -4,7 +4,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressKit;
 
 @implementation MenusService

--- a/WordPress/Classes/Services/PostCategoryService.h
+++ b/WordPress/Classes/Services/PostCategoryService.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/Services/PostCategoryService.h
+++ b/WordPress/Classes/Services/PostCategoryService.h
@@ -1,14 +1,11 @@
+@import CoreData;
 #import <Foundation/Foundation.h>
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
 @class Blog;
 @class PostCategory;
+@protocol CoreDataStack;
 
 typedef NS_ENUM(NSInteger, PostCategoryServiceErrors) {
     PostCategoryServiceErrorsBlogNotFound

--- a/WordPress/Classes/Services/PostCategoryService.m
+++ b/WordPress/Classes/Services/PostCategoryService.m
@@ -1,9 +1,5 @@
 #import "PostCategoryService.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 @import WordPressKit;
 

--- a/WordPress/Classes/Services/PostCategoryService.m
+++ b/WordPress/Classes/Services/PostCategoryService.m
@@ -4,7 +4,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressKit;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/WordPress/Classes/Services/PostCategoryService.m
+++ b/WordPress/Classes/Services/PostCategoryService.m
@@ -4,11 +4,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressKit;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/WordPress/Classes/Services/PostTagService.h
+++ b/WordPress/Classes/Services/PostTagService.h
@@ -6,9 +6,6 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@class Blog;
-@class PostTag;
-
 @interface PostTagService : LocalCoreDataService
 
 /**

--- a/WordPress/Classes/Services/PostTagService.h
+++ b/WordPress/Classes/Services/PostTagService.h
@@ -1,4 +1,8 @@
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/Services/PostTagService.h
+++ b/WordPress/Classes/Services/PostTagService.h
@@ -1,8 +1,4 @@
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -1,9 +1,5 @@
 #import "PostTagService.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 @import WordPressKit;
 

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -4,7 +4,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressKit;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -4,11 +4,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressKit;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/WordPress/Classes/Services/Reader Post/ReaderPostService.h
+++ b/WordPress/Classes/Services/Reader Post/ReaderPostService.h
@@ -1,9 +1,5 @@
+@import CoreData;
 #import <Foundation/Foundation.h>
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnullability-completeness"
@@ -11,6 +7,7 @@
 @class ReaderPost;
 @class ReaderAbstractTopic;
 @class WordPressComRestApi;
+@protocol CoreDataStack;
 
 extern NSString * const ReaderPostServiceErrorDomain;
 extern NSString * const ReaderPostServiceToggleSiteFollowingState;

--- a/WordPress/Classes/Services/Reader Post/ReaderPostService.h
+++ b/WordPress/Classes/Services/Reader Post/ReaderPostService.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wnullability-completeness"

--- a/WordPress/Classes/Services/Reader Post/ReaderPostService.m
+++ b/WordPress/Classes/Services/Reader Post/ReaderPostService.m
@@ -4,12 +4,7 @@
 #import "ReaderGapMarker.h"
 #import "ReaderSiteService.h"
 #import "WPAppAnalytics.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressData;
 @import WordPressKit;
 @import WordPressShared;

--- a/WordPress/Classes/Services/Reader Post/ReaderPostService.m
+++ b/WordPress/Classes/Services/Reader Post/ReaderPostService.m
@@ -10,7 +10,11 @@
 #import "WordPress-Swift.h"
 #endif
 
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressKit;
 @import WordPressShared;
 

--- a/WordPress/Classes/Services/Reader Post/ReaderPostService.m
+++ b/WordPress/Classes/Services/Reader Post/ReaderPostService.m
@@ -10,11 +10,7 @@
 #import "WordPress-Swift.h"
 #endif
 
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressKit;
 @import WordPressShared;
 

--- a/WordPress/Classes/Services/ReaderSiteService.h
+++ b/WordPress/Classes/Services/ReaderSiteService.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/Services/ReaderSiteService.h
+++ b/WordPress/Classes/Services/ReaderSiteService.h
@@ -1,9 +1,6 @@
 #import <Foundation/Foundation.h>
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+
+@protocol CoreDataStack;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -2,11 +2,7 @@
 
 #import "AccountService.h"
 #import "ReaderPostService.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 #import "WPAppAnalytics.h"
 @import WordPressData;
 @import WordPressKit;

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -8,7 +8,11 @@
 #import "WordPress-Swift.h"
 #endif
 #import "WPAppAnalytics.h"
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressKit;
 
 NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";

--- a/WordPress/Classes/Services/ReaderSiteService.m
+++ b/WordPress/Classes/Services/ReaderSiteService.m
@@ -8,11 +8,7 @@
 #import "WordPress-Swift.h"
 #endif
 #import "WPAppAnalytics.h"
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressKit;
 
 NSString * const ReaderSiteServiceErrorDomain = @"ReaderSiteServiceErrorDomain";

--- a/WordPress/Classes/Services/ReaderTopicService.h
+++ b/WordPress/Classes/Services/ReaderTopicService.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/Services/ReaderTopicService.h
+++ b/WordPress/Classes/Services/ReaderTopicService.h
@@ -1,9 +1,5 @@
+@import CoreData;
 #import <Foundation/Foundation.h>
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 
@@ -13,6 +9,7 @@ extern NSString * const ReaderTopicFreshlyPressedPathCommponent;
 @class ReaderTagTopic;
 @class ReaderSiteTopic;
 @class ReaderSearchTopic;
+@protocol CoreDataStack;
 
 @interface ReaderTopicService : NSObject
 

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -1,11 +1,7 @@
 #import "ReaderTopicService.h"
 #import "AccountService.h"
 #import "ReaderPostService.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 @import WordPressKit;
 @import WordPressShared;

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -6,11 +6,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressKit;
 @import WordPressShared;
 

--- a/WordPress/Classes/Services/ReaderTopicService.m
+++ b/WordPress/Classes/Services/ReaderTopicService.m
@@ -6,7 +6,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressKit;
 @import WordPressShared;
 

--- a/WordPress/Classes/Services/ThemeService.h
+++ b/WordPress/Classes/Services/ThemeService.h
@@ -1,14 +1,9 @@
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
-
 NS_ASSUME_NONNULL_BEGIN
 
 @class Blog;
 @class Theme;
 @class WPAccount;
+@protocol CoreDataStack;
 
 typedef void(^ThemeServiceSuccessBlock)(void);
 typedef void(^ThemeServiceThemeRequestSuccessBlock)(Theme * _Nullable theme);

--- a/WordPress/Classes/Services/ThemeService.h
+++ b/WordPress/Classes/Services/ThemeService.h
@@ -1,4 +1,8 @@
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/Services/ThemeService.m
+++ b/WordPress/Classes/Services/ThemeService.m
@@ -1,10 +1,6 @@
 #import "ThemeService.h"
 
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 @import WordPressKit;
 

--- a/WordPress/Classes/Services/ThemeService.m
+++ b/WordPress/Classes/Services/ThemeService.m
@@ -5,11 +5,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressKit;
 
 /**

--- a/WordPress/Classes/Services/ThemeService.m
+++ b/WordPress/Classes/Services/ThemeService.m
@@ -5,7 +5,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressKit;
 
 /**

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -3,11 +3,7 @@
 
 #import "WPAppAnalytics.h"
 
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 
 NSString * const WPAppAnalyticsDefaultsUserOptedOut                 = @"tracks_opt_out";

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -8,7 +8,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 NSString * const WPAppAnalyticsDefaultsUserOptedOut                 = @"tracks_opt_out";
 NSString * const WPAppAnalyticsKeyBlogID                            = @"blog_id";

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics.m
@@ -8,11 +8,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 NSString * const WPAppAnalyticsDefaultsUserOptedOut                 = @"tracks_opt_out";
 NSString * const WPAppAnalyticsKeyBlogID                            = @"blog_id";

--- a/WordPress/Classes/Utility/Logging/WPLogger.m
+++ b/WordPress/Classes/Utility/Logging/WPLogger.m
@@ -2,12 +2,7 @@
 @import WordPressShared;
 
 #import "WPLogger.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 DDLogLevel ddLogLevel = DDLogLevelInfo;
 
 void SetCocoaLumberjackObjCLogLevel(NSUInteger ddLogLevelRawValue)

--- a/WordPress/Classes/Utility/UIAlertControllerProxy.m
+++ b/WordPress/Classes/Utility/UIAlertControllerProxy.m
@@ -1,11 +1,7 @@
 @import WordPressShared;
 
 #import "UIAlertControllerProxy.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressShared;
 
 @implementation UIAlertControllerProxy

--- a/WordPress/Classes/Utility/WPError.m
+++ b/WordPress/Classes/Utility/WPError.m
@@ -1,10 +1,5 @@
 #import "WPError.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressData;
 @import WordPressShared;
 @import WordPressKit;

--- a/WordPress/Classes/Utility/WPError.m
+++ b/WordPress/Classes/Utility/WPError.m
@@ -5,7 +5,11 @@
 #import "WordPress-Swift.h"
 #endif
 
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressShared;
 @import WordPressKit;
 

--- a/WordPress/Classes/Utility/WPError.m
+++ b/WordPress/Classes/Utility/WPError.m
@@ -5,11 +5,7 @@
 #import "WordPress-Swift.h"
 #endif
 
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressShared;
 @import WordPressKit;
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -7,11 +7,7 @@
 #import "SharingViewController.h"
 #import "StatsViewController.h"
 #import "WPAppAnalytics.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 #import "MenusViewController.h"
 
 @import Gridicons;

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -16,11 +16,7 @@
 
 @import Gridicons;
 @import Reachability;
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressShared;
 
 static NSString *const BlogDetailsCellIdentifier = @"BlogDetailsCell";

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.m
@@ -16,7 +16,11 @@
 
 @import Gridicons;
 @import Reachability;
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressShared;
 
 static NSString *const BlogDetailsCellIdentifier = @"BlogDetailsCell";

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingAuthorizationHelper.m
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingAuthorizationHelper.m
@@ -3,11 +3,7 @@
 #import "SharingAuthorizationHelper.h"
 #import "BlogService.h"
 
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 
 

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingAuthorizationHelper.m
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingAuthorizationHelper.m
@@ -8,11 +8,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 
 

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingAuthorizationHelper.m
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingAuthorizationHelper.m
@@ -8,7 +8,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 
 

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingConnectionsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingConnectionsViewController.m
@@ -3,12 +3,7 @@
 #import "BlogService.h"
 #import "SharingDetailViewController.h"
 #import "SharingAuthorizationHelper.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressData;
 @import WordPressShared;
 

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingConnectionsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingConnectionsViewController.m
@@ -9,7 +9,11 @@
 #import "WordPress-Swift.h"
 #endif
 
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressShared;
 
 static NSString *const CellIdentifier = @"CellIdentifier";

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingConnectionsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingConnectionsViewController.m
@@ -9,11 +9,7 @@
 #import "WordPress-Swift.h"
 #endif
 
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressShared;
 
 static NSString *const CellIdentifier = @"CellIdentifier";

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingDetailViewController.m
@@ -1,12 +1,7 @@
 #import "SharingDetailViewController.h"
 #import "BlogService.h"
 #import "SharingAuthorizationHelper.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressData;
 @import WordPressShared;
 

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingDetailViewController.m
@@ -7,7 +7,11 @@
 #import "WordPress-Swift.h"
 #endif
 
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressShared;
 
 static NSString *const CellIdentifier = @"CellIdentifier";

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingDetailViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingDetailViewController.m
@@ -7,11 +7,7 @@
 #import "WordPress-Swift.h"
 #endif
 
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressShared;
 
 static NSString *const CellIdentifier = @"CellIdentifier";

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingViewController.m
@@ -1,12 +1,7 @@
 #import "SharingViewController.h"
 #import "BlogService.h"
 #import "SharingConnectionsViewController.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressData;
 @import WordPressUI;
 @import WordPressShared;

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingViewController.m
@@ -7,7 +7,11 @@
 #import "WordPress-Swift.h"
 #endif
 
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressUI;
 @import WordPressShared;
 

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingViewController.m
@@ -7,11 +7,7 @@
 #import "WordPress-Swift.h"
 #endif
 
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressUI;
 @import WordPressShared;
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SettingTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SettingTableViewCell.m
@@ -1,10 +1,5 @@
 #import "SettingTableViewCell.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 NSString * const SettingsTableViewCellReuseIdentifier = @"org.wordpress.SettingTableViewCell";
 
 @implementation SettingTableViewCell

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -6,11 +6,7 @@
 #import "SettingsMultiTextViewController.h"
 #import "SettingTableViewCell.h"
 #import "SettingsTextViewController.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 #import "AccountService.h"
 @import WordPressData;
 @import WordPressKit;

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -12,11 +12,7 @@
 #import "WordPress-Swift.h"
 #endif
 #import "AccountService.h"
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressKit;
 @import WordPressShared;
 @import NSURL_IDN;

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -12,7 +12,11 @@
 #import "WordPress-Swift.h"
 #endif
 #import "AccountService.h"
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressKit;
 @import WordPressShared;
 @import NSURL_IDN;

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentsViewController.m
@@ -1,10 +1,5 @@
 #import "CommentsViewController.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressData;
 @import WordPressLegacy;
 @import WordPressShared;

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentsViewController.m
@@ -5,7 +5,11 @@
 #import "WordPress-Swift.h"
 #endif
 
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressLegacy;
 @import WordPressShared;
 

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/CommentsViewController.m
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/CommentsViewController.m
@@ -5,11 +5,7 @@
 #import "WordPress-Swift.h"
 #endif
 
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressLegacy;
 @import WordPressShared;
 

--- a/WordPress/Classes/ViewRelated/Menus/Categories/MenuItem+ViewDesign.h
+++ b/WordPress/Classes/ViewRelated/Menus/Categories/MenuItem+ViewDesign.h
@@ -1,8 +1,4 @@
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 #import "Menu+ViewDesign.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/WordPress/Classes/ViewRelated/Menus/Categories/MenuItem+ViewDesign.h
+++ b/WordPress/Classes/ViewRelated/Menus/Categories/MenuItem+ViewDesign.h
@@ -1,4 +1,8 @@
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 #import "Menu+ViewDesign.h"
 
 NS_ASSUME_NONNULL_BEGIN

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuDetailsViewController.m
@@ -1,11 +1,7 @@
 #import "MenuDetailsViewController.h"
 #import "Menu+ViewDesign.h"
 #import "WPAppAnalytics.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 @import WordPressShared;
 

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuDetailsViewController.m
@@ -6,11 +6,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressShared;
 
 @import Gridicons;

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuDetailsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuDetailsViewController.m
@@ -6,7 +6,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressShared;
 
 @import Gridicons;

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuHeaderViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuHeaderViewController.m
@@ -1,11 +1,7 @@
 #import "MenuHeaderViewController.h"
 #import "MenusSelectionView.h"
 #import "Menu+ViewDesign.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 @import WordPressShared;
 

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuHeaderViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuHeaderViewController.m
@@ -6,7 +6,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressShared;
 
 static CGFloat ViewExpansionAnimationDelay = 0.15;

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuHeaderViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuHeaderViewController.m
@@ -6,11 +6,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressShared;
 
 static CGFloat ViewExpansionAnimationDelay = 0.15;

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemAbstractPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemAbstractPostsViewController.m
@@ -1,9 +1,5 @@
 #import "MenuItemAbstractPostsViewController.h"
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressKit;
 
 @interface MenuItemAbstractPostsViewController () <MenuItemSourcePostAbstractViewSubclass>

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemAbstractPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemAbstractPostsViewController.m
@@ -1,5 +1,9 @@
 #import "MenuItemAbstractPostsViewController.h"
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressKit;
 
 @interface MenuItemAbstractPostsViewController () <MenuItemSourcePostAbstractViewSubclass>

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemCategoriesViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemCategoriesViewController.m
@@ -1,10 +1,6 @@
 #import "MenuItemCategoriesViewController.h"
 #import "PostCategoryService.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 
 static NSUInteger const CategorySyncLimit = 1000;

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemCategoriesViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemCategoriesViewController.m
@@ -5,11 +5,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 static NSUInteger const CategorySyncLimit = 1000;
 static NSString * const CategorySortKey = @"categoryName";

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemCategoriesViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemCategoriesViewController.m
@@ -5,7 +5,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 static NSUInteger const CategorySyncLimit = 1000;
 static NSString * const CategorySortKey = @"categoryName";

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemEditingViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemEditingViewController.m
@@ -3,11 +3,7 @@
 #import "MenuItemEditingFooterView.h"
 #import "MenuItemSourceViewController.h"
 #import "MenuItemTypeViewController.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 @import WordPressShared;
 

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemEditingViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemEditingViewController.m
@@ -8,11 +8,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressShared;
 
 NSString * const MenuItemEditingTypeSelectionChangedNotification = @"MenuItemEditingTypeSelectionChangedNotification";

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemEditingViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemEditingViewController.m
@@ -8,7 +8,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressShared;
 
 NSString * const MenuItemEditingTypeSelectionChangedNotification = @"MenuItemEditingTypeSelectionChangedNotification";

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemLinkViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemLinkViewController.m
@@ -1,11 +1,6 @@
 #import "MenuItemLinkViewController.h"
 #import "MenuItemCheckButtonView.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressShared;
 
 static CGFloat const LinkTextBarHeight = 48.0;

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemPagesViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemPagesViewController.m
@@ -1,9 +1,5 @@
 #import "MenuItemPagesViewController.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 
 @interface MenuItemAbstractPostsViewController () <MenuItemSourcePostAbstractViewSubclass>

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemPagesViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemPagesViewController.m
@@ -4,7 +4,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 @interface MenuItemAbstractPostsViewController () <MenuItemSourcePostAbstractViewSubclass>
 @end

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemPagesViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemPagesViewController.m
@@ -4,11 +4,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 @interface MenuItemAbstractPostsViewController () <MenuItemSourcePostAbstractViewSubclass>
 @end

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemPostsViewController.m
@@ -1,9 +1,5 @@
 #import "MenuItemPostsViewController.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 
 @interface MenuItemAbstractPostsViewController () <MenuItemSourcePostAbstractViewSubclass>

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemPostsViewController.m
@@ -4,7 +4,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 @interface MenuItemAbstractPostsViewController () <MenuItemSourcePostAbstractViewSubclass>
 @end

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemPostsViewController.m
@@ -4,11 +4,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 @interface MenuItemAbstractPostsViewController () <MenuItemSourcePostAbstractViewSubclass>
 @end

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemSourceResultsViewController.h
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemSourceResultsViewController.h
@@ -1,7 +1,11 @@
 #import <UIKit/UIKit.h>
 #import "MenuItemSourceTextBar.h"
 #import "MenuItemSourceCell.h"
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemSourceResultsViewController.h
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemSourceResultsViewController.h
@@ -1,11 +1,7 @@
+@import CoreData;
 #import <UIKit/UIKit.h>
 #import "MenuItemSourceTextBar.h"
 #import "MenuItemSourceCell.h"
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemSourceResultsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemSourceResultsViewController.m
@@ -2,11 +2,7 @@
 #import "MenuItemSourceTextBar.h"
 #import "MenuItemSourceFooterView.h"
 #import "Menu+ViewDesign.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 @import WordPressShared;
 

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemSourceResultsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemSourceResultsViewController.m
@@ -7,11 +7,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressShared;
 
 static NSTimeInterval const SearchBarFetchRequestUpdateDelay = 0.10;

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemSourceResultsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemSourceResultsViewController.m
@@ -7,7 +7,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressShared;
 
 static NSTimeInterval const SearchBarFetchRequestUpdateDelay = 0.10;

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemSourceViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemSourceViewController.m
@@ -6,11 +6,7 @@
 #import "MenuItemTagsViewController.h"
 #import "MenuItemPostsViewController.h"
 #import "Menu.h"
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 static CGFloat const SourceHeaderViewHeight = 60.0;
 

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemSourceViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemSourceViewController.m
@@ -6,6 +6,11 @@
 #import "MenuItemTagsViewController.h"
 #import "MenuItemPostsViewController.h"
 #import "Menu.h"
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 static CGFloat const SourceHeaderViewHeight = 60.0;
 

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemTagsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemTagsViewController.m
@@ -1,10 +1,6 @@
 #import "MenuItemTagsViewController.h"
 #import "PostTagService.h"
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 static NSUInteger const MenuItemSourceTagSyncLimit = 100;
 

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemTagsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemTagsViewController.m
@@ -1,6 +1,10 @@
 #import "MenuItemTagsViewController.h"
 #import "PostTagService.h"
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 static NSUInteger const MenuItemSourceTagSyncLimit = 100;
 

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemTypeViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemTypeViewController.m
@@ -1,11 +1,7 @@
 #import "MenuItemTypeViewController.h"
 #import "MenuItemTypeSelectionView.h"
 #import "BlogService.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 
 @interface MenuItemTypeViewController () <MenuItemTypeViewDelegate>

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemTypeViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemTypeViewController.m
@@ -6,7 +6,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 @interface MenuItemTypeViewController () <MenuItemTypeViewDelegate>
 

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemTypeViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemTypeViewController.m
@@ -6,11 +6,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 @interface MenuItemTypeViewController () <MenuItemTypeViewDelegate>
 

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemsViewController.m
@@ -4,12 +4,7 @@
 #import "MenuItemInsertionView.h"
 #import "MenuItemsVisualOrderingView.h"
 #import "Menu+ViewDesign.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressData;
 @import WordPressShared;
 

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemsViewController.m
@@ -10,11 +10,7 @@
 #import "WordPress-Swift.h"
 #endif
 
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressShared;
 
 static CGFloat const ItemHoriztonalDragDetectionWidthRatio = 0.05;

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemsViewController.m
@@ -10,7 +10,11 @@
 #import "WordPress-Swift.h"
 #endif
 
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressShared;
 
 static CGFloat const ItemHoriztonalDragDetectionWidthRatio = 0.05;

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenusViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenusViewController.m
@@ -6,12 +6,7 @@
 #import "MenuItemEditingViewController.h"
 #import "Menu+ViewDesign.h"
 #import "WPAppAnalytics.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressData;
 @import WordPressShared;
 

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenusViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenusViewController.m
@@ -12,11 +12,7 @@
 #import "WordPress-Swift.h"
 #endif
 
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressShared;
 
 static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenusViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenusViewController.m
@@ -12,7 +12,11 @@
 #import "WordPress-Swift.h"
 #endif
 
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressShared;
 
 static CGFloat const ScrollViewOffsetAdjustmentPadding = 10.0;

--- a/WordPress/Classes/ViewRelated/Menus/View Models/MenusSelectionItem.m
+++ b/WordPress/Classes/ViewRelated/Menus/View Models/MenusSelectionItem.m
@@ -1,5 +1,9 @@
 #import "MenusSelectionItem.h"
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 NSString * const MenusSelectionViewItemChangedSelectedNotification = @"MenusSelectionViewItemChangedSelectedNotification";
 NSString * const MenusSelectionViewItemUpdatedItemObjectNotification = @"MenusSelectionViewItemUpdatedItemObjectNotification";

--- a/WordPress/Classes/ViewRelated/Menus/View Models/MenusSelectionItem.m
+++ b/WordPress/Classes/ViewRelated/Menus/View Models/MenusSelectionItem.m
@@ -1,9 +1,5 @@
 #import "MenusSelectionItem.h"
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 NSString * const MenusSelectionViewItemChangedSelectedNotification = @"MenusSelectionViewItemChangedSelectedNotification";
 NSString * const MenusSelectionViewItemUpdatedItemObjectNotification = @"MenusSelectionViewItemUpdatedItemObjectNotification";

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemAbstractView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemAbstractView.m
@@ -1,11 +1,6 @@
 #import "MenuItemAbstractView.h"
 #import "MenuItem+ViewDesign.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressUI;
 @import WordPressShared;
 

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemCheckButtonView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemCheckButtonView.m
@@ -1,11 +1,6 @@
 #import "MenuItemCheckButtonView.h"
 #import "Menu+ViewDesign.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressShared;
 @import Gridicons;
 

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemEditingFooterView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemEditingFooterView.m
@@ -1,10 +1,5 @@
 #import "MenuItemEditingFooterView.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import Gridicons;
 @import WordPressShared;
 

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemEditingHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemEditingHeaderView.m
@@ -1,10 +1,6 @@
 #import "MenuItemEditingHeaderView.h"
 #import "MenuItem+ViewDesign.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 
 @import WordPressShared;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemEditingHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemEditingHeaderView.m
@@ -5,11 +5,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 @import WordPressShared;
 

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemEditingHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemEditingHeaderView.m
@@ -5,7 +5,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 @import WordPressShared;
 

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemInsertionView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemInsertionView.m
@@ -1,10 +1,5 @@
 #import "MenuItemInsertionView.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import Gridicons;
 
 @implementation MenuItemInsertionView

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceCell.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceCell.m
@@ -1,11 +1,6 @@
 #import "MenuItemSourceCell.h"
 #import "Menu+ViewDesign.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressShared;
 
 #pragma mark - MenuItemSourceRadioButton

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceFooterView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceFooterView.m
@@ -1,12 +1,7 @@
 #import "MenuItemSourceFooterView.h"
 #import "MenuItemSourceCell.h"
 #import "Menu+ViewDesign.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressShared;
 
 @interface MenuItemSourceFooterView ()

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.m
@@ -1,11 +1,7 @@
 #import "MenuItemSourceHeaderView.h"
 #import "MenuItem+ViewDesign.h"
 #import "MenuItem.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 
 @import WordPressShared;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.m
@@ -6,7 +6,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 @import WordPressShared;
 @import Gridicons;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceHeaderView.m
@@ -6,11 +6,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 @import WordPressShared;
 @import Gridicons;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTextBar.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemSourceTextBar.m
@@ -1,11 +1,6 @@
 #import "MenuItemSourceTextBar.h"
 #import "Menu+ViewDesign.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import Gridicons;
 @import WordPressShared;
 

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemTypeSelectionView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemTypeSelectionView.m
@@ -2,11 +2,7 @@
 #import "Menu+ViewDesign.h"
 #import "MenuItem+ViewDesign.h"
 #import "MenuItem.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 
 @import WordPressShared;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemTypeSelectionView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemTypeSelectionView.m
@@ -7,11 +7,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 @import WordPressShared;
 @import Gridicons;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemTypeSelectionView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemTypeSelectionView.m
@@ -7,7 +7,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 @import WordPressShared;
 @import Gridicons;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemView.m
@@ -1,10 +1,6 @@
 #import "MenuItemView.h"
 #import "MenuItem+ViewDesign.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 
 @import Gridicons;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemView.m
@@ -5,7 +5,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 @import Gridicons;
 @import WordPressShared;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemView.m
@@ -5,11 +5,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 @import Gridicons;
 @import WordPressShared;

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemsVisualOrderingView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemsVisualOrderingView.m
@@ -1,10 +1,6 @@
 #import "MenuItemsVisualOrderingView.h"
 #import "MenuItemView.h"
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 
 @interface MenuItemsVisualOrderingView ()

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenuItemsVisualOrderingView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenuItemsVisualOrderingView.m
@@ -1,6 +1,10 @@
 #import "MenuItemsVisualOrderingView.h"
 #import "MenuItemView.h"
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 
 @interface MenuItemsVisualOrderingView ()

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionDetailView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionDetailView.m
@@ -2,12 +2,7 @@
 #import "Menu+ViewDesign.h"
 #import "MenusSelectionView.h"
 
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressShared;
 @import Gridicons;
 

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionItemView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionItemView.m
@@ -1,12 +1,7 @@
 #import "MenusSelectionItemView.h"
 #import "MenusSelectionView.h"
 #import "Menu+ViewDesign.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressShared;
 @import Gridicons;
 

--- a/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionView.m
+++ b/WordPress/Classes/ViewRelated/Menus/Views/MenusSelectionView.m
@@ -2,12 +2,7 @@
 #import "MenusSelectionDetailView.h"
 #import "MenusSelectionItemView.h"
 #import "Menu+ViewDesign.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressShared;
 
 @interface MenusSelectionView () <MenusSelectionDetailViewDelegate, MenusSelectionItemViewDelegate>

--- a/WordPress/Classes/ViewRelated/Pages/PageSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Pages/PageSettingsViewController.m
@@ -1,11 +1,6 @@
 #import "PageSettingsViewController.h"
 #import "PostSettingsViewController_Internal.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @interface PageSettingsViewController ()
 
 @end

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.h
@@ -1,10 +1,6 @@
 #import <UIKit/UIKit.h>
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
 
+@class AbstractPost;
 // TODO: It can be removed when the new editor is released. It only exists to support the "Featured" badge on featured images in Gutenberg mobile.
 @protocol FeaturedImageDelegate
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.h
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.h
@@ -1,5 +1,9 @@
 #import <UIKit/UIKit.h>
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 // TODO: It can be removed when the new editor is released. It only exists to support the "Featured" badge on featured images in Gutenberg mobile.
 @protocol FeaturedImageDelegate

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -3,11 +3,7 @@
 #import "SettingsSelectionViewController.h"
 #import "SharingDetailViewController.h"
 #import "MediaService.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 
 @import Gridicons;

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -8,11 +8,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 @import Gridicons;
 @import WordPressShared;

--- a/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Post/PostSettingsViewController.m
@@ -8,7 +8,11 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 
 @import Gridicons;
 @import WordPressShared;

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -1,10 +1,6 @@
 #import "StatsViewController.h"
 #import "BlogService.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 #import "WPAppAnalytics.h"
 
 @import WordPressData;

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -7,11 +7,7 @@
 #endif
 #import "WPAppAnalytics.h"
 
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressShared;
 @import Reachability;
 

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -7,7 +7,11 @@
 #endif
 #import "WPAppAnalytics.h"
 
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressShared;
 @import Reachability;
 

--- a/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
+++ b/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
@@ -5,11 +5,7 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 CGFloat const STVDefaultMinHeaderHeight = 0.f;
 NSString * const CellIdentifier = @"SuggestionsTableViewCell";

--- a/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
+++ b/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
@@ -1,10 +1,6 @@
 #import "SuggestionsTableView.h"
 #import "SuggestionsTableViewCell.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 
 CGFloat const STVDefaultMinHeaderHeight = 0.f;

--- a/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
+++ b/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableView.m
@@ -5,7 +5,9 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, the modular import does not work.
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
 // @import WordPressData;
 #import <WordPressData/WordPressData.h>
 

--- a/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableViewCell.m
+++ b/WordPress/Classes/ViewRelated/Suggestions/SuggestionsTableViewCell.m
@@ -1,10 +1,5 @@
 #import "SuggestionsTableViewCell.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressShared;
 
 NSInteger const SuggestionsTableViewCellIconSize = 24;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.h
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.h
@@ -9,14 +9,10 @@ extern NSString * const WPTabBarCurrentlySelectedScreenReader;
 extern NSString * const WPTabBarCurrentlySelectedScreenNotifications;
 extern NSNotificationName const WPTabBarHeightChangedNotification;
 
-@class AbstractPost;
-@class Blog;
-@class BloggingPromptCoordinator;
 @class MeViewController;
 @class MySitesCoordinator;
 @class NotificationsViewController;
 @class ReaderPresenter;
-@protocol ScenePresenter;
 
 @interface WPTabBarController : UITabBarController <UIViewControllerTransitioningDelegate>
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -5,11 +5,7 @@
 
 #import "BlogDetailsViewController.h"
 #import "WPAppAnalytics.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
 @import WordPressData;
 
 @import Gridicons;

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -10,12 +10,18 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, the modular import does not work.
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
 // @import WordPressData;
 #import <WordPressData/WordPressData.h>
 
 @import Gridicons;
-@import WordPressData;
+// For some reason, and only in some files, the modular import does not work.
+// Just to be on the safe side, _all_ imports use the angle brackets style.
+// We shall try to go back to the modular style on Keystone successfully builds for testing.
+// @import WordPressData;
+#import <WordPressData/WordPressData.h>
 @import WordPressShared;
 @import WordPressUI;
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -10,18 +10,10 @@
 #else
 #import "WordPress-Swift.h"
 #endif
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 
 @import Gridicons;
-// For some reason, and only in some files, the modular import does not work.
-// Just to be on the safe side, _all_ imports use the angle brackets style.
-// We shall try to go back to the modular style on Keystone successfully builds for testing.
-// @import WordPressData;
-#import <WordPressData/WordPressData.h>
+@import WordPressData;
 @import WordPressShared;
 @import WordPressUI;
 

--- a/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsMultiTextViewController.m
@@ -1,10 +1,5 @@
 #import "SettingsMultiTextViewController.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressShared;
 
 static CGVector const SettingsTextPadding = {11.0f, 3.0f};

--- a/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsSelectionViewController.m
@@ -1,12 +1,7 @@
 #import "SettingsSelectionViewController.h"
 #import "SettingsTextViewController.h"
 #import "NSDictionary+SafeExpectations.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressShared;
 
 NSString * const SettingsSelectionTitleKey = @"Title";

--- a/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
+++ b/WordPress/Classes/ViewRelated/Tools/SettingsTextViewController.m
@@ -1,10 +1,5 @@
 #import "SettingsTextViewController.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressShared;
 
 #pragma mark - Constants

--- a/WordPress/Classes/ViewRelated/Views/WPUploadStatusButton.m
+++ b/WordPress/Classes/ViewRelated/Views/WPUploadStatusButton.m
@@ -1,10 +1,5 @@
 #import "WPUploadStatusButton.h"
-#ifdef KEYSTONE
-#import "Keystone-Swift.h"
-#else
 #import "WordPress-Swift.h"
-#endif
-
 @import WordPressShared;
 @import WordPressUI;
 


### PR DESCRIPTION
In my effort to get Keystone to build for testing (Keystone scheme > Shift Cmd U) I'm running into weird build failures.

One of the things I've done to try and wrangle them is to tidy up the Objective-C imports for Keystone and WordPressData.

This PR:

- Updates all Objective-C headers to prefer forward declaration whenever possible for WordPressData, to keep the build lean
- Use modular header for WordPressData, `@import WordPressData`
- Remove the unused `#ifdef KEYSTONE`. Notice that the custom build setting had removed weeks ago via 216b4c69dd618c91f9d2262338ec48200a359a94