### PR TITLE
Do not call the failure block if the weak ref `self` is nil

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -231,7 +231,7 @@ extension BlogDashboardViewController {
 
     private enum Strings {
         static let home = NSLocalizedString("Home", comment: "Title for the dashboard screen.")
-        static let failureTitle = NSLocalizedString("Couldn't update. Check that you're online and refresh.", comment: "Content show when the dashboard fails to load")
+        static let failureTitle = NSLocalizedString("Couldn't load data. Please refresh again later.", comment: "Content show when the dashboard fails to load")
         static let dismiss = NSLocalizedString(
             "blogDashboard.dismiss",
             value: "Dismiss",

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Service/BlogDashboardService.swift
@@ -47,24 +47,24 @@ final class BlogDashboardService {
         let deviceID = remoteFeatureFlagStore.deviceID
 
         remoteService.fetch(cards: cardsToFetch, forBlogID: dotComID, deviceId: deviceID, success: { [weak self] cardsDictionary in
+            guard let self else {
+                DDLogError("The BlogDashboardService instance is deallocated")
+                return
+            }
 
-            guard let cardsDictionary = self?.parseCardsForLocalContent(cardsDictionary, blog: blog) else {
+            guard let cardsDictionary = self.parseCardsForLocalContent(cardsDictionary, blog: blog) else {
                 failure?([])
                 return
             }
 
-            if let cards = self?.decode(cardsDictionary, blog: blog) {
+            if let cards = self.decode(cardsDictionary, blog: blog) {
 
                 blog.dashboardState.hasCachedData = true
                 blog.dashboardState.failedToLoad = false
 
-                self?.persistence.persist(cards: cardsDictionary, for: dotComID)
+                self.persistence.persist(cards: cardsDictionary, for: dotComID)
 
-                guard let items = self?.parse(cards, blog: blog, dotComID: dotComID) else {
-                    failure?([])
-                    return
-                }
-
+                let items = self.parse(cards, blog: blog, dotComID: dotComID)
                 completion(items)
             } else {
                 blog.dashboardState.failedToLoad = true
@@ -73,9 +73,15 @@ final class BlogDashboardService {
 
         }, failure: { [weak self] error in
             DDLogError("Failed to fetch Dashboard Cards: \(error.localizedDescription)")
+
+            guard let self else {
+                DDLogError("The BlogDashboardService instance is deallocated")
+                return
+            }
+
             blog.dashboardState.failedToLoad = true
-            let items = self?.fetchLocal(blog: blog)
-            failure?(items ?? [])
+            let items = self.fetchLocal(blog: blog)
+            failure?(items)
         })
     }
 


### PR DESCRIPTION
## Description

Fixes https://linear.app/a8c/issue/CMM-542.

The "Couldn't update. Check that you're online and refresh" error message is displayed when the `failure` closure is called in the code below.

https://github.com/wordpress-mobile/WordPress-iOS/blob/60411906213224e0aeebf8b24e4f1181476804eb/WordPress/Classes/ViewRelated/Blog/Blog%20Dashboard/Service/BlogDashboardService.swift#L49-L79

I can see three possibilities:
1. The server returned an error.
2. The server returned a response (the `cardsDictionary`) that is not parsable by the app.
3. The weak `self` is nil when the `success` closure is called.

I managed to reproduce the issue once and verified that `self` is nil while debugging the app. But I only get that to happen once in that debug session. I could not reproduce the issue, with or without this PR's changes.

I couldn't figure out why `self` will become nil, though.

## Testing instructions

I used the following steps to reproduce the issue. Again, not 100% reproducible.

1. Launch the Jetpack app, go to the Reader tab, and view a subscription site.
2. Go to the device home screen, and use other apps.
3. Bring the Jetpack app back.
  If you are lucky, you can reproduce the issue, where the app shows "Couldn't update. Check that you're online and refresh".

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
