### PR TITLE
Show information about application passwords when enabling the feature toggle

### DIFF
--- a/WordPress/Classes/ApplicationToken/ApplicationPasswordsInfoView.swift
+++ b/WordPress/Classes/ApplicationToken/ApplicationPasswordsInfoView.swift
@@ -1,0 +1,46 @@
+import Foundation
+import SwiftUI
+import DesignSystem
+
+struct ApplicationPasswordsInfoView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(Strings.allInfo)
+                .font(.body)
+
+            Spacer()
+
+            DSButton(
+                title: Strings.gotItButton,
+                style: DSButtonStyle(emphasis: .primary, size: .large)
+            ) {
+                dismiss()
+            }
+        }
+        .padding()
+        .navigationTitle(Strings.title)
+        .navigationBarTitleDisplayMode(.inline)
+    }
+}
+
+private enum Strings {
+    static let title = NSLocalizedString(
+        "applicationPassword.info.title",
+        value: "About Application Passwords",
+        comment: "Title for the application passwords information view"
+    )
+
+    static let allInfo = NSLocalizedString(
+        "applicationPassword.info.content",
+        value: "Application passwords are a more secure way for this app to access your site content without using your actual account password.\n\nWhen you add sites to the app, application passwords will be created automatically as needed.\n\nYou can view and manage these passwords in your user profile within your WordPress site's admin panel.\n\nPlease note that revoking application passwords used by the app will terminate the app's access to your site. Be cautious when revoking application passwords created by the app.",
+        comment: "Complete information about application passwords with security benefits, creation process, management instructions, and revocation warning"
+    )
+
+    static let gotItButton = NSLocalizedString(
+        "applicationPassword.info.gotIt.button",
+        value: "Got it",
+        comment: "Button to dismiss the application password information view"
+    )
+}

--- a/WordPress/Classes/System/Root View/WordPressAuthenticatorProtocol.swift
+++ b/WordPress/Classes/System/Root View/WordPressAuthenticatorProtocol.swift
@@ -47,7 +47,7 @@ extension WordPressAuthenticator: WordPressAuthenticatorProtocol {
     }
 
     private static func selfHostedSiteLogin(_ viewController: UIViewController) -> Bool {
-        guard FeatureFlag.authenticateUsingApplicationPassword.enabled else { return false }
+        guard FeatureFlag.allowApplicationPasswords.enabled else { return false }
         guard let navigationController = viewController.navigationController else { return false }
 
         let view = LoginWithUrlView(presenter: viewController) { [weak viewController] blogID in

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -19,7 +19,7 @@ public enum FeatureFlag: Int, CaseIterable {
     case compliancePopover
     case googleDomainsCard
     case voiceToContent
-    case authenticateUsingApplicationPassword
+    case allowApplicationPasswords
     case newGutenbergThemeStyles
     case selfHostedSiteUserManagement
     case readerGutenbergCommentComposer
@@ -68,7 +68,7 @@ public enum FeatureFlag: Int, CaseIterable {
             return false
         case .voiceToContent:
             return app == .jetpack && BuildConfiguration.current.isInternal
-        case .authenticateUsingApplicationPassword:
+        case .allowApplicationPasswords:
             return false
         case .newGutenbergThemeStyles:
             return false
@@ -118,7 +118,7 @@ extension FeatureFlag {
         case .compliancePopover: "Compliance Popover"
         case .googleDomainsCard: "Google Domains Promotional Card"
         case .voiceToContent: "Voice to Content"
-        case .authenticateUsingApplicationPassword: "Application Passwords for self-hosted sites"
+        case .allowApplicationPasswords: "Allow creating Application Passwords"
         case .newGutenbergThemeStyles: "Experimental Block Editor Styles"
         case .selfHostedSiteUserManagement: "Self-hosted Site User Management"
         case .pluginManagementOverhaul: "Plugin Management Overhaul"
@@ -136,7 +136,16 @@ extension FeatureFlag: OverridableFlag {
     }
 
     var key: String {
-        return "ff-override-\(String(describing: self))"
+        let key: String
+        switch self {
+        case .allowApplicationPasswords:
+            // This feature toggle description is already shipped and used in the production.
+            // We want to keep using the same key, but change the description.
+            key = "Application Passwords for self-hosted sites"
+        default:
+            key = String(describing: self)
+        }
+        return "ff-override-\(key)"
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
@@ -351,7 +351,7 @@ extension BlogDetailsViewController {
     }
 
     @objc public func checkApplicationPasswordEligibility() {
-        guard FeatureFlag.authenticateUsingApplicationPassword.enabled else { return }
+        guard FeatureFlag.allowApplicationPasswords.enabled else { return }
 
         // We have already got an application token for this site, no need to ask for another one.
         guard (try? blog.getApplicationToken()) == nil, let url = blog.url else { return }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/AddSiteController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/AddSiteController.swift
@@ -33,7 +33,7 @@ struct AddSiteController {
     }
 
     func showSelfHostedSiteLoginScreen() {
-        guard FeatureFlag.authenticateUsingApplicationPassword.enabled else {
+        guard FeatureFlag.allowApplicationPasswords.enabled else {
             WordPressAuthenticator.showLoginForSelfHostedSite(viewController)
             return
         }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
@@ -1,11 +1,12 @@
 import Foundation
 import WordPressUI
 import UIKit
+import SwiftUI
 
 class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvider {
 
     let flags: [OverridableFlag] = [
-        FeatureFlag.authenticateUsingApplicationPassword,
+        FeatureFlag.allowApplicationPasswords,
         RemoteFeatureFlag.newGutenberg,
         FeatureFlag.newGutenbergThemeStyles,
     ]
@@ -42,6 +43,16 @@ class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvid
             }))
 
             self.presentViewController(alert)
+
+            return
+        }
+
+        if feature.key == FeatureFlag.allowApplicationPasswords.key && newValue {
+            let view = NavigationStack {
+                ApplicationPasswordsInfoView()
+            }
+            self.presentViewController(UIHostingController(rootView: view))
+            return
         }
     }
 


### PR DESCRIPTION
## Description

The content needs some design touch to make it look nicer.

<img width="500" src="https://github.com/user-attachments/assets/6acb5355-3c14-4fe6-8623-3ba6112b9f3c" />

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
