### PR TITLE
Remove error popup from dashboard

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 26.1
 -----
-
+* [*] Remove global error popups from the site dashboard [#24707]
 
 26.0
 -----

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -106,10 +106,6 @@ final class BlogDashboardViewController: UIViewController {
     ///
     func stopLoading() { }
 
-    func loadingFailure() {
-        displayActionableNotice(title: Strings.failureTitle, actionTitle: Strings.dismiss)
-    }
-
     func update(blog: Blog) {
         guard self.blog.dotComID != blog.dotComID else {
             return

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -155,7 +155,6 @@ final class BlogDashboardViewModel {
             completion?(cards)
         }, failure: { [weak self] cards in
             self?.viewController?.stopLoading()
-            self?.loadingFailure()
             self?.updateCurrentCards(cards: cards)
 
             completion?(cards)
@@ -244,15 +243,6 @@ private extension BlogDashboardViewModel {
 }
 
 // MARK: - Ghost/Skeleton cards and failures
-
-private extension BlogDashboardViewModel {
-
-    func loadingFailure() {
-        if blog.dashboardState.hasCachedData {
-            viewController?.loadingFailure()
-        }
-    }
-}
 
 private extension Collection where Element == DashboardCardModel {
     var hasDrafts: Bool {


### PR DESCRIPTION
I was on a spotty connection and kept getting these. The app should never use global `Notice` just for a background refresh. Let's just remove these for now.