### PR TITLE
Add Archive top list

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f282a9bbd2eb46463022d668957f80330ad95f693c8bec3425a741e12e4b2f39",
+  "originHash" : "e3e823d31b833eca898ce70bd04f75d481070d36c5823cfffae0afc36ad263fc",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -381,7 +381,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/WordPressKit-iOS",
       "state" : {
-        "revision" : "c31ddf14716f5ce5d810a21d1cacb5c2da8709d5"
+        "revision" : "2613f213b1a958266f88fa7e99d990292096bffb"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -50,7 +50,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(
             url: "https://github.com/wordpress-mobile/WordPressKit-iOS",
-            revision: "c31ddf14716f5ce5d810a21d1cacb5c2da8709d5" // see wpios-edition branch
+            revision: "2613f213b1a958266f88fa7e99d990292096bffb" // see wpios-edition branch
         ),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.

--- a/Modules/Sources/JetpackStats/Cards/RealtimeTopListCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/RealtimeTopListCard.swift
@@ -7,23 +7,23 @@ struct RealtimeTopListCard: View {
     @State private var selectedItem: TopListItemType
 
     @Environment(\.context) var context
-    
+
     init(
         availableDataTypes: [TopListItemType] = TopListItemType.allCases,
         initialDataType: TopListItemType = .postsAndPages,
         service: any StatsServiceProtocol
     ) {
         self.availableItems = availableDataTypes
-        
+
         let selectedItem = availableDataTypes.contains(initialDataType) ? initialDataType : availableDataTypes.first ?? .postsAndPages
         self._selectedItem = State(initialValue: selectedItem)
-        
+
         let viewModel = RealtimeTopListCardViewModel(service: service)
         self._viewModel = StateObject(wrappedValue: viewModel)
-        
+
         viewModel.loadData(for: selectedItem)
     }
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack {
@@ -43,7 +43,6 @@ struct RealtimeTopListCard: View {
             viewModel.loadData(for: newValue)
         }
     }
-    
 
     private var headerView: some View {
         HStack {
@@ -99,7 +98,7 @@ struct RealtimeTopListCard: View {
             previousItems: [:], // No previous data for realtime
             maxValue: viewModel.maxValue
         )
-        
+
         return TopListItemsView(
             data: chartData,
             itemLimit: 6,
@@ -111,7 +110,7 @@ struct RealtimeTopListCard: View {
     private var loadingView: some View {
         topListItemsView(data: mockData)
     }
-    
+
     private var mockData: TopListData {
         let chartData = TopListChartData.mock(
             for: selectedItem,
@@ -120,7 +119,7 @@ struct RealtimeTopListCard: View {
         )
         return TopListData(items: chartData.items)
     }
-    
+
 }
 
 // MARK: - Preview
@@ -137,7 +136,7 @@ struct RealtimeTopListCard: View {
             .padding()
             .background(Color(.systemBackground))
             .cornerRadius(12)
-            
+
             // Referrers
             RealtimeTopListCard(
                 availableDataTypes: [.referrers],
@@ -147,7 +146,7 @@ struct RealtimeTopListCard: View {
             .padding()
             .background(Color(.systemBackground))
             .cornerRadius(12)
-            
+
             // Locations
             RealtimeTopListCard(
                 availableDataTypes: [.locations],

--- a/Modules/Sources/JetpackStats/Cards/RealtimeTopListCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/RealtimeTopListCard.swift
@@ -95,11 +95,9 @@ struct RealtimeTopListCard: View {
         let chartData = TopListChartData(
             item: selectedItem,
             metric: .views,
-            items: data.items.map {
-                let itemID = TopListChartData.ItemID(type: selectedItem, id: $0.id)
-                return TopListChartData.Item(id: itemID, current: $0, previous: nil)
-            },
-            maxValue: viewModel.maxValue,
+            items: data.items,
+            previousItems: [:], // No previous data for realtime
+            maxValue: viewModel.maxValue
         )
         
         return TopListItemsView(
@@ -120,7 +118,7 @@ struct RealtimeTopListCard: View {
             metric: .views,
             itemCount: 6
         )
-        return TopListData(items: chartData.items.map { $0.current })
+        return TopListData(items: chartData.items)
     }
     
 }

--- a/Modules/Sources/JetpackStats/Cards/TopListCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListCard.swift
@@ -155,7 +155,7 @@ struct TopListCard: View {
                     .font(.callout)
                     .foregroundColor(.primary)
                 Image(systemName: "chevron.right")
-                    .font(.caption)
+                    .font(.caption.weight(.semibold))
                     .foregroundColor(.secondary)
             }
             .font(.body)

--- a/Modules/Sources/JetpackStats/Cards/TopListCardViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListCardViewModel.swift
@@ -131,7 +131,7 @@ final class TopListCardViewModel: ObservableObject, TrafficCardViewModel {
             interval: dateRange.dateInterval,
             granularity: granularity
         )
-        
+
         // Fetch previous data only for items that support it
         async let previousTask: TopListData? = {
             guard selection.item != .archive else { return nil }

--- a/Modules/Sources/JetpackStats/Cards/TopListCardViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListCardViewModel.swift
@@ -145,11 +145,12 @@ final class TopListCardViewModel: ObservableObject, TrafficCardViewModel {
 
         let (current, previous) = try await (currentTask, previousTask)
 
-        // Match current items with their previous counterparts
-        let matchedItems = current.items.map { currentItem in
-            let previousItem = previous?.items.first { $0.id == currentItem.id }
-            let itemID = TopListChartData.ItemID(type: selection.item, id: currentItem.id)
-            return TopListChartData.Item(id: itemID, current: currentItem, previous: previousItem)
+        // Build previous items dictionary
+        var previousItemsDict: [String: any TopListItem] = [:]
+        if let previousItems = previous?.items {
+            for item in previousItems {
+                previousItemsDict[item.id] = item
+            }
         }
 
         // Calculate max value from current items based on selected metric
@@ -158,6 +159,12 @@ final class TopListCardViewModel: ObservableObject, TrafficCardViewModel {
             .compactMap { $0.metrics[metric] }
             .max() ?? 1
 
-        return TopListChartData(item: selection.item, metric: metric, items: matchedItems, maxValue: maxValue)
+        return TopListChartData(
+            item: selection.item,
+            metric: metric,
+            items: current.items,
+            previousItems: previousItemsDict,
+            maxValue: maxValue
+        )
     }
 }

--- a/Modules/Sources/JetpackStats/Cards/TopListCardViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListCardViewModel.swift
@@ -124,25 +124,30 @@ final class TopListCardViewModel: ObservableObject, TrafficCardViewModel {
     private func getTopListData(for selection: Selection, dateRange: StatsDateRange) async throws -> TopListChartData {
         let granularity = dateRange.dateInterval.preferredGranularity
 
-        // Fetch both current and previous period data concurrently
+        // Fetch current data
         async let currentTask = service.getTopListData(
             selection.item,
             metric: selection.metric,
             interval: dateRange.dateInterval,
             granularity: granularity
         )
-        async let previousTask = service.getTopListData(
-            selection.item,
-            metric: selection.metric,
-            interval: dateRange.effectiveComparisonInterval,
-            granularity: granularity
-        )
+        
+        // Fetch previous data only for items that support it
+        async let previousTask: TopListData? = {
+            guard selection.item != .archive else { return nil }
+            return try await service.getTopListData(
+                selection.item,
+                metric: selection.metric,
+                interval: dateRange.effectiveComparisonInterval,
+                granularity: granularity
+            )
+        }()
 
         let (current, previous) = try await (currentTask, previousTask)
 
         // Match current items with their previous counterparts
         let matchedItems = current.items.map { currentItem in
-            let previousItem = previous.items.first { $0.id == currentItem.id }
+            let previousItem = previous?.items.first { $0.id == currentItem.id }
             let itemID = TopListChartData.ItemID(type: selection.item, id: currentItem.id)
             return TopListChartData.Item(id: itemID, current: currentItem, previous: previousItem)
         }

--- a/Modules/Sources/JetpackStats/Cards/TopListCardViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListCardViewModel.swift
@@ -146,7 +146,7 @@ final class TopListCardViewModel: ObservableObject, TrafficCardViewModel {
         let (current, previous) = try await (currentTask, previousTask)
 
         // Build previous items dictionary
-        var previousItemsDict: [String: any TopListItem] = [:]
+        var previousItemsDict: [TopListItemID: any TopListItem] = [:]
         if let previousItems = previous?.items {
             for item in previousItems {
                 previousItemsDict[item.id] = item

--- a/Modules/Sources/JetpackStats/Resources/Mocks/HistoricalData/historical-archive.json
+++ b/Modules/Sources/JetpackStats/Resources/Mocks/HistoricalData/historical-archive.json
@@ -1,0 +1,74 @@
+[
+  {
+    "sectionName": "other",
+    "items": [
+      {
+        "href": "http://example.com/wp-admin/admin.php?page=stats",
+        "value": "/wp-admin/admin.php?page=stats",
+        "metrics": {
+          "views": 10
+        }
+      },
+      {
+        "href": "http://example.com/wp-admin/",
+        "value": "/wp-admin/",
+        "metrics": {
+          "views": 4
+        }
+      },
+      {
+        "href": "http://example.com/wp-admin/edit.php",
+        "value": "/wp-admin/edit.php",
+        "metrics": {
+          "views": 4
+        }
+      },
+      {
+        "href": "http://example.com/wp-admin/index.php",
+        "value": "/wp-admin/index.php",
+        "metrics": {
+          "views": 2
+        }
+      },
+      {
+        "href": "http://example.com/wp-admin/revision.php?revision=12345",
+        "value": "/wp-admin/revision.php?revision=12345",
+        "metrics": {
+          "views": 2
+        }
+      }
+    ],
+    "metrics": {
+      "views": 25
+    }
+  },
+  {
+    "sectionName": "author",
+    "items": [
+      {
+        "href": "http://example.com/author/johndoe/",
+        "value": "johndoe",
+        "metrics": {
+          "views": 31
+        }
+      },
+      {
+        "href": "http://example.com/author/janedoe/",
+        "value": "janedoe",
+        "metrics": {
+          "views": 5
+        }
+      },
+      {
+        "href": "http://example.com/author/testuser/",
+        "value": "testuser",
+        "metrics": {
+          "views": 2
+        }
+      }
+    ],
+    "metrics": {
+      "views": 40
+    }
+  }
+]

--- a/Modules/Sources/JetpackStats/Resources/Mocks/HistoricalData/historical-external-links.json
+++ b/Modules/Sources/JetpackStats/Resources/Mocks/HistoricalData/historical-external-links.json
@@ -1,0 +1,50 @@
+[
+  {
+    "url": "https://developer.apple.com",
+    "title": "Apple Developer",
+    "metrics": {
+      "views": 1800,
+      "visitors": 1200
+    }
+  },
+  {
+    "url": "https://swift.org",
+    "title": "Swift.org",
+    "metrics": {
+      "views": 1500,
+      "visitors": 1000
+    }
+  },
+  {
+    "url": "https://github.com",
+    "title": "GitHub",
+    "metrics": {
+      "views": 1200,
+      "visitors": 800
+    }
+  },
+  {
+    "url": "https://stackoverflow.com",
+    "title": "Stack Overflow",
+    "metrics": {
+      "views": 1000,
+      "visitors": 700
+    }
+  },
+  {
+    "url": "https://raywenderlich.com",
+    "title": "Ray Wenderlich",
+    "metrics": {
+      "views": 800,
+      "visitors": 500
+    }
+  },
+  {
+    "url": "https://nshipster.com",
+    "title": "NSHipster",
+    "metrics": {
+      "views": 600,
+      "visitors": 400
+    }
+  }
+]

--- a/Modules/Sources/JetpackStats/Resources/Mocks/HistoricalData/historical-file-downloads.json
+++ b/Modules/Sources/JetpackStats/Resources/Mocks/HistoricalData/historical-file-downloads.json
@@ -1,0 +1,44 @@
+[
+  {
+    "fileName": "annual-report-2024.pdf",
+    "filePath": "/downloads/reports/annual-report-2024.pdf",
+    "metrics": {
+      "downloads": 2500
+    }
+  },
+  {
+    "fileName": "swift-cheatsheet.pdf",
+    "filePath": "/downloads/docs/swift-cheatsheet.pdf",
+    "metrics": {
+      "downloads": 2100
+    }
+  },
+  {
+    "fileName": "app-screenshots.zip",
+    "filePath": "/downloads/media/app-screenshots.zip",
+    "metrics": {
+      "downloads": 1800
+    }
+  },
+  {
+    "fileName": "tutorial-video.mp4",
+    "filePath": "/downloads/videos/tutorial-video.mp4",
+    "metrics": {
+      "downloads": 1500
+    }
+  },
+  {
+    "fileName": "code-samples.zip",
+    "filePath": "/downloads/code/code-samples.zip",
+    "metrics": {
+      "downloads": 1200
+    }
+  },
+  {
+    "fileName": "whitepaper.pdf",
+    "filePath": "/downloads/docs/whitepaper.pdf",
+    "metrics": {
+      "downloads": 900
+    }
+  }
+]

--- a/Modules/Sources/JetpackStats/Resources/Mocks/HistoricalData/historical-search-terms.json
+++ b/Modules/Sources/JetpackStats/Resources/Mocks/HistoricalData/historical-search-terms.json
@@ -1,0 +1,44 @@
+[
+  {
+    "term": "swiftui tutorial",
+    "metrics": {
+      "views": 3200,
+      "visitors": 2500
+    }
+  },
+  {
+    "term": "ios development guide",
+    "metrics": {
+      "views": 2800,
+      "visitors": 2200
+    }
+  },
+  {
+    "term": "swift async await",
+    "metrics": {
+      "views": 2400,
+      "visitors": 1900
+    }
+  },
+  {
+    "term": "xcode tips",
+    "metrics": {
+      "views": 2000,
+      "visitors": 1600
+    }
+  },
+  {
+    "term": "swift performance",
+    "metrics": {
+      "views": 1600,
+      "visitors": 1300
+    }
+  },
+  {
+    "term": "ios app architecture",
+    "metrics": {
+      "views": 1200,
+      "visitors": 1000
+    }
+  }
+]

--- a/Modules/Sources/JetpackStats/Resources/Mocks/HistoricalData/historical-videos.json
+++ b/Modules/Sources/JetpackStats/Resources/Mocks/HistoricalData/historical-videos.json
@@ -1,0 +1,56 @@
+[
+  {
+    "title": "Getting Started with SwiftUI",
+    "postId": "101",
+    "videoUrl": "https://example.com/videos/swiftui-intro.mp4",
+    "metrics": {
+      "views": 4500,
+      "likes": 250
+    }
+  },
+  {
+    "title": "iOS Development Best Practices",
+    "postId": "102",
+    "videoUrl": "https://example.com/videos/best-practices.mp4",
+    "metrics": {
+      "views": 3800,
+      "likes": 210
+    }
+  },
+  {
+    "title": "Advanced Swift Techniques",
+    "postId": "103",
+    "videoUrl": "https://example.com/videos/advanced-swift.mp4",
+    "metrics": {
+      "views": 3200,
+      "likes": 180
+    }
+  },
+  {
+    "title": "Building Custom Views",
+    "postId": "104",
+    "videoUrl": "https://example.com/videos/custom-views.mp4",
+    "metrics": {
+      "views": 2600,
+      "likes": 140
+    }
+  },
+  {
+    "title": "App Performance Optimization",
+    "postId": "105",
+    "videoUrl": "https://example.com/videos/performance.mp4",
+    "metrics": {
+      "views": 2000,
+      "likes": 110
+    }
+  },
+  {
+    "title": "Debugging Like a Pro",
+    "postId": "106",
+    "videoUrl": "https://example.com/videos/debugging.mp4",
+    "metrics": {
+      "views": 1500,
+      "likes": 90
+    }
+  }
+]

--- a/Modules/Sources/JetpackStats/Resources/Mocks/RealtimeData/realtime-archive.json
+++ b/Modules/Sources/JetpackStats/Resources/Mocks/RealtimeData/realtime-archive.json
@@ -1,0 +1,74 @@
+[
+  {
+    "sectionName": "other",
+    "items": [
+      {
+        "href": "http://example.com/wp-admin/admin.php?page=stats",
+        "value": "/wp-admin/admin.php?page=stats",
+        "metrics": {
+          "views": 10
+        }
+      },
+      {
+        "href": "http://example.com/wp-admin/",
+        "value": "/wp-admin/",
+        "metrics": {
+          "views": 4
+        }
+      },
+      {
+        "href": "http://example.com/wp-admin/edit.php",
+        "value": "/wp-admin/edit.php",
+        "metrics": {
+          "views": 4
+        }
+      },
+      {
+        "href": "http://example.com/wp-admin/index.php",
+        "value": "/wp-admin/index.php",
+        "metrics": {
+          "views": 2
+        }
+      },
+      {
+        "href": "http://example.com/wp-admin/revision.php?revision=12345",
+        "value": "/wp-admin/revision.php?revision=12345",
+        "metrics": {
+          "views": 2
+        }
+      }
+    ],
+    "metrics": {
+      "views": 25
+    }
+  },
+  {
+    "sectionName": "author",
+    "items": [
+      {
+        "href": "http://example.com/author/johndoe/",
+        "value": "johndoe",
+        "metrics": {
+          "views": 31
+        }
+      },
+      {
+        "href": "http://example.com/author/janedoe/",
+        "value": "janedoe",
+        "metrics": {
+          "views": 5
+        }
+      },
+      {
+        "href": "http://example.com/author/testuser/",
+        "value": "testuser",
+        "metrics": {
+          "views": 2
+        }
+      }
+    ],
+    "metrics": {
+      "views": 40
+    }
+  }
+]

--- a/Modules/Sources/JetpackStats/Resources/Mocks/RealtimeData/realtime-external-links.json
+++ b/Modules/Sources/JetpackStats/Resources/Mocks/RealtimeData/realtime-external-links.json
@@ -1,0 +1,50 @@
+[
+  {
+    "url": "https://developer.apple.com",
+    "title": "Apple Developer",
+    "metrics": {
+      "views": 180,
+      "visitors": 120
+    }
+  },
+  {
+    "url": "https://swift.org",
+    "title": "Swift.org",
+    "metrics": {
+      "views": 150,
+      "visitors": 100
+    }
+  },
+  {
+    "url": "https://github.com",
+    "title": "GitHub",
+    "metrics": {
+      "views": 120,
+      "visitors": 80
+    }
+  },
+  {
+    "url": "https://stackoverflow.com",
+    "title": "Stack Overflow",
+    "metrics": {
+      "views": 100,
+      "visitors": 70
+    }
+  },
+  {
+    "url": "https://raywenderlich.com",
+    "title": "Ray Wenderlich",
+    "metrics": {
+      "views": 80,
+      "visitors": 50
+    }
+  },
+  {
+    "url": "https://nshipster.com",
+    "title": "NSHipster",
+    "metrics": {
+      "views": 60,
+      "visitors": 40
+    }
+  }
+]

--- a/Modules/Sources/JetpackStats/Resources/Mocks/RealtimeData/realtime-file-downloads.json
+++ b/Modules/Sources/JetpackStats/Resources/Mocks/RealtimeData/realtime-file-downloads.json
@@ -1,0 +1,44 @@
+[
+  {
+    "fileName": "annual-report-2024.pdf",
+    "filePath": "/downloads/reports/annual-report-2024.pdf",
+    "metrics": {
+      "downloads": 25
+    }
+  },
+  {
+    "fileName": "swift-cheatsheet.pdf",
+    "filePath": "/downloads/docs/swift-cheatsheet.pdf",
+    "metrics": {
+      "downloads": 21
+    }
+  },
+  {
+    "fileName": "app-screenshots.zip",
+    "filePath": "/downloads/media/app-screenshots.zip",
+    "metrics": {
+      "downloads": 18
+    }
+  },
+  {
+    "fileName": "tutorial-video.mp4",
+    "filePath": "/downloads/videos/tutorial-video.mp4",
+    "metrics": {
+      "downloads": 15
+    }
+  },
+  {
+    "fileName": "code-samples.zip",
+    "filePath": "/downloads/code/code-samples.zip",
+    "metrics": {
+      "downloads": 12
+    }
+  },
+  {
+    "fileName": "whitepaper.pdf",
+    "filePath": "/downloads/docs/whitepaper.pdf",
+    "metrics": {
+      "downloads": 9
+    }
+  }
+]

--- a/Modules/Sources/JetpackStats/Resources/Mocks/RealtimeData/realtime-search-terms.json
+++ b/Modules/Sources/JetpackStats/Resources/Mocks/RealtimeData/realtime-search-terms.json
@@ -1,0 +1,44 @@
+[
+  {
+    "term": "swiftui tutorial",
+    "metrics": {
+      "views": 32,
+      "visitors": 25
+    }
+  },
+  {
+    "term": "ios development guide",
+    "metrics": {
+      "views": 28,
+      "visitors": 22
+    }
+  },
+  {
+    "term": "swift async await",
+    "metrics": {
+      "views": 24,
+      "visitors": 19
+    }
+  },
+  {
+    "term": "xcode tips",
+    "metrics": {
+      "views": 20,
+      "visitors": 16
+    }
+  },
+  {
+    "term": "swift performance",
+    "metrics": {
+      "views": 16,
+      "visitors": 13
+    }
+  },
+  {
+    "term": "ios app architecture",
+    "metrics": {
+      "views": 12,
+      "visitors": 10
+    }
+  }
+]

--- a/Modules/Sources/JetpackStats/Resources/Mocks/RealtimeData/realtime-videos.json
+++ b/Modules/Sources/JetpackStats/Resources/Mocks/RealtimeData/realtime-videos.json
@@ -1,0 +1,56 @@
+[
+  {
+    "title": "Getting Started with SwiftUI",
+    "postId": "101",
+    "videoUrl": "https://example.com/videos/swiftui-intro.mp4",
+    "metrics": {
+      "views": 45,
+      "likes": 5
+    }
+  },
+  {
+    "title": "iOS Development Best Practices",
+    "postId": "102",
+    "videoUrl": "https://example.com/videos/best-practices.mp4",
+    "metrics": {
+      "views": 38,
+      "likes": 4
+    }
+  },
+  {
+    "title": "Advanced Swift Techniques",
+    "postId": "103",
+    "videoUrl": "https://example.com/videos/advanced-swift.mp4",
+    "metrics": {
+      "views": 32,
+      "likes": 3
+    }
+  },
+  {
+    "title": "Building Custom Views",
+    "postId": "104",
+    "videoUrl": "https://example.com/videos/custom-views.mp4",
+    "metrics": {
+      "views": 26,
+      "likes": 2
+    }
+  },
+  {
+    "title": "App Performance Optimization",
+    "postId": "105",
+    "videoUrl": "https://example.com/videos/performance.mp4",
+    "metrics": {
+      "views": 20,
+      "likes": 2
+    }
+  },
+  {
+    "title": "Debugging Like a Pro",
+    "postId": "106",
+    "videoUrl": "https://example.com/videos/debugging.mp4",
+    "metrics": {
+      "views": 15,
+      "likes": 1
+    }
+  }
+]

--- a/Modules/Sources/JetpackStats/Screens/TrafficTabView.swift
+++ b/Modules/Sources/JetpackStats/Screens/TrafficTabView.swift
@@ -57,17 +57,16 @@ struct TrafficTabView: View {
         }
     }
 
-    #warning("TEMP")
     private func configureViewModels() {
         guard viewModels.isEmpty else {
             return
         }
         viewModels = [
-//            ChartCardViewModel(
-//                metrics: context.service.supportedMetrics,
-//                dateRange: dateRange,
-//                service: context.service
-//            ),
+            ChartCardViewModel(
+                metrics: context.service.supportedMetrics,
+                dateRange: dateRange,
+                service: context.service
+            ),
             TopListCardViewModel(
                 selection: .init(item: .postsAndPages, metric: .views),
                 dateRange: dateRange,

--- a/Modules/Sources/JetpackStats/Screens/TrafficTabView.swift
+++ b/Modules/Sources/JetpackStats/Screens/TrafficTabView.swift
@@ -29,15 +29,13 @@ struct TrafficTabView: View {
             }
         }
         .background(Constants.Colors.background)
-        .toolbar {
-            if #available(iOS 26, *) {
-                normalModeToolbarContent
-            }
-        }
+//        .toolbar {
+//            if #available(iOS 26, *) {
+//                normalModeToolbarContent
+//            }
+//        }
         .safeAreaInset(edge: .bottom) {
-            if #unavailable(iOS 26) {
-                LegacyFloatingDateControl(dateRange: $dateRange)
-            }
+            LegacyFloatingDateControl(dateRange: $dateRange)
         }
         .sheet(isPresented: $isShowingCustomRangePicker) {
             CustomDateRangePicker(dateRange: $dateRange)
@@ -59,16 +57,17 @@ struct TrafficTabView: View {
         }
     }
 
+    #warning("TEMP")
     private func configureViewModels() {
         guard viewModels.isEmpty else {
             return
         }
         viewModels = [
-            ChartCardViewModel(
-                metrics: context.service.supportedMetrics,
-                dateRange: dateRange,
-                service: context.service
-            ),
+//            ChartCardViewModel(
+//                metrics: context.service.supportedMetrics,
+//                dateRange: dateRange,
+//                service: context.service
+//            ),
             TopListCardViewModel(
                 selection: .init(item: .postsAndPages, metric: .views),
                 dateRange: dateRange,

--- a/Modules/Sources/JetpackStats/Services/Data/TopListChartData.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListChartData.swift
@@ -88,6 +88,8 @@ extension TopListChartData {
             return mockSearchTerms(metric: metric, count: count)
         case .videos:
             return mockVideos(metric: metric, count: count)
+        case .archive:
+            return mockArchive(metric: metric, count: count)
         }
     }
 
@@ -281,6 +283,58 @@ extension TopListChartData {
             )
         }
     }
+    
+    private static func mockArchive(metric: SiteMetric, count: Int) -> [any TopListItem] {
+        // Create mock archive sections
+        let archiveSections = [
+            ("pages", [
+                ("/about/", 2500),
+                ("/contact/", 1800),
+                ("/privacy-policy/", 1200),
+                ("/terms-of-service/", 800),
+                ("/faq/", 600)
+            ]),
+            ("categories", [
+                ("/category/technology/", 3200),
+                ("/category/design/", 2800),
+                ("/category/business/", 2400),
+                ("/category/lifestyle/", 1600)
+            ]),
+            ("tags", [
+                ("/tag/swift/", 2100),
+                ("/tag/ios/", 1900),
+                ("/tag/swiftui/", 1700),
+                ("/tag/mobile/", 1400)
+            ]),
+            ("archives", [
+                ("/2024/01/", 1500),
+                ("/2023/12/", 1300),
+                ("/2023/11/", 1100),
+                ("/2023/10/", 900)
+            ])
+        ]
+        
+        return archiveSections.prefix(count).map { sectionData in
+            let sectionName = sectionData.0
+            let items = sectionData.1.map { itemData in
+                let metrics = createMetrics(baseValue: itemData.1, metric: metric)
+                return TopListData.ArchiveItem(
+                    href: "https://example.com\(itemData.0)",
+                    value: itemData.0,
+                    metrics: metrics
+                )
+            }
+            
+            // Calculate total views for the section
+            let totalViews = items.reduce(0) { $0 + ($1.metrics[metric] ?? 0) }
+            
+            return TopListData.ArchiveSection(
+                sectionName: sectionName,
+                items: items,
+                metrics: SiteMetricsSet(views: totalViews)
+            )
+        }
+    }
 
     private static func createMetrics(baseValue: Int, metric: SiteMetric) -> SiteMetricsSet {
         // Add some variation to make it more realistic
@@ -324,6 +378,17 @@ extension TopListChartData {
         let trendFactor = Double.random(in: 0.7...1.3)
         let currentValue = item.metrics[metric] ?? 0
         item.metrics[metric] = Int(Double(currentValue) * trendFactor)
+        
+        // Special handling for archive sections - update child items too
+        if var archiveSection = item as? TopListData.ArchiveSection {
+            archiveSection.items = archiveSection.items.map { archiveItem in
+                var mutableItem = archiveItem
+                let itemCurrentValue = mutableItem.metrics[metric] ?? 0
+                mutableItem.metrics[metric] = Int(Double(itemCurrentValue) * trendFactor)
+                return mutableItem
+            }
+            return archiveSection
+        }
 
         return item
     }

--- a/Modules/Sources/JetpackStats/Services/Data/TopListChartData.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListChartData.swift
@@ -4,7 +4,7 @@ final class TopListChartData {
     let item: TopListItemType
     let metric: SiteMetric
     let items: [any TopListItem]
-    let previousItems: [String: any TopListItem]
+    let previousItems: [TopListItemID: any TopListItem]
     let maxValue: Int
 
     struct ListID: Hashable {
@@ -16,7 +16,7 @@ final class TopListChartData {
         ListID(item: item, metric: metric)
     }
 
-    init(item: TopListItemType, metric: SiteMetric, items: [any TopListItem], previousItems: [String: any TopListItem] = [:], maxValue: Int) {
+    init(item: TopListItemType, metric: SiteMetric, items: [any TopListItem], previousItems: [TopListItemID: any TopListItem] = [:], maxValue: Int) {
         self.item = item
         self.metric = metric
         self.items = items
@@ -40,7 +40,7 @@ extension TopListChartData {
         let currentItems = mockItems(for: itemType, metric: metric, count: itemCount)
         
         // Create previous items dictionary
-        var previousItemsDict: [String: any TopListItem] = [:]
+        var previousItemsDict: [TopListItemID: any TopListItem] = [:]
         for item in currentItems {
             let previousItem = mockPreviousItem(from: item, metric: metric)
             previousItemsDict[item.id] = previousItem

--- a/Modules/Sources/JetpackStats/Services/Data/TopListChartData.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListChartData.swift
@@ -23,7 +23,7 @@ final class TopListChartData {
         self.previousItems = previousItems
         self.maxValue = maxValue
     }
-    
+
     func previousItem(for currentItem: any TopListItem) -> (any TopListItem)? {
         previousItems[currentItem.id]
     }
@@ -38,7 +38,7 @@ extension TopListChartData {
         itemCount: Int = 6
     ) -> TopListChartData {
         let currentItems = mockItems(for: itemType, metric: metric, count: itemCount)
-        
+
         // Create previous items dictionary
         var previousItemsDict: [TopListItemID: any TopListItem] = [:]
         for item in currentItems {
@@ -276,7 +276,7 @@ extension TopListChartData {
             )
         }
     }
-    
+
     private static func mockArchive(metric: SiteMetric, count: Int) -> [any TopListItem] {
         // Create mock archive sections
         let archiveSections = [
@@ -306,7 +306,7 @@ extension TopListChartData {
                 ("/2023/10/", 900)
             ])
         ]
-        
+
         return archiveSections.prefix(count).map { sectionData in
             let sectionName = sectionData.0
             let items = sectionData.1.map { itemData in
@@ -317,10 +317,10 @@ extension TopListChartData {
                     metrics: metrics
                 )
             }
-            
+
             // Calculate total views for the section
             let totalViews = items.reduce(0) { $0 + ($1.metrics[metric] ?? 0) }
-            
+
             return TopListData.ArchiveSection(
                 sectionName: sectionName,
                 items: items,
@@ -371,7 +371,7 @@ extension TopListChartData {
         let trendFactor = Double.random(in: 0.7...1.3)
         let currentValue = item.metrics[metric] ?? 0
         item.metrics[metric] = Int(Double(currentValue) * trendFactor)
-        
+
         // Special handling for archive sections - update child items too
         if var archiveSection = item as? TopListData.ArchiveSection {
             archiveSection.items = archiveSection.items.map { archiveItem in

--- a/Modules/Sources/JetpackStats/Services/Data/TopListChartData.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListChartData.swift
@@ -1,24 +1,10 @@
 import Foundation
 
 final class TopListChartData {
-    struct Item: Identifiable {
-        let id: ItemID
-        let current: any TopListItem
-        let previous: (any TopListItem)?
-    }
-
-    /// - warning: It's required for animations in ``TopListItemsView`` to work
-    /// well for IDs to be unique across the domains. If we were just to use
-    /// `String`, there would be collisions across domains, e.g. post and author
-    /// using the same String ID "1".
-    struct ItemID: Hashable {
-        let type: TopListItemType
-        let id: String
-    }
-
     let item: TopListItemType
     let metric: SiteMetric
-    let items: [Item]
+    let items: [any TopListItem]
+    let previousItems: [String: any TopListItem]
     let maxValue: Int
 
     struct ListID: Hashable {
@@ -30,11 +16,16 @@ final class TopListChartData {
         ListID(item: item, metric: metric)
     }
 
-    init(item: TopListItemType, metric: SiteMetric, items: [Item], maxValue: Int) {
+    init(item: TopListItemType, metric: SiteMetric, items: [any TopListItem], previousItems: [String: any TopListItem] = [:], maxValue: Int) {
         self.item = item
         self.metric = metric
         self.items = items
+        self.previousItems = previousItems
         self.maxValue = maxValue
+    }
+    
+    func previousItem(for currentItem: any TopListItem) -> (any TopListItem)? {
+        previousItems[currentItem.id]
     }
 }
 
@@ -46,22 +37,24 @@ extension TopListChartData {
         metric: SiteMetric = .views,
         itemCount: Int = 6
     ) -> TopListChartData {
-        let items = mockItems(for: itemType, metric: metric, count: itemCount)
-        let matchedItems = items.map { item in
-            // Create previous item with slightly different values
+        let currentItems = mockItems(for: itemType, metric: metric, count: itemCount)
+        
+        // Create previous items dictionary
+        var previousItemsDict: [String: any TopListItem] = [:]
+        for item in currentItems {
             let previousItem = mockPreviousItem(from: item, metric: metric)
-            let itemID = ItemID(type: itemType, id: item.id)
-            return Item(id: itemID, current: item, previous: previousItem)
+            previousItemsDict[item.id] = previousItem
         }
 
-        let maxValue = items
+        let maxValue = currentItems
             .compactMap { $0.metrics[metric] }
             .max() ?? 1
 
         return TopListChartData(
             item: itemType,
             metric: metric,
-            items: matchedItems,
+            items: currentItems,
+            previousItems: previousItemsDict,
             maxValue: maxValue
         )
     }

--- a/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
@@ -4,6 +4,10 @@ struct TopListData: Sendable {
     let items: [any TopListItem]
 }
 
+/// - warning: It's required for animations in ``TopListItemsView`` to work
+/// well for IDs to be unique across the domains. If we were just to use
+/// `String`, there would be collisions across domains, e.g. post and author
+/// using the same String ID "1".
 struct TopListItemID: Hashable {
     let type: TopListItemType
     let id: String

--- a/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
@@ -80,4 +80,20 @@ extension TopListData {
 
         var id: String { postId }
     }
+
+    struct ArchiveItem: Codable, TopListItem {
+        let href: String
+        let value: String
+        var metrics: SiteMetricsSet
+
+        var id: String { href }
+    }
+
+    struct ArchiveSection: Codable, TopListItem {
+        let sectionName: String
+        var items: [ArchiveItem]
+        var metrics: SiteMetricsSet
+
+        var id: String { sectionName }
+    }
 }

--- a/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
@@ -4,14 +4,18 @@ struct TopListData: Sendable {
     let items: [any TopListItem]
 }
 
+struct TopListItemID: Hashable {
+    let type: TopListItemType
+    let id: String
+}
+
 protocol TopListItem: Codable, Sendable, Identifiable {
     var metrics: SiteMetricsSet { get set }
-    var id: String { get }
+    var id: TopListItemID { get }
 }
 
 protocol TopListExpandableItem: TopListItem {
-    associatedtype ItemType: TopListItem
-    var items: [ItemType] { get }
+    var children: [any TopListItem] { get }
     var displayName: String { get }
 }
 
@@ -25,7 +29,9 @@ extension TopListData {
         let author: String?
         var metrics: SiteMetricsSet
 
-        var id: String { postID ?? title }
+        var id: TopListItemID { 
+            TopListItemID(type: .postsAndPages, id: postID ?? title)
+        }
     }
 
     struct Referrer: Codable, TopListItem {
@@ -33,7 +39,9 @@ extension TopListData {
         let domain: String?
         var metrics: SiteMetricsSet
 
-        var id: String { domain ?? name }
+        var id: TopListItemID { 
+            TopListItemID(type: .referrers, id: domain ?? name)
+        }
     }
 
     struct Location: Codable, TopListItem {
@@ -42,7 +50,9 @@ extension TopListData {
         let countryCode: String?
         var metrics: SiteMetricsSet
 
-        var id: String { countryCode ?? country }
+        var id: TopListItemID { 
+            TopListItemID(type: .locations, id: countryCode ?? country)
+        }
     }
 
     struct Author: Codable, TopListItem {
@@ -52,7 +62,9 @@ extension TopListData {
         var metrics: SiteMetricsSet
         var avatarURL: URL?
 
-        var id: String { userId }
+        var id: TopListItemID { 
+            TopListItemID(type: .authors, id: userId)
+        }
     }
 
     struct ExternalLink: Codable, TopListItem {
@@ -60,7 +72,9 @@ extension TopListData {
         let title: String?
         var metrics: SiteMetricsSet
 
-        var id: String { url }
+        var id: TopListItemID { 
+            TopListItemID(type: .externalLinks, id: url)
+        }
     }
 
     struct FileDownload: Codable, TopListItem {
@@ -68,14 +82,18 @@ extension TopListData {
         let filePath: String?
         var metrics: SiteMetricsSet
 
-        var id: String { filePath ?? fileName }
+        var id: TopListItemID { 
+            TopListItemID(type: .fileDownloads, id: filePath ?? fileName)
+        }
     }
 
     struct SearchTerm: Codable, TopListItem {
         let term: String
         var metrics: SiteMetricsSet
 
-        var id: String { term }
+        var id: TopListItemID { 
+            TopListItemID(type: .searchTerms, id: term)
+        }
     }
 
     struct Video: Codable, TopListItem {
@@ -84,7 +102,9 @@ extension TopListData {
         let videoUrl: URL?
         var metrics: SiteMetricsSet
 
-        var id: String { postId }
+        var id: TopListItemID { 
+            TopListItemID(type: .videos, id: postId)
+        }
     }
 
     struct ArchiveItem: Codable, TopListItem {
@@ -92,7 +112,9 @@ extension TopListData {
         let value: String
         var metrics: SiteMetricsSet
 
-        var id: String { href }
+        var id: TopListItemID { 
+            TopListItemID(type: .archive, id: href)
+        }
     }
 
     struct ArchiveSection: Codable, TopListExpandableItem {
@@ -100,7 +122,11 @@ extension TopListData {
         var items: [ArchiveItem]
         var metrics: SiteMetricsSet
 
-        var id: String { sectionName }
+        var children: [any TopListItem] { items }
+
+        var id: TopListItemID { 
+            TopListItemID(type: .archive, id: sectionName)
+        }
 
         var displayName: String {
             switch sectionName.lowercased() {

--- a/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
@@ -29,7 +29,7 @@ extension TopListData {
         let author: String?
         var metrics: SiteMetricsSet
 
-        var id: TopListItemID { 
+        var id: TopListItemID {
             TopListItemID(type: .postsAndPages, id: postID ?? title)
         }
     }
@@ -39,7 +39,7 @@ extension TopListData {
         let domain: String?
         var metrics: SiteMetricsSet
 
-        var id: TopListItemID { 
+        var id: TopListItemID {
             TopListItemID(type: .referrers, id: domain ?? name)
         }
     }
@@ -50,7 +50,7 @@ extension TopListData {
         let countryCode: String?
         var metrics: SiteMetricsSet
 
-        var id: TopListItemID { 
+        var id: TopListItemID {
             TopListItemID(type: .locations, id: countryCode ?? country)
         }
     }
@@ -62,7 +62,7 @@ extension TopListData {
         var metrics: SiteMetricsSet
         var avatarURL: URL?
 
-        var id: TopListItemID { 
+        var id: TopListItemID {
             TopListItemID(type: .authors, id: userId)
         }
     }
@@ -72,7 +72,7 @@ extension TopListData {
         let title: String?
         var metrics: SiteMetricsSet
 
-        var id: TopListItemID { 
+        var id: TopListItemID {
             TopListItemID(type: .externalLinks, id: url)
         }
     }
@@ -82,7 +82,7 @@ extension TopListData {
         let filePath: String?
         var metrics: SiteMetricsSet
 
-        var id: TopListItemID { 
+        var id: TopListItemID {
             TopListItemID(type: .fileDownloads, id: filePath ?? fileName)
         }
     }
@@ -91,7 +91,7 @@ extension TopListData {
         let term: String
         var metrics: SiteMetricsSet
 
-        var id: TopListItemID { 
+        var id: TopListItemID {
             TopListItemID(type: .searchTerms, id: term)
         }
     }
@@ -102,7 +102,7 @@ extension TopListData {
         let videoUrl: URL?
         var metrics: SiteMetricsSet
 
-        var id: TopListItemID { 
+        var id: TopListItemID {
             TopListItemID(type: .videos, id: postId)
         }
     }
@@ -112,7 +112,7 @@ extension TopListData {
         let value: String
         var metrics: SiteMetricsSet
 
-        var id: TopListItemID { 
+        var id: TopListItemID {
             TopListItemID(type: .archive, id: href)
         }
     }
@@ -124,7 +124,7 @@ extension TopListData {
 
         var children: [any TopListItem] { items }
 
-        var id: TopListItemID { 
+        var id: TopListItemID {
             TopListItemID(type: .archive, id: sectionName)
         }
 

--- a/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
@@ -9,6 +9,12 @@ protocol TopListItem: Codable, Sendable, Identifiable {
     var id: String { get }
 }
 
+protocol TopListExpandableItem: TopListItem {
+    associatedtype ItemType: TopListItem
+    var items: [ItemType] { get }
+    var displayName: String { get }
+}
+
 extension TopListData {
     struct Post: Codable, TopListItem {
         let title: String
@@ -89,11 +95,22 @@ extension TopListData {
         var id: String { href }
     }
 
-    struct ArchiveSection: Codable, TopListItem {
+    struct ArchiveSection: Codable, TopListExpandableItem {
         let sectionName: String
         var items: [ArchiveItem]
         var metrics: SiteMetricsSet
 
         var id: String { sectionName }
+
+        var displayName: String {
+            switch sectionName.lowercased() {
+            case "author":
+                return Strings.ArchiveSections.author
+            case "other":
+                return Strings.ArchiveSections.other
+            default:
+                return sectionName.capitalized
+            }
+        }
     }
 }

--- a/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
@@ -104,12 +104,9 @@ extension TopListData {
 
         var displayName: String {
             switch sectionName.lowercased() {
-            case "author":
-                return Strings.ArchiveSections.author
-            case "other":
-                return Strings.ArchiveSections.other
-            default:
-                return sectionName.capitalized
+            case "author": Strings.ArchiveSections.author
+            case "other": Strings.ArchiveSections.other
+            default: sectionName.capitalized
             }
         }
     }

--- a/Modules/Sources/JetpackStats/Services/Data/TopListItemType.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListItemType.swift
@@ -9,6 +9,7 @@ enum TopListItemType: Identifiable, CaseIterable, Sendable {
     case fileDownloads
     case searchTerms
     case videos
+    case archive
 
     var id: TopListItemType { self }
 
@@ -22,12 +23,13 @@ enum TopListItemType: Identifiable, CaseIterable, Sendable {
         case .fileDownloads: Strings.SiteDataTypes.fileDownloads
         case .searchTerms: Strings.SiteDataTypes.searchTerms
         case .videos: Strings.SiteDataTypes.videos
+        case .archive: Strings.SiteDataTypes.archive
         }
     }
 
     var systemImage: String {
         switch self {
-        case .postsAndPages: "doc.text"
+        case .postsAndPages: "text.page"
         case .referrers: "link"
         case .locations: "map"
         case .authors: "person.2"
@@ -35,6 +37,7 @@ enum TopListItemType: Identifiable, CaseIterable, Sendable {
         case .fileDownloads: "arrow.down.circle"
         case .searchTerms: "magnifyingglass"
         case .videos: "play.rectangle"
+        case .archive: "rectangle.and.text.magnifyingglass"
         }
     }
 
@@ -52,6 +55,6 @@ enum TopListItemType: Identifiable, CaseIterable, Sendable {
     }
 
     static let secondaryItems: Set<TopListItemType> = [
-        .externalLinks, .fileDownloads, .searchTerms, .videos
+        .externalLinks, .fileDownloads, .searchTerms, .videos, .archive
     ]
 }

--- a/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
@@ -186,7 +186,7 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
         case .postsAndPages:
             fileName = "postsAndPages"
         case .archive:
-            return generateMockArchiveData()
+            fileName = "archive"
         case .referrers:
             fileName = "referrers"
         case .locations:
@@ -246,8 +246,8 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
                 let posts = try decoder.decode([TopListData.Post].self, from: data)
                 return posts
             case .archive:
-                // This case is handled by generateMockArchiveData
-                return []
+                let sections = try decoder.decode([TopListData.ArchiveSection].self, from: data)
+                return sections
             }
         } catch {
             print("Failed to load \(fileName).json: \(error)")
@@ -310,7 +310,7 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
         case .postsAndPages:
             fileName = "historical-postsAndPages"
         case .archive:
-            return generateMockArchiveData()
+            fileName = "historical-archive"
         case .referrers:
             fileName = "historical-referrers"
         case .locations:
@@ -370,8 +370,8 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
                 let posts = try decoder.decode([TopListData.Post].self, from: data)
                 return posts
             case .archive:
-                // This case is handled by generateMockArchiveData
-                return []
+                let sections = try decoder.decode([TopListData.ArchiveSection].self, from: data)
+                return sections
             }
         } catch {
             print("Failed to load \(fileName).json: \(error)")
@@ -548,31 +548,4 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
         }
     }
 
-    /// Generates mock archive data with expandable sections
-    private func generateMockArchiveData() -> [any TopListItem] {
-        // Create mock archive sections based on the example JSON structure
-        let otherSection = TopListData.ArchiveSection(
-            sectionName: "other",
-            items: [
-                TopListData.ArchiveItem(href: "http://example.com/wp-admin/admin.php?page=stats", value: "/wp-admin/admin.php?page=stats", metrics: SiteMetricsSet(views: 10)),
-                TopListData.ArchiveItem(href: "http://example.com/wp-admin/", value: "/wp-admin/", metrics: SiteMetricsSet(views: 4)),
-                TopListData.ArchiveItem(href: "http://example.com/wp-admin/edit.php", value: "/wp-admin/edit.php", metrics: SiteMetricsSet(views: 4)),
-                TopListData.ArchiveItem(href: "http://example.com/wp-admin/index.php", value: "/wp-admin/index.php", metrics: SiteMetricsSet(views: 2)),
-                TopListData.ArchiveItem(href: "http://example.com/wp-admin/revision.php?revision=12345", value: "/wp-admin/revision.php?revision=12345", metrics: SiteMetricsSet(views: 2))
-            ],
-            metrics: SiteMetricsSet(views: 25) // Total views for the section
-        )
-
-        let authorSection = TopListData.ArchiveSection(
-            sectionName: "author",
-            items: [
-                TopListData.ArchiveItem(href: "http://example.com/author/johndoe/", value: "johndoe", metrics: SiteMetricsSet(views: 31)),
-                TopListData.ArchiveItem(href: "http://example.com/author/janedoe/", value: "janedoe", metrics: SiteMetricsSet(views: 5)),
-                TopListData.ArchiveItem(href: "http://example.com/author/testuser/", value: "testuser", metrics: SiteMetricsSet(views: 2))
-            ],
-            metrics: SiteMetricsSet(views: 40) // Total views for the section
-        )
-
-        return [otherSection, authorSection]
-    }
 }

--- a/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
@@ -13,6 +13,7 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
     nonisolated func getSupportedMetrics(for item: TopListItemType) -> [SiteMetric] {
         switch item {
         case .postsAndPages: [.views, .visitors, .comments, .likes]
+        case .archive: [.views]
         case .referrers: [.views, .visitors]
         case .locations: [.views, .visitors]
         case .authors: [.views, .comments, .likes]
@@ -184,6 +185,8 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
         switch dataType {
         case .postsAndPages:
             fileName = "postsAndPages"
+        case .archive:
+            return generateMockArchiveData()
         case .referrers:
             fileName = "referrers"
         case .locations:
@@ -242,6 +245,9 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
             case .postsAndPages:
                 let posts = try decoder.decode([TopListData.Post].self, from: data)
                 return posts
+            case .archive:
+                // This case is handled by generateMockArchiveData
+                return []
             }
         } catch {
             print("Failed to load \(fileName).json: \(error)")
@@ -303,6 +309,8 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
         switch dataType {
         case .postsAndPages:
             fileName = "historical-postsAndPages"
+        case .archive:
+            return generateMockArchiveData()
         case .referrers:
             fileName = "historical-referrers"
         case .locations:
@@ -361,6 +369,9 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
             case .postsAndPages:
                 let posts = try decoder.decode([TopListData.Post].self, from: data)
                 return posts
+            case .archive:
+                // This case is handled by generateMockArchiveData
+                return []
             }
         } catch {
             print("Failed to load \(fileName).json: \(error)")
@@ -535,5 +546,33 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
 
             dailyTopListData[dataType] = typeData
         }
+    }
+    
+    /// Generates mock archive data with expandable sections
+    private func generateMockArchiveData() -> [any TopListItem] {
+        // Create mock archive sections based on the example JSON structure
+        let otherSection = TopListData.ArchiveSection(
+            sectionName: "other",
+            items: [
+                TopListData.ArchiveItem(href: "http://example.com/wp-admin/admin.php?page=stats", value: "/wp-admin/admin.php?page=stats", metrics: SiteMetricsSet(views: 10)),
+                TopListData.ArchiveItem(href: "http://example.com/wp-admin/", value: "/wp-admin/", metrics: SiteMetricsSet(views: 4)),
+                TopListData.ArchiveItem(href: "http://example.com/wp-admin/edit.php", value: "/wp-admin/edit.php", metrics: SiteMetricsSet(views: 4)),
+                TopListData.ArchiveItem(href: "http://example.com/wp-admin/index.php", value: "/wp-admin/index.php", metrics: SiteMetricsSet(views: 2)),
+                TopListData.ArchiveItem(href: "http://example.com/wp-admin/revision.php?revision=12345", value: "/wp-admin/revision.php?revision=12345", metrics: SiteMetricsSet(views: 2))
+            ],
+            metrics: SiteMetricsSet(views: 25) // Total views for the section
+        )
+        
+        let authorSection = TopListData.ArchiveSection(
+            sectionName: "author",
+            items: [
+                TopListData.ArchiveItem(href: "http://example.com/author/johndoe/", value: "johndoe", metrics: SiteMetricsSet(views: 31)),
+                TopListData.ArchiveItem(href: "http://example.com/author/janedoe/", value: "janedoe", metrics: SiteMetricsSet(views: 5)),
+                TopListData.ArchiveItem(href: "http://example.com/author/testuser/", value: "testuser", metrics: SiteMetricsSet(views: 2))
+            ],
+            metrics: SiteMetricsSet(views: 40) // Total views for the section
+        )
+        
+        return [otherSection, authorSection]
     }
 }

--- a/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
@@ -82,7 +82,7 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
         }
 
         // Aggregate all items across the date range
-        var aggregatedItems: [String: (any TopListItem, Int)] = [:] // Store item and aggregated metrics
+        var aggregatedItems: [TopListItemID: (any TopListItem, Int)] = [:] // Store item and aggregated metrics
 
         for (_, dailyItems) in filteredData {
             for item in dailyItems {

--- a/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
@@ -547,7 +547,7 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
             dailyTopListData[dataType] = typeData
         }
     }
-    
+
     /// Generates mock archive data with expandable sections
     private func generateMockArchiveData() -> [any TopListItem] {
         // Create mock archive sections based on the example JSON structure
@@ -562,7 +562,7 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
             ],
             metrics: SiteMetricsSet(views: 25) // Total views for the section
         )
-        
+
         let authorSection = TopListData.ArchiveSection(
             sectionName: "author",
             items: [
@@ -572,7 +572,7 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
             ],
             metrics: SiteMetricsSet(views: 40) // Total views for the section
         )
-        
+
         return [otherSection, authorSection]
     }
 }

--- a/Modules/Sources/JetpackStats/Services/StatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/StatsService.swift
@@ -181,7 +181,7 @@ actor StatsService: StatsServiceProtocol {
             default:
                 throw StatsServiceError.unavailable
             }
-            
+
         case .archive:
             switch metric {
             case .views:
@@ -432,12 +432,12 @@ actor StatsService: StatsServiceProtocol {
         }
         return TopListData(items: items)
     }
-    
+
     private func mapArchiveToTopListData(_ data: StatsArchiveTimeIntervalData) -> TopListData {
         // Convert the summary dictionary into archive sections
         let sections = data.summary.compactMap { (sectionName, items) -> TopListData.ArchiveSection? in
             guard !items.isEmpty else { return nil }
-            
+
             // Map archive items
             let archiveItems = items.map { item in
                 TopListData.ArchiveItem(
@@ -446,20 +446,20 @@ actor StatsService: StatsServiceProtocol {
                     metrics: SiteMetricsSet(views: item.views)
                 )
             }
-            
+
             // Calculate total views for the section
             let totalViews = items.reduce(0) { $0 + $1.views }
-            
+
             return TopListData.ArchiveSection(
                 sectionName: sectionName,
                 items: archiveItems,
                 metrics: SiteMetricsSet(views: totalViews)
             )
         }
-        
+
         // Sort sections by total views
         let sortedSections = sections.sorted { ($0.metrics.views ?? 0) > ($1.metrics.views ?? 0) }
-        
+
         return TopListData(items: sortedSections)
     }
 }

--- a/Modules/Sources/JetpackStats/Services/StatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/StatsService.swift
@@ -24,13 +24,14 @@ actor StatsService: StatsServiceProtocol {
     ]
 
     let supportedItems: [TopListItemType] = [
-        .postsAndPages, .referrers, .locations, .authors, .externalLinks,
+        .postsAndPages, .archive, .referrers, .locations, .authors, .externalLinks,
         .fileDownloads, .searchTerms, .videos
     ]
 
     nonisolated func getSupportedMetrics(for item: TopListItemType) -> [SiteMetric] {
         switch item {
         case .postsAndPages: [.views]
+        case .archive: [.views]
         case .referrers: [.views]
         case .locations: [.views]
         case .authors: [.views]
@@ -177,6 +178,15 @@ actor StatsService: StatsServiceProtocol {
             case .views:
                 let data = try await getData(StatsTopVideosTimeIntervalData.self)
                 return mapVideosToTopListData(data)
+            default:
+                throw StatsServiceError.unavailable
+            }
+            
+        case .archive:
+            switch metric {
+            case .views:
+                let data = try await getData(StatsArchiveTimeIntervalData.self)
+                return mapArchiveToTopListData(data)
             default:
                 throw StatsServiceError.unavailable
             }
@@ -421,6 +431,36 @@ actor StatsService: StatsServiceProtocol {
             )
         }
         return TopListData(items: items)
+    }
+    
+    private func mapArchiveToTopListData(_ data: StatsArchiveTimeIntervalData) -> TopListData {
+        // Convert the summary dictionary into archive sections
+        let sections = data.summary.compactMap { (sectionName, items) -> TopListData.ArchiveSection? in
+            guard !items.isEmpty else { return nil }
+            
+            // Map archive items
+            let archiveItems = items.map { item in
+                TopListData.ArchiveItem(
+                    href: item.href,
+                    value: item.value,
+                    metrics: SiteMetricsSet(views: item.views)
+                )
+            }
+            
+            // Calculate total views for the section
+            let totalViews = items.reduce(0) { $0 + $1.views }
+            
+            return TopListData.ArchiveSection(
+                sectionName: sectionName,
+                items: archiveItems,
+                metrics: SiteMetricsSet(views: totalViews)
+            )
+        }
+        
+        // Sort sections by total views
+        let sortedSections = sections.sorted { ($0.metrics.views ?? 0) > ($1.metrics.views ?? 0) }
+        
+        return TopListData(items: sortedSections)
     }
 }
 

--- a/Modules/Sources/JetpackStats/StatsRouter.swift
+++ b/Modules/Sources/JetpackStats/StatsRouter.swift
@@ -40,7 +40,7 @@ public final class StatsRouter: @unchecked Sendable {
         let commentsVC = factory.makeCommentsListViewController(siteID: siteID, postID: postID)
         navigationController?.pushViewController(commentsVC, animated: true)
     }
-    
+
     @MainActor
     func openURL(_ url: URL) {
         // Open URL in in-app Safari

--- a/Modules/Sources/JetpackStats/StatsRouter.swift
+++ b/Modules/Sources/JetpackStats/StatsRouter.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import UIKit
+import SafariServices
 
 @MainActor
 public protocol StatsRouterScreenFactory: AnyObject {
@@ -38,6 +39,13 @@ public final class StatsRouter: @unchecked Sendable {
     func navigateToCommentsList(siteID: Int, postID: Int) {
         let commentsVC = factory.makeCommentsListViewController(siteID: siteID, postID: postID)
         navigationController?.pushViewController(commentsVC, animated: true)
+    }
+    
+    @MainActor
+    func openURL(_ url: URL) {
+        // Open URL in in-app Safari
+        let safariViewController = SFSafariViewController(url: url)
+        viewController?.present(safariViewController, animated: true)
     }
 }
 

--- a/Modules/Sources/JetpackStats/Strings.swift
+++ b/Modules/Sources/JetpackStats/Strings.swift
@@ -120,7 +120,7 @@ enum Strings {
         static let author = AppLocalizedString("jetpackStats.archiveSections.author", value: "Authors", comment: "Archive section for authors")
         static let other = AppLocalizedString("jetpackStats.archiveSections.other", value: "Other", comment: "Archive section for other items")
     }
-    
+
     enum PostDetails {
         static let title = AppLocalizedString("jetpackStats.postDetails.title", value: "Post Stats", comment: "Navigation title")
         static func published(_ date: String) -> String {

--- a/Modules/Sources/JetpackStats/Strings.swift
+++ b/Modules/Sources/JetpackStats/Strings.swift
@@ -46,6 +46,7 @@ enum Strings {
 
     enum SiteDataTypes {
         static let postsAndPages = AppLocalizedString("jetpackStats.siteDataTypes.postsAndPages", value: "Posts & Pages", comment: "Posts and pages data type")
+        static let archive = AppLocalizedString("jetpackStats.siteDataTypes.archive", value: "Archive", comment: "Archive data type")
         static let posts = AppLocalizedString("jetpackStats.siteDataTypes.posts", value: "Posts", comment: "Posts data type")
         static let pages = AppLocalizedString("jetpackStats.siteDataTypes.pages", value: "Pages", comment: "Pages data type")
         static let authors = AppLocalizedString("jetpackStats.siteDataTypes.authors", value: "Authors", comment: "Authors data type")
@@ -115,6 +116,11 @@ enum Strings {
         }
     }
 
+    enum ArchiveSections {
+        static let author = AppLocalizedString("jetpackStats.archiveSections.author", value: "Authors", comment: "Archive section for authors")
+        static let other = AppLocalizedString("jetpackStats.archiveSections.other", value: "Other", comment: "Archive section for other items")
+    }
+    
     enum PostDetails {
         static let title = AppLocalizedString("jetpackStats.postDetails.title", value: "Post Stats", comment: "Navigation title")
         static func published(_ date: String) -> String {

--- a/Modules/Sources/JetpackStats/Views/LegacyFloatingDateControl.swift
+++ b/Modules/Sources/JetpackStats/Views/LegacyFloatingDateControl.swift
@@ -48,11 +48,11 @@ struct LegacyFloatingDateControl: View {
             dateRangeButtonContent
                 .contentShape(Rectangle())
                 .frame(height: buttonHeight)
+                .floatingStyle()
         }
         .tint(Color.primary)
         .menuOrder(.fixed)
         .buttonStyle(.plain)
-        .floatingStyle()
     }
 
     private var dateRangeButtonContent: some View {

--- a/Modules/Sources/JetpackStats/Views/TopList/Rows/TopListArchiveItemRowView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/Rows/TopListArchiveItemRowView.swift
@@ -1,0 +1,22 @@
+import SwiftUI
+
+struct TopListArchiveItemRowView: View {
+    let item: TopListData.ArchiveItem
+    let showDetails: Bool
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            ZStack(alignment: .leading) {
+                // Ensure stable height
+                Text(item.value)
+                    .lineLimit(1, reservesSpace: true)
+                    .opacity(0)
+                Text(item.value)
+            }
+            .font(.callout)
+            .foregroundColor(.primary)
+            .lineLimit(1)
+            .padding(.trailing, 4)
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Views/TopList/Rows/TopListArchiveItemRowView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/Rows/TopListArchiveItemRowView.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct TopListArchiveItemRowView: View {
     let item: TopListData.ArchiveItem
     let showDetails: Bool
-    
+
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
             ZStack(alignment: .leading) {

--- a/Modules/Sources/JetpackStats/Views/TopList/Rows/TopListArchiveSectionRowView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/Rows/TopListArchiveSectionRowView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct TopListArchiveSectionRowView: View {
+    let item: TopListData.ArchiveSection
+    let showDetails: Bool
+    var isExpanded: Bool = false
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(spacing: 4) {
+                Image(systemName: isExpanded ? "chevron.down" : "chevron.forward")
+                    .frame(width: 16)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .animation(.none, value: isExpanded)
+                
+                Text(localizedSectionName)
+                    .font(.callout)
+                    .foregroundColor(.primary)
+                    .lineLimit(1)
+            }
+            .padding(.trailing, 4)
+        }
+    }
+    
+    private var localizedSectionName: String {
+        switch item.sectionName.lowercased() {
+        case "author":
+            return Strings.ArchiveSections.author
+        case "other":
+            return Strings.ArchiveSections.other
+        default:
+            // Fallback to capitalized for any unknown sections
+            return item.sectionName.capitalized
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Views/TopList/Rows/TopListArchiveSectionRowView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/Rows/TopListArchiveSectionRowView.swift
@@ -6,21 +6,20 @@ struct TopListArchiveSectionRowView: View {
     var isExpanded: Bool = false
     
     var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack(spacing: 4) {
-                Image(systemName: isExpanded ? "chevron.down" : "chevron.forward")
-                    .frame(width: 16)
-                    .font(.caption)
-                    .foregroundColor(.secondary)
-                    .animation(.none, value: isExpanded)
-                
-                Text(localizedSectionName)
-                    .font(.callout)
-                    .foregroundColor(.primary)
-                    .lineLimit(1)
-            }
-            .padding(.trailing, 4)
+        HStack(spacing: 0) {
+            Image(systemName: isExpanded ? "chevron.down" : "chevron.forward")
+                .frame(width: 12) // Centering
+                .font(.caption.weight(.semibold))
+                .foregroundColor(.secondary)
+                .frame(width: Constants.step2, alignment: .leading)
+                .animation(.none, value: isExpanded)
+
+            Text(localizedSectionName)
+                .font(.callout)
+                .foregroundColor(.primary)
+                .lineLimit(1)
         }
+        .padding(.trailing, 4)
     }
     
     private var localizedSectionName: String {

--- a/Modules/Sources/JetpackStats/Views/TopList/Rows/TopListExpandableSectionRowView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/Rows/TopListExpandableSectionRowView.swift
@@ -4,7 +4,7 @@ struct TopListExpandableSectionRowView: View {
     let item: any TopListExpandableItem
     let showDetails: Bool
     var isExpanded: Bool = false
-    
+
     var body: some View {
         HStack(spacing: 0) {
             Image(systemName: isExpanded ? "chevron.down" : "chevron.forward")

--- a/Modules/Sources/JetpackStats/Views/TopList/Rows/TopListExpandableSectionRowView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/Rows/TopListExpandableSectionRowView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
-struct TopListArchiveSectionRowView: View {
-    let item: TopListData.ArchiveSection
+struct TopListExpandableSectionRowView: View {
+    let item: any TopListExpandableItem
     let showDetails: Bool
     var isExpanded: Bool = false
     
@@ -14,23 +14,11 @@ struct TopListArchiveSectionRowView: View {
                 .frame(width: Constants.step2, alignment: .leading)
                 .animation(.none, value: isExpanded)
 
-            Text(localizedSectionName)
+            Text(item.displayName)
                 .font(.callout)
                 .foregroundColor(.primary)
                 .lineLimit(1)
         }
         .padding(.trailing, 4)
-    }
-    
-    private var localizedSectionName: String {
-        switch item.sectionName.lowercased() {
-        case "author":
-            return Strings.ArchiveSections.author
-        case "other":
-            return Strings.ArchiveSections.other
-        default:
-            // Fallback to capitalized for any unknown sections
-            return item.sectionName.capitalized
-        }
     }
 }

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemView.swift
@@ -83,6 +83,8 @@ private extension TopListItemView {
         switch currentItem {
         case is TopListData.Post:
             return true
+        case is TopListData.ArchiveItem:
+            return true
         default:
             return false
         }
@@ -95,6 +97,10 @@ private extension TopListItemView {
                 .environment(\.context, context)
                 .environment(\.router, router)
             router.navigate(to: detailsView)
+        case let archiveItem as TopListData.ArchiveItem:
+            if let url = URL(string: archiveItem.href) {
+                router.openURL(url)
+            }
         default:
             break
         }

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemView.swift
@@ -44,6 +44,10 @@ struct TopListItemView: View {
                 TopListSearchTermRowView(item: searchTerm, showDetails: showDetails)
             case let video as TopListData.Video:
                 TopListVideoRowView(item: video, showDetails: showDetails)
+            case let archiveItem as TopListData.ArchiveItem:
+                TopListArchiveItemRowView(item: archiveItem, showDetails: showDetails)
+            case let archiveSection as TopListData.ArchiveSection:
+                TopListArchiveSectionRowView(item: archiveSection, showDetails: showDetails)
             default:
                 let _ = assertionFailure("unsupported item: \(currentItem)")
                 EmptyView()

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemView.swift
@@ -46,8 +46,6 @@ struct TopListItemView: View {
                 TopListVideoRowView(item: video, showDetails: showDetails)
             case let archiveItem as TopListData.ArchiveItem:
                 TopListArchiveItemRowView(item: archiveItem, showDetails: showDetails)
-            case let archiveSection as TopListData.ArchiveSection:
-                TopListArchiveSectionRowView(item: archiveSection, showDetails: showDetails)
             default:
                 let _ = assertionFailure("unsupported item: \(currentItem)")
                 EmptyView()

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
@@ -5,23 +5,120 @@ struct TopListItemsView: View {
     let itemLimit: Int
     let dateRange: StatsDateRange
     var showDetails = true
+    
+    @State private var expandedSections: Set<String> = []
 
     var body: some View {
         VStack(spacing: Constants.step1 / 2) {
             ForEach(data.items.prefix(itemLimit)) { item in
-                TopListItemView(
-                    currentItem: item.current,
-                    previousItem: item.previous,
-                    metric: data.metric,
-                    maxValue: data.maxValue,
-                    showDetails: showDetails,
-                    dateRange: dateRange
-                )
-                .transition(.move(edge: .leading)
-                    .combined(with: .scale(scale: 0.75))
-                    .combined(with: .opacity))
+                if let archiveSection = item.current as? TopListData.ArchiveSection {
+                    // Archive section with expandable items
+                    VStack(spacing: Constants.step1 / 2) {
+                        // Section header
+                        Button {
+                            withAnimation(.easeInOut(duration: 0.25)) {
+                                toggleSection(archiveSection.id)
+                            }
+                        } label: {
+                            ArchiveSectionItemView(
+                                section: archiveSection,
+                                previousItem: item.previous,
+                                metric: data.metric,
+                                maxValue: data.maxValue,
+                                dateRange: dateRange,
+                                isExpanded: expandedSections.contains(archiveSection.id)
+                            )
+                        }
+                        .buttonStyle(PlainButtonStyle())
+                        
+                        // Expandable items
+                        if expandedSections.contains(archiveSection.id) {
+                            VStack(spacing: Constants.step1 / 2) {
+                                ForEach(archiveSection.items) { archiveItem in
+                                    TopListItemView(
+                                        currentItem: archiveItem,
+                                        previousItem: nil,
+                                        metric: data.metric,
+                                        maxValue: data.maxValue,
+                                        showDetails: showDetails,
+                                        dateRange: dateRange
+                                    )
+                                    .padding(.leading, Constants.step4)
+                                    .transition(.asymmetric(
+                                        insertion: .opacity.combined(with: .move(edge: .top)),
+                                        removal: .opacity.combined(with: .move(edge: .top))
+                                    ))
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    // Regular item
+                    TopListItemView(
+                        currentItem: item.current,
+                        previousItem: item.previous,
+                        metric: data.metric,
+                        maxValue: data.maxValue,
+                        showDetails: showDetails,
+                        dateRange: dateRange
+                    )
+                    .transition(.move(edge: .leading)
+                        .combined(with: .scale(scale: 0.75))
+                        .combined(with: .opacity))
+                }
             }
         }
         .animation(.spring, value: ObjectIdentifier(data))
+        .animation(.easeInOut(duration: 0.25), value: expandedSections)
+    }
+    
+    private func toggleSection(_ sectionId: String) {
+        if expandedSections.contains(sectionId) {
+            expandedSections.remove(sectionId)
+        } else {
+            expandedSections.insert(sectionId)
+        }
+    }
+}
+
+// Custom view for archive section header that can show expanded state
+private struct ArchiveSectionItemView: View {
+    let section: TopListData.ArchiveSection
+    let previousItem: (any TopListItem)?
+    let metric: SiteMetric
+    let maxValue: Int
+    let dateRange: StatsDateRange
+    let isExpanded: Bool
+    
+    @Environment(\.router) private var router
+    @Environment(\.context) private var context
+    
+    var body: some View {
+        HStack(spacing: 0) {
+            TopListArchiveSectionRowView(
+                item: section,
+                showDetails: false,
+                isExpanded: isExpanded
+            )
+            
+            Spacer(minLength: 4)
+            
+            TopListMetricsView(
+                currentValue: section.metrics[metric] ?? 0,
+                previousValue: previousItem?.metrics[metric],
+                metric: metric,
+                showDetails: false,
+                showChevron: false
+            )
+        }
+        .padding(.vertical, 7)
+        .background(
+            TopListItemBarBackground(
+                value: section.metrics[metric] ?? 0,
+                maxValue: maxValue,
+                barColor: metric.primaryColor
+            )
+            .padding(.horizontal, -(Constants.step2 / 2))
+        )
     }
 }

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
@@ -1,5 +1,17 @@
 import SwiftUI
 
+// MARK: - View Extension for Conditional Modifiers
+private extension View {
+    @ViewBuilder
+    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
+        if condition {
+            transform(self)
+        } else {
+            self
+        }
+    }
+}
+
 struct TopListItemsView: View {
     let data: TopListChartData
     let itemLimit: Int
@@ -10,33 +22,30 @@ struct TopListItemsView: View {
 
     var body: some View {
         VStack(spacing: Constants.step1 / 2) {
-            ForEach(data.items.prefix(itemLimit)) { item in
-                if let archiveSection = item.current as? TopListData.ArchiveSection {
-                    // Archive section with expandable items
+            ForEach(Array(data.items.prefix(itemLimit))) { item in
+                if let expandableItem = item.current as? any TopListExpandableItem {
+                    // Expandable section with child items
                     VStack(spacing: Constants.step1 / 2) {
-                        // Section header
                         Button {
-                            withAnimation(.easeInOut(duration: 0.25)) {
-                                toggleSection(archiveSection.id)
-                            }
+                            toggleSection(expandableItem.id)
                         } label: {
-                            ArchiveSectionItemView(
-                                section: archiveSection,
-                                previousItem: item.previous,
+                            ExpandableItemView(
+                                section: expandableItem,
+                                previousItem: item.previous as? (any TopListExpandableItem),
                                 metric: data.metric,
                                 maxValue: data.maxValue,
                                 dateRange: dateRange,
-                                isExpanded: expandedSections.contains(archiveSection.id)
+                                isExpanded: expandedSections.contains(expandableItem.id)
                             )
                         }
-                        .buttonStyle(PlainButtonStyle())
-                        
+                        .buttonStyle(.plain)
+
                         // Expandable items
-                        if expandedSections.contains(archiveSection.id) {
+                        if expandedSections.contains(expandableItem.id) {
                             VStack(spacing: Constants.step1 / 2) {
-                                ForEach(archiveSection.items) { archiveItem in
+                                ForEach(Array(expandableItem.items), id: \.id) { childItem in
                                     TopListItemView(
-                                        currentItem: archiveItem,
+                                        currentItem: childItem,
                                         previousItem: nil,
                                         metric: data.metric,
                                         maxValue: data.maxValue,
@@ -53,25 +62,28 @@ struct TopListItemsView: View {
                         }
                     }
                 } else {
-                    // Regular item
-                    TopListItemView(
-                        currentItem: item.current,
-                        previousItem: item.previous,
-                        metric: data.metric,
-                        maxValue: data.maxValue,
-                        showDetails: showDetails,
-                        dateRange: dateRange
-                    )
-                    .transition(.move(edge: .leading)
+                    makeItemView(for: item)
+                        .transition(.move(edge: .leading)
                         .combined(with: .scale(scale: 0.75))
                         .combined(with: .opacity))
                 }
             }
         }
         .animation(.spring, value: ObjectIdentifier(data))
-        .animation(.easeInOut(duration: 0.25), value: expandedSections)
+        .animation(.spring, value: expandedSections)
     }
-    
+
+    private func makeItemView(for item: TopListChartData.Item) -> some View {
+        TopListItemView(
+            currentItem: item.current,
+            previousItem: item.previous,
+            metric: data.metric,
+            maxValue: data.maxValue,
+            showDetails: showDetails,
+            dateRange: dateRange
+        )
+    }
+
     private func toggleSection(_ sectionId: String) {
         if expandedSections.contains(sectionId) {
             expandedSections.remove(sectionId)
@@ -81,22 +93,18 @@ struct TopListItemsView: View {
     }
 }
 
-// Custom view for archive section header that can show expanded state
-private struct ArchiveSectionItemView: View {
-    let section: TopListData.ArchiveSection
-    let previousItem: (any TopListItem)?
+// Generic view for expandable section headers that can show expanded state
+private struct ExpandableItemView: View {
+    let section: any TopListExpandableItem
+    let previousItem: (any TopListExpandableItem)?
     let metric: SiteMetric
     let maxValue: Int
-    let dateRange: StatsDateRange
     let isExpanded: Bool
-    
-    @Environment(\.router) private var router
-    @Environment(\.context) private var context
 
     var body: some View {
         HStack(spacing: 0) {
-            TopListArchiveSectionRowView(
-                item: section,
+            TopListExpandableSectionRowView(
+                item: section as any TopListExpandableItem,
                 showDetails: false,
                 isExpanded: isExpanded
             )

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
@@ -1,17 +1,5 @@
 import SwiftUI
 
-// MARK: - View Extension for Conditional Modifiers
-private extension View {
-    @ViewBuilder
-    func `if`<Content: View>(_ condition: Bool, transform: (Self) -> Content) -> some View {
-        if condition {
-            transform(self)
-        } else {
-            self
-        }
-    }
-}
-
 struct TopListItemsView: View {
     let data: TopListChartData
     let itemLimit: Int
@@ -22,8 +10,8 @@ struct TopListItemsView: View {
 
     var body: some View {
         VStack(spacing: Constants.step1 / 2) {
-            ForEach(Array(data.items.prefix(itemLimit))) { item in
-                if let expandableItem = item.current as? any TopListExpandableItem {
+            ForEach(Array(data.items.prefix(itemLimit)), id: \.id) { item in
+                if let expandableItem = item as? any TopListExpandableItem {
                     // Expandable section with child items
                     VStack(spacing: Constants.step1 / 2) {
                         Button {
@@ -31,7 +19,7 @@ struct TopListItemsView: View {
                         } label: {
                             ExpandableItemView(
                                 section: expandableItem,
-                                previousItem: item.previous as? (any TopListExpandableItem),
+                                previousItem: data.previousItem(for: expandableItem) as? (any TopListExpandableItem),
                                 metric: data.metric,
                                 maxValue: data.maxValue,
                                 dateRange: dateRange,
@@ -62,8 +50,15 @@ struct TopListItemsView: View {
                         }
                     }
                 } else {
-                    makeItemView(for: item)
-                        .transition(.move(edge: .leading)
+                    TopListItemView(
+                        currentItem: item,
+                        previousItem: data.previousItem(for: item),
+                        metric: data.metric,
+                        maxValue: data.maxValue,
+                        showDetails: showDetails,
+                        dateRange: dateRange
+                    )
+                    .transition(.move(edge: .leading)
                         .combined(with: .scale(scale: 0.75))
                         .combined(with: .opacity))
                 }
@@ -71,17 +66,6 @@ struct TopListItemsView: View {
         }
         .animation(.spring, value: ObjectIdentifier(data))
         .animation(.spring, value: expandedSections)
-    }
-
-    private func makeItemView(for item: TopListChartData.Item) -> some View {
-        TopListItemView(
-            currentItem: item.current,
-            previousItem: item.previous,
-            metric: data.metric,
-            maxValue: data.maxValue,
-            showDetails: showDetails,
-            dateRange: dateRange
-        )
     }
 
     private func toggleSection(_ sectionId: String) {

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
@@ -43,7 +43,7 @@ struct TopListItemsView: View {
                                         showDetails: showDetails,
                                         dateRange: dateRange
                                     )
-                                    .padding(.leading, Constants.step4)
+                                    .padding(.leading, Constants.step2)
                                     .transition(.asymmetric(
                                         insertion: .opacity.combined(with: .move(edge: .top)),
                                         removal: .opacity.combined(with: .move(edge: .top))

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
@@ -5,7 +5,7 @@ struct TopListItemsView: View {
     let itemLimit: Int
     let dateRange: StatsDateRange
     var showDetails = true
-    
+
     @State private var expandedSections: Set<TopListItemID> = []
 
     var body: some View {
@@ -94,9 +94,9 @@ private struct ExpandableItemView: View {
                 showDetails: false,
                 isExpanded: isExpanded
             )
-            
+
             Spacer(minLength: 4)
-            
+
             TopListMetricsView(
                 currentValue: section.metrics[metric] ?? 0,
                 previousValue: previousItem?.metrics[metric],

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
@@ -92,7 +92,7 @@ private struct ArchiveSectionItemView: View {
     
     @Environment(\.router) private var router
     @Environment(\.context) private var context
-    
+
     var body: some View {
         HStack(spacing: 0) {
             TopListArchiveSectionRowView(

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
@@ -49,10 +49,6 @@ struct TopListItemsView: View {
                             .transition(.move(edge: .leading)
                                 .combined(with: .scale(scale: 0.75))
                                 .combined(with: .opacity))
-//                            .transition(.asymmetric(
-//                                insertion: .opacity.combined(with: .move(edge: .top)),
-//                                removal: .opacity.combined(with: .move(edge: .top))
-//                            ))
                     }
                 }
             }

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
@@ -6,69 +6,71 @@ struct TopListItemsView: View {
     let dateRange: StatsDateRange
     var showDetails = true
     
-    @State private var expandedSections: Set<String> = []
+    @State private var expandedSections: Set<TopListItemID> = []
 
     var body: some View {
         VStack(spacing: Constants.step1 / 2) {
-            ForEach(Array(data.items.prefix(itemLimit)), id: \.id) { item in
-                if let expandableItem = item as? any TopListExpandableItem {
-                    // Expandable section with child items
-                    VStack(spacing: Constants.step1 / 2) {
-                        Button {
-                            toggleSection(expandableItem.id)
-                        } label: {
-                            ExpandableItemView(
-                                section: expandableItem,
-                                previousItem: data.previousItem(for: expandableItem) as? (any TopListExpandableItem),
-                                metric: data.metric,
-                                maxValue: data.maxValue,
-                                dateRange: dateRange,
-                                isExpanded: expandedSections.contains(expandableItem.id)
-                            )
-                        }
-                        .buttonStyle(.plain)
-
-                        // Expandable items
-                        if expandedSections.contains(expandableItem.id) {
-                            VStack(spacing: Constants.step1 / 2) {
-                                ForEach(Array(expandableItem.items), id: \.id) { childItem in
-                                    TopListItemView(
-                                        currentItem: childItem,
-                                        previousItem: nil,
-                                        metric: data.metric,
-                                        maxValue: data.maxValue,
-                                        showDetails: showDetails,
-                                        dateRange: dateRange
-                                    )
-                                    .padding(.leading, Constants.step2)
-                                    .transition(.asymmetric(
-                                        insertion: .opacity.combined(with: .move(edge: .top)),
-                                        removal: .opacity.combined(with: .move(edge: .top))
-                                    ))
-                                }
-                            }
-                        }
-                    }
+            ForEach(data.items.prefix(itemLimit), id: \.id) { item in
+                if let item = item as? any TopListExpandableItem {
+                    makeExpandableSection(with: item)
                 } else {
-                    TopListItemView(
-                        currentItem: item,
-                        previousItem: data.previousItem(for: item),
-                        metric: data.metric,
-                        maxValue: data.maxValue,
-                        showDetails: showDetails,
-                        dateRange: dateRange
-                    )
-                    .transition(.move(edge: .leading)
-                        .combined(with: .scale(scale: 0.75))
-                        .combined(with: .opacity))
+                    makeView(for: item)
+                        .transition(.move(edge: .leading)
+                            .combined(with: .scale(scale: 0.75))
+                            .combined(with: .opacity))
                 }
             }
         }
         .animation(.spring, value: ObjectIdentifier(data))
-        .animation(.spring, value: expandedSections)
     }
 
-    private func toggleSection(_ sectionId: String) {
+    private func makeExpandableSection(with item: any TopListExpandableItem) -> some View {
+        VStack(spacing: Constants.step1 / 2) {
+            Button {
+                withAnimation(.spring) {
+                    toggleSection(item.id)
+                }
+            } label: {
+                ExpandableItemView(
+                    section: item,
+                    previousItem: data.previousItem(for: item) as? (any TopListExpandableItem),
+                    metric: data.metric,
+                    maxValue: data.maxValue,
+                    isExpanded: expandedSections.contains(item.id)
+                )
+            }
+            .buttonStyle(.plain)
+
+            if expandedSections.contains(item.id) {
+                VStack(spacing: Constants.step1 / 2) {
+                    ForEach(Array(item.children), id: \.id) { child in
+                        makeView(for: child)
+                            .padding(.leading, Constants.step2)
+                            .transition(.move(edge: .leading)
+                                .combined(with: .scale(scale: 0.75))
+                                .combined(with: .opacity))
+//                            .transition(.asymmetric(
+//                                insertion: .opacity.combined(with: .move(edge: .top)),
+//                                removal: .opacity.combined(with: .move(edge: .top))
+//                            ))
+                    }
+                }
+            }
+        }
+    }
+
+    private func makeView(for item: any TopListItem) -> some View {
+        TopListItemView(
+            currentItem: item,
+            previousItem: data.previousItem(for: item),
+            metric: data.metric,
+            maxValue: data.maxValue,
+            showDetails: showDetails,
+            dateRange: dateRange
+        )
+    }
+
+    private func toggleSection(_ sectionId: TopListItemID) {
         if expandedSections.contains(sectionId) {
             expandedSections.remove(sectionId)
         } else {

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListMetricsView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListMetricsView.swift
@@ -15,7 +15,7 @@ struct TopListMetricsView: View {
                     .foregroundColor(.primary)
                     .contentTransition(.numericText())
 
-                if hasDetails {
+                if showChevron {
                     Image(systemName: "chevron.forward")
                         .font(.caption2.weight(.bold))
                         .foregroundStyle(Color(.tertiaryLabel))

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListMetricsView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListMetricsView.swift
@@ -15,9 +15,11 @@ struct TopListMetricsView: View {
                     .foregroundColor(.primary)
                     .contentTransition(.numericText())
 
-                Image(systemName: "chevron.forward")
-                    .font(.caption2.weight(.bold))
-                    .foregroundStyle(Color(.tertiaryLabel))
+                if hasDetails {
+                    Image(systemName: "chevron.forward")
+                        .font(.caption2.weight(.bold))
+                        .foregroundStyle(Color(.tertiaryLabel))
+                }
             }
             if showDetails, let trend {
                 Text(trend.formattedTrend)


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/CMM-620/top-list-archive.

Adds the new "Archive" top list, powered by the new API. Adds support for expandable sections in top lists.

<img width="360"  alt="Screenshot 2025-07-25 at 9 33 11 AM" src="https://github.com/user-attachments/assets/f894e617-af8a-4ffc-a90e-cc6ef605c178" />
<img width="338" alt="Screenshot 2025-07-25 at 9 33 07 AM" src="https://github.com/user-attachments/assets/12e211a8-530e-4f32-a6e9-c06fa3cee749" />
