### PR TITLE
Fixes for Users

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -14,6 +14,8 @@
 * [*] Fix incorrectly capitalized tag "WordPress" in Reader [#24649]
 * [*] Fix an issue with domains sometimes being incorrectly sorted on the "Domain Search" screen [#24631]
 * [*] Fix a couple of visual issues in Post List [#24647]
+* [*] Fix an issue where the empty state view covering top tabs on the "Users" screen [#24659]
+* [*] Fix an issue with invisible "Super Admin" badge on the "Users" screen [#24659]
 
 25.9
 -----

--- a/WordPress/Classes/ViewRelated/People/Controllers/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/Controllers/PeopleViewController.swift
@@ -7,8 +7,6 @@ import WordPressUI
 // MARK: - PeopleViewController
 
 class PeopleViewController: UITableViewController {
-    private let isUsersOnly = FeatureFlag.newsletterSubscribers.enabled
-
     // MARK: Properties
 
     private static let refreshRowPadding = 4
@@ -337,10 +335,9 @@ private extension PeopleViewController {
 
     func filtersAvailableForBlog(_ blog: Blog?) -> [Filter] {
         guard let blog, blog.siteVisibility == .private else {
-            return Filter.defaultFilters
+            return [.users]
         }
-
-        return Filter.allCases
+        return [.users, .viewers]
     }
 
     func refreshInterface() {
@@ -534,8 +531,8 @@ private extension PeopleViewController {
     }
 
     func setupTableView() {
-        guard !isUsersOnly else {
-            return
+        guard filtersAvailableForBlog(blog).count > 1 else {
+            return // Do not show the filter bar
         }
 
         filterBar.translatesAutoresizingMaskIntoConstraints = false
@@ -550,7 +547,7 @@ private extension PeopleViewController {
     }
 
     func setupView() {
-        title = isUsersOnly ? Strings.title : NSLocalizedString("People", comment: "Noun. Title of the people management feature.")
+        title = Strings.title
 
         navigationItem.rightBarButtonItem = UIBarButtonItem(barButtonSystemItem: .add,
                                                             target: self,

--- a/WordPress/Classes/ViewRelated/People/Controllers/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/Controllers/PeopleViewController.swift
@@ -478,7 +478,7 @@ private extension PeopleViewController {
             return
         }
         addChild(noResultsViewController)
-        tableView.addSubview(withFadeAnimation: noResultsViewController.view)
+        tableView.addSubview(noResultsViewController.view)
         noResultsViewController.view.translatesAutoresizingMaskIntoConstraints = false
 
         if let headerView = tableView.tableHeaderView {
@@ -533,7 +533,6 @@ private extension PeopleViewController {
 
         let indexToSet = Filter.allCases.firstIndex(where: { $0 == defaultFilter }) ?? 0
         filterBar.setSelectedIndex(indexToSet)
-        filter = defaultFilter
     }
 
     func setupTableView() {
@@ -563,6 +562,9 @@ private extension PeopleViewController {
 
         setupFilterBar()
         setupTableView()
+
+        /// - warning: This needs to happen after the view it fully configured
+        filter = defaultFilter
     }
 
     @objc private func selectedFilterDidChange(_ filterBar: FilterTabBar) {

--- a/WordPress/Classes/ViewRelated/People/Controllers/PeopleViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/Controllers/PeopleViewController.swift
@@ -480,7 +480,13 @@ private extension PeopleViewController {
         addChild(noResultsViewController)
         tableView.addSubview(withFadeAnimation: noResultsViewController.view)
         noResultsViewController.view.translatesAutoresizingMaskIntoConstraints = false
-        view.pinSubviewToSafeArea(noResultsViewController.view)
+
+        if let headerView = tableView.tableHeaderView {
+            noResultsViewController.view.topAnchor.constraint(equalTo: headerView.bottomAnchor).isActive = true
+        } else {
+            noResultsViewController.view.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
+        }
+        noResultsViewController.view.pinEdges([.horizontal, .bottom], to: view.safeAreaLayoutGuide)
 
         noResultsViewController.didMove(toParent: self)
     }

--- a/WordPress/Classes/ViewRelated/People/ViewModels/PeopleCellViewModel.swift
+++ b/WordPress/Classes/ViewRelated/People/ViewModels/PeopleCellViewModel.swift
@@ -61,7 +61,7 @@ struct PeopleCellViewModel {
     }
 
     var superAdminBackgroundColor: UIColor {
-        return .secondarySystemGroupedBackground
+        return UIAppColor.red(.shade50)
     }
 
     var superAdminHidden: Bool {


### PR DESCRIPTION
- Fix https://linear.app/a8c/issue/CMM-81/tab-bar-disappears-when-tapping-viewers-for-sites-that-have-no-viewers – an issue where the "no results" view was covering the top tabs. It is now shown below the tabs, so you can still switch between them.
- Fix an issue with the "Viewers" tab not visible for "Private" sites
- Fix an issue with invisible "Super Admin" badge on the "Users" screen

Before / After

<img width="320" alt="Screenshot 2025-07-08 at 10 00 40 AM" src="https://github.com/user-attachments/assets/e28b4742-36b4-4d1f-b543-7bc84e702c21" /> <img width="320" alt="Screenshot 2025-07-08 at 10 08 06 AM" src="https://github.com/user-attachments/assets/79a01093-1367-49ea-b4bf-d6e454b1ef12" />

After

<img width="320" alt="Screenshot 2025-07-08 at 10 28 01 AM" src="https://github.com/user-attachments/assets/86743791-7219-43b0-a53b-18ba399a8b95" />


