### PR TITLE
Stats Review: Add types to represent date period, granularity, presets, and more (P4)

### DIFF
--- a/Modules/Sources/JetpackStats/Extensions/Calendar+ComparisonPeriod.swift
+++ b/Modules/Sources/JetpackStats/Extensions/Calendar+ComparisonPeriod.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+enum DateRangeComparisonPeriod: Equatable, Sendable, CaseIterable, Identifiable {
+    case precedingPeriod
+    case samePeriodLastYear
+
+    var id: DateRangeComparisonPeriod { self }
+
+    var localizedTitle: String {
+        switch self {
+        case .precedingPeriod: Strings.DatePicker.precedingPeriod
+        case .samePeriodLastYear: Strings.DatePicker.samePeriodLastYear
+        }
+    }
+}
+
+extension Calendar {
+    func comparisonRange(for dateInterval: DateInterval, period: DateRangeComparisonPeriod, component: Calendar.Component) -> DateInterval {
+        switch period {
+        case .precedingPeriod:
+            return navigate(dateInterval, direction: .backward, component: component)
+        case .samePeriodLastYear:
+            guard let newStart = date(byAdding: .year, value: -1, to: dateInterval.start),
+                  let newEnd = date(byAdding: .year, value: -1, to: dateInterval.end) else {
+                assertionFailure("something went wrong: invalid range for: \(dateInterval)")
+                return dateInterval
+            }
+            return DateInterval(start: newStart, end: newEnd)
+        }
+    }
+
+    /// Determines if a date represents a period that might have incomplete data.
+    ///
+    /// - Returns: True if the date's period might have incomplete data
+    func isIncompleteDataPeriod(for date: Date, granularity: DateRangeGranularity, now: Date = .now) -> Bool {
+        isDate(date, equalTo: now, toGranularity: granularity.component)
+    }
+}

--- a/Modules/Sources/JetpackStats/Extensions/Calendar+Navigation.swift
+++ b/Modules/Sources/JetpackStats/Extensions/Calendar+Navigation.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+extension Calendar {
+    enum NavigationDirection {
+        case backward
+        case forward
+
+        var systemImage: String {
+            switch self {
+            case .backward: "chevron.backward"
+            case .forward: "chevron.forward"
+            }
+        }
+    }
+
+    /// Navigates to the next or previous period from the given date interval.
+    ///
+    /// This method navigates by the length of the period for the given component.
+    /// For example, if the interval represents 6 months and the component is `.month`,
+    /// it will navigate forward or backward by 6 months.
+    ///
+    /// - Parameters:
+    ///   - interval: The date interval to navigate from
+    ///   - direction: Whether to navigate forward (.forward) or backward (.backward)
+    ///   - component: The calendar component to use for navigation
+    /// - Returns: A new date interval representing the navigated period
+    func navigate(_ interval: DateInterval, direction: NavigationDirection, component: Calendar.Component) -> DateInterval {
+        let multiplier = direction == .forward ? 1 : -1
+
+        // Calculate the offset based on the interval length and component
+        let offset = calculateOffset(for: interval, component: component)
+
+        // Navigate by the calculated offset
+        guard let newStart = date(byAdding: component, value: offset * multiplier, to: interval.start),
+              let newEnd = date(byAdding: component, value: offset * multiplier, to: interval.end) else {
+            assertionFailure("Failed to navigate \(component) interval by \(offset)")
+            return interval
+        }
+
+        return DateInterval(start: newStart, end: newEnd)
+    }
+
+    /// Calculates the number of units of the given component in the interval
+    private func calculateOffset(for interval: DateInterval, component: Calendar.Component) -> Int {
+        let components = dateComponents([component], from: interval.start, to: interval.end)
+        return switch component {
+        case .day: components.day ?? 1
+        case .weekOfYear: components.weekOfYear ?? 1
+        case .month: components.month ?? 1
+        case .quarter: components.quarter ?? 1
+        case .year: components.year ?? 1
+        default: 1
+        }
+    }
+
+    /// Determines if navigation is allowed in the specified direction
+    func canNavigate(_ interval: DateInterval, direction: NavigationDirection, minYear: Int = 2000, now: Date = .now) -> Bool {
+        switch direction {
+        case .backward:
+            let components = dateComponents([.year], from: interval.start)
+            return (components.year ?? 0) > minYear
+        case .forward:
+            let currentEndDate = startOfDay(for: interval.end)
+            let today = startOfDay(for: now)
+            return currentEndDate <= today
+        }
+    }
+
+    /// Determines the appropriate navigation component for a given date interval.
+    ///
+    /// This method analyzes the interval to determine if it represents a standard calendar period
+    /// (day, week, month, or year) and returns the corresponding component for navigation.
+    ///
+    /// - Parameter interval: The date interval to analyze
+    /// - Returns: The calendar component that best represents the interval, or nil if it's a custom period
+    func determineNavigationComponent(for interval: DateInterval) -> Calendar.Component? {
+        let start = interval.start
+        let end = interval.end.addingTimeInterval(-1)
+
+        // Check if it's a single day
+        if isDate(start, equalTo: end, toGranularity: .day) {
+            return .day
+        }
+
+        // Check if it's a complete month
+        let startOfMonth = dateInterval(of: .month, for: start)
+        if let monthInterval = startOfMonth,
+           abs(monthInterval.start.timeIntervalSince(start)) < 1,
+           abs(monthInterval.end.timeIntervalSince(interval.end)) < 1 {
+            return .month
+        }
+
+        // Check if it's a complete year
+        let startOfYear = dateInterval(of: .year, for: start)
+        if let yearInterval = startOfYear,
+           abs(yearInterval.start.timeIntervalSince(start)) < 1,
+           abs(yearInterval.end.timeIntervalSince(interval.end)) < 1 {
+            return .year
+        }
+
+        // Check if it's a complete week
+        let startOfWeek = dateInterval(of: .weekOfYear, for: start)
+        if let weekInterval = startOfWeek,
+           abs(weekInterval.start.timeIntervalSince(start)) < 1,
+           abs(weekInterval.end.timeIntervalSince(interval.end)) < 1 {
+            return .weekOfYear
+        }
+
+        return nil
+    }
+}

--- a/Modules/Sources/JetpackStats/Extensions/Calendar+Presets.swift
+++ b/Modules/Sources/JetpackStats/Extensions/Calendar+Presets.swift
@@ -1,0 +1,140 @@
+import Foundation
+
+/// Represents predefined date range options for stats filtering.
+/// Each preset defines a specific time period relative to the current date.
+enum DateIntervalPreset: String, CaseIterable, Identifiable {
+    /// The current calendar day
+    case today
+    /// The current calendar week
+    case thisWeek
+    /// The current calendar month
+    case thisMonth
+    /// The current calendar quarter
+    case thisQuarter
+    /// The current calendar year
+    case thisYear
+    /// The previous 7 days, not including today
+    case last7Days
+    /// The previous 28 days, not including today
+    case last28Days
+    /// The previous 30 days, not including today
+    case last30Days
+    /// The previous 90 days, not including today
+    case last90Days
+    /// The last 6 months, including the current month
+    case last6Months
+    /// The last 12 months, including the current month
+    case last12Months
+    /// The last 3 complete years, including the current year
+    case last3Years
+    /// The last 10 complete years, including the current year
+    case last10Years
+
+    var id: DateIntervalPreset { self }
+
+    var localizedString: String {
+        switch self {
+        case .today: Strings.Calendar.today
+        case .thisWeek: Strings.Calendar.thisWeek
+        case .thisMonth: Strings.Calendar.thisMonth
+        case .thisQuarter: Strings.Calendar.thisQuarter
+        case .thisYear: Strings.Calendar.thisYear
+        case .last7Days: Strings.Calendar.last7Days
+        case .last28Days: Strings.Calendar.last28Days
+        case .last30Days: Strings.Calendar.last30Days
+        case .last90Days: Strings.Calendar.last90Days
+        case .last6Months: Strings.Calendar.last6Months
+        case .last12Months: Strings.Calendar.last12Months
+        case .last3Years: Strings.Calendar.last3Years
+        case .last10Years: Strings.Calendar.last10Years
+        }
+    }
+
+    var prefersDateIntervalFormatting: Bool {
+        switch self {
+        case .today, .last7Days, .last28Days, .last30Days, .last90Days, .last6Months, .last12Months, .thisWeek:
+            return false
+        case .thisMonth, .thisYear, .thisQuarter, .last3Years, .last10Years:
+            return true
+        }
+    }
+
+    /// Returns a calendar component for navigation behavior
+    var component: Calendar.Component {
+        switch self {
+        case .today:
+            return .day
+        case .thisWeek:
+            return .weekOfYear
+        case .thisMonth, .last6Months, .last12Months:
+            return .month
+        case .thisQuarter:
+            return .quarter
+        case .thisYear, .last3Years, .last10Years:
+            return .year
+        case .last7Days, .last28Days, .last30Days, .last90Days:
+            return .day
+        }
+    }
+}
+
+extension Calendar {
+    /// Creates a DateInterval for the given preset relative to the specified date.
+    /// - Parameters:
+    ///   - preset: The date range preset to convert to a DateInterval
+    ///   - now: The reference date for relative calculations (defaults to current date)
+    /// - Returns: A DateInterval representing the date range
+    ///
+    /// ## Examples
+    /// ```swift
+    /// let calendar = Calendar.current
+    /// let now = Date("2025-01-15T14:30:00Z")
+    ///
+    /// // Today: Returns interval for January 15
+    /// let today = calendar.makeDateInterval(for: .today, now: now)
+    /// // Start: 2025-01-15 00:00:00
+    /// // End: 2025-01-16 00:00:00
+    ///
+    /// // Last 7 days: Returns previous 7 complete days, not including today
+    /// let last7 = calendar.makeDateInterval(for: .last7Days, now: now)
+    /// // Start: 2025-01-08 00:00:00
+    /// // End: 2025-01-15 00:00:00
+    /// ```
+    func makeDateInterval(for preset: DateIntervalPreset, now: Date = .now) -> DateInterval {
+        switch preset {
+        case .today: makeDateInterval(of: .day, for: now)
+        case .thisWeek: makeDateInterval(of: .weekOfYear, for: now)
+        case .thisMonth: makeDateInterval(of: .month, for: now)
+        case .thisQuarter: makeDateInterval(of: .quarter, for: now)
+        case .thisYear: makeDateInterval(of: .year, for: now)
+        case .last7Days: makeDateInterval(offset: -7, component: .day, for: now)
+        case .last28Days: makeDateInterval(offset: -28, component: .day, for: now)
+        case .last30Days: makeDateInterval(offset: -30, component: .day, for: now)
+        case .last90Days: makeDateInterval(offset: -90, component: .day, for: now)
+        case .last6Months: makeDateInterval(offset: -6, component: .month, for: now)
+        case .last12Months: makeDateInterval(offset: -12, component: .month, for: now)
+        case .last3Years: makeDateInterval(offset: -3, component: .year, for: now)
+        case .last10Years: makeDateInterval(offset: -10, component: .year, for: now)
+        }
+    }
+
+    private func makeDateInterval(of component: Component, for date: Date) -> DateInterval {
+        guard let interval = self.dateInterval(of: component, for: date) else {
+            assertionFailure("Failed to get \(component) interval for \(date)")
+            return DateInterval(start: date, duration: 0)
+        }
+        return interval
+    }
+
+    private func makeDateInterval(offset: Int, component: Component, for date: Date) -> DateInterval {
+        var endDate = makeDateInterval(of: component, for: date).end
+        if component == .day {
+            endDate = self.date(byAdding: .day, value: -1, to: endDate) ?? endDate
+        }
+        guard let startDate = self.date(byAdding: component, value: offset, to: endDate), endDate >= startDate else {
+            assertionFailure("Failed to calculate start date for \(offset) \(component) from \(endDate)")
+            return DateInterval(start: date, end: date)
+        }
+        return DateInterval(start: startDate, end: endDate)
+    }
+}

--- a/Modules/Sources/JetpackStats/Extensions/UIColor+Extensions.swift
+++ b/Modules/Sources/JetpackStats/Extensions/UIColor+Extensions.swift
@@ -1,0 +1,13 @@
+import UIKit
+
+extension UIColor {
+    convenience init(light: UIColor, dark: UIColor) {
+        self.init { traitCollection in
+            if traitCollection.userInterfaceStyle == .dark {
+                return dark
+            } else {
+                return light
+            }
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Utilities/DateRangeGranularity.swift
+++ b/Modules/Sources/JetpackStats/Utilities/DateRangeGranularity.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+enum DateRangeGranularity: Comparable {
+    case hour
+    case day
+    case month
+    case year
+}
+
+extension DateInterval {
+    /// Automatically determine the appropriate period for chart display based
+    /// on date range. This aims to show between 7 and 30 data points for optimal
+    /// visualization on both bar charts and line charts where you can use drag
+    /// gesture to see information about individual periods.
+    var preferredGranularity: DateRangeGranularity {
+        // Calculate total days for more accurate granularity selection
+        let totalDays = Int(ceil(duration / 86400)) // 86400 seconds in a day
+
+        // For ranges <= 1 day: show hourly data (up to 24 points)
+        if totalDays <= 1 {
+            return .hour
+        }
+        // For ranges 2-90 days: show daily data (2-90 points)
+        else if totalDays <= 90 {
+            return .day
+        }
+        // For ranges under about 4 years, show months
+        else if totalDays <= 365 * 4 {
+            return .month
+        }
+        // For ranges > 2 years: show yearly data
+        else {
+            return .year
+        }
+    }
+}
+
+extension DateRangeGranularity {
+    /// Components needed to aggregate data at this granularity
+    var calendarComponents: Set<Calendar.Component> {
+        switch self {
+        case .hour: [.year, .month, .day, .hour]
+        case .day: [.year, .month, .day]
+        case .month: [.year, .month]
+        case .year: [.year]
+        }
+    }
+
+    /// Component to increment when generating date sequences
+    var component: Calendar.Component {
+        switch self {
+        case .hour: .hour
+        case .day: .day
+        case .month: .month
+        case .year: .year
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Utilities/Formatters/StatsDateFormatter.swift
+++ b/Modules/Sources/JetpackStats/Utilities/Formatters/StatsDateFormatter.swift
@@ -1,0 +1,96 @@
+import Foundation
+
+struct StatsDateFormatter: Sendable {
+    enum Context {
+        case compact
+        case regular
+    }
+
+    var locale: Locale {
+        didSet {
+            updateFormatters()
+        }
+    }
+
+    var timeZone: TimeZone {
+        didSet {
+            updateFormatters()
+        }
+    }
+
+    final class CachedFormatters: Sendable {
+        let hour: DateFormatter
+
+        let compactDay: DateFormatter
+        let compactMonth: DateFormatter
+
+        let regularDay: DateFormatter
+        let regularMonth: DateFormatter
+
+        let year: DateFormatter
+
+        let timeOffset: DateFormatter
+
+        init(locale: Locale, timeZone: TimeZone) {
+            func makeFormatter(_ dateFormat: String) -> DateFormatter {
+                let formatter = DateFormatter()
+                formatter.locale = locale
+                formatter.timeZone = timeZone
+                formatter.dateFormat = dateFormat
+                return formatter
+            }
+
+            hour = makeFormatter("h a")
+
+            compactDay = makeFormatter("MMM d")
+            compactMonth = makeFormatter("MMM")
+
+            regularDay = makeFormatter("EEEE, MMMM d")
+            regularMonth = makeFormatter("MMMM yyyy")
+
+            year = makeFormatter("yyyy")
+
+            timeOffset = makeFormatter("ZZZZ")
+        }
+
+        func formatter(granularity: DateRangeGranularity, context: Context) -> DateFormatter {
+            switch context {
+            case .compact:
+                switch granularity {
+                case .hour: hour
+                case .day: compactDay
+                case .month: compactMonth
+                case .year: year
+                }
+            case .regular:
+                switch granularity {
+                case .hour: hour
+                case .day: regularDay
+                case .month: regularMonth
+                case .year: year
+                }
+            }
+        }
+    }
+
+    private var formatters: CachedFormatters
+
+    private mutating func updateFormatters() {
+        formatters = CachedFormatters(locale: locale, timeZone: timeZone)
+    }
+
+    init(locale: Locale = .current, timeZone: TimeZone = .current) {
+        self.locale = locale
+        self.timeZone = timeZone
+        self.formatters = CachedFormatters(locale: locale, timeZone: timeZone)
+    }
+
+    func formatDate(_ date: Date, granularity: DateRangeGranularity, context: Context = .compact) -> String {
+        let formatter = formatters.formatter(granularity: granularity, context: context)
+        return formatter.string(from: date)
+    }
+
+    var formattedTimeOffset: String {
+        formatters.timeOffset.string(from: .now)
+    }
+}

--- a/Modules/Sources/JetpackStats/Utilities/Formatters/StatsDateRangeFormatter.swift
+++ b/Modules/Sources/JetpackStats/Utilities/Formatters/StatsDateRangeFormatter.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+/// Formats date intervals for display in stats UI, with smart year display.
+///
+/// Years are shown only when dates are not in the current year.
+///
+/// ## Examples
+///
+/// ```swift
+/// // Current year: no year shown
+/// "Mar 15"                           // Single day
+/// "Jan 1 – 5"                        // Same month
+/// "Jan 31 – Feb 2"                   // Cross month
+///
+/// // Previous year: year shown
+/// "Mar 15, 2024"                     // Single day
+/// "Jan 1 – 5, 2024"                  // Same month
+/// "Jan 31 – Feb 2, 2024"             // Cross month
+///
+/// // Cross-year ranges: both years shown
+/// "Dec 31, 2024 – Jan 2, 2025"
+///
+/// // Special cases
+/// "Jan 2025"                         // Entire month
+/// "Jan – May 2025"                   // Multiple full months
+/// "2025"                             // Entire year
+/// "2020 – 2023"                      // Multiple full years
+/// ```
+struct StatsDateRangeFormatter {
+    private let locale: Locale
+    private let timeZone: TimeZone
+    private let dateFormatter = DateFormatter()
+    private let dateIntervalFormatter = DateIntervalFormatter()
+
+    init(locale: Locale = .current, timeZone: TimeZone = .current) {
+        self.locale = locale
+        self.timeZone = timeZone
+
+        dateFormatter.locale = locale
+        dateFormatter.timeZone = timeZone
+
+        dateIntervalFormatter.locale = locale
+        dateIntervalFormatter.timeZone = timeZone
+        dateIntervalFormatter.dateStyle = .medium
+        dateIntervalFormatter.timeStyle = .none
+    }
+
+    func string(from interval: DateInterval, now: Date = Date()) -> String {
+        var calendar = Calendar.current
+        calendar.timeZone = timeZone
+
+        let startDate = interval.start
+        let endDate = interval.end
+        let currentYear = calendar.component(.year, from: now)
+
+        // Check if it's an entire year
+        if let yearInterval = calendar.dateInterval(of: .year, for: startDate),
+           calendar.isDate(yearInterval.start, inSameDayAs: startDate) &&
+            calendar.isDate(yearInterval.end, inSameDayAs: endDate) {
+            dateFormatter.dateFormat = "yyyy"
+            return dateFormatter.string(from: startDate)
+        }
+
+        // Check if it's an entire month
+        if let monthInterval = calendar.dateInterval(of: .month, for: startDate),
+           calendar.isDate(monthInterval.start, inSameDayAs: startDate) &&
+            calendar.isDate(monthInterval.end, inSameDayAs: endDate) {
+            dateFormatter.dateFormat = "MMM yyyy"
+            return dateFormatter.string(from: startDate)
+        }
+
+        // Check if it's multiple full years
+        if isMultipleFullYears(interval: interval, calendar: calendar) {
+            let displayedEndDate = calendar.date(byAdding: .second, value: -1, to: endDate) ?? endDate
+            dateFormatter.dateFormat = "yyyy"
+            let startYear = dateFormatter.string(from: startDate)
+            let endYear = dateFormatter.string(from: displayedEndDate)
+            return "\(startYear) – \(endYear)"
+        }
+
+        // Check if it's multiple full months
+        if isMultipleFullMonths(interval: interval, calendar: calendar) {
+            let startYear = calendar.component(.year, from: startDate)
+            let endYear = calendar.component(.year, from: endDate)
+            let displayedEndDate = calendar.date(byAdding: .second, value: -1, to: endDate) ?? endDate
+
+            if startYear == endYear {
+                // Same year: "Jan – May 2025"
+                dateFormatter.dateFormat = "MMM"
+                let startMonth = dateFormatter.string(from: startDate)
+                let endMonth = dateFormatter.string(from: displayedEndDate)
+                dateFormatter.dateFormat = "yyyy"
+                let year = dateFormatter.string(from: startDate)
+                return "\(startMonth) – \(endMonth) \(year)"
+            } else {
+                // Different years: "Dec 2024 – Feb 2025"
+                dateFormatter.dateFormat = "MMM yyyy"
+                let start = dateFormatter.string(from: startDate)
+                let end = dateFormatter.string(from: displayedEndDate)
+                return "\(start) – \(end)"
+            }
+        }
+
+        // Default formatting for other ranges
+        let displayedEndDate = calendar.date(byAdding: .second, value: -1, to: endDate) ?? endDate
+
+        if calendar.component(.year, from: startDate) == currentYear && calendar.component(.year, from: displayedEndDate) == currentYear {
+            dateIntervalFormatter.dateTemplate = "MMM d"
+        } else {
+            dateIntervalFormatter.dateTemplate = nil
+            dateIntervalFormatter.dateStyle = .medium
+            dateIntervalFormatter.timeStyle = .none
+        }
+
+        return dateIntervalFormatter.string(from: startDate, to: displayedEndDate)
+    }
+
+    private func isMultipleFullYears(interval: DateInterval, calendar: Calendar) -> Bool {
+        let startDate = interval.start
+        let endDate = interval.end
+
+        // Check if start date is January 1st
+        guard calendar.component(.month, from: startDate) == 1 else { return false }
+        guard calendar.component(.day, from: startDate) == 1 else { return false }
+
+        // Check if end date is January 1st (open interval)
+        guard calendar.component(.month, from: endDate) == 1 else { return false }
+        guard calendar.component(.day, from: endDate) == 1 else { return false }
+
+        // Check if it spans more than one year
+        let startYear = calendar.component(.year, from: startDate)
+        let endYear = calendar.component(.year, from: endDate)
+
+        return endYear > startYear + 1
+    }
+
+    private func isMultipleFullMonths(interval: DateInterval, calendar: Calendar) -> Bool {
+        let startDate = interval.start
+        let endDate = interval.end
+
+        // Check if start date is the first day of a month
+        guard calendar.component(.day, from: startDate) == 1 else { return false }
+
+        // Check if end date is the first day of a month (open interval)
+        guard calendar.component(.day, from: endDate) == 1 else { return false }
+
+        // Check if it spans more than one month
+        let startMonth = calendar.component(.month, from: startDate)
+        let startYear = calendar.component(.year, from: startDate)
+        let endMonth = calendar.component(.month, from: endDate)
+        let endYear = calendar.component(.year, from: endDate)
+
+        if startYear == endYear {
+            return endMonth > startMonth + 1
+        } else {
+            // Cross-year: always multiple months
+            return true
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Utilities/Formatters/StatsValueFormatter.swift
+++ b/Modules/Sources/JetpackStats/Utilities/Formatters/StatsValueFormatter.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Formats site metric values for display based on the metric type and context.
+///
+/// Example usage:
+/// ```swift
+/// let formatter = StatsValueFormatter(metric: .timeOnSite)
+/// formatter.format(value: 90) // "1m 30s"
+/// formatter.format(value: 90, context: .compact) // "1m"
+///
+/// let viewsFormatter = StatsValueFormatter(metric: .views)
+/// viewsFormatter.format(value: 15789) // "15,789"
+/// viewsFormatter.format(value: 15789, context: .compact) // "16K"
+/// ```
+struct StatsValueFormatter {
+    enum Context {
+        case regular
+        case compact
+    }
+
+    let metric: SiteMetric
+
+    init(metric: SiteMetric) {
+        self.metric = metric
+    }
+
+    func format(value: Int, context: Context = .regular) -> String {
+        switch metric {
+        case .timeOnSite:
+            let minutes = value / 60
+            let seconds = value % 60
+            if minutes > 0 {
+                switch context {
+                case .regular:
+                    return "\(minutes)m \(seconds)s"
+                case .compact:
+                    return "\(minutes)m"
+                }
+            } else {
+                return "\(seconds)s"
+            }
+        case .bounceRate:
+            return "\(value)%"
+        default:
+            return Self.formatNumber(value, onlyLarge: context == .regular)
+        }
+    }
+
+    /// Formats a number with appropriate abbreviations for large values.
+    ///
+    /// - Parameters:
+    ///   - value: The number to format
+    ///   - onlyLarge: If true, only abbreviates numbers >= 10,000
+    /// - Returns: A formatted string (e.g., "1.2K", "1.5M")
+    ///
+    /// Example:
+    /// ```swift
+    /// StatsValueFormatter.formatNumber(1234) // "1.2K"
+    /// StatsValueFormatter.formatNumber(1234, onlyLarge: true) // "1,234"
+    /// StatsValueFormatter.formatNumber(15789) // "16K"
+    /// ```
+    static func formatNumber(_ value: Int, onlyLarge: Bool = false) -> String {
+        if onlyLarge && abs(value) < 10_000 {
+            return value.formatted(.number)
+        }
+        return value.formatted(.number.notation(.compactName))
+    }
+
+    /// Calculates the percentage change between two values.
+    ///
+    /// - Parameters:
+    ///   - current: The current value
+    ///   - previous: The previous value to compare against
+    /// - Returns: The percentage change as a decimal (0.5 = 50% increase, -0.5 = 50% decrease)
+    ///
+    /// Example:
+    /// ```swift
+    /// let formatter = StatsValueFormatter(metric: .views)
+    /// formatter.percentageChange(current: 150, previous: 100) // 0.5 (50% increase)
+    /// formatter.percentageChange(current: 50, previous: 100) // -0.5 (50% decrease)
+    /// ```
+    func percentageChange(current: Int, previous: Int) -> Double {
+        guard previous > 0 else { return 0 }
+        return Double(current - previous) / Double(previous)
+    }
+}

--- a/Modules/Sources/JetpackStats/Utilities/StatsDateRange.swift
+++ b/Modules/Sources/JetpackStats/Utilities/StatsDateRange.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+struct StatsDateRange: Equatable, Sendable {
+    /// The primary date range for statistics.
+    var dateInterval: DateInterval
+
+    /// The navigation component (.day, .month, .year). If it's provided, it means
+    /// the date interval was created with a preset to represet the respective
+    /// date period. If nil, uses duration-based navigation.
+    var component: Calendar.Component
+
+    /// The comparison period type. Defaults to `.precedingPeriod` if nil.
+    var comparison: DateRangeComparisonPeriod
+
+    /// The calculated comparison date range.
+    var effectiveComparisonInterval: DateInterval
+
+    /// The calendar used for date calculations.
+    let calendar: Calendar
+
+    /// The preset that was used to create this date range, if any.
+    var preset: DateIntervalPreset?
+
+    init(
+        interval: DateInterval,
+        component: Calendar.Component,
+        comparison: DateRangeComparisonPeriod = .precedingPeriod,
+        calendar: Calendar,
+        preset: DateIntervalPreset? = nil
+    ) {
+        self.dateInterval = interval
+        self.comparison = comparison
+        self.component = component
+        self.calendar = calendar
+        self.preset = preset
+        self.effectiveComparisonInterval = interval
+        self.refreshEffectiveComparisonPeriodInterval()
+    }
+
+    mutating func update(preset: DateIntervalPreset) {
+        dateInterval = calendar.makeDateInterval(for: preset)
+        component = preset.component
+        self.preset = preset
+        refreshEffectiveComparisonPeriodInterval()
+    }
+
+    mutating func update(comparisonPeriod: DateRangeComparisonPeriod) {
+        self.comparison = comparisonPeriod
+        refreshEffectiveComparisonPeriodInterval()
+    }
+
+    private mutating func refreshEffectiveComparisonPeriodInterval() {
+        effectiveComparisonInterval = calendar.comparisonRange(for: dateInterval, period: comparison, component: component)
+    }
+
+    // MARK: - Navigation
+
+    /// Navigates to the specified direction (previous or next period).
+    func navigate(_ direction: Calendar.NavigationDirection) -> StatsDateRange {
+        // Use the component if available, otherwise determine it from the interval
+        let newInterval = calendar.navigate(dateInterval, direction: direction, component: component)
+        // When navigating, we lose the preset since it's no longer a standard preset
+        return StatsDateRange(interval: newInterval, component: component, comparison: comparison, calendar: calendar, preset: nil)
+    }
+
+    /// Returns true if can navigate in the specified direction.
+    func canNavigate(in direction: Calendar.NavigationDirection) -> Bool {
+        calendar.canNavigate(dateInterval, direction: direction)
+    }
+
+    /// Generates a list of available adjacent periods in the specified direction.
+    /// - Parameters:
+    ///   - direction: The navigation direction (previous or next)
+    ///   - maxCount: Maximum number of periods to generate (default: 10)
+    /// - Returns: Array of AdjacentPeriod structs
+    func availableAdjacentPeriods(in direction: Calendar.NavigationDirection, maxCount: Int = 10) -> [AdjacentPeriod] {
+        var periods: [AdjacentPeriod] = []
+        var currentRange = self
+        let formatter = StatsDateRangeFormatter(timeZone: calendar.timeZone)
+        for _ in 0..<maxCount {
+            if currentRange.canNavigate(in: direction) {
+                currentRange = currentRange.navigate(direction)
+                let displayText = formatter.string(from: currentRange.dateInterval)
+                periods.append(AdjacentPeriod(range: currentRange, displayText: displayText))
+            } else {
+                break
+            }
+        }
+        return periods
+    }
+}
+
+/// Represents an adjacent period for navigation
+struct AdjacentPeriod: Identifiable {
+    let id = UUID()
+    let range: StatsDateRange
+    let displayText: String
+}
+
+extension Calendar {
+    func makeDateRange(
+        for preset: DateIntervalPreset,
+        comparison: DateRangeComparisonPeriod = .precedingPeriod
+    ) -> StatsDateRange {
+        StatsDateRange(
+            interval: makeDateInterval(for: preset),
+            component: preset.component,
+            comparison: comparison,
+            calendar: self,
+            preset: preset
+        )
+    }
+}

--- a/Modules/Tests/JetpackStatsTests/CalendarNavigationTests.swift
+++ b/Modules/Tests/JetpackStatsTests/CalendarNavigationTests.swift
@@ -1,0 +1,550 @@
+import Testing
+import Foundation
+@testable import JetpackStats
+
+@Suite
+struct CalendarNavigationTests {
+    let calendar = Calendar.mock(timeZone: .eastern)
+    let now = Date("2025-01-15T14:30:00-03:00")
+
+    // MARK: - Calendar-Based Navigation
+
+    @Test("Navigate single day forward")
+    func navigateSingleDayForward() {
+        // GIVEN
+        let interval = DateInterval(
+            start: Date("2025-01-15T00:00:00-03:00"),
+            end: Date("2025-01-16T00:00:00-03:00")
+        )
+
+        // WHEN
+        let result = calendar.navigate(interval, direction: .forward, component: .day)
+
+        // THEN
+        #expect(result.start == Date("2025-01-16T00:00:00-03:00"))
+        #expect(result.end == Date("2025-01-17T00:00:00-03:00"))
+    }
+
+    @Test("Navigate single day backward")
+    func navigateSingleDayBackward() {
+        // GIVEN
+        let interval = DateInterval(
+            start: Date("2025-01-15T00:00:00-03:00"),
+            end: Date("2025-01-16T00:00:00-03:00")
+        )
+
+        // WHEN
+        let result = calendar.navigate(interval, direction: .backward, component: .day)
+
+        // THEN
+        #expect(result.start == Date("2025-01-14T00:00:00-03:00"))
+        #expect(result.end == Date("2025-01-15T00:00:00-03:00"))
+    }
+
+    @Test("Navigate month forward")
+    func navigateMonthForward() {
+        // GIVEN
+        let interval = DateInterval(
+            start: Date("2025-01-01T00:00:00-03:00"),
+            end: Date("2025-02-01T00:00:00-03:00")
+        )
+
+        // WHEN
+        let result = calendar.navigate(interval, direction: .forward, component: .month)
+
+        // THEN
+        #expect(result.start == Date("2025-02-01T00:00:00-03:00"))
+        #expect(result.end == Date("2025-03-01T00:00:00-03:00"))
+    }
+
+    @Test("Navigate year forward")
+    func navigateYearForward() {
+        // GIVEN
+        let interval = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2025-01-01T00:00:00-03:00")
+        )
+
+        // WHEN
+        let result = calendar.navigate(interval, direction: .forward, component: .year)
+
+        // THEN
+        #expect(result.start == Date("2025-01-01T00:00:00-03:00"))
+        #expect(result.end == Date("2026-01-01T00:00:00-03:00"))
+    }
+
+    @Test("Navigate week forward")
+    func navigateWeekForward() {
+        // GIVEN
+        let interval = DateInterval(
+            start: Date("2025-01-12T00:00:00-03:00"),
+            end: Date("2025-01-19T00:00:00-03:00")
+        )
+
+        // WHEN
+        let result = calendar.navigate(interval, direction: .forward, component: .weekOfYear)
+
+        // THEN
+        #expect(result.start == Date("2025-01-19T00:00:00-03:00"))
+        #expect(result.end == Date("2025-01-26T00:00:00-03:00"))
+    }
+
+    @Test("Navigate month backward")
+    func navigateMonthBackward() {
+        // GIVEN
+        let interval = DateInterval(
+            start: Date("2025-02-01T00:00:00-03:00"),
+            end: Date("2025-03-01T00:00:00-03:00")
+        )
+
+        // WHEN
+        let result = calendar.navigate(interval, direction: .backward, component: .month)
+
+        // THEN
+        #expect(result.start == Date("2025-01-01T00:00:00-03:00"))
+        #expect(result.end == Date("2025-02-01T00:00:00-03:00"))
+    }
+
+    @Test("Navigate year backward")
+    func navigateYearBackward() {
+        // GIVEN
+        let interval = DateInterval(
+            start: Date("2025-01-01T00:00:00-03:00"),
+            end: Date("2026-01-01T00:00:00-03:00")
+        )
+
+        // WHEN
+        let result = calendar.navigate(interval, direction: .backward, component: .year)
+
+        // THEN
+        #expect(result.start == Date("2024-01-01T00:00:00-03:00"))
+        #expect(result.end == Date("2025-01-01T00:00:00-03:00"))
+    }
+
+    @Test("Navigate week backward")
+    func navigateWeekBackward() {
+        // GIVEN
+        let interval = DateInterval(
+            start: Date("2025-01-19T00:00:00-03:00"),
+            end: Date("2025-01-26T00:00:00-03:00")
+        )
+
+        // WHEN
+        let result = calendar.navigate(interval, direction: .backward, component: .weekOfYear)
+
+        // THEN
+        #expect(result.start == Date("2025-01-12T00:00:00-03:00"))
+        #expect(result.end == Date("2025-01-19T00:00:00-03:00"))
+    }
+
+    // MARK: - Custom Period
+
+    @Test("Navigate custom period (7 days)")
+    func navigateCustomPeriod() {
+        // GIVEN - 7 day period
+        let interval = DateInterval(
+            start: Date("2025-01-10T00:00:00-03:00"),
+            end: Date("2025-01-17T00:00:00-03:00")
+        )
+
+        // WHEN
+        let next = calendar.navigate(interval, direction: .forward, component: .day)
+        let previous = calendar.navigate(interval, direction: .backward, component: .day)
+
+        // THEN - Should shift by exactly 7 days
+        #expect(next.start == Date("2025-01-17T00:00:00-03:00"))
+        #expect(next.end == Date("2025-01-24T00:00:00-03:00"))
+
+        #expect(previous.start == Date("2025-01-03T00:00:00-03:00"))
+        #expect(previous.end == Date("2025-01-10T00:00:00-03:00"))
+    }
+
+    @Test("Navigate preserves duration", arguments: [
+        (3, Date("2025-01-10T00:00:00-03:00"), Date("2025-01-13T00:00:00-03:00")),
+        (7, Date("2025-01-10T00:00:00-03:00"), Date("2025-01-17T00:00:00-03:00")),
+        (15, Date("2025-01-10T00:00:00-03:00"), Date("2025-01-25T00:00:00-03:00")),
+        (30, Date("2025-01-01T00:00:00-03:00"), Date("2025-01-31T00:00:00-03:00"))
+    ])
+    func navigatePreservesDuration(days: Int, startDate: Date, endDate: Date) {
+        // GIVEN
+        let interval = DateInterval(start: startDate, end: endDate)
+        let originalDuration = interval.duration
+
+        // WHEN
+        let next = calendar.navigate(interval, direction: .forward, component: .day)
+        let previous = calendar.navigate(interval, direction: .backward, component: .day)
+
+        // THEN - Duration should be preserved (within 1 second tolerance for DST)
+        #expect(abs(next.duration - originalDuration) < 1)
+        #expect(abs(previous.duration - originalDuration) < 1)
+    }
+
+    // MARK: - Can Navigate Tests
+
+    @Test("Can navigate to previous checks year boundary", arguments: [
+        (2001, Date("2001-01-15T00:00:00-03:00"), true, 2000),
+        (2000, Date("2000-01-15T00:00:00-03:00"), false, 2000),
+        (1999, Date("1999-01-15T00:00:00-03:00"), false, 2000),
+        (2000, Date("2000-01-15T00:00:00-03:00"), true, 1999),
+        (1999, Date("1999-01-15T00:00:00-03:00"), false, 1999)
+    ])
+    func canNavigateToPreviousYear(year: Int, date: Date, expectedResult: Bool, minYear: Int) {
+        // GIVEN
+        let interval = DateInterval(
+            start: date,
+            end: calendar.date(byAdding: .day, value: 1, to: date)!
+        )
+
+        // WHEN/THEN
+        #expect(calendar.canNavigate(interval, direction: .backward, minYear: minYear) == expectedResult)
+    }
+
+    @Test("Can navigate to next checks against today")
+    func canNavigateToNextToday() {
+        // GIVEN
+        let today = Date("2025-01-10T00:00:00-03:00")
+        let yesterday = calendar.date(byAdding: .day, value: -1, to: today)!
+        let tomorrow = calendar.date(byAdding: .day, value: 1, to: today)!
+
+        let intervalYesterday = DateInterval(
+            start: calendar.startOfDay(for: yesterday),
+            end: calendar.startOfDay(for: today)
+        )
+        let intervalToday = DateInterval(
+            start: calendar.startOfDay(for: today),
+            end: calendar.startOfDay(for: tomorrow)
+        )
+        let intervalTomorrow = DateInterval(
+            start: calendar.startOfDay(for: tomorrow),
+            end: calendar.date(byAdding: .day, value: 1, to: tomorrow)!
+        )
+
+        // WHEN/THEN
+        #expect(calendar.canNavigate(intervalYesterday, direction: .forward, now: today))
+        #expect(!calendar.canNavigate(intervalToday, direction: .forward, now: today))
+        #expect(!calendar.canNavigate(intervalTomorrow, direction: .forward, now: today))
+    }
+
+    // MARK: - Preset Navigation Tests
+
+    @Test("Navigate preset intervals correctly", arguments: [
+        // 6-month period should navigate by 6 months
+        (Date("2024-08-01T00:00:00-03:00"), Date("2025-02-01T00:00:00-03:00"), Calendar.Component.month,
+         Date("2024-02-01T00:00:00-03:00"), Date("2024-08-01T00:00:00-03:00")),
+        // 12-month period should navigate by 12 months
+        (Date("2024-02-01T00:00:00-03:00"), Date("2025-02-01T00:00:00-03:00"), Calendar.Component.month,
+         Date("2023-02-01T00:00:00-03:00"), Date("2024-02-01T00:00:00-03:00")),
+        // 5-year period should navigate by 5 years
+        (Date("2021-01-01T00:00:00-03:00"), Date("2026-01-01T00:00:00-03:00"), Calendar.Component.year,
+         Date("2016-01-01T00:00:00-03:00"), Date("2021-01-01T00:00:00-03:00")),
+        // 7-day period should navigate by 7 days
+        (Date("2025-01-08T00:00:00-03:00"), Date("2025-01-15T00:00:00-03:00"), Calendar.Component.day,
+         Date("2025-01-01T00:00:00-03:00"), Date("2025-01-08T00:00:00-03:00"))
+    ])
+    func navigatePresetIntervals(startDate: Date, endDate: Date, component: Calendar.Component,
+                                 expectedPrevStart: Date, expectedPrevEnd: Date) {
+        // GIVEN - An interval representing a preset period
+        let interval = DateInterval(start: startDate, end: endDate)
+
+        // WHEN - Navigate backward
+        let previous = calendar.navigate(interval, direction: .backward, component: component)
+
+        // THEN - Should navigate by the period length
+        #expect(previous.start == expectedPrevStart)
+        #expect(previous.end == expectedPrevEnd)
+    }
+
+    // MARK: - Edge Case Tests
+
+    @Test("Navigate handles boundary transitions", arguments: [
+        // Leap year February - 29 days should navigate to another 29-day period
+        (Date("2024-02-01T00:00:00-03:00"), Date("2024-03-01T00:00:00-03:00"), Date("2024-03-01T00:00:00-03:00"), Date("2024-03-30T00:00:00-03:00")),
+        // Year boundary - 31 days should navigate to another 31-day period
+        (Date("2024-12-01T00:00:00-03:00"), Date("2025-01-01T00:00:00-03:00"), Date("2025-01-01T00:00:00-03:00"), Date("2025-02-01T00:00:00-03:00")),
+        // Week at year boundary - 7 days should navigate to another 7-day period
+        (Date("2024-12-29T00:00:00-03:00"), Date("2025-01-05T00:00:00-03:00"), Date("2025-01-05T00:00:00-03:00"), Date("2025-01-12T00:00:00-03:00"))
+    ])
+    func navigateBoundaryTransitions(startDate: Date, endDate: Date, expectedStart: Date, expectedEnd: Date) {
+        // GIVEN
+        let interval = DateInterval(start: startDate, end: endDate)
+
+        // WHEN - Navigate with day component
+        let next = calendar.navigate(interval, direction: .forward, component: .day)
+
+        // THEN
+        #expect(next.start == expectedStart)
+        #expect(next.end == expectedEnd)
+    }
+
+    @Test("Navigate partial periods by duration", arguments: [
+        // 15-day partial month period
+        (15, Date("2025-01-10T00:00:00-03:00"), Date("2025-01-25T00:00:00-03:00"), Date("2025-01-25T00:00:00-03:00"), Date("2025-02-09T00:00:00-03:00")),
+        // 5-day partial week period
+        (5, Date("2025-01-13T00:00:00-03:00"), Date("2025-01-18T00:00:00-03:00"), Date("2025-01-18T00:00:00-03:00"), Date("2025-01-23T00:00:00-03:00")),
+        // Custom 10-day period
+        (10, Date("2025-01-05T00:00:00-03:00"), Date("2025-01-15T00:00:00-03:00"), Date("2025-01-15T00:00:00-03:00"), Date("2025-01-25T00:00:00-03:00"))
+    ])
+    func navigatePartialPeriods(days: Int, startDate: Date, endDate: Date, expectedStart: Date, expectedEnd: Date) {
+        // GIVEN
+        let interval = DateInterval(start: startDate, end: endDate)
+
+        // WHEN
+        let next = calendar.navigate(interval, direction: .forward, component: .day)
+
+        // THEN - Should navigate by the number of days
+        #expect(next.start == expectedStart)
+        #expect(next.end == expectedEnd)
+
+        // Verify duration is preserved
+        #expect(abs(next.duration - interval.duration) < 1)
+    }
+
+    // MARK: - Navigation Without Components Tests
+
+    @Test("Navigate with component uses calendar-based navigation")
+    func navigateWithComponentUsesCalendarNavigation() {
+        // GIVEN - Various intervals that happen to align with calendar boundaries
+        let fullMonth = DateInterval(
+            start: Date("2025-02-01T00:00:00-03:00"),
+            end: Date("2025-03-01T00:00:00-03:00")
+        )
+        let fullYear = DateInterval(
+            start: Date("2025-01-01T00:00:00-03:00"),
+            end: Date("2026-01-01T00:00:00-03:00")
+        )
+
+        // WHEN - Navigate with appropriate components
+        let monthNext = calendar.navigate(fullMonth, direction: .forward, component: .month)
+        let yearNext = calendar.navigate(fullYear, direction: .forward, component: .year)
+
+        // THEN - Should navigate by calendar unit
+        #expect(monthNext.start == Date("2025-03-01T00:00:00-03:00"))
+        #expect(monthNext.end == Date("2025-04-01T00:00:00-03:00")) // Next month
+
+        // Year interval navigated by 1 year
+        #expect(yearNext.start == Date("2026-01-01T00:00:00-03:00"))
+        #expect(yearNext.end == Date("2027-01-01T00:00:00-03:00"))
+    }
+
+    // MARK: - Week Navigation Tests
+
+    @Test("Navigate week with component at year boundary")
+    func navigateWeekYearBoundary() {
+        // GIVEN - Week that crosses year boundary
+        let interval = DateInterval(
+            start: Date("2024-12-29T00:00:00-03:00"), // Sunday
+            end: Date("2025-01-05T00:00:00-03:00")   // Next Sunday
+        )
+
+        // WHEN - Navigate with week component
+        let next = calendar.navigate(interval, direction: .forward, component: .weekOfYear)
+        let previous = calendar.navigate(interval, direction: .backward, component: .weekOfYear)
+
+        // THEN
+        #expect(next.start == Date("2025-01-05T00:00:00-03:00"))
+        #expect(next.end == Date("2025-01-12T00:00:00-03:00"))
+
+        #expect(previous.start == Date("2024-12-22T00:00:00-03:00"))
+        #expect(previous.end == Date("2024-12-29T00:00:00-03:00"))
+    }
+
+    @Test("Navigate respects provided calendar parameter")
+    func navigateRespectsCalendarParameter() {
+        // GIVEN - Custom period that doesn't align with calendar boundaries
+        let interval = DateInterval(
+            start: Date("2025-01-10T12:00:00-03:00"),
+            end: Date("2025-01-20T12:00:00-03:00")
+        )
+
+        // Different calendar with different week start
+        var mondayCalendar = Calendar.mock(timeZone: .eastern)
+        mondayCalendar.firstWeekday = 2 // Monday
+
+        var sundayCalendar = Calendar.mock(timeZone: .eastern)
+        sundayCalendar.firstWeekday = 1 // Sunday
+
+        // WHEN - Navigate with different calendars using day component
+        let nextWithMondayCalendar = mondayCalendar.navigate(interval, direction: .forward, component: .day)
+        let nextWithSundayCalendar = sundayCalendar.navigate(interval, direction: .forward, component: .day)
+
+        // THEN - Since we're using day component, both should navigate by 10 days
+        #expect(nextWithMondayCalendar.start == Date("2025-01-20T12:00:00-03:00"))
+        #expect(nextWithMondayCalendar.end == Date("2025-01-30T12:00:00-03:00"))
+
+        #expect(nextWithSundayCalendar.start == Date("2025-01-20T12:00:00-03:00"))
+        #expect(nextWithSundayCalendar.end == Date("2025-01-30T12:00:00-03:00"))
+    }
+
+    // MARK: - Determine Navigation Component Tests
+
+    @Test("Determine navigation component for single day")
+    func determineNavigationComponentSingleDay() {
+        // GIVEN
+        let interval = DateInterval(
+            start: Date("2025-01-15T00:00:00-03:00"),
+            end: Date("2025-01-16T00:00:00-03:00")
+        )
+
+        // WHEN
+        let component = calendar.determineNavigationComponent(for: interval)
+
+        // THEN
+        #expect(component == .day)
+    }
+
+    @Test("Determine navigation component for complete month", arguments: [
+        (Date("2025-01-01T00:00:00-03:00"), Date("2025-02-01T00:00:00-03:00")),  // January
+        (Date("2025-02-01T00:00:00-03:00"), Date("2025-03-01T00:00:00-03:00")),  // February (non-leap)
+        (Date("2024-02-01T00:00:00-03:00"), Date("2024-03-01T00:00:00-03:00")),  // February (leap)
+        (Date("2025-04-01T00:00:00-03:00"), Date("2025-05-01T00:00:00-03:00")),  // April (30 days)
+        (Date("2025-12-01T00:00:00-03:00"), Date("2026-01-01T00:00:00-03:00"))   // December
+    ])
+    func determineNavigationComponentMonth(startDate: Date, endDate: Date) {
+        // GIVEN
+        let interval = DateInterval(start: startDate, end: endDate)
+
+        // WHEN
+        let component = calendar.determineNavigationComponent(for: interval)
+
+        // THEN
+        #expect(component == .month)
+    }
+
+    @Test("Determine navigation component for complete year", arguments: [
+        (Date("2025-01-01T00:00:00-03:00"), Date("2026-01-01T00:00:00-03:00")),  // Regular year
+        (Date("2024-01-01T00:00:00-03:00"), Date("2025-01-01T00:00:00-03:00")),  // Leap year
+        (Date("2023-01-01T00:00:00-03:00"), Date("2024-01-01T00:00:00-03:00"))   // Year before leap
+    ])
+    func determineNavigationComponentYear(startDate: Date, endDate: Date) {
+        // GIVEN
+        let interval = DateInterval(start: startDate, end: endDate)
+
+        // WHEN
+        let component = calendar.determineNavigationComponent(for: interval)
+
+        // THEN
+        #expect(component == .year)
+    }
+
+    @Test("Determine navigation component for complete week")
+    func determineNavigationComponentWeek() {
+        // GIVEN - Full week (Sunday to Sunday in eastern calendar)
+        let interval = DateInterval(
+            start: Date("2025-01-12T00:00:00-03:00"),  // Sunday
+            end: Date("2025-01-19T00:00:00-03:00")     // Next Sunday
+        )
+
+        // WHEN
+        let component = calendar.determineNavigationComponent(for: interval)
+
+        // THEN
+        #expect(component == .weekOfYear)
+    }
+
+    @Test("Determine navigation component for week at year boundary")
+    func determineNavigationComponentWeekYearBoundary() {
+        // GIVEN - Week that crosses year boundary
+        let interval = DateInterval(
+            start: Date("2024-12-29T00:00:00-03:00"),  // Sunday
+            end: Date("2025-01-05T00:00:00-03:00")     // Next Sunday
+        )
+
+        // WHEN
+        let component = calendar.determineNavigationComponent(for: interval)
+
+        // THEN
+        #expect(component == .weekOfYear)
+    }
+
+    @Test("Determine navigation component for custom periods returns nil", arguments: [
+        // 3 days
+        (Date("2025-01-10T00:00:00-03:00"), Date("2025-01-13T00:00:00-03:00")),
+        // 10 days
+        (Date("2025-01-10T00:00:00-03:00"), Date("2025-01-20T00:00:00-03:00")),
+        // 15 days (partial month)
+        (Date("2025-01-10T00:00:00-03:00"), Date("2025-01-25T00:00:00-03:00")),
+        // 5 days (partial week)
+        (Date("2025-01-13T00:00:00-03:00"), Date("2025-01-18T00:00:00-03:00")),
+        // Partial month starting mid-month
+        (Date("2025-01-15T00:00:00-03:00"), Date("2025-02-15T00:00:00-03:00")),
+        // 6 months (half year)
+        (Date("2025-01-01T00:00:00-03:00"), Date("2025-07-01T00:00:00-03:00"))
+    ])
+    func determineNavigationComponentCustomPeriods(startDate: Date, endDate: Date) {
+        // GIVEN
+        let interval = DateInterval(start: startDate, end: endDate)
+
+        // WHEN
+        let component = calendar.determineNavigationComponent(for: interval)
+
+        // THEN
+        #expect(component == nil)
+    }
+
+    @Test("Determine navigation component with time offsets")
+    func determineNavigationComponentTimeOffsets() {
+        // GIVEN - Month interval with slight time offsets (within 1 second tolerance)
+        let start = Date("2025-01-01T00:00:00-03:00").addingTimeInterval(0.5)  // 0.5 seconds offset
+        let end = Date("2025-02-01T00:00:00-03:00").addingTimeInterval(0.5)
+        let intervalWithOffset = DateInterval(start: start, end: end)
+
+        // WHEN
+        let component = calendar.determineNavigationComponent(for: intervalWithOffset)
+
+        // THEN - Should still recognize as month
+        #expect(component == .month)
+    }
+
+    @Test("Determine navigation component rejects intervals beyond tolerance")
+    func determineNavigationComponentBeyondTolerance() {
+        // GIVEN - Month interval with time offset beyond 1 second
+        let intervalBeyondTolerance = DateInterval(
+            start: Date("2025-01-01T00:00:02-03:00"),  // 2 seconds offset
+            end: Date("2025-02-01T00:00:00-03:00")
+        )
+
+        // WHEN
+        let component = calendar.determineNavigationComponent(for: intervalBeyondTolerance)
+
+        // THEN - Should not recognize as month
+        #expect(component == nil)
+    }
+
+    @Test("Determine navigation component for different calendar configurations")
+    func determineNavigationComponentDifferentCalendars() {
+        // GIVEN
+        var mondayCalendar = Calendar.mock(timeZone: .eastern)
+        mondayCalendar.firstWeekday = 2  // Monday
+
+        // Week starting on Monday
+        let mondayWeekInterval = DateInterval(
+            start: Date("2025-01-13T00:00:00-03:00"),  // Monday
+            end: Date("2025-01-20T00:00:00-03:00")     // Next Monday
+        )
+
+        // WHEN
+        let component = mondayCalendar.determineNavigationComponent(for: mondayWeekInterval)
+
+        // THEN
+        #expect(component == .weekOfYear)
+    }
+
+    @Test("Determine navigation component edge cases")
+    func determineNavigationComponentEdgeCases() {
+        // GIVEN - Zero duration interval (same start and end)
+        let zeroDuration = DateInterval(
+            start: Date("2025-01-15T00:00:00-03:00"),
+            end: Date("2025-01-15T00:00:00-03:00")
+        )
+
+        // Almost a day (23 hours 59 minutes 59 seconds)
+        let almostDay = DateInterval(
+            start: Date("2025-01-15T00:00:00-03:00"),
+            end: Date("2025-01-15T23:59:59-03:00")
+        )
+
+        // WHEN/THEN
+        #expect(calendar.determineNavigationComponent(for: zeroDuration) == nil)
+        #expect(calendar.determineNavigationComponent(for: almostDay) == .day)
+    }
+}

--- a/Modules/Tests/JetpackStatsTests/CalendarPresetsTests.swift
+++ b/Modules/Tests/JetpackStatsTests/CalendarPresetsTests.swift
@@ -1,0 +1,239 @@
+import Testing
+import Foundation
+@testable import JetpackStats
+
+@Suite
+struct CalendarDateRangePresetTests {
+    let calendar = Calendar.mock(timeZone: .eastern)
+
+    @Test("Date range presets", arguments: [
+        (DateIntervalPreset.today, Date("2025-01-15T00:00:00-03:00"), Date("2025-01-16T00:00:00-03:00")),
+        (.thisWeek, Date("2025-01-12T00:00:00-03:00"), Date("2025-01-19T00:00:00-03:00")),
+        (.thisMonth, Date("2025-01-01T00:00:00-03:00"), Date("2025-02-01T00:00:00-03:00")),
+        (.thisQuarter, Date("2025-01-01T00:00:00-03:00"), Date("2025-04-01T00:00:00-03:00")),
+        (.thisYear, Date("2025-01-01T00:00:00-03:00"), Date("2026-01-01T00:00:00-03:00")),
+        (.last7Days, Date("2025-01-08T00:00:00-03:00"), Date("2025-01-15T00:00:00-03:00")),
+        (.last28Days, Date("2024-12-18T00:00:00-03:00"), Date("2025-01-15T00:00:00-03:00")),
+        (.last30Days, Date("2024-12-16T00:00:00-03:00"), Date("2025-01-15T00:00:00-03:00")),
+        (.last90Days, Date("2024-10-17T00:00:00-03:00"), Date("2025-01-15T00:00:00-03:00")),
+        (.last6Months, Date("2024-08-01T00:00:00-03:00"), Date("2025-02-01T00:00:00-03:00")),
+        (.last12Months, Date("2024-02-01T00:00:00-03:00"), Date("2025-02-01T00:00:00-03:00")),
+        (.last3Years, Date("2023-01-01T00:00:00-03:00"), Date("2026-01-01T00:00:00-03:00")),
+        (.last10Years, Date("2016-01-01T00:00:00-03:00"), Date("2026-01-01T00:00:00-03:00"))
+    ])
+    func dateRangePresets(preset: DateIntervalPreset, expectedStart: Date, expectedEnd: Date) {
+        // GIVEN
+        let now = Date("2025-01-15T14:30:00-03:00")
+        let interval = calendar.makeDateInterval(for: preset, now: now)
+
+        // THEN
+        #expect(interval.start == expectedStart)
+        #expect(interval.end == expectedEnd)
+    }
+
+    // MARK: - Edge Cases
+
+    @Test("Preset handles leap year February correctly")
+    func presetLeapYearFebruary() {
+        // GIVEN - Date in February of leap year
+        let now = Date("2024-02-15T14:30:00-03:00")
+
+        // WHEN
+        let monthToDate = calendar.makeDateInterval(for: .thisMonth, now: now)
+
+        // THEN - Should include all 29 days
+        #expect(monthToDate.start == Date("2024-02-01T00:00:00-03:00"))
+        #expect(monthToDate.end == Date("2024-03-01T00:00:00-03:00"))
+    }
+
+    @Test("Preset handles year boundary correctly", arguments: [
+        (DateIntervalPreset.last7Days, Date("2024-12-29T00:00:00-03:00"), Date("2025-01-05T00:00:00-03:00")),
+        (DateIntervalPreset.last30Days, Date("2024-12-06T00:00:00-03:00"), Date("2025-01-05T00:00:00-03:00"))
+    ])
+    func presetYearBoundary(preset: DateIntervalPreset, expectedStart: Date, expectedEnd: Date) {
+        // GIVEN
+        let now = Date("2025-01-05T14:30:00-03:00")
+
+        // WHEN
+        let interval = calendar.makeDateInterval(for: preset, now: now)
+
+        // THEN
+        #expect(interval.start == expectedStart)
+        #expect(interval.end == expectedEnd)
+    }
+
+    @Test("Preset handles daylight saving time transitions")
+    func presetDSTTransition() {
+        // GIVEN - Using UTC to avoid DST complications in tests
+        let utcCalendar = Calendar.mock(timeZone: TimeZone(secondsFromGMT: 0)!)
+        let beforeDST = Date("2024-03-09T12:00:00Z") // Day before DST in US
+        let afterDST = Date("2024-03-11T12:00:00Z") // Day after DST in US
+
+        // WHEN
+        let intervalBefore = utcCalendar.makeDateInterval(for: .today, now: beforeDST)
+        let intervalAfter = utcCalendar.makeDateInterval(for: .today, now: afterDST)
+
+        // THEN - Both should be exactly 24 hours
+        #expect(intervalBefore.duration == 86400)
+        #expect(intervalAfter.duration == 86400)
+    }
+
+    // MARK: - Time Zone Tests
+
+    @Test("Presets work correctly across different time zones", arguments: [
+        (TimeZone(secondsFromGMT: 0)!, Date("2025-01-15T00:00:00Z")),
+        (TimeZone(secondsFromGMT: 6 * 3600)!, Date("2025-01-15T00:00:00+06:00")),
+        (TimeZone(secondsFromGMT: 12 * 3600)!, Date("2025-01-16T00:00:00+12:00")),
+        (TimeZone(secondsFromGMT: 18 * 3600)!, Date("2025-01-16T00:00:00+18:00")),
+        (TimeZone(secondsFromGMT: -6 * 3600)!, Date("2025-01-15T00:00:00-06:00")),
+        (TimeZone(secondsFromGMT: -12 * 3600)!, Date("2025-01-15T00:00:00-12:00")),
+        (TimeZone(secondsFromGMT: -18 * 3600)!, Date("2025-01-14T00:00:00-18:00"))
+    ])
+    func presetsWithDifferentTimeZones(timeZone: TimeZone, expectedStart: Date) {
+        // GIVEN reporting time zone is differnet from your current time zone (UTC)
+        let calendar = Calendar.mock(timeZone: timeZone)
+
+        // GIVEN it's 3 PM in UTC (your current time zone)
+        let now = Date("2025-01-15T15:00:00Z")
+
+        // WHEN
+        let interval = calendar.makeDateInterval(for: .today, now: now)
+
+        // THEN "today" is picked according to your site reporting time zone
+        // and not your local time zone
+        #expect(interval.start == expectedStart)
+    }
+
+    // MARK: - Edge Cases for All Presets
+
+    @Test("All presets handle month boundaries correctly", arguments: [
+        (DateIntervalPreset.today, Date("2025-01-31T00:00:00-03:00"), Date("2025-02-01T00:00:00-03:00")),
+        (.thisWeek, Date("2025-01-26T00:00:00-03:00"), Date("2025-02-02T00:00:00-03:00")),
+        (.thisMonth, Date("2025-01-01T00:00:00-03:00"), Date("2025-02-01T00:00:00-03:00")),
+        (.thisQuarter, Date("2025-01-01T00:00:00-03:00"), Date("2025-04-01T00:00:00-03:00")),
+        (.thisYear, Date("2025-01-01T00:00:00-03:00"), Date("2026-01-01T00:00:00-03:00")),
+        (.last7Days, Date("2025-01-24T00:00:00-03:00"), Date("2025-01-31T00:00:00-03:00")),
+        (.last28Days, Date("2025-01-03T00:00:00-03:00"), Date("2025-01-31T00:00:00-03:00")),
+        (.last30Days, Date("2025-01-01T00:00:00-03:00"), Date("2025-01-31T00:00:00-03:00")),
+        (.last90Days, Date("2024-11-02T00:00:00-03:00"), Date("2025-01-31T00:00:00-03:00")),
+        (.last6Months, Date("2024-08-01T00:00:00-03:00"), Date("2025-02-01T00:00:00-03:00")),
+        (.last12Months, Date("2024-02-01T00:00:00-03:00"), Date("2025-02-01T00:00:00-03:00")),
+        (.last3Years, Date("2023-01-01T00:00:00-03:00"), Date("2026-01-01T00:00:00-03:00")),
+        (.last10Years, Date("2016-01-01T00:00:00-03:00"), Date("2026-01-01T00:00:00-03:00"))
+    ])
+    func allPresetsMonthBoundaries(preset: DateIntervalPreset, expectedStart: Date, expectedEnd: Date) {
+        // GIVEN today is the last day of the month
+        let endOfMonth = Date("2025-01-31T14:30:00-03:00")
+
+        // WHEN
+        let interval = calendar.makeDateInterval(for: preset, now: endOfMonth)
+
+        // THEN
+        #expect(interval.start == expectedStart)
+        #expect(interval.end == expectedEnd)
+    }
+
+    @Test("All presets handle year boundaries correctly", arguments: [
+        (DateIntervalPreset.today, Date("2025-01-01T00:00:00-03:00"), Date("2025-01-02T00:00:00-03:00")),
+        (.thisWeek, Date("2024-12-29T00:00:00-03:00"), Date("2025-01-05T00:00:00-03:00")),
+        (.thisMonth, Date("2025-01-01T00:00:00-03:00"), Date("2025-02-01T00:00:00-03:00")),
+        (.thisQuarter, Date("2025-01-01T00:00:00-03:00"), Date("2025-04-01T00:00:00-03:00")),
+        (.thisYear, Date("2025-01-01T00:00:00-03:00"), Date("2026-01-01T00:00:00-03:00")),
+        (.last7Days, Date("2024-12-25T00:00:00-03:00"), Date("2025-01-01T00:00:00-03:00")),
+        (.last28Days, Date("2024-12-04T00:00:00-03:00"), Date("2025-01-01T00:00:00-03:00")),
+        (.last30Days, Date("2024-12-02T00:00:00-03:00"), Date("2025-01-01T00:00:00-03:00")),
+        (.last90Days, Date("2024-10-03T00:00:00-03:00"), Date("2025-01-01T00:00:00-03:00")),
+        (.last6Months, Date("2024-08-01T00:00:00-03:00"), Date("2025-02-01T00:00:00-03:00")),
+        (.last12Months, Date("2024-02-01T00:00:00-03:00"), Date("2025-02-01T00:00:00-03:00")),
+        (.last3Years, Date("2023-01-01T00:00:00-03:00"), Date("2026-01-01T00:00:00-03:00")),
+        (.last10Years, Date("2016-01-01T00:00:00-03:00"), Date("2026-01-01T00:00:00-03:00"))
+    ])
+    func allPresetsYearBoundaries(preset: DateIntervalPreset, expectedStart: Date, expectedEnd: Date) {
+        // GIVEN today is the first day of the year
+        let startOfYear = Date("2025-01-01T14:30:00-03:00")
+
+        // WHEN
+        let interval = calendar.makeDateInterval(for: preset, now: startOfYear)
+
+        // THEN
+        #expect(interval.start == expectedStart)
+        #expect(interval.end == expectedEnd)
+    }
+
+    // MARK: - Duration Tests
+
+    @Test("DateInterval durations are calculated correctly")
+    func intervalDurations() {
+        // GIVEN
+        let now = Date("2025-01-15T14:30:00-03:00")
+
+        // Single day
+        let day = calendar.makeDateInterval(for: .today, now: now)
+        #expect(abs(day.duration - 86400) < 2) // ~24 hours
+
+        // Week
+        let week = calendar.makeDateInterval(for: .last7Days, now: now)
+        #expect(abs(week.duration - (86400 * 7)) < 8) // ~7 days
+
+        // Month (30 days)
+        let month = calendar.makeDateInterval(for: .last30Days, now: now)
+        #expect(abs(month.duration - (86400 * 30)) < 31) // ~30 days
+    }
+
+    // MARK: - Quarter Tests
+
+    @Test("Quarter calculations work correctly", arguments: [
+        // Q1: Jan-Mar
+        (Date("2025-01-15T14:30:00-03:00"), Date("2025-01-01T00:00:00-03:00"), Date("2025-04-01T00:00:00-03:00")),
+        (Date("2025-02-28T14:30:00-03:00"), Date("2025-01-01T00:00:00-03:00"), Date("2025-04-01T00:00:00-03:00")),
+        (Date("2025-03-31T14:30:00-03:00"), Date("2025-01-01T00:00:00-03:00"), Date("2025-04-01T00:00:00-03:00")),
+        // Q2: Apr-Jun
+        (Date("2025-04-01T14:30:00-03:00"), Date("2025-04-01T00:00:00-03:00"), Date("2025-07-01T00:00:00-03:00")),
+        (Date("2025-05-15T14:30:00-03:00"), Date("2025-04-01T00:00:00-03:00"), Date("2025-07-01T00:00:00-03:00")),
+        (Date("2025-06-30T14:30:00-03:00"), Date("2025-04-01T00:00:00-03:00"), Date("2025-07-01T00:00:00-03:00")),
+        // Q3: Jul-Sep
+        (Date("2025-07-01T14:30:00-03:00"), Date("2025-07-01T00:00:00-03:00"), Date("2025-10-01T00:00:00-03:00")),
+        (Date("2025-08-15T14:30:00-03:00"), Date("2025-07-01T00:00:00-03:00"), Date("2025-10-01T00:00:00-03:00")),
+        (Date("2025-09-30T14:30:00-03:00"), Date("2025-07-01T00:00:00-03:00"), Date("2025-10-01T00:00:00-03:00")),
+        // Q4: Oct-Dec
+        (Date("2025-10-01T14:30:00-03:00"), Date("2025-10-01T00:00:00-03:00"), Date("2026-01-01T00:00:00-03:00")),
+        (Date("2025-11-15T14:30:00-03:00"), Date("2025-10-01T00:00:00-03:00"), Date("2026-01-01T00:00:00-03:00")),
+        (Date("2025-12-31T14:30:00-03:00"), Date("2025-10-01T00:00:00-03:00"), Date("2026-01-01T00:00:00-03:00"))
+    ])
+    func quarterCalculations(now: Date, expectedStart: Date, expectedEnd: Date) {
+        // WHEN
+        let interval = calendar.makeDateInterval(for: .thisQuarter, now: now)
+
+        // THEN
+        #expect(interval.start == expectedStart)
+        #expect(interval.end == expectedEnd)
+    }
+
+    // MARK: - Special Date Tests
+
+    @Test("Presets at exact midnight")
+    func presetsAtMidnight() {
+        // GIVEN
+        let midnight = Date("2025-01-15T00:00:00-03:00")
+
+        // WHEN
+        let interval = calendar.makeDateInterval(for: .today, now: midnight)
+
+        // THEN
+        #expect(interval.start == Date("2025-01-15T00:00:00-03:00"))
+        #expect(interval.end == Date("2025-01-16T00:00:00-03:00"))
+    }
+
+    @Test("Presets handle very old dates")
+    func presetsWithOldDates() {
+        // GIVEN - Date from year 2000
+        let oldDate = Date("2000-06-15T14:30:00-03:00")
+
+        // WHEN
+        let threeYears = calendar.makeDateInterval(for: .last3Years, now: oldDate)
+
+        // THEN
+        #expect(threeYears.start == Date("1998-01-01T00:00:00-03:00"))
+        #expect(threeYears.end == Date("2001-01-01T00:00:00-03:00"))
+    }
+}

--- a/Modules/Tests/JetpackStatsTests/DataPointTests.swift
+++ b/Modules/Tests/JetpackStatsTests/DataPointTests.swift
@@ -1,0 +1,143 @@
+import Testing
+import Foundation
+@testable import JetpackStats
+
+@Suite
+struct DataPointTests {
+    let calendar = Calendar.mock(timeZone: .eastern)
+
+    @Test("Maps previous data to current period with simple day offset")
+    func testMapPreviousDataToCurrentSimpleDayOffset() {
+        // GIVEN
+        let previousStart = Date("2025-01-01T00:00:00-03:00")
+        let previousEnd = Date("2025-01-08T00:00:00-03:00")
+        let previousRange = DateInterval(start: previousStart, end: previousEnd)
+
+        let currentStart = Date("2025-01-08T00:00:00-03:00")
+        let currentEnd = Date("2025-01-15T00:00:00-03:00")
+        let currentRange = DateInterval(start: currentStart, end: currentEnd)
+
+        let previousData = [
+            DataPoint(date: Date("2025-01-01T00:00:00-03:00"), value: 100),
+            DataPoint(date: Date("2025-01-02T00:00:00-03:00"), value: 200),
+            DataPoint(date: Date("2025-01-03T00:00:00-03:00"), value: 300),
+            DataPoint(date: Date("2025-01-04T00:00:00-03:00"), value: 400),
+            DataPoint(date: Date("2025-01-05T00:00:00-03:00"), value: 500),
+            DataPoint(date: Date("2025-01-06T00:00:00-03:00"), value: 600),
+            DataPoint(date: Date("2025-01-07T00:00:00-03:00"), value: 700)
+        ]
+
+        // WHEN
+        let mappedData = DataPoint.mapDataPoints(
+            previousData,
+            from: previousRange,
+            to: currentRange,
+            component: .day,
+            calendar: calendar
+        )
+
+        // THEN
+        #expect(mappedData.count == 7)
+        #expect(mappedData[0].date == Date("2025-01-08T00:00:00-03:00"))
+        #expect(mappedData[0].value == 100)
+        #expect(mappedData[1].date == Date("2025-01-09T00:00:00-03:00"))
+        #expect(mappedData[1].value == 200)
+        #expect(mappedData[6].date == Date("2025-01-14T00:00:00-03:00"))
+        #expect(mappedData[6].value == 700)
+    }
+
+    @Test("Maps previous month data to current month")
+    func testMapPreviousMonthDataToCurrent() {
+        // GIVEN
+        let previousStart = Date("2024-12-01T00:00:00-03:00")
+        let previousEnd = Date("2025-01-01T00:00:00-03:00")
+        let previousRange = DateInterval(start: previousStart, end: previousEnd)
+
+        let currentStart = Date("2025-01-01T00:00:00-03:00")
+        let currentEnd = Date("2025-02-01T00:00:00-03:00")
+        let currentRange = DateInterval(start: currentStart, end: currentEnd)
+
+        let previousData = [
+            DataPoint(date: Date("2024-12-01T00:00:00-03:00"), value: 1000),
+            DataPoint(date: Date("2024-12-15T00:00:00-03:00"), value: 2000),
+            DataPoint(date: Date("2024-12-31T00:00:00-03:00"), value: 3000)
+        ]
+
+        // WHEN
+        let mappedData = DataPoint.mapDataPoints(
+            previousData,
+            from: previousRange,
+            to: currentRange,
+            component: .month,
+            calendar: calendar
+        )
+
+        // THEN
+        #expect(mappedData.count == 3)
+        #expect(mappedData[0].date == Date("2025-01-01T00:00:00-03:00"))
+        #expect(mappedData[0].value == 1000)
+        #expect(mappedData[1].date == Date("2025-01-15T00:00:00-03:00"))
+        #expect(mappedData[1].value == 2000)
+        #expect(mappedData[2].date == Date("2025-01-31T00:00:00-03:00"))
+        #expect(mappedData[2].value == 3000)
+    }
+
+    @Test("Maps with empty previous data")
+    func testMapEmptyPreviousData() {
+        // GIVEN
+        let previousRange = DateInterval(
+            start: Date("2025-01-01T00:00:00-03:00"),
+            end: Date("2025-01-08T00:00:00-03:00")
+        )
+        let currentRange = DateInterval(
+            start: Date("2025-01-08T00:00:00-03:00"),
+            end: Date("2025-01-15T00:00:00-03:00")
+        )
+        let previousData: [DataPoint] = []
+
+        // WHEN
+        let mappedData = DataPoint.mapDataPoints(
+            previousData,
+            from: previousRange,
+            to: currentRange,
+            component: .day,
+            calendar: calendar
+        )
+
+        // THEN
+        #expect(mappedData.isEmpty)
+    }
+
+    @Test("Maps year-over-year comparison")
+    func testMapYearOverYearComparison() {
+        // GIVEN
+        let previousStart = Date("2024-01-01T00:00:00-03:00")
+        let previousEnd = Date("2024-01-08T00:00:00-03:00")
+        let previousRange = DateInterval(start: previousStart, end: previousEnd)
+
+        let currentStart = Date("2025-01-01T00:00:00-03:00")
+        let currentEnd = Date("2025-01-08T00:00:00-03:00")
+        let currentRange = DateInterval(start: currentStart, end: currentEnd)
+
+        let previousData = [
+            DataPoint(date: Date("2024-01-01T00:00:00-03:00"), value: 1000),
+            DataPoint(date: Date("2024-01-07T00:00:00-03:00"), value: 2000)
+        ]
+
+        // WHEN
+        let mappedData = DataPoint.mapDataPoints(
+            previousData,
+            from: previousRange,
+            to: currentRange,
+            component: .year,
+            calendar: calendar
+        )
+
+        // THEN
+        #expect(mappedData.count == 2)
+        #expect(mappedData[0].date == Date("2025-01-01T00:00:00-03:00"))
+        #expect(mappedData[0].value == 1000)
+        #expect(mappedData[1].date == Date("2025-01-07T00:00:00-03:00"))
+        #expect(mappedData[1].value == 2000)
+    }
+}

--- a/Modules/Tests/JetpackStatsTests/DateIntervalTests.swift
+++ b/Modules/Tests/JetpackStatsTests/DateIntervalTests.swift
@@ -1,0 +1,51 @@
+import Testing
+import Foundation
+@testable import JetpackStats
+
+@Suite
+struct DateIntervalTests {
+    let calendar = Calendar.mock(timeZone: .eastern)
+
+    @Test("DateInterval assumptions")
+    func assumptions() throws {
+        // GIVEN
+        let timeZone = try #require(TimeZone(secondsFromGMT: -10800)) // -3 hours
+
+        var calendar = Calendar.current
+        calendar.timeZone = timeZone
+
+        // WHEN
+        var interval = try #require(calendar.dateInterval(of: .day, for: Date("2025-01-15T14:30:00-03:00")))
+
+        // THEN the beginning is the beginnig of the given day
+        #expect(interval.start == Date("2025-01-15T00:00:00-03:00"))
+
+        // THEN the end is the beginning of the next day
+        #expect(interval.end == Date("2025-01-16T00:00:00-03:00"))
+
+        // THEN the interval technically contains the date with "2025-01-16" date
+        #expect(interval.contains(Date("2025-01-16T00:00:00-03:00")))
+
+        // GIVEN
+        let formatter = DateIntervalFormatter()
+        formatter.timeZone = timeZone
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        formatter.locale = Locale(identifier: "en_us")
+
+        // THEN `DateIntervalFormatter` is fundamentally designed to represent time ranges
+        #expect(formatter.string(from: interval) == "1/15/25, 12:00 AM – 1/16/25, 12:00 AM")
+
+        // WHEN
+        formatter.timeStyle = .none
+
+        // THEN date without time may appear off
+        #expect(formatter.string(from: interval) == "1/15/25 – 1/16/25")
+
+        // WHEN date is adjusted
+        interval.end = try #require(calendar.date(byAdding: .second, value: -1, to: interval.end))
+
+        // THEN the formatting matches what the user would expect
+        #expect(formatter.string(from: interval) == "1/15/25")
+    }
+}

--- a/Modules/Tests/JetpackStatsTests/DateRangeComparisonPeriodTests.swift
+++ b/Modules/Tests/JetpackStatsTests/DateRangeComparisonPeriodTests.swift
@@ -1,0 +1,184 @@
+import Testing
+import Foundation
+@testable import JetpackStats
+
+@Suite
+struct DateRangeComparisonPeriodTests {
+    let calendar = Calendar.mock(timeZone: TimeZone(secondsFromGMT: 0)!)
+
+    // MARK: - DateRangeComparisonPeriod Tests
+
+    @Test
+    func testPrecedingPeriodForDay() {
+        // GIVEN
+        let currentRange = DateInterval(
+            start: Date("2025-01-15T00:00:00Z"),
+            end: Date("2025-01-16T00:00:00Z")
+        )
+
+        // WHEN
+        let comparisonRange = calendar.comparisonRange(for: currentRange, period: .precedingPeriod, component: .day)
+
+        // THEN
+        #expect(comparisonRange.start == Date("2025-01-14T00:00:00Z"))
+        #expect(comparisonRange.end == Date("2025-01-15T00:00:00Z"))
+    }
+
+    @Test
+    func testPrecedingPeriodForWeek() {
+        // GIVEN
+        let currentRange = DateInterval(
+            start: Date("2025-01-12T00:00:00Z"), // Sunday
+            end: Date("2025-01-19T00:00:00Z")    // Next Sunday
+        )
+
+        // WHEN
+        let comparisonRange = calendar.comparisonRange(for: currentRange, period: .precedingPeriod, component: .weekOfYear)
+
+        // THEN
+        #expect(comparisonRange.start == Date("2025-01-05T00:00:00Z"))
+        #expect(comparisonRange.end == Date("2025-01-12T00:00:00Z"))
+    }
+
+    @Test
+    func testPrecedingPeriodForMonth() {
+        // GIVEN
+        let currentRange = DateInterval(
+            start: Date("2025-02-01T00:00:00Z"),
+            end: Date("2025-03-01T00:00:00Z")
+        )
+
+        // WHEN
+        let comparisonRange = calendar.comparisonRange(for: currentRange, period: .precedingPeriod, component: .month)
+
+        // THEN
+        #expect(comparisonRange.start == Date("2025-01-01T00:00:00Z"))
+        #expect(comparisonRange.end == Date("2025-02-01T00:00:00Z"))
+    }
+
+    @Test
+    func testPrecedingPeriodForYear() {
+        // GIVEN
+        let currentRange = DateInterval(
+            start: Date("2025-01-01T00:00:00Z"),
+            end: Date("2026-01-01T00:00:00Z")
+        )
+
+        // WHEN
+        let comparisonRange = calendar.comparisonRange(for: currentRange, period: .precedingPeriod, component: .year)
+
+        // THEN
+        #expect(comparisonRange.start == Date("2024-01-01T00:00:00Z"))
+        #expect(comparisonRange.end == Date("2025-01-01T00:00:00Z"))
+    }
+
+    @Test
+    func testPrecedingPeriodForCustomRange() {
+        // GIVEN - 7 day custom range
+        let currentRange = DateInterval(
+            start: Date("2025-01-08T00:00:00Z"),
+            end: Date("2025-01-15T00:00:00Z")
+        )
+
+        // WHEN - Use nil component for custom ranges
+        let comparisonRange = calendar.comparisonRange(for: currentRange, period: .precedingPeriod, component: .day)
+
+        // THEN - Should shift by duration (7 days)
+        #expect(comparisonRange.start == Date("2025-01-01T00:00:00Z"))
+        #expect(comparisonRange.end == Date("2025-01-08T00:00:00Z"))
+    }
+
+    @Test
+    func testSamePeriodLastYearForDay() {
+        // GIVEN
+        let currentRange = DateInterval(
+            start: Date("2025-01-15T00:00:00Z"),
+            end: Date("2025-01-16T00:00:00Z")
+        )
+
+        // WHEN
+        let comparisonRange = calendar.comparisonRange(for: currentRange, period: .samePeriodLastYear, component: .day)
+
+        // THEN
+        #expect(comparisonRange.start == Date("2024-01-15T00:00:00Z"))
+        #expect(comparisonRange.end == Date("2024-01-16T00:00:00Z"))
+    }
+
+    @Test
+    func testSamePeriodLastYearForMonth() {
+        // GIVEN
+        let currentRange = DateInterval(
+            start: Date("2025-02-01T00:00:00Z"),
+            end: Date("2025-03-01T00:00:00Z")
+        )
+
+        // WHEN
+        let comparisonRange = calendar.comparisonRange(for: currentRange, period: .samePeriodLastYear, component: .month)
+
+        // THEN
+        #expect(comparisonRange.start == Date("2024-02-01T00:00:00Z"))
+        #expect(comparisonRange.end == Date("2024-03-01T00:00:00Z"))
+    }
+
+    @Test
+    func testSamePeriodLastYearForLeapYear() {
+        // GIVEN - February 29, 2024 (leap year)
+        let currentRange = DateInterval(
+            start: Date("2024-02-29T00:00:00Z"),
+            end: Date("2024-03-01T00:00:00Z")
+        )
+
+        // WHEN
+        let comparisonRange = calendar.comparisonRange(for: currentRange, period: .samePeriodLastYear, component: .day)
+
+        // THEN - Should handle leap year correctly
+        #expect(comparisonRange.start == Date("2023-02-28T00:00:00Z"))
+        #expect(comparisonRange.end == Date("2023-03-01T00:00:00Z"))
+    }
+
+    // MARK: - StatsDateRange Integration Tests
+
+    @Test
+    func testStatsDateRangeWithComparisonType() {
+        // GIVEN
+        let currentRange = DateInterval(
+            start: Date("2025-01-15T00:00:00Z"),
+            end: Date("2025-01-16T00:00:00Z")
+        )
+
+        // WHEN
+        let dateRange = StatsDateRange(
+            interval: currentRange,
+            component: .day,
+            comparison: .precedingPeriod,
+            calendar: calendar
+        )
+
+        // THEN
+        #expect(dateRange.comparison == DateRangeComparisonPeriod.precedingPeriod)
+        #expect(dateRange.effectiveComparisonInterval.start == Date("2025-01-14T00:00:00Z"))
+        #expect(dateRange.effectiveComparisonInterval.end == Date("2025-01-15T00:00:00Z"))
+    }
+
+    @Test
+    func testNavigationPreservesComparisonType() {
+        // GIVEN
+        let initialRange = StatsDateRange(
+            interval: DateInterval(
+                start: Date("2025-01-15T00:00:00Z"),
+                end: Date("2025-01-16T00:00:00Z")
+            ),
+            component: .day,
+            comparison: .samePeriodLastYear,
+            calendar: calendar
+        )
+
+        // WHEN
+        let nextRange = initialRange.navigate(.forward)
+
+        // THEN - Comparison type should be preserved
+        #expect(nextRange.comparison == .samePeriodLastYear)
+        #expect(nextRange.dateInterval.start == Date("2025-01-16T00:00:00Z"))
+        #expect(nextRange.effectiveComparisonInterval.start == Date("2024-01-16T00:00:00Z"))
+    }
+}

--- a/Modules/Tests/JetpackStatsTests/DateRangeGranularityTests.swift
+++ b/Modules/Tests/JetpackStatsTests/DateRangeGranularityTests.swift
@@ -1,0 +1,174 @@
+import Testing
+import Foundation
+@testable import JetpackStats
+
+@Suite
+struct DateRangeGranularityTests {
+    let calendar = Calendar.mock(timeZone: .eastern)
+
+    @Test("Determined period for 1 day or less returns hour granularity")
+    func granularityForLessThanOneDay() {
+        // Same day (1 day exclusive upper bound)
+        let singleDay = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2024-01-02T00:00:00-03:00")
+        )
+        #expect(singleDay.preferredGranularity == .hour)
+    }
+
+    @Test("Determined period for 2+ days returns day granularity")
+    func granularityForDays() {
+        // 2 days
+        let twoDays = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2024-01-03T00:00:00-03:00")
+        )
+        #expect(twoDays.preferredGranularity == .day)
+
+        // 3 days
+        let threeDays = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2024-01-04T00:00:00-03:00")
+        )
+        #expect(threeDays.preferredGranularity == .day)
+
+        // 7 days
+        let sevenDays = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2024-01-08T00:00:00-03:00")
+        )
+        #expect(sevenDays.preferredGranularity == .day)
+
+        // 15 days
+        let fifteenDays = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2024-01-16T00:00:00-03:00")
+        )
+        #expect(fifteenDays.preferredGranularity == .day)
+
+        // 31 days (full month)
+        let fullMonth = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2024-02-01T00:00:00-03:00")
+        )
+        #expect(fullMonth.preferredGranularity == .day)
+
+        // 90 days
+        let ninetyDays = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2024-03-31T00:00:00-03:00")
+        )
+        #expect(ninetyDays.preferredGranularity == .day)
+    }
+
+    @Test("Determined period for 91+ days returns month granularity")
+    func granularityForMonths() {
+        // 91 days
+        let ninetyOneDays = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2024-04-01T00:00:00-03:00")
+        )
+        #expect(ninetyOneDays.preferredGranularity == .month)
+
+        // ~181 days (6 months)
+        let sixMonths = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2024-07-01T00:00:00-03:00")
+        )
+        #expect(sixMonths.preferredGranularity == .month)
+
+        // 366 days (leap year)
+        let leapYear = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2025-01-01T00:00:00-03:00")
+        )
+        #expect(leapYear.preferredGranularity == .month)
+
+        // 730 days (2 years)
+        let twoYears = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2025-12-31T00:00:00-03:00")
+        )
+        #expect(twoYears.preferredGranularity == .month)
+    }
+
+    @Test("Determined period for 25+ months returns year granularity")
+    func granularityForYears() {
+        // 25 months (just over 2 years)
+        let twentyFiveMonths = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2026-02-02T00:00:00-03:00")
+        )
+        #expect(twentyFiveMonths.preferredGranularity == .month)
+
+        // 3 years
+        let threeYears = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2027-01-02T00:00:00-03:00")
+        )
+        #expect(threeYears.preferredGranularity == .month)
+
+        // 5 years
+        let fiveYears = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2029-01-02T00:00:00-03:00")
+        )
+        #expect(fiveYears.preferredGranularity == .year)
+    }
+
+    @Test("Granularity respects transitions at 14 and 90 day boundaries")
+    func granularityBoundaryTransitions() {
+        // Single day - should be hour
+        let singleDay = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2024-01-02T00:00:00-03:00")
+        )
+        #expect(singleDay.preferredGranularity == .hour)
+
+        // 14 days - should be day
+        let fourteenDays = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2024-01-15T00:00:00-03:00")
+        )
+        #expect(fourteenDays.preferredGranularity == .day)
+
+        // 15 days - should be day
+        let fifteenDays = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2024-01-16T00:00:00-03:00")
+        )
+        #expect(fifteenDays.preferredGranularity == .day)
+
+        // 90 days - should be day
+        let ninetyDays = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2024-03-31T00:00:00-03:00")
+        )
+        #expect(ninetyDays.preferredGranularity == .day)
+
+        // 91 days - should be month
+        let ninetyOneDays = DateInterval(
+            start: Date("2024-01-01T00:00:00-03:00"),
+            end: Date("2024-04-01T00:00:00-03:00")
+        )
+        #expect(ninetyOneDays.preferredGranularity == .month)
+    }
+
+    @Test("Granularity for preset ranges matches expected values")
+    func granularityForPresets() {
+        // Today - should be hour (single day)
+        #expect(calendar.makeDateInterval(for: .today).preferredGranularity == .hour)
+
+        // Yesterday - should be hour (single day)
+        #expect(calendar.makeDateInterval(for: .today).preferredGranularity == .hour)
+
+        // Last 7 days - should be day
+        #expect(calendar.makeDateInterval(for: .last7Days).preferredGranularity == .day)
+
+        // Last 30 days - should be day
+        #expect(calendar.makeDateInterval(for: .last30Days).preferredGranularity == .day)
+
+        // Last 12 months - should be month
+        #expect(calendar.makeDateInterval(for: .last12Months).preferredGranularity == .month)
+    }
+}

--- a/Modules/Tests/JetpackStatsTests/StatsDateFormatterTests.swift
+++ b/Modules/Tests/JetpackStatsTests/StatsDateFormatterTests.swift
@@ -1,0 +1,71 @@
+import Testing
+import Foundation
+@testable import JetpackStats
+
+@Suite
+struct StatsDateFormatterTests {
+    let formatter = StatsDateFormatter(
+        locale: Locale(identifier: "en_us"),
+        timeZone: .eastern
+    )
+
+    @Test func hourFormattingCompact() {
+        let date = Date("2025-03-15T14:00:00-03:00")
+        let result = formatter.formatDate(date, granularity: .hour)
+        #expect(result == "2 PM")
+
+        let midnight = Date("2025-03-15T00:00:00-03:00")
+        let midnightResult = formatter.formatDate(midnight, granularity: .hour)
+        #expect(midnightResult == "12 AM")
+
+        let noon = Date("2025-03-15T12:00:00-03:00")
+        let noonResult = formatter.formatDate(noon, granularity: .hour)
+        #expect(noonResult == "12 PM")
+    }
+
+    @Test func hourFormattingRegular() {
+        let date = Date("2025-03-15T14:00:00-03:00")
+        let result = formatter.formatDate(date, granularity: .hour, context: .regular)
+        #expect(result == "2 PM")
+
+        let midnight = Date("2025-03-15T00:00:00-03:00")
+        let midnightResult = formatter.formatDate(midnight, granularity: .hour, context: .regular)
+        #expect(midnightResult == "12 AM")
+    }
+
+    @Test func dayFormattingCompact() {
+        let date = Date("2025-03-15T14:00:00-03:00")
+        let result = formatter.formatDate(date, granularity: .day)
+        #expect(result == "Mar 15")
+    }
+
+    @Test func dayFormattingRegular() {
+        let date = Date("2025-03-15T14:00:00-03:00")
+        let result = formatter.formatDate(date, granularity: .day, context: .regular)
+        #expect(result == "Saturday, March 15")
+    }
+
+    @Test func monthFormattingCompact() {
+        let date = Date("2025-03-15T14:00:00-03:00")
+        let result = formatter.formatDate(date, granularity: .month)
+        #expect(result == "Mar")
+    }
+
+    @Test func monthFormattingRegular() {
+        let date = Date("2025-03-15T14:00:00-03:00")
+        let result = formatter.formatDate(date, granularity: .month, context: .regular)
+        #expect(result == "March 2025")
+    }
+
+    @Test func yearFormattingCompact() {
+        let date = Date("2025-03-15T14:00:00-03:00")
+        let result = formatter.formatDate(date, granularity: .year)
+        #expect(result == "2025")
+    }
+
+    @Test func yearFormattingRegular() {
+        let date = Date("2025-03-15T14:00:00-03:00")
+        let result = formatter.formatDate(date, granularity: .year, context: .regular)
+        #expect(result == "2025")
+    }
+}

--- a/Modules/Tests/JetpackStatsTests/StatsDateRangeFormatterTests.swift
+++ b/Modules/Tests/JetpackStatsTests/StatsDateRangeFormatterTests.swift
@@ -1,0 +1,229 @@
+import Testing
+import Foundation
+@testable import JetpackStats
+
+@Suite
+struct StatsDateRangeFormatterTests {
+    let calendar = Calendar.mock(timeZone: .eastern)
+    let locale = Locale(identifier: "en_US")
+    let now = Date("2025-07-15T10:00:00-03:00")
+
+    // MARK: - Date Range Formatting
+
+    @Test("Date range formatting", arguments: [
+        // Single day
+        (Date("2025-01-01T00:00:00-03:00"), Date("2025-01-02T00:00:00-03:00"), "Jan 1"),
+        // Same month range
+        (Date("2025-01-01T00:00:00-03:00"), Date("2025-01-06T00:00:00-03:00"), "Jan 1 – 5"),
+        (Date("2025-01-03T00:00:00-03:00"), Date("2025-01-13T00:00:00-03:00"), "Jan 3 – 12"),
+        // Cross month range
+        (Date("2025-01-31T00:00:00-03:00"), Date("2025-02-03T00:00:00-03:00"), "Jan 31 – Feb 2"),
+        // Cross year range
+        (Date("2024-12-31T00:00:00-03:00"), Date("2025-01-03T00:00:00-03:00"), "Dec 31, 2024 – Jan 2, 2025"),
+        // Same year, different months
+        (Date("2025-03-15T00:00:00-03:00"), Date("2025-05-20T00:00:00-03:00"), "Mar 15 – May 19")
+    ])
+    func dateRangeFormatting(startDate: Date, endDate: Date, expected: String) {
+        let interval = DateInterval(start: startDate, end: endDate)
+        let formatter = StatsDateRangeFormatter(locale: locale, timeZone: calendar.timeZone)
+        #expect(formatter.string(from: interval) == expected)
+    }
+
+    // MARK: - Special Period Formatting
+
+    @Test("Entire month formatting", arguments: [
+        (Date("2025-01-01T00:00:00-03:00"), Date("2025-02-01T00:00:00-03:00"), "Jan 2025"),
+        (Date("2024-02-01T00:00:00-03:00"), Date("2024-03-01T00:00:00-03:00"), "Feb 2024"), // Leap year
+        (Date("2023-12-01T00:00:00-03:00"), Date("2024-01-01T00:00:00-03:00"), "Dec 2023"),
+        (Date("2025-04-01T00:00:00-03:00"), Date("2025-05-01T00:00:00-03:00"), "Apr 2025") // 30-day month
+    ])
+    func entireMonthFormatting(startDate: Date, endDate: Date, expected: String) {
+        let interval = DateInterval(start: startDate, end: endDate)
+        let formatter = StatsDateRangeFormatter(locale: locale, timeZone: calendar.timeZone)
+        #expect(formatter.string(from: interval) == expected)
+    }
+
+    @Test("Multiple full months formatting", arguments: [
+        // Two months
+        (Date("2025-01-01T00:00:00-03:00"), Date("2025-03-01T00:00:00-03:00"), "Jan – Feb 2025"),
+        // Three months
+        (Date("2025-01-01T00:00:00-03:00"), Date("2025-04-01T00:00:00-03:00"), "Jan – Mar 2025"),
+        // Five months
+        (Date("2025-01-01T00:00:00-03:00"), Date("2025-06-01T00:00:00-03:00"), "Jan – May 2025"),
+        // Cross-year multiple months
+        (Date("2024-11-01T00:00:00-03:00"), Date("2025-02-01T00:00:00-03:00"), "Nov 2024 – Jan 2025"),
+        // Full quarter
+        (Date("2025-04-01T00:00:00-03:00"), Date("2025-07-01T00:00:00-03:00"), "Apr – Jun 2025"),
+        // Most of year
+        (Date("2025-02-01T00:00:00-03:00"), Date("2025-12-01T00:00:00-03:00"), "Feb – Nov 2025")
+    ])
+    func multipleFullMonthsFormatting(startDate: Date, endDate: Date, expected: String) {
+        let interval = DateInterval(start: startDate, end: endDate)
+        let formatter = StatsDateRangeFormatter(locale: locale, timeZone: calendar.timeZone)
+        #expect(formatter.string(from: interval) == expected)
+    }
+
+    @Test("Entire week formatting", arguments: [
+        // Monday to Monday (full week)
+        (Date("2025-01-13T00:00:00-03:00"), Date("2025-01-20T00:00:00-03:00"), "Jan 13 – 19"),
+        // Sunday to Sunday (full week starting Sunday)
+        (Date("2025-01-12T00:00:00-03:00"), Date("2025-01-19T00:00:00-03:00"), "Jan 12 – 18"),
+        // Week crossing months
+        (Date("2025-01-27T00:00:00-03:00"), Date("2025-02-03T00:00:00-03:00"), "Jan 27 – Feb 2"),
+        // Week crossing years
+        (Date("2024-12-30T00:00:00-03:00"), Date("2025-01-06T00:00:00-03:00"), "Dec 30, 2024 – Jan 5, 2025")
+    ])
+    func entireWeekFormatting(startDate: Date, endDate: Date, expected: String) {
+        let interval = DateInterval(start: startDate, end: endDate)
+        let formatter = StatsDateRangeFormatter(locale: locale, timeZone: calendar.timeZone)
+        #expect(formatter.string(from: interval) == expected)
+    }
+
+    @Test("Entire year formatting", arguments: [
+        (Date("2025-01-01T00:00:00-03:00"), Date("2026-01-01T00:00:00-03:00"), "2025"),
+        (Date("2024-01-01T00:00:00-03:00"), Date("2025-01-01T00:00:00-03:00"), "2024"),
+        (Date("2000-01-01T00:00:00-03:00"), Date("2001-01-01T00:00:00-03:00"), "2000")
+    ])
+    func entireYearFormatting(startDate: Date, endDate: Date, expected: String) {
+        let interval = DateInterval(start: startDate, end: endDate)
+        let formatter = StatsDateRangeFormatter(locale: locale, timeZone: calendar.timeZone)
+        #expect(formatter.string(from: interval) == expected)
+    }
+
+    @Test("Multiple full years formatting", arguments: [
+        // Two years
+        (Date("2023-01-01T00:00:00-03:00"), Date("2025-01-01T00:00:00-03:00"), "2023 – 2024"),
+        // Three years
+        (Date("2020-01-01T00:00:00-03:00"), Date("2023-01-01T00:00:00-03:00"), "2020 – 2022"),
+        // Four years
+        (Date("2020-01-01T00:00:00-03:00"), Date("2024-01-01T00:00:00-03:00"), "2020 – 2023"),
+        // Ten years
+        (Date("2015-01-01T00:00:00-03:00"), Date("2025-01-01T00:00:00-03:00"), "2015 – 2024"),
+        // Century boundary
+        (Date("1999-01-01T00:00:00-03:00"), Date("2002-01-01T00:00:00-03:00"), "1999 – 2001")
+    ])
+    func multipleFullYearsFormatting(startDate: Date, endDate: Date, expected: String) {
+        let interval = DateInterval(start: startDate, end: endDate)
+        let formatter = StatsDateRangeFormatter(locale: locale, timeZone: calendar.timeZone)
+        #expect(formatter.string(from: interval) == expected)
+    }
+
+    // MARK: - Current vs Previous Year Tests
+
+    @Test("Same year as current year formatting")
+    func sameYearAsCurrentFormatting() {
+        let formatter = StatsDateRangeFormatter(locale: locale, timeZone: calendar.timeZone)
+        let now = Date("2025-07-15T10:00:00-03:00") // Fixed date in 2025
+
+        // Single day in current year - no year shown
+        let singleDay = DateInterval(start: Date("2025-03-15T00:00:00-03:00"), end: Date("2025-03-16T00:00:00-03:00"))
+        #expect(formatter.string(from: singleDay, now: now) == "Mar 15")
+
+        // Range within current year - no year shown
+        let rangeInYear = DateInterval(start: Date("2025-05-01T00:00:00-03:00"), end: Date("2025-05-08T00:00:00-03:00"))
+        #expect(formatter.string(from: rangeInYear, now: now) == "May 1 – 7")
+
+        // Cross month range in current year - no year shown
+        let crossMonth = DateInterval(start: Date("2025-06-28T00:00:00-03:00"), end: Date("2025-07-03T00:00:00-03:00"))
+        #expect(formatter.string(from: crossMonth, now: now) == "Jun 28 – Jul 2")
+    }
+
+    @Test("Previous year formatting")
+    func previousYearFormatting() {
+        let formatter = StatsDateRangeFormatter(locale: locale, timeZone: calendar.timeZone)
+        let now = Date("2025-07-15T10:00:00-03:00") // Fixed date in 2025
+
+        // Single day in previous year - year shown
+        let singleDay = DateInterval(start: Date("2024-03-15T00:00:00-03:00"), end: Date("2024-03-16T00:00:00-03:00"))
+        #expect(formatter.string(from: singleDay, now: now) == "Mar 15, 2024")
+
+        // Range within previous year - year shown at end
+        let rangeInYear = DateInterval(start: Date("2024-05-01T00:00:00-03:00"), end: Date("2024-05-08T00:00:00-03:00"))
+        #expect(formatter.string(from: rangeInYear, now: now) == "May 1 – 7, 2024")
+
+        // Cross month range in previous year - year shown at end
+        let crossMonth = DateInterval(start: Date("2024-06-28T00:00:00-03:00"), end: Date("2024-07-03T00:00:00-03:00"))
+        #expect(formatter.string(from: crossMonth, now: now) == "Jun 28 – Jul 2, 2024")
+    }
+
+    @Test("Cross year formatting with current year")
+    func crossYearWithCurrentFormatting() {
+        let formatter = StatsDateRangeFormatter(locale: locale, timeZone: calendar.timeZone)
+        let now = Date("2025-07-15T10:00:00-03:00") // Fixed date in 2025
+
+        // Range from previous to current year - both years shown
+        let crossYear = DateInterval(start: Date("2024-12-28T00:00:00-03:00"), end: Date("2025-01-03T00:00:00-03:00"))
+        #expect(formatter.string(from: crossYear, now: now) == "Dec 28, 2024 – Jan 2, 2025")
+    }
+
+    // MARK: - DateRangePreset Integration Tests
+
+    @Test("DateRangePreset formatting - current year", arguments: [
+        (DateIntervalPreset.today, "Mar 15"),
+        (DateIntervalPreset.thisWeek, "Mar 9 – 15"),
+        (DateIntervalPreset.thisMonth, "Mar 2025"),
+        (DateIntervalPreset.thisYear, "2025"),
+        (DateIntervalPreset.last7Days, "Mar 8 – 14"),
+        (DateIntervalPreset.last30Days, "Feb 13 – Mar 14")
+    ])
+    func dateRangePresetFormattingCurrentYear(preset: DateIntervalPreset, expected: String) {
+        // Set up a specific date in 2025
+        let now = Date("2025-03-15T14:30:00-03:00")
+        let formatter = StatsDateRangeFormatter(locale: locale, timeZone: calendar.timeZone)
+
+        let interval = calendar.makeDateInterval(for: preset, now: now)
+        #expect(formatter.string(from: interval, now: now) == expected)
+    }
+
+    @Test("DateRangePreset formatting - year boundaries")
+    func dateRangePresetFormattingYearBoundaries() {
+        // Test date near year boundary - January 5, 2025
+        let now = Date("2025-01-05T10:00:00-03:00")
+        let formatter = StatsDateRangeFormatter(locale: locale, timeZone: calendar.timeZone)
+
+        // Last 30 days crosses year boundary
+        let last30Days = calendar.makeDateInterval(for: .last30Days, now: now)
+        #expect(formatter.string(from: last30Days, now: now) == "Dec 6, 2024 – Jan 4, 2025")
+    }
+
+    @Test("DateRangePreset formatting - custom ranges")
+    func dateRangePresetFormattingCustomRanges() {
+        let formatter = StatsDateRangeFormatter(locale: locale, timeZone: calendar.timeZone)
+
+        // Custom single day
+        let customDay = DateInterval(
+            start: Date("2025-06-10T00:00:00-03:00"),
+            end: Date("2025-06-11T00:00:00-03:00")
+        )
+        #expect(formatter.string(from: customDay, now: now) == "Jun 10")
+
+        // Custom range in same month
+        let customRange = DateInterval(
+            start: Date("2025-06-05T00:00:00-03:00"),
+            end: Date("2025-06-15T00:00:00-03:00")
+        )
+        #expect(formatter.string(from: customRange) == "Jun 5 – 14")
+
+        // Custom range across months
+        let customCrossMonth = DateInterval(
+            start: Date("2025-05-25T00:00:00-03:00"),
+            end: Date("2025-06-05T00:00:00-03:00")
+        )
+        #expect(formatter.string(from: customCrossMonth) == "May 25 – Jun 4")
+    }
+
+    // MARK: - Localization Tests
+
+    @Test("Different locales", arguments: [
+        ("en_US", Date("2025-01-15T00:00:00-03:00"), Date("2025-01-16T00:00:00-03:00"), "Jan 15"),
+        ("es_ES", Date("2025-01-15T00:00:00-03:00"), Date("2025-01-16T00:00:00-03:00"), "15 ene"),
+        ("fr_FR", Date("2025-01-15T00:00:00-03:00"), Date("2025-01-16T00:00:00-03:00"), "15 janv."),
+        ("de_DE", Date("2025-01-15T00:00:00-03:00"), Date("2025-01-16T00:00:00-03:00"), "15. Jan.")
+    ])
+    func differentLocales(localeId: String, startDate: Date, endDate: Date, expected: String) {
+        let locale = Locale(identifier: localeId)
+        let interval = DateInterval(start: startDate, end: endDate)
+        let formatter = StatsDateRangeFormatter(locale: locale, timeZone: calendar.timeZone)
+        #expect(formatter.string(from: interval) == expected)
+    }
+}

--- a/Modules/Tests/JetpackStatsTests/StatsDateRangeTests.swift
+++ b/Modules/Tests/JetpackStatsTests/StatsDateRangeTests.swift
@@ -1,0 +1,114 @@
+import Testing
+import Foundation
+@testable import JetpackStats
+
+@Suite
+struct StatsDateRangeTests {
+    let calendar = Calendar.mock(timeZone: TimeZone(secondsFromGMT: 0)!)
+
+    @Test
+    func testNavigateToPrevious() {
+        // GIVEN
+        let initialRange = StatsDateRange(
+            interval: DateInterval(
+                start: Date("2025-01-15T00:00:00Z"),
+                end: Date("2025-01-16T00:00:00Z")
+            ),
+            component: .day,
+            calendar: calendar
+        )
+
+        // WHEN
+        let previousRange = initialRange.navigate(.backward)
+
+        // THEN
+        #expect(previousRange.dateInterval.start == Date("2025-01-14T00:00:00Z"))
+        #expect(previousRange.dateInterval.end == Date("2025-01-15T00:00:00Z"))
+        #expect(previousRange.calendar == calendar)
+        #expect(previousRange.component == .day)
+    }
+
+    @Test
+    func testNavigateToNext() {
+        // GIVEN
+        let initialRange = StatsDateRange(
+            interval: DateInterval(
+                start: Date("2025-01-15T00:00:00Z"),
+                end: Date("2025-01-16T00:00:00Z")
+            ),
+            component: .day,
+            calendar: calendar
+        )
+
+        // WHEN
+        let nextRange = initialRange.navigate(.forward)
+
+        // THEN
+        #expect(nextRange.dateInterval.start == Date("2025-01-16T00:00:00Z"))
+        #expect(nextRange.dateInterval.end == Date("2025-01-17T00:00:00Z"))
+        #expect(nextRange.calendar == calendar)
+        #expect(nextRange.component == .day)
+    }
+
+    @Test
+    func testCalendarIsPreservedInNavigation() {
+        // GIVEN
+        var customCalendar = Calendar(identifier: .gregorian)
+        customCalendar.timeZone = TimeZone(identifier: "America/New_York")!
+
+        let initialRange = StatsDateRange(
+            interval: DateInterval(
+                start: Date("2025-01-15T00:00:00Z"),
+                end: Date("2025-01-16T00:00:00Z")
+            ),
+            component: .day,
+            calendar: customCalendar
+        )
+
+        // WHEN
+        let nextRange = initialRange.navigate(.forward)
+
+        // THEN
+        #expect(nextRange.calendar.timeZone == customCalendar.timeZone)
+    }
+
+    @Test
+    func testAvailableAdjacentPeriods() {
+        // GIVEN
+        let initialRange = StatsDateRange(
+            interval: DateInterval(
+                start: Date("2020-01-01T00:00:00Z"),
+                end: Date("2021-01-01T00:00:00Z")
+            ),
+            component: .year,
+            calendar: calendar
+        )
+
+        // WHEN - Test backward navigation
+        let backwardPeriods = initialRange.availableAdjacentPeriods(in: .backward, maxCount: 10)
+
+        // THEN
+        #expect(backwardPeriods.count == 10)
+        #expect(backwardPeriods[0].displayText == "2019")
+        #expect(backwardPeriods[1].displayText == "2018")
+        #expect(backwardPeriods[2].displayText == "2017")
+        #expect(backwardPeriods[9].displayText == "2010")
+
+        // Verify ranges are correct
+        #expect(backwardPeriods[0].range.dateInterval.start == Date("2019-01-01T00:00:00Z"))
+        #expect(backwardPeriods[0].range.dateInterval.end == Date("2020-01-01T00:00:00Z"))
+
+        // WHEN - Test forward navigation (should be limited by current date)
+        let forwardPeriods = initialRange.availableAdjacentPeriods(in: .forward, maxCount: 10)
+
+        // THEN - Should have 5 periods available (2021, 2022, 2023, 2024, 2025)
+        #expect(forwardPeriods.count == 5)
+        #expect(forwardPeriods[0].displayText == "2021")
+        #expect(forwardPeriods[1].displayText == "2022")
+        #expect(forwardPeriods[4].displayText == "2025")
+
+        // Verify all periods have unique IDs
+        let ids = backwardPeriods.map(\.id) + forwardPeriods.map(\.id)
+        #expect(Set(ids).count == ids.count)
+    }
+}

--- a/Modules/Tests/JetpackStatsTests/StatsValueFormatterTests.swift
+++ b/Modules/Tests/JetpackStatsTests/StatsValueFormatterTests.swift
@@ -1,0 +1,146 @@
+import Testing
+@testable import JetpackStats
+
+struct StatsValueFormatterTests {
+
+    @Test
+    func formatTimeOnSite() {
+        let formatter = StatsValueFormatter(metric: .timeOnSite)
+
+        #expect(formatter.format(value: 0) == "0s")
+        #expect(formatter.format(value: 30) == "30s")
+        #expect(formatter.format(value: 59) == "59s")
+        #expect(formatter.format(value: 60) == "1m 0s")
+        #expect(formatter.format(value: 90) == "1m 30s")
+        #expect(formatter.format(value: 120) == "2m 0s")
+        #expect(formatter.format(value: 3661) == "61m 1s")
+    }
+
+    @Test
+    func formatTimeOnSiteCompact() {
+        let formatter = StatsValueFormatter(metric: .timeOnSite)
+
+        #expect(formatter.format(value: 0, context: .compact) == "0s")
+        #expect(formatter.format(value: 30, context: .compact) == "30s")
+        #expect(formatter.format(value: 59, context: .compact) == "59s")
+        #expect(formatter.format(value: 60, context: .compact) == "1m")
+        #expect(formatter.format(value: 90, context: .compact) == "1m")
+        #expect(formatter.format(value: 120, context: .compact) == "2m")
+        #expect(formatter.format(value: 3661, context: .compact) == "61m")
+    }
+
+    @Test
+    func formatBounceRate() {
+        let formatter = StatsValueFormatter(metric: .bounceRate)
+
+        #expect(formatter.format(value: 0) == "0%")
+        #expect(formatter.format(value: 25) == "25%")
+        #expect(formatter.format(value: 50) == "50%")
+        #expect(formatter.format(value: 75) == "75%")
+        #expect(formatter.format(value: 100) == "100%")
+    }
+
+    @Test
+    func formatBounceRateCompact() {
+        let formatter = StatsValueFormatter(metric: .bounceRate)
+
+        #expect(formatter.format(value: 0, context: .compact) == "0%")
+        #expect(formatter.format(value: 25, context: .compact) == "25%")
+        #expect(formatter.format(value: 50, context: .compact) == "50%")
+        #expect(formatter.format(value: 75, context: .compact) == "75%")
+        #expect(formatter.format(value: 100, context: .compact) == "100%")
+    }
+
+    @Test
+    func formatRegularMetrics() {
+        let metrics: [SiteMetric] = [.views, .visitors, .likes, .comments]
+
+        for metric in metrics {
+            let formatter = StatsValueFormatter(metric: metric)
+
+            #expect(formatter.format(value: 0) == "0")
+            #expect(formatter.format(value: 123) == "123")
+            #expect(formatter.format(value: 1234) == "1,234")
+            #expect(formatter.format(value: 9999) == "9,999")
+            #expect(formatter.format(value: 10000) == "10K")
+            #expect(formatter.format(value: 15789) == "16K")
+            #expect(formatter.format(value: 999999) == "1M")
+            #expect(formatter.format(value: 1000000) == "1M")
+            #expect(formatter.format(value: 1500000) == "1.5M")
+        }
+    }
+
+    @Test
+    func formatRegularMetricsCompact() {
+        let metrics: [SiteMetric] = [.views, .visitors, .likes, .comments]
+
+        for metric in metrics {
+            let formatter = StatsValueFormatter(metric: metric)
+
+            #expect(formatter.format(value: 0, context: .compact) == "0")
+            #expect(formatter.format(value: 123, context: .compact) == "123")
+            #expect(formatter.format(value: 1234, context: .compact) == "1.2K")
+            #expect(formatter.format(value: 9999, context: .compact) == "10K")
+            #expect(formatter.format(value: 10000, context: .compact) == "10K")
+            #expect(formatter.format(value: 15789, context: .compact) == "16K")
+            #expect(formatter.format(value: 999999, context: .compact) == "1M")
+            #expect(formatter.format(value: 1000000, context: .compact) == "1M")
+            #expect(formatter.format(value: 1500000, context: .compact) == "1.5M")
+        }
+    }
+
+    @Test
+    func formatNumberStatic() {
+        #expect(StatsValueFormatter.formatNumber(0) == "0")
+        #expect(StatsValueFormatter.formatNumber(123) == "123")
+        #expect(StatsValueFormatter.formatNumber(1234) == "1.2K")
+        #expect(StatsValueFormatter.formatNumber(9999) == "10K")
+        #expect(StatsValueFormatter.formatNumber(10000) == "10K")
+        #expect(StatsValueFormatter.formatNumber(15789) == "16K")
+        #expect(StatsValueFormatter.formatNumber(999999) == "1M")
+        #expect(StatsValueFormatter.formatNumber(1000000) == "1M")
+        #expect(StatsValueFormatter.formatNumber(1500000) == "1.5M")
+        #expect(StatsValueFormatter.formatNumber(-1234) == "-1.2K")
+        #expect(StatsValueFormatter.formatNumber(-10000) == "-10K")
+    }
+
+    @Test
+    func formatNumberStaticOnlyLarge() {
+        #expect(StatsValueFormatter.formatNumber(0, onlyLarge: true) == "0")
+        #expect(StatsValueFormatter.formatNumber(123, onlyLarge: true) == "123")
+        #expect(StatsValueFormatter.formatNumber(1234, onlyLarge: true) == "1,234")
+        #expect(StatsValueFormatter.formatNumber(9999, onlyLarge: true) == "9,999")
+        #expect(StatsValueFormatter.formatNumber(10000, onlyLarge: true) == "10K")
+        #expect(StatsValueFormatter.formatNumber(15789, onlyLarge: true) == "16K")
+        #expect(StatsValueFormatter.formatNumber(999999, onlyLarge: true) == "1M")
+        #expect(StatsValueFormatter.formatNumber(1000000, onlyLarge: true) == "1M")
+        #expect(StatsValueFormatter.formatNumber(1500000, onlyLarge: true) == "1.5M")
+        #expect(StatsValueFormatter.formatNumber(-9999, onlyLarge: true) == "-9,999")
+        #expect(StatsValueFormatter.formatNumber(-10000, onlyLarge: true) == "-10K")
+    }
+
+    @Test
+    func percentageChange() {
+        let formatter = StatsValueFormatter(metric: .views)
+
+        #expect(formatter.percentageChange(current: 100, previous: 100) == 0.0)
+        #expect(formatter.percentageChange(current: 150, previous: 100) == 0.5)
+        #expect(formatter.percentageChange(current: 200, previous: 100) == 1.0)
+        #expect(formatter.percentageChange(current: 50, previous: 100) == -0.5)
+        #expect(formatter.percentageChange(current: 0, previous: 100) == -1.0)
+        #expect(formatter.percentageChange(current: 100, previous: 0) == 0.0)
+        #expect(formatter.percentageChange(current: 0, previous: 0) == 0.0)
+    }
+
+    @Test
+    func percentageChangeEdgeCases() {
+        let formatter = StatsValueFormatter(metric: .views)
+
+        #expect(formatter.percentageChange(current: 75, previous: 50) == 0.5)
+        #expect(formatter.percentageChange(current: 25, previous: 50) == -0.5)
+        #expect(formatter.percentageChange(current: 110, previous: 100) == 0.1)
+        #expect(formatter.percentageChange(current: 90, previous: 100) == -0.1)
+        #expect(formatter.percentageChange(current: 1, previous: 10) == -0.9)
+        #expect(formatter.percentageChange(current: 10, previous: 1) == 9.0)
+    }
+}

--- a/Modules/Tests/JetpackStatsTests/TestHelpers.swift
+++ b/Modules/Tests/JetpackStatsTests/TestHelpers.swift
@@ -1,0 +1,31 @@
+import Foundation
+@testable import JetpackStats
+
+extension TimeZone {
+    /// For simplicity, returns a timezone with a -3 hours offset from GMT.
+    static let eastern = TimeZone(secondsFromGMT: -10_800)!
+}
+
+extension Calendar {
+    /// Returns a mock Calendar with the given time zone. By default, uses
+    /// ``TimeZone/est``.
+    static func mock(timeZone: TimeZone = .eastern) -> Calendar {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = timeZone
+        calendar.locale = Locale(identifier: "en_US")
+        return calendar
+    }
+}
+
+extension Date {
+    /// Creates a Date from an ISO 8601 string.
+    /// Supports formats like "2025-01-15T14:30:00Z" or "2025-01-15T14:30:00-03:00"
+    init(_ isoString: String) {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        guard let date = formatter.date(from: isoString) else {
+            fatalError("Invalid date string: \(isoString)")
+        }
+        self = date
+    }
+}


### PR DESCRIPTION
Add the following types and respective unit tests:

- `DateIntervalPreset` and `Calendar+Presets` to represent the presents like `Last 7 Days`
- `DateRangeComparisonPeriod` to represent a comparison period (last period or same period last year)
- `Calendar+Navigation` to implement "backward" and "forward" actions
- `StatsDateFormatter` and `StatsDateRangeFormatter` to format individual dates and date periods (see unit tests and docs)
- `StatsValueFormatter` to format values for metrics (`SiteMetric`)

**Alternative considered**: using [NaiveDate](https://github.com/CreateAPI/NaiveDate) or date components to represent date periods. I tried it, but it turned out completely impractical as you still needed to convert to `Date` and use `Calendar` for all manipulations (which there are many needed). So instead, it uses `Date` with a site timezone. The site time zone is used throughout the module.