### PR TITLE
Use `Blog.restApiRootURL` in GutenbergKit

### DIFF
--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -842,7 +842,7 @@ extension NewGutenbergViewController {
 
 extension EditorConfiguration {
     init(blog: Blog) {
-        let selfHostedApiUrl = blog.url(withPath: "wp-json/")
+        let selfHostedApiUrl = blog.restApiRootURL ?? blog.url(withPath: "wp-json/")
         let isWPComSite = blog.isHostedAtWPcom || blog.isAtomic()
         let siteApiRoot = blog.isAccessibleThroughWPCom() && isWPComSite ? blog.wordPressComRestApi?.baseURL.absoluteString : selfHostedApiUrl
         let siteId = blog.dotComID?.stringValue


### PR DESCRIPTION
## Description

When the blog is added via wordpress-rs's login process, we store the site's API root URL in `restApiRootURL`. Use the property in GBK editor when available.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
