### PR TITLE
New tags list using Data View

### DIFF
--- a/WordPress/Classes/ViewRelated/Tags/RemotePostTag+Identifiable.swift
+++ b/WordPress/Classes/ViewRelated/Tags/RemotePostTag+Identifiable.swift
@@ -1,0 +1,8 @@
+import Foundation
+import WordPressKit
+
+extension RemotePostTag: @retroactive Identifiable {
+    public var id: Int {
+        return tagID?.intValue ?? 0
+    }
+}

--- a/WordPress/Classes/ViewRelated/Tags/TagsService.swift
+++ b/WordPress/Classes/ViewRelated/Tags/TagsService.swift
@@ -1,0 +1,66 @@
+import Foundation
+import WordPressKit
+import WordPressData
+
+@MainActor
+class TagsService {
+    private let blog: Blog
+    private let remote: TaxonomyServiceRemote?
+
+    init(blog: Blog) {
+        self.blog = blog
+        self.remote = Self.createRemote(for: blog)
+    }
+
+    private static func createRemote(for blog: Blog) -> TaxonomyServiceRemote? {
+        if let siteID = blog.dotComID, let api = blog.wordPressComRestApi {
+            return TaxonomyServiceRemoteREST(wordPressComRestApi: api, siteID: siteID)
+        }
+
+        if let username = blog.username, let password = blog.password, let xmlrpcApi = blog.xmlrpcApi {
+            return TaxonomyServiceRemoteXMLRPC(api: xmlrpcApi, username: username, password: password)
+        }
+
+        return nil
+    }
+
+    func getTags(number: Int = 100, offset: Int = 0) async throws -> [RemotePostTag] {
+        guard let remote else {
+            throw TagsServiceError.noRemoteService
+        }
+
+        let paging = RemoteTaxonomyPaging()
+        paging.number = NSNumber(value: number)
+        paging.offset = NSNumber(value: offset)
+
+        return try await withCheckedThrowingContinuation { continuation in
+            remote.getTagsWith(paging, success: { remoteTags in
+                continuation.resume(returning: remoteTags)
+            }, failure: { error in
+                continuation.resume(throwing: error)
+            })
+        }
+    }
+
+    func searchTags(with query: String) async throws -> [RemotePostTag] {
+        guard let remote else {
+            throw TagsServiceError.noRemoteService
+        }
+
+        guard !query.isEmpty else {
+            return []
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            remote.searchTags(withName: query, success: { remoteTags in
+                continuation.resume(returning: remoteTags)
+            }, failure: { error in
+                continuation.resume(throwing: error)
+            })
+        }
+    }
+}
+
+enum TagsServiceError: Error {
+    case noRemoteService
+}

--- a/WordPress/Classes/ViewRelated/Tags/TagsView.swift
+++ b/WordPress/Classes/ViewRelated/Tags/TagsView.swift
@@ -1,0 +1,126 @@
+import SwiftUI
+import WordPressUI
+import WordPressKit
+import WordPressData
+
+struct TagsView: View {
+    @ObservedObject var viewModel: TagsViewModel
+
+    var body: some View {
+        Group {
+            if !viewModel.searchText.isEmpty {
+                TagsSearchView(viewModel: viewModel)
+            } else {
+                TagsListView(viewModel: viewModel)
+            }
+        }
+        .navigationTitle(Strings.title)
+        .searchable(text: $viewModel.searchText)
+        .textInputAutocapitalization(.never)
+    }
+}
+
+private struct TagsListView: View {
+    @ObservedObject var viewModel: TagsViewModel
+
+    var body: some View {
+        List {
+            if let response = viewModel.response {
+                DataViewPaginatedForEach(response: response) { tag in
+                    TagRowView(tag: tag)
+                }
+            }
+        }
+        .listStyle(.plain)
+        .overlay {
+            if let response = viewModel.response {
+                if response.isEmpty {
+                    EmptyStateView(
+                        Strings.empty,
+                        systemImage: "tag",
+                        description: Strings.emptyDescription
+                    )
+                }
+            } else if viewModel.isLoading {
+                ProgressView()
+            } else if let error = viewModel.error {
+                EmptyStateView.failure(error: error) {
+                    Task { await viewModel.refresh() }
+                }
+            }
+        }
+        .onAppear {
+            viewModel.onAppear()
+        }
+        .refreshable {
+            await viewModel.refresh()
+        }
+    }
+}
+
+private struct TagsSearchView: View {
+    @ObservedObject var viewModel: TagsViewModel
+
+    var body: some View {
+        DataViewSearchView(
+            searchText: viewModel.searchText,
+            search: viewModel.search
+        ) { response in
+            DataViewPaginatedForEach(response: response) { tag in
+                TagRowView(tag: tag)
+            }
+        }
+    }
+}
+
+private struct TagsPaginatedForEach: View {
+    @ObservedObject var response: TagsPaginatedResponse
+
+    var body: some View {
+        DataViewPaginatedForEach(response: response) { tag in
+            TagRowView(tag: tag)
+        }
+    }
+}
+
+private struct TagRowView: View {
+    let tag: RemotePostTag
+
+    var body: some View {
+        Text(tag.name ?? "")
+            .font(.body)
+    }
+}
+
+private enum Strings {
+    static let title = NSLocalizedString(
+        "tags.title",
+        value: "Tags",
+        comment: "Title for the tags screen"
+    )
+
+    static let empty = NSLocalizedString(
+        "tags.empty.title",
+        value: "No Tags",
+        comment: "Title for empty state when there are no tags"
+    )
+
+    static let emptyDescription = NSLocalizedString(
+        "tags.empty.description",
+        value: "Tags help organize your content and make it easier for readers to find related posts.",
+        comment: "Description for empty state when there are no tags"
+    )
+}
+
+class TagsViewController: UIHostingController<TagsView> {
+    let viewModel: TagsViewModel
+
+    init(blog: Blog) {
+        viewModel = TagsViewModel(blog: blog)
+        super.init(rootView: .init(viewModel: viewModel))
+    }
+
+    @MainActor @preconcurrency required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Tags/TagsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Tags/TagsViewModel.swift
@@ -1,0 +1,81 @@
+import Foundation
+import WordPressKit
+import WordPressData
+import WordPressUI
+
+typealias TagsPaginatedResponse = DataViewPaginatedResponse<RemotePostTag, Int>
+
+@MainActor
+class TagsViewModel: ObservableObject {
+    @Published var searchText = ""
+    @Published var response: TagsPaginatedResponse?
+    @Published var isLoading = false
+    @Published var error: Error?
+
+    let blog: Blog
+    private let tagsService: TagsService
+
+    init(blog: Blog) {
+        self.blog = blog
+        self.tagsService = TagsService(blog: blog)
+    }
+
+    func onAppear() {
+        guard response == nil else { return }
+        Task {
+            await loadInitialTags()
+        }
+    }
+
+    @MainActor
+    func refresh() async {
+        response = nil
+        error = nil
+        await loadInitialTags()
+    }
+
+    private func loadInitialTags() async {
+        isLoading = true
+        defer { isLoading = false}
+
+        error = nil
+
+        do {
+            let paginatedResponse = try await TagsPaginatedResponse { [weak self] pageIndex in
+                guard let self else {
+                    throw TagsServiceError.noRemoteService
+                }
+
+                let offset = pageIndex ?? 0
+                let remoteTags = try await self.tagsService.getTags(number: 100, offset: offset)
+
+                let hasMore = remoteTags.count == 100
+                let nextPage = hasMore ? offset + 100 : nil
+
+                return TagsPaginatedResponse.Page(
+                    items: remoteTags,
+                    total: nil,
+                    hasMore: hasMore,
+                    nextPage: nextPage
+                )
+            }
+
+            self.response = paginatedResponse
+        } catch {
+            self.error = error
+        }
+    }
+
+    func search() async throws -> DataViewPaginatedResponse<RemotePostTag, Int> {
+        let remoteTags = try await tagsService.searchTags(with: searchText)
+
+        return try await DataViewPaginatedResponse { _ in
+            return DataViewPaginatedResponse.Page(
+                items: remoteTags,
+                total: remoteTags.count,
+                hasMore: false,
+                nextPage: nil
+            )
+        }
+    }
+}


### PR DESCRIPTION
## Description

There are three different implementations of tags list:
1. Post Settings -> Add tag
2. Site Settings -> Tags
3. Menu -> add  tag as menu item

The three implementations do not share any UI part, but only share the loading and searching tags code (via `PostTagService`. There are issues in loading tags, where tags are not all displayed, and the search result is not accurate (see https://linear.app/a8c/issue/CMM-96).

I want to create a new `TagsView`, using the new Data View component. I plan to use the new view to serve all three features mentioned above. It's not used anywhere yet in this PR, but will be used in future PRs.

## Testing instructions

None.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
