### PR TITLE
Integrate GutenbergKit remote editor asset caching

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8c8d98aed7eab1f454a6d3f34ad7f1d90ae38d5b0ca1d5e9ce24c7675adf295c",
+  "originHash" : "3f445cf3127a60fa8c80d3cb9dd354e15f35aca33571cb38d1e22016ed869f37",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "a211f6cd0391a8d15ae4570d28c66b12ef020134",
-        "version" : "0.3.0"
+        "revision" : "49f0212d086687835d760def804d3e035c9fc654",
+        "version" : "0.4.0"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250523"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.3.0"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.4.0"),
         .package(
             url: "https://github.com/Automattic/color-studio",
             revision: "bf141adc75e2769eb469a3e095bdc93dc30be8de"

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -171,7 +171,9 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         subscribeToWillEnterForeground()
 
         if RemoteFeatureFlag.newGutenberg.enabled() {
-            GutenbergKit.EditorViewController.warmup()
+            GutenbergKit.EditorViewController.warmup(
+                configuration: blog.flatMap(EditorConfiguration.init(blog:)) ?? .default
+            )
         }
     }
 

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -865,9 +865,8 @@ extension EditorConfiguration {
         if isWPComSite {
             if let siteId {
                 siteApiNamespace.append("sites/\(siteId)")
-            } else {
-                siteApiNamespace.append("sites/\(siteDomain)")
             }
+            siteApiNamespace.append("sites/\(siteDomain)")
         }
 
         self = EditorConfiguration()
@@ -883,9 +882,11 @@ extension EditorConfiguration {
         if RemoteFeatureFlag.newGutenbergPlugins.enabled() && blog.isHostedAtWPcom {
             self.plugins = true
             if var editorAssetsEndpoint = blog.wordPressComRestApi?.baseURL {
-                editorAssetsEndpoint.appendPathComponent("wpcom/v2")
-                for part in siteApiNamespace {
-                    editorAssetsEndpoint.appendPathComponent(part)
+                editorAssetsEndpoint.appendPathComponent("wpcom/v2/sites")
+                if let siteId {
+                    editorAssetsEndpoint.appendPathComponent(siteId)
+                } else {
+                    editorAssetsEndpoint.appendPathComponent(siteDomain)
                 }
                 editorAssetsEndpoint.appendPathComponent("editor-assets")
                 self.editorAssetsEndpoint = editorAssetsEndpoint

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -127,62 +127,11 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         self.editorSession = PostEditorAnalyticsSession(editor: .gutenbergKit, post: post)
         self.navigationBarManager = navigationBarManager ?? PostEditorNavigationBarManager()
 
-        let selfHostedApiUrl = post.blog.url(withPath: "wp-json/")
-        let isWPComSite = post.blog.isHostedAtWPcom || post.blog.isAtomic()
-        let siteApiRoot = post.blog.isAccessibleThroughWPCom() && isWPComSite ? post.blog.wordPressComRestApi?.baseURL.absoluteString : selfHostedApiUrl
-        let siteId = post.blog.dotComID?.stringValue
-        let siteDomain = post.blog.primaryDomainAddress
-        let authToken = post.blog.authToken ?? ""
-        var authHeader = "Bearer \(authToken)"
-
-        let applicationPassword = try? post.blog.getApplicationToken()
-
-        if let appPassword = applicationPassword, let username = post.blog.username {
-            let credentials = "\(username):\(appPassword)"
-            if let credentialsData = credentials.data(using: .utf8) {
-                let base64Credentials = credentialsData.base64EncodedString()
-                authHeader = "Basic \(base64Credentials)"
-            }
-        }
-
-        // Must provide both namespace forms to detect usages of both forms in third-party code
-        var siteApiNamespace: [String] = []
-        if isWPComSite {
-            if let siteId {
-                siteApiNamespace.append("sites/\(siteId)")
-            }
-            siteApiNamespace.append("sites/\(siteDomain)")
-        }
-
-        var conf = EditorConfiguration(
-            title: post.postTitle ?? "",
-            content: post.content ?? ""
-        )
+        var conf = EditorConfiguration(blog: post.blog)
+        conf.title = post.postTitle ?? ""
+        conf.content = post.content ?? ""
         conf.postID = post.postID?.intValue != -1 ? post.postID?.intValue : nil
         conf.postType = post is Page ? "page" : "post"
-
-        conf.siteURL = post.blog.url ?? ""
-        conf.siteApiRoot = siteApiRoot ?? ""
-        conf.siteApiNamespace = siteApiNamespace
-        conf.namespaceExcludedPaths = ["/wpcom/v2/following/recommendations", "/wpcom/v2/following/mine"]
-        conf.authHeader = authHeader
-
-        conf.themeStyles = FeatureFlag.newGutenbergThemeStyles.enabled
-        // Limited to Simple sites until application password auth is supported
-        conf.plugins = RemoteFeatureFlag.newGutenbergPlugins.enabled() && post.blog.isHostedAtWPcom
-        conf.locale = WordPressComLanguageDatabase().deviceLanguage.slug
-
-        if !post.blog.isSelfHosted {
-            let siteType: String = post.blog.isHostedAtWPcom ? "simple" : "atomic"
-            do {
-                conf.webViewGlobals = [
-                    try WebViewGlobal(name: "_currentSiteType", value: .string(siteType))
-                ]
-            } catch {
-                wpAssertionFailure("Failed to create WebViewGlobal", userInfo: ["error": "\(error)"])
-                conf.webViewGlobals = []
-            }
-        }
 
         self.editorViewController = GutenbergKit.EditorViewController(configuration: conf)
 
@@ -888,6 +837,63 @@ extension NewGutenbergViewController {
                 DDLogError("Error fetching settings: \(err)")
             }
         })
+    }
+}
+
+extension EditorConfiguration {
+    init(blog: Blog) {
+        let selfHostedApiUrl = blog.url(withPath: "wp-json/")
+        let isWPComSite = blog.isHostedAtWPcom || blog.isAtomic()
+        let siteApiRoot = blog.isAccessibleThroughWPCom() && isWPComSite ? blog.wordPressComRestApi?.baseURL.absoluteString : selfHostedApiUrl
+        let siteId = blog.dotComID?.stringValue
+        let siteDomain = blog.primaryDomainAddress
+        let authToken = blog.authToken ?? ""
+        var authHeader = "Bearer \(authToken)"
+
+        let applicationPassword = try? blog.getApplicationToken()
+
+        if let appPassword = applicationPassword, let username = blog.username {
+            let credentials = "\(username):\(appPassword)"
+            if let credentialsData = credentials.data(using: .utf8) {
+                let base64Credentials = credentialsData.base64EncodedString()
+                authHeader = "Basic \(base64Credentials)"
+            }
+        }
+
+        // Must provide both namespace forms to detect usages of both forms in third-party code
+        var siteApiNamespace: [String] = []
+        if isWPComSite {
+            if let siteId {
+                siteApiNamespace.append("sites/\(siteId)")
+            } else {
+                siteApiNamespace.append("sites/\(siteDomain)")
+            }
+        }
+
+        self = EditorConfiguration()
+
+        self.siteURL = blog.url ?? ""
+        self.siteApiRoot = siteApiRoot ?? ""
+        self.siteApiNamespace = siteApiNamespace
+        self.namespaceExcludedPaths = ["/wpcom/v2/following/recommendations", "/wpcom/v2/following/mine"]
+        self.authHeader = authHeader
+
+        self.themeStyles = FeatureFlag.newGutenbergThemeStyles.enabled
+        // Limited to Simple sites until application password auth is supported
+        self.plugins =  RemoteFeatureFlag.newGutenbergPlugins.enabled() && blog.isHostedAtWPcom
+        self.locale = WordPressComLanguageDatabase().deviceLanguage.slug
+
+        if !blog.isSelfHosted {
+            let siteType: String = blog.isHostedAtWPcom ? "simple" : "atomic"
+            do {
+                self.webViewGlobals = [
+                    try WebViewGlobal(name: "_currentSiteType", value: .string(siteType))
+                ]
+            } catch {
+                wpAssertionFailure("Failed to create WebViewGlobal", userInfo: ["error": "\(error)"])
+                self.webViewGlobals = []
+            }
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -880,7 +880,17 @@ extension EditorConfiguration {
 
         self.themeStyles = FeatureFlag.newGutenbergThemeStyles.enabled
         // Limited to Simple sites until application password auth is supported
-        self.plugins = RemoteFeatureFlag.newGutenbergPlugins.enabled() && blog.isHostedAtWPcom
+        if RemoteFeatureFlag.newGutenbergPlugins.enabled() && blog.isHostedAtWPcom {
+            self.plugins = true
+            if var editorAssetsEndpoint = blog.wordPressComRestApi?.baseURL {
+                editorAssetsEndpoint.appendPathComponent("wpcom/v2")
+                for part in siteApiNamespace {
+                    editorAssetsEndpoint.appendPathComponent(part)
+                }
+                editorAssetsEndpoint.appendPathComponent("editor-assets")
+                self.editorAssetsEndpoint = editorAssetsEndpoint
+            }
+        }
         self.locale = WordPressComLanguageDatabase().deviceLanguage.slug
 
         if !blog.isSelfHosted {

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -880,7 +880,7 @@ extension EditorConfiguration {
 
         self.themeStyles = FeatureFlag.newGutenbergThemeStyles.enabled
         // Limited to Simple sites until application password auth is supported
-        self.plugins =  RemoteFeatureFlag.newGutenbergPlugins.enabled() && blog.isHostedAtWPcom
+        self.plugins = RemoteFeatureFlag.newGutenbergPlugins.enabled() && blog.isHostedAtWPcom
         self.locale = WordPressComLanguageDatabase().deviceLanguage.slug
 
         if !blog.isSelfHosted {


### PR DESCRIPTION
## Description

Close CMM-509. This PR uses https://github.com/wordpress-mobile/GutenbergKit/pull/148.

To try it out locally:
1. Checkout https://github.com/wordpress-mobile/GutenbergKit/pull/148 in your local GutenbergKit repo.
2. Update the Package.swift to reference your local GutenbergKit repo.
3. Build & run to launch the Jetpack app.
4. Log in with your a8c account and open a post.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
