### PR TITLE
Stats Review: Add Data Types (P3)

### DIFF
--- a/Modules/Sources/JetpackStats/Services/Data/DataPoint.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/DataPoint.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+struct DataPoint: Identifiable, Hashable, Sendable {
+    let id = UUID()
+    let date: Date
+    let value: Int
+
+    static func == (lhs: DataPoint, rhs: DataPoint) -> Bool {
+        lhs.date == rhs.date && lhs.value == rhs.value
+    }
+}
+
+extension DataPoint {
+    /// Maps previous period data points to align with current period dates.
+    /// - Parameters:
+    ///   - previousData: The data points from the previous period
+    ///   - from: The date interval of the previous period
+    ///   - to: The date interval of the current period
+    ///   - component: The calendar component to use for date calculations
+    ///   - calendar: The calendar to use for date calculations
+    /// - Returns: An array of data points with dates shifted to align with the current period
+    static func mapDataPoints(
+        _ dataPoits: [DataPoint],
+        from: DateInterval,
+        to: DateInterval,
+        component: Calendar.Component,
+        calendar: Calendar
+    ) -> [DataPoint] {
+        let offset = calendar.dateComponents([component], from: from.start, to: to.start).value(for: component) ?? 0
+        return dataPoits.map { dataPoint in
+            DataPoint(
+                date: calendar.date(byAdding: component, value: offset, to: dataPoint.date) ?? dataPoint.date,
+                value: dataPoint.value
+            )
+        }
+    }
+
+    static func getTotalValue(for dataPoints: [DataPoint], metric: SiteMetric) -> Int? {
+        guard !dataPoints.isEmpty else {
+            return nil
+        }
+        let total = dataPoints.reduce(0) { $0 + $1.value }
+        switch metric.aggregationStrategy {
+        case .average:
+            return total / dataPoints.count
+        case .sum:
+            return total
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Services/Data/PostLikeUser.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/PostLikeUser.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+struct PostLikesData: Equatable, Sendable {
+    let users: [PostLikeUser]
+    let totalCount: Int
+
+    init(users: [PostLikeUser], totalCount: Int) {
+        self.users = users
+        self.totalCount = totalCount
+    }
+
+    struct PostLikeUser: Equatable, Identifiable, Sendable {
+        let id: Int
+        let name: String
+        let avatarURL: URL?
+
+        init(id: Int, name: String, avatarURL: URL? = nil) {
+            self.id = id
+            self.name = name
+            self.avatarURL = avatarURL
+        }
+    }
+
+    static let mock = PostLikesData(users: [
+        PostLikeUser(id: 0, name: "Alex Chen"),
+        PostLikeUser(id: 1, name: "Maya Rodriguez"),
+        PostLikeUser(id: 2, name: "James Wilson"),
+        PostLikeUser(id: 3, name: "Zara Okafor"),
+        PostLikeUser(id: 4, name: "Liam O'Connor"),
+        PostLikeUser(id: 5, name: "Priya Patel"),
+        PostLikeUser(id: 6, name: "Noah Kim"),
+        PostLikeUser(id: 7, name: "Sofia Andersson"),
+        PostLikeUser(id: 8, name: "Marcus Thompson"),
+        PostLikeUser(id: 9, name: "Fatima Al-Zahra"),
+        PostLikeUser(id: 10, name: "Diego Santos"),
+        PostLikeUser(id: 11, name: "Emma Johansson")
+    ], totalCount: 12)
+}

--- a/Modules/Sources/JetpackStats/Services/Data/SiteMetric.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/SiteMetric.swift
@@ -1,0 +1,84 @@
+import SwiftUI
+
+enum SiteMetric: String, CaseIterable, Identifiable, Sendable, Codable {
+    case views
+    case visitors
+    case likes
+    case comments
+    case posts
+    case timeOnSite
+    case bounceRate
+    case downloads
+
+    var id: SiteMetric { self }
+
+    var localizedTitle: String {
+        switch self {
+        case .views: Strings.SiteMetrics.views
+        case .visitors: Strings.SiteMetrics.visitors
+        case .likes: Strings.SiteMetrics.likes
+        case .comments: Strings.SiteMetrics.comments
+        case .posts: Strings.SiteMetrics.posts
+        case .timeOnSite: Strings.SiteMetrics.timeOnSite
+        case .bounceRate: Strings.SiteMetrics.bounceRate
+        case .downloads: Strings.SiteMetrics.downloads
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .views: "eyeglasses"
+        case .visitors: "person"
+        case .likes: "star"
+        case .comments: "bubble.left"
+        case .posts: "text.page"
+        case .timeOnSite: "clock"
+        case .bounceRate: "rectangle.portrait.and.arrow.right"
+        case .downloads: "arrow.down.circle"
+        }
+    }
+
+    var primaryColor: Color {
+        switch self {
+        case .views: Constants.Colors.blue
+        case .visitors: Constants.Colors.purple
+        case .likes: Constants.Colors.pink
+        case .comments: Constants.Colors.green
+        case .posts: Constants.Colors.celadon
+        case .timeOnSite: Constants.Colors.orange
+        case .bounceRate: Constants.Colors.pink
+        case .downloads: Constants.Colors.blue
+        }
+    }
+
+    func backgroundColor(in colorScheme: ColorScheme) -> Color {
+        primaryColor.opacity(colorScheme == .light ? 0.05 : 0.15)
+    }
+}
+
+extension SiteMetric {
+    var isHigherValueBetter: Bool {
+        switch self {
+        case .views, .visitors, .likes, .comments, .timeOnSite, .posts, .downloads:
+            return true
+        case .bounceRate:
+            return false
+        }
+    }
+
+    var aggregationStrategy: AggregationStrategy {
+        switch self {
+        case .views, .visitors, .likes, .comments, .posts, .downloads:
+            return .sum
+        case .timeOnSite, .bounceRate:
+            return .average
+        }
+    }
+
+    enum AggregationStrategy {
+        /// Simply sum the values for the given period.
+        case sum
+        /// Calculate the avarege value for the given period.
+        case average
+    }
+}

--- a/Modules/Sources/JetpackStats/Services/Data/SiteMetricsResponse.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/SiteMetricsResponse.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct SiteMetricsResponse: Sendable {
+    var total: SiteMetricsSet
+
+    /// Data points with the requested granularity.
+    ///
+    /// - note: The dates are in the site reporting time zone.
+    ///
+    /// - warning: Hourly data is not available for some metrics, but total
+    /// metrics still are.
+    var metrics: [SiteMetric: [DataPoint]]
+}

--- a/Modules/Sources/JetpackStats/Services/Data/SiteMetricsSet.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/SiteMetricsSet.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// A memory-efficient collection of metrics with direct memory layout and no
+/// heap allocations.
+struct SiteMetricsSet: Codable {
+    var views: Int?
+    var visitors: Int?
+    var likes: Int?
+    var comments: Int?
+    var posts: Int?
+    var bounceRate: Int?
+    var timeOnSite: Int?
+    var downloads: Int?
+
+    subscript(metric: SiteMetric) -> Int? {
+        get {
+            switch metric {
+            case .views: views
+            case .visitors: visitors
+            case .likes: likes
+            case .comments: comments
+            case .posts: posts
+            case .bounceRate: bounceRate
+            case .timeOnSite: timeOnSite
+            case .downloads: downloads
+            }
+        }
+        set {
+            switch metric {
+            case .views: views = newValue
+            case .visitors: visitors = newValue
+            case .likes: likes = newValue
+            case .comments: comments = newValue
+            case .posts: posts = newValue
+            case .bounceRate: bounceRate = newValue
+            case .timeOnSite: timeOnSite = newValue
+            case .downloads: downloads = newValue
+            }
+        }
+    }
+
+    static var mock: SiteMetricsSet {
+        SiteMetricsSet(
+            views: Int.random(in: 10...10000),
+            visitors: Int.random(in: 10...1000),
+            likes: Int.random(in: 10...1000),
+            comments: Int.random(in: 10...1000),
+            posts: Int.random(in: 10...100),
+            bounceRate: Int.random(in: 50...80),
+            timeOnSite: Int.random(in: 10...200),
+            downloads: Int.random(in: 10...500)
+        )
+    }
+}

--- a/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
@@ -1,0 +1,434 @@
+import Foundation
+
+final class TopListData {
+    let item: TopListItemType
+    let metric: SiteMetric
+    let items: [any TopListItemProtocol]
+    let previousItems: [TopListItemID: any TopListItemProtocol]
+    let metrics: Metrics
+
+    struct Metrics {
+        let maxValue: Int
+        let total: Int
+        let previousTotal: Int
+    }
+
+    struct ListID: Hashable {
+        let item: TopListItemType
+        let metric: SiteMetric
+    }
+
+    var listID: ListID {
+        ListID(item: item, metric: metric)
+    }
+
+    init(item: TopListItemType, metric: SiteMetric, items: [any TopListItemProtocol], previousItems: [TopListItemID: any TopListItemProtocol] = [:]) {
+        self.item = item
+        self.metric = metric
+        self.items = items
+        self.previousItems = previousItems
+
+        // Precompute metrics
+        let maxValue = items.compactMap { $0.metrics[metric] }.max() ?? 0
+        let total = items.reduce(0) { $0 + ($1.metrics[metric] ?? 0) }
+        let previousTotal = previousItems.values.reduce(0) { $0 + ($1.metrics[metric] ?? 0) }
+
+        self.metrics = Metrics(
+            maxValue: maxValue,
+            total: total,
+            previousTotal: previousTotal
+        )
+    }
+
+    func previousItem(for currentItem: any TopListItemProtocol) -> (any TopListItemProtocol)? {
+        previousItems[currentItem.id]
+    }
+}
+
+// MARK: - Mock Data
+
+extension TopListData {
+    private struct CacheKey: Hashable {
+        let itemType: TopListItemType
+        let metric: SiteMetric
+        let itemCount: Int
+    }
+
+    @MainActor
+    private static var mockDataCache: [CacheKey: TopListData] = [:]
+
+    @MainActor
+    static func mock(
+        for itemType: TopListItemType,
+        metric: SiteMetric = .views,
+        itemCount: Int = 6
+    ) -> TopListData {
+        let cacheKey = CacheKey(itemType: itemType, metric: metric, itemCount: itemCount)
+
+        // Return cached data if available
+        if let cachedData = mockDataCache[cacheKey] {
+            return cachedData
+        }
+
+        let currentItems = mockItems(for: itemType, metric: metric)
+            .prefix(itemCount)
+
+        // Create previous items dictionary
+        var previousItemsDict: [TopListItemID: any TopListItemProtocol] = [:]
+        for item in currentItems {
+            let previousItem = mockPreviousItem(from: item, metric: metric)
+            previousItemsDict[item.id] = previousItem
+        }
+
+        let chartData = TopListData(
+            item: itemType,
+            metric: metric,
+            items: Array(currentItems),
+            previousItems: previousItemsDict
+        )
+
+        // Cache the generated data
+        mockDataCache[cacheKey] = chartData
+
+        return chartData
+    }
+
+    private static func mockItems(for item: TopListItemType, metric: SiteMetric) -> [any TopListItemProtocol] {
+        switch item {
+        case .postsAndPages: mockPosts(metric: metric)
+        case .referrers: mockReferrers(metric: metric)
+        case .locations: mockLocations(metric: metric)
+        case .authors: mockAuthors(metric: metric)
+        case .externalLinks: mockExternalLinks(metric: metric)
+        case .fileDownloads: mockFileDownloads(metric: metric)
+        case .searchTerms: mockSearchTerms(metric: metric)
+        case .videos: mockVideos(metric: metric)
+        case .archive: mockArchive(metric: metric)
+        }
+    }
+
+    private static func mockPosts(metric: SiteMetric) -> [TopListItem.Post] {
+        let posts = [
+            ("Getting Started with SwiftUI", "John Doe", 3500),
+            ("Understanding Async/Await in Swift", "Jane Smith", 2800),
+            ("Building Better iOS Apps", "Mike Johnson", 2200),
+            ("SwiftUI vs UIKit: A Comparison", "Sarah Wilson", 1900),
+            ("Advanced Swift Techniques", "Tom Brown", 1600),
+            ("iOS App Architecture Patterns", "Emma Davis", 1300),
+            ("Swift Performance Tips", "Chris Miller", 1000),
+            ("Debugging in Xcode", "Lisa Anderson", 850)
+        ]
+
+        return posts.enumerated().map { index, data in
+            let baseValue = data.2
+            let metrics = createMetrics(baseValue: baseValue, metric: metric)
+            return TopListItem.Post(
+                title: data.0,
+                postID: "\(index + 1)",
+                postURL: nil,
+                date: nil,
+                type: nil,
+                author: data.1,
+                metrics: metrics
+            )
+        }
+    }
+
+    private static func mockReferrers(metric: SiteMetric) -> [TopListItem.Referrer] {
+        let referrers = [
+            ("Google", "google.com", 4200),
+            ("Twitter", "twitter.com", 3100),
+            ("Facebook", "facebook.com", 2400),
+            ("LinkedIn", "linkedin.com", 1800),
+            ("Reddit", "reddit.com", 1500),
+            ("Stack Overflow", "stackoverflow.com", 1200),
+            ("GitHub", "github.com", 900),
+            ("Medium", "medium.com", 600)
+        ]
+
+        return referrers.enumerated().map { index, data in
+            let baseValue = data.2
+            let metrics = createMetrics(baseValue: baseValue, metric: metric)
+            return TopListItem.Referrer(
+                name: data.0,
+                domain: data.1,
+                iconURL: nil,
+                children: [
+                    TopListItem.Referrer(
+                        name: "wordpress development tutorial",
+                        domain: "google.com",
+                        iconURL: URL(string: "https://www.google.com/favicon.ico"),
+                        children: [],
+                        metrics: SiteMetricsSet(views: 850)
+                    ),
+                    TopListItem.Referrer(
+                        name: "swift programming blog",
+                        domain: "google.com",
+                        iconURL: URL(string: "https://www.google.com/favicon.ico"),
+                        children: [],
+                        metrics: SiteMetricsSet(views: 750)
+                    ),
+                    TopListItem.Referrer(
+                        name: "ios app development best practices",
+                        domain: "google.com",
+                        iconURL: URL(string: "https://www.google.com/favicon.ico"),
+                        children: [],
+                        metrics: SiteMetricsSet(views: 600)
+                    )
+                ],
+                metrics: metrics
+            )
+        }
+    }
+
+    private static func mockLocations(metric: SiteMetric) -> [TopListItem.Location] {
+        let locations = [
+            ("United States", "US", "🇺🇸", 5600),
+            ("United Kingdom", "GB", "🇬🇧", 3200),
+            ("Canada", "CA", "🇨🇦", 2800),
+            ("Germany", "DE", "🇩🇪", 2100),
+            ("France", "FR", "🇫🇷", 1800),
+            ("Japan", "JP", "🇯🇵", 1500),
+            ("Australia", "AU", "🇦🇺", 1200),
+            ("Netherlands", "NL", "🇳🇱", 900)
+        ]
+
+        return locations.enumerated().map { index, data in
+            let baseValue = data.3
+            let metrics = createMetrics(baseValue: baseValue, metric: metric)
+            return TopListItem.Location(
+                country: data.0,
+                flag: data.2,
+                countryCode: data.1,
+                metrics: metrics
+            )
+        }
+    }
+
+    private static func mockAuthors(metric: SiteMetric) -> [TopListItem.Author] {
+        let authors = [
+            ("Alex Thompson", "Editor", 1, 2400),
+            ("Maria Garcia", "Contributor", 2, 2100),
+            ("David Chen", "Editor", 3, 1800),
+            ("Sophie Martin", "Author", 4, 1500),
+            ("James Wilson", "Contributor", 5, 1200),
+            ("Emma Johnson", "Editor", 6, 900),
+            ("Michael Brown", "Author", 7, 600),
+            ("Sarah Davis", "Contributor", 8, 400)
+        ]
+
+        return authors.enumerated().map { index, data in
+            let baseValue = data.3
+            let metrics = createMetrics(baseValue: baseValue, metric: metric)
+            return TopListItem.Author(
+                name: data.0,
+                userId: String(data.2),
+                role: data.1,
+                metrics: metrics,
+                avatarURL: Bundle.module.path(forResource: "author\(data.2)", ofType: "jpg").map { URL(filePath: $0) }
+            )
+        }
+    }
+
+    private static func mockExternalLinks(metric: SiteMetric) -> [TopListItem.ExternalLink] {
+        let links = [
+            ("Apple Developer", "https://developer.apple.com", 1800),
+            ("Swift.org", "https://swift.org", 1500),
+            ("GitHub", "https://github.com", 1200),
+            ("Stack Overflow", "https://stackoverflow.com", 1000),
+            ("Ray Wenderlich", "https://raywenderlich.com", 800),
+            ("NSHipster", "https://nshipster.com", 600),
+            ("Hacking with Swift", "https://hackingwithswift.com", 450),
+            ("SwiftUI Lab", "https://swiftui-lab.com", 300)
+        ]
+
+        return links.enumerated().map { index, data in
+            let baseValue = data.2
+            let metrics = createMetrics(baseValue: baseValue, metric: metric)
+            return TopListItem.ExternalLink(
+                url: data.1,
+                title: data.0,
+                children: [],
+                metrics: metrics
+            )
+        }
+    }
+
+    private static func mockFileDownloads(metric: SiteMetric) -> [TopListItem.FileDownload] {
+        let files = [
+            ("annual-report-2024.pdf", "/downloads/reports/annual-report-2024.pdf", 2500),
+            ("swift-cheatsheet.pdf", "/downloads/docs/swift-cheatsheet.pdf", 2100),
+            ("app-screenshots.zip", "/downloads/media/app-screenshots.zip", 1800),
+            ("tutorial-video.mp4", "/downloads/videos/tutorial-video.mp4", 1500),
+            ("code-samples.zip", "/downloads/code/code-samples.zip", 1200),
+            ("whitepaper.pdf", "/downloads/docs/whitepaper.pdf", 900),
+            ("presentation.pptx", "/downloads/presentations/presentation.pptx", 600),
+            ("dataset.csv", "/downloads/data/dataset.csv", 400)
+        ]
+
+        return files.enumerated().map { index, data in
+            let baseValue = data.2
+            let metrics = createMetrics(baseValue: baseValue, metric: metric)
+            return TopListItem.FileDownload(
+                fileName: data.0,
+                filePath: data.1,
+                metrics: metrics
+            )
+        }
+    }
+
+    private static func mockSearchTerms(metric: SiteMetric) -> [TopListItem.SearchTerm] {
+        let terms = [
+            ("swiftui tutorial", 3200),
+            ("ios development guide", 2800),
+            ("swift async await", 2400),
+            ("xcode tips", 2000),
+            ("swift performance", 1600),
+            ("ios app architecture", 1200),
+            ("swiftui animation", 800),
+            ("swift best practices", 500)
+        ]
+
+        return terms.enumerated().map { index, data in
+            let baseValue = data.1
+            let metrics = createMetrics(baseValue: baseValue, metric: metric)
+            return TopListItem.SearchTerm(
+                term: data.0,
+                metrics: metrics
+            )
+        }
+    }
+
+    private static func mockVideos(metric: SiteMetric) -> [TopListItem.Video] {
+        let videos = [
+            ("Getting Started with SwiftUI", "101", "https://example.com/videos/swiftui-intro.mp4", 4500),
+            ("iOS Development Best Practices", "102", "https://example.com/videos/best-practices.mp4", 3800),
+            ("Advanced Swift Techniques", "103", "https://example.com/videos/advanced-swift.mp4", 3200),
+            ("Building Custom Views", "104", "https://example.com/videos/custom-views.mp4", 2600),
+            ("App Performance Optimization", "105", "https://example.com/videos/performance.mp4", 2000),
+            ("Debugging Like a Pro", "106", "https://example.com/videos/debugging.mp4", 1500),
+            ("SwiftUI Animations", "107", "https://example.com/videos/animations.mp4", 1000),
+            ("Testing Strategies", "108", "https://example.com/videos/testing.mp4", 700)
+        ]
+
+        return videos.enumerated().map { index, data in
+            let baseValue = data.3
+            let metrics = createMetrics(baseValue: baseValue, metric: metric)
+            return TopListItem.Video(
+                title: data.0,
+                postId: data.1,
+                videoURL: URL(string: data.2),
+                metrics: metrics
+            )
+        }
+    }
+
+    private static func mockArchive(metric: SiteMetric) -> [any TopListItemProtocol] {
+        // Create mock archive sections
+        let archiveSections = [
+            ("pages", [
+                ("/about/", 2500),
+                ("/contact/", 1800),
+                ("/privacy-policy/", 1200),
+                ("/terms-of-service/", 800),
+                ("/faq/", 600)
+            ]),
+            ("categories", [
+                ("/category/technology/", 3200),
+                ("/category/design/", 2800),
+                ("/category/business/", 2400),
+                ("/category/lifestyle/", 1600)
+            ]),
+            ("tags", [
+                ("/tag/swift/", 2100),
+                ("/tag/ios/", 1900),
+                ("/tag/swiftui/", 1700),
+                ("/tag/mobile/", 1400)
+            ]),
+            ("archives", [
+                ("/2024/01/", 1500),
+                ("/2023/12/", 1300),
+                ("/2023/11/", 1100),
+                ("/2023/10/", 900)
+            ])
+        ]
+
+        return archiveSections.map { sectionData in
+            let sectionName = sectionData.0
+            let items = sectionData.1.map { itemData in
+                let metrics = createMetrics(baseValue: itemData.1, metric: metric)
+                return TopListItem.ArchiveItem(
+                    href: "https://example.com\(itemData.0)",
+                    value: itemData.0,
+                    metrics: metrics
+                )
+            }
+
+            // Calculate total views for the section
+            let totalViews = items.reduce(0) { $0 + ($1.metrics[metric] ?? 0) }
+
+            return TopListItem.ArchiveSection(
+                sectionName: sectionName,
+                items: items,
+                metrics: SiteMetricsSet(views: totalViews)
+            )
+        }
+    }
+
+    private static func createMetrics(baseValue: Int, metric: SiteMetric) -> SiteMetricsSet {
+        // Add some variation to make it more realistic
+        let variation = Double.random(in: 0.8...1.2)
+        let value = Int(Double(baseValue) * variation)
+
+        switch metric {
+        case .views:
+            return SiteMetricsSet(views: value)
+        case .visitors:
+            // Visitors are typically 60-80% of views
+            let visitorRatio = Double.random(in: 0.6...0.8)
+            return SiteMetricsSet(visitors: Int(Double(value) * visitorRatio))
+        case .likes:
+            // Likes are typically 2-5% of views
+            let likeRatio = Double.random(in: 0.02...0.05)
+            return SiteMetricsSet(likes: Int(Double(value) * likeRatio))
+        case .comments:
+            // Comments are typically 0.5-2% of views
+            let commentRatio = Double.random(in: 0.005...0.02)
+            return SiteMetricsSet(comments: Int(Double(value) * commentRatio))
+        case .posts:
+            let postsRatio = Double.random(in: 0.002...0.005)
+            return SiteMetricsSet(posts: Int(Double(value) * postsRatio))
+        case .downloads:
+            // Generic count metric (used for downloads, etc.)
+            return SiteMetricsSet(downloads: value)
+        case .timeOnSite:
+            // Time on site not applicable for top list items
+            return SiteMetricsSet(views: value)
+        case .bounceRate:
+            // Bounce rate not applicable for top list items
+            return SiteMetricsSet(views: value)
+        }
+    }
+
+    private static func mockPreviousItem(from item: any TopListItemProtocol, metric: SiteMetric) -> any TopListItemProtocol {
+        var item = item
+
+        // Create previous value that's 70-130% of current value for realistic trends
+        let trendFactor = Double.random(in: 0.7...1.3)
+        let currentValue = item.metrics[metric] ?? 0
+        item.metrics[metric] = Int(Double(currentValue) * trendFactor)
+
+        // Special handling for archive sections - update child items too
+        if var archiveSection = item as? TopListItem.ArchiveSection {
+            archiveSection.items = archiveSection.items.map { archiveItem in
+                var mutableItem = archiveItem
+                let itemCurrentValue = mutableItem.metrics[metric] ?? 0
+                mutableItem.metrics[metric] = Int(Double(itemCurrentValue) * trendFactor)
+                return mutableItem
+            }
+            return archiveSection
+        }
+
+        return item
+    }
+}

--- a/Modules/Sources/JetpackStats/Services/Data/TopListItem+WordPressKit.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListItem+WordPressKit.swift
@@ -1,0 +1,137 @@
+import Foundation
+@preconcurrency import WordPressKit
+
+extension TopListItem.Post {
+    init(_ post: WordPressKit.StatsTopPost, dateFormatter: DateFormatter) {
+        self.init(
+            title: post.title,
+            postID: String(post.postID),
+            postURL: post.postURL,
+            date: post.date.flatMap(dateFormatter.date),
+            type: post.kind.description,
+            author: nil,
+            metrics: SiteMetricsSet(views: post.viewsCount)
+        )
+    }
+}
+
+extension TopListItem.Referrer {
+    init(_ referrer: WordPressKit.StatsReferrer) {
+        self.init(
+            name: referrer.title,
+            domain: referrer.url?.host,
+            iconURL: referrer.iconURL,
+            children: referrer.children.map { TopListItem.Referrer($0) },
+            metrics: SiteMetricsSet(views: referrer.viewsCount)
+        )
+    }
+}
+
+extension TopListItem.Location {
+    init(_ country: WordPressKit.StatsCountry) {
+        self.init(
+            country: country.name,
+            flag: Self.countryCodeToEmoji(country.code),
+            countryCode: country.code,
+            metrics: SiteMetricsSet(views: country.viewsCount)
+        )
+    }
+
+    private static func countryCodeToEmoji(_ code: String) -> String? {
+        let base: UInt32 = 127397
+        var scalarView = String.UnicodeScalarView()
+        for i in code.uppercased().unicodeScalars {
+            guard let scalar = UnicodeScalar(base + i.value) else { return nil }
+            scalarView.append(scalar)
+        }
+        return String(scalarView)
+    }
+}
+
+extension TopListItem.Author {
+    init(_ author: WordPressKit.StatsTopAuthor, dateFormatter: DateFormatter) {
+        self.init(
+            name: author.name,
+            userId: author.name, // NOTE: WordPressKit doesn't provide user ID
+            role: nil,
+            metrics: SiteMetricsSet(views: author.viewsCount),
+            avatarURL: author.iconURL,
+            posts: author.posts.map { TopListItem.Post($0, dateFormatter: dateFormatter) }
+        )
+    }
+}
+
+extension TopListItem.ExternalLink {
+    init(_ click: WordPressKit.StatsClick) {
+        self.init(
+            url: click.clickedURL?.absoluteString ?? "",
+            title: click.title,
+            children: click.children.map { TopListItem.ExternalLink($0) },
+            metrics: SiteMetricsSet(views: click.clicksCount)
+        )
+    }
+}
+
+extension TopListItem.FileDownload {
+    init(_ download: WordPressKit.StatsFileDownload) {
+        self.init(
+            fileName: URL(string: download.file)?.lastPathComponent ?? download.file,
+            filePath: download.file,
+            metrics: SiteMetricsSet(downloads: download.downloadCount)
+        )
+    }
+}
+
+extension TopListItem.SearchTerm {
+    init(_ searchTerm: WordPressKit.StatsSearchTerm) {
+        self.init(
+            term: searchTerm.term,
+            metrics: SiteMetricsSet(views: searchTerm.viewsCount)
+        )
+    }
+}
+
+extension TopListItem.Video {
+    init(_ video: WordPressKit.StatsVideo) {
+        self.init(
+            title: video.title,
+            postId: String(video.postID),
+            videoURL: video.videoURL,
+            metrics: SiteMetricsSet(views: video.playsCount)
+        )
+    }
+}
+
+extension TopListItem.ArchiveItem {
+    init(_ item: WordPressKit.StatsArchiveItem) {
+        self.init(
+            href: item.href,
+            value: item.value,
+            metrics: SiteMetricsSet(views: item.views)
+        )
+    }
+}
+
+extension TopListItem.ArchiveSection {
+    init(sectionName: String, items: [WordPressKit.StatsArchiveItem]) {
+        let archiveItems = items.map { TopListItem.ArchiveItem($0) }
+        let totalViews = items.reduce(0) { $0 + $1.views }
+
+        self.init(
+            sectionName: sectionName,
+            items: archiveItems,
+            metrics: SiteMetricsSet(views: totalViews)
+        )
+    }
+}
+
+private extension StatsTopPost.Kind {
+    var description: String {
+        switch self {
+        case .post: "post"
+        case .page: "page"
+        case .homepage: "homepage"
+        case .unknown: "unknown"
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Services/Data/TopListItem.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListItem.swift
@@ -1,0 +1,144 @@
+import Foundation
+
+struct TopListResponse: Sendable {
+    let items: [any TopListItemProtocol]
+}
+
+struct TopListItem: Sendable {
+    let items: [any TopListItemProtocol]
+}
+
+/// - warning: It's required for animations in ``TopListItemsView`` to work
+/// well for IDs to be unique across the domains. If we were just to use
+/// `String`, there would be collisions across domains, e.g. post and author
+/// using the same String ID "1".
+struct TopListItemID: Hashable {
+    let type: TopListItemType
+    let id: String
+}
+
+protocol TopListItemProtocol: Codable, Sendable, Identifiable {
+    var metrics: SiteMetricsSet { get set }
+    var id: TopListItemID { get }
+}
+
+extension TopListItem {
+    struct Post: Codable, TopListItemProtocol {
+        let title: String
+        let postID: String?
+        var postURL: URL?
+        let date: Date?
+        let type: String?
+        let author: String?
+        var metrics: SiteMetricsSet
+
+        var id: TopListItemID {
+            TopListItemID(type: .postsAndPages, id: postID ?? title)
+        }
+    }
+
+    struct Referrer: Codable, TopListItemProtocol {
+        let name: String
+        let domain: String?
+        let iconURL: URL?
+        let children: [Referrer]
+        var metrics: SiteMetricsSet
+
+        var id: TopListItemID {
+            TopListItemID(type: .referrers, id: (domain ?? "–") + name)
+        }
+    }
+
+    struct Location: Codable, TopListItemProtocol {
+        let country: String
+        let flag: String?
+        let countryCode: String?
+        var metrics: SiteMetricsSet
+
+        var id: TopListItemID {
+            TopListItemID(type: .locations, id: countryCode ?? country)
+        }
+    }
+
+    struct Author: Codable, TopListItemProtocol {
+        let name: String
+        let userId: String
+        let role: String?
+        var metrics: SiteMetricsSet
+        var avatarURL: URL?
+        var posts: [Post]?
+
+        var id: TopListItemID {
+            TopListItemID(type: .authors, id: userId)
+        }
+    }
+
+    struct ExternalLink: Codable, TopListItemProtocol {
+        let url: String
+        let title: String?
+        let children: [ExternalLink]
+        var metrics: SiteMetricsSet
+
+        var id: TopListItemID {
+            TopListItemID(type: .externalLinks, id: url)
+        }
+    }
+
+    struct FileDownload: Codable, TopListItemProtocol {
+        let fileName: String
+        let filePath: String?
+        var metrics: SiteMetricsSet
+
+        var id: TopListItemID {
+            TopListItemID(type: .fileDownloads, id: filePath ?? fileName)
+        }
+    }
+
+    struct SearchTerm: Codable, TopListItemProtocol {
+        let term: String
+        var metrics: SiteMetricsSet
+
+        var id: TopListItemID {
+            TopListItemID(type: .searchTerms, id: term)
+        }
+    }
+
+    struct Video: Codable, TopListItemProtocol {
+        let title: String
+        let postId: String
+        let videoURL: URL?
+        var metrics: SiteMetricsSet
+
+        var id: TopListItemID {
+            TopListItemID(type: .videos, id: postId)
+        }
+    }
+
+    struct ArchiveItem: Codable, TopListItemProtocol {
+        let href: String
+        let value: String
+        var metrics: SiteMetricsSet
+
+        var id: TopListItemID {
+            TopListItemID(type: .archive, id: href)
+        }
+    }
+
+    struct ArchiveSection: Codable, TopListItemProtocol {
+        let sectionName: String
+        var items: [ArchiveItem]
+        var metrics: SiteMetricsSet
+
+        var id: TopListItemID {
+            TopListItemID(type: .archive, id: sectionName)
+        }
+
+        var displayName: String {
+            switch sectionName.lowercased() {
+            case "author": Strings.ArchiveSections.author
+            case "other": Strings.ArchiveSections.other
+            default: sectionName.capitalized
+            }
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Services/Data/TopListItemType.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListItemType.swift
@@ -1,0 +1,85 @@
+import SwiftUI
+
+enum TopListItemType: String, Identifiable, CaseIterable, Sendable, Codable {
+    case postsAndPages
+    case authors
+    case referrers
+    case locations
+    case videos
+    case externalLinks
+    case searchTerms
+    case fileDownloads
+    case archive
+
+    var id: TopListItemType { self }
+
+    var localizedTitle: String {
+        switch self {
+        case .postsAndPages: Strings.SiteDataTypes.postsAndPages
+        case .authors: Strings.SiteDataTypes.authors
+        case .referrers: Strings.SiteDataTypes.referrers
+        case .locations: Strings.SiteDataTypes.locations
+        case .externalLinks: Strings.SiteDataTypes.externalLinks
+        case .fileDownloads: Strings.SiteDataTypes.fileDownloads
+        case .searchTerms: Strings.SiteDataTypes.searchTerms
+        case .videos: Strings.SiteDataTypes.videos
+        case .archive: Strings.SiteDataTypes.archive
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .postsAndPages: "text.page"
+        case .referrers: "link"
+        case .locations: "map"
+        case .authors: "person"
+        case .externalLinks: "cursorarrow.click"
+        case .fileDownloads: "arrow.down.circle"
+        case .searchTerms: "magnifyingglass"
+        case .videos: "play.rectangle"
+        case .archive: "folder"
+        }
+    }
+
+    func getTitle(for metric: SiteMetric) -> String {
+        switch metric {
+        case .views: Strings.TopListTitles.mostViewed
+        case .visitors: Strings.TopListTitles.mostVisitors
+        case .comments: Strings.TopListTitles.mostCommented
+        case .likes: Strings.TopListTitles.mostLiked
+        case .posts: Strings.TopListTitles.mostPosts
+        case .bounceRate: Strings.TopListTitles.highestBounceRate
+        case .timeOnSite: Strings.TopListTitles.longestTimeOnSite
+        case .downloads: Strings.TopListTitles.mostDownloadeded
+        }
+    }
+
+    static let secondaryItems: Set<TopListItemType> = [
+        .externalLinks, .fileDownloads, .searchTerms, .archive
+    ]
+
+    var documentationURL: URL? {
+        URL(string: documentationPath)
+    }
+
+    private var documentationPath: String {
+        switch self {
+        case .postsAndPages, .archive:
+            "https://wordpress.com/support/stats/analyze-content-performance/#view-posts-pages-traffic"
+        case .authors:
+            "https://wordpress.com/support/stats/analyze-content-performance/#check-author-performance"
+        case .referrers:
+            "https://wordpress.com/support/stats/understand-traffic-sources/#identify-referrers"
+        case .searchTerms:
+            "https://wordpress.com/support/stats/understand-traffic-sources/#analyze-search-terms"
+        case .fileDownloads:
+            "https://wordpress.com/support/stats/analyze-content-performance/#track-file-downloads"
+        case .externalLinks:
+            "https://wordpress.com/support/stats/analyze-content-performance/#analyze-clicks"
+        case .locations:
+            "https://wordpress.com/support/stats/audience-insights/"
+        case .videos:
+            "https://wordpress.com/support/stats/analyze-content-performance/#see-video-traffic"
+        }
+    }
+}


### PR DESCRIPTION
This PR introduces data types:
- `DataPoint` to represent points on charts (future `ChartCard`)
- `TopListItem` and nested structs to represent types in the top lists (future `TopListCard`)
- And more

The structs have localized titles, icons, etc. Some of the items have small in-memory mock data to be used in production for skeleton views (`.redacted(reason: .placeholder)`). It's not the same data as in https://github.com/wordpress-mobile/WordPress-iOS/pull/24713 (for the full-blown service that covers data over 10+ years).