### PR TITLE
Integrate Native Block Inserter

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3f7fae5443359ddd34bf7d4357249316e3177f81c7e0d3e77467dee73dc24131",
+  "originHash" : "fa20aa25a9175838313543f726c7d0e88ab8ab5d611ea8d159bc549c27b0cda7",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,8 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "fd9ea8b910b89cf973d464a3d147e94685f1458e",
-        "version" : "0.10.0"
+        "revision" : "df43b1d70fef11fb9035b1d9da7d4a80503c2a6f",
+        "version" : "0.10.1"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c309bd4a10359e813e6b0c4b70e353fb5e054a0a93db9045a8dbb3c7ba8b1c05",
+  "originHash" : "3f7fae5443359ddd34bf7d4357249316e3177f81c7e0d3e77467dee73dc24131",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,7 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "ed8ddd5a8af42b092834e6a3cfbd9944e71b9d59"
+        "revision" : "fd9ea8b910b89cf973d464a3d147e94685f1458e",
+        "version" : "0.10.0"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "4c7d004ff26e92b4a1aced9ed653f925454fd22c6c582cddc07f1e7ef0611720",
+  "originHash" : "c309bd4a10359e813e6b0c4b70e353fb5e054a0a93db9045a8dbb3c7ba8b1c05",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,8 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "4cc0684226c358a430f3d9bc81815883d71cfafa",
-        "version" : "0.10.0-alpha.0"
+        "revision" : "ed8ddd5a8af42b092834e6a3cfbd9944e71b9d59"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "ed8ddd5a8af42b092834e6a3cfbd9944e71b9d59"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.10.0"),
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20251101"),
         .package(
             url: "https://github.com/Automattic/color-studio",

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.10.0"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.10.1"),
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20251101"),
         .package(
             url: "https://github.com/Automattic/color-studio",

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.10.0-alpha.0"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "ed8ddd5a8af42b092834e6a3cfbd9944e71b9d59"),
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20251101"),
         .package(
             url: "https://github.com/Automattic/color-studio",

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -27,6 +27,7 @@ public enum FeatureFlag: Int, CaseIterable {
     case mediaQuotaView
     case intelligence
     case newSupport
+    case nativeBlockInserter
 
     /// Returns a boolean indicating if the feature is enabled.
     ///
@@ -86,6 +87,8 @@ public enum FeatureFlag: Int, CaseIterable {
             return (languageCode ?? "en").hasPrefix("en")
         case .newSupport:
             return false
+        case .nativeBlockInserter:
+            return false
         }
     }
 
@@ -130,6 +133,7 @@ extension FeatureFlag {
         case .mediaQuotaView: "Media Quota"
         case .intelligence: "Intelligence"
         case .newSupport: "New Support"
+        case .nativeBlockInserter: "Native Block Inserter"
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/Editor/CommentGutenbergEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/Editor/CommentGutenbergEditorViewController.swift
@@ -108,8 +108,4 @@ extension CommentGutenbergEditorViewController: GutenbergKit.EditorViewControlle
     func editor(_ viewController: GutenbergKit.EditorViewController, didCloseModalDialog dialogType: String) {
         // Do nothing
     }
-
-    func editor(_ viewController: GutenbergKit.EditorViewController, didLogMessage message: String, level: GutenbergKit.LogLevel) {
-        // Do nothing
-    }
 }

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/Editor/CommentGutenbergEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/Editor/CommentGutenbergEditorViewController.swift
@@ -108,4 +108,8 @@ extension CommentGutenbergEditorViewController: GutenbergKit.EditorViewControlle
     func editor(_ viewController: GutenbergKit.EditorViewController, didCloseModalDialog dialogType: String) {
         // Do nothing
     }
+
+    func editor(_ viewController: GutenbergKit.EditorViewController, didLogMessage message: String, level: GutenbergKit.LogLevel) {
+        // Do nothing
+    }
 }

--- a/WordPress/Classes/ViewRelated/Media/MediaPicker/Helpers/MediaPickerController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPicker/Helpers/MediaPickerController.swift
@@ -1,0 +1,173 @@
+import UIKit
+import GutenbergKit
+import WordPressData
+import WordPressShared
+
+/// A adapter for GutenbergKit that manages media picker sources the editor.
+final class MediaPickerController: GutenbergKit.MediaPickerController {
+    private let blog: Blog
+
+    init(blog: Blog) {
+        self.blog = blog
+    }
+
+    func getActions(for parameters: MediaPickerParameters) -> [MediaPickerActionGroup] {
+        let menu = MediaPickerMenu(
+            filter: convertFilter(parameters.filter),
+            isMultipleSelectionEnabled: parameters.isMultipleSelectionEnabled
+        )
+
+        // Create a temporary controller just to extract action metadata
+        let tempController = MediaPickerMenuController()
+
+        // Define media sources with their identifiers
+        let sources: [(source: MediaPickerSource, id: MediaPickerID)] = [
+            (.siteMedia(blog: blog), .siteMedia),
+            (.freePhotos(blog: blog), .freePhotos),
+            (.freeGIFs(blog: blog), .freeGIFs)
+        ]
+
+        // Create actions from enabled sources
+        let actions = sources.compactMap { source, id -> MediaPickerAction? in
+            guard source.isEnabled else { return nil }
+
+            let uiAction = createUIAction(for: source, menu: menu, controller: tempController)
+            guard let uiAction else { return nil }
+
+            return MediaPickerAction(
+                id: id.rawValue,
+                title: uiAction.title,
+                image: uiAction.image ?? UIImage()
+            )
+        }
+
+        return [MediaPickerActionGroup(id: "primary", actions: actions)]
+            .filter { !$0.actions.isEmpty }
+    }
+
+    func perform(_ action: MediaPickerAction, parameters: MediaPickerParameters, from presentingViewController: UIViewController) async -> [MediaInfo] {
+        // Find the source for this action
+        guard let pickerID = MediaPickerID(rawValue: action.id) else {
+            return []
+        }
+
+        let source = getSource(for: pickerID)
+        guard source.isEnabled else {
+            return []
+        }
+
+        // Create menu and controller
+        let menu = MediaPickerMenu(
+            filter: convertFilter(parameters.filter),
+            isMultipleSelectionEnabled: parameters.isMultipleSelectionEnabled
+        )
+
+        let controller = MediaPickerMenuController()
+
+        // Use continuation to wait for the selection
+        return await withCheckedContinuation { continuation in
+            controller.onSelection = { [weak self] selection in
+                guard let self else {
+                    continuation.resume(returning: [])
+                    return
+                }
+                let mediaInfos = self.convertSelectionToMediaInfo(selection)
+                continuation.resume(returning: mediaInfos)
+            }
+
+            // Create and perform the UIAction
+            if let uiAction = createUIAction(for: source, menu: menu, controller: controller) {
+                MainActor.assumeIsolated {
+                    uiAction.performWithSender(nil, target: nil)
+                }
+            } else {
+                continuation.resume(returning: [])
+            }
+        }
+    }
+
+    // MARK: - Private Methods
+
+    private func getSource(for id: MediaPickerID) -> MediaPickerSource {
+        switch id {
+        case .imagePlayground: .playground
+        case .siteMedia: .siteMedia(blog: blog)
+        case .applePhotos: .photos
+        case .freePhotos: .freePhotos(blog: blog)
+        case .freeGIFs: .freeGIFs(blog: blog)
+        default: fatalError("Unsupported: \(id)")
+        }
+    }
+
+    private func convertFilter(_ filter: MediaPickerParameters.MediaFilter?) -> MediaPickerMenu.MediaFilter? {
+        guard let filter else { return nil }
+        switch filter {
+        case .images: return .images
+        case .videos: return .videos
+        case .all: return nil
+        }
+    }
+
+    private func createUIAction(for source: MediaPickerSource, menu: MediaPickerMenu, controller: MediaPickerMenuController) -> UIAction? {
+        switch source {
+        case .playground: menu.makeImagePlaygroundAction(delegate: controller)
+        case .siteMedia: menu.makeSiteMediaAction(blog: blog, delegate: controller)
+        case .photos: menu.makePhotosAction(delegate: controller)
+        case .freePhotos: menu.makeStockPhotos(blog: blog, delegate: controller)
+        case .freeGIFs: menu.makeFreeGIFAction(blog: blog, delegate: controller)
+        default: nil
+        }
+    }
+
+    private func convertSelectionToMediaInfo(_ selection: MediaPickerSelection) -> [MediaInfo] {
+        var output: [MediaInfo] = []
+
+        for item in selection.items {
+            switch item {
+            case .media(let media):
+                var metadata: [String: String] = [:]
+                if let videopressGUID = media.videopressGUID {
+                    metadata["videopressGUID"] = videopressGUID
+                }
+                let mediaInfo = MediaInfo(
+                    id: media.mediaID?.int32Value,
+                    url: media.remoteURL,
+                    type: media.mimeType,
+                    caption: media.caption,
+                    title: media.filename,
+                    alt: media.alt,
+                    metadata: metadata
+                )
+                output.append(mediaInfo)
+
+            case .external(let asset):
+                let mediaInfo = MediaInfo(
+                    id: nil,
+                    url: asset.largeURL.absoluteString,
+                    type: asset.largeURL.preferredMimeType,
+                    caption: asset.caption,
+                    title: asset.name,
+                    alt: nil,
+                    metadata: [:]
+                )
+                output.append(mediaInfo)
+
+            case .image, .pickerResult:
+                wpAssertionFailure("unused case")
+                break
+            }
+        }
+
+        return output
+    }
+}
+
+private extension URL {
+    var preferredMimeType: String {
+        if let mimeType = UTType(filenameExtension: pathExtension)?.preferredMIMEType {
+            return mimeType
+        } else {
+            return "application/octet-stream"
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Media/MediaPicker/Helpers/MediaPickerMenuController.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPicker/Helpers/MediaPickerMenuController.swift
@@ -6,7 +6,7 @@ import WordPressData
 final class MediaPickerMenuController: NSObject {
     var onSelection: ((MediaPickerSelection) -> Void)?
 
-    fileprivate func didSelect(_ items: [MediaPickerItem], source: String) {
+    fileprivate func didSelect(_ items: [MediaPickerItem], source: MediaPickerID) {
         let selection = MediaPickerSelection(items: items, source: source)
         DispatchQueue.main.async {
             self.onSelection?(selection)
@@ -18,7 +18,7 @@ extension MediaPickerMenuController: PHPickerViewControllerDelegate {
     public func picker(_ picker: PHPickerViewController, didFinishPicking results: [PHPickerResult]) {
         picker.presentingViewController?.dismiss(animated: true)
         if !results.isEmpty {
-            self.didSelect(results.map(MediaPickerItem.pickerResult), source: "apple_photos")
+            self.didSelect(results.map(MediaPickerItem.pickerResult), source: .applePhotos)
         }
     }
 }
@@ -27,7 +27,7 @@ extension MediaPickerMenuController: ImagePickerControllerDelegate {
     func imagePicker(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
         picker.presentingViewController?.dismiss(animated: true)
         if let image = info[.originalImage] as? UIImage {
-            self.didSelect([.image(image)], source: "camera")
+            self.didSelect([.image(image)], source: .camera)
         }
     }
 }
@@ -36,7 +36,7 @@ extension MediaPickerMenuController: SiteMediaPickerViewControllerDelegate {
     func siteMediaPickerViewController(_ viewController: SiteMediaPickerViewController, didFinishWithSelection selection: [Media]) {
         viewController.presentingViewController?.dismiss(animated: true)
         if !selection.isEmpty {
-            self.didSelect(selection.map(MediaPickerItem.media), source: "site_media")
+            self.didSelect(selection.map(MediaPickerItem.media), source: .siteMedia)
         }
     }
 }
@@ -46,7 +46,7 @@ extension MediaPickerMenuController: ImagePlaygroundPickerDelegate {
 
         viewController.presentingViewController?.dismiss(animated: true)
         if let data = try? Data(contentsOf: imageURL), let image = UIImage(data: data) {
-            self.didSelect([.image(image)], source: "image_playground")
+            self.didSelect([.image(image)], source: .imagePlayground)
         } else {
             wpAssertionFailure("failed to read the image created by ImagePlayground")
         }
@@ -57,7 +57,7 @@ extension MediaPickerMenuController: ExternalMediaPickerViewDelegate {
     func externalMediaPickerViewController(_ viewController: ExternalMediaPickerViewController, didFinishWithSelection selection: [ExternalMediaAsset]) {
         viewController.presentingViewController?.dismiss(animated: true)
         if !selection.isEmpty {
-            let source = viewController.source == .tenor ? "free_gifs" : "free_photos"
+            let source: MediaPickerID = viewController.source == .tenor ? .freeGIFs : .freePhotos
             self.didSelect(selection.map(MediaPickerItem.external), source: source)
         }
     }

--- a/WordPress/Classes/ViewRelated/Media/MediaPicker/MediaPicker.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPicker/MediaPicker.swift
@@ -101,7 +101,7 @@ enum MediaPickerSource {
 
 struct MediaPickerSelection {
     var items: [MediaPickerItem]
-    var source: String
+    var source: MediaPickerID
 }
 
 enum MediaPickerItem {

--- a/WordPress/Classes/ViewRelated/Media/MediaPicker/Menu/MediaPickerMenu.swift
+++ b/WordPress/Classes/ViewRelated/Media/MediaPicker/Menu/MediaPickerMenu.swift
@@ -53,3 +53,12 @@ extension MediaPickerMenu.MediaFilter {
         }
     }
 }
+
+enum MediaPickerID: String {
+    case applePhotos = "apple_photos"
+    case camera = "camera"
+    case siteMedia = "site_media"
+    case imagePlayground = "image_playground"
+    case freeGIFs = "free_gifs"
+    case freePhotos = "free_photos"
+}

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Jetpack.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Jetpack.xcscheme
@@ -122,6 +122,11 @@
             value = "disable"
             isEnabled = "NO">
          </EnvironmentVariable>
+         <EnvironmentVariable
+            key = "GUTENBERG_EDITOR_URL"
+            value = "http://localhost:5173/"
+            isEnabled = "NO">
+         </EnvironmentVariable>
       </EnvironmentVariables>
       <AdditionalOptions>
          <AdditionalOption


### PR DESCRIPTION
Integrates new native inserter for Gutenberg.

## Testing Instructions

**Important**: enable "Native Inserter" FF.

-  **Verify** that the new inserter is shown and smoke test it
- **Verify** that for Dotcom sites, "Site Media", "Free Photos", and "Free GIFs" options are available as "secondary" media picker options. 
- **Verify** that for self-hosted sites, only "Site Media" is an available option.

## Known Issues

The routine that handles the selection needs to updated to support using site media without uploading it.

## Screenshots

<img width="360" alt="Screenshot 2025-11-06 at 5 07 05 PM" src="https://github.com/user-attachments/assets/33ccfc94-4179-487d-9b83-bbefdc5e9ec5" />

