### PR TITLE
Create application password without user interaction

### DIFF
--- a/Tests/KeystoneTests/Helpers/BlogBuilder.swift
+++ b/Tests/KeystoneTests/Helpers/BlogBuilder.swift
@@ -23,7 +23,7 @@ final class BlogBuilder {
         }
 
         // Non-null properties in Core Data
-        blog.url = "https://\(blog.dotComID?.stringValue ?? "wwww").example.com"
+        blog.url = "https://\(blog.dotComID?.stringValue ?? "www").example.com"
         blog.xmlrpc = "\(blog.url!)/xmlrpc.php"
     }
 

--- a/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
@@ -94,11 +94,7 @@ private extension ApplicationPasswordsRepositoryTests {
         user.username = "testuser"
         user.email = "testuser@example.com"
         let service = AccountService(coreDataStack: coreDataStack)
-        let objectID = service.createOrUpdateAccount(withUserDetails: user, authToken: "token")
-        try await coreDataStack.performAndSave { context in
-            let account = try #require(try context.existingObject(with: objectID) as? WPAccount)
-            service.setDefaultWordPressComAccount(account)
-        }
+        service.createOrUpdateAccount(withUsername: "testuser", authToken: "token")
     }
 
     func createSimpleSite() async throws -> TaggedManagedObjectID<Blog> {

--- a/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
@@ -45,6 +45,7 @@ struct ApplicationPasswordsRepositoryTests {
         let blog = try await createSelfHostedSite()
 
         stubApiDiscovery(siteHost: "www.example.com")
+        stubSelfHostedSiteWpV2GetUser()
         stubSelfHostedSiteCreateApplicationPassword(host: "www.example.com", password: "1234 5678")
 
         let repository = ApplicationPasswordRepository.forTesting(coreDataStack: coreDataStack, keychain: keychain)
@@ -54,6 +55,33 @@ struct ApplicationPasswordsRepositoryTests {
             try context.existingObject(with: blog).getApplicationToken(using: keychain)
         }
         #expect(password == "1234 5678")
+    }
+
+    @Test
+    func selfHostedSiteWithInaccessibleRestApi() async throws {
+        let blog = try await createSelfHostedSite()
+
+        stubApiDiscovery(siteHost: "www.example.com")
+
+        stub(condition: isHost("www.example.com") && isPath("/wp-login.php")) { _ in
+            HTTPStubsResponse(data: "<html>Logged in</html>".data(using: .utf8)!, statusCode: 200, headers: nil)
+        }
+        stub(condition: isHost("www.example.com") && isPath("/wp-admin/admin-ajax.php") && containsQueryParams(["action": "rest-nonce"])) { _ in
+            HTTPStubsResponse(data: "<html>not allowed</html>".data(using: .utf8)!, statusCode: 400, headers: nil)
+        }
+        stub(condition: isHost("www.example.com") && isPath("/wp-admin/post-new.php")) { _ in
+            HTTPStubsResponse(data: "<html>not allowed</html>".data(using: .utf8)!, statusCode: 400, headers: nil)
+        }
+        stub(condition: isHost("www.example.com") && isPath("/wp-json/wp/v2/users/me")) { _ in
+            let json = #"{"code":"rest_not_logged_in","message":"You are not currently logged in.","data":{"status":401}}"#
+            return HTTPStubsResponse(data: json.data(using: .utf8)!, statusCode: 401, headers: nil)
+        }
+
+        let repository = ApplicationPasswordRepository.forTesting(coreDataStack: coreDataStack, keychain: keychain)
+
+        await #expect(throws: ApplicationPasswordRepositoryError.restApiInaccessible) {
+            try await repository.createPasswordIfNeeded(for: blog)
+        }
     }
 }
 
@@ -74,6 +102,7 @@ private extension ApplicationPasswordsRepositoryTests {
     }
 
     func createSimpleSite() async throws -> TaggedManagedObjectID<Blog> {
+        stubApiDiscoveryFailure(siteHost: "simple.wordpress.com")
         stub(condition: isHost("simple.wordpress.com") && isPath("/wp-json")) { _ in
             HTTPStubsResponse(data: "<html>Page not found</html>".data(using: .utf8)!, statusCode: 404, headers: nil)
         }
@@ -114,7 +143,7 @@ private extension ApplicationPasswordsRepositoryTests {
         stub(condition: isHost(host) && isPath("/wp-login.php")) { _ in
             HTTPStubsResponse(data: "<html>Logged in</html>".data(using: .utf8)!, statusCode: 200, headers: nil)
         }
-        stub(condition: isHost(host) && isPath("/wp-admin/admin-ajax.php?action=rest-nonce")) { _ in
+        stub(condition: isHost(host) && isPath("/wp-admin/admin-ajax.php") && containsQueryParams(["action": "rest-nonce"])) { _ in
             HTTPStubsResponse(data: "abcd".data(using: .utf8)!, statusCode: 200, headers: nil)
         }
         stub(condition: isHost(host) && isPath("/wp-json/wp/v2/users/me/application-passwords")) { _ in
@@ -236,6 +265,70 @@ private extension ApplicationPasswordsRepositoryTests {
         }
     }
 
+    func stubSelfHostedSiteWpV2GetUser() {
+        stub(condition: isPath("/wp-json/wp/v2/users/me")) { _ in
+            let json = """
+                {
+                  "id": 1,
+                  "username": "demo",
+                  "name": "demo",
+                  "first_name": "",
+                  "last_name": "",
+                  "email": "tony.li@automattic.com",
+                  "url": "https://atomic.com",
+                  "description": "",
+                  "link": "https://atomic.com/author/demo/",
+                  "locale": "en_US",
+                  "nickname": "demo",
+                  "slug": "demo",
+                  "roles": [
+                    "administrator"
+                  ],
+                  "registered_date": "2025-07-11T04:37:16+00:00",
+                  "capabilities": {
+                    "switch_themes": true,
+                    "edit_themes": true,
+                    "activate_plugins": true
+                  },
+                  "extra_capabilities": {
+                    "administrator": true
+                  },
+                  "avatar_urls": {
+                    "24": "https://secure.gravatar.com/avatar/hash?s=24&d=mm&r=g",
+                    "48": "https://secure.gravatar.com/avatar/hash?s=48&d=mm&r=g",
+                    "96": "https://secure.gravatar.com/avatar/hash?s=96&d=mm&r=g"
+                  },
+                  "meta": {
+                    "persisted_preferences": [],
+                    "jetpack_donation_warning_dismissed": false
+                  },
+                  "_links": {
+                    "self": [
+                      {
+                        "href": "https://atomic.com/wp-json/wp/v2/users/1",
+                        "targetHints": {
+                          "allow": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH",
+                            "DELETE"
+                          ]
+                        }
+                      }
+                    ],
+                    "collection": [
+                      {
+                        "href": "https://atomic.com/wp-json/wp/v2/users"
+                      }
+                    ]
+                  }
+                }
+                """
+            return HTTPStubsResponse(data: json.data(using: .utf8)!, statusCode: 201, headers: nil)
+        }
+    }
+
     func stubApiDiscovery(siteHost: String) {
         stub(condition: isHost(siteHost) && isPath("/")) { _ in
             HTTPStubsResponse(
@@ -294,6 +387,14 @@ private extension ApplicationPasswordsRepositoryTests {
                 """
             return HTTPStubsResponse(data: json.data(using: .utf8)!, statusCode: 200, headers: nil)
         }
+    }
 
+    func stubApiDiscoveryFailure(siteHost: String) {
+        stub(condition: isHost(siteHost) && isPath("/")) { _ in
+            HTTPStubsResponse(data: "<html>homepage</html>".data(using: .utf8)!, statusCode: 200, headers: nil)
+        }
+        stub(condition: isHost(siteHost) && isPath("/wp-json")) { _ in
+            HTTPStubsResponse(data: "<html>page not found</html>".data(using: .utf8)!, statusCode: 404, headers: nil)
+        }
     }
 }

--- a/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
@@ -12,7 +12,7 @@ struct ApplicationPasswordsRepositoryTests {
     let keychain = TestKeychain()
 
     @Test
-    func simplSite() async throws {
+    func simpleSite() async throws {
         try await signInWPComAccount()
         let blog = try await createSimpleSite()
 

--- a/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
@@ -1,0 +1,299 @@
+import Foundation
+import Testing
+import WordPressData
+import WordPressAPI
+import OHHTTPStubs
+import OHHTTPStubsSwift
+
+@testable import WordPress
+
+struct ApplicationPasswordsRepositoryTests {
+    let coreDataStack = ContextManager.forTesting()
+    let keychain = TestKeychain()
+
+    @Test
+    func simplSite() async throws {
+        try await signInWPComAccount()
+        let blog = try await createSimpleSite()
+
+        let repository = ApplicationPasswordRepository.forTesting(coreDataStack: coreDataStack, keychain: keychain)
+        await #expect(throws: AutoDiscoveryAttemptFailure.self, "Simple site does not support application passwords", performing: {
+            try await repository.createPasswordIfNeeded(for: blog)
+        })
+    }
+
+    @Test
+    func atomicSite() async throws {
+        try await signInWPComAccount()
+        let blog = try await createAtomicSite()
+
+        stubApiDiscovery(siteHost: "atomic.com")
+        stubJetpackProxyCreateApplicationPassword(siteId: 456, password: "abcd efgh")
+        stubWPComWpV2GetUser(siteId: 456)
+
+        let repository = ApplicationPasswordRepository.forTesting(coreDataStack: coreDataStack, keychain: keychain)
+        try await repository.createPasswordIfNeeded(for: blog)
+
+        let password = try await coreDataStack.performQuery { context in
+            try context.existingObject(with: blog).getApplicationToken(using: keychain)
+        }
+        #expect(password == "abcd efgh")
+    }
+
+    @Test
+    func selfHostedSite() async throws {
+        let blog = try await createSelfHostedSite()
+
+        stubApiDiscovery(siteHost: "www.example.com")
+        stubSelfHostedSiteCreateApplicationPassword(host: "www.example.com", password: "1234 5678")
+
+        let repository = ApplicationPasswordRepository.forTesting(coreDataStack: coreDataStack, keychain: keychain)
+        try await repository.createPasswordIfNeeded(for: blog)
+
+        let password = try await coreDataStack.performQuery { context in
+            try context.existingObject(with: blog).getApplicationToken(using: keychain)
+        }
+        #expect(password == "1234 5678")
+    }
+}
+
+// MARK: - Helpers
+
+private extension ApplicationPasswordsRepositoryTests {
+    func signInWPComAccount() async throws {
+        let user = RemoteUser()
+        user.userID = 1
+        user.username = "testuser"
+        user.email = "testuser@example.com"
+        let service = AccountService(coreDataStack: coreDataStack)
+        let objectID = service.createOrUpdateAccount(withUserDetails: user, authToken: "token")
+        try await coreDataStack.performAndSave { context in
+            let account = try #require(try context.existingObject(with: objectID) as? WPAccount)
+            service.setDefaultWordPressComAccount(account)
+        }
+    }
+
+    func createSimpleSite() async throws -> TaggedManagedObjectID<Blog> {
+        stub(condition: isHost("simple.wordpress.com") && isPath("/wp-json")) { _ in
+            HTTPStubsResponse(data: "<html>Page not found</html>".data(using: .utf8)!, statusCode: 404, headers: nil)
+        }
+
+        return try await coreDataStack.performAndSave { context in
+            let account = try #require(try WPAccount.lookupDefaultWordPressComAccount(in: context))
+            let blog = try BlogBuilder(context, dotComID: 123)
+                .with(url: "https://simple.wordpress.com")
+                .withAccount(id: account.objectID)
+                .build()
+            return TaggedManagedObjectID(blog)
+        }
+    }
+
+    func createAtomicSite() async throws -> TaggedManagedObjectID<Blog> {
+        try await coreDataStack.performAndSave { context in
+            let account = try #require(try WPAccount.lookupDefaultWordPressComAccount(in: context))
+            let blog = try BlogBuilder(context, dotComID: 456)
+                .with(url: "https://atomic.com")
+                .withAccount(id: account.objectID)
+                .with(atomic: true)
+                .build()
+            return TaggedManagedObjectID(blog)
+        }
+    }
+
+    func createSelfHostedSite() async throws -> TaggedManagedObjectID<Blog> {
+        try await coreDataStack.performAndSave { context in
+            let blog = BlogBuilder(context, dotComID: nil)
+                .with(username: "demo")
+                .with(password: "pass")
+                .build()
+            return TaggedManagedObjectID(blog)
+        }
+    }
+
+    func stubSelfHostedSiteCreateApplicationPassword(host: String, password: String) {
+        stub(condition: isHost(host) && isPath("/wp-login.php")) { _ in
+            HTTPStubsResponse(data: "<html>Logged in</html>".data(using: .utf8)!, statusCode: 200, headers: nil)
+        }
+        stub(condition: isHost(host) && isPath("/wp-admin/admin-ajax.php?action=rest-nonce")) { _ in
+            HTTPStubsResponse(data: "abcd".data(using: .utf8)!, statusCode: 200, headers: nil)
+        }
+        stub(condition: isHost(host) && isPath("/wp-json/wp/v2/users/me/application-passwords")) { _ in
+            let json = """
+                {
+                    "uuid": "56cadaa8-e810-4752-abf9-cc39e120ea97",
+                    "app_id": "",
+                    "name": "Test",
+                    "password": "\(password)",
+                    "created": "2025-07-15T22:14:13",
+                    "last_used": "2025-07-25T02:43:58",
+                    "last_ip": "127.0.0.1",
+                    "_links": {
+                      "self": [
+                        {
+                          "href": "https://\(host)/wp-json/wp/v2/users/1/application-passwords/56cadaa8-e810-4752-abf9-cc39e120ea97",
+                          "targetHints": {
+                            "allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+                          }
+                        }
+                      ]
+                    }
+                }
+                """
+            return HTTPStubsResponse(data: json.data(using: .utf8)!, statusCode: 200, headers: nil)
+        }
+    }
+
+    func stubJetpackProxyCreateApplicationPassword(siteId: Int, password: String) {
+        stub(condition: isHost("public-api.wordpress.com") && isPath("/rest/v1.1/jetpack-blogs/\(siteId)/rest-api")) { _ in
+            let json = """
+                {
+                  "data": {
+                    "uuid": "56cadaa8-e810-4752-abf9-cc39e120ea97",
+                    "app_id": "",
+                    "name": "Test",
+                    "password": "\(password)",
+                    "created": "2025-07-15T22:14:13",
+                    "last_used": "2025-07-25T02:43:58",
+                    "last_ip": "127.0.0.1",
+                    "_links": {
+                      "self": [
+                        {
+                          "href": "https://atomic/wp-json/wp/v2/users/1/application-passwords/56cadaa8-e810-4752-abf9-cc39e120ea97",
+                          "targetHints": {
+                            "allow": ["GET", "POST", "PUT", "PATCH", "DELETE"]
+                          }
+                        }
+                      ]
+                    }
+                  }
+                }
+                """
+            return HTTPStubsResponse(data: json.data(using: .utf8)!, statusCode: 200, headers: nil)
+        }
+    }
+
+    func stubWPComWpV2GetUser(siteId: Int) {
+        stub(condition: isHost("public-api.wordpress.com") && isPath("/wp/v2/sites/\(siteId)/users/me")) { _ in
+            let json = """
+                {
+                  "id": 1,
+                  "username": "demo",
+                  "name": "demo",
+                  "first_name": "",
+                  "last_name": "",
+                  "email": "tony.li@automattic.com",
+                  "url": "https://atomic.com",
+                  "description": "",
+                  "link": "https://atomic.com/author/demo/",
+                  "locale": "en_US",
+                  "nickname": "demo",
+                  "slug": "demo",
+                  "roles": [
+                    "administrator"
+                  ],
+                  "registered_date": "2025-07-11T04:37:16+00:00",
+                  "capabilities": {
+                    "switch_themes": true,
+                    "edit_themes": true,
+                    "activate_plugins": true
+                  },
+                  "extra_capabilities": {
+                    "administrator": true
+                  },
+                  "avatar_urls": {
+                    "24": "https://secure.gravatar.com/avatar/hash?s=24&d=mm&r=g",
+                    "48": "https://secure.gravatar.com/avatar/hash?s=48&d=mm&r=g",
+                    "96": "https://secure.gravatar.com/avatar/hash?s=96&d=mm&r=g"
+                  },
+                  "meta": {
+                    "persisted_preferences": [],
+                    "jetpack_donation_warning_dismissed": false
+                  },
+                  "_links": {
+                    "self": [
+                      {
+                        "href": "https://atomic.com/wp-json/wp/v2/users/1",
+                        "targetHints": {
+                          "allow": [
+                            "GET",
+                            "POST",
+                            "PUT",
+                            "PATCH",
+                            "DELETE"
+                          ]
+                        }
+                      }
+                    ],
+                    "collection": [
+                      {
+                        "href": "https://atomic.com/wp-json/wp/v2/users"
+                      }
+                    ]
+                  }
+                }
+                """
+            return HTTPStubsResponse(data: json.data(using: .utf8)!, statusCode: 201, headers: nil)
+        }
+    }
+
+    func stubApiDiscovery(siteHost: String) {
+        stub(condition: isHost(siteHost) && isPath("/")) { _ in
+            HTTPStubsResponse(
+                data: "<html>homepage</html>".data(using: .utf8)!,
+                statusCode: 200,
+                headers: ["Link": "<https://\(siteHost)/wp-json/>; rel=\"https://api.w.org/\""]
+            )
+        }
+        stub(condition: isHost(siteHost) && isPath("/wp-json")) { _ in
+            let json = """
+                {
+                  "name": "Site",
+                  "description": "",
+                  "url": "https://\(siteHost)",
+                  "home": "https://\(siteHost)",
+                  "gmt_offset": "0",
+                  "timezone_string": "",
+                  "page_for_posts": 0,
+                  "page_on_front": 0,
+                  "show_on_front": "posts",
+                  "namespaces": [
+                    "jetpack/v4",
+                    "wpcom/v2",
+                    "jetpack/v4/stats-app",
+                    "jetpack/v4/import",
+                    "wpcom/v3",
+                    "jetpack-boost/v1",
+                    "my-jetpack/v1",
+                    "jetpack/v4/explat",
+                    "jetpack/v4/blaze-app",
+                    "jetpack/v4/blaze",
+                    "wp/v2",
+                    "wp-site-health/v1",
+                    "wp-block-editor/v1"
+                  ],
+                  "authentication": {
+                    "application-passwords": {
+                      "endpoints": {
+                        "authorization": "https://\(siteHost)/wp-admin/authorize-application.php"
+                      }
+                    }
+                  },
+                  "routes": {
+                  },
+                  "site_logo": 0,
+                  "site_icon": 0,
+                  "site_icon_url": "",
+                  "_links": {
+                    "help": [
+                      {
+                        "href": "https://developer.wordpress.org/rest-api/"
+                      }
+                    ]
+                  }
+                }
+                """
+            return HTTPStubsResponse(data: json.data(using: .utf8)!, statusCode: 200, headers: nil)
+        }
+
+    }
+}

--- a/WordPress/Classes/Login/SelfHostedSiteAuthenticator.swift
+++ b/WordPress/Classes/Login/SelfHostedSiteAuthenticator.swift
@@ -7,9 +7,38 @@ import WordPressData
 import WordPressKit
 import WordPressAuthenticator
 import WordPressShared
+import BuildSettingsKit
 import SVProgressHUD
 
 struct SelfHostedSiteAuthenticator {
+
+    static var wordPressAppId: String {
+        switch BuildSettings.current.brand {
+        case .wordpress:
+            return "a9cb72ed-311b-4f01-a0ac-a7af563d103e"
+        case .jetpack:
+            return "7088f42d-34e9-4402-ab50-b506b819f3e4"
+        case .reader:
+            return "d7753a1f-ec90-4fb5-80db-951929239796"
+        }
+    }
+
+    static var wordPressAppName: String {
+        let appName: String
+        switch BuildSettings.current.brand {
+        case .wordpress:
+            appName = "WordPress"
+        case .jetpack:
+            appName = "Jetpack"
+        case .reader:
+            appName = "WordPress Reader"
+        }
+
+        let deviceName = UIDevice.current.name
+        let timestamp = ISO8601DateFormatter.string(from: .now, timeZone: .current, formatOptions: .withInternetDateTime)
+
+        return "\(appName) iOS app on \(deviceName) (\(timestamp))"
+    }
 
     static let applicationPasswordUpdated = Foundation.Notification.Name(rawValue: "SelfHostedSiteAuthenticator.applicationPasswordUpdated")
 
@@ -114,23 +143,11 @@ struct SelfHostedSiteAuthenticator {
 
     @MainActor
     private func authenticate(details: AutoDiscoveryAttemptSuccess, from viewController: UIViewController) async throws(SignInError) -> (apiRootURL: URL, credentials: WpApiApplicationPasswordDetails) {
-        let appId: WpUuid
-        let appName: String
-
-        if AppConfiguration.isJetpack {
-            appId = try! WpUuid.parse(input: "7088f42d-34e9-4402-ab50-b506b819f3e4")
-            appName = "Jetpack iOS"
-        } else {
-            appId = try! WpUuid.parse(input: "a9cb72ed-311b-4f01-a0ac-a7af563d103e")
-            appName = "WordPress iOS"
-        }
-
-        let deviceName = UIDevice.current.name
-        let timestamp = ISO8601DateFormatter.string(from: .now, timeZone: .current, formatOptions: .withInternetDateTime)
-        let appNameValue = "\(appName) - \(deviceName) (\(timestamp))"
+        let appId = try! WpUuid.parse(input: Self.wordPressAppId)
+        let appName = Self.wordPressAppName
 
         do {
-            let loginURL = details.loginURL(for: .init(id: appId, name: appNameValue, callbackUrl: SelfHostedSiteAuthenticator.callbackURL.absoluteString))
+            let loginURL = details.loginURL(for: .init(id: appId, name: appName, callbackUrl: SelfHostedSiteAuthenticator.callbackURL.absoluteString))
             let callback = try await authorize(url: loginURL, callbackURL: SelfHostedSiteAuthenticator.callbackURL, from: viewController)
             return (details.apiRootUrl.asURL(), try internalClient.credentials(from: callback))
         } catch {
@@ -187,6 +204,8 @@ struct SelfHostedSiteAuthenticator {
                 blogID: context.blogID,
                 in: ContextManager.shared
             )
+
+            try await ApplicationPasswordRepository.shared.saveApplicationPassword(of: blog)
         } catch {
             throw .savingSiteFailure
         }

--- a/WordPress/Classes/Login/SelfHostedSiteAuthenticator.swift
+++ b/WordPress/Classes/Login/SelfHostedSiteAuthenticator.swift
@@ -12,15 +12,18 @@ import SVProgressHUD
 
 struct SelfHostedSiteAuthenticator {
 
-    static var wordPressAppId: String {
-        switch BuildSettings.current.brand {
+    static var wordPressAppId: WpUuid {
+        // The following UUIDs must be UUID v4.
+        let uuid = switch BuildSettings.current.brand {
         case .wordpress:
-            return "a9cb72ed-311b-4f01-a0ac-a7af563d103e"
+            "a9cb72ed-311b-4f01-a0ac-a7af563d103e"
         case .jetpack:
-            return "7088f42d-34e9-4402-ab50-b506b819f3e4"
+            "7088f42d-34e9-4402-ab50-b506b819f3e4"
         case .reader:
-            return "d7753a1f-ec90-4fb5-80db-951929239796"
+            "d7753a1f-ec90-4fb5-80db-951929239796"
         }
+
+        return try! WpUuid.parse(input: uuid)
     }
 
     static var wordPressAppName: String {
@@ -143,7 +146,7 @@ struct SelfHostedSiteAuthenticator {
 
     @MainActor
     private func authenticate(details: AutoDiscoveryAttemptSuccess, from viewController: UIViewController) async throws(SignInError) -> (apiRootURL: URL, credentials: WpApiApplicationPasswordDetails) {
-        let appId = try! WpUuid.parse(input: Self.wordPressAppId)
+        let appId = Self.wordPressAppId
         let appName = Self.wordPressAppName
 
         do {

--- a/WordPress/Classes/Services/ApplicationPasswordRepository.swift
+++ b/WordPress/Classes/Services/ApplicationPasswordRepository.swift
@@ -69,7 +69,7 @@ actor ApplicationPasswordRepository {
             return
         }
 
-        // `createPasswordIfNeeded` can be called by mutiple callers at the same time. We want to avoid
+        // `createPasswordIfNeeded` can be called by multiple callers at the same time. We want to avoid
         // creating multiple application passwords on one site.
         if let subject = ongoing[blogId] {
             let publisher = subject

--- a/WordPress/Classes/Services/ApplicationPasswordRepository.swift
+++ b/WordPress/Classes/Services/ApplicationPasswordRepository.swift
@@ -215,6 +215,10 @@ private extension ApplicationPasswordRepository {
 
         DDLogInfo("Application password is created for user \(siteUsername) to access REST API at \(apiRootURL)")
 
+        Task { @MainActor in
+            NotificationCenter.default.post(name: SelfHostedSiteAuthenticator.applicationPasswordUpdated, object: nil)
+        }
+
         return password
     }
 

--- a/WordPress/Classes/Services/ApplicationPasswordRepository.swift
+++ b/WordPress/Classes/Services/ApplicationPasswordRepository.swift
@@ -128,18 +128,23 @@ private extension ApplicationPasswordRepository {
         for password in passwords {
             let api = WordPressAPI(urlSession: session, apiRootUrl: apiRootURL, authentication: .init(username: siteUsername, password: password.password))
             do {
-                _ = try await api.users.retrieveMeWithViewContext()
+                _ = try await api.applicationPasswords.retrieveCurrentWithViewContext()
                 validPasswords.append(password)
-            } catch {
-                invalidPasswords.append(password)
+            } catch let error as WpApiError {
+                if case let .WpError(errorCode, _, _, _) = error {
+                    if errorCode == .Unauthorized {
+                        invalidPasswords.append(password)
+                    }
+                }
             }
         }
-
-        DDLogInfo("\(validPasswords.count) valid passwords, \(invalidPasswords.count) invalid passwords found for user (\(siteUsername)) on \(siteUrl)")
 
         if !invalidPasswords.isEmpty {
             try await storage.delete(invalidPasswords)
         }
+
+        DDLogInfo("\(passwords.count) passwords stored for user (\(siteUsername)) on \(siteUrl).")
+        DDLogInfo("\(validPasswords.count) have been verified, and \(invalidPasswords.count) invalid ones have been deleted.")
 
         // Make sure the saved password in `Blog` is one of the valid ones.
         if !validPasswords.isEmpty {

--- a/WordPress/Classes/Services/ApplicationPasswordRepository.swift
+++ b/WordPress/Classes/Services/ApplicationPasswordRepository.swift
@@ -37,6 +37,10 @@ actor ApplicationPasswordRepository {
     private let storage: ApplicationPasswordStorage
     private var ongoing: [TaggedManagedObjectID<Blog>: CurrentValueSubject<ApplicationPassword?, Error>] = [:]
 
+    static func forTesting(coreDataStack: CoreDataStackSwift, keychain: KeychainAccessible) -> ApplicationPasswordRepository {
+        ApplicationPasswordRepository(coreDataStack: coreDataStack, keychain: keychain)
+    }
+
     private init(coreDataStack: CoreDataStackSwift, keychain: KeychainAccessible) {
         self.coreDataStack = coreDataStack
         self.storage = .init(keychain: keychain)

--- a/WordPress/Classes/Services/ApplicationPasswordRepository.swift
+++ b/WordPress/Classes/Services/ApplicationPasswordRepository.swift
@@ -181,7 +181,7 @@ private extension ApplicationPasswordRepository {
         }
 
         let parameters: [String: AnyHashable] = [
-            "app_id": SelfHostedSiteAuthenticator.wordPressAppId,
+            "app_id": SelfHostedSiteAuthenticator.wordPressAppId.uuidString(),
             "name": SelfHostedSiteAuthenticator.wordPressAppName
         ]
 

--- a/WordPress/Classes/Services/ApplicationPasswordRepository.swift
+++ b/WordPress/Classes/Services/ApplicationPasswordRepository.swift
@@ -1,0 +1,380 @@
+import Foundation
+import Combine
+import WordPressData
+import WordPressShared
+import WordPressKit
+import WordPressAPI
+import WordPressCore
+
+/// Application passwords are stored on the WordPress site. We _can_ create as many application passwords as we want, which
+/// should have no major impact on the users or the site itself. We should avoid that, though, because users can
+/// see all of their application passwords in their profile, and it may give a messy impression if the app creates multiple
+/// application passwords. One, and only one, is all the app needs after all.
+///
+/// `ApplicationPasswordRepository`'s main responsibility is to ensure only one application password is created.
+///
+/// We use a singleton for this type, so that we can track all password creation requests in one instance. This
+/// prevents multiple application passwords from being created when the function is called repeatedly at the same time.
+///
+/// Imagine a scenario where a user adds an atomic site as a self-hosted site via the "Entering your existing site address" option.
+/// The app automatically creates an application password on the site. Then the user decides to remove the site and sign in
+/// with their WP.com account. We want to avoid creating another application password, because the one created before is still
+/// usable.
+///
+/// All created application passwords are stored in a single entry in the Keychain. They are stored as a JSON array, with the
+/// structure of `[Entry]`.
+/// Each entry has the password value, and the "owner" to whom the password belongs. In practice, all application passwords
+/// should be associated with two "owners": one by their Jetpack site ID, and one by the site address. That means the same
+/// password can be used no matter whether the site is added to the app via WP.com account, or as a self-hosted site.
+///
+/// The same application password is also added as a separate Keychain item, to keep `Blog.getApplicationToken`
+/// continuing to work as it is. The `createPasswordIfNeeded` function ensures the `Blog.getApplicationToken` returns the valid one.
+
+actor ApplicationPasswordRepository {
+    static let shared: ApplicationPasswordRepository = .init(coreDataStack: ContextManager.shared, keychain: KeychainUtils())
+
+    private let coreDataStack: CoreDataStackSwift
+    private let storage: ApplicationPasswordStorage
+    private var ongoing: [TaggedManagedObjectID<Blog>: CurrentValueSubject<ApplicationPassword?, Error>] = [:]
+
+    private init(coreDataStack: CoreDataStackSwift, keychain: KeychainAccessible) {
+        self.coreDataStack = coreDataStack
+        self.storage = .init(keychain: keychain)
+    }
+
+    /// The application password was stored via `Blog.setApplicationToken`, not in the `ApplicationPasswordStorage`.
+    /// We want to copy the `Blog.getApplicationToken` to `ApplicationPasswordStorage` if needed.
+    func saveApplicationPassword(of blogId: TaggedManagedObjectID<Blog>) async throws {
+        let (owners, site) = try await coreDataStack.performQuery { context in
+            let blog = try context.existingObject(with: blogId)
+            return (blog.asApplicationPasswordOwners(), try? WordPressSite(blog: blog))
+        }
+
+        guard case let .selfHosted(_, apiRootURL, username, authToken) = site else {
+            return
+        }
+
+        let api = WordPressAPI(urlSession: URLSession(configuration: .ephemeral), apiRootUrl: apiRootURL, authentication: .init(username: username, password: authToken))
+        let uuid = try await api.applicationPasswords.retrieveCurrentWithViewContext().data.uuid.uuid
+        try await storage.save(.init(password: .init(uuid: uuid, password: authToken), owners: owners))
+    }
+
+    /// When returning true, a valid application password is guaranteed to be returned by the `Blog.getApplicationToken` function.
+    func createPasswordIfNeeded(for blogId: TaggedManagedObjectID<Blog>) async throws {
+        if let _ = try await validatePasswords(in: blogId) {
+            return
+        }
+
+        // `createPasswordIfNeeded` can be called by mutiple callers at the same time. We want to avoid
+        // creating multiple application passwords on one site.
+        if let subject = ongoing[blogId] {
+            let publisher = subject
+                .compactMap { $0 }
+                .first()
+                .eraseToAnyPublisher()
+            // This sequence can only results in an error or a one element array. See the `subject.send` calls below.
+            let outputs = try await AsyncThrowingPublisher(publisher).reduce(into: []) { $0.append($1) }
+            if outputs.isEmpty {
+                throw ApplicationPasswordRepositoryError.unknown
+            }
+
+            return
+        }
+
+        let subject: CurrentValueSubject<ApplicationPassword?, Error> = CurrentValueSubject(nil)
+        ongoing[blogId] = subject
+        defer {
+            ongoing[blogId] = nil
+        }
+
+        do {
+            let password = try await createPassword(for: blogId)
+            subject.value = password
+            subject.send(completion: .finished)
+            return
+        } catch {
+            subject.send(completion: .failure(error))
+            throw error
+        }
+    }
+}
+
+private extension ApplicationPasswordRepository {
+    func validatePasswords(in blogId: TaggedManagedObjectID<Blog>) async throws -> ApplicationPassword? {
+        try await saveApplicationPassword(of: blogId)
+
+        let (owners, siteUrl) = try await coreDataStack.performQuery { context in
+            let blog = try context.existingObject(with: blogId)
+            return try (
+                blog.asApplicationPasswordOwners(),
+                blog.getUrlString(),
+            )
+        }
+        let passwords = await storage.getAll()
+            .filter {
+                // This nested loop should not have too much negative impact on performance, since `owners` is a short list (2 elements).
+                $0.owners.contains { owners.contains($0) }
+            }
+            .map {
+                $0.password
+            }
+
+        let apiRootURL = try await updateRestAPIURLIfNeeded(blogId)
+        let siteUsername = try await updateSiteUsernameIfNeeded(blogId)
+
+        let session = URLSession(configuration: .ephemeral)
+        var validPasswords = [ApplicationPassword]()
+        var invalidPasswords = [ApplicationPassword]()
+        for password in passwords {
+            let api = WordPressAPI(urlSession: session, apiRootUrl: apiRootURL, authentication: .init(username: siteUsername, password: password.password))
+            do {
+                _ = try await api.users.retrieveMeWithViewContext()
+                validPasswords.append(password)
+            } catch {
+                invalidPasswords.append(password)
+            }
+        }
+
+        DDLogInfo("\(validPasswords.count) valid passwords, \(invalidPasswords.count) invalid passwords found for user (\(siteUsername)) on \(siteUrl)")
+
+        if !invalidPasswords.isEmpty {
+            try await storage.delete(invalidPasswords)
+        }
+
+        // Make sure the saved password in `Blog` is one of the valid ones.
+        if !validPasswords.isEmpty {
+            let saved = try await coreDataStack.performQuery { context in
+                let blog = try context.existingObject(with: blogId)
+                return try? blog.getApplicationToken()
+            }
+
+            if let saved, !validPasswords.map(\.password).contains(saved), let newPassword = validPasswords.first {
+                try await assign(newPassword, apiRootURL: apiRootURL, to: blogId)
+            }
+        }
+
+        return validPasswords.first
+    }
+
+    func createPassword(for blogId: TaggedManagedObjectID<Blog>) async throws -> ApplicationPassword {
+        // Update `Blog.username` so that we can associate the created password with the site itself, in addition to the Jetpack site ID.
+        let siteUsername = try await updateSiteUsernameIfNeeded(blogId)
+        let apiRootURL = try await updateRestAPIURLIfNeeded(blogId)
+
+        let (owners, dotComSiteId, dotComApi, dotOrgApi) = try await coreDataStack.performQuery { context in
+            let blog = try context.existingObject(with: blogId)
+            return (
+                blog.asApplicationPasswordOwners(),
+                blog.dotComID,
+                blog.account?.wordPressComRestApi,
+                WordPressOrgRestApi(blog: blog)
+            )
+        }
+
+        let parameters: [String: AnyHashable] = [
+            "app_id": SelfHostedSiteAuthenticator.wordPressAppId,
+            "name": SelfHostedSiteAuthenticator.wordPressAppName
+        ]
+
+        let password: ApplicationPassword
+        if let dotComApi, let dotComSiteId {
+            let remote = JetpackProxyServiceRemote(wordPressComRestApi: dotComApi)
+            let result = try await withCheckedThrowingContinuation { continuation in
+                remote.proxyRequest(
+                    for: dotComSiteId.intValue,
+                    path: "/wp/v2/users/me/application-passwords",
+                    method: .post,
+                    parameters: parameters
+                ) { result in
+                    continuation.resume(with: result)
+                }
+            }
+
+            let json = try JSONSerialization.data(withJSONObject: result, options: [])
+            struct Response: Decodable {
+                var data: ApplicationPassword
+            }
+
+            password = try JSONDecoder().decode(Response.self, from: json).data
+        } else if let dotOrgApi {
+            let result = try await dotOrgApi.post(path: "/wp/v2/users/me/application-passwords", parameters: parameters).get()
+            let json = try JSONSerialization.data(withJSONObject: result, options: [])
+            password = try JSONDecoder().decode(ApplicationPassword.self, from: json)
+        } else {
+            // This error should never happen since a blog is accessible via either dot-com or a dot-org API.
+            throw ApplicationPasswordRepositoryError.unknown
+        }
+
+        try await storage.save(.init(password: password, owners: owners))
+        try await assign(password, apiRootURL: apiRootURL, to: blogId)
+
+        DDLogInfo("Application password is created for user \(siteUsername) to access REST API at \(apiRootURL)")
+
+        return password
+    }
+
+    func assign(_ password: ApplicationPassword, apiRootURL: ParsedUrl, to blogId: TaggedManagedObjectID<Blog>) async throws {
+        _ = try await updateSiteUsernameIfNeeded(blogId)
+
+        let keychain = await storage.keychain
+        try await coreDataStack.performAndSave { context in
+            let blog = try context.existingObject(with: blogId)
+            blog.restApiRootURL = apiRootURL.url()
+            try blog.setApplicationToken(password.password, using: keychain)
+        }
+    }
+
+    func updateRestAPIURLIfNeeded(_ blogId: TaggedManagedObjectID<Blog>) async throws -> ParsedUrl {
+        let (siteUrl, restApiRootUrl) = try await coreDataStack.performQuery { context in
+            let blog = try context.existingObject(with: blogId)
+            return try (blog.getUrlString(), blog.restApiRootURL)
+        }
+
+        let session = URLSession(configuration: .ephemeral)
+        let loginClient = WordPressLoginClient(urlSession: session)
+        let apiRootURL: ParsedUrl
+        if let restApiRootUrl, let parsed = try? ParsedUrl.parse(input: restApiRootUrl) {
+            apiRootURL = parsed
+        } else {
+            apiRootURL = try await loginClient.details(ofSite: siteUrl).apiRootUrl
+
+            try await coreDataStack.performAndSave { context in
+                let blog = try context.existingObject(with: blogId)
+                blog.restApiRootURL = apiRootURL.url()
+            }
+        }
+
+        return apiRootURL
+    }
+
+    func updateSiteUsernameIfNeeded(_ blogId: TaggedManagedObjectID<Blog>) async throws -> String {
+        let (username, dotComId, dotComAuthToken) = try await coreDataStack.performQuery { context in
+            let blog = try context.existingObject(with: blogId)
+            return (
+                blog.username,
+                blog.dotComID,
+                blog.account?.authToken,
+            )
+        }
+
+        let siteUsername: String
+        if let username {
+            siteUsername = username
+        } else if let dotComId, let dotComAuthToken {
+            let site = WordPressSite.dotCom(siteId: dotComId.intValue, authToken: dotComAuthToken)
+            let client = WordPressClient(site: site)
+            siteUsername = try await client.api.users.retrieveMeWithEditContext().data.username
+            try await coreDataStack.performAndSave { context in
+                let blog = try context.existingObject(with: blogId)
+                blog.username = siteUsername
+            }
+        } else {
+            throw ApplicationPasswordRepositoryError.usernameNotFound
+        }
+
+        return siteUsername
+    }
+}
+
+private extension Blog {
+    func asApplicationPasswordOwners() -> [ApplicationPasswordOwner] {
+        var owners = [ApplicationPasswordOwner]()
+        if let account, let siteId = dotComID?.intValue {
+            owners.append(.dotCom(username: account.username, siteId: siteId))
+        }
+        if let username, let url {
+            owners.append(.selfHosted(username: username, site: url))
+        }
+        return owners
+    }
+}
+
+// Since all application passwords are saved in one entry, it's very easy to overwrite them when multiple writes happen at the same time.
+// We use an `actor` type here and expose individual write functions to avoid that problem.
+private actor ApplicationPasswordStorage {
+    // IMPORTANT: DO NOT CHANGE these values.
+    private let username = "ApplicationPasswords"
+    private let service = "com.automattic.sites.ApplicationPasswords"
+
+    let keychain: KeychainAccessible
+
+    init(keychain: KeychainAccessible) {
+        self.keychain = keychain
+    }
+
+    func save(_ entry: Entry) throws {
+        var entries = getAll()
+        if let index = entries.firstIndex(where: { $0.id == entry.id }) {
+            entries[index] = entry
+        } else {
+            entries.append(entry)
+        }
+        try saveAll(entries)
+    }
+
+    func delete(_ passwords: [ApplicationPassword]) throws {
+        guard !passwords.isEmpty else { return }
+
+        let uuids = passwords.reduce(into: Set()) { $0.insert($1.uuid) }
+        var entries = getAll()
+        entries.removeAll { uuids.contains($0.password.uuid) }
+        try saveAll(entries)
+    }
+
+    func getAll() -> [Entry] {
+        guard let value = try? keychain.getPassword(for: username, serviceName: service) else {
+            return []
+        }
+
+        return (try? JSONDecoder().decode([Entry].self, from: Data(value.utf8))) ?? []
+    }
+
+    private func saveAll(_ entries: [Entry]) throws {
+        let data = try JSONEncoder().encode(entries)
+        try keychain.setPassword(for: username, to: String(data: data, encoding: .utf8), serviceName: service)
+    }
+}
+
+enum ApplicationPasswordRepositoryError: LocalizedError {
+    case usernameNotFound
+    case unknown
+
+    var errorDescription: String? {
+        switch self {
+        case .usernameNotFound:
+            return NSLocalizedString(
+                "applicationPasswordRepository.error.usernameNotFound",
+                value: "Unable to find username for the site",
+                comment: "Error message when the username cannot be found for application password creation"
+            )
+        case .unknown:
+            return NSLocalizedString(
+                "applicationPasswordRepository.error.unknown",
+                value: "Unable to create application password",
+                comment: "Error message when application password creation fails for unknown reasons"
+            )
+        }
+    }
+}
+
+// MARK: - Keychain data storage
+
+/// IMPORTANT: Changing properties in the following types means we may need to migrate the stored data to the new type.
+private struct Entry: Codable, Identifiable {
+    var password: ApplicationPassword
+    var owners: [ApplicationPasswordOwner]
+
+    var id: String {
+        password.uuid
+    }
+}
+
+private struct ApplicationPassword: Codable {
+    var uuid: String
+    var password: String
+}
+
+private enum ApplicationPasswordOwner: Codable, Hashable {
+    case dotCom(username: String, siteId: Int)
+    case selfHosted(username: String, site: String)
+}

--- a/WordPress/Classes/Services/ApplicationPasswordRepository.swift
+++ b/WordPress/Classes/Services/ApplicationPasswordRepository.swift
@@ -187,28 +187,9 @@ private extension ApplicationPasswordRepository {
 
         let password: ApplicationPassword
         if let dotComApi, let dotComSiteId {
-            let remote = JetpackProxyServiceRemote(wordPressComRestApi: dotComApi)
-            let result = try await withCheckedThrowingContinuation { continuation in
-                remote.proxyRequest(
-                    for: dotComSiteId.intValue,
-                    path: "/wp/v2/users/me/application-passwords",
-                    method: .post,
-                    parameters: parameters
-                ) { result in
-                    continuation.resume(with: result)
-                }
-            }
-
-            let json = try JSONSerialization.data(withJSONObject: result, options: [])
-            struct Response: Decodable {
-                var data: ApplicationPassword
-            }
-
-            password = try JSONDecoder().decode(Response.self, from: json).data
+            password = try await createPasswordOnJetpackSites(api: dotComApi, siteid: dotComSiteId.intValue, parameters: parameters)
         } else if let dotOrgApi {
-            let result = try await dotOrgApi.post(path: "/wp/v2/users/me/application-passwords", parameters: parameters).get()
-            let json = try JSONSerialization.data(withJSONObject: result, options: [])
-            password = try JSONDecoder().decode(ApplicationPassword.self, from: json)
+            password = try await createPasswordOnSelfHostedSites(api: dotOrgApi, parameters: parameters)
         } else {
             // This error should never happen since a blog is accessible via either dot-com or a dot-org API.
             throw ApplicationPasswordRepositoryError.unknown
@@ -224,6 +205,53 @@ private extension ApplicationPasswordRepository {
         }
 
         return password
+    }
+
+    // When a site is fully connected to Jetpack (a.k.a, "user connection"), we can use the Jetpack Proxy endpoint to
+    // call its REST API.
+    func createPasswordOnJetpackSites(api: WordPressComRestApi, siteid: Int, parameters: [String: AnyHashable]) async throws -> ApplicationPassword {
+        let remote = JetpackProxyServiceRemote(wordPressComRestApi: api)
+        let result = try await withCheckedThrowingContinuation { continuation in
+            remote.proxyRequest(
+                for: siteid,
+                path: "/wp/v2/users/me/application-passwords",
+                method: .post,
+                parameters: parameters
+            ) { result in
+                continuation.resume(with: result)
+            }
+        }
+
+        let json = try JSONSerialization.data(withJSONObject: result, options: [])
+        struct Response: Decodable {
+            var data: ApplicationPassword
+        }
+
+        return try JSONDecoder().decode(Response.self, from: json).data
+    }
+
+    // For sites that are not on WP.com, we try to create an application password via wp-json REST API using `WordPressOrgRestApi`.
+    func createPasswordOnSelfHostedSites(api: WordPressOrgRestApi, parameters: [String: AnyHashable]) async throws -> ApplicationPassword {
+        // WordPressOrgRestApi uses cookie and nonce authentication to access the wp-json REST API. Cookies are
+        // obtained by simulating wp-login with the site's username and password, and the nonce is fetched from wp-admin.
+        // Some sites may block these authentication requests. We verify REST API accessibility before attempting
+        // to create the application password and throw an appropriate error if access fails.
+        do {
+            let _ = try await api.get(path: "/wp/v2/users/me", parameters: ["context": "edit"]).get()
+        } catch {
+            switch error {
+            case let .endpointError(error) where error.code == "rest_not_logged_in":
+                fallthrough
+            case .unparsableResponse, .unacceptableStatusCode:
+                throw ApplicationPasswordRepositoryError.restApiInaccessible
+            default:
+                break
+            }
+        }
+
+        let result = try await api.post(path: "/wp/v2/users/me/application-passwords", parameters: parameters).get()
+        let json = try JSONSerialization.data(withJSONObject: result, options: [])
+        return try JSONDecoder().decode(ApplicationPassword.self, from: json)
     }
 
     func assign(_ password: ApplicationPassword, apiRootURL: ParsedUrl, to blogId: TaggedManagedObjectID<Blog>) async throws {
@@ -350,6 +378,7 @@ private actor ApplicationPasswordStorage {
 
 enum ApplicationPasswordRepositoryError: LocalizedError {
     case usernameNotFound
+    case restApiInaccessible
     case unknown
 
     var errorDescription: String? {
@@ -359,6 +388,12 @@ enum ApplicationPasswordRepositoryError: LocalizedError {
                 "applicationPasswordRepository.error.usernameNotFound",
                 value: "Unable to find username for the site",
                 comment: "Error message when the username cannot be found for application password creation"
+            )
+        case .restApiInaccessible:
+            return NSLocalizedString(
+                "applicationPasswordRepository.error.restApiInaccessible",
+                value: "Unable to access the site's REST API",
+                comment: "Error message when the site's REST API is not accessible for application password creation"
             )
         case .unknown:
             return NSLocalizedString(

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -646,7 +646,7 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
 
         blogDetailsViewController.showInitialDetailsForBlog()
 
-        if FeatureFlag.authenticateUsingApplicationPassword.enabled {
+        if FeatureFlag.allowApplicationPasswords.enabled {
             Task {
                 do {
                     try await ApplicationPasswordRepository.shared.createPasswordIfNeeded(for: TaggedManagedObjectID(blog))

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -645,6 +645,16 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         stackView.sendSubviewToBack(blogDetailsViewController.view)
 
         blogDetailsViewController.showInitialDetailsForBlog()
+
+        if FeatureFlag.authenticateUsingApplicationPassword.enabled {
+            Task {
+                do {
+                    try await ApplicationPasswordRepository.shared.createPasswordIfNeeded(for: TaggedManagedObjectID(blog))
+                } catch {
+                    DDLogError("Failed to create an application password. \(error)")
+                }
+            }
+        }
     }
 
     private func blogDetailsViewController(for blog: Blog) -> BlogDetailsViewController {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -645,16 +645,6 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         stackView.sendSubviewToBack(blogDetailsViewController.view)
 
         blogDetailsViewController.showInitialDetailsForBlog()
-
-        if FeatureFlag.allowApplicationPasswords.enabled {
-            Task {
-                do {
-                    try await ApplicationPasswordRepository.shared.createPasswordIfNeeded(for: TaggedManagedObjectID(blog))
-                } catch {
-                    DDLogError("Failed to create an application password. \(error)")
-                }
-            }
-        }
     }
 
     private func blogDetailsViewController(for blog: Blog) -> BlogDetailsViewController {


### PR DESCRIPTION
## Description

This PR introduces an API `ApplicationPasswordRepository.shared.createPasswordIfNeeded(for: TaggedManagedObjectID(blog))` to create an application password using the existing site credentials, instead of using the application password authentication web flow.

I have not deleted the web authentication entrance yet, but will do that in separate PRs.

I have added some inline comments about the implementation. I won't repeat them here.

## Testing instructions

Turn on the application password feature toggle. Switching to a site or relaunch the app, you can see console logs like:

```
1 valid passwords, 0 invalid passwords found for user (demo) on https://frequent-reindeer.jurassic.ninja
```

Or
```
Failed to create an application password.
```

This error log is expected on simple sites.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
