### PR TITLE
Fix crash in BlobEntity.data save

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 26.1
 -----
 * [*] Remove global error popups from the site dashboard [#24707]
+* [*] Fix crash when saving raw block editor settings [#24711]
 
 26.0
 -----

--- a/Sources/WordPressData/Objective-C/include/Blog.h
+++ b/Sources/WordPressData/Objective-C/include/Blog.h
@@ -176,7 +176,7 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 @property (nonatomic, strong, readwrite, nullable) NSNumber *quotaSpaceAllowed;
 @property (nonatomic, strong, readwrite, nullable) NSNumber *quotaSpaceUsed;
 @property (nullable, nonatomic, retain) NSSet<PageTemplateCategory *> *pageTemplateCategories;
-@property (nonatomic, strong, readwrite, nullable) BlobEntity *rawBlockEditorSettings;
+@property (nonatomic, strong, readwrite, nullable) BlobEntity *rawBlockEditorSettings __deprecated_msg("Use BlockEditorCache instead");;
 
 /**
  *  @details    Maps to a BlogSettings instance, which contains a collection of the available preferences, 

--- a/WordPress/Classes/Models/Blog/Blog+Editor.swift
+++ b/WordPress/Classes/Models/Blog/Blog+Editor.swift
@@ -47,39 +47,4 @@ extension Blog {
     @objc public var isGutenbergEnabled: Bool {
         return editor == .gutenberg
     }
-
-    /// - warning: Decoding can take a non-trivial amount of time.
-    func getBlockEditorSettings() -> [String: Any]? {
-        guard let data = rawBlockEditorSettings?.data else {
-            return nil
-        }
-        do {
-            let object = try JSONSerialization.jsonObject(with: data, options: [])
-            guard let settings = object as? [String: Any] else {
-                wpAssertionFailure("invalid block editor settings object")
-                return nil
-            }
-            return settings
-        } catch {
-            wpAssertionFailure("failed to decode block editor settings", userInfo: ["error": "\(error)"])
-        }
-        return nil
-    }
-
-    func setBlockEditorSettings(_ settings: [String: Any]) {
-        guard JSONSerialization.isValidJSONObject(settings) else {
-            return wpAssertionFailure("invalid block editor settings object")
-        }
-        guard let context = managedObjectContext else {
-            return wpAssertionFailure("missing managed object context")
-        }
-        do {
-            let data = try JSONSerialization.data(withJSONObject: settings, options: [])
-            let blob = NSEntityDescription.insertNewObject(forEntityName: "BlobEntity", into: context) as! BlobEntity
-            blob.data = data
-            self.rawBlockEditorSettings = blob
-        } catch {
-            wpAssertionFailure("failed to encode block editor settings", userInfo: ["error": "\(error)"])
-        }
-    }
 }

--- a/WordPress/Classes/Services/BlockEditorCache.swift
+++ b/WordPress/Classes/Services/BlockEditorCache.swift
@@ -1,0 +1,87 @@
+import Foundation
+import CryptoKit
+import WordPressShared
+import WordPressData
+
+final class BlockEditorCache {
+    static let shared = BlockEditorCache()
+
+    private let rootURL: URL
+    private let blockSettingsURL: URL
+
+    private init() {
+        rootURL = URL.cachesDirectory
+            .appendingPathComponent("GutenbergKit", isDirectory: true)
+        blockSettingsURL = rootURL
+            .appendingPathComponent("BlockSettings", isDirectory: true)
+
+        // Create directory if it doesn't exist
+        try? FileManager.default.createDirectory(at: blockSettingsURL, withIntermediateDirectories: true)
+    }
+
+    // MARK: - Block Settings
+
+    func saveBlockSettings(_ settings: [String: Any], for blogID: TaggedManagedObjectID<Blog>) {
+        let fileURL = makeBlockSettingsURL(for: blogID)
+
+        do {
+            let data = try JSONSerialization.data(withJSONObject: settings, options: [.prettyPrinted])
+            try data.write(to: fileURL)
+        } catch {
+            DDLogError("Failed to save block editor settings: \(error)")
+        }
+    }
+
+    func getBlockSettings(for blogID: TaggedManagedObjectID<Blog>) -> [String: Any]? {
+        let fileURL = makeBlockSettingsURL(for: blogID)
+
+        guard FileManager.default.fileExists(atPath: fileURL.path) else {
+            return nil
+        }
+
+        do {
+            let data = try Data(contentsOf: fileURL)
+            let object = try JSONSerialization.jsonObject(with: data, options: [])
+            return object as? [String: Any]
+        } catch {
+            DDLogError("Failed to load block editor settings: \(error)")
+            // If the file is corrupted, delete it
+            try? FileManager.default.removeItem(at: fileURL)
+            return nil
+        }
+    }
+
+    func deleteBlockSettings(for blogID: TaggedManagedObjectID<Blog>) {
+        let fileURL = makeBlockSettingsURL(for: blogID)
+
+        do {
+            try FileManager.default.removeItem(at: fileURL)
+        } catch {
+            DDLogError("Failed to delete block editor settings: \(error)")
+        }
+    }
+
+    private func makeBlockSettingsURL(for blogID: TaggedManagedObjectID<Blog>) -> URL {
+        let key = sha256(objectID: blogID.objectID)
+        return blockSettingsURL.appendingPathComponent("\(key).json")
+    }
+
+    private func sha256(objectID: NSManagedObjectID) -> String {
+        let uriString = objectID.uriRepresentation().absoluteString
+        let data = Data(uriString.utf8)
+        let hash = SHA256.hash(data: data)
+        return hash.compactMap { String(format: "%02x", $0) }.joined()
+    }
+
+    // MARK: - Misc
+
+    func deleteAll() {
+        do {
+            try FileManager.default.removeItem(at: rootURL)
+            // Recreate the directory
+            try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        } catch {
+            DDLogError("Failed to delete all block editor settings: \(error)")
+        }
+    }
+}

--- a/WordPress/Classes/Utility/AccountHelper.swift
+++ b/WordPress/Classes/Utility/AccountHelper.swift
@@ -106,5 +106,8 @@ import WordPressData
 
         // Delete all the logs after logging out
         WPLogger.shared().deleteAllLogs()
+
+        // Delete all cached block editor settings
+        BlockEditorCache.shared.deleteAll()
     }
 }


### PR DESCRIPTION
Fixes https://a8c.sentry.io/issues/5511798858. 

I'm not entirely sure what I did wrong in https://github.com/wordpress-mobile/WordPress-iOS/pull/24510 (my bad), but let's switch to a simple disk-based cache instead of Core Data – this is bulletproof. 

I added `BlockEditorCache`, integrated it into `RawBlockEditorSettingsService`, and made sure the reads and writes happen in the background.

### Testing Instructions

Go through the steps in https://github.com/wordpress-mobile/WordPress-iOS/pull/24510 and/or verify that saveSettings/getSettings save data correctly using breakpoints.

