### PR TITLE
Post List: Fix Visual Issues

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * [*] Add search to “Jetpack Activity List” and display actors and dates [#24597]
 * [*] Fix an issue with content in "Restore" and "Download Backup" flows covering the navigation bar [#24597]
 * [*] Show when the downloadable backup expires in Backup List [#24597]
+* [*] Fix a couple of visual issues in Post List [#24647]
 
 25.9
 -----

--- a/Sources/WordPressData/Swift/Post.swift
+++ b/Sources/WordPressData/Swift/Post.swift
@@ -231,14 +231,14 @@ public class Post: AbstractPost {
             if let preview = PostPreviewCache.shared.excerpt[excerpt] {
                 return preview
             }
-            let preview = excerpt.makePlainText()
+            let preview = excerpt.makePlainText().withCollapsedNewlines()
             PostPreviewCache.shared.excerpt[excerpt] = preview
             return preview
         } else if let content {
             if let preview = PostPreviewCache.shared.content[content] {
                 return preview
             }
-            let preview = content.summarized()
+            let preview = content.summarized().withCollapsedNewlines()
             PostPreviewCache.shared.content[content] = preview
             return preview
         } else {
@@ -257,6 +257,13 @@ public class Post: AbstractPost {
         }
 
         return title
+    }
+}
+
+private extension String {
+    // Normalize newlines by collapsing multiple occurrences of newlines to a single newline
+    func withCollapsedNewlines() -> String {
+        replacingOccurrences(of: "[\n]{2,}", with: "\n", options: .regularExpression)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Media/NoResultsViewController+MediaLibrary.swift
+++ b/WordPress/Classes/ViewRelated/Media/NoResultsViewController+MediaLibrary.swift
@@ -10,7 +10,7 @@ extension NoResultsViewController {
     }
 
     @objc func configureForFetching() {
-        configure(title: LocalizedText.fetchingTitle, accessoryView: NoResultsViewController.loadingAccessoryView())
+        configure(title: "", accessoryView: NoResultsViewController.loadingAccessoryView())
         view.layoutIfNeeded()
     }
 

--- a/WordPress/Classes/ViewRelated/Pages/Controllers/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/Controllers/PageListViewController.swift
@@ -471,7 +471,7 @@ private extension PageListViewController {
 
     func noResultsTitle() -> String {
         if syncHelper.isSyncing == true {
-            return NoResultsText.fetchingTitle
+            return ""
         }
         return noResultsFilteredTitle()
     }
@@ -493,7 +493,6 @@ private extension PageListViewController {
     }
 
     struct NoResultsText {
-        static let fetchingTitle = NSLocalizedString("Fetching pages...", comment: "A brief prompt shown when the reader is empty, letting the user know the app is currently fetching new pages.")
         static let noDraftsTitle = NSLocalizedString("You don't have any draft pages", comment: "Displayed when the user views drafts in the pages list and there are no pages")
         static let noScheduledTitle = NSLocalizedString("You don't have any scheduled pages", comment: "Displayed when the user views scheduled pages in the pages list and there are no pages")
         static let noTrashedTitle = NSLocalizedString("You don't have any trashed pages", comment: "Displayed when the user views trashed in the pages list and there are no pages")

--- a/WordPress/Classes/ViewRelated/Pages/Views/PageListCell.swift
+++ b/WordPress/Classes/ViewRelated/Pages/Views/PageListCell.swift
@@ -21,9 +21,14 @@ final class PageListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
 
     // MARK: - PostSearchResultCell
 
-    var attributedText: NSAttributedString? {
+    var titleAttributedText: NSAttributedString? {
         get { titleLabel.attributedText }
         set { titleLabel.attributedText = newValue }
+    }
+
+    var excerptAttributedText: NSAttributedString? {
+        get { nil }  // Pages don't have excerpts in the list
+        set { }  // Pages don't have excerpts in the list
     }
 
     // MARK: AbstractPostListCell

--- a/WordPress/Classes/ViewRelated/Post/Controllers/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Controllers/AbstractPostListViewController.swift
@@ -300,7 +300,7 @@ class AbstractPostListViewController: UIViewController,
         if noResultsViewController.view.isDescendant(of: tableView) == false {
             self.addChild(noResultsViewController)
             tableView.addSubview(noResultsViewController.view)
-            noResultsViewController.view.frame = tableView.frame.offsetBy(dx: 0, dy: -view.safeAreaInsets.top + 40)
+            noResultsViewController.view.pinEdges(to: view.safeAreaLayoutGuide)
             noResultsViewController.didMove(toParent: self)
         }
 

--- a/WordPress/Classes/ViewRelated/Post/Controllers/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Controllers/PostListViewController.swift
@@ -284,7 +284,7 @@ private extension PostListViewController {
 
     func noResultsTitle() -> String {
         if syncHelper.isSyncing == true {
-            return NoResultsText.fetchingTitle
+            return ""
         }
         return noResultsFilteredTitle()
     }
@@ -306,7 +306,6 @@ private extension PostListViewController {
     }
 
     struct NoResultsText {
-        static let fetchingTitle = NSLocalizedString("Fetching posts...", comment: "A brief prompt shown when the reader is empty, letting the user know the app is currently fetching new posts.")
         static let noDraftsTitle = NSLocalizedString("You don't have any draft posts", comment: "Displayed when the user views drafts in the posts list and there are no posts")
         static let noScheduledTitle = NSLocalizedString("You don't have any scheduled posts", comment: "Displayed when the user views scheduled posts in the posts list and there are no posts")
         static let noTrashedTitle = NSLocalizedString("You don't have any trashed posts", comment: "Displayed when the user views trashed in the posts list and there are no posts")

--- a/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Search/PostSearchViewController.swift
@@ -235,10 +235,19 @@ final class PostSearchViewController: UIViewController, UITableViewDelegate, UIS
         for cell in cells {
             guard let cell = cell as? PostSearchResultCell else { continue }
 
-            assert(cell.attributedText != nil)
-            let string = NSMutableAttributedString(attributedString: cell.attributedText ?? .init())
-            PostSearchViewModel.highlight(terms: terms, in: string)
-            cell.attributedText = string
+            // Highlight title
+            if let titleText = cell.titleAttributedText {
+                let titleString = NSMutableAttributedString(attributedString: titleText)
+                PostSearchViewModel.highlight(terms: terms, in: titleString)
+                cell.titleAttributedText = titleString
+            }
+
+            // Highlight excerpt
+            if let excerptText = cell.excerptAttributedText {
+                let excerptString = NSMutableAttributedString(attributedString: excerptText)
+                PostSearchViewModel.highlight(terms: terms, in: excerptString)
+                cell.excerptAttributedText = excerptString
+            }
         }
     }
 }
@@ -250,5 +259,6 @@ private enum Constants {
 }
 
 protocol PostSearchResultCell: AnyObject {
-    var attributedText: NSAttributedString? { get set }
+    var titleAttributedText: NSAttributedString? { get set }
+    var excerptAttributedText: NSAttributedString? { get set }
 }

--- a/WordPress/Classes/ViewRelated/Post/Views/AbstractPostHelper.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/AbstractPostHelper.swift
@@ -40,14 +40,15 @@ enum AbstractPostHelper {
         for (badge, color) in badges {
             if string.length > 0 {
                 string.append(NSAttributedString(string: " · ", attributes: [
-                    .foregroundColor: UIColor.secondaryLabel
+                    .foregroundColor: UIColor.secondaryLabel,
+                    .font: UIFont.preferredFont(forTextStyle: .footnote).withWeight(.bold)
                 ]))
             }
             string.append(NSAttributedString(string: badge, attributes: [
-                .foregroundColor: color ?? UIColor.secondaryLabel
+                .foregroundColor: color ?? UIColor.secondaryLabel,
+                .font: UIFont.preferredFont(forTextStyle: .footnote)
             ]))
         }
-        string.addAttribute(.font, value: WPStyleGuide.fontForTextStyle(.footnote), range: NSRange(location: 0, length: string.length))
         return string
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Views/PostListCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PostListCell.swift
@@ -26,7 +26,8 @@ final class PostListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
 
     private let headerView = PostListHeaderView()
     private let ellipsisButton = UIButton(type: .system)
-    private let contentLabel = UILabel()
+    private let titleLabel = UILabel()
+    private let excerptLabel = UILabel()
     private let featuredImageView = AsyncImageView()
     private let statusLabel = UILabel()
 
@@ -36,9 +37,14 @@ final class PostListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
 
     // MARK: - PostSearchResultCell
 
-    var attributedText: NSAttributedString? {
-        get { contentLabel.attributedText }
-        set { contentLabel.attributedText = newValue }
+    var titleAttributedText: NSAttributedString? {
+        get { titleLabel.attributedText }
+        set { titleLabel.attributedText = newValue }
+    }
+
+    var excerptAttributedText: NSAttributedString? {
+        get { excerptLabel.attributedText }
+        set { excerptLabel.attributedText = newValue }
     }
 
     // MARK: AbstractPostListCell
@@ -73,7 +79,8 @@ final class PostListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
 
     private func _configure(with viewModel: PostListItemViewModel, delegate: InteractivePostViewDelegate? = nil) {
         headerView.configure(with: viewModel)
-        contentLabel.attributedText = viewModel.content
+        titleLabel.attributedText = viewModel.title
+        excerptLabel.attributedText = viewModel.excerpt
 
         featuredImageView.isHidden = viewModel.imageURL == nil
         featuredImageView.layer.opacity = viewModel.syncStateViewModel.isEditable ? 1 : 0.25
@@ -111,15 +118,20 @@ final class PostListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
     // MARK: - Setup
 
     private func setupViews() {
-        setupContentLabel()
+        setupTitleLabel()
+        setupExcerptLabel()
         setupFeaturedImageView()
         setupStatusLabel()
 
+        let textStackView = UIStackView(arrangedSubviews: [titleLabel, excerptLabel])
+        textStackView.axis = .vertical
+        textStackView.spacing = 3
+
         contentStackView.addArrangedSubviews([
-            contentLabel,
+            textStackView,
             featuredImageView
         ])
-        contentStackView.spacing = 16
+        contentStackView.spacing = 8
         contentStackView.alignment = .top
 
         mainStackView.addArrangedSubviews([
@@ -129,28 +141,30 @@ final class PostListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
         ])
         mainStackView.spacing = 4
         contentView.addSubview(mainStackView)
-        mainStackView.pinEdges(to: contentView.layoutMarginsGuide, insets: UIEdgeInsets (horizontal: 0, vertical: 2))
+        mainStackView.pinEdges(to: contentView.layoutMarginsGuide, insets: UIEdgeInsets(top: 0, left: 0, bottom: 2, right: -2))
 
         // It is added last to ensure it's tappable
         setupEllipsisButton()
     }
 
-    private func setupContentLabel() {
-        contentLabel.adjustsFontForContentSizeCategory = true
-        contentLabel.numberOfLines = 3
-        contentLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    private func setupTitleLabel() {
+        titleLabel.adjustsFontForContentSizeCategory = true
+        titleLabel.numberOfLines = 2
+        titleLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+    }
+
+    private func setupExcerptLabel() {
+        excerptLabel.adjustsFontForContentSizeCategory = true
+        excerptLabel.numberOfLines = 2
+        excerptLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
     }
 
     private func setupFeaturedImageView() {
         featuredImageView.contentMode = .scaleAspectFill
         featuredImageView.layer.masksToBounds = true
-        featuredImageView.layer.cornerRadius = 5
+        featuredImageView.layer.cornerRadius = 8
         featuredImageView.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
-        featuredImageView.layer.shadowColor = UIColor.black.cgColor
-        featuredImageView.layer.shadowOpacity = 0.15
-        featuredImageView.layer.shadowRadius = 6
-        featuredImageView.layer.shadowOffset = CGSize(width: 0, height: 3)
-        featuredImageView.layer.shadowPath = UIBezierPath(rect: CGRect(origin: .zero, size: Constants.imageSize)).cgPath
+        featuredImageView.configuration.isErrorViewEnabled = false
 
         NSLayoutConstraint.activate([
             featuredImageView.widthAnchor.constraint(equalToConstant: Constants.imageSize.width),
@@ -166,11 +180,11 @@ final class PostListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
 
     private func setupEllipsisButton() {
         ellipsisButton.setImage(UIImage(named: "more-horizontal-mobile"), for: .normal)
-        ellipsisButton.tintColor = .secondaryLabel
+        ellipsisButton.tintColor = .tertiaryLabel
 
         NSLayoutConstraint.activate([
-            ellipsisButton.heightAnchor.constraint(equalToConstant: 44),
-            ellipsisButton.widthAnchor.constraint(equalToConstant: 54)
+            ellipsisButton.heightAnchor.constraint(equalToConstant: 40),
+            ellipsisButton.widthAnchor.constraint(equalToConstant: 56)
         ])
 
         contentView.addSubview(ellipsisButton)
@@ -179,5 +193,5 @@ final class PostListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
 }
 
 private enum Constants {
-    static let imageSize = CGSize(width: 60, height: 60)
+    static let imageSize = CGSize(width: 54, height: 54)
 }

--- a/WordPress/Classes/ViewRelated/Post/Views/PostListCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PostListCell.swift
@@ -140,6 +140,7 @@ final class PostListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
             statusLabel
         ])
         mainStackView.spacing = 4
+        mainStackView.setCustomSpacing(5, after: headerView)
         contentView.addSubview(mainStackView)
         mainStackView.pinEdges(to: contentView.layoutMarginsGuide, insets: UIEdgeInsets(top: 0, left: 0, bottom: 2, right: -2))
 
@@ -182,6 +183,7 @@ final class PostListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
         ellipsisButton.setImage(UIImage(named: "more-horizontal-mobile"), for: .normal)
         ellipsisButton.tintColor = .tertiaryLabel
 
+        /// warning: See `spacer` in `PostListHeaderView` to understand the layout
         NSLayoutConstraint.activate([
             ellipsisButton.heightAnchor.constraint(equalToConstant: 40),
             ellipsisButton.widthAnchor.constraint(equalToConstant: 56)

--- a/WordPress/Classes/ViewRelated/Post/Views/PostListCell.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PostListCell.swift
@@ -129,7 +129,7 @@ final class PostListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
         ])
         mainStackView.spacing = 4
         contentView.addSubview(mainStackView)
-        mainStackView.pinEdges(to: contentView.layoutMarginsGuide)
+        mainStackView.pinEdges(to: contentView.layoutMarginsGuide, insets: UIEdgeInsets (horizontal: 0, vertical: 2))
 
         // It is added last to ensure it's tappable
         setupEllipsisButton()
@@ -146,6 +146,11 @@ final class PostListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
         featuredImageView.layer.masksToBounds = true
         featuredImageView.layer.cornerRadius = 5
         featuredImageView.setContentCompressionResistancePriority(.defaultHigh, for: .vertical)
+        featuredImageView.layer.shadowColor = UIColor.black.cgColor
+        featuredImageView.layer.shadowOpacity = 0.15
+        featuredImageView.layer.shadowRadius = 6
+        featuredImageView.layer.shadowOffset = CGSize(width: 0, height: 3)
+        featuredImageView.layer.shadowPath = UIBezierPath(rect: CGRect(origin: .zero, size: Constants.imageSize)).cgPath
 
         NSLayoutConstraint.activate([
             featuredImageView.widthAnchor.constraint(equalToConstant: Constants.imageSize.width),
@@ -174,5 +179,5 @@ final class PostListCell: UITableViewCell, AbstractPostListCell, PostSearchResul
 }
 
 private enum Constants {
-    static let imageSize = CGSize(width: 64, height: 64)
+    static let imageSize = CGSize(width: 60, height: 60)
 }

--- a/WordPress/Classes/ViewRelated/Post/Views/PostListHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PostListHeaderView.swift
@@ -8,6 +8,7 @@ final class PostListHeaderView: UIView {
     private let textLabel = UILabel()
     private let icon = UIImageView()
     private let indicator = UIActivityIndicatorView(style: .medium)
+    private let spacer = SpacerView(width: 24)
 
     // MARK: - Initializer
 
@@ -34,6 +35,7 @@ final class PostListHeaderView: UIView {
         }
         icon.isHidden = viewModel.iconInfo == nil
         indicator.isHidden = !viewModel.isShowingIndicator
+        spacer.isHidden = !viewModel.isShowingEllipsis
 
         if viewModel.isShowingIndicator {
             indicator.startAnimating()
@@ -46,7 +48,7 @@ final class PostListHeaderView: UIView {
         setupIcon()
 
         // Trailing spacer to allocate enough space for the "More" button.
-        let accessoriesStackView = UIStackView(arrangedSubviews: [icon, indicator, SpacerView(width: 40)])
+        let accessoriesStackView = UIStackView(arrangedSubviews: [icon, indicator, spacer])
         accessoriesStackView.spacing = 4
         let stackView = UIStackView(arrangedSubviews: [textLabel, accessoriesStackView])
 

--- a/WordPress/Classes/ViewRelated/Post/Views/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PostListItemViewModel.swift
@@ -68,7 +68,7 @@ private func makeContentString(for post: Post, syncStateViewModel: PostSyncState
     let string = NSMutableAttributedString()
     if !title.isEmpty {
         let attributes: [NSAttributedString.Key: Any] = [
-            .font: WPStyleGuide.fontForTextStyle(.callout, fontWeight: .semibold),
+            .font: UIFont.preferredFont(forTextStyle: .headline),
             .foregroundColor: foregroundColor
         ]
         let titleAttributedString = NSAttributedString(string: title, attributes: attributes)
@@ -81,8 +81,8 @@ private func makeContentString(for post: Post, syncStateViewModel: PostSyncState
             string.append(NSAttributedString(string: "\n"))
         }
         let attributes: [NSAttributedString.Key: Any] = [
-            .font: WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .regular),
-            .foregroundColor: foregroundColor
+            .font: UIFont.preferredFont(forTextStyle: .subheadline),
+            .foregroundColor: UIColor.secondaryLabel
         ]
         let snippetAttributedString = NSAttributedString(string: adjustedSnippet, attributes: attributes)
         string.append(snippetAttributedString)
@@ -90,6 +90,8 @@ private func makeContentString(for post: Post, syncStateViewModel: PostSyncState
 
     let paragraphStyle = NSMutableParagraphStyle()
     paragraphStyle.paragraphSpacing = 4
+    paragraphStyle.lineBreakMode = .byTruncatingTail
+
     string.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: string.length))
 
     return string

--- a/WordPress/Classes/ViewRelated/Post/Views/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PostListItemViewModel.swift
@@ -4,7 +4,8 @@ import WordPressShared
 
 final class PostListItemViewModel {
     let post: Post
-    let content: NSAttributedString
+    let title: NSAttributedString
+    let excerpt: NSAttributedString
     let imageURL: URL?
     let badges: NSAttributedString
     let syncStateViewModel: PostSyncStateViewModel
@@ -20,7 +21,8 @@ final class PostListItemViewModel {
         self.statusViewModel = PostCardStatusViewModel(post: post)
         self.syncStateViewModel = PostSyncStateViewModel(post: post)
         self.badges = makeBadgesString(for: post, syncStateViewModel: syncStateViewModel, shouldHideAuthor: shouldHideAuthor)
-        self.content = makeContentString(for: post, syncStateViewModel: syncStateViewModel)
+        self.title = makeTitleString(for: post, isDisabled: !syncStateViewModel.isEditable)
+        self.excerpt = makeExcerptString(for: post, isDisabled: !syncStateViewModel.isEditable)
     }
 }
 
@@ -60,38 +62,39 @@ private func makeAccessibilityLabel(for post: Post, statusViewModel: PostCardSta
         .joined(separator: " ")
 }
 
-private func makeContentString(for post: Post, syncStateViewModel: PostSyncStateViewModel) -> NSAttributedString {
+private func makeTitleString(for post: Post, isDisabled: Bool) -> NSAttributedString {
     let title = post.titleForDisplay()
-    let snippet = post.contentPreviewForDisplay()
-    let foregroundColor = syncStateViewModel.isEditable ? UIColor.label : UIColor.tertiaryLabel
 
-    let string = NSMutableAttributedString()
-    if !title.isEmpty {
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: UIFont.preferredFont(forTextStyle: .headline),
-            .foregroundColor: foregroundColor
-        ]
-        let titleAttributedString = NSAttributedString(string: title, attributes: attributes)
-        string.append(titleAttributedString)
-    }
-    if !snippet.isEmpty {
-        // Normalize newlines by collapsing multiple occurrences of newlines to a single newline
-        let adjustedSnippet = snippet.replacingOccurrences(of: "[\n]{2,}", with: "\n", options: .regularExpression)
-        if string.length > 0 {
-            string.append(NSAttributedString(string: "\n"))
-        }
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: UIFont.preferredFont(forTextStyle: .subheadline),
-            .foregroundColor: UIColor.secondaryLabel
-        ]
-        let snippetAttributedString = NSAttributedString(string: adjustedSnippet, attributes: attributes)
-        string.append(snippetAttributedString)
-    }
+    let foregroundColor = isDisabled ? UIColor.tertiaryLabel : UIColor.label
+
+    let attributes: [NSAttributedString.Key: Any] = [
+        .font: UIFont.preferredFont(forTextStyle: .headline),
+        .foregroundColor: foregroundColor
+    ]
 
     let paragraphStyle = NSMutableParagraphStyle()
-    paragraphStyle.paragraphSpacing = 4
     paragraphStyle.lineBreakMode = .byTruncatingTail
 
+    let string = NSMutableAttributedString(string: title, attributes: attributes)
+    string.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: string.length))
+
+    return string
+}
+
+private func makeExcerptString(for post: Post, isDisabled: Bool) -> NSAttributedString {
+    let excerpt = post.contentPreviewForDisplay()
+
+    let foregroundColor = isDisabled ? UIColor.tertiaryLabel : UIColor.secondaryLabel
+
+    let attributes: [NSAttributedString.Key: Any] = [
+        .font: UIFont.preferredFont(forTextStyle: .subheadline),
+        .foregroundColor: foregroundColor
+    ]
+
+    let paragraphStyle = NSMutableParagraphStyle()
+    paragraphStyle.lineBreakMode = .byTruncatingTail
+
+    let string = NSMutableAttributedString(string: excerpt, attributes: attributes)
     string.addAttribute(.paragraphStyle, value: paragraphStyle, range: NSRange(location: 0, length: string.length))
 
     return string


### PR DESCRIPTION
### 1. Fix loading state by using Auto Layout. Remove redundant label.

<img width="320" alt="Screenshot 2025-06-30 at 12 00 36 PM" src="https://github.com/user-attachments/assets/77ad6f08-d380-45bd-bc26-56ef2bc5db39" /> <img width="320" alt="Screenshot 2025-06-30 at 11 55 07 AM" src="https://github.com/user-attachments/assets/8f89edf5-9a5b-4610-ae5a-f605308eae80" />

### 2. Fix missing "..." in titles and excerpts.

In the previous implementation, "..." were missing:

<img width="320" src="https://github.com/user-attachments/assets/1b4e65c6-4172-4f28-8170-b740ced19f40">

### 3. Visual improvements.

Use standard system typography and secondary color to establish better visual hierarchy.
Reduce the size of featured images and reduce the spacing between the text and the images.
The "More" button is now more visually centered vertically when image is present.
Other minor improvements.

Before / After

<img width="320" alt="Screenshot 2025-06-30 at 12 02 49 PM" src="https://github.com/user-attachments/assets/b7b0cd22-4a7a-4c8d-b6fa-955616766bc1" /> <img width="320" alt="Screenshot 2025-06-30 at 1 28 50 PM" src="https://github.com/user-attachments/assets/e1904c07-ff7e-4af8-ac3d-4081539f72b9" />

### 4. Fix placement of a loading indicator when deleting posts

Before:

<img width="320" alt="Screenshot 2025-06-30 at 2 05 03 PM" src="https://github.com/user-attachments/assets/44b46cfe-89ff-45c0-b5d9-fdbbd7fd5987" />

After:

<img width="320" alt="Screenshot 2025-06-30 at 2 13 35 PM" src="https://github.com/user-attachments/assets/0ca480f9-b84c-4dfe-986f-549c04def4a6" />

**Note**: I tested all other combinations too.






