### PR TITLE
Use tags and categories endpoints in wordpress-rs

### DIFF
--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/106707880 - Tri-County Real Estate - Personal Plan/rest_sites_106707880_taxonomies_category_terms.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/106707880 - Tri-County Real Estate - Personal Plan/rest_sites_106707880_taxonomies_category_terms.json
@@ -1,47 +1,86 @@
 {
   "request": {
     "method": "GET",
-    "urlPath": "/rest/v1.1/sites/106707880/taxonomies/category/terms/"
+    "urlPath": "/wp/v2/sites/106707880/categories"
   },
   "response": {
     "status": 200,
-    "jsonBody": {
-      "found": 3,
-      "terms": [
-        {
-          "ID": 1,
-          "name": "Uncategorized",
-          "slug": "uncategorized",
-          "description": "",
-          "post_count": 1,
-          "feed_url": "http://tricountyrealestate.wordpress.com/category/uncategorized/feed/",
-          "parent": 0,
-          "meta": {
-            "links": {
-              "self": "{{request.requestLine.baseUrl}}/rest/v1.1/sites/106707880/categories/slug:uncategorized",
-              "help": "{{request.requestLine.baseUrl}}/rest/v1.1/sites/106707880/categories/slug:uncategorized/help",
-              "site": "{{request.requestLine.baseUrl}}/rest/v1.1/sites/106707880"
+    "jsonBody": [
+      {
+        "id": 1,
+        "count": 1,
+        "description": "",
+        "link": "http://tricountyrealestate.wordpress.com/category/uncategorized/",
+        "name": "Uncategorized",
+        "slug": "uncategorized",
+        "taxonomy": "category",
+        "parent": 0,
+        "meta": [],
+        "_links": {
+          "self": [
+            {
+              "href": "{{request.requestLine.baseUrl}}/wp-json/wp/v2/categories/1",
+              "targetHints": { "allow": ["GET", "POST", "PUT", "PATCH", "DELETE"] }
             }
-          }
-        },
-        {
-          "ID": 1674,
-          "name": "Wedding",
-          "slug": "wedding",
-          "description": "",
-          "post_count": 1,
-          "feed_url": "http://tricountyrealestate.wordpress.com/category/wedding/feed/",
-          "parent": 0,
-          "meta": {
-            "links": {
-              "self": "{{request.requestLine.baseUrl}}/rest/v1.1/sites/106707880/categories/slug:wedding",
-              "help": "{{request.requestLine.baseUrl}}/rest/v1.1/sites/106707880/categories/slug:wedding/help",
-              "site": "{{request.requestLine.baseUrl}}/rest/v1.1/sites/106707880"
+          ],
+          "collection": [
+            {
+              "href": "{{request.requestLine.baseUrl}}/wp-json/wp/v2/categories"
             }
-          }
+          ],
+          "about": [
+            {
+              "href": "{{request.requestLine.baseUrl}}/wp-json/wp/v2/taxonomies/category"
+            }
+          ],
+          "wp:post_type": [
+            {
+              "href": "{{request.requestLine.baseUrl}}/wp-json/wp/v2/posts?categories=1"
+            }
+          ],
+          "curies": [
+            { "name": "wp", "href": "https://api.w.org/{rel}", "templated": true }
+          ]
         }
-      ]
-    },
+      },
+      {
+        "id": 1674,
+        "count": 1,
+        "description": "",
+        "link": "http://tricountyrealestate.wordpress.com/category/wedding/",
+        "name": "Wedding",
+        "slug": "wedding",
+        "taxonomy": "category",
+        "parent": 0,
+        "meta": [],
+        "_links": {
+          "self": [
+            {
+              "href": "{{request.requestLine.baseUrl}}/wp-json/wp/v2/categories/1674",
+              "targetHints": { "allow": ["GET", "POST", "PUT", "PATCH", "DELETE"] }
+            }
+          ],
+          "collection": [
+            {
+              "href": "{{request.requestLine.baseUrl}}/wp-json/wp/v2/categories"
+            }
+          ],
+          "about": [
+            {
+              "href": "{{request.requestLine.baseUrl}}/wp-json/wp/v2/taxonomies/category"
+            }
+          ],
+          "wp:post_type": [
+            {
+              "href": "{{request.requestLine.baseUrl}}/wp-json/wp/v2/posts?categories=1674"
+            }
+          ],
+          "curies": [
+            { "name": "wp", "href": "https://api.w.org/{rel}", "templated": true }
+          ]
+        }
+      }
+    ],
     "headers": {
       "Content-Type": "application/json",
       "Connection": "keep-alive",

--- a/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/106707880 - Tri-County Real Estate - Personal Plan/rest_sites_106707880_taxonomies_post_tag.json
+++ b/API-Mocks/WordPressMocks/src/main/assets/mocks/mappings/wpcom/sites/106707880 - Tri-County Real Estate - Personal Plan/rest_sites_106707880_taxonomies_post_tag.json
@@ -1,38 +1,22 @@
 {
   "request": {
     "method": "GET",
-    "urlPath": "/rest/v1.1/sites/106707880/taxonomies/post_tag/terms/",
-    "queryParameters": {
-      "number": {
-        "equalTo": "1000"
-      },
-      "locale": {
-        "matches": "(.*)"
-      }
-    }
+    "urlPath": "/wp/v2/sites/106707880/tags"
   },
   "response": {
     "status": 200,
-    "jsonBody": {
-      "found": 1,
-      "terms": [
-        {
-          "ID": 2500,
-          "name": "tag",
-          "slug": "tag",
-          "description": "",
-          "post_count": 1,
-          "feed_url": "https://tricountyrealestate.wordpress.com/tag/tag/feed/",
-          "meta": {
-            "links": {
-              "self": "{{request.requestLine.baseUrl}}/rest/v1.1/sites/106707880/tags/slug:tag",
-              "help": "{{request.requestLine.baseUrl}}/rest/v1.1/sites/106707880/tags/slug:tag/help",
-              "site": "{{request.requestLine.baseUrl}}/rest/v1.1/sites/106707880"
-            }
-          }
-        }
-      ]
-    },
+    "jsonBody": [
+      {
+        "id": 2500,
+        "count": 1,
+        "description": "",
+        "link": "https://tricountyrealestate.wordpress.com/tag/tag/",
+        "name": "tag",
+        "slug": "tag",
+        "taxonomy": "post_tag",
+        "meta": []
+      }
+    ],
     "headers": {
       "Content-Type": "application/json",
       "Connection": "keep-alive",

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "729318612d504c093c0c0969353bb1df8e1a20bf7b46836e8885bb622196c02d",
+  "originHash" : "157c9fc9d14f9944adbd41e9aadebf6d69bb64d65a08a9dd95721683d9def727",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -372,8 +372,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/wordpress-rs",
       "state" : {
-        "branch" : "alpha-20250707",
-        "revision" : "85c59d8ab88b26abca41a1a8b5e7c461110b3801"
+        "branch" : "alpha-20250715",
+        "revision" : "cafbc63b28c9d2b3fe3b646f808aee415550b89f"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         ),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
-        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250707"),
+        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250715"),
         .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.4.1"),
         .package(
             url: "https://github.com/Automattic/color-studio",

--- a/WordPress/Classes/Services/PostCategoryService.m
+++ b/WordPress/Classes/Services/PostCategoryService.m
@@ -180,6 +180,11 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable id<TaxonomyServiceRemote>)remoteForBlog:(Blog *)blog {
+    TaxonomyServiceRemoteCoreREST *instance = [[TaxonomyServiceRemoteCoreREST alloc] initWithBlog:blog];
+    if (instance != nil) {
+        return instance;
+    }
+
     if ([blog supports:BlogFeatureWPComRESTAPI]) {
         if (blog.wordPressComRestApi) {
             return [[TaxonomyServiceRemoteREST alloc] initWithWordPressComRestApi:blog.wordPressComRestApi siteID:blog.dotComID];

--- a/WordPress/Classes/Services/PostTagService.m
+++ b/WordPress/Classes/Services/PostTagService.m
@@ -159,6 +159,11 @@ static const NSInteger PostTagIdDefaultValue = -1;
 #pragma mark - helpers
 
 - (nullable id<TaxonomyServiceRemote>)remoteForBlog:(Blog *)blog {
+    TaxonomyServiceRemoteCoreREST *instance = [[TaxonomyServiceRemoteCoreREST alloc] initWithBlog:blog];
+    if (instance != nil) {
+        return instance;
+    }
+
     if ([blog supports:BlogFeatureWPComRESTAPI]) {
         if (blog.wordPressComRestApi) {
             return [[TaxonomyServiceRemoteREST alloc] initWithWordPressComRestApi:blog.wordPressComRestApi siteID:blog.dotComID];

--- a/WordPress/Classes/Services/TaxonomyServiceRemoteCoreREST.swift
+++ b/WordPress/Classes/Services/TaxonomyServiceRemoteCoreREST.swift
@@ -5,9 +5,6 @@ import WordPressData
 import WordPressAPI
 import WordPressAPIInternal
 
-// This variable is used to match the behaviour in `TaxonomyServiceRemoteREST`. See `TaxonomyRESTNumberMaxValue`.
-private let defaultPerPage: UInt32 = 1000;
-
 @objc class TaxonomyServiceRemoteCoreREST: NSObject, TaxonomyServiceRemote {
     let client: WordPressClient
 
@@ -40,7 +37,7 @@ private let defaultPerPage: UInt32 = 1000;
     func getCategoriesWithSuccess(_ success: @escaping ([RemotePostCategory]) -> Void, failure: ((any Error) -> Void)? = nil) {
         Task { @MainActor in
             do {
-                let response = try await client.api.categories.listWithEditContext(params: CategoryListParams(perPage: defaultPerPage))
+                let response = try await client.api.categories.listWithEditContext(params: CategoryListParams())
                 let categories = response.data.map(RemotePostCategory.init(category:))
                 success(categories)
             } catch {
@@ -139,7 +136,7 @@ private let defaultPerPage: UInt32 = 1000;
     func getTagsWithSuccess(_ success: @escaping ([RemotePostTag]) -> Void, failure: ((any Error) -> Void)? = nil) {
         Task { @MainActor in
             do {
-                let response = try await client.api.tags.listWithEditContext(params: TagListParams(perPage: defaultPerPage))
+                let response = try await client.api.tags.listWithEditContext(params: TagListParams())
                 let tags = response.data.map(RemotePostTag.init(tag:))
                 success(tags)
             } catch {

--- a/WordPress/Classes/Services/TaxonomyServiceRemoteCoreREST.swift
+++ b/WordPress/Classes/Services/TaxonomyServiceRemoteCoreREST.swift
@@ -1,0 +1,240 @@
+import Foundation
+import WordPressKit
+import WordPressCore
+import WordPressData
+import WordPressAPI
+import WordPressAPIInternal
+
+// This variable is used to match the behaviour in `TaxonomyServiceRemoteREST`. See `TaxonomyRESTNumberMaxValue`.
+private let defaultPerPage: UInt32 = 1000;
+
+@objc class TaxonomyServiceRemoteCoreREST: NSObject, TaxonomyServiceRemote {
+    let client: WordPressClient
+
+    @objc convenience init?(blog: Blog) {
+        guard let site = try? WordPressSite(blog: blog) else { return nil }
+
+        self.init(client: .init(site: site))
+    }
+
+    init(client: WordPressClient) {
+        self.client = client
+    }
+
+    func createCategory(_ category: RemotePostCategory, success: ((RemotePostCategory) -> Void)?, failure: ((any Error) -> Void)? = nil) {
+        Task { @MainActor in
+            do {
+                let params = CategoryCreateParams(
+                    name: category.name ?? "",
+                    parent: category.parentID?.int64Value
+                )
+                let response = try await client.api.categories.create(params: params)
+                let remoteCategory = RemotePostCategory(category: response.data)
+                success?(remoteCategory)
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func getCategoriesWithSuccess(_ success: @escaping ([RemotePostCategory]) -> Void, failure: ((any Error) -> Void)? = nil) {
+        Task { @MainActor in
+            do {
+                let response = try await client.api.categories.listWithEditContext(params: CategoryListParams(perPage: defaultPerPage))
+                let categories = response.data.map(RemotePostCategory.init(category:))
+                success(categories)
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func getCategoriesWith(_ paging: RemoteTaxonomyPaging, success: @escaping ([RemotePostCategory]) -> Void, failure: ((any Error) -> Void)? = nil) {
+        Task { @MainActor in
+            do {
+                let params = CategoryListParams(
+                    page: paging.page?.uint32Value,
+                    perPage: paging.number?.uint32Value,
+                    offset: paging.offset?.uint32Value,
+                    order: .init(paging.order),
+                    orderby: .init(paging.orderBy)
+                )
+                let response = try await client.api.categories.listWithEditContext(params: params)
+                let categories = response.data.map(RemotePostCategory.init(category:))
+                success(categories)
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func searchCategories(withName nameQuery: String, success: @escaping ([RemotePostCategory]) -> Void, failure: ((any Error) -> Void)? = nil) {
+        Task { @MainActor in
+            do {
+                let params = CategoryListParams(search: nameQuery)
+                let response = try await client.api.categories.listWithEditContext(params: params)
+                let categories = response.data.map(RemotePostCategory.init(category:))
+                success(categories)
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func createTag(_ tag: RemotePostTag, success: ((RemotePostTag) -> Void)?, failure: ((any Error) -> Void)? = nil) {
+        Task { @MainActor in
+            do {
+                let params = TagCreateParams(
+                    name: tag.name ?? "",
+                    description: tag.tagDescription,
+                    slug: tag.slug
+                )
+                let response = try await client.api.tags.create(params: params)
+                let remoteTag = RemotePostTag(tag: response.data)
+                success?(remoteTag)
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func update(_ tag: RemotePostTag, success: ((RemotePostTag) -> Void)?, failure: ((any Error) -> Void)? = nil) {
+        guard let tagID = tag.tagID else {
+            failure?(URLError(.unknown))
+            return
+        }
+
+        Task { @MainActor in
+            do {
+                let params = TagUpdateParams(
+                    name: tag.name,
+                    description: tag.tagDescription,
+                    slug: tag.slug
+                )
+                let response = try await client.api.tags.update(tagId: TagId(tagID.int64Value), params: params)
+                let remoteTag = RemotePostTag(tag: response.data)
+                success?(remoteTag)
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func delete(_ tag: RemotePostTag, success: (() -> Void)?, failure: ((any Error) -> Void)? = nil) {
+        guard let tagID = tag.tagID else {
+            failure?(URLError(.unknown))
+            return
+        }
+
+        Task { @MainActor in
+            do {
+                let _ = try await client.api.tags.delete(tagId: TagId(tagID.int64Value))
+                success?()
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func getTagsWithSuccess(_ success: @escaping ([RemotePostTag]) -> Void, failure: ((any Error) -> Void)? = nil) {
+        Task { @MainActor in
+            do {
+                let response = try await client.api.tags.listWithEditContext(params: TagListParams(perPage: defaultPerPage))
+                let tags = response.data.map(RemotePostTag.init(tag:))
+                success(tags)
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func getTagsWith(_ paging: RemoteTaxonomyPaging, success: @escaping ([RemotePostTag]) -> Void, failure: ((any Error) -> Void)? = nil) {
+        Task { @MainActor in
+            do {
+                let params = TagListParams(
+                    page: paging.page?.uint32Value,
+                    perPage: paging.number?.uint32Value,
+                    offset: paging.offset?.uint32Value,
+                    order: .init(paging.order),
+                    orderby: .init(paging.orderBy)
+                )
+                let response = try await client.api.tags.listWithEditContext(params: params)
+                let tags = response.data.map(RemotePostTag.init(tag:))
+                success(tags)
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+
+    func searchTags(withName nameQuery: String, success: @escaping ([RemotePostTag]) -> Void, failure: ((any Error) -> Void)? = nil) {
+        Task { @MainActor in
+            do {
+                let response = try await client.api.tags.listWithEditContext(params: TagListParams(search: nameQuery))
+                let tags = response.data.map(RemotePostTag.init(tag:))
+                success(tags)
+            } catch {
+                failure?(error)
+            }
+        }
+    }
+}
+
+private extension RemotePostCategory {
+    convenience init(category: CategoryWithEditContext) {
+        self.init()
+        self.categoryID = NSNumber(value: category.id)
+        self.name = category.name
+        self.parentID = NSNumber(value: category.parent)
+    }
+}
+
+private extension RemotePostTag {
+    convenience init(tag: TagWithEditContext) {
+        self.init()
+        self.tagID = NSNumber(value: tag.id)
+        self.name = tag.name
+        self.slug = tag.slug
+        self.tagDescription = tag.description
+        self.postCount = NSNumber(value: tag.count)
+    }
+}
+
+private extension WpApiParamOrder {
+    init(_ other: RemoteTaxonomyPagingResultsOrder) {
+        switch other {
+        case .orderAscending:
+            self = .asc
+        case .orderDescending:
+            self = .desc
+        @unknown default:
+            self = .asc
+        }
+    }
+}
+
+private extension WpApiParamCategoriesOrderBy {
+    init(_ other: RemoteTaxonomyPagingResultsOrdering) {
+        switch other {
+        case .byName:
+            self = .name
+        case .byCount:
+            self = .count
+        @unknown default:
+            self = .name
+        }
+    }
+}
+
+private extension WpApiParamTagsOrderBy {
+    init(_ other: RemoteTaxonomyPagingResultsOrdering) {
+        switch other {
+        case .byName:
+            self = .name
+        case .byCount:
+            self = .count
+        @unknown default:
+            self = .name
+        }
+    }
+}

--- a/WordPress/Classes/Services/TaxonomyServiceRemoteCoreREST.swift
+++ b/WordPress/Classes/Services/TaxonomyServiceRemoteCoreREST.swift
@@ -5,10 +5,10 @@ import WordPressData
 import WordPressAPI
 import WordPressAPIInternal
 
-@objc class TaxonomyServiceRemoteCoreREST: NSObject, TaxonomyServiceRemote {
+@objc public class TaxonomyServiceRemoteCoreREST: NSObject, TaxonomyServiceRemote {
     let client: WordPressClient
 
-    @objc convenience init?(blog: Blog) {
+    @objc public convenience init?(blog: Blog) {
         guard let site = try? WordPressSite(blog: blog) else { return nil }
 
         self.init(client: .init(site: site))
@@ -18,7 +18,7 @@ import WordPressAPIInternal
         self.client = client
     }
 
-    func createCategory(_ category: RemotePostCategory, success: ((RemotePostCategory) -> Void)?, failure: ((any Error) -> Void)? = nil) {
+    public func createCategory(_ category: RemotePostCategory, success: ((RemotePostCategory) -> Void)?, failure: ((any Error) -> Void)? = nil) {
         Task { @MainActor in
             do {
                 let params = CategoryCreateParams(
@@ -34,7 +34,7 @@ import WordPressAPIInternal
         }
     }
 
-    func getCategoriesWithSuccess(_ success: @escaping ([RemotePostCategory]) -> Void, failure: ((any Error) -> Void)? = nil) {
+    public func getCategoriesWithSuccess(_ success: @escaping ([RemotePostCategory]) -> Void, failure: ((any Error) -> Void)? = nil) {
         Task { @MainActor in
             do {
                 let response = try await client.api.categories.listWithEditContext(params: CategoryListParams())
@@ -46,7 +46,7 @@ import WordPressAPIInternal
         }
     }
 
-    func getCategoriesWith(_ paging: RemoteTaxonomyPaging, success: @escaping ([RemotePostCategory]) -> Void, failure: ((any Error) -> Void)? = nil) {
+    public func getCategoriesWith(_ paging: RemoteTaxonomyPaging, success: @escaping ([RemotePostCategory]) -> Void, failure: ((any Error) -> Void)? = nil) {
         Task { @MainActor in
             do {
                 let params = CategoryListParams(
@@ -65,7 +65,7 @@ import WordPressAPIInternal
         }
     }
 
-    func searchCategories(withName nameQuery: String, success: @escaping ([RemotePostCategory]) -> Void, failure: ((any Error) -> Void)? = nil) {
+    public func searchCategories(withName nameQuery: String, success: @escaping ([RemotePostCategory]) -> Void, failure: ((any Error) -> Void)? = nil) {
         Task { @MainActor in
             do {
                 let params = CategoryListParams(search: nameQuery)
@@ -78,7 +78,7 @@ import WordPressAPIInternal
         }
     }
 
-    func createTag(_ tag: RemotePostTag, success: ((RemotePostTag) -> Void)?, failure: ((any Error) -> Void)? = nil) {
+    public func createTag(_ tag: RemotePostTag, success: ((RemotePostTag) -> Void)?, failure: ((any Error) -> Void)? = nil) {
         Task { @MainActor in
             do {
                 let params = TagCreateParams(
@@ -95,7 +95,7 @@ import WordPressAPIInternal
         }
     }
 
-    func update(_ tag: RemotePostTag, success: ((RemotePostTag) -> Void)?, failure: ((any Error) -> Void)? = nil) {
+    public func update(_ tag: RemotePostTag, success: ((RemotePostTag) -> Void)?, failure: ((any Error) -> Void)? = nil) {
         guard let tagID = tag.tagID else {
             failure?(URLError(.unknown))
             return
@@ -117,7 +117,7 @@ import WordPressAPIInternal
         }
     }
 
-    func delete(_ tag: RemotePostTag, success: (() -> Void)?, failure: ((any Error) -> Void)? = nil) {
+    public func delete(_ tag: RemotePostTag, success: (() -> Void)?, failure: ((any Error) -> Void)? = nil) {
         guard let tagID = tag.tagID else {
             failure?(URLError(.unknown))
             return
@@ -133,7 +133,7 @@ import WordPressAPIInternal
         }
     }
 
-    func getTagsWithSuccess(_ success: @escaping ([RemotePostTag]) -> Void, failure: ((any Error) -> Void)? = nil) {
+    public func getTagsWithSuccess(_ success: @escaping ([RemotePostTag]) -> Void, failure: ((any Error) -> Void)? = nil) {
         Task { @MainActor in
             do {
                 let response = try await client.api.tags.listWithEditContext(params: TagListParams())
@@ -145,7 +145,7 @@ import WordPressAPIInternal
         }
     }
 
-    func getTagsWith(_ paging: RemoteTaxonomyPaging, success: @escaping ([RemotePostTag]) -> Void, failure: ((any Error) -> Void)? = nil) {
+    public func getTagsWith(_ paging: RemoteTaxonomyPaging, success: @escaping ([RemotePostTag]) -> Void, failure: ((any Error) -> Void)? = nil) {
         Task { @MainActor in
             do {
                 let params = TagListParams(
@@ -164,7 +164,7 @@ import WordPressAPIInternal
         }
     }
 
-    func searchTags(withName nameQuery: String, success: @escaping ([RemotePostTag]) -> Void, failure: ((any Error) -> Void)? = nil) {
+    public func searchTags(withName nameQuery: String, success: @escaping ([RemotePostTag]) -> Void, failure: ((any Error) -> Void)? = nil) {
         Task { @MainActor in
             do {
                 let response = try await client.api.tags.listWithEditContext(params: TagListParams(search: nameQuery))


### PR DESCRIPTION
> [!Note]
> This PR requires changes in https://github.com/Automattic/wordpress-rs/pull/804.

## Description

Add a new `TaxonomyServiceRemoteCoreREST` class which uses wordpress-rs to call the core REST API. The class takes effect on WP.com sites and self-hosted site that has an application password.

## Testing instructions

Tags and categories can be loaded from Post Settings.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
