### PR TITLE
Adopt Recoleta

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -233,7 +233,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
         configureSubtitleToCategoryBarSpacing()
         configureHeaderImageView()
         navigationItem.titleView = titleView
-        largeTitleView.font = WPStyleGuide.serifFontForTextStyle(UIFont.TextStyle.largeTitle, fontWeight: .semibold)
+        largeTitleView.font = UIFont.make(.recoleta, textStyle: .largeTitle, weight: .medium)
         toggleFilterBarConstraints()
         styleButtons()
         setStaticText()


### PR DESCRIPTION
Adopt the standard Dotcom font for tiles across screens with large header that already use similar serifs (but not quite the same).

Before / after

<img width="320" alt="before" src="https://github.com/user-attachments/assets/4b8f9e94-a339-4413-827b-8e843290262d" /> <img width="320" alt="after" src="https://github.com/user-attachments/assets/64cd1d72-0c2e-4843-9197-ec0e52e5cc63" />

