### PR TITLE
Fix "Can't add self as subview" crash

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -212,6 +212,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         return true
     }
 
+    override func contentScrollView(for edge: NSDirectionalRectEdge) -> UIScrollView? {
+        scrollView
+    }
+
     func render(_ post: ReaderPost) {
         configureDiscoverAttribution(post)
 
@@ -230,8 +234,16 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
         if post.content?.hasSuffix("[…]") == true {
             let viewMoreView = ReaderReadMoreView(post: post)
-            webView.addSubview(viewMoreView)
-            viewMoreView.pinEdges([.horizontal, .bottom])
+            // Add to the scroll view's parent view instead of directly to webView
+            if let containerView = webView.superview {
+                containerView.addSubview(viewMoreView)
+                viewMoreView.translatesAutoresizingMaskIntoConstraints = false
+                NSLayoutConstraint.activate([
+                    viewMoreView.leadingAnchor.constraint(equalTo: webView.leadingAnchor),
+                    viewMoreView.trailingAnchor.constraint(equalTo: webView.trailingAnchor),
+                    viewMoreView.bottomAnchor.constraint(equalTo: webView.bottomAnchor)
+                ])
+            }
         }
 
         coordinator?.storeAuthenticationCookies(in: webView) { [weak self] in
@@ -543,7 +555,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
         featuredImageView.delegate = coordinator
 
-        view.insertSubview(featuredImageView, belowSubview: webView)
+        view.insertSubview(featuredImageView, belowSubview: scrollView)
 
         NSLayoutConstraint.activate([
             featuredImageView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 0),


### PR DESCRIPTION
Fixes https://a8c.sentry.io/issues/3140539221.

I have no idea what causes this, but Claude is confident it's the featured image layout. We'll see if it fixes it. Ideally, I would rewrite this screen with SwiftUI (later).

## Clues from the issue:

"The _UINavigationParallaxTransition animation may be incorrectly attempting to add a view to itself, possibly due to a recursive view hierarchy."

"NSInvalidArgumentException: Can't add self as subview".

"{
beingPresented: false,
parentViewController: UINavigationController,
screen: ReaderDetailViewController
}"


## Claude Output:



⏺ Ah! This is a critical detail. The _UINavigationParallaxTransition is the iOS navigation controller's push/pop animation system. The crash is
  happening during the navigation transition animation, not just during view setup.

  The issue is that when the navigation controller is trying to create its parallax transition effect, it's encountering a malformed view hierarchy
  where it ends up trying to add a view to itself.

  Looking at the code again with this context, the problem is definitely at line 554 (which shows as line 546 in your note):

  view.insertSubview(featuredImageView, belowSubview: webView)

  The webView is NOT a direct child of view - it's a child of scrollView. When the navigation parallax transition tries to snapshot and animate the
  view hierarchy, this incorrect reference causes the animation system to get confused about the view hierarchy, potentially leading to a recursive
  situation where it tries to add a view to itself.

  Let me fix this:

```
⏺ Update(WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift)
  ⎿  Updated WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift with 1 addition and 1 removal
       551
       552            featuredImageView.delegate = coordinator
       553
       554 -          view.insertSubview(featuredImageView, belowSubview: webView)
       554 +          view.insertSubview(featuredImageView, belowSubview: scrollView)
       555
       556            NSLayoutConstraint.activate([
       557                featuredImageView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 0),

⏺ This fix is correct because:

  1. scrollView IS a direct child of the view controller's view (as shown in the storyboard)
  2. webView is a child of scrollView, not view
  3. Using a non-direct-child as the reference view in insertSubview(_:belowSubview:) creates an invalid view hierarchy that confuses the navigation
  transition animation

  The navigation parallax transition needs a clean, valid view hierarchy to create its animation snapshots. The invalid reference was causing it to
  encounter a recursive or circular reference during its hierarchy traversal, leading to the "Can't add self as subview" error.
```

## Screenshots

The "View More" view is still displayed correctly.

<img width="320" alt="Screenshot 2025-08-04 at 1 31 41 PM" src="https://github.com/user-attachments/assets/4bb1cdc1-e10b-4975-b1b7-a685a6ee9fa3" />

The featured image also is, and it's animated correctly when you scroll.