### PR TITLE
Fix false positive Keystone and WordPressData tests in CI

### DIFF
--- a/.buildkite/commands/run-unit-tests-for-scheme.sh
+++ b/.buildkite/commands/run-unit-tests-for-scheme.sh
@@ -1,0 +1,17 @@
+#!/bin/bash -euo pipefail
+
+SCHEME="${1:?Usage $0 SCHEME}"
+DEVICE="iPhone 16"
+OS_VERSION="18.4"
+
+if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type validation; then
+  exit 0
+fi
+
+$(dirname "${BASH_SOURCE[0]}")/shared-set-up.sh
+
+xcodebuild \
+  -scheme "${SCHEME}" \
+  -destination "platform=iOS Simulator,OS=${OS_VERSION},name=${DEVICE}" \
+  test \
+  | xcbeautify

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -111,19 +111,7 @@ steps:
           - github_commit_status:
               context: "Reader Unit Tests"
       - label: "🔬 Keystone Unit Tests"
-        command: |
-          if .buildkite/commands/should-skip-job.sh --job-type validation; then
-            exit 0
-          fi
-
-          set -o pipefail
-
-          .buildkite/commands/shared-set-up.sh
-          xcodebuild \
-            -scheme Keystone \
-            -destination 'platform=iOS Simulator,OS=18.4,name=iPhone 16' \
-            test \
-            | xcbeautify
+        command: .buildkite/commands/run-unit-tests-for-scheme.sh Keystone
         plugins: [$CI_TOOLKIT_PLUGIN]
         artifact_paths:
           - "build/results/*"
@@ -131,19 +119,7 @@ steps:
           - github_commit_status:
               context: "Unit Tests Keystone"
       - label: "🔬 WordPressData Unit Tests"
-        command: |
-          if .buildkite/commands/should-skip-job.sh --job-type validation; then
-            exit 0
-          fi
-
-          set -o pipefail
-
-          .buildkite/commands/shared-set-up.sh
-          xcodebuild \
-            -scheme WordPressData \
-            -destination 'platform=iOS Simulator,OS=18.4,name=iPhone 16' \
-            test \
-            | xcbeautify
+        command: .buildkite/commands/run-unit-tests-for-scheme.sh WordPressData
         plugins: [$CI_TOOLKIT_PLUGIN]
         artifact_paths:
           - "build/results/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -116,6 +116,8 @@ steps:
             exit 0
           fi
 
+          set -o pipefail
+
           .buildkite/commands/shared-set-up.sh
           xcodebuild \
             -scheme Keystone \
@@ -133,6 +135,8 @@ steps:
           if .buildkite/commands/should-skip-job.sh --job-type validation; then
             exit 0
           fi
+
+          set -o pipefail
 
           .buildkite/commands/shared-set-up.sh
           xcodebuild \

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,3 +1,6 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
+---
+
 # Most of the steps need to run on a macOS agent, so let's define it as a root property.
 agents:
   queue: mac
@@ -113,7 +116,10 @@ steps:
       - label: "🔬 Keystone Unit Tests"
         command: .buildkite/commands/run-unit-tests-for-scheme.sh Keystone
         # Disabled till https://github.com/wordpress-mobile/WordPress-iOS/pull/24537 is completed
-        if: false
+        #
+        # The boolean value has to be a string explicitly.
+        # See validation error against schema.
+        if: "false"
         plugins: [$CI_TOOLKIT_PLUGIN]
         artifact_paths:
           - "build/results/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -112,6 +112,8 @@ steps:
               context: "Reader Unit Tests"
       - label: "🔬 Keystone Unit Tests"
         command: .buildkite/commands/run-unit-tests-for-scheme.sh Keystone
+        # Disabled till https://github.com/wordpress-mobile/WordPress-iOS/pull/24537 is completed
+        if: false
         plugins: [$CI_TOOLKIT_PLUGIN]
         artifact_paths:
           - "build/results/*"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -121,7 +121,7 @@ steps:
           .buildkite/commands/shared-set-up.sh
           xcodebuild \
             -scheme Keystone \
-            -destination 'platform=iOS Simulator,OS=18.2,name=iPhone 16' \
+            -destination 'platform=iOS Simulator,OS=18.4,name=iPhone 16' \
             test \
             | xcbeautify
         plugins: [$CI_TOOLKIT_PLUGIN]
@@ -141,7 +141,7 @@ steps:
           .buildkite/commands/shared-set-up.sh
           xcodebuild \
             -scheme WordPressData \
-            -destination 'platform=iOS Simulator,OS=18.2,name=iPhone 16' \
+            -destination 'platform=iOS Simulator,OS=18.4,name=iPhone 16' \
             test \
             | xcbeautify
         plugins: [$CI_TOOLKIT_PLUGIN]


### PR DESCRIPTION
The tests for Keystone and WordPressData used `| xcbeautify` but without `set -o pipefail`, meaning that if the test failed, the error would have been swallowed by the pipe. Example:

<img width="933" alt="image" src="https://github.com/user-attachments/assets/18e6320a-7f98-4f90-baab-f1fe76196957" />


Case in point, [this build](https://buildkite.com/automattic/wordpress-ios/builds/28007/steps/canvas?jid=0197aba1-e3fa-4d6c-bfca-983087b3b030) where we can now see Keystone failing.

<img width="918" alt="image" src="https://github.com/user-attachments/assets/4b8dbb90-5510-4f06-b377-30627b64b4f8" />


This PR addresses that. It also disables the Keystone tests from CI. Until the work in #24537 is completed, there's no point running them only to see them fail to build.