### PR TITLE
[Tooling] Remove age rating configuration after ASC API failure

### DIFF
--- a/fastlane/lanes/localization.rb
+++ b/fastlane/lanes/localization.rb
@@ -115,7 +115,10 @@ UPLOAD_TO_APP_STORE_COMMON_PARAMS = {
   phased_release: true,
   precheck_include_in_app_purchases: false,
   api_key_path: APP_STORE_CONNECT_KEY_PATH,
-  app_rating_config_path: File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'metadata', 'ratings_config.json'),
+  # [AINFRA-933] Disabling the use of `app_rating_config_path` after seeing the ASC API error:
+  # > The provided entity includes an unknown attribute - 'seventeenPlus' is not an attribute on the
+  # > resource 'ageRatingDeclarations'
+  # app_rating_config_path: File.join(PROJECT_ROOT_FOLDER, 'fastlane', 'metadata', 'ratings_config.json'),
   copyright: "© #{Time.now.year} Automattic, Inc."
 }.freeze
 


### PR DESCRIPTION
Fixes AINFRA-933 

## Description

We started seeing this error from the ASC API when submitting the AppStore metadata:

```
The provided entity includes an unknown attribute - 'seventeenPlus' is not an attribute on the resource 'ageRatingDeclarations' - /data/attributes/seventeenPlus
```

This seems to be an issue with [Fastlane not being up to date with the latest ASC API](https://github.com/fastlane/fastlane/blob/master/spaceship/lib/spaceship/connect_api/models/age_rating_declaration.rb), and perhaps Apple is now enforcing errors after API deprecations.

--- 

**Alternatively**, I've also created the branch [iangmaia/update-ratings-config](https://github.com/wordpress-mobile/WordPress-iOS/compare/release/26.0...iangmaia/update-ratings-config) only removing the `seventeenPlus` attribute instead of discarding the entire `app_rating_config_path`.