### PR TITLE
Stats Review: Add LineChartView and BarChartView (P11)

### DIFF
--- a/Modules/Sources/JetpackStats/Charts/BarChartView.swift
+++ b/Modules/Sources/JetpackStats/Charts/BarChartView.swift
@@ -1,0 +1,253 @@
+import SwiftUI
+import Charts
+
+struct BarChartView: View {
+    let data: ChartData
+
+    @State private var selectedDate: Date?
+    @State private var selectedDataPoints: SelectedDataPoints?
+
+    @Environment(\.context) var context
+
+    private var valueFormatter: StatsValueFormatter {
+        StatsValueFormatter(metric: data.metric)
+    }
+
+    private var currentAverage: Double {
+        guard !data.currentData.isEmpty else { return 0 }
+        return Double(data.currentTotal) / Double(data.currentData.count)
+    }
+
+    var body: some View {
+        Chart {
+            previousPeriodBars
+            currentPeriodBars
+            averageLine
+            significantPointAnnotations
+            selectionIndicatorMarks
+        }
+        .chartXAxis { xAxis }
+        .chartYAxis { yAxis }
+        .chartYScale(domain: yAxisDomain)
+        .chartLegend(.hidden)
+        .environment(\.timeZone, context.timeZone)
+        .modifier(ChartSelectionModifier(selection: $selectedDate))
+        .animation(.spring, value: ObjectIdentifier(data))
+        .onChange(of: selectedDate) {
+            selectedDataPoints = SelectedDataPoints.compute(for: $0, data: data)
+        }
+        .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
+        .accessibilityElement()
+        .accessibilityLabel(Strings.Accessibility.chartContainer)
+        .accessibilityHint(Strings.Accessibility.viewChartData)
+    }
+
+    // MARK: - Chart Marks
+
+    @ChartContentBuilder
+    private var currentPeriodBars: some ChartContent {
+        ForEach(data.currentData) { point in
+            BarMark(
+                x: .value("Date", point.date, unit: data.granularity.component),
+                y: .value("Value", point.value),
+                width: .automatic
+            )
+            .foregroundStyle(
+                LinearGradient(
+                    colors: [
+                        data.metric.primaryColor,
+                        data.metric.primaryColor.opacity(0.5)
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+            .cornerRadius(6)
+            .opacity(getOpacityForCurrentPeriodBar(for: point))
+        }
+    }
+
+    private func getOpacityForCurrentPeriodBar(for point: DataPoint) -> CGFloat {
+        guard let selectedDataPoints else {
+            let isIncomplete = context.calendar.isIncompleteDataPeriod(for: point.date, granularity: data.granularity)
+            return isIncomplete ? 0.5 : 1
+        }
+        return selectedDataPoints.current?.id == point.id ? 1.0 : 0.5
+    }
+
+    @ChartContentBuilder
+    private var previousPeriodBars: some ChartContent {
+        ForEach(data.mappedPreviousData) { point in
+            BarMark(
+                x: .value("Date", point.date, unit: data.granularity.component),
+                y: .value("Value", point.value),
+                width: .automatic,
+                stacking: .unstacked
+            )
+            .foregroundStyle(Color.secondary)
+            .cornerRadius(6)
+            .opacity(shouldHighlightPreviousDataPoint(point) ? 0.5 : 0.2)
+        }
+    }
+
+    private func shouldHighlightPreviousDataPoint(_ dataPoint: DataPoint) -> Bool {
+        guard let selectedDataPoints else {
+            return false
+        }
+        return selectedDataPoints.current == nil && selectedDataPoints.previous?.id == dataPoint.id
+    }
+
+    @ChartContentBuilder
+    private var averageLine: some ChartContent {
+        if currentAverage > 0 {
+            RuleMark(y: .value("Average", currentAverage))
+                .foregroundStyle(Color.secondary.opacity(0.33))
+                .lineStyle(StrokeStyle(lineWidth: 1, dash: [6, 6]))
+                .annotation(position: .trailing, alignment: .trailing) {
+                    ChartAverageAnnotation(value: Int(currentAverage), formatter: valueFormatter)
+                }
+        }
+    }
+
+    @ChartContentBuilder
+    private var significantPointAnnotations: some ChartContent {
+        if let maxPoint = data.significantPoints.currentMax, data.currentData.count > 0 {
+            PointMark(
+                x: .value("Date", maxPoint.date, unit: data.granularity.component),
+                y: .value("Value", maxPoint.value)
+            )
+            .opacity(0)
+            .annotation(position: .top, spacing: 8) {
+                SignificantPointAnnotation(
+                    value: maxPoint.value,
+                    metric: data.metric
+                )
+                // Important for drag selection to work correctly.
+                .opacity(selectedDate == nil ? 1 : 0)
+            }
+        }
+    }
+
+    @ChartContentBuilder
+    private var selectionIndicatorMarks: some ChartContent {
+        if #available(iOS 17.0, *),
+           let selectedDate,
+           let selectedDataPoints {
+
+            if let currentPoint = selectedDataPoints.current {
+                RuleMark(x: .value("Selected", currentPoint.date))
+                    .foregroundStyle(Color.clear)
+                    .lineStyle(StrokeStyle(lineWidth: 1))
+                    .offset(yStart: 32)
+                    .zIndex(3)
+                    .annotation(
+                        position: .top,
+                        spacing: 0,
+                        overflowResolution: .init(
+                            x: .fit(to: .chart),
+                            y: .disabled
+                        )
+                    ) {
+                        tooltipView
+                    }
+            } else if let previousPoint = selectedDataPoints.previous {
+                RuleMark(x: .value("Selected", previousPoint.date))
+                    .foregroundStyle(Color.clear)
+                    .lineStyle(StrokeStyle(lineWidth: 1))
+                    .offset(yStart: 32)
+                    .zIndex(3)
+                    .annotation(
+                        position: .top,
+                        spacing: 0,
+                        overflowResolution: .init(
+                            x: .fit(to: .chart),
+                            y: .disabled
+                        )
+                    ) {
+                        tooltipView
+                    }
+            }
+        }
+    }
+
+    // MARK: - Axis Configuration
+
+    private var xAxis: some AxisContent {
+        AxisMarks { value in
+            if let date = value.as(Date.self) {
+                AxisValueLabel {
+                    ChartAxisDateLabel(date: date, granularity: data.granularity)
+                }
+            }
+        }
+    }
+
+    private var yAxis: some AxisContent {
+        AxisMarks(values: .automatic) { value in
+            if let value = value.as(Int.self) {
+                AxisGridLine()
+                    .foregroundStyle(Color.secondary.opacity(0.33))
+                AxisValueLabel {
+                    if value > 0 {
+                        Text(valueFormatter.format(value: value, context: .compact))
+                            .font(.caption2.weight(.medium))
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    private var yAxisDomain: ClosedRange<Int> {
+        // If all values are zero, show a reasonable range
+        if data.maxValue == 0 {
+            return 0...100
+        }
+        guard data.maxValue > 0 else {
+            return data.maxValue...0 // Just in case; should never happend
+        }
+        // Add some padding above the max value
+        let padding = max(Int(Double(data.maxValue) * 0.66), 1)
+        return 0...(data.maxValue + padding)
+    }
+
+    // MARK: - Helper Views
+
+    @ViewBuilder
+    private var tooltipView: some View {
+        if let selectedPoints = selectedDataPoints {
+            ChartValueTooltipView(
+                selectedPoints: selectedPoints,
+                metric: data.metric,
+                granularity: data.granularity
+            )
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    VStack(spacing: 20) {
+        BarChartView(
+            data: ChartData.mock(
+                metric: .visitors,
+                granularity: .day,
+                range: Calendar.demo.makeDateRange(for: .last7Days)
+            )
+        )
+        .frame(height: 250)
+        .padding()
+
+        BarChartView(
+            data: ChartData.mock(
+                metric: .likes,
+                granularity: .month,
+                range: Calendar.demo.makeDateRange(for: .thisYear)
+            )
+        )
+        .frame(height: 250)
+        .padding()
+    }
+    .background(Color(.systemGroupedBackground))
+}

--- a/Modules/Sources/JetpackStats/Charts/Helpers/ChartAverageAnnotation.swift
+++ b/Modules/Sources/JetpackStats/Charts/Helpers/ChartAverageAnnotation.swift
@@ -1,0 +1,21 @@
+import SwiftUI
+
+struct ChartAverageAnnotation: View {
+    let value: Int
+    let formatter: StatsValueFormatter
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        Text(formatter.format(value: value, context: .compact))
+            .font(.caption2.weight(.medium)).tracking(-0.1)
+            .foregroundStyle(Color.secondary)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(
+                colorScheme == .light ? Constants.Colors.background : Color(.opaqueSeparator).opacity(0.8)
+            )
+            .clipShape(.capsule)
+            .padding(.leading, -5)
+    }
+}

--- a/Modules/Sources/JetpackStats/Charts/Helpers/ChartData.swift
+++ b/Modules/Sources/JetpackStats/Charts/Helpers/ChartData.swift
@@ -1,0 +1,152 @@
+import SwiftUI
+
+final class ChartData: Sendable {
+    let metric: SiteMetric
+    let granularity: DateRangeGranularity
+    let currentTotal: Int
+    let currentData: [DataPoint]
+    let previousTotal: Int
+    let previousData: [DataPoint]
+    let mappedPreviousData: [DataPoint]
+    let maxValue: Int
+    let significantPoints: SignificantPoints
+    let isEmptyOrZero: Bool
+
+    var isEmpty: Bool {
+        currentData.isEmpty && previousData.isEmpty
+    }
+
+    struct SignificantPoints: Sendable {
+        let currentMax: DataPoint?
+        let currentMin: DataPoint?
+        let previousMax: DataPoint?
+        let previousMin: DataPoint?
+    }
+
+    init(metric: SiteMetric, granularity: DateRangeGranularity, currentTotal: Int, currentData: [DataPoint], previousTotal: Int, previousData: [DataPoint], mappedPreviousData: [DataPoint]) {
+        self.metric = metric
+        self.granularity = granularity
+        self.currentTotal = currentTotal
+        self.currentData = currentData
+        self.previousTotal = previousTotal
+        self.previousData = previousData
+        self.mappedPreviousData = mappedPreviousData
+
+        var maxValue = 0 // Faster without creating intermediate arrays
+        var currentMaxPoint: DataPoint?
+        var currentMinPoint: DataPoint?
+
+        for point in currentData {
+            if point.value > maxValue {
+                maxValue = point.value
+                currentMaxPoint = point
+            }
+            if point.value > 0 && (currentMinPoint == nil || point.value < currentMinPoint!.value) {
+                currentMinPoint = point
+            }
+        }
+
+        var previousMaxPoint: DataPoint?
+        var previousMinPoint: DataPoint?
+
+        for point in mappedPreviousData {
+            maxValue = max(maxValue, point.value)
+            if previousMaxPoint == nil || point.value > previousMaxPoint!.value {
+                previousMaxPoint = point
+            }
+            if point.value > 0 && (previousMinPoint == nil || point.value < previousMinPoint!.value) {
+                previousMinPoint = point
+            }
+        }
+
+        self.maxValue = maxValue
+        self.significantPoints = SignificantPoints(
+            currentMax: currentMaxPoint,
+            currentMin: currentMinPoint,
+            previousMax: previousMaxPoint,
+            previousMin: previousMinPoint
+        )
+
+        // Check if all data points are zero
+        self.isEmptyOrZero = currentData.allSatisfy { $0.value == 0 } && previousData.allSatisfy { $0.value == 0 }
+    }
+}
+
+// MARK: - Placeholder Data
+
+extension ChartData {
+    static func mock(metric: SiteMetric, granularity: DateRangeGranularity, range: StatsDateRange) -> ChartData {
+        let dataPoints = generateMockDataPoints(
+            granularity: granularity,
+            range: range,
+            metric: metric
+        )
+        let previousData = dataPoints.map { dataPoint in
+            let variation = Double.random(in: 0.75...0.95)
+            return DataPoint(
+                date: dataPoint.date,
+                value: Int(Double(dataPoint.value) * variation)
+            )
+        }
+        return ChartData(
+            metric: metric,
+            granularity: granularity,
+            currentTotal: DataPoint.getTotalValue(for: dataPoints, metric: metric) ?? 0,
+            currentData: dataPoints,
+            previousTotal: DataPoint.getTotalValue(for: previousData, metric: metric) ?? 0,
+            previousData: previousData,
+            mappedPreviousData: previousData
+        )
+    }
+
+    private static func generateMockDataPoints(
+        granularity: DateRangeGranularity,
+        range: StatsDateRange,
+        metric: SiteMetric
+    ) -> [DataPoint] {
+        let calendar = range.calendar
+        var dataPoints: [DataPoint] = []
+
+        let valueRange = valueRange(for: metric)
+
+        // Generate data points for each component in the range
+        var currentDate = range.dateInterval.start
+        while currentDate < range.dateInterval.end {
+            let value = Int.random(in: valueRange)
+            dataPoints.append(DataPoint(date: currentDate, value: value))
+
+            guard let nextDate = calendar.date(byAdding: granularity.component, value: 1, to: currentDate) else { break }
+            currentDate = nextDate
+        }
+
+        return dataPoints
+    }
+
+    private static func valueRange(for metric: SiteMetric) -> ClosedRange<Int> {
+        switch metric {
+        case .views: 1000...5000
+        case .visitors: 500...2500
+        case .likes: 50...300
+        case .comments: 10...100
+        case .posts: 10...50
+        case .timeOnSite: 120...300
+        case .bounceRate: 40...80
+        case .downloads: 100...250
+        }
+    }
+
+    /// Clamps the given date to be within the range of current data points
+    func clampDateToDataRange(_ date: Date) -> Date {
+        guard let firstDate = currentData.first?.date,
+              let lastDate = currentData.last?.date else {
+            return date
+        }
+
+        if date < firstDate {
+            return firstDate
+        } else if date > lastDate {
+            return lastDate
+        }
+        return date
+    }
+}

--- a/Modules/Sources/JetpackStats/Charts/Helpers/SignificantPointAnnotation.swift
+++ b/Modules/Sources/JetpackStats/Charts/Helpers/SignificantPointAnnotation.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+struct SignificantPointAnnotation: View {
+    let value: Int
+    let metric: SiteMetric
+    let valueFormatter: StatsValueFormatter
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    init(value: Int, metric: SiteMetric) {
+        self.value = value
+        self.metric = metric
+        self.valueFormatter = StatsValueFormatter(metric: metric)
+    }
+
+    var body: some View {
+        Text(valueFormatter.format(value: value, context: .compact))
+            .fixedSize()
+            .font(.system(.caption, design: .rounded, weight: .semibold))
+            .foregroundColor(metric.primaryColor)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background {
+                ZStack {
+                    Capsule()
+                        .fill(Color(.systemBackground).opacity(0.75))
+                    Capsule()
+                        .fill(metric.primaryColor.opacity(colorScheme == .light ? 0.1 : 0.25))
+                }
+            }
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        SignificantPointAnnotation(value: 50000, metric: .views)
+        SignificantPointAnnotation(value: 1234, metric: .visitors)
+        SignificantPointAnnotation(value: 89, metric: .likes)
+    }
+    .padding()
+    .background(Color(.systemGroupedBackground))
+}

--- a/Modules/Sources/JetpackStats/Charts/LineChartView.swift
+++ b/Modules/Sources/JetpackStats/Charts/LineChartView.swift
@@ -1,0 +1,268 @@
+import SwiftUI
+import Charts
+
+struct LineChartView: View {
+    let data: ChartData
+
+    @State private var selectedDate: Date?
+    @State private var selectedDataPoints: SelectedDataPoints?
+
+    @Environment(\.colorScheme) var colorScheme
+    @Environment(\.context) var context
+
+    private var valueFormatter: StatsValueFormatter {
+        StatsValueFormatter(metric: data.metric)
+    }
+
+    private var currentAverage: Double {
+        guard !data.currentData.isEmpty else { return 0 }
+        return Double(data.currentTotal) / Double(data.currentData.count)
+    }
+
+    var body: some View {
+        Chart {
+            currentPeriodMarks
+            previousPeriodMarks
+            averageLine
+            significantPointAnnotations
+            selectionIndicatorMarks
+        }
+        .chartXAxis { xAxis }
+        .chartYAxis { yAxis }
+        .chartYScale(domain: yAxisDomain)
+        .chartLegend(.hidden)
+        .environment(\.timeZone, context.timeZone)
+        .modifier(ChartSelectionModifier(selection: $selectedDate))
+        .animation(.spring, value: ObjectIdentifier(data))
+        .onChange(of: selectedDate) {
+            selectedDataPoints = SelectedDataPoints.compute(for: $0, data: data)
+        }
+        .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
+        .accessibilityElement()
+        .accessibilityLabel(Strings.Accessibility.chartContainer)
+        .accessibilityHint(Strings.Accessibility.viewChartData)
+    }
+
+    // MARK: - Chart Marks
+
+    @ChartContentBuilder
+    private var currentPeriodMarks: some ChartContent {
+        ForEach(data.currentData) { point in
+            AreaMark(
+                x: .value("Date", point.date),
+                y: .value("Value", point.value),
+                series: .value("Period", "Current")
+            )
+            .foregroundStyle(
+                LinearGradient(
+                    colors: [
+                        data.metric.primaryColor.opacity(colorScheme == .light ? 0.15 : 0.25),
+                        data.metric.primaryColor.opacity(0.0)
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+            .interpolationMethod(.linear)
+
+            LineMark(
+                x: .value("Date", point.date),
+                y: .value("Value", point.value),
+                series: .value("Period", "Current")
+            )
+            .foregroundStyle(data.metric.primaryColor)
+            .lineStyle(StrokeStyle(
+                lineWidth: 3,
+                lineCap: .round,
+                lineJoin: .round
+            ))
+            .interpolationMethod(.linear)
+        }
+    }
+
+    @ChartContentBuilder
+    private var previousPeriodMarks: some ChartContent {
+        ForEach(data.mappedPreviousData) { point in
+            // Important: AreaMark is needed for smooth animation
+            AreaMark(
+                x: .value("Date", point.date),
+                y: .value("Value", point.value),
+                series: .value("Period", "Previous")
+            )
+            .foregroundStyle(Color.clear)
+            .interpolationMethod(.linear)
+
+            LineMark(
+                x: .value("Date", point.date),
+                y: .value("Value", point.value),
+                series: .value("Period", "Previous")
+            )
+            .foregroundStyle(Color.secondary.opacity(0.8))
+            .lineStyle(StrokeStyle(
+                lineWidth: 2,
+                lineCap: .round,
+                lineJoin: .round,
+                dash: [5, 6]
+            ))
+            .interpolationMethod(.linear)
+        }
+    }
+
+    @ChartContentBuilder
+    private var averageLine: some ChartContent {
+        if currentAverage > 0 {
+            RuleMark(y: .value("Average", currentAverage))
+                .foregroundStyle(Color.secondary.opacity(0.33))
+                .lineStyle(StrokeStyle(lineWidth: 1, dash: [6, 6]))
+                .annotation(position: .trailing, alignment: .trailing) {
+                    ChartAverageAnnotation(value: Int(currentAverage), formatter: valueFormatter)
+                }
+        }
+    }
+
+    @ChartContentBuilder
+    private var significantPointAnnotations: some ChartContent {
+        if let maxPoint = data.significantPoints.currentMax, data.currentData.count > 0 {
+            PointMark(
+                x: .value("Date", maxPoint.date),
+                y: .value("Value", maxPoint.value)
+            )
+            .foregroundStyle(data.metric.primaryColor)
+            .symbolSize(60)
+            .annotation(position: .top, spacing: 4) {
+                SignificantPointAnnotation(value: maxPoint.value, metric: data.metric)
+                    .opacity(selectedDate == nil ? 1 : 0)
+            }
+            .opacity(selectedDate == nil ? 1 : 0)
+        }
+    }
+
+    @ChartContentBuilder
+    private var selectionIndicatorMarks: some ChartContent {
+        if #available(iOS 17.0, *),
+           let selectedDate, let selectedPoints = selectedDataPoints {
+
+            if let currentPoint = selectedPoints.current {
+                RuleMark(x: .value("Selected", currentPoint.date))
+                    .foregroundStyle(Color.secondary.opacity(0.33))
+                    .lineStyle(StrokeStyle(lineWidth: 1))
+                    .offset(yStart: 28)
+                    .zIndex(1)
+                    .annotation(
+                        position: .top,
+                        spacing: 0,
+                        overflowResolution: .init(x: .fit(to: .chart), y: .disabled)
+                    ) {
+                        tooltipView
+                    }
+
+                PointMark(
+                    x: .value("Date", currentPoint.date),
+                    y: .value("Value", currentPoint.value)
+                )
+                .foregroundStyle(data.metric.primaryColor)
+                .symbolSize(80)
+            } else if let previousPoint = selectedPoints.previous {
+                RuleMark(x: .value("Selected", previousPoint.date))
+                    .foregroundStyle(Color.secondary.opacity(0.33))
+                    .lineStyle(StrokeStyle(lineWidth: 1))
+                    .offset(yStart: 28)
+                    .zIndex(1)
+                    .annotation(
+                        position: .top,
+                        spacing: 0,
+                        overflowResolution: .init(x: .fit(to: .chart), y: .disabled)
+                    ) {
+                        tooltipView
+                    }
+
+                PointMark(
+                    x: .value("Date", previousPoint.date),
+                    y: .value("Value", previousPoint.value)
+                )
+                .foregroundStyle(Color.secondary)
+                .symbolSize(60)
+            }
+        }
+    }
+
+    // MARK: - Axis Configuration
+
+    private var xAxis: some AxisContent {
+        AxisMarks { value in
+            if let date = value.as(Date.self) {
+                AxisValueLabel {
+                    ChartAxisDateLabel(date: date, granularity: data.granularity)
+                }
+            }
+        }
+    }
+
+    private var yAxis: some AxisContent {
+        AxisMarks { value in
+            if let value = value.as(Int.self) {
+                AxisGridLine()
+                    .foregroundStyle(Color(.opaqueSeparator).opacity(0.5))
+
+                AxisValueLabel {
+                    Text(valueFormatter.format(value: value, context: .compact))
+                        .font(.caption2.weight(.medium)).tracking(-0.1)
+                        .foregroundColor(.secondary)
+                }
+            }
+        }
+    }
+
+    private var yAxisDomain: ClosedRange<Int> {
+        // If all values are zero, show a reasonable range
+        if data.maxValue == 0 {
+            return 0...100
+        }
+        guard data.maxValue > 0 else {
+            return data.maxValue...0 // Just in case; should never happend
+        }
+        // Add some padding above the max value
+        let padding = max(Int(Double(data.maxValue) * 0.66), 1)
+        return 0...(data.maxValue + padding)
+    }
+
+    // MARK: - Helper Views
+
+    @ViewBuilder
+    private var tooltipView: some View {
+        if let selectedPoints = selectedDataPoints {
+            ChartValueTooltipView(
+                selectedPoints: selectedPoints,
+                metric: data.metric,
+                granularity: data.granularity
+            )
+        }
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    VStack(spacing: 20) {
+        LineChartView(
+            data: ChartData.mock(
+                metric: .views,
+                granularity: .day,
+                range: Calendar.demo.makeDateRange(for: .last7Days)
+            )
+        )
+        .frame(height: 250)
+        .padding()
+
+        LineChartView(
+            data: ChartData.mock(
+                metric: .timeOnSite,
+                granularity: .month,
+                range: Calendar.demo.makeDateRange(for: .thisYear)
+            )
+        )
+        .frame(height: 250)
+        .padding()
+    }
+    .background(Color(.systemGroupedBackground))
+}

--- a/Modules/Sources/JetpackStats/Screens/ChartDataListView.swift
+++ b/Modules/Sources/JetpackStats/Screens/ChartDataListView.swift
@@ -1,0 +1,261 @@
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct ChartDataListView: View {
+    let data: ChartData
+    let dateRange: StatsDateRange
+
+    @Environment(\.context) var context
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: Constants.step4) {
+                summaryCard(for: data, metric: data.metric)
+                    .padding(.vertical, Constants.step2)
+                    .padding(.horizontal, Constants.step3)
+                    .background(Constants.Colors.background.opacity(0.66))
+                    .cardStyle()
+                    .padding(.top, Constants.step2)
+                    .dynamicTypeSize(...DynamicTypeSize.xLarge)
+
+                dataItemsView(for: data, metric: data.metric)
+                    .padding(.horizontal, Constants.step1)
+            }
+            .padding(.horizontal, Constants.cardHorizontalInset(for: horizontalSizeClass))
+            .frame(maxWidth: horizontalSizeClass == .regular ? Constants.maxHortizontalWidth : .infinity)
+            .frame(maxWidth: .infinity)
+            .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
+        }
+        .background(Constants.Colors.secondaryBackground)
+        .navigationTitle(Strings.ChartData.title)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarLeading) {
+                Button(Strings.Buttons.done) {
+                    dismiss()
+                }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
+                Menu {
+                    ShareLink(
+                        item: ChartDataCSVRepresentation(
+                            data: data,
+                            dateRange: dateRange,
+                            context: context
+                        ),
+                        preview: SharePreview(
+                            generateCSVFilename(),
+                            image: Image(systemName: "doc.text")
+                        )
+                    ) {
+                        Label(Strings.Buttons.downloadCSV, systemImage: "square.and.arrow.down")
+                    }
+                } label: {
+                    Image(systemName: "square.and.arrow.up")
+                }
+                .accessibilityLabel(Strings.Buttons.share)
+            }
+        }
+    }
+
+    private func summaryCard(for chartData: ChartData, metric: SiteMetric) -> some View {
+        let formatter = StatsValueFormatter(metric: metric)
+        let trendViewModel = TrendViewModel(
+            currentValue: chartData.currentTotal,
+            previousValue: chartData.previousTotal,
+            metric: metric
+        )
+        return VStack(alignment: .leading, spacing: 16) {
+            // Header section
+            VStack(alignment: .leading, spacing: 2) {
+                Text(metric.localizedTitle)
+                    .font(.title3.weight(.medium))
+                Text(context.formatters.dateRange.string(from: dateRange.dateInterval))
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+
+            // Metrics section
+            HStack(alignment: .top, spacing: 0) {
+                metricColumn(
+                    label: Strings.ChartData.total,
+                    value: formatter.format(value: chartData.currentTotal, context: .compact),
+                    formatter: formatter
+                )
+                .padding(.trailing, Constants.step2)
+
+                metricColumn(
+                    label: Strings.ChartData.previous,
+                    value: formatter.format(value: chartData.previousTotal, context: .compact),
+                    formatter: formatter
+                )
+                .foregroundColor(.secondary)
+
+                Spacer(minLength: 0)
+
+                VStack(alignment: .trailing, spacing: 2) {
+                    Text(Strings.ChartData.change.uppercased())
+                        .font(.caption.weight(.medium))
+                        .foregroundColor(.secondary)
+
+                    HStack(spacing: 2) {
+                        Text(trendViewModel.sign)
+                            .font(.body.weight(.medium))
+
+                        Text(formatter.format(value: abs(trendViewModel.currentValue - trendViewModel.previousValue), context: .compact))
+                            .font(.title3.weight(.medium))
+                            .padding(.trailing, 8)
+
+                        Image(systemName: trendViewModel.systemImage)
+                            .font(.footnote.weight(.medium))
+                            .padding(.bottom, 1)
+
+                        Text(trendViewModel.formattedPercentage)
+                            .font(.title3.weight(.medium))
+                    }
+                    .foregroundStyle(trendViewModel.sentiment.foregroundColor)
+                }
+            }
+            .lineLimit(1)
+        }
+    }
+
+    private func metricColumn(label: String, value: String, formatter: StatsValueFormatter) -> some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(label.uppercased())
+                .font(.caption.weight(.medium))
+                .foregroundColor(.secondary)
+
+            Text(value)
+                .font(.title3.weight(.medium))
+        }
+    }
+
+    private func generateCSVFilename() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        let dateString = dateFormatter.string(from: Date())
+
+        let metricName = data.metric.localizedTitle
+            .replacingOccurrences(of: " ", with: "_")
+
+        let dateRangeString = context.formatters.dateRange.string(from: dateRange.dateInterval)
+            .replacingOccurrences(of: "/", with: "-")
+            .replacingOccurrences(of: ",", with: "")
+            .replacingOccurrences(of: " ", with: "_")
+
+        return "\(metricName)_\(dateRangeString)_\(dateString).csv"
+    }
+
+    private func dataItemsView(for chartData: ChartData, metric: SiteMetric) -> some View {
+        let formatter = StatsValueFormatter(metric: metric)
+        return VStack(alignment: .leading, spacing: Constants.step1) {
+            VStack(alignment: .leading, spacing: Constants.step2) {
+                Text(Strings.ChartData.detailedData)
+                    .font(.subheadline.weight(.semibold))
+
+                // Header
+                HStack {
+                    Text(Strings.ChartData.date)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundColor(.secondary)
+                        .tracking(0.5)
+
+                    Spacer()
+
+                    Text(Strings.ChartData.value)
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundColor(.secondary)
+                        .tracking(0.5)
+                }
+            }
+            .padding(.horizontal)
+
+            VStack(spacing: Constants.step1 / 2) {
+                ForEach(chartData.currentData.reversed()) { point in
+                    DataItemRow(
+                        date: context.formatters.date.formatDate(point.date, granularity: chartData.granularity, context: .regular),
+                        value: point.value,
+                        maxValue: chartData.maxValue,
+                        formatter: formatter,
+                        metric: metric
+                    )
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Data Item Row
+
+private struct DataItemRow: View {
+    let date: String
+    let value: Int
+    let maxValue: Int
+    let formatter: StatsValueFormatter
+    let metric: SiteMetric
+
+    var body: some View {
+        HStack(spacing: 16) {
+            Text(date)
+                .font(.callout)
+                .foregroundColor(.primary)
+                .lineLimit(1)
+
+            Spacer(minLength: 8)
+
+            Text(formatter.format(value: value))
+                .font(.callout.weight(.medium))
+                .foregroundColor(.primary)
+                .contentTransition(.numericText())
+        }
+        .padding(.vertical, 12)
+        .padding(.horizontal, 12)
+        .background(
+            TopListItemBarBackground(value: value, maxValue: maxValue, barColor: metric.primaryColor)
+        )
+    }
+}
+
+struct RoundedCorner: Shape {
+    var radius: CGFloat = .infinity
+    var corners: UIRectCorner = .allCorners
+
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(roundedRect: rect, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
+        return Path(path.cgPath)
+    }
+}
+
+#Preview {
+    NavigationStack {
+        ChartDataListView(
+            data: ChartData(
+                metric: .views,
+                granularity: .day,
+                currentTotal: 3000,
+                currentData: [
+                    DataPoint(date: Date(), value: 1000),
+                    DataPoint(date: Date().addingTimeInterval(-86400), value: 1200),
+                    DataPoint(date: Date().addingTimeInterval(-172800), value: 800)
+                ],
+                previousTotal: 2750,
+                previousData: [
+                    DataPoint(date: Date().addingTimeInterval(-604800), value: 900),
+                    DataPoint(date: Date().addingTimeInterval(-691200), value: 1100),
+                    DataPoint(date: Date().addingTimeInterval(-777600), value: 750)
+                ],
+                mappedPreviousData: [
+                    DataPoint(date: Date(), value: 900),
+                    DataPoint(date: Date().addingTimeInterval(-86400), value: 1100),
+                    DataPoint(date: Date().addingTimeInterval(-172800), value: 750)
+                ]
+            ),
+            dateRange: Calendar.demo.makeDateRange(for: .last7Days)
+        )
+    }
+}

--- a/Modules/Sources/JetpackStats/Views/ChartAxisDateLabel.swift
+++ b/Modules/Sources/JetpackStats/Views/ChartAxisDateLabel.swift
@@ -1,0 +1,64 @@
+import SwiftUI
+
+struct ChartAxisDateLabel: View {
+    let date: Date
+    let granularity: DateRangeGranularity
+
+    @Environment(\.context) var context
+
+    var body: some View {
+        Group {
+            if granularity == .hour {
+                hourLabel
+            } else {
+                standardLabel
+            }
+        }
+        .fixedSize() // Prevent from clipping (sometimes happens)
+    }
+
+    private var standardLabel: some View {
+        Text(context.formatters.date.formatDate(date, granularity: granularity))
+            .font(.caption2.weight(.medium))
+            .foregroundColor(.secondary)
+    }
+
+    @ViewBuilder
+    private var hourLabel: some View {
+        let formatted = context.formatters.date.formatDate(date, granularity: granularity)
+
+        if let (time, period) = parseHourFormat(formatted) {
+            (Text(time.uppercased())
+                .font(.caption2.weight(.medium))
+             + Text(period.lowercased())
+                .font(.caption2.weight(.medium).lowercaseSmallCaps()))
+                .foregroundColor(.secondary)
+        } else {
+            standardLabel
+        }
+    }
+
+    /// Parses hour format string into time and period components
+    /// - Parameter formatted: The formatted date string (e.g., "1 PM", "12 AM")
+    /// - Returns: A tuple of (time, period) if successfully parsed, nil otherwise
+    private func parseHourFormat(_ formatted: String) -> (time: String, period: String)? {
+        let components = formatted.split(separator: " ")
+        guard components.count == 2 else { return nil }
+
+        return (String(components[0]), String(components[1]))
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        // Hour format
+        ChartAxisDateLabel(date: Date(), granularity: .hour)
+
+        // Day format
+        ChartAxisDateLabel(date: Date(), granularity: .day)
+
+        // Month format
+        ChartAxisDateLabel(date: Date(), granularity: .month)
+    }
+    .padding()
+}

--- a/Modules/Sources/JetpackStats/Views/ChartLegendView.swift
+++ b/Modules/Sources/JetpackStats/Views/ChartLegendView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+struct ChartLegendView: View {
+    let metric: SiteMetric
+    let currentPeriod: DateInterval
+    let previousPeriod: DateInterval
+
+    @Environment(\.context) var context
+    @ScaledMetric(relativeTo: .footnote) private var circleSize: CGFloat = 6
+
+    var body: some View {
+        VStack(alignment: .trailing, spacing: 1) {
+            // Current period
+            HStack(spacing: 6) {
+                Text(context.formatters.dateRange.string(from: currentPeriod))
+                    .foregroundColor(.primary)
+                Circle()
+                    .fill(metric.primaryColor)
+                    .frame(width: circleSize, height: circleSize)
+            }
+
+            // Previous period
+            HStack(spacing: 6) {
+                Text(context.formatters.dateRange.string(from: previousPeriod))
+                    .foregroundColor(.secondary.opacity(0.75))
+                    .font(.footnote)
+                Circle()
+                    .fill(Color.secondary.opacity(0.75))
+                    .frame(width: circleSize, height: circleSize)
+            }
+        }
+        .font(.footnote.weight(.medium))
+        .allowsTightening(true)
+        .lineLimit(1)
+        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+    }
+}

--- a/Modules/Sources/JetpackStats/Views/ChartValueTooltipView.swift
+++ b/Modules/Sources/JetpackStats/Views/ChartValueTooltipView.swift
@@ -1,0 +1,96 @@
+import SwiftUI
+
+struct ChartValueTooltipView: View {
+    let selectedPoints: SelectedDataPoints
+    let metric: SiteMetric
+    let granularity: DateRangeGranularity
+
+    @Environment(\.context) var context
+
+    private var currentPoint: DataPoint? {
+        selectedPoints.current
+    }
+
+    private var previousPoint: DataPoint? {
+        selectedPoints.previous
+    }
+
+    private var unmappedPreviousPoint: DataPoint? {
+        selectedPoints.unmappedPrevious
+    }
+
+    private var formattedDate: String? {
+        guard let date = currentPoint?.date ?? previousPoint?.date else { return nil }
+        return formattedDate(date)
+    }
+
+    private func formattedDate(_ date: Date) -> String {
+         context.formatters.date.formatDate(date, granularity: granularity, context: .regular)
+    }
+
+    private var trend: TrendViewModel? {
+        guard let currentPoint, let previousPoint else {
+            return nil
+        }
+        return TrendViewModel(
+            currentValue: currentPoint.value,
+            previousValue: previousPoint.value,
+            metric: metric,
+            context: .regular
+        )
+    }
+
+    private var isIncompleteData: Bool {
+        guard let date = currentPoint?.date else { return false }
+        return context.calendar.isIncompleteDataPeriod(for: date, granularity: granularity)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Constants.step1) {
+            // Legend-style period indicators
+            VStack(alignment: .leading, spacing: 2) {
+                if let currentPoint {
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(metric.primaryColor)
+                            .frame(width: 8, height: 8)
+                        Text(formattedDate(currentPoint.date))
+                            .font(.footnote)
+                            .foregroundColor(.primary)
+                    }
+                }
+
+                if let unmappedPreviousPoint {
+                    HStack(spacing: 8) {
+                        Circle()
+                            .fill(Color.secondary.opacity(0.75))
+                            .frame(width: 8, height: 8)
+                        Text(formattedDate(unmappedPreviousPoint.date))
+                            .font(.footnote)
+                            .foregroundColor(.secondary.opacity(0.8))
+                    }
+                }
+            }
+
+            // Summary view
+            if let trend {
+                ChartValuesSummaryView(trend: trend, style: .compact)
+            } else if let previousValue = previousPoint?.value {
+                Text(StatsValueFormatter(metric: metric).format(value: previousValue, context: .regular))
+                    .font(.subheadline.weight(.medium))
+            }
+
+            if isIncompleteData {
+                Text(Strings.Chart.incompleteData)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+                    .padding(.top, -6)
+            }
+        }
+        .fixedSize()
+        .padding(12)
+        .background(Color(.systemBackground))
+        .cornerRadius(12)
+        .shadow(color: Constants.Colors.shadowColor, radius: 4, x: 0, y: 2)
+    }
+}

--- a/Modules/Sources/JetpackStats/Views/ChartValuesSummaryView.swift
+++ b/Modules/Sources/JetpackStats/Views/ChartValuesSummaryView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+
+struct ChartValuesSummaryView: View {
+    let trend: TrendViewModel
+    var style: SummaryStyle = .standard
+
+    enum SummaryStyle: CaseIterable {
+        case standard
+        case compact
+    }
+
+    var body: some View {
+        Group {
+            switch style {
+            case .standard: standard
+            case .compact: compact
+            }
+        }
+        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+    }
+
+    private var standard: some View {
+        HStack(alignment: .center, spacing: 16) {
+            Text(trend.formattedCurrentValue)
+                .font(Font.make(.recoleta, textStyle: .title, weight: .medium))
+                .foregroundColor(.primary)
+                .contentTransition(.numericText())
+
+            BadgeTrendIndicator(trend: trend)
+        }
+    }
+
+    private var compact: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack(alignment: .lastTextBaseline, spacing: 6) {
+                Text(trend.formattedCurrentValue)
+                    .font(.system(.headline, design: .rounded, weight: .semibold))
+                    .foregroundColor(.primary)
+                    .contentTransition(.numericText())
+
+                Text(trend.formattedPreviousValue)
+                    .font(.system(.footnote, design: .rounded))
+                    .foregroundColor(.secondary.opacity(0.75)).tracking(-0.2)
+                    .contentTransition(.numericText())
+            }
+
+            Text(trend.formattedTrendShort2)
+                .contentTransition(.numericText())
+                .font(.system(.footnote, design: .rounded, weight: .medium)).tracking(-0.33)
+                .foregroundColor(trend.sentiment.foregroundColor)
+        }
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        ForEach(ChartValuesSummaryView.SummaryStyle.allCases, id: \.self) { style in
+            ChartValuesSummaryView(trend: .init(currentValue: 1000, previousValue: 500, metric: .views), style: style)
+            ChartValuesSummaryView(trend: .init(currentValue: 500, previousValue: 1000, metric: .views), style: style)
+            ChartValuesSummaryView(trend: .init(currentValue: 100, previousValue: 100, metric: .views), style: style)
+            ChartValuesSummaryView(trend: .init(currentValue: 56, previousValue: 60, metric: .bounceRate), style: style)
+            ChartValuesSummaryView(trend: .init(currentValue: 42, previousValue: 0, metric: .views), style: style)
+            Divider()
+        }
+    }
+    .frame(maxWidth: .infinity, maxHeight: .infinity)
+}


### PR DESCRIPTION
This PR adds individual chart views and some helper views. There are not the actual cards on "Traffic" but just the reusable charts. The charts support interactions to show individual data points annotations, show significant data points (max value), show averages, etc.

<img width="380"  alt="Screenshot 2025-08-05 at 11 16 52 AM" src="https://github.com/user-attachments/assets/fd7f0538-8edf-44e4-aa6d-daa283ffaf00" />  <img width="380" alt="Screenshot 2025-08-05 at 11 17 53 AM" src="https://github.com/user-attachments/assets/9cfa3b45-38e7-4cdd-bb2d-92e3b14cce0d" />

It also adds `ChartDataListView` to view raw data for either of those charts:

<img width="380" alt="Screenshot 2025-08-05 at 11 16 19 AM" src="https://github.com/user-attachments/assets/2a431500-6c2d-4b06-a29e-14bbc849ced1" />
