### PR TITLE
feat: Authenticate GutenbergKit WebView requests for private sites

### DIFF
--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -354,7 +354,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         // Clear expired cookies before loading authentication
         await clearExpiredAuthenticationCookies(in: cookieJar)
 
-        guard let authURL = URL(string: post.blog.url ?? "") else {
+        guard let blogURL = post.blog.url, let authURL = URL(string: blogURL) else {
             return false
         }
 

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -349,14 +349,47 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
             return false
         }
 
-        // Use the blog's main URL to trigger cookie loading
-        let authURL = URL(string: post.blog.url ?? "https://wordpress.com")!
+        let cookieJar = WKWebsiteDataStore.default().httpCookieStore
+
+        // Clear expired cookies before loading authentication
+        await clearExpiredAuthenticationCookies(in: cookieJar)
 
         return await withCheckedContinuation { continuation in
-            let cookieJar = WKWebsiteDataStore.default().httpCookieStore
-
+            // Always call authenticator.request() to ensure cookies are properly loaded into WKWebView
+            // The authenticator will check for existing valid cookies and only fetch new ones if needed
+            let authURL = URL(string: post.blog.url ?? "https://wordpress.com")!
             authenticator.request(url: authURL, cookieJar: cookieJar) { _ in
+                DDLogInfo("Authentication cookies loaded into shared cookie store for GutenbergKit")
                 continuation.resume(returning: true)
+            }
+        }
+    }
+
+    private func clearExpiredAuthenticationCookies(in cookieStore: WKHTTPCookieStore) async {
+        await withCheckedContinuation { continuation in
+            cookieStore.getAllCookies { cookies in
+                let expiredAuthCookies = cookies.filter { cookie in
+                    let isAuthCookie = (cookie.name == "wordpress_logged_in" || cookie.name.hasPrefix("wordpress_logged_in_")) &&
+                                      cookie.domain.contains("wordpress.com")
+                    let isExpired = cookie.expiresDate?.timeIntervalSinceNow ?? 0 <= 300 // Expired or expiring within 5 minutes
+                    return isAuthCookie && isExpired
+                }
+
+                // Remove expired cookies
+                let group = DispatchGroup()
+                for cookie in expiredAuthCookies {
+                    group.enter()
+                    cookieStore.delete(cookie) {
+                        group.leave()
+                    }
+                }
+
+                group.notify(queue: .main) {
+                    if !expiredAuthCookies.isEmpty {
+                        DDLogInfo("Cleared \(expiredAuthCookies.count) expired authentication cookies")
+                    }
+                    continuation.resume()
+                }
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -374,7 +374,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
                 let expiredAuthCookies = cookies.filter { cookie in
                     let isAuthCookie = (cookie.name == "wordpress_logged_in" || cookie.name.hasPrefix("wordpress_logged_in_")) &&
                                       cookie.domain.contains("wordpress.com")
-                    let isExpired = cookie.expiresDate?.timeIntervalSinceNow ?? 0 <= 0
+                    let isExpired = cookie.expiresDate.map { $0 < Date() } ?? false
                     return isAuthCookie && isExpired
                 }
 

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -354,10 +354,13 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         // Clear expired cookies before loading authentication
         await clearExpiredAuthenticationCookies(in: cookieJar)
 
+        guard let authURL = URL(string: post.blog.url ?? "") else {
+            return false
+        }
+
         return await withCheckedContinuation { continuation in
             // Always call authenticator.request() to ensure cookies are properly loaded into WKWebView
             // The authenticator will check for existing valid cookies and only fetch new ones if needed
-            let authURL = URL(string: post.blog.url ?? "https://wordpress.com")!
             authenticator.request(url: authURL, cookieJar: cookieJar) { _ in
                 DDLogInfo("Authentication cookies loaded into shared cookie store for GutenbergKit")
                 continuation.resume(returning: true)

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -158,11 +158,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         configureNavigationBar()
         refreshInterface()
 
-        // Show activity indicator while fetching settings
-        showActivityIndicator()
-
-        // Fetch block editor settings
-        fetchBlockEditorSettings()
+        setupEditor()
 
         // TODO: reimplement
 //        service?.syncJetpackSettingsForBlog(post.blog, success: { [weak self] in
@@ -300,32 +296,67 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         activityIndicator = nil
     }
 
-    // MARK: - Block Editor Settings
+    // MARK: - Editor Setup
 
-    private func fetchBlockEditorSettings() {
-        let service = RawBlockEditorSettingsService.getService(forBlog: post.blog)
-        service.refreshSettings()
+    private func setupEditor() {
+        showActivityIndicator()
 
         Task { @MainActor in
-            // Load authentication cookies for private sites
-            await loadAuthenticationCookiesIfNeeded()
-
-            // Start the editor with default settings after 3 seconds
             let timeoutTask = Task {
                 try await Task.sleep(nanoseconds: 3_000_000_000) // 3 seconds
-                if !Task.isCancelled {
+                if !Task.isCancelled && !hasEditorStarted {
                     startEditor()
                 }
             }
 
-            do {
-                let settings = try await service.getSettings()
-                timeoutTask.cancel()
-                startEditor(with: settings)
-            } catch {
-                timeoutTask.cancel()
-                DDLogError("Error fetching block editor settings: \(error)")
-                startEditor()
+            async let settingsResult = fetchBlockEditorSettingsAsync()
+            async let cookiesResult = loadAuthenticationCookiesAsync()
+
+            let settings = await settingsResult
+            let cookiesLoaded = await cookiesResult
+
+            timeoutTask.cancel()
+
+            if settings == nil {
+                DDLogError("Failed fetching block editor settings")
+            }
+            if !cookiesLoaded {
+                DDLogWarn("Failed loading Authentication cookies")
+            }
+
+            startEditor(with: settings)
+        }
+    }
+
+    private func fetchBlockEditorSettingsAsync() async -> [String: Any]? {
+        let service = RawBlockEditorSettingsService.getService(forBlog: post.blog)
+        service.refreshSettings()
+
+        do {
+            let settings = try await service.getSettings()
+            return settings
+        } catch {
+            return nil
+        }
+    }
+
+    private func loadAuthenticationCookiesAsync() async -> Bool {
+        guard post.blog.isPrivate() else {
+            return true
+        }
+
+        guard let authenticator = RequestAuthenticator(blog: post.blog) else {
+            return false
+        }
+
+        // Use the blog's main URL to trigger cookie loading
+        let authURL = URL(string: post.blog.url ?? "https://wordpress.com")!
+
+        return await withCheckedContinuation { continuation in
+            let cookieJar = WKWebsiteDataStore.default().httpCookieStore
+
+            authenticator.request(url: authURL, cookieJar: cookieJar) { _ in
+                continuation.resume(returning: true)
             }
         }
     }
@@ -340,38 +371,6 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
             self.editorViewController.updateConfiguration(updatedConfig)
         }
         self.editorViewController.startEditorSetup()
-    }
-
-    // MARK: - Authentication
-
-    private func loadAuthenticationCookiesIfNeeded() async {
-        // Only load cookies if the site is private
-        guard post.blog.isPrivate() else {
-            DDLogInfo("Site is not private, skipping cookie loading for GutenbergKit")
-            return
-        }
-
-        DDLogInfo("Pre-loading authentication cookies for private site into shared cookie store")
-
-        guard let authenticator = RequestAuthenticator(blog: post.blog) else {
-            DDLogError("Failed to create RequestAuthenticator for blog")
-            return
-        }
-
-        // Use the blog's main URL to trigger cookie loading (same as preview does)
-        let authURL = URL(string: post.blog.url ?? "https://wordpress.com")!
-
-        await withCheckedContinuation { continuation in
-            // Use the default WKWebsiteDataStore cookie store that GutenbergKit will inherit
-            let cookieJar = WKWebsiteDataStore.default().httpCookieStore
-
-            // This mirrors exactly what PreviewWebKitViewController does:
-            // RequestAuthenticator.request() loads cookies into the cookie store
-            authenticator.request(url: authURL, cookieJar: cookieJar) { _ in
-                DDLogInfo("Authentication cookies loaded into shared cookie store for GutenbergKit")
-                continuation.resume()
-            }
-        }
     }
 }
 
@@ -855,26 +854,6 @@ private extension NewGutenbergViewController {
     }
 }
 
-// Block Editor Settings
-extension NewGutenbergViewController {
-
-    private func fetchBlockSettings() {
-        guard let service = editorSettingsService else {
-            return // TODO: when can it happen?
-        }
-        service.fetchSettings({ [weak self] result in
-            switch result {
-            case .success(let response):
-                if response.hasChanges {
-                    // TODO: inject in hte editor
-                    // self.gutenberg.updateEditorSettings(response.blockEditorSettings)
-                }
-            case .failure(let err):
-                DDLogError("Error fetching settings: \(err)")
-            }
-        })
-    }
-}
 
 extension EditorConfiguration {
     init(blog: Blog) {

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -6,6 +6,7 @@ import GutenbergKit
 import SafariServices
 import WordPressData
 import WordPressShared
+import WebKit
 
 class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor {
     let errorDomain: String = "GutenbergViewController.errorDomain"
@@ -306,6 +307,9 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         service.refreshSettings()
 
         Task { @MainActor in
+            // Load authentication cookies for private sites
+            await loadAuthenticationCookiesIfNeeded()
+
             // Start the editor with default settings after 3 seconds
             let timeoutTask = Task {
                 try await Task.sleep(nanoseconds: 3_000_000_000) // 3 seconds
@@ -336,6 +340,38 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
             self.editorViewController.updateConfiguration(updatedConfig)
         }
         self.editorViewController.startEditorSetup()
+    }
+
+    // MARK: - Authentication
+
+    private func loadAuthenticationCookiesIfNeeded() async {
+        // Only load cookies if the site is private
+        guard post.blog.isPrivate() else {
+            DDLogInfo("Site is not private, skipping cookie loading for GutenbergKit")
+            return
+        }
+
+        DDLogInfo("Pre-loading authentication cookies for private site into shared cookie store")
+
+        guard let authenticator = RequestAuthenticator(blog: post.blog) else {
+            DDLogError("Failed to create RequestAuthenticator for blog")
+            return
+        }
+
+        // Use the blog's main URL to trigger cookie loading (same as preview does)
+        let authURL = URL(string: post.blog.url ?? "https://wordpress.com")!
+
+        await withCheckedContinuation { continuation in
+            // Use the default WKWebsiteDataStore cookie store that GutenbergKit will inherit
+            let cookieJar = WKWebsiteDataStore.default().httpCookieStore
+
+            // This mirrors exactly what PreviewWebKitViewController does:
+            // RequestAuthenticator.request() loads cookies into the cookie store
+            authenticator.request(url: authURL, cookieJar: cookieJar) { _ in
+                DDLogInfo("Authentication cookies loaded into shared cookie store for GutenbergKit")
+                continuation.resume()
+            }
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -309,7 +309,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
                 }
             }
 
-            async let settingsResult = fetchBlockEditorSettingsAsync()
+            async let settingsResult = fetchBlockEditorSettings()
             async let cookiesResult = loadAuthenticationCookiesAsync()
 
             let settings = await settingsResult
@@ -328,7 +328,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         }
     }
 
-    private func fetchBlockEditorSettingsAsync() async -> [String: Any]? {
+    private func fetchBlockEditorSettings() async -> [String: Any]? {
         let service = RawBlockEditorSettingsService.getService(forBlog: post.blog)
         service.refreshSettings()
 

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -345,15 +345,13 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
             return true
         }
 
-        guard let authenticator = RequestAuthenticator(blog: post.blog) else {
+        guard let authenticator = RequestAuthenticator(blog: post.blog),
+            let blogURL = post.blog.url,
+            let authURL = URL(string: blogURL) else {
             return false
         }
 
         let cookieJar = WKWebsiteDataStore.default().httpCookieStore
-
-        guard let blogURL = post.blog.url, let authURL = URL(string: blogURL) else {
-            return false
-        }
 
         return await withCheckedContinuation { continuation in
             // Always call authenticator.request() to ensure cookies are properly loaded into WKWebView

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -371,7 +371,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
                 let expiredAuthCookies = cookies.filter { cookie in
                     let isAuthCookie = (cookie.name == "wordpress_logged_in" || cookie.name.hasPrefix("wordpress_logged_in_")) &&
                                       cookie.domain.contains("wordpress.com")
-                    let isExpired = cookie.expiresDate?.timeIntervalSinceNow ?? 0 <= 300 // Expired or expiring within 5 minutes
+                    let isExpired = cookie.expiresDate?.timeIntervalSinceNow ?? 0 <= 0
                     return isAuthCookie && isExpired
                 }
 

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -304,7 +304,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         Task { @MainActor in
             let timeoutTask = Task {
                 try await Task.sleep(nanoseconds: 3_000_000_000) // 3 seconds
-                if !Task.isCancelled && !hasEditorStarted {
+                if !Task.isCancelled {
                     startEditor()
                 }
             }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -369,11 +369,15 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     }
 
     private func clearExpiredAuthenticationCookies(in cookieStore: WKHTTPCookieStore) async {
+        guard let blogURLString = post.blog.url, let blogURL = URL(string: blogURLString) else {
+            return
+        }
+
         await withCheckedContinuation { continuation in
             cookieStore.getAllCookies { cookies in
                 let expiredAuthCookies = cookies.filter { cookie in
-                    let isAuthCookie = (cookie.name == "wordpress_logged_in" || cookie.name.hasPrefix("wordpress_logged_in_")) &&
-                                      cookie.domain.contains("wordpress.com")
+                    let isAuthCookie = cookie.name.hasPrefix("wordpress_logged_in") &&
+                        self.cookieMatchesBlogDomain(cookie, blogURL: blogURL)
                     let isExpired = cookie.expiresDate.map { $0 < Date() } ?? false
                     return isAuthCookie && isExpired
                 }
@@ -388,13 +392,25 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
                 }
 
                 group.notify(queue: .main) {
-                    if !expiredAuthCookies.isEmpty {
-                        DDLogInfo("Cleared \(expiredAuthCookies.count) expired authentication cookies")
-                    }
                     continuation.resume()
                 }
             }
         }
+    }
+
+    private func cookieMatchesBlogDomain(_ cookie: HTTPCookie, blogURL: URL) -> Bool {
+        guard let host = blogURL.host else { return false }
+
+        let matchesDomain: Bool
+        if cookie.domain.hasPrefix(".") {
+            // Wildcard domain (e.g., ".wordpress.com" matches "site.wordpress.com")
+            matchesDomain = host.hasSuffix(cookie.domain) || host == String(cookie.domain.dropFirst())
+        } else {
+            // Exact domain match
+            matchesDomain = host == cookie.domain
+        }
+
+        return matchesDomain
     }
 
     private func startEditor(with settings: [String: Any]? = nil) {

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -887,7 +887,6 @@ private extension NewGutenbergViewController {
     }
 }
 
-
 extension EditorConfiguration {
     init(blog: Blog) {
         let selfHostedApiUrl = blog.restApiRootURL ?? blog.url(withPath: "wp-json/")

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -351,66 +351,17 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
         let cookieJar = WKWebsiteDataStore.default().httpCookieStore
 
-        // Clear expired cookies before loading authentication
-        await clearExpiredAuthenticationCookies(in: cookieJar)
-
         guard let blogURL = post.blog.url, let authURL = URL(string: blogURL) else {
             return false
         }
 
         return await withCheckedContinuation { continuation in
             // Always call authenticator.request() to ensure cookies are properly loaded into WKWebView
-            // The authenticator will check for existing valid cookies and only fetch new ones if needed
             authenticator.request(url: authURL, cookieJar: cookieJar) { _ in
                 DDLogInfo("Authentication cookies loaded into shared cookie store for GutenbergKit")
                 continuation.resume(returning: true)
             }
         }
-    }
-
-    private func clearExpiredAuthenticationCookies(in cookieStore: WKHTTPCookieStore) async {
-        guard let blogURLString = post.blog.url, let blogURL = URL(string: blogURLString) else {
-            return
-        }
-
-        await withCheckedContinuation { continuation in
-            cookieStore.getAllCookies { cookies in
-                let expiredAuthCookies = cookies.filter { cookie in
-                    let isAuthCookie = cookie.name.hasPrefix("wordpress_logged_in") &&
-                        self.cookieMatchesBlogDomain(cookie, blogURL: blogURL)
-                    let isExpired = cookie.expiresDate.map { $0 < Date() } ?? false
-                    return isAuthCookie && isExpired
-                }
-
-                // Remove expired cookies
-                let group = DispatchGroup()
-                for cookie in expiredAuthCookies {
-                    group.enter()
-                    cookieStore.delete(cookie) {
-                        group.leave()
-                    }
-                }
-
-                group.notify(queue: .main) {
-                    continuation.resume()
-                }
-            }
-        }
-    }
-
-    private func cookieMatchesBlogDomain(_ cookie: HTTPCookie, blogURL: URL) -> Bool {
-        guard let host = blogURL.host else { return false }
-
-        let matchesDomain: Bool
-        if cookie.domain.hasPrefix(".") {
-            // Wildcard domain (e.g., ".wordpress.com" matches "site.wordpress.com")
-            matchesDomain = host.hasSuffix(cookie.domain) || host == String(cookie.domain.dropFirst())
-        } else {
-            // Exact domain match
-            matchesDomain = host == cookie.domain
-        }
-
-        return matchesDomain
     }
 
     private func startEditor(with settings: [String: Any]? = nil) {


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Provide GutenbergKit authentication cookies to allow loading protected resources for private WordPress.com sites. This utilizes the `RequestAuthenticator` for loading necessary cookies into the WebView, which appears to be an established practice in the project for other WebViews. 

Close CMM-451. Dependent upon https://github.com/wordpress-mobile/GutenbergKit/pull/157. 

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
1. Open the editor for a private WordPress.com site.
1. Insert various media.
1. Verify the media displays/functions as expected.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
