### PR TITLE
Fix a flaky unit test

### DIFF
--- a/Tests/KeystoneTests/Tests/Models/Blog+RestAPITests.swift
+++ b/Tests/KeystoneTests/Tests/Models/Blog+RestAPITests.swift
@@ -14,8 +14,9 @@ final class Blog_RestAPITests: CoreDataTestCase {
 
     private var blog: Blog!
 
+    @MainActor
     override func setUp() async throws {
-        _ = try await Blog.createRestApiBlog(
+        let blogId = try await Blog.createRestApiBlog(
             with: loginDetails,
             restApiRootURL: URL(string: "https://example.com/wp-json")!,
             xmlrpcEndpointURL: URL(string: "https://example.com/dir/xmlrpc.php")!,
@@ -23,7 +24,7 @@ final class Blog_RestAPITests: CoreDataTestCase {
             in: contextManager,
             using: testKeychain
         )
-        self.blog = try XCTUnwrap(contextManager.mainContext.fetch(NSFetchRequest<Blog>(entityName: "Blog")).first)
+        self.blog = try XCTUnwrap(contextManager.mainContext.existingObject(with: blogId))
         try blog.setPassword(to: "account-password", using: testKeychain)
     }
 


### PR DESCRIPTION
## Description

The unit test has been randomly causing crashes in unit test runs.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
