### PR TITLE
New Stats: Analytics

### DIFF
--- a/Modules/Sources/JetpackStats/Analytics/MockStatsTracker.swift
+++ b/Modules/Sources/JetpackStats/Analytics/MockStatsTracker.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// A no-op implementation of StatsTracker for testing and development
+final class MockStatsTracker: StatsTracker, Sendable {
+    static let shared = MockStatsTracker()
+
+    private init() {}
+
+    func send(_ event: StatsEvent, properties: [String: String]) {
+#if DEBUG
+        // In debug builds, print events to console for debugging
+        debugPrint("[StatsTracker] Event: \(event) \(properties)")
+#endif
+    }
+}

--- a/Modules/Sources/JetpackStats/Analytics/StatsEvent.swift
+++ b/Modules/Sources/JetpackStats/Analytics/StatsEvent.swift
@@ -59,38 +59,21 @@ public enum StatsEvent {
 
     // MARK: - Card Events
 
-    /// Card added to dashboard
-    /// - Parameters:
-    ///   - "card_type": Type of card (e.g., "chart", "top_list", "realtime_metrics")
-    ///   - "configuration": Card configuration details
-    case cardAdded
-
-    /// Card removed from dashboard
-    /// - Parameters:
-    ///   - "card_type": Type of card
-    case cardRemoved
-
-    /// Card customization initiated
-    /// - Parameters:
-    ///   - "card_type": Type of card
-    case cardCustomizationOpened
-
-    /// Card configuration saved
-    /// - Parameters:
-    ///   - "card_type": Type of card
-    ///   - "changes": Summary of changes made
-    case cardConfigurationSaved
-
     /// Card shown on screen
     /// - Parameters:
     ///   - "card_type": Type of card (e.g., "chart", "top_list")
     ///   - "configuration": Card configuration details (e.g., metrics, item type)
     case cardShown
 
-    /// Card edit menu opened
+    /// Card added to dashboard
+    /// - Parameters:
+    ///   - "card_type": Type of card (e.g., "chart", "top_list")
+    case cardAdded
+
+    /// Card removed from dashboard
     /// - Parameters:
     ///   - "card_type": Type of card
-    case cardEditMenuOpened
+    case cardRemoved
 
     // MARK: - Chart Events
 
@@ -105,13 +88,6 @@ public enum StatsEvent {
     ///   - "metric": The metric selected (e.g., "visitors", "views", "likes")
     case chartMetricSelected
 
-    /// Chart data point selected
-    /// - Parameters:
-    ///   - "metric": The metric being viewed
-    ///   - "date": The date of the data point
-    ///   - "value": The value at that point
-    case chartDataPointSelected
-
     // MARK: - List Events
 
     /// Top list item tapped
@@ -119,42 +95,6 @@ public enum StatsEvent {
     ///   - "item_type": Type of item (e.g., "posts_and_pages", "authors", "locations", "referrers")
     ///   - "metric": The metric being sorted by
     case topListItemTapped
-
-    /// Top list filter applied
-    /// - Parameters:
-    ///   - "filter_type": Type of filter applied
-    ///   - "filter_value": Value of the filter
-    ///   - "list_type": Type of list being filtered
-    case topListFilterApplied
-
-    /// Top list sorted
-    /// - Parameters:
-    ///   - "sort_by": Metric used for sorting
-    ///   - "list_type": Type of list being sorted
-    case topListSorted
-
-    // MARK: - Export Events
-
-    /// Export completed
-    /// - Parameters:
-    ///   - "export_type": Type of export
-    ///   - "data_type": What was exported
-    ///   - "row_count": Number of rows exported
-    case exportCompleted
-
-    /// Export failed
-    /// - Parameters:
-    ///   - "export_type": Type of export
-    ///   - "error_type": Type of error encountered
-    case exportFailed
-
-    // MARK: - Map Events
-
-    /// Map interaction
-    /// - Parameters:
-    ///   - "interaction_type": Type of interaction (e.g., "tap", "zoom", "pan")
-    ///   - "country_code": Country code if a country was selected
-    case mapInteraction
 
     // MARK: - Navigation Events
 
@@ -164,29 +104,6 @@ public enum StatsEvent {
     ///   - "previous_tab": Name of the previous tab
     case statsTabSelected
 
-    /// Back navigation
-    /// - Parameters:
-    ///   - "from_screen": Screen navigating from
-    ///   - "to_screen": Screen navigating to
-    case backNavigationTapped
-
-    // MARK: - Action Events
-
-    /// Refresh initiated
-    case refreshInitiated
-
-    /// Share action
-    /// - Parameters:
-    ///   - "content_type": What's being shared (e.g., "chart", "stats_summary")
-    ///   - "share_method": How it's being shared (e.g., "copy", "email", "social")
-    case shareActionPerformed
-
-    /// Help accessed
-    /// - Parameters:
-    ///   - "help_topic": Topic of help accessed
-    ///   - "source_screen": Where help was accessed from
-    case helpAccessed
-
     // MARK: - Error Events
 
     /// Error encountered
@@ -195,12 +112,6 @@ public enum StatsEvent {
     ///   - "error_code": Specific error code if available
     ///   - "screen": Where the error occurred
     case errorEncountered
-
-    /// Error retry attempted
-    /// - Parameters:
-    ///   - "error_type": Type of error being retried
-    ///   - "retry_count": Number of retry attempts
-    case errorRetryAttempted
 }
 
 // MARK: - StatsTracker Protocol

--- a/Modules/Sources/JetpackStats/Analytics/StatsEvent.swift
+++ b/Modules/Sources/JetpackStats/Analytics/StatsEvent.swift
@@ -1,0 +1,280 @@
+import Foundation
+
+/// Analytics events for tracking user interactions within the Stats module
+///
+/// IMPORTANT: Do not include personally identifiable information (PII) in analytics events.
+/// This includes but is not limited to:
+/// - User IDs, author IDs, or any unique identifiers
+/// - Email addresses
+/// - URLs that might contain sensitive information
+/// - Post IDs or content identifiers
+///
+/// Instead, track only:
+/// - Event types and categories
+/// - Navigation sources
+/// - UI states and configurations
+/// - Aggregated metrics
+public enum StatsEvent {
+    // MARK: - Screen View Events
+
+    /// Main stats screen shown
+    case statsMainScreenShown
+
+    /// Traffic tab shown
+    case trafficTabShown
+
+    /// Realtime tab shown
+    case realtimeTabShown
+
+    /// Subscribers tab shown
+    case subscribersTabShown
+
+    /// Post details screen shown
+    case postDetailsScreenShown
+
+    /// Author stats screen shown
+    case authorStatsScreenShown
+
+    /// Archive stats screen shown
+    case archiveStatsScreenShown
+
+    /// External link stats screen shown
+    case externalLinkStatsScreenShown
+
+    /// Referrer stats screen shown
+    case referrerStatsScreenShown
+
+    // MARK: - Date Range Events
+
+    /// Date range preset selected
+    /// - Parameters:
+    ///   - "selected_preset": The preset selected (e.g., "last_7_days", "last_28_days", "last_90_days", "last_365_days")
+    case dateRangePresetSelected
+
+    /// Custom date range selected
+    /// - Parameters:
+    ///   - "start_date": Start date in ISO format
+    ///   - "end_date": End date in ISO format
+    case customDateRangeSelected
+
+    // MARK: - Card Events
+
+    /// Card added to dashboard
+    /// - Parameters:
+    ///   - "card_type": Type of card (e.g., "chart", "top_list", "realtime_metrics")
+    ///   - "configuration": Card configuration details
+    case cardAdded
+
+    /// Card removed from dashboard
+    /// - Parameters:
+    ///   - "card_type": Type of card
+    case cardRemoved
+
+    /// Card customization initiated
+    /// - Parameters:
+    ///   - "card_type": Type of card
+    case cardCustomizationOpened
+
+    /// Card configuration saved
+    /// - Parameters:
+    ///   - "card_type": Type of card
+    ///   - "changes": Summary of changes made
+    case cardConfigurationSaved
+
+    /// Card shown on screen
+    /// - Parameters:
+    ///   - "card_type": Type of card (e.g., "chart", "top_list")
+    ///   - "configuration": Card configuration details (e.g., metrics, item type)
+    case cardShown
+
+    /// Card edit menu opened
+    /// - Parameters:
+    ///   - "card_type": Type of card
+    case cardEditMenuOpened
+
+    // MARK: - Chart Events
+
+    /// Chart type changed
+    /// - Parameters:
+    ///   - "from_type": Previous chart type (e.g., "line", "bar")
+    ///   - "to_type": New chart type
+    case chartTypeChanged
+
+    /// Chart metric selected
+    /// - Parameters:
+    ///   - "metric": The metric selected (e.g., "visitors", "views", "likes")
+    case chartMetricSelected
+
+    /// Chart data point selected
+    /// - Parameters:
+    ///   - "metric": The metric being viewed
+    ///   - "date": The date of the data point
+    ///   - "value": The value at that point
+    case chartDataPointSelected
+
+    // MARK: - List Events
+
+    /// Top list item tapped
+    /// - Parameters:
+    ///   - "item_type": Type of item (e.g., "posts_and_pages", "authors", "locations", "referrers")
+    ///   - "metric": The metric being sorted by
+    case topListItemTapped
+
+    /// Top list filter applied
+    /// - Parameters:
+    ///   - "filter_type": Type of filter applied
+    ///   - "filter_value": Value of the filter
+    ///   - "list_type": Type of list being filtered
+    case topListFilterApplied
+
+    /// Top list sorted
+    /// - Parameters:
+    ///   - "sort_by": Metric used for sorting
+    ///   - "list_type": Type of list being sorted
+    case topListSorted
+
+    // MARK: - Export Events
+
+    /// Export completed
+    /// - Parameters:
+    ///   - "export_type": Type of export
+    ///   - "data_type": What was exported
+    ///   - "row_count": Number of rows exported
+    case exportCompleted
+
+    /// Export failed
+    /// - Parameters:
+    ///   - "export_type": Type of export
+    ///   - "error_type": Type of error encountered
+    case exportFailed
+
+    // MARK: - Map Events
+
+    /// Map interaction
+    /// - Parameters:
+    ///   - "interaction_type": Type of interaction (e.g., "tap", "zoom", "pan")
+    ///   - "country_code": Country code if a country was selected
+    case mapInteraction
+
+    // MARK: - Navigation Events
+
+    /// Stats tab selected
+    /// - Parameters:
+    ///   - "tab_name": Name of the tab selected
+    ///   - "previous_tab": Name of the previous tab
+    case statsTabSelected
+
+    /// Back navigation
+    /// - Parameters:
+    ///   - "from_screen": Screen navigating from
+    ///   - "to_screen": Screen navigating to
+    case backNavigationTapped
+
+    // MARK: - Action Events
+
+    /// Refresh initiated
+    case refreshInitiated
+
+    /// Share action
+    /// - Parameters:
+    ///   - "content_type": What's being shared (e.g., "chart", "stats_summary")
+    ///   - "share_method": How it's being shared (e.g., "copy", "email", "social")
+    case shareActionPerformed
+
+    /// Help accessed
+    /// - Parameters:
+    ///   - "help_topic": Topic of help accessed
+    ///   - "source_screen": Where help was accessed from
+    case helpAccessed
+
+    // MARK: - Error Events
+
+    /// Error encountered
+    /// - Parameters:
+    ///   - "error_type": Type of error (e.g., "network", "parsing", "permission")
+    ///   - "error_code": Specific error code if available
+    ///   - "screen": Where the error occurred
+    case errorEncountered
+
+    /// Error retry attempted
+    /// - Parameters:
+    ///   - "error_type": Type of error being retried
+    ///   - "retry_count": Number of retry attempts
+    case errorRetryAttempted
+}
+
+// MARK: - StatsTracker Protocol
+
+/// Protocol for tracking analytics events in the Stats module
+public protocol StatsTracker: Sendable {
+    /// Send an analytics event
+    /// - Parameters:
+    ///   - event: The event to track
+    ///   - properties: Additional properties for the event
+    func send(_ event: StatsEvent, properties: [String: String])
+}
+
+// MARK: - StatsTracker Convenience
+
+extension StatsTracker {
+    /// Convenience method to send events without properties
+    func send(_ event: StatsEvent) {
+        send(event, properties: [:])
+    }
+}
+
+// MARK: - Private Extensions
+
+extension DateIntervalPreset {
+    /// Analytics tracking name for the preset
+    var analyticsName: String {
+        switch self {
+        case .today: "today"
+        case .thisWeek: "this_week"
+        case .thisMonth: "this_month"
+        case .thisQuarter: "this_quarter"
+        case .thisYear: "this_year"
+        case .last7Days: "last_7_days"
+        case .last28Days: "last_28_days"
+        case .last30Days: "last_30_days"
+        case .last90Days: "last_90_days"
+        case .last6Months: "last_6_months"
+        case .last12Months: "last_12_months"
+        case .last3Years: "last_3_years"
+        case .last10Years: "last_10_years"
+        }
+    }
+}
+
+extension TopListItemType {
+    /// Analytics tracking name for the item type
+    var analyticsName: String {
+        switch self {
+        case .postsAndPages: "posts_and_pages"
+        case .authors: "authors"
+        case .referrers: "referrers"
+        case .locations: "locations"
+        case .videos: "videos"
+        case .externalLinks: "external_links"
+        case .searchTerms: "search_terms"
+        case .fileDownloads: "file_downloads"
+        case .archive: "archive"
+        }
+    }
+}
+
+extension SiteMetric {
+    /// Analytics tracking name for the metric
+    var analyticsName: String {
+        switch self {
+        case .views: "views"
+        case .visitors: "visitors"
+        case .likes: "likes"
+        case .comments: "comments"
+        case .posts: "posts"
+        case .timeOnSite: "time_on_site"
+        case .bounceRate: "bounce_rate"
+        case .downloads: "downloads"
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Analytics/StatsTracker+ErrorTracking.swift
+++ b/Modules/Sources/JetpackStats/Analytics/StatsTracker+ErrorTracking.swift
@@ -40,26 +40,16 @@ extension StatsTracker {
     /// Determine specific network error type
     private func urlErrorType(_ error: URLError) -> String {
         switch error.code {
-        case .notConnectedToInternet:
-            return "network_offline"
-        case .timedOut:
-            return "network_timeout"
-        case .cannotFindHost, .cannotConnectToHost:
-            return "network_host_unreachable"
-        case .networkConnectionLost:
-            return "network_connection_lost"
-        case .dnsLookupFailed:
-            return "network_dns_failed"
-        case .httpTooManyRedirects:
-            return "network_too_many_redirects"
-        case .resourceUnavailable:
-            return "network_resource_unavailable"
-        case .dataNotAllowed:
-            return "network_data_not_allowed"
-        case .secureConnectionFailed:
-            return "network_ssl_failed"
-        default:
-            return "network"
+        case .notConnectedToInternet: "network_offline"
+        case .timedOut: "network_timeout"
+        case .cannotFindHost, .cannotConnectToHost: "network_host_unreachable"
+        case .networkConnectionLost: "network_connection_lost"
+        case .dnsLookupFailed: "network_dns_failed"
+        case .httpTooManyRedirects: "network_too_many_redirects"
+        case .resourceUnavailable: "network_resource_unavailable"
+        case .dataNotAllowed: "network_data_not_allowed"
+        case .secureConnectionFailed: "network_ssl_failed"
+        default: "other"
         }
     }
 }

--- a/Modules/Sources/JetpackStats/Analytics/StatsTracker+ErrorTracking.swift
+++ b/Modules/Sources/JetpackStats/Analytics/StatsTracker+ErrorTracking.swift
@@ -16,7 +16,7 @@ extension StatsTracker {
         case is DecodingError:
             errorType = "parsing"
         case is CancellationError:
-            errorType = "cancelled"
+            return
         default:
             // Check for common error domains
             let nsError = error as NSError

--- a/Modules/Sources/JetpackStats/Analytics/StatsTracker+ErrorTracking.swift
+++ b/Modules/Sources/JetpackStats/Analytics/StatsTracker+ErrorTracking.swift
@@ -1,0 +1,65 @@
+import Foundation
+
+extension StatsTracker {
+    /// Convenience method to track errors with automatic type detection
+    /// - Parameters:
+    ///   - error: The error to track
+    ///   - screen: The screen where the error occurred
+    func trackError(_ error: Error, screen: String) {
+        let errorType: String
+        let errorCode = (error as NSError).code
+
+        // Determine error type based on the error instance
+        switch error {
+        case let urlError as URLError:
+            errorType = urlErrorType(urlError)
+        case is DecodingError:
+            errorType = "parsing"
+        case is CancellationError:
+            errorType = "cancelled"
+        default:
+            // Check for common error domains
+            let nsError = error as NSError
+            switch nsError.domain {
+            case NSCocoaErrorDomain:
+                errorType = "cocoa_\(errorCode)"
+            case NSURLErrorDomain:
+                errorType = "url_\(errorCode)"
+            default:
+                errorType = "unknown"
+            }
+        }
+
+        send(.errorEncountered, properties: [
+            "error_type": errorType,
+            "error_code": "\(errorCode)",
+            "screen": screen
+        ])
+    }
+
+    /// Determine specific network error type
+    private func urlErrorType(_ error: URLError) -> String {
+        switch error.code {
+        case .notConnectedToInternet:
+            return "network_offline"
+        case .timedOut:
+            return "network_timeout"
+        case .cannotFindHost, .cannotConnectToHost:
+            return "network_host_unreachable"
+        case .networkConnectionLost:
+            return "network_connection_lost"
+        case .dnsLookupFailed:
+            return "network_dns_failed"
+        case .httpTooManyRedirects:
+            return "network_too_many_redirects"
+        case .resourceUnavailable:
+            return "network_resource_unavailable"
+        case .dataNotAllowed:
+            return "network_data_not_allowed"
+        case .secureConnectionFailed:
+            return "network_ssl_failed"
+        default:
+            return "network"
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Cards/ChartCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/ChartCard.swift
@@ -129,7 +129,12 @@ struct ChartCard: View {
     private var cardFooterView: some View {
         MetricsOverviewTabView(
             data: viewModel.isFirstLoad ? viewModel.placeholderTabViewData : viewModel.tabViewData,
-            selectedMetric: $viewModel.selectedMetric
+            selectedMetric: $viewModel.selectedMetric,
+            onMetricSelected: { metric in
+                viewModel.tracker?.send(.chartMetricSelected, properties: [
+                    "metric": metric.analyticsName
+                ])
+            }
         )
         .redacted(reason: viewModel.isFirstLoad ? .placeholder : [])
         .pulsating(viewModel.isFirstLoad)
@@ -170,7 +175,14 @@ struct ChartCard: View {
             ControlGroup {
                 ForEach(ChartType.allCases, id: \.self) { type in
                     Button {
+                        let previousType = viewModel.selectedChartType
                         viewModel.selectedChartType = type
+
+                        // Track chart type change
+                        viewModel.tracker?.send(.chartTypeChanged, properties: [
+                            "from_type": previousType.rawValue,
+                            "to_type": type.rawValue
+                        ])
                     } label: {
                         Label(type.localizedTitle, systemImage: type.systemImage)
                     }
@@ -257,7 +269,8 @@ private struct ChartCardPreview: View {
             metrics: [.views, .visitors, .likes, .comments]
         ),
         dateRange: Calendar.demo.makeDateRange(for: .today),
-        service: MockStatsService()
+        service: MockStatsService(),
+        tracker: MockStatsTracker.shared
     )
 
     var body: some View {

--- a/Modules/Sources/JetpackStats/Cards/ChartCardViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/ChartCardViewModel.swift
@@ -30,6 +30,7 @@ final class ChartCardViewModel: ObservableObject, TrafficCardViewModel {
     }
 
     private let service: any StatsServiceProtocol
+    let tracker: (any StatsTracker)?
 
     private var loadingTask: Task<Void, Never>?
     private var loadRequestCount = 0
@@ -38,12 +39,18 @@ final class ChartCardViewModel: ObservableObject, TrafficCardViewModel {
 
     var isFirstLoad: Bool { isLoading && chartData.isEmpty }
 
-    init(configuration: ChartCardConfiguration, dateRange: StatsDateRange, service: any StatsServiceProtocol) {
+    init(
+        configuration: ChartCardConfiguration,
+        dateRange: StatsDateRange,
+        service: any StatsServiceProtocol,
+        tracker: (any StatsTracker)? = nil
+    ) {
         self.configuration = configuration
         self.selectedMetric = configuration.metrics.first ?? .views
         self.selectedChartType = configuration.chartType
         self.dateRange = dateRange
         self.service = service
+        self.tracker = tracker
     }
 
     func updateConfiguration(_ newConfiguration: ChartCardConfiguration) {
@@ -65,6 +72,14 @@ final class ChartCardViewModel: ObservableObject, TrafficCardViewModel {
     func onAppear() {
         guard isFirstAppear else { return }
         isFirstAppear = false
+
+        // Track card shown event
+        tracker?.send(.cardShown, properties: [
+            "card_type": "chart",
+            "configuration": metrics.map { $0.analyticsName }.joined(separator: "_"),
+            "chart_type": selectedChartType.rawValue
+        ])
+
         loadData(for: dateRange)
     }
 
@@ -121,6 +136,7 @@ final class ChartCardViewModel: ObservableObject, TrafficCardViewModel {
             return
         } catch {
             loadingError = error
+            tracker?.trackError(error, screen: "chart_card")
         }
 
         loadRequestCount = 0

--- a/Modules/Sources/JetpackStats/Cards/TopListCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListCard.swift
@@ -130,6 +130,7 @@ struct TopListCard: View {
             selection: viewModel.selection,
             dateRange: viewModel.dateRange,
             service: context.service,
+            context: context,
             initialData: viewModel.data,
             filter: viewModel.filter
         )
@@ -318,7 +319,8 @@ private struct TopListCardPreview: View {
                 metric: item == .fileDownloads ? .downloads : .views
             ),
             dateRange: Calendar.demo.makeDateRange(for: .last28Days),
-            service: MockStatsService()
+            service: MockStatsService(),
+            tracker: MockStatsTracker.shared
         ))
     }
 

--- a/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
@@ -35,6 +35,7 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
     let filter: Filter?
 
     private let service: any StatsServiceProtocol
+    let tracker: (any StatsTracker)?
     private let fetchLimit: Int?
 
     private var loadingTask: Task<Void, Never>?
@@ -62,6 +63,7 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
         configuration: TopListCardConfiguration,
         dateRange: StatsDateRange,
         service: any StatsServiceProtocol,
+        tracker: (any StatsTracker)? = nil,
         items: [TopListItemType]? = nil,
         fetchLimit: Int? = 100,
         filter: Filter? = nil,
@@ -72,6 +74,7 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
         self.items = items ?? service.supportedItems
         self.dateRange = dateRange
         self.service = service
+        self.tracker = tracker
         self.fetchLimit = fetchLimit
         self.filter = filter
         self.data = initialData
@@ -99,6 +102,15 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
     func onAppear() {
         guard isFirstAppear else { return }
         isFirstAppear = false
+
+        // Track card shown event
+        tracker?.send(.cardShown, properties: [
+            "card_type": "top_list",
+            "configuration": "\(selection.item.analyticsName)_\(selection.metric.analyticsName)",
+            "item_type": selection.item.analyticsName,
+            "metric": selection.metric.analyticsName
+        ])
+
         loadData()
     }
 
@@ -163,6 +175,7 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
         } catch {
             loadingError = error
             data = nil
+            tracker?.trackError(error, screen: "top_list_card")
         }
 
         loadRequestCount = 0

--- a/Modules/Sources/JetpackStats/Charts/Helpers/ChartAverageAnnotation.swift
+++ b/Modules/Sources/JetpackStats/Charts/Helpers/ChartAverageAnnotation.swift
@@ -3,7 +3,7 @@ import SwiftUI
 struct ChartAverageAnnotation: View {
     let value: Int
     let formatter: StatsValueFormatter
-    
+
     var body: some View {
         Text(formatter.format(value: value, context: .compact))
             .font(.caption2.weight(.medium)).tracking(-0.1)

--- a/Modules/Sources/JetpackStats/Screens/ArchiveStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/ArchiveStatsView.swift
@@ -21,6 +21,9 @@ struct ArchiveStatsView: View {
             .padding(.horizontal, Constants.cardHorizontalInset(for: horizontalSizeClass))
         }
         .background(Constants.Colors.background)
+        .onAppear {
+            context.tracker?.send(.archiveStatsScreenShown)
+        }
         .navigationTitle(archiveSection.displayName)
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/Modules/Sources/JetpackStats/Screens/AuthorStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/AuthorStatsView.swift
@@ -28,6 +28,7 @@ struct AuthorStatsView: View {
             configuration: configuration,
             dateRange: range,
             service: context.service,
+            tracker: context.tracker,
             items: [.postsAndPages],
             filter: .author(userId: author.userId)
         ))
@@ -55,6 +56,9 @@ struct AuthorStatsView: View {
         .animation(.spring, value: viewModel.data.map(ObjectIdentifier.init))
         .onChange(of: dateRange) { newRange in
             viewModel.dateRange = newRange
+        }
+        .onAppear {
+            context.tracker?.send(.authorStatsScreenShown)
         }
         .navigationTitle(Strings.AuthorDetails.title)
         .navigationBarTitleDisplayMode(.inline)

--- a/Modules/Sources/JetpackStats/Screens/ExternalLinkStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/ExternalLinkStatsView.swift
@@ -26,6 +26,9 @@ struct ExternalLinkStatsView: View {
             .frame(maxWidth: .infinity)
         }
         .background(Constants.Colors.background)
+        .onAppear {
+            context.tracker?.send(.externalLinkStatsScreenShown)
+        }
         .navigationTitle(Strings.ExternalLinkDetails.title)
         .navigationBarTitleDisplayMode(.inline)
     }

--- a/Modules/Sources/JetpackStats/Screens/PostStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/PostStatsView.swift
@@ -73,6 +73,9 @@ public struct PostStatsView: View {
         .background(Constants.Colors.background)
         .navigationTitle(Strings.PostDetails.title)
         .navigationBarTitleDisplayMode(.inline)
+        .onAppear {
+            context.tracker?.send(.postDetailsScreenShown)
+        }
         .task {
             await loadPostDetails()
         }

--- a/Modules/Sources/JetpackStats/Screens/ReferrerStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/ReferrerStatsView.swift
@@ -30,6 +30,9 @@ struct ReferrerStatsView: View {
             .frame(maxWidth: .infinity)
         }
         .background(Constants.Colors.background)
+        .onAppear {
+            context.tracker?.send(.referrerStatsScreenShown)
+        }
         .navigationTitle(Strings.ReferrerDetails.title)
         .navigationBarTitleDisplayMode(.inline)
         .alert(Strings.ReferrerDetails.errorAlertTitle, isPresented: $showErrorAlert) {

--- a/Modules/Sources/JetpackStats/Screens/StatsMainView.swift
+++ b/Modules/Sources/JetpackStats/Screens/StatsMainView.swift
@@ -33,12 +33,21 @@ public struct StatsMainView: View {
                 .navigationBarTitleDisplayMode(.inline)
                 .environment(\.context, context)
                 .environment(\.router, router)
+                .onAppear {
+                    context.tracker?.send(.statsMainScreenShown)
+                }
+                .onChange(of: selectedTab) { newValue in
+                    trackTabChange(from: selectedTab, to: newValue)
+                }
         } else {
             // When tabs are hidden, show only traffic tab without the tab bar
             TrafficTabView(viewModel: viewModel, topPadding: Constants.step1)
                 .background(Constants.Colors.background)
                 .environment(\.context, context)
                 .environment(\.router, router)
+                .onAppear {
+                    context.tracker?.send(.statsMainScreenShown)
+                }
         }
     }
 
@@ -47,13 +56,29 @@ public struct StatsMainView: View {
         switch selectedTab {
         case .traffic:
             TrafficTabView(viewModel: viewModel)
+                .onAppear {
+                    context.tracker?.send(.trafficTabShown)
+                }
         case .realtime:
             RealtimeTabView()
+                .onAppear {
+                    context.tracker?.send(.realtimeTabShown)
+                }
         case .insights:
             InsightsTabView()
         case .subscribers:
             SubscribersTabView()
+                .onAppear {
+                    context.tracker?.send(.subscribersTabShown)
+                }
         }
+    }
+
+    private func trackTabChange(from oldTab: StatsTab, to newTab: StatsTab) {
+        context.tracker?.send(.statsTabSelected, properties: [
+            "tab_name": newTab.analyticsName,
+            "previous_tab": oldTab.analyticsName
+        ])
     }
 }
 

--- a/Modules/Sources/JetpackStats/Screens/TopListScreenView.swift
+++ b/Modules/Sources/JetpackStats/Screens/TopListScreenView.swift
@@ -13,6 +13,7 @@ struct TopListScreenView: View {
         selection: TopListViewModel.Selection,
         dateRange: StatsDateRange,
         service: any StatsServiceProtocol,
+        context: StatsContext,
         initialData: TopListData? = nil,
         filter: TopListViewModel.Filter? = nil,
     ) {
@@ -24,6 +25,7 @@ struct TopListScreenView: View {
             configuration: configuration,
             dateRange: dateRange,
             service: service,
+            tracker: context.tracker,
             fetchLimit: nil, // Get all items
             filter: filter,
             initialData: initialData
@@ -233,7 +235,8 @@ struct TopListScreenView: View {
         TopListScreenView(
             selection: .init(item: .postsAndPages, metric: .views),
             dateRange: Calendar.demo.makeDateRange(for: .last28Days),
-            service: MockStatsService()
+            service: MockStatsService(),
+            context: .demo
         )
     }
 }

--- a/Modules/Sources/JetpackStats/Services/StatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/StatsService.swift
@@ -163,8 +163,6 @@ actor StatsService: StatsServiceProtocol {
                     TopListItem.Post($0, dateFormatter: dateFormatter)
                 }
                 return TopListResponse(items: sortItems(items))
-            case .comments:
-                fatalError()
             default:
                 throw StatsServiceError.unavailable
             }

--- a/Modules/Sources/JetpackStats/StatsContext.swift
+++ b/Modules/Sources/JetpackStats/StatsContext.swift
@@ -11,6 +11,8 @@ public struct StatsContext: Sendable {
     let siteID: Int
     /// A closure to preprocess avatar URLs to request the appropriate pixel size.
     public var preprocessAvatar: (@Sendable (URL, CGFloat) -> URL)?
+    /// Analytics tracker for monitoring user interactions
+    public var tracker: (any StatsTracker)?
 
     public init(timeZone: TimeZone, siteID: Int, api: WordPressComRestApi) {
         self.init(timeZone: timeZone, siteID: siteID, service: StatsService(siteID: siteID, api: api, timeZone: timeZone))
@@ -28,9 +30,16 @@ public struct StatsContext: Sendable {
         self.service = service
         self.formatters = StatsFormatters(timeZone: timeZone)
         self.preprocessAvatar = nil
+        self.tracker = nil
     }
 
-    public static let demo = StatsContext(timeZone: .current, siteID: 1, service: MockStatsService())
+    public static let demo: StatsContext = {
+        var context = StatsContext(timeZone: .current, siteID: 1, service: MockStatsService())
+        #if DEBUG
+        context.tracker = MockStatsTracker.shared
+        #endif
+        return context
+    }()
 
     /// Memoized formatted pre-configured to work with the reporting time zone.
     final class StatsFormatters: Sendable {

--- a/Modules/Sources/JetpackStats/StatsViewModel.swift
+++ b/Modules/Sources/JetpackStats/StatsViewModel.swift
@@ -104,13 +104,15 @@ final class StatsViewModel: ObservableObject, CardConfigurationDelegate {
             viewModel = ChartCardViewModel(
                 configuration: configuration,
                 dateRange: dateRange,
-                service: context.service
+                service: context.service,
+                tracker: context.tracker
             )
         case .topList(let configuration):
             viewModel = TopListViewModel(
                 configuration: configuration,
                 dateRange: dateRange,
-                service: context.service
+                service: context.service,
+                tracker: context.tracker
             )
         }
 

--- a/Modules/Sources/JetpackStats/StatsViewModel.swift
+++ b/Modules/Sources/JetpackStats/StatsViewModel.swift
@@ -133,6 +133,9 @@ final class StatsViewModel: ObservableObject, CardConfigurationDelegate {
         trafficCardConfiguration.cards.append(card)
         saveConfiguration()
 
+        // Track card added event
+        context.tracker?.send(.cardAdded, properties: ["card_type": cardType(for: card)])
+
         // Create and append the view model
         if let viewModel = createViewModel(for: card) {
             cards.append(viewModel)
@@ -178,6 +181,9 @@ final class StatsViewModel: ObservableObject, CardConfigurationDelegate {
     }
 
     func deleteCard(_ card: any TrafficCardViewModel) {
+        // Track card removed event
+        context.tracker?.send(.cardRemoved, properties: ["card_type": cardType(for: card)])
+
         // Find and remove the card from configuration using the protocol's id property
         trafficCardConfiguration.cards.removeAll { $0.id == card.id }
 
@@ -258,5 +264,22 @@ final class StatsViewModel: ObservableObject, CardConfigurationDelegate {
 
         // Reset date range to default
         dateRange = context.calendar.makeDateRange(for: .last7Days)
+    }
+
+    // MARK: - Helper Methods
+
+    private func cardType(for card: TrafficCardConfiguration.Card) -> String {
+        switch card {
+        case .chart: return "chart"
+        case .topList: return "top_list"
+        }
+    }
+
+    private func cardType(for viewModel: any TrafficCardViewModel) -> String {
+        switch viewModel {
+        case is ChartCardViewModel: return "chart"
+        case is TopListViewModel: return "top_list"
+        default: return "unknown"
+        }
     }
 }

--- a/Modules/Sources/JetpackStats/Views/CustomDateRangePicker.swift
+++ b/Modules/Sources/JetpackStats/Views/CustomDateRangePicker.swift
@@ -74,6 +74,15 @@ struct CustomDateRangePicker: View {
         let component = calendar.determineNavigationComponent(for: interval) ?? .day
         dateRange = StatsDateRange(interval: interval, component: component, comparison: dateRange.comparison, calendar: calendar)
         UIImpactFeedbackGenerator(style: .light).impactOccurred()
+
+        // Track custom date range selection
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withFullDate]
+        context.tracker?.send(.customDateRangeSelected, properties: [
+            "start_date": dateFormatter.string(from: startDate),
+            "end_date": dateFormatter.string(from: endDate)
+        ])
+
         dismiss()
     }
 

--- a/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
+++ b/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
@@ -40,7 +40,7 @@ struct MetricsOverviewTabView: View {
     }
 
     private func selectDataType(_ type: SiteMetric, proxy: ScrollViewProxy) {
-        withAnimation(.smooth) {
+        withAnimation(.spring(response: 0.35, dampingFraction: 0.8)) {
             selectedMetric = type
             proxy.scrollTo(type, anchor: .center)
         }
@@ -71,13 +71,13 @@ private struct MetricItemView: View {
         Button(action: onTap) {
             VStack(alignment: .leading, spacing: 0) {
                 selectionIndicator
-                    .padding(.leading, Constants.step3)
                     .padding(.trailing, Constants.step1)
+                    .padding(.horizontal, Constants.step2)
                 tabContent
                     .padding(.top, Constants.step1 + 3)
                     .padding(.bottom, Constants.step2 + 2)
                     .padding(.leading, Constants.step3)
-
+                    .animation(.spring(response: 0.3, dampingFraction: 0.9), value: isSelected)
             }
         }
         .buttonStyle(.plain)
@@ -102,7 +102,7 @@ private struct MetricItemView: View {
                 .font(.caption.weight(.medium))
         }
         .foregroundColor(isSelected ? .primary : .secondary)
-        .animation(.smooth, value: isSelected)
+        .animation(.easeInOut(duration: 0.25), value: isSelected)
         .padding(.trailing, 4) // Visually spacing matters less than for metricsView
     }
 
@@ -131,9 +131,12 @@ private struct MetricItemView: View {
 
     private var selectionIndicator: some View {
         Rectangle()
-            .fill(isSelected ? Color.primary : Color.clear)
+            .fill(Color.primary)
             .frame(height: 3)
             .cornerRadius(1.5)
+            .opacity(isSelected ? 1 : 0)
+            .scaleEffect(x: isSelected ? 1 : 0.8, anchor: .center)
+            .animation(.spring, value: isSelected)
     }
 }
 

--- a/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
+++ b/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
@@ -14,6 +14,7 @@ struct MetricsOverviewTabView: View {
 
     let data: [MetricData]
     @Binding var selectedMetric: SiteMetric
+    var onMetricSelected: ((SiteMetric) -> Void)?
 
     @ScaledMetric(relativeTo: .title) private var minTabWidth: CGFloat = 100
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
@@ -45,6 +46,7 @@ struct MetricsOverviewTabView: View {
             proxy.scrollTo(type, anchor: .center)
         }
         UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+        onMetricSelected?(type)
     }
 }
 

--- a/Modules/Sources/JetpackStats/Views/StatsDateRangePickerMenu.swift
+++ b/Modules/Sources/JetpackStats/Views/StatsDateRangePickerMenu.swift
@@ -50,6 +50,11 @@ struct StatsDateRangePickerMenu: View {
             Button(preset.localizedString) {
                 selection.update(preset: preset)
                 UIImpactFeedbackGenerator(style: .light).impactOccurred()
+
+                // Track preset selection
+                context.tracker?.send(.dateRangePresetSelected, properties: [
+                    "selected_preset": preset.analyticsName
+                ])
             }
         }
     }

--- a/Modules/Sources/JetpackStats/Views/StatsTabBar.swift
+++ b/Modules/Sources/JetpackStats/Views/StatsTabBar.swift
@@ -14,6 +14,15 @@ enum StatsTab: CaseIterable {
         case .subscribers: return Strings.Tabs.subscribers
         }
     }
+
+    var analyticsName: String {
+        switch self {
+        case .traffic: return "traffic"
+        case .realtime: return "realtime"
+        case .insights: return "insights"
+        case .subscribers: return "subscribers"
+        }
+    }
 }
 
 struct StatsTabBar: View {

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemView.swift
@@ -21,6 +21,9 @@ struct TopListItemView: View {
     var body: some View {
         if hasDetails {
             Button {
+                // Track item tap
+                trackItemTap()
+
                 // Trigger animation
                 withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
                     isTapped = true
@@ -125,6 +128,13 @@ private extension TopListItemView {
         default:
             return false
         }
+    }
+
+    func trackItemTap() {
+        context.tracker?.send(.topListItemTapped, properties: [
+            "item_type": item.id.type.analyticsName,
+            "metric": metric.analyticsName
+        ])
     }
 
     func navigateToDetails() {

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
@@ -10,7 +10,7 @@ struct TopListItemsView: View {
 
     var body: some View {
         VStack(spacing: Constants.step1 / 2) {
-            ForEach(data.items.prefix(itemLimit), id: \.id) { item in
+            ForEach(Array(data.items.prefix(itemLimit).enumerated()), id: \.element.id) { index, item in
                 makeView(for: item)
                     .transition(.move(edge: .leading)
                         .combined(with: .scale(scale: 0.75))

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent+JetpackStats.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent+JetpackStats.swift
@@ -1,0 +1,61 @@
+import Foundation
+import JetpackStats
+
+extension StatsEvent {
+    /// Maps JetpackStats events to WordPress analytics events
+    var wpEvent: WPAnalyticsEvent {
+        switch self {
+        // Screen View Events
+        case .statsMainScreenShown:
+            return .jetpackStatsMainScreenShown
+        case .trafficTabShown:
+            return .jetpackStatsTrafficTabShown
+        case .realtimeTabShown:
+            return .jetpackStatsRealtimeTabShown
+        case .subscribersTabShown:
+            return .jetpackStatsSubscribersTabShown
+        case .postDetailsScreenShown:
+            return .jetpackStatsPostDetailsScreenShown
+        case .authorStatsScreenShown:
+            return .jetpackStatsAuthorStatsScreenShown
+        case .archiveStatsScreenShown:
+            return .jetpackStatsArchiveStatsScreenShown
+        case .externalLinkStatsScreenShown:
+            return .jetpackStatsExternalLinkStatsScreenShown
+        case .referrerStatsScreenShown:
+            return .jetpackStatsReferrerStatsScreenShown
+
+        // Date Range Events
+        case .dateRangePresetSelected:
+            return .jetpackStatsDateRangePresetSelected
+        case .customDateRangeSelected:
+            return .jetpackStatsCustomDateRangeSelected
+
+        // Card Events
+        case .cardShown:
+            return .jetpackStatsCardShown
+        case .cardAdded:
+            return .jetpackStatsCardAdded
+        case .cardRemoved:
+            return .jetpackStatsCardRemoved
+
+        // Chart Events
+        case .chartTypeChanged:
+            return .jetpackStatsChartTypeChanged
+        case .chartMetricSelected:
+            return .jetpackStatsChartMetricSelected
+
+        // List Events
+        case .topListItemTapped:
+            return .jetpackStatsTopListItemTapped
+
+        // Navigation Events
+        case .statsTabSelected:
+            return .jetpackStatsTabSelected
+
+        // Error Events
+        case .errorEncountered:
+            return .jetpackStatsErrorEncountered
+        }
+    }
+}

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent+JetpackStats.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent+JetpackStats.swift
@@ -59,3 +59,7 @@ extension StatsEvent {
         }
     }
 }
+
+extension WPAnalyticsEvent {
+    static let isNewStatsKey = "new_stats"
+}

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -623,6 +623,42 @@ import WordPressShared
 
     case wpcomWebSignIn
 
+    // MARK: - Jetpack Stats
+
+    // Screen View Events
+    case jetpackStatsMainScreenShown
+    case jetpackStatsTrafficTabShown
+    case jetpackStatsRealtimeTabShown
+    case jetpackStatsSubscribersTabShown
+    case jetpackStatsPostDetailsScreenShown
+    case jetpackStatsAuthorStatsScreenShown
+    case jetpackStatsArchiveStatsScreenShown
+    case jetpackStatsExternalLinkStatsScreenShown
+    case jetpackStatsReferrerStatsScreenShown
+
+    // Date Range Events
+    case jetpackStatsDateRangePresetSelected
+    case jetpackStatsCustomDateRangeSelected
+
+    // Card Events
+    case jetpackStatsCardShown
+    case jetpackStatsCardAdded
+    case jetpackStatsCardRemoved
+    case jetpackStatsCardEditMenuOpened
+
+    // Chart Events
+    case jetpackStatsChartTypeChanged
+    case jetpackStatsChartMetricSelected
+
+    // List Events
+    case jetpackStatsTopListItemTapped
+
+    // Navigation Events
+    case jetpackStatsTabSelected
+
+    // Error Events
+    case jetpackStatsErrorEncountered
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -1688,6 +1724,62 @@ import WordPressShared
 
         case .wpcomWebSignIn:
             return "wpcom_web_sign_in"
+
+        // MARK: - Jetpack Stats
+
+        // Screen View Events
+        case .jetpackStatsMainScreenShown:
+            return "jetpack_stats_main_screen_shown"
+        case .jetpackStatsTrafficTabShown:
+            return "jetpack_stats_traffic_tab_shown"
+        case .jetpackStatsRealtimeTabShown:
+            return "jetpack_stats_realtime_tab_shown"
+        case .jetpackStatsSubscribersTabShown:
+            return "jetpack_stats_subscribers_tab_shown"
+        case .jetpackStatsPostDetailsScreenShown:
+            return "jetpack_stats_post_details_screen_shown"
+        case .jetpackStatsAuthorStatsScreenShown:
+            return "jetpack_stats_author_stats_screen_shown"
+        case .jetpackStatsArchiveStatsScreenShown:
+            return "jetpack_stats_archive_stats_screen_shown"
+        case .jetpackStatsExternalLinkStatsScreenShown:
+            return "jetpack_stats_external_link_stats_screen_shown"
+        case .jetpackStatsReferrerStatsScreenShown:
+            return "jetpack_stats_referrer_stats_screen_shown"
+
+        // Date Range Events
+        case .jetpackStatsDateRangePresetSelected:
+            return "jetpack_stats_date_range_preset_selected"
+        case .jetpackStatsCustomDateRangeSelected:
+            return "jetpack_stats_custom_date_range_selected"
+
+        // Card Events
+        case .jetpackStatsCardShown:
+            return "jetpack_stats_card_shown"
+        case .jetpackStatsCardAdded:
+            return "jetpack_stats_card_added"
+        case .jetpackStatsCardRemoved:
+            return "jetpack_stats_card_removed"
+        case .jetpackStatsCardEditMenuOpened:
+            return "jetpack_stats_card_edit_menu_opened"
+
+        // Chart Events
+        case .jetpackStatsChartTypeChanged:
+            return "jetpack_stats_chart_type_changed"
+        case .jetpackStatsChartMetricSelected:
+            return "jetpack_stats_chart_metric_selected"
+
+        // List Events
+        case .jetpackStatsTopListItemTapped:
+            return "jetpack_stats_top_list_item_tapped"
+
+        // Navigation Events
+        case .jetpackStatsTabSelected:
+            return "jetpack_stats_tab_selected"
+
+        // Error Events
+        case .jetpackStatsErrorEncountered:
+            return "jetpack_stats_error_encountered"
         } // END OF SWITCH
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
@@ -122,7 +122,14 @@ final class DashboardQuickActionsCardCell: UICollectionViewCell, Reusable, UITab
     }
 
     private func trackQuickActionsEvent(_ event: WPAnalyticsStat, blog: Blog) {
-        WPAppAnalytics.track(event, properties: [WPAppAnalyticsKeyTabSource: "dashboard", WPAppAnalyticsKeyTapSource: "quick_actions"], blog: blog)
+        var properties: [String: Any] = [
+            WPAppAnalyticsKeyTabSource: "dashboard",
+            WPAppAnalyticsKeyTapSource: "quick_actions"
+        ]
+        if event == .statsAccessed, FeatureFlag.newStats.enabled {
+            properties[WPAnalyticsEvent.isNewStatsKey] = "1"
+        }
+        WPAppAnalytics.track(event, properties: properties, blog: blog)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
@@ -418,10 +418,14 @@ extension BlogDetailsViewController {
 
 extension BlogDetailsViewController {
     @objc public func trackEvent(_ event: WPAnalyticsStat, from source: BlogDetailsNavigationSource) {
-        WPAppAnalytics.track(event, properties: [
+        var properties: [String: Any] = [
             WPAppAnalyticsKeyTapSource: source.string,
             WPAppAnalyticsKeyTabSource: "site_menu"
-        ], blog: blog)
+        ]
+        if event == .statsAccessed, FeatureFlag.newStats.enabled {
+            properties[WPAnalyticsEvent.isNewStatsKey] = "1"
+        }
+        WPAppAnalytics.track(event, properties: properties, blog: blog)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationContentRouter.swift
@@ -116,7 +116,10 @@ struct NotificationContentRouter {
     }
 
     private func trackStatsRoute() {
-        let properties: [AnyHashable: Any] = [WPAppAnalyticsKeyTapSource: "notification"]
+        var properties: [AnyHashable: Any] = [WPAppAnalyticsKeyTapSource: "notification"]
+        if FeatureFlag.newStats.enabled {
+            properties[WPAnalyticsEvent.isNewStatsKey] = "1"
+        }
         WPAppAnalytics.track(.statsAccessed, withProperties: properties)
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Post Stats/PostStatsTableViewController.swift
@@ -136,6 +136,10 @@ private extension PostStatsTableViewController {
             properties["post_id"] = postIdentifier
         }
 
+        if FeatureFlag.newStats.enabled {
+            properties[WPAnalyticsEvent.isNewStatsKey] = "1"
+        }
+
         WPAppAnalytics.track(.statsAccessed, withProperties: properties)
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/StatsHostingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/StatsHostingViewController.swift
@@ -60,6 +60,9 @@ extension StatsContext {
             let options = AvatarQueryOptions(preferredSize: .points(size))
             return avatarURL.replacing(options: options)?.url ?? url
         }
+
+        // Configure analytics tracker
+        self.tracker = WPAnalyticsStatsTracker()
     }
 }
 
@@ -129,5 +132,19 @@ private class SafeAreaHostingController<Content: View>: UIHostingController<Cont
         if additionalSafeAreaInsets.bottom != bottomInset {
             additionalSafeAreaInsets = UIEdgeInsets(top: 0, left: 0, bottom: min(20, bottomInset), right: 0)
         }
+    }
+}
+
+// MARK: - WPAnalyticsStatsTracker
+
+/// A StatsTracker implementation that bridges JetpackStats analytics to WPAnalytics
+private final class WPAnalyticsStatsTracker: StatsTracker {
+    func send(_ event: StatsEvent, properties: [String: String]) {
+        // Convert String properties to [AnyHashable: Any]
+        let wpProperties: [AnyHashable: Any] = properties.reduce(into: [:]) { result, pair in
+            result[pair.key] = pair.value
+        }
+
+        WPAnalytics.track(event.wpEvent, properties: wpProperties)
     }
 }


### PR DESCRIPTION
Add analytics for JetpackStats. The way it works, JetpackStats sends new `StatsEvent` via new `StatsTracker`. The app has an adapter that uses `WPAnalyticsEvent` to map and track these. I considered using `StatsEvent` as raw string values, but I think this is clearer (and it was all auto-generated anyway so I didn't have to spent time writing it).

I also added a new `new_stats` field to the existing `stats_accessed` event:

```
🔵 Tracked: stats_accessed <blog_id: 239619264, new_stats: 1, site_type: blog, tab_source: site_menu, tap_source: row>
```