### PR TITLE
Add missing retroactive conformance modifiers

### DIFF
--- a/WordPress/Classes/Models/Gutenberg/BlockEditorSettings+GutenbergEditorSettings.swift
+++ b/WordPress/Classes/Models/Gutenberg/BlockEditorSettings+GutenbergEditorSettings.swift
@@ -3,7 +3,7 @@ import WordPressData
 import WordPressKit
 import Gutenberg
 
-extension BlockEditorSettings: GutenbergEditorSettings {
+extension BlockEditorSettings: @retroactive GutenbergEditorSettings {
     public var colors: [[String: String]]? {
         elementsByType(.color)
     }

--- a/WordPress/Classes/Models/Notifications/Notification+AppsTargets.swift
+++ b/WordPress/Classes/Models/Notifications/Notification+AppsTargets.swift
@@ -363,7 +363,7 @@ extension WordPressData.Notification {
 
 // MARK: - Notifiable
 
-extension WordPressData.Notification: Notifiable {
+extension WordPressData.Notification: @retroactive Notifiable {
     public var notificationIdentifier: String {
         return notificationId
     }

--- a/WordPress/Classes/Models/ReaderPost+Searchable.swift
+++ b/WordPress/Classes/Models/ReaderPost+Searchable.swift
@@ -1,7 +1,7 @@
 import Foundation
 import WordPressData
 
-extension ReaderPost: SearchableItemConvertable {
+extension ReaderPost: @retroactive SearchableItemConvertable {
     public var searchItemType: SearchItemType {
         return .readerPost
     }

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController+Sharing.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController+Sharing.swift
@@ -81,7 +81,7 @@ private extension ReaderSiteTopic {
     }
 }
 
-extension ReaderSiteTopic: UIActivityItemSource {
+extension ReaderSiteTopic: @retroactive UIActivityItemSource {
     public func activityViewControllerPlaceholderItem(_ activityViewController: UIActivityViewController) -> Any {
         return shareableURL as Any
     }


### PR DESCRIPTION
Fixes these new warnings that were due to WordPressData.

<img width="472" alt="Screenshot 2025-06-30 at 5 18 48 PM" src="https://github.com/user-attachments/assets/59ed4e35-eb77-47a8-b6f4-ad7543394f0a" />
