### PR TITLE
Use the user agent that contains app info

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,6 +16,7 @@
 * [*] Fix a couple of visual issues in Post List [#24647]
 * [*] Fix an issue where the empty state view covering top tabs on the "Users" screen [#24659]
 * [*] Fix an issue with invisible "Super Admin" badge on the "Users" screen [#24659]
+* [*] Fix the "network connection lost" issue [#24661]
 
 25.9
 -----

--- a/Sources/WordPressData/Swift/WPAccount+RestApi.swift
+++ b/Sources/WordPressData/Swift/WPAccount+RestApi.swift
@@ -30,7 +30,7 @@ extension WPAccount {
     private func makeWordPressComRestApi(authToken: String) -> WordPressComRestApi {
         let api = WordPressComRestApi.defaultApi(
             oAuthToken: authToken,
-            userAgent: WPUserAgent.defaultUserAgent(),
+            userAgent: WPUserAgent.wordPress(),
             localeKey: WordPressComRestApi.LocaleKeyDefault
         )
 

--- a/WordPress/Classes/Services/AccountService.m
+++ b/WordPress/Classes/Services/AccountService.m
@@ -180,7 +180,7 @@ NSString * const WPAccountEmailAndDefaultBlogUpdatedNotification = @"WPAccountEm
                                    success:(void (^)(WPAccount * _Nonnull))success
                                    failure:(void (^)(NSError * _Nonnull))failure
 {
-    WordPressComRestApi *api = [WordPressComRestApi defaultApiWithOAuthToken:authToken userAgent:[WPUserAgent defaultUserAgent] localeKey:[WordPressComRestApi LocaleKeyDefault]];
+    WordPressComRestApi *api = [WordPressComRestApi defaultApiWithOAuthToken:authToken userAgent:[WPUserAgent wordPressUserAgent] localeKey:[WordPressComRestApi LocaleKeyDefault]];
     AccountServiceRemoteREST *remote = [[AccountServiceRemoteREST alloc] initWithWordPressComRestApi:api];
     [remote getAccountDetailsWithSuccess:^(RemoteUser *remoteUser) {
         NSManagedObjectID *objectID = [self createOrUpdateAccountWithUserDetails:remoteUser authToken:authToken];


### PR DESCRIPTION
## Description

We should always use the app user agent ("... wp-iphone/*") to make API requests.

Internal references: pMz3w-mit-p2

<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->