### PR TITLE
Post Settings: Social Sharing (Prototype)

### DIFF
--- a/Sources/WordPressData/Objective-C/include/Blog.h
+++ b/Sources/WordPressData/Objective-C/include/Blog.h
@@ -17,6 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class PublicizeInfo;
 @class BlobEntity;
 @class PostCategory;
+@class PublicizeConnection;
 
 extern NSString * const BlogEntityName;
 extern NSString * const PostFormatStandard;
@@ -136,7 +137,7 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 @property (nonatomic, strong, readwrite, nullable) NSSet<PostCategory *> *categories;
 @property (nonatomic, strong, readwrite, nullable) NSSet *tags;
 @property (nonatomic, strong, readwrite, nullable) NSSet *comments;
-@property (nonatomic, strong, readwrite, nullable) NSSet *connections;
+@property (nonatomic, strong, readwrite, nullable) NSSet<PublicizeConnection *> *connections;
 @property (nonatomic, strong, readwrite, nullable) NSSet *inviteLinks;
 @property (nonatomic, strong, readwrite, nullable) NSSet *domains;
 @property (nonatomic, strong, readwrite, nullable) NSSet *themes;

--- a/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialNoConnectionView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialNoConnectionView.swift
@@ -5,7 +5,7 @@ import WordPressUI
 
 struct JetpackSocialNoConnectionView: View {
 
-    private let viewModel: JetpackSocialNoConnectionViewModel
+    let viewModel: JetpackSocialNoConnectionViewModel
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12.0) {

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
@@ -25,6 +25,8 @@ struct PostSettings: Hashable {
     // MARK: - Post-specific
     var postFormat: String?
     var isStickyPost = false
+    var publicizeMessage: String?
+    var disabledPublicizeConnectionKeyringIDs: Set<Int> = []
 
     // MARK: - Page-specific
     var parentPageID: Int?
@@ -57,6 +59,17 @@ struct PostSettings: Hashable {
             categoryIDs = Set((post.categories ?? []).compactMap {
                 $0.categoryID?.intValue
             })
+            publicizeMessage = post.publicizeMessage
+            
+            // Extract disabled connection keyring IDs
+            if let disabledConnections = post.disabledPublicizeConnections {
+                disabledPublicizeConnectionKeyringIDs = Set(disabledConnections.compactMap { keyringID, entry in
+                    guard entry[Post.Constants.publicizeValueKey] == Post.Constants.publicizeDisabledValue else {
+                        return nil
+                    }
+                    return keyringID.intValue
+                })
+            }
         case let page as Page:
             parentPageID = page.parentID?.intValue
         default:
@@ -128,6 +141,37 @@ struct PostSettings: Hashable {
             // Update sticky post setting
             if post.isStickyPost != isStickyPost {
                 post.isStickyPost = isStickyPost
+            }
+            
+            // Update publicize message
+            if post.publicizeMessage != publicizeMessage {
+                post.publicizeMessage = publicizeMessage
+            }
+            
+            // Update disabled publicize connections
+            if let disabledConnections = post.disabledPublicizeConnections {
+                // Get current disabled keyring IDs
+                let currentDisabledKeyringIDs = Set(disabledConnections.compactMap { keyringID, entry in
+                    guard entry[Post.Constants.publicizeValueKey] == Post.Constants.publicizeDisabledValue else {
+                        return nil
+                    }
+                    return keyringID.intValue
+                })
+                
+                // Enable connections that were disabled but are now enabled
+                for keyringID in currentDisabledKeyringIDs.subtracting(disabledPublicizeConnectionKeyringIDs) {
+                    post.enablePublicizeConnectionWithKeyringID(NSNumber(value: keyringID))
+                }
+                
+                // Disable connections that were enabled but are now disabled
+                for keyringID in disabledPublicizeConnectionKeyringIDs.subtracting(currentDisabledKeyringIDs) {
+                    post.disablePublicizeConnectionWithKeyringID(NSNumber(value: keyringID))
+                }
+            } else if !disabledPublicizeConnectionKeyringIDs.isEmpty {
+                // If there were no disabled connections before, disable the ones in settings
+                for keyringID in disabledPublicizeConnectionKeyringIDs {
+                    post.disablePublicizeConnectionWithKeyringID(NSNumber(value: keyringID))
+                }
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -49,6 +49,7 @@ private struct PostSettingsView: View {
                 taxonomySection
             }
             excerptSection
+            socialSharingSection
             moreOptionsSection
         }
         .disabled(viewModel.isSaving)
@@ -231,6 +232,15 @@ private struct PostSettingsView: View {
         }
     }
 
+    // MARK: - "Jetpack Social" Section
+
+    @ViewBuilder
+    private var socialSharingSection: some View {
+        if let socialViewModel = viewModel.socialSharingViewModel {
+            PostSettingsSocialSection(viewModel: socialViewModel)
+        }
+    }
+
     // MARK: - "More Options" Section
 
     @ViewBuilder
@@ -376,6 +386,21 @@ private struct SettingsTextFieldView: View {
     }
 }
 
+@MainActor
+private struct PostSettingsSocialSection: View {
+    @ObservedObject var viewModel: PostSettingsSocialSharingViewModel
+
+    var body: some View {
+        if !viewModel.isHidden {
+            Section {
+                PostSettingsSocialSharingRow(viewModel: viewModel)
+            } header: {
+                Text(Strings.jetpackSocialHeader)
+            }
+        }
+    }
+}
+
 private enum Strings {
     static let generalHeader = NSLocalizedString(
         "postSettings.section.general",
@@ -495,5 +520,11 @@ private enum Strings {
         "postSettings.slug.hint",
         value: "The slug is the URL-friendly version of the post title.",
         comment: "Hint text for the slug field. Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso."
+    )
+
+    static let jetpackSocialHeader = NSLocalizedString(
+        "postSettings.jetpackSocial.header",
+        value: "Jetpack Social",
+        comment: "Label for the Jetpack Social section in post Settings. Should be the same as WP core."
     )
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -9,6 +9,7 @@ final class PostSettingsViewModel: ObservableObject {
     let post: AbstractPost
     let isStandalone: Bool
     let featuredImageViewModel: PostSettingsFeaturedImageViewModel
+    private(set) var socialSharingViewModel: PostSettingsSocialSharingViewModel?
 
     @Published var settings: PostSettings {
         didSet {
@@ -94,7 +95,11 @@ final class PostSettingsViewModel: ObservableObject {
 
     /// Weak reference to the view controller for navigation.
     /// This is temporary until we can fully migrate to SwiftUI navigation.
-    weak var viewController: UIViewController?
+    weak var viewController: UIViewController? {
+        didSet {
+            socialSharingViewModel?.viewController = viewController
+        }
+    }
 
     init(post: AbstractPost, isStandalone: Bool = false) {
         self.post = post
@@ -116,7 +121,30 @@ final class PostSettingsViewModel: ObservableObject {
         // Initialize cached text values
         refresh(with: settings)
 
+        // Initialize social sharing view model if this is a post
+        if let post = post as? Post {
+            setupSocialSharingViewModel(post: post)
+        }
+
         WPAnalytics.track(.postSettingsShown)
+    }
+    
+    private func setupSocialSharingViewModel(post: Post) {
+        // Create a binding to settings that the social sharing view model can use
+        let settingsBinding = Binding<PostSettings>(
+            get: { [weak self] in
+                self?.settings ?? PostSettings(from: post)
+            },
+            set: { [weak self] newValue in
+                self?.settings = newValue
+            }
+        )
+        
+        socialSharingViewModel = PostSettingsSocialSharingViewModel(
+            blog: post.blog,
+            settings: settingsBinding
+        )
+        socialSharingViewModel?.viewController = viewController
     }
 
     private func refresh(with settings: PostSettings) {
@@ -194,6 +222,9 @@ final class PostSettingsViewModel: ObservableObject {
             settings.status = .publishPrivate
         }
         settings.password = selection.password.isEmpty ? nil : selection.password
+
+        // Refresh social sharing when visibility changes
+        socialSharingViewModel?.refresh()
     }
 
     // MARK: - Navigation

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/SocialSharing/PostSettingsSocialAccountsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/SocialSharing/PostSettingsSocialAccountsView.swift
@@ -1,0 +1,23 @@
+import SwiftUI
+import WordPressData
+
+@MainActor
+struct PostSettingsSocialAccountsView: UIViewControllerRepresentable {
+    let blogID: Int
+    let model: PrepublishingAutoSharingModel
+    weak var delegate: PrepublishingSocialAccountsDelegate?
+    let coreDataStack: CoreDataStackSwift
+
+    func makeUIViewController(context: Context) -> PrepublishingSocialAccountsViewController {
+        PrepublishingSocialAccountsViewController(
+            blogID: blogID,
+            model: model,
+            delegate: delegate,
+            coreDataStack: coreDataStack
+        )
+    }
+
+    func updateUIViewController(_ uiViewController: PrepublishingSocialAccountsViewController, context: Context) {
+        // No updates needed
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/SocialSharing/PostSettingsSocialSharingRow.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/SocialSharing/PostSettingsSocialSharingRow.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import WordPressUI
+
+@MainActor
+struct PostSettingsSocialSharingRow: View {
+    @ObservedObject var viewModel: PostSettingsSocialSharingViewModel
+
+    var body: some View {
+        switch viewModel.state {
+        case .noConnection(let viewModel):
+            JetpackSocialNoConnectionView(viewModel: viewModel)
+        case .hasConnections(let viewModel):
+            autoSharingView(viewModel: viewModel)
+        case .hidden:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private func autoSharingView(viewModel model: PrepublishingAutoSharingModel) -> some View {
+        NavigationLink {
+            PostSettingsSocialAccountsView(
+                blogID: viewModel.blogID ?? 0,
+                model: model,
+                delegate: viewModel,
+                coreDataStack: viewModel.coreDataStack
+            )
+            .ignoresSafeArea()
+        } label: {
+            PrepublishingAutoSharingView(model: model)
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/SocialSharing/PostSettingsSocialSharingViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/SocialSharing/PostSettingsSocialSharingViewModel.swift
@@ -1,0 +1,252 @@
+import Foundation
+import SwiftUI
+import Combine
+import WordPressData
+import WordPressKit
+import WordPressShared
+
+@MainActor
+final class PostSettingsSocialSharingViewModel: NSObject, ObservableObject {
+    let blog: Blog
+    @Binding var settings: PostSettings
+    let coreDataStack: CoreDataStackSwift
+    private let persistentStore: UserPersistentRepository
+
+    @Published private(set) var state: SocialSharingState = .hidden
+
+    var isHidden: Bool {
+        if case .hidden = state { return true }
+        return false
+    }
+
+    var blogID: Int? {
+        blog.dotComID?.intValue
+    }
+
+    /// A temporary workaround for showing the sharing view controller.
+    weak var viewController: UIViewController?
+
+    enum SocialSharingState {
+        case noConnection(JetpackSocialNoConnectionViewModel)
+        case hasConnections(PrepublishingAutoSharingModel)
+        case hidden
+    }
+
+    init(
+        blog: Blog,
+        settings: Binding<PostSettings>,
+        coreDataStack: CoreDataStackSwift = ContextManager.shared,
+        persistentStore: UserPersistentRepository = UserPersistentStoreFactory.instance()
+    ) {
+        self.blog = blog
+        self._settings = settings
+        self.coreDataStack = coreDataStack
+        self.persistentStore = persistentStore
+        super.init()
+
+        isNoConnectionDismissed = false
+        refresh()
+    }
+
+    func refresh() {
+        guard canDisplaySocialRow() else {
+            state = .hidden
+            return
+        }
+
+        if hasExistingConnections {
+            let viewModel = makeAutoSharingViewModel()
+            state = .hasConnections(viewModel)
+
+            if viewModel.sharingLimit != nil {
+                WPAnalytics.track(.jetpackSocialShareLimitDisplayed, properties: ["source": Constants.trackingSource])
+            }
+        } else {
+            let viewModel = makeNoConnectionViewModel()
+            state = .noConnection(viewModel)
+            WPAnalytics.track(.jetpackSocialNoConnectionCardDisplayed, properties: ["source": Constants.trackingSource])
+        }
+    }
+
+    // MARK: - Eligibility
+
+    private func canDisplaySocialRow(
+        isJetpack: Bool = AppConfiguration.isJetpack,
+        isFeatureEnabled: Bool = RemoteFeatureFlag.jetpackSocialImprovements.enabled()
+    ) -> Bool {
+        guard isJetpack &&
+                isFeatureEnabled &&
+                !isPostPrivate &&
+                post.blog.supportsPublicize() &&
+                !getPublisizeServices().isEmpty
+        else {
+            return false
+        }
+
+        guard hasExistingConnections else {
+            // if the site has no connections, ensure that the No Connection view hasn't been dismissed before.
+            return !isNoConnectionDismissed
+        }
+
+        return true
+    }
+
+    private var postBlogID: Int? {
+        blog.dotComID?.intValue
+    }
+
+    private var isPostPrivate: Bool {
+        settings.status == .publishPrivate
+    }
+
+    private var hasExistingConnections: Bool {
+        !(blog.connections ?? []).isEmpty
+    }
+
+    private func getPublisizeServices() -> [PublicizeService] {
+        let context = blog.managedObjectContext ?? coreDataStack.mainContext
+        do {
+            return try PublicizeService.allSupportedServices(in: context)
+        } catch {
+            wpAssertionFailure("Failed to fetch publicize services", userInfo: ["error": error.localizedDescription])
+            return []
+        }
+    }
+
+    // MARK: - No Connection Management
+
+    private var isNoConnectionDismissed: Bool {
+        get {
+            guard let postBlogID,
+                  let dictionary = persistentStore.dictionary(forKey: Constants.noConnectionKey) as? [String: Bool],
+                  let storedValue = dictionary["\(postBlogID)"] else {
+                return false
+            }
+            return storedValue
+        }
+
+        set {
+            guard let postBlogID else {
+                return
+            }
+            var dictionary = (persistentStore.dictionary(forKey: Constants.noConnectionKey) as? [String: Bool]) ?? .init()
+            dictionary["\(postBlogID)"] = newValue
+            persistentStore.set(dictionary, forKey: Constants.noConnectionKey)
+        }
+    }
+
+    // MARK: - Actions
+
+    func connectSocialAccounts() {
+        guard let sharingVC = SharingViewController(blog: blog, delegate: self) else {
+            return
+        }
+
+        WPAnalytics.track(.jetpackSocialNoConnectionCTATapped, properties: ["source": Constants.trackingSource])
+
+        let navigationController = UINavigationController(rootViewController: sharingVC)
+        viewController?.show(navigationController, sender: nil)
+    }
+
+    func dismissNoConnection() {
+        WPAnalytics.track(.jetpackSocialNoConnectionCardDismissed, properties: ["source": Constants.trackingSource])
+
+        withAnimation {
+            isNoConnectionDismissed = true
+            state = .hidden
+        }
+    }
+
+    // MARK: - Model Creation
+
+    private func makeNoConnectionViewModel() -> JetpackSocialNoConnectionViewModel {
+        let services = getPublisizeServices()
+        return JetpackSocialNoConnectionViewModel(
+            services: services,
+            padding: EdgeInsets(top: 12, leading: 0, bottom: 0, trailing: 0),
+            onConnectTap: { [weak self] in
+                self?.connectSocialAccounts()
+            },
+            onNotNowTap: { [weak self] in
+                self?.dismissNoConnection()
+            }
+        )
+    }
+
+    private func makeAutoSharingViewModel() -> PrepublishingAutoSharingModel {
+        let supportedServices = getPublisizeServices()
+        let connections = blog.sortedConnections
+
+        // first, build a dictionary to categorize the connections.
+        var connectionsMap = [PublicizeService.ServiceName: [PublicizeConnection]]()
+        connections.filter { !$0.requiresUserAction() }.forEach { connection in
+            let serviceName = PublicizeService.ServiceName(rawValue: connection.service) ?? .unknown
+            var serviceConnections = connectionsMap[serviceName] ?? []
+            serviceConnections.append(connection)
+            connectionsMap[serviceName] = serviceConnections
+        }
+
+        // then, transform [PublicizeService] to [PrepublishingAutoSharingModel.Service].
+        let modelServices = supportedServices.compactMap { service -> PrepublishingAutoSharingModel.Service? in
+            // skip services without connections.
+            guard let serviceConnections = connectionsMap[service.name],
+                  !serviceConnections.isEmpty else {
+                return nil
+            }
+
+            return PrepublishingAutoSharingModel.Service(
+                name: service.name,
+                connections: serviceConnections.map {
+                    .init(account: $0.externalDisplay,
+                          keyringID: $0.keyringConnectionID.intValue,
+                          enabled: !settings.disabledPublicizeConnectionKeyringIDs.contains($0.keyringConnectionID.intValue))
+                }
+            )
+        }
+
+        return PrepublishingAutoSharingModel(
+            services: modelServices,
+            message: settings.publicizeMessage ?? "",
+            sharingLimit: blog.sharingLimit
+        )
+    }
+
+    // MARK: - Constants
+
+    private enum Constants {
+        static let trackingSource = "post_settings"
+        static let noConnectionKey = "post-settings-social-no-connection-view-hidden"
+    }
+}
+
+// MARK: - SharingViewControllerDelegate
+
+extension PostSettingsSocialSharingViewModel: @preconcurrency SharingViewControllerDelegate {
+    func didChangePublicizeServices() {
+        refresh()
+    }
+}
+
+// MARK: - PrepublishingSocialAccountsDelegate
+
+extension PostSettingsSocialSharingViewModel: @preconcurrency PrepublishingSocialAccountsDelegate {
+    func didUpdateSharingLimit(with newValue: PublicizeInfo.SharingLimit?) {
+        refresh()
+    }
+
+    func didFinish(with connectionChanges: [Int: Bool], message: String?) {
+        // Update the settings binding
+        connectionChanges.forEach { (keyringID, enabled) in
+            if enabled {
+                settings.disabledPublicizeConnectionKeyringIDs.remove(keyringID)
+            } else {
+                settings.disabledPublicizeConnectionKeyringIDs.insert(keyringID)
+            }
+        }
+        
+        let isMessageEmpty = message?.isEmpty ?? true
+        settings.publicizeMessage = isMessageEmpty ? nil : message
+        
+        refresh()
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingAutoSharingView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingAutoSharingView.swift
@@ -34,6 +34,7 @@ struct PrepublishingAutoSharingView: View {
                 socialIconsView
             }
         }
+        .lineLimit(1)
     }
 
     private var textStack: some View {
@@ -66,7 +67,7 @@ struct PrepublishingAutoSharingView: View {
     }
 
     private var socialIconsView: some View {
-        HStack(spacing: -2.0) {
+        HStack(spacing: -6) {
             ForEach(model.services, id: \.self) { service in
                 iconImage(service.name.localIconImage, opaque: service.usesOpaqueIcon)
             }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
@@ -89,7 +89,7 @@ private extension PrepublishingViewController {
     var hasExistingConnections: Bool {
         coreDataStack.performQuery { [postObjectID = post.objectID] context in
             guard let post = (try? context.existingObject(with: postObjectID)) as? Post,
-                  let connections = post.blog.connections as? Set<PublicizeConnection> else {
+                  let connections = post.blog.connections else {
                 return false
             }
             return !connections.isEmpty


### PR DESCRIPTION
This a prototype developed in the scope of the "Post Settings" rework. Ultimately, it was decided not to include this option on "Post Settings" to match the behavior on the web and simplify the UX. The code could be useful later for "Prepublishing".