### PR TITLE
feat: GutenbergKit uploads VideoPress files

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9cbaa51b129a2c5eb1aea5185c1bdfc8efe503a288e975757630633a68c909e0",
+  "originHash" : "374b89a1741ec026fbdf4bef9d3124faa4a0377220646185adb467ed59563ef8",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,7 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "17bc44d2a2fea31f70de02b4e053aad65be0eb62"
+        "revision" : "780efc3905275804aa52127aa532c3fc12d81a68",
+        "version" : "0.7.0"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b1fb7c230ac6bba7fef0398912e86c03c8a9329d742c0c971d3945e9308ee8f2",
+  "originHash" : "9cbaa51b129a2c5eb1aea5185c1bdfc8efe503a288e975757630633a68c909e0",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,8 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "3afb350113614db42bee4c30d00b1697209b25fc",
-        "version" : "0.6.0"
+        "revision" : "17bc44d2a2fea31f70de02b4e053aad65be0eb62"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250715"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "17bc44d2a2fea31f70de02b4e053aad65be0eb62"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.7.0"),
         .package(
             url: "https://github.com/Automattic/color-studio",
             revision: "bf141adc75e2769eb469a3e095bdc93dc30be8de"

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250715"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.6.0"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "17bc44d2a2fea31f70de02b4e053aad65be0eb62"),
         .package(
             url: "https://github.com/Automattic/color-studio",
             revision: "bf141adc75e2769eb469a3e095bdc93dc30be8de"


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Enable GutenbergKit uploading VideoPress files to match similar features in
Gutenberg Mobile.

Dependent upon https://github.com/wordpress-mobile/GutenbergKit/pull/161. 

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
> [!important]
> Enable the following settings:
> - `Experimental Block Editor` experimental feature 
> - `Experimental Block Editor Plugins` debug feature flag

1. Create a post on a WPCOM Simple site using the WPCOM web editor. 
1. Insert a Video block and attach media. 
1. Open the same post in the mobile editor. 
1. Tap _Replace_ in the block toolbar. 
1. Upload replacement media. 
1. Verify the upload succeeds and a _Done_ button is presented. 

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
