### PR TITLE
Replace the Combine code with `Task`

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "374b89a1741ec026fbdf4bef9d3124faa4a0377220646185adb467ed59563ef8",
+  "originHash" : "d755e1afd7f7c7e6ce1c005aa1657876c10cdf60de188a23262ab5de91e5e6c3",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -381,7 +381,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/WordPressKit-iOS",
       "state" : {
-        "revision" : "ae3961ce89ac0c43a90e88d4963a04aa92008443"
+        "branch" : "trunk",
+        "revision" : "2b7d4f6acf2641b671c66b20873f5935f22210ed"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -49,7 +49,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(
             url: "https://github.com/wordpress-mobile/WordPressKit-iOS",
-            revision: "ae3961ce89ac0c43a90e88d4963a04aa92008443" // see wpios-edition branch
+            revision: "2b7d4f6acf2641b671c66b20873f5935f22210ed"
         ),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.

--- a/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
@@ -193,7 +193,7 @@ class ApplicationPasswordsRepositoryTests {
         #expect(password == uuid)
     }
 
-    @Test(arguments: [1, 2, 3, 4])
+    @Test(arguments: [0, 1, 2, 3, 4])
     func cancelConcurrentCall(nthTaskToBeCancelled: Int) async throws {
         defer { HTTPStubs.removeAllStubs()}
 
@@ -226,7 +226,13 @@ class ApplicationPasswordsRepositoryTests {
             }
         }
 
-        #expect(monitor.numberOfRequests == 1)
+        // If the first call is cancelled, then another password creation attempt should be made by one of the
+        // waiting callers. And the rest of the callers should wait on the second attempt.
+        if nthTaskToBeCancelled == 0 {
+            #expect(monitor.numberOfRequests == 2)
+        } else {
+            #expect(monitor.numberOfRequests == 1)
+        }
 
         let password = await password(of: blog)
         #expect(password == uuid)

--- a/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
@@ -7,12 +7,21 @@ import OHHTTPStubsSwift
 
 @testable import WordPress
 
-struct ApplicationPasswordsRepositoryTests {
+@Suite(.serialized)
+class ApplicationPasswordsRepositoryTests {
     let coreDataStack = ContextManager.forTesting()
     let keychain = TestKeychain()
 
+    func password(of blog: TaggedManagedObjectID<Blog>) async -> String? {
+        await coreDataStack.performQuery { [keychain] context in
+            try? context.existingObject(with: blog).getApplicationToken(using: keychain)
+        }
+    }
+
     @Test
     func simpleSite() async throws {
+        defer { HTTPStubs.removeAllStubs()}
+
         try await signInWPComAccount()
         let blog = try await createSimpleSite()
 
@@ -24,6 +33,8 @@ struct ApplicationPasswordsRepositoryTests {
 
     @Test
     func atomicSite() async throws {
+        defer { HTTPStubs.removeAllStubs()}
+
         try await signInWPComAccount()
         let blog = try await createAtomicSite()
 
@@ -34,45 +45,48 @@ struct ApplicationPasswordsRepositoryTests {
         let repository = ApplicationPasswordRepository.forTesting(coreDataStack: coreDataStack, keychain: keychain)
         try await repository.createPasswordIfNeeded(for: blog)
 
-        let password = try await coreDataStack.performQuery { context in
-            try context.existingObject(with: blog).getApplicationToken(using: keychain)
-        }
+        let password = await password(of: blog)
         #expect(password == "abcd efgh")
     }
 
     @Test
     func selfHostedSite() async throws {
-        let blog = try await createSelfHostedSite()
+        defer { HTTPStubs.removeAllStubs()}
 
-        stubApiDiscovery(siteHost: "www.example.com")
+        let uuid = UUID().uuidString.lowercased()
+        let host = "\(uuid).example.com"
+        let blog = try await createSelfHostedSite(host: host)
+
+        stubApiDiscovery(siteHost: host)
         stubSelfHostedSiteWpV2GetUser()
-        stubSelfHostedSiteCreateApplicationPassword(host: "www.example.com", password: "1234 5678")
+        stubSelfHostedSiteCreateApplicationPassword(host: host, password: uuid)
 
         let repository = ApplicationPasswordRepository.forTesting(coreDataStack: coreDataStack, keychain: keychain)
         try await repository.createPasswordIfNeeded(for: blog)
 
-        let password = try await coreDataStack.performQuery { context in
-            try context.existingObject(with: blog).getApplicationToken(using: keychain)
-        }
-        #expect(password == "1234 5678")
+        let password = await password(of: blog)
+        #expect(password == uuid)
     }
 
     @Test
     func selfHostedSiteWithInaccessibleRestApi() async throws {
-        let blog = try await createSelfHostedSite()
+        defer { HTTPStubs.removeAllStubs()}
 
-        stubApiDiscovery(siteHost: "www.example.com")
+        let host = "2.example.com"
+        let blog = try await createSelfHostedSite(host: host)
 
-        stub(condition: isHost("www.example.com") && isPath("/wp-login.php")) { _ in
+        stubApiDiscovery(siteHost: host)
+
+        stub(condition: isHost(host) && isPath("/wp-login.php")) { _ in
             HTTPStubsResponse(data: "<html>Logged in</html>".data(using: .utf8)!, statusCode: 200, headers: nil)
         }
-        stub(condition: isHost("www.example.com") && isPath("/wp-admin/admin-ajax.php") && containsQueryParams(["action": "rest-nonce"])) { _ in
+        stub(condition: isHost(host) && isPath("/wp-admin/admin-ajax.php") && containsQueryParams(["action": "rest-nonce"])) { _ in
             HTTPStubsResponse(data: "<html>not allowed</html>".data(using: .utf8)!, statusCode: 400, headers: nil)
         }
-        stub(condition: isHost("www.example.com") && isPath("/wp-admin/post-new.php")) { _ in
+        stub(condition: isHost(host) && isPath("/wp-admin/post-new.php")) { _ in
             HTTPStubsResponse(data: "<html>not allowed</html>".data(using: .utf8)!, statusCode: 400, headers: nil)
         }
-        stub(condition: isHost("www.example.com") && isPath("/wp-json/wp/v2/users/me")) { _ in
+        stub(condition: isHost(host) && isPath("/wp-json/wp/v2/users/me")) { _ in
             let json = #"{"code":"rest_not_logged_in","message":"You are not currently logged in.","data":{"status":401}}"#
             return HTTPStubsResponse(data: json.data(using: .utf8)!, statusCode: 401, headers: nil)
         }
@@ -82,6 +96,140 @@ struct ApplicationPasswordsRepositoryTests {
         await #expect(throws: ApplicationPasswordRepositoryError.restApiInaccessible) {
             try await repository.createPasswordIfNeeded(for: blog)
         }
+    }
+
+    @Test
+    func concurrentCalls() async throws {
+        defer { HTTPStubs.removeAllStubs()}
+
+        let host = "3.example.com"
+        let blog = try await createSelfHostedSite(host: host)
+
+        let monitor = Monitor(delay: 0.1)
+        stubApiDiscovery(siteHost: host)
+        stubSelfHostedSiteWpV2GetUser()
+        stubSelfHostedSiteCreateApplicationPassword(host: host, password: "1234 5678", monitor: monitor)
+
+        let repository = ApplicationPasswordRepository.forTesting(coreDataStack: coreDataStack, keychain: keychain)
+
+        await withThrowingTaskGroup(of: Void.self) { group in
+            for index in 1...5 {
+                group.addTask {
+                    try await Task.sleep(for: .milliseconds(10))
+
+                    do {
+                        try await repository.createPasswordIfNeeded(for: blog)
+                    } catch {
+                        Issue.record("Task \(index) receives an unexpected error: \(error)")
+                    }
+                }
+            }
+        }
+
+        #expect(monitor.numberOfRequests == 1)
+
+        let password = await password(of: blog)
+        #expect(password == "1234 5678")
+    }
+
+    @Test
+    func cancel() async throws {
+        defer { HTTPStubs.removeAllStubs()}
+
+        let uuid = UUID().uuidString.lowercased()
+        let host = "\(uuid).example.com"
+        let blog = try await createSelfHostedSite(host: host)
+
+        let monitor = Monitor(delay: 0.1)
+        stubApiDiscovery(siteHost: host)
+        stubSelfHostedSiteWpV2GetUser()
+        stubSelfHostedSiteCreateApplicationPassword(host: host, password: uuid, monitor: monitor)
+
+        let repository = ApplicationPasswordRepository.forTesting(coreDataStack: coreDataStack, keychain: keychain)
+        let task = Task {
+            try await repository.createPasswordIfNeeded(for: blog)
+        }
+
+        try await Task.sleep(for: .milliseconds(50))
+        task.cancel()
+
+        let result = await task.result
+        #expect(result.isCancellationError())
+
+        let password = await password(of: blog)
+        #expect(password == nil)
+    }
+
+    @Test
+    func cancelFirstCall() async throws {
+        defer { HTTPStubs.removeAllStubs()}
+
+        let uuid = UUID().uuidString.lowercased()
+        let host = "\(uuid).example.com"
+        let blog = try await createSelfHostedSite(host: host)
+
+        let monitor = Monitor(delay: 0.1)
+        stubApiDiscovery(siteHost: host)
+        stubSelfHostedSiteWpV2GetUser()
+        stubSelfHostedSiteCreateApplicationPassword(host: host, password: uuid, monitor: monitor)
+
+        let repository = ApplicationPasswordRepository.forTesting(coreDataStack: coreDataStack, keychain: keychain)
+
+        let first = Task { try await repository.createPasswordIfNeeded(for: blog) }
+        try await Task.sleep(for: .milliseconds(10))
+        let second = Task { try await repository.createPasswordIfNeeded(for: blog) }
+
+        first.cancel()
+
+        let firstResult = await first.result
+        let secondResult = await second.result
+
+        #expect(firstResult.isCancellationError())
+        #expect(secondResult.isSuccess())
+
+        #expect(monitor.numberOfRequests == 2)
+
+        let password = await password(of: blog)
+        #expect(password == uuid)
+    }
+
+    @Test(arguments: [1, 2, 3, 4])
+    func cancelConcurrentCall(nthTaskToBeCancelled: Int) async throws {
+        defer { HTTPStubs.removeAllStubs()}
+
+        let uuid = UUID().uuidString.lowercased()
+        let host = "\(uuid).example.com"
+        let blog = try await createSelfHostedSite(host: host)
+
+        let monitor = Monitor(delay: 0.1)
+        stubApiDiscovery(siteHost: host)
+        stubSelfHostedSiteWpV2GetUser()
+        stubSelfHostedSiteCreateApplicationPassword(host: host, password: uuid, monitor: monitor)
+
+        let repository = ApplicationPasswordRepository.forTesting(coreDataStack: coreDataStack, keychain: keychain)
+
+        let numberOfTasks = 5
+        var tasks: [Task<Void, Error>] = []
+        for _ in 0..<numberOfTasks {
+            tasks.append(Task { try await repository.createPasswordIfNeeded(for: blog) })
+            try await Task.sleep(for: .milliseconds(10))
+        }
+
+        tasks[nthTaskToBeCancelled].cancel()
+
+        for (index, task) in tasks.enumerated() {
+            let result = await task.result
+            if index == nthTaskToBeCancelled {
+                #expect(result.isCancellationError())
+            } else {
+                #expect(result.isSuccess())
+            }
+        }
+
+        #expect(monitor.numberOfRequests == 1)
+
+        let password = await password(of: blog)
+        #expect(password == uuid)
     }
 }
 
@@ -125,17 +273,19 @@ private extension ApplicationPasswordsRepositoryTests {
         }
     }
 
-    func createSelfHostedSite() async throws -> TaggedManagedObjectID<Blog> {
+    func createSelfHostedSite(host: String) async throws -> TaggedManagedObjectID<Blog> {
         try await coreDataStack.performAndSave { context in
-            let blog = BlogBuilder(context, dotComID: nil)
-                .with(username: "demo")
-                .with(password: "pass")
-                .build()
+            let blog = Blog(context: context)
+            blog.url = "https://\(host)"
+            blog.xmlrpc = "https://\(host)/xmlrpc.php"
+            blog.setValue("admin_url", forOption: "https://\(host)/wp-admin")
+            blog.username = "demo"
+            blog.password = "pass"
             return TaggedManagedObjectID(blog)
         }
     }
 
-    func stubSelfHostedSiteCreateApplicationPassword(host: String, password: String) {
+    func stubSelfHostedSiteCreateApplicationPassword(host: String, password: String, monitor: Monitor? = nil) {
         stub(condition: isHost(host) && isPath("/wp-login.php")) { _ in
             HTTPStubsResponse(data: "<html>Logged in</html>".data(using: .utf8)!, statusCode: 200, headers: nil)
         }
@@ -143,6 +293,8 @@ private extension ApplicationPasswordsRepositoryTests {
             HTTPStubsResponse(data: "abcd".data(using: .utf8)!, statusCode: 200, headers: nil)
         }
         stub(condition: isHost(host) && isPath("/wp-json/wp/v2/users/me/application-passwords")) { _ in
+            monitor?.requestReceived()
+
             let json = """
                 {
                     "uuid": "56cadaa8-e810-4752-abf9-cc39e120ea97",
@@ -164,7 +316,11 @@ private extension ApplicationPasswordsRepositoryTests {
                     }
                 }
                 """
-            return HTTPStubsResponse(data: json.data(using: .utf8)!, statusCode: 200, headers: nil)
+            let response = HTTPStubsResponse(data: json.data(using: .utf8)!, statusCode: 200, headers: nil)
+            if let delay = monitor?.delay {
+                response.responseTime = delay
+            }
+            return response
         }
     }
 
@@ -392,5 +548,43 @@ private extension ApplicationPasswordsRepositoryTests {
         stub(condition: isHost(siteHost) && isPath("/wp-json")) { _ in
             HTTPStubsResponse(data: "<html>page not found</html>".data(using: .utf8)!, statusCode: 404, headers: nil)
         }
+    }
+}
+
+private class Monitor {
+    let delay: TimeInterval?
+    private(set) var numberOfRequests: Int = 0
+
+    private let lock = NSLock()
+
+    init(delay: TimeInterval? = nil) {
+        self.delay = delay
+    }
+
+    func requestReceived() {
+        lock.lock()
+        defer { lock.unlock() }
+
+        numberOfRequests += 1
+    }
+}
+
+@globalActor
+private final actor BackgroundActor: GlobalActor {
+    static let shared = BackgroundActor()
+}
+
+private extension Result {
+    func isSuccess() -> Bool {
+        if case .success = self {
+            return true
+        }
+        return false
+    }
+    func isCancellationError() -> Bool {
+        if case let .failure(error) = self {
+            return error.isCancellationError()
+        }
+        return false
     }
 }

--- a/WordPress/Classes/Extensions/Error.swift
+++ b/WordPress/Classes/Extensions/Error.swift
@@ -17,7 +17,7 @@ extension Error {
             return true
         }
 
-        if let error = wrapped as? WordPressAPIError<WordPressOrgRestApiError>, error.urlError?.code == .cancelled {
+        if let error = wrapped as? WordPressAPIError<WordPressComRestApiEndpointError>, error.urlError?.code == .cancelled {
             return true
         }
 

--- a/WordPress/Classes/Extensions/Error.swift
+++ b/WordPress/Classes/Extensions/Error.swift
@@ -1,0 +1,39 @@
+import Foundation
+import WordPressKit
+import WordPressAPI
+
+extension Error {
+    func isCancellationError() -> Bool {
+        let wrapped = self
+        if wrapped is CancellationError {
+            return true
+        }
+
+        if let error = wrapped as? URLError, error.code == .cancelled {
+            return true
+        }
+
+        if let error = wrapped as? WordPressAPIError<WordPressOrgRestApiError>, error.urlError?.code == .cancelled {
+            return true
+        }
+
+        if let error = wrapped as? WordPressAPIError<WordPressOrgRestApiError>, error.urlError?.code == .cancelled {
+            return true
+        }
+
+        if let error = wrapped as? WpApiError, error.isCancellationError {
+            return true
+        }
+
+        return false
+    }
+}
+
+private extension WordPressAPIError {
+    var urlError: URLError? {
+        if case let .connection(error) = self {
+            return error
+        }
+        return nil
+    }
+}

--- a/WordPress/Classes/Services/ApplicationPasswordRepository.swift
+++ b/WordPress/Classes/Services/ApplicationPasswordRepository.swift
@@ -36,6 +36,7 @@ actor ApplicationPasswordRepository {
     private let coreDataStack: CoreDataStackSwift
     private let storage: ApplicationPasswordStorage
     private var ongoing: [TaggedManagedObjectID<Blog>: CurrentValueSubject<ApplicationPassword?, Error>] = [:]
+    private var inflightTasks: [TaggedManagedObjectID<Blog>: Task<ApplicationPassword, Error>] = [:]
 
     static func forTesting(coreDataStack: CoreDataStackSwift, keychain: KeychainAccessible) -> ApplicationPasswordRepository {
         ApplicationPasswordRepository(coreDataStack: coreDataStack, keychain: keychain)
@@ -71,18 +72,36 @@ actor ApplicationPasswordRepository {
 
         // `createPasswordIfNeeded` can be called by multiple callers at the same time. We want to avoid
         // creating multiple application passwords on one site.
+
+//        _ = try await withCombine(for: blogId)
+        _ = try await withTask(for: blogId)
+    }
+
+    private func withCombine(for blogId: TaggedManagedObjectID<Blog>) async throws -> ApplicationPassword {
         if let subject = ongoing[blogId] {
             let publisher = subject
                 .compactMap { $0 }
                 .first()
                 .eraseToAnyPublisher()
             // This sequence can only results in an error or a one element array. See the `subject.send` calls below.
-            let outputs = try await AsyncThrowingPublisher(publisher).reduce(into: []) { $0.append($1) }
-            if outputs.isEmpty {
-                throw ApplicationPasswordRepositoryError.unknown
+            let outputs: [ApplicationPassword]
+            do {
+                outputs = try await AsyncThrowingPublisher(publisher).reduce(into: []) { $0.append($1) }
+            } catch {
+                if error.isCancellationError() {
+                    return try await self.withCombine(for: blogId)
+                }
+
+                throw error
             }
 
-            return
+            // when cancelling the `await` call on waiting the async sequence to produce output, the `await` call
+            // does not thrown an cancellation error.
+            if let result = outputs.first {
+                return result
+            } else {
+                throw CancellationError()
+            }
         }
 
         let subject: CurrentValueSubject<ApplicationPassword?, Error> = CurrentValueSubject(nil)
@@ -94,11 +113,52 @@ actor ApplicationPasswordRepository {
         do {
             let password = try await createPassword(for: blogId)
             subject.value = password
-            subject.send(completion: .finished)
-            return
+            return password
         } catch {
             subject.send(completion: .failure(error))
             throw error
+        }
+    }
+
+    private func withTask(for blogId: TaggedManagedObjectID<Blog>) async throws -> ApplicationPassword {
+        if let task = inflightTasks[blogId] {
+            // If the current task, which is waiting for the inflight task result, is cancelled, the function should
+            // throw a `CancellationError`.
+            var cancelled = false
+            let result = await withTaskCancellationHandler {
+                await task.result
+            } onCancel: {
+                cancelled = true
+            }
+
+            if cancelled {
+                throw CancellationError()
+            }
+
+            do {
+                return try result.get()
+            } catch {
+                // If the inflight task is cancelled, the current Task should start a new call to create an application
+                // password.
+                if error.isCancellationError() {
+                    return try await self.withTask(for: blogId)
+                }
+
+                // For other errors, we can still retry, but I don't see the need to do that.
+                throw error
+            }
+        }
+
+        let task = Task { try await createPassword(for: blogId) }
+        inflightTasks[blogId] = task
+        defer {
+            inflightTasks[blogId] = nil
+        }
+
+        return try await withTaskCancellationHandler {
+            try await task.value
+        } onCancel: {
+            task.cancel()
         }
     }
 }

--- a/WordPress/Classes/Services/ApplicationPasswordRepository.swift
+++ b/WordPress/Classes/Services/ApplicationPasswordRepository.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Combine
 import WordPressData
 import WordPressShared
 import WordPressKit
@@ -35,7 +34,6 @@ actor ApplicationPasswordRepository {
 
     private let coreDataStack: CoreDataStackSwift
     private let storage: ApplicationPasswordStorage
-    private var ongoing: [TaggedManagedObjectID<Blog>: CurrentValueSubject<ApplicationPassword?, Error>] = [:]
     private var inflightTasks: [TaggedManagedObjectID<Blog>: Task<ApplicationPassword, Error>] = [:]
 
     static func forTesting(coreDataStack: CoreDataStackSwift, keychain: KeychainAccessible) -> ApplicationPasswordRepository {
@@ -72,94 +70,61 @@ actor ApplicationPasswordRepository {
 
         // `createPasswordIfNeeded` can be called by multiple callers at the same time. We want to avoid
         // creating multiple application passwords on one site.
-
-//        _ = try await withCombine(for: blogId)
-        _ = try await withTask(for: blogId)
+        _ = try await waitForInflightTaskIfNeeded(blogId: blogId)
     }
 
-    private func withCombine(for blogId: TaggedManagedObjectID<Blog>) async throws -> ApplicationPassword {
-        if let subject = ongoing[blogId] {
-            let publisher = subject
-                .compactMap { $0 }
-                .first()
-                .eraseToAnyPublisher()
-            // This sequence can only results in an error or a one element array. See the `subject.send` calls below.
-            let outputs: [ApplicationPassword]
-            do {
-                outputs = try await AsyncThrowingPublisher(publisher).reduce(into: []) { $0.append($1) }
-            } catch {
-                if error.isCancellationError() {
-                    return try await self.withCombine(for: blogId)
-                }
-
-                throw error
-            }
-
-            // when cancelling the `await` call on waiting the async sequence to produce output, the `await` call
-            // does not thrown an cancellation error.
-            if let result = outputs.first {
-                return result
-            } else {
-                throw CancellationError()
-            }
-        }
-
-        let subject: CurrentValueSubject<ApplicationPassword?, Error> = CurrentValueSubject(nil)
-        ongoing[blogId] = subject
-        defer {
-            ongoing[blogId] = nil
-        }
-
-        do {
-            let password = try await createPassword(for: blogId)
-            subject.value = password
-            return password
-        } catch {
-            subject.send(completion: .failure(error))
-            throw error
-        }
-    }
-
-    private func withTask(for blogId: TaggedManagedObjectID<Blog>) async throws -> ApplicationPassword {
+    private func waitForInflightTaskIfNeeded(blogId: TaggedManagedObjectID<Blog>) async throws -> ApplicationPassword {
         if let task = inflightTasks[blogId] {
-            // If the current task, which is waiting for the inflight task result, is cancelled, the function should
-            // throw a `CancellationError`.
-            var cancelled = false
-            let result = await withTaskCancellationHandler {
-                await task.result
-            } onCancel: {
-                cancelled = true
-            }
-
-            if cancelled {
-                throw CancellationError()
-            }
-
-            do {
-                return try result.get()
-            } catch {
-                // If the inflight task is cancelled, the current Task should start a new call to create an application
-                // password.
-                if error.isCancellationError() {
-                    return try await self.withTask(for: blogId)
-                }
-
-                // For other errors, we can still retry, but I don't see the need to do that.
+            switch await waitForInflightTask(task, blogId: blogId) {
+            case let .success(value):
+                return value
+            case let .failure(error):
                 throw error
+            case .restart:
+                // We'll make another attempt to create an application password.
+                return try await waitForInflightTaskIfNeeded(blogId: blogId)
             }
         }
 
-        let task = Task { try await createPassword(for: blogId) }
+        let task = Task {
+            try await createPassword(for: blogId)
+        }
         inflightTasks[blogId] = task
         defer {
             inflightTasks[blogId] = nil
         }
 
+        // We need to explicitly cancel the created `Task` above.
+        // https://forums.swift.org/t/understanding-task-cancellation/75329/2
         return try await withTaskCancellationHandler {
             try await task.value
         } onCancel: {
             task.cancel()
         }
+    }
+
+    private func waitForInflightTask(_ inflight: Task<ApplicationPassword, Error>, blogId: TaggedManagedObjectID<Blog>) async -> WaitResult {
+        let result = await inflight.result
+
+        // If the current task, which is waiting for the inflight task result, is cancelled, the function should
+        // throw a `CancellationError`.
+        if Task.isCancelled {
+            return .failure(CancellationError())
+        }
+
+        return switch result {
+            case let .success(value):
+                .success(value)
+            case let .failure(error):
+                // If the inflight task is cancelled, the current Task should start a new call to create an application
+                // password.
+                if error.isCancellationError() {
+                    .restart
+                } else {
+                    // For other errors, we can still retry, but I don't see the need to do that.
+                    .failure(error)
+                }
+            }
     }
 }
 
@@ -485,4 +450,10 @@ private struct ApplicationPassword: Codable {
 private enum ApplicationPasswordOwner: Codable, Hashable {
     case dotCom(username: String, siteId: Int)
     case selfHosted(username: String, site: String)
+}
+
+private enum WaitResult {
+    case success(ApplicationPassword)
+    case failure(Error)
+    case restart
 }


### PR DESCRIPTION
## Description

Follow up of https://github.com/wordpress-mobile/WordPress-iOS/pull/24679#discussion_r2240961695, this PR replaces the Combine code with async `Task`. Comparing the Combine implementation and the `Task` implementation (see [here](https://github.com/wordpress-mobile/WordPress-iOS/blob/79ea3e8e12649a2a11277d29babb68a77b74d4f7/WordPress/Classes/Services/ApplicationPasswordRepository.swift#L80)), they are very similar, but `Task` is less convoluted.

Also added a few unit tests to make sure `ApplicationPasswordRepository` behaves correctly when called multiple times.


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
