### PR TITLE
Remove the `pickOne` mode from `TagsView`

### DIFF
--- a/WordPress/Classes/ViewRelated/Tags/TagsView.swift
+++ b/WordPress/Classes/ViewRelated/Tags/TagsView.swift
@@ -354,8 +354,6 @@ private struct TagRowView: View {
                         switch viewModel.mode {
                         case .selection:
                             viewModel.toggleSelection(for: tag)
-                        case .pickOne(let onTagTapped):
-                            onTagTapped(tag)
                         case .browse:
                             break
                         }
@@ -455,10 +453,6 @@ class TagsViewController: UIHostingController<TagsView> {
 
     convenience init(blog: Blog, selectedTags: String? = nil, onSelectedTagsChanged: ((String) -> Void)? = nil) {
         self.init(blog: blog, selectedTags: selectedTags, mode: .selection(onSelectedTagsChanged: onSelectedTagsChanged))
-    }
-
-    convenience init(blog: Blog, onTagTapped: @escaping (RemotePostTag) -> Void) {
-        self.init(blog: blog, mode: .pickOne(onTagTapped: onTagTapped))
     }
 
     convenience init(blog: Blog) {

--- a/WordPress/Classes/ViewRelated/Tags/TagsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Tags/TagsViewModel.swift
@@ -7,7 +7,6 @@ typealias TagsPaginatedResponse = DataViewPaginatedResponse<RemotePostTag, Int>
 
 enum TagsViewMode {
     case selection(onSelectedTagsChanged: ((String) -> Void)?)
-    case pickOne(onTagTapped: (RemotePostTag) -> Void)
     case browse
 }
 


### PR DESCRIPTION
## Description

I originally planned to use the `pickOne` mode for adding tags as menu items. But after trying that, it did not work out. Because the menu item editing (`MenuItemSourceResultsViewController` specifically) is coupled with `UITableView` and `UISearchBar` - they need to be used by the tags selection view. We can't do that, because `TagsView` is implemented in SwiftUI.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
