### PR TITLE
Revert Reader menu changes

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarViewController.swift
@@ -124,15 +124,6 @@ private struct ReaderSidebarView: View {
     private var regularContent: some View {
         Section {
             makeForEach(for: viewModel.menu)
-
-            if !viewModel.library.isEmpty {
-                Text(Strings.library)
-                    .font(.subheadline.weight(.semibold))
-                    .foregroundStyle(.secondary)
-                    .listRowInsets(EdgeInsets(top: 8, leading: 20, bottom: 0, trailing: 20))
-
-                makeForEach(for: viewModel.library)
-            }
         }
         if !favorites.isEmpty || isEditing {
             makeSection(Strings.favorites, isExpanded: $isSectionFavoritesExpanded) {
@@ -147,20 +138,29 @@ private struct ReaderSidebarView: View {
             }
         }
         makeSection(Strings.subscriptions, isExpanded: $isSectionSubscriptionsExpanded) {
+            if !viewModel.isReaderAppModeEnabled {
+                makeForEach(for: [.subscrtipions], isChevronHidden: true)
+            }
             ReaderSidebarSubscriptionsSection(viewModel: viewModel)
                 .environment(\.siteIconBackgroundColor, Color(viewModel.isCompact ? .secondarySystemBackground : .systemBackground))
         }
         makeSection(Strings.lists, isExpanded: $isSectionListsExpanded) {
+            if !viewModel.isReaderAppModeEnabled {
+                makeForEach(for: [.lists], isChevronHidden: true)
+            }
             ReaderSidebarListsSection(viewModel: viewModel)
         }
         makeSection(Strings.tags, isExpanded: $isSectionTagsExpanded) {
+            if !viewModel.isReaderAppModeEnabled {
+                makeForEach(for: [.tags], isChevronHidden: true)
+            }
             ReaderSidebarTagsSection(viewModel: viewModel)
         }
     }
 
-    private func makeForEach(for items: [ReaderStaticScreen]) -> some View {
+    private func makeForEach(for items: [ReaderStaticScreen], isChevronHidden: Bool = false) -> some View {
         ForEach(items) {
-            makePrimaryNavigationItem($0.localizedTitle, imageName: $0.imageName)
+            makePrimaryNavigationItem($0.localizedTitle, imageName: $0.imageName, isChevronHidden: isChevronHidden)
                 .tag(ReaderSidebarItem.main($0))
                 .listRowSeparator((viewModel.isCompact && $0 != items.last) ? .visible : .hidden, edges: .bottom)
                 .accessibilityIdentifier($0.accessibilityIdentifier)
@@ -168,7 +168,7 @@ private struct ReaderSidebarView: View {
         }
     }
 
-    private func makePrimaryNavigationItem(_ title: String, imageName: String) -> some View {
+    private func makePrimaryNavigationItem(_ title: String, imageName: String, isChevronHidden: Bool) -> some View {
         HStack {
             Label {
                 Text(title)
@@ -177,7 +177,7 @@ private struct ReaderSidebarView: View {
                 ScaledImage(imageName, height: 24, relativeTo: .headline)
             }
             .lineLimit(1)
-            if viewModel.isCompact {
+            if viewModel.isCompact && !isChevronHidden {
                 Spacer()
                 Image(systemName: "chevron.forward")
                     .font(.system(size: 14).weight(.medium))

--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarViewModel.swift
@@ -17,7 +17,6 @@ final class ReaderSidebarViewModel: ObservableObject {
     let isReaderAppModeEnabled: Bool
 
     let menu: [ReaderStaticScreen]
-    let library: [ReaderStaticScreen]
 
     init(menuStore: ReaderMenuStoreProtocol = ReaderMenuStore(),
          contextManager: CoreDataStackSwift = ContextManager.shared,
@@ -28,10 +27,8 @@ final class ReaderSidebarViewModel: ObservableObject {
         self.isReaderAppModeEnabled = isReaderAppModeEnabled
         if isReaderAppModeEnabled {
             menu = [.subscrtipions, .lists, .tags, .saved, .likes]
-            library = []
         } else {
             menu = [.recent, .discover, .saved, .likes, .search]
-            library = [.subscrtipions, .lists, .tags]
             restoreSelection(defaultValue: .main(.recent))
         }
 


### PR DESCRIPTION
Revert the changes from https://github.com/wordpress-mobile/WordPress-iOS/pull/24650 except for the "Tags" management simplification. I also keep the new style of primary menu items. It looks much better being consistent with the main menu.

<img width="340" alt="Screenshot 2025-07-08 at 10 45 04 AM" src="https://github.com/user-attachments/assets/11f8c82c-4680-4d5c-8388-83399f697d2f" />
