### PR TITLE
Fix Split View mode on iPad

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] New Stats: Add support for "weeks" granularity [#24767]
 * [*] New Stats: Fix dark mode support in custom range picker [#24770]
+* [*] Fix Split View mode on iPad on some scenarios in portrait mode [#24705]
 
 26.1
 -----

--- a/WordPress/Classes/System/Root View/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/Root View/SplitViewRootPresenter.swift
@@ -79,12 +79,7 @@ final class SplitViewRootPresenter: RootViewPresenter {
             splitVC.preferredSupplementaryColumnWidth = UISplitViewController.automaticDimension
         }
 
-        switch selection {
-        case .notifications:
-            splitVC.preferredSplitBehavior = .tile
-        default:
-            splitVC.preferredSplitBehavior = .displace
-        }
+        splitVC.preferredSplitBehavior = selection == .notifications ? .tile : .automatic
 
         let content: SplitViewDisplayable
         switch selection {


### PR DESCRIPTION
I made it worse but trying to change it from the default (`.automatic`) behavior. It also doesn't like when you change it dynamically.

**Before:**

It will sometimes tile the content in the portrait mode where there is not enough space. It will fix itself only after going to landscape and back.

<img width="360" alt="ipad-before-01" src="https://github.com/user-attachments/assets/95808616-95e9-4382-84fc-3ec61aab5a75" />


**After:**

It will now work basically as you would expect the iPad sidebar to work. The landscape – still tile. Portrait – overlay if not enough space. 

The only scenario where you want to use `.tile` in the portrait mode is when the sidebar is used for switching between different collections of the same types of items that are optimized for the short screen and you want to be able to quickly toggle between.

<img width="360" alt="Screenshot 2025-07-31 at 10 08 04 AM" src="https://github.com/user-attachments/assets/71c721ae-2db9-4056-9ffe-cff0c40a2dee" />
<img width="360" alt="Screenshot 2025-07-31 at 10 08 07 AM" src="https://github.com/user-attachments/assets/8add4d61-9d86-49ae-8689-f6f0ecc1a86f" />
