### PR TITLE
Stats Review: Add ChartCard, TopListCard, StandaloneChartView (P12)

### DIFF
--- a/Modules/Sources/JetpackStats/Cards/CardConfigurationDelegate.swift
+++ b/Modules/Sources/JetpackStats/Cards/CardConfigurationDelegate.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+enum MoveDirection {
+    case up
+    case down
+    case top
+    case bottom
+}
+
+@MainActor
+protocol CardConfigurationDelegate: AnyObject {
+    func saveConfiguration(for card: any TrafficCardViewModel)
+    func deleteCard(_ card: any TrafficCardViewModel)
+    func moveCard(_ card: any TrafficCardViewModel, direction: MoveDirection)
+}

--- a/Modules/Sources/JetpackStats/Cards/CardViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/CardViewModel.swift
@@ -1,0 +1,9 @@
+import Foundation
+
+@MainActor
+protocol TrafficCardViewModel: AnyObject {
+    var id: UUID { get }
+    var dateRange: StatsDateRange { get set }
+    var isEditing: Bool { get set }
+    var configurationDelegate: CardConfigurationDelegate? { get set }
+}

--- a/Modules/Sources/JetpackStats/Cards/ChartCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/ChartCard.swift
@@ -1,0 +1,296 @@
+import SwiftUI
+import Charts
+
+struct ChartCard: View {
+    @ObservedObject private var viewModel: ChartCardViewModel
+
+    private var dateRange: StatsDateRange { viewModel.dateRange }
+    private var metrics: [SiteMetric] { viewModel.metrics }
+    private var selectedMetric: SiteMetric { viewModel.selectedMetric }
+    private var selectedChartType: ChartType { viewModel.selectedChartType }
+
+    @State private var isShowingRawData = false
+
+    @ScaledMetric(relativeTo: .largeTitle) private var chartHeight = 180
+
+    init(viewModel: ChartCardViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            VStack(spacing: Constants.step1) {
+                headerView(for: selectedMetric)
+                    .unredacted()
+                contentView
+            }
+            .padding(.vertical, Constants.step2)
+            .padding(.horizontal, Constants.step3)
+
+            if metrics.count > 1 {
+                Divider()
+                cardFooterView
+            }
+        }
+        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+        .onAppear {
+            viewModel.onAppear()
+        }
+        .overlay(alignment: .topTrailing) {
+            moreMenu
+        }
+        .cardStyle()
+        .grayscale(viewModel.isStale ? 1 : 0)
+        .opacity(viewModel.isEditing ? 0.6 : 1)
+        .scaleEffect(viewModel.isEditing ? 0.95 : 1)
+        .animation(.smooth, value: viewModel.isStale)
+        .animation(.spring, value: viewModel.isEditing)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(Strings.Accessibility.chartContainer)
+        .sheet(isPresented: $viewModel.isEditing) {
+            NavigationStack {
+                ChartCardCustomizationView(chartViewModel: viewModel)
+                    .navigationTitle(Strings.AddChart.selectMetric)
+                    .navigationBarTitleDisplayMode(.inline)
+            }
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
+        }
+        .sheet(isPresented: $isShowingRawData) {
+            if let data = viewModel.chartData[selectedMetric] {
+                NavigationStack {
+                    ChartDataListView(data: data, dateRange: dateRange)
+                }
+            }
+        }
+    }
+
+    private func headerView(for metric: SiteMetric) -> some View {
+        HStack {
+            StatsCardTitleView(title: metric.localizedTitle, showChevron: false)
+            Spacer(minLength: 44)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Strings.Accessibility.cardTitle(metric.localizedTitle))
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        VStack(spacing: Constants.step0_5) {
+            chartHeaderView
+                .padding(.trailing, -Constants.step0_5)
+            chartContentView
+        }
+        .animation(.spring, value: selectedMetric)
+        .animation(.spring, value: selectedChartType)
+        .animation(.easeInOut, value: viewModel.isFirstLoad)
+    }
+
+    private var chartHeaderView: some View {
+        // Showing currently selected (not loaded period) by design
+        HStack(alignment: .center, spacing: 0) {
+            if let data = viewModel.chartData[selectedMetric] {
+                ChartValuesSummaryView(
+                    trend: .make(data, context: .regular),
+                    style: .compact
+                )
+            } else if viewModel.isFirstLoad {
+                ChartValuesSummaryView(
+                    trend: .init(currentValue: 100, previousValue: 10, metric: .views),
+                    style: .compact
+                )
+                .redacted(reason: .placeholder)
+            }
+
+            Spacer(minLength: 8)
+
+            ChartLegendView(
+                metric: selectedMetric,
+                currentPeriod: dateRange.dateInterval,
+                previousPeriod: dateRange.effectiveComparisonInterval
+            )
+        }
+        .dynamicTypeSize(...DynamicTypeSize.xxLarge)
+    }
+
+    @ViewBuilder
+    private var chartContentView: some View {
+        if viewModel.isFirstLoad {
+            mainChartView(metric: selectedMetric, data: mockChartData)
+                .redacted(reason: .placeholder)
+                .opacity(0.2)
+                .pulsating()
+        } else if let data = viewModel.chartData[selectedMetric] {
+            if data.isEmpty, data.granularity == .hour {
+                loadingErrorView(with: Strings.Chart.hourlyDataUnavailable)
+            } else {
+                mainChartView(metric: selectedMetric, data: data)
+                    .transition(.opacity.combined(with: .scale(scale: 0.97)))
+            }
+        } else {
+            loadingErrorView(with: viewModel.loadingError?.localizedDescription ?? Strings.Errors.generic)
+        }
+    }
+
+    private var cardFooterView: some View {
+        MetricsOverviewTabView(
+            data: viewModel.isFirstLoad ? viewModel.placeholderTabViewData : viewModel.tabViewData,
+            selectedMetric: $viewModel.selectedMetric,
+            onMetricSelected: { metric in
+                viewModel.tracker?.send(.chartMetricSelected, properties: [
+                    "metric": metric.analyticsName
+                ])
+            }
+        )
+        .redacted(reason: viewModel.isFirstLoad ? .placeholder : [])
+        .pulsating(viewModel.isFirstLoad)
+        .background(CardGradientBackground(metric: selectedMetric))
+    }
+
+    private func loadingErrorView(with message: String) -> some View {
+        mainChartView(metric: selectedMetric, data: mockChartData)
+            .redacted(reason: .placeholder)
+            .grayscale(1)
+            .opacity(0.1)
+            .overlay {
+                SimpleErrorView(message: message)
+            }
+    }
+
+    private var mockChartData: ChartData {
+        ChartData.mock(metric: .views, granularity: dateRange.dateInterval.preferredGranularity, range: dateRange)
+    }
+
+    // MARK: - Header View
+
+    private var moreMenu: some View {
+        Menu {
+            moreMenuContent
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 17))
+                .foregroundColor(.secondary)
+                .frame(width: 56, height: 50)
+        }
+        .tint(Color.primary)
+    }
+
+    @ViewBuilder
+    private var moreMenuContent: some View {
+        Section {
+            ControlGroup {
+                ForEach(ChartType.allCases, id: \.self) { type in
+                    Button {
+                        let previousType = viewModel.selectedChartType
+                        viewModel.selectedChartType = type
+
+                        // Track chart type change
+                        viewModel.tracker?.send(.chartTypeChanged, properties: [
+                            "from_type": previousType.rawValue,
+                            "to_type": type.rawValue
+                        ])
+                    } label: {
+                        Label(type.localizedTitle, systemImage: type.systemImage)
+                    }
+                }
+            }
+        }
+        Section {
+            Button {
+                isShowingRawData = true
+            } label: {
+                Label(Strings.Chart.showData, systemImage: "tablecells")
+            }
+            Link(destination: URL(string: "https://wordpress.com/support/stats/understand-your-sites-traffic/")!) {
+                Label(Strings.Buttons.learnMore, systemImage: "info.circle")
+            }
+        }
+        EditCardMenuContent(cardViewModel: viewModel)
+    }
+
+    // MARK: - Chart View
+
+    @ViewBuilder
+    private func mainChartView(metric: SiteMetric, data: ChartData) -> some View {
+        VStack(alignment: .leading, spacing: Constants.step1 / 2) {
+            chartContentView(data: data)
+                .frame(height: chartHeight)
+                .padding(.horizontal, -Constants.step1)
+                .transition(.push(from: .trailing).combined(with: .opacity).combined(with: .scale))
+        }
+    }
+
+    @ViewBuilder
+    private func chartContentView(data: ChartData) -> some View {
+        switch selectedChartType {
+        case .line:
+            LineChartView(data: data)
+        case .columns:
+            BarChartView(data: data)
+        }
+    }
+}
+
+private struct CardGradientBackground: View {
+    let metric: SiteMetric
+
+    @Environment(\.colorScheme) var colorScheme
+
+    var body: some View {
+        LinearGradient(
+            colors: [
+                metric.primaryColor.opacity(colorScheme == .light ? 0.03 : 0.04),
+                Constants.Colors.secondaryBackground
+            ],
+            startPoint: .top,
+            endPoint: .center
+        )
+    }
+}
+
+enum ChartType: String, CaseIterable, Codable {
+    case line
+    case columns
+
+    var localizedTitle: String {
+        switch self {
+        case .line: Strings.Chart.lineChart
+        case .columns: Strings.Chart.barChart
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .line: "chart.line.uptrend.xyaxis"
+        case .columns: "chart.bar"
+        }
+    }
+}
+
+// MARK: - Preview
+
+private struct ChartCardPreview: View {
+    @StateObject var viewModel = ChartCardViewModel(
+        configuration: ChartCardConfiguration(
+            metrics: [.views, .visitors, .likes, .comments]
+        ),
+        dateRange: Calendar.demo.makeDateRange(for: .today),
+        service: MockStatsService(),
+        tracker: MockStatsTracker.shared
+    )
+
+    var body: some View {
+        ChartCard(viewModel: viewModel)
+            .cardStyle()
+    }
+}
+
+#Preview {
+    ScrollView {
+        VStack(spacing: 20) {
+            ChartCardPreview()
+        }
+        .padding(.vertical)
+    }
+    .background(Color(.systemGroupedBackground))
+}

--- a/Modules/Sources/JetpackStats/Cards/ChartCardConfiguration.swift
+++ b/Modules/Sources/JetpackStats/Cards/ChartCardConfiguration.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct ChartCardConfiguration: Codable {
+    let id: UUID
+    var metrics: [SiteMetric]
+    var chartType: ChartType
+
+    init(id: UUID = UUID(), metrics: [SiteMetric], chartType: ChartType = .line) {
+        self.id = id
+        self.metrics = metrics
+        self.chartType = chartType
+    }
+}

--- a/Modules/Sources/JetpackStats/Cards/ChartCardViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/ChartCardViewModel.swift
@@ -1,0 +1,209 @@
+import SwiftUI
+
+@MainActor
+final class ChartCardViewModel: ObservableObject, TrafficCardViewModel {
+    var id: UUID { configuration.id }
+    var metrics: [SiteMetric] { configuration.metrics }
+
+    @Published private(set) var configuration: ChartCardConfiguration
+    @Published private(set) var chartData: [SiteMetric: ChartData] = [:]
+    @Published private(set) var isLoading = true
+    @Published private(set) var loadingError: Error?
+    @Published private(set) var isStale = false
+
+    @Published var isEditing = false
+    @Published var selectedMetric: SiteMetric
+    @Published var selectedChartType: ChartType {
+        didSet {
+            // Update configuration when chart type changes
+            configuration.chartType = selectedChartType
+            configurationDelegate?.saveConfiguration(for: self)
+        }
+    }
+
+    weak var configurationDelegate: CardConfigurationDelegate?
+
+    var dateRange: StatsDateRange {
+        didSet {
+            loadData(for: dateRange)
+        }
+    }
+
+    private let service: any StatsServiceProtocol
+    let tracker: (any StatsTracker)?
+
+    private var loadingTask: Task<Void, Never>?
+    private var loadRequestCount = 0
+    private var staleTimer: Task<Void, Never>?
+    private var isFirstAppear = true
+
+    var isFirstLoad: Bool { isLoading && chartData.isEmpty }
+
+    init(
+        configuration: ChartCardConfiguration,
+        dateRange: StatsDateRange,
+        service: any StatsServiceProtocol,
+        tracker: (any StatsTracker)? = nil
+    ) {
+        self.configuration = configuration
+        self.selectedMetric = configuration.metrics.first ?? .views
+        self.selectedChartType = configuration.chartType
+        self.dateRange = dateRange
+        self.service = service
+        self.tracker = tracker
+    }
+
+    func updateConfiguration(_ newConfiguration: ChartCardConfiguration) {
+        self.configuration = newConfiguration
+
+        // Update selectedMetric if it's no longer available in the new configuration
+        if !newConfiguration.metrics.contains(selectedMetric) {
+            selectedMetric = newConfiguration.metrics.first ?? .views
+        }
+
+        // Update chart type from configuration (without triggering didSet)
+        if selectedChartType != newConfiguration.chartType {
+            selectedChartType = newConfiguration.chartType
+        }
+
+        configurationDelegate?.saveConfiguration(for: self)
+    }
+
+    func onAppear() {
+        guard isFirstAppear else { return }
+        isFirstAppear = false
+
+        // Track card shown event
+        tracker?.send(.cardShown, properties: [
+            "card_type": "chart",
+            "configuration": metrics.map { $0.analyticsName }.joined(separator: "_"),
+            "chart_type": selectedChartType.rawValue
+        ])
+
+        loadData(for: dateRange)
+    }
+
+    private func loadData(for dateRange: StatsDateRange) {
+        loadingTask?.cancel()
+        staleTimer?.cancel()
+
+        // Increment request count to track if this is the first request
+        loadRequestCount += 1
+        let isFirstRequest = loadRequestCount == 1
+
+        // If we have data, start a timer to mark data as stale if there is
+        // no response in more than T seconds.
+        if !chartData.isEmpty {
+            staleTimer = Task { [weak self] in
+                try? await Task.sleep(for: .seconds(2))
+                guard !Task.isCancelled else { return }
+                self?.isStale = true
+            }
+        }
+
+        // Create a new loading task
+        loadingTask = Task { [weak self] in
+            guard let self else { return }
+
+            // Add delay for subsequent requests to avoid rapid API calls when
+            // the user quickly switches between date intervals.
+            if !isFirstRequest {
+                try? await Task.sleep(for: .milliseconds(250))
+            }
+
+            guard !Task.isCancelled else { return }
+            await self.actuallyLoadData(dateRange: dateRange)
+        }
+    }
+
+    private func actuallyLoadData(dateRange: StatsDateRange) async {
+        isLoading = true
+        loadingError = nil
+
+        do {
+            try Task.checkCancellation()
+
+            let data = try await getSiteStats(dateRange: dateRange)
+
+            // Check for cancellation before updating the state
+            try Task.checkCancellation()
+
+            // Cancel stale timer and reset stale flag when data is successfully loaded
+            staleTimer?.cancel()
+            isStale = false
+            chartData = data
+        } catch is CancellationError {
+            return
+        } catch {
+            loadingError = error
+            tracker?.trackError(error, screen: "chart_card")
+        }
+
+        loadRequestCount = 0
+        isLoading = false
+    }
+
+    private func getSiteStats(dateRange: StatsDateRange) async throws -> [SiteMetric: ChartData] {
+        var output: [SiteMetric: ChartData] = [:]
+
+        let granularity = dateRange.dateInterval.preferredGranularity
+
+        // Fetch both current and previous period data concurrently
+        async let currentResponseTask = service.getSiteStats(
+            interval: dateRange.dateInterval,
+            granularity: granularity
+        )
+        async let previousResponseTask = service.getSiteStats(
+            interval: dateRange.effectiveComparisonInterval,
+            granularity: granularity
+        )
+
+        let (currentResponse, previousResponse) = try await (currentResponseTask, previousResponseTask)
+
+        for (metric, dataPoints) in currentResponse.metrics {
+            let previousDataPoints = previousResponse.metrics[metric] ?? []
+
+            // Map previous data to align with current period dates so they
+            // are displayed on the same timeline on the charts.
+            let mappedPreviousDataPoints = DataPoint.mapDataPoints(
+                previousDataPoints,
+                from: dateRange.effectiveComparisonInterval,
+                to: dateRange.dateInterval,
+                component: dateRange.component,
+                calendar: dateRange.calendar
+            )
+
+            output[metric] = ChartData(
+                metric: metric,
+                granularity: granularity,
+                currentTotal: currentResponse.total[metric] ?? 0,
+                currentData: dataPoints,
+                previousTotal: previousResponse.total[metric] ?? 0,
+                previousData: previousDataPoints,
+                mappedPreviousData: mappedPreviousDataPoints
+            )
+        }
+
+        return output
+    }
+
+    var tabViewData: [MetricsOverviewTabView.MetricData] {
+        metrics.map { metric in
+            if let chartData = chartData[metric] {
+                return .init(
+                    metric: metric,
+                    value: chartData.currentTotal,
+                    previousValue: chartData.previousTotal
+                )
+            } else {
+                return .init(metric: metric, value: nil, previousValue: nil)
+            }
+        }
+    }
+
+    var placeholderTabViewData: [MetricsOverviewTabView.MetricData] {
+        metrics.map { metric in
+            .init(metric: metric, value: 12345, previousValue: 11234)
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Cards/StandaloneChartCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/StandaloneChartCard.swift
@@ -1,0 +1,336 @@
+import SwiftUI
+import Charts
+
+/// A reusable chart card component that displays metric data over time with date range controls.
+///
+/// This component provides:
+/// - Line and bar chart visualization options
+/// - Date range selection and navigation
+/// - Comparison with previous period
+/// - Automatic data aggregation based on selected granularity
+struct StandaloneChartCard: View {
+    /// The data points to display in the chart
+    let dataPoints: [DataPoint]
+
+    /// The metric type being displayed (e.g., views, likes, comments)
+    let metric: SiteMetric
+
+    private let configuration: Configuration
+
+    @State private var dateRange: StatsDateRange
+    @Binding var chartType: ChartType
+    @State private var isShowingDatePicker = false
+    @State private var chartData: ChartData?
+
+    @ScaledMetric(relativeTo: .largeTitle) private var chartHeight = 180
+
+    @Environment(\.context) private var context
+
+    @Environment(\.redactionReasons) private var redactionReasons
+
+    struct Configuration {
+        var minimumGranularity: DateRangeGranularity = .hour
+    }
+
+    /// Creates a new standalone chart card.
+    /// - Parameters:
+    ///   - dataPoints: The array of data points to display
+    ///   - metric: The metric type for proper formatting and colors
+    ///   - initialDateRange: The initial date range to display
+    ///   - chartType: Binding to the chart type
+    init(
+        dataPoints: [DataPoint],
+        metric: SiteMetric,
+        initialDateRange: StatsDateRange,
+        chartType: Binding<ChartType>,
+        configuration: Configuration = .init()
+    ) {
+        self.dataPoints = dataPoints
+        self.metric = metric
+        self._dateRange = State(initialValue: initialDateRange)
+        self._chartType = chartType
+        self.configuration = configuration
+    }
+
+    var body: some View {
+        VStack(spacing: Constants.step1) {
+            StatsCardTitleView(title: metric.localizedTitle)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            chartHeaderView
+                .padding(.trailing, -Constants.step0_5)
+            chartContentView
+                .padding(.horizontal, -Constants.step1)
+            dateRangeControls
+                .dynamicTypeSize(...DynamicTypeSize.xLarge)
+        }
+        .padding(.vertical, Constants.step2)
+        .padding(.horizontal, Constants.step3)
+        .dynamicTypeSize(...DynamicTypeSize.xxLarge)
+        .overlay(alignment: .topTrailing) {
+            moreMenu
+        }
+        .sheet(isPresented: $isShowingDatePicker) {
+            CustomDateRangePicker(dateRange: $dateRange)
+        }
+        .task(id: dateRange) {
+            await refreshChartData()
+        }
+    }
+
+    private var chartHeaderView: some View {
+        // Showing currently selected (not loaded period) by design
+        HStack(alignment: .firstTextBaseline, spacing: 0) {
+            if let data = chartData {
+                ChartValuesSummaryView(
+                    trend: .make(data, context: .regular),
+                    style: .compact
+                )
+            } else {
+                ChartValuesSummaryView(
+                    trend: .init(currentValue: 100, previousValue: 10, metric: .views),
+                    style: .compact
+                )
+                .redacted(reason: .placeholder)
+            }
+
+            Spacer(minLength: 8)
+
+            ChartLegendView(
+                metric: metric,
+                currentPeriod: dateRange.dateInterval,
+                previousPeriod: dateRange.effectiveComparisonInterval
+            )
+        }
+    }
+
+    private var chartContentView: some View {
+        Group {
+            if dateRange.dateInterval.preferredGranularity < configuration.minimumGranularity {
+                loadingErrorView(with: Strings.Chart.hourlyDataUnavailable)
+            } else if let chartData {
+                if chartData.isEmptyOrZero {
+                    loadingErrorView(with: Strings.Chart.empty)
+                } else {
+                    chartContent(chartData: chartData)
+                        .opacity(redactionReasons.contains(.placeholder) ? 0.2 : 1.0)
+                }
+            } else {
+                chartContent(chartData: mockData)
+                    .redacted(reason: .placeholder)
+                    .opacity(0.33)
+            }
+        }
+        .frame(height: chartHeight)
+    }
+
+    @ViewBuilder
+    private func chartContent(chartData: ChartData) -> some View {
+        switch chartType {
+        case .line:
+            LineChartView(data: chartData)
+        case .columns:
+            BarChartView(data: chartData)
+        }
+    }
+
+    private func loadingErrorView(with message: String) -> some View {
+        chartContent(chartData: mockData)
+            .redacted(reason: .placeholder)
+            .grayscale(1)
+            .opacity(0.1)
+            .overlay {
+                SimpleErrorView(message: message)
+            }
+    }
+
+    // MARK: –
+
+    private var trend: TrendViewModel {
+        guard let chartData else {
+            return TrendViewModel(currentValue: 0, previousValue: 0, metric: metric)
+        }
+        return TrendViewModel(
+            currentValue: chartData.currentTotal,
+            previousValue: chartData.previousTotal,
+            metric: metric
+        )
+    }
+
+    private func refreshChartData() async {
+        let chartData = await generateChartData(
+            dataPoints: dataPoints,
+            dateRange: dateRange,
+            metric: metric,
+            calendar: context.calendar,
+            granularity: max(dateRange.dateInterval.preferredGranularity, configuration.minimumGranularity)
+        )
+        guard !Task.isCancelled else { return }
+        self.chartData = chartData
+    }
+
+    private var mockData: ChartData {
+        ChartData.mock(metric: .views, granularity: .day, range: dateRange)
+    }
+
+    // MARK: - Controls
+
+    private var moreMenu: some View {
+        Menu {
+            Section {
+                ControlGroup {
+                    ForEach(ChartType.allCases, id: \.self) { type in
+                        Button {
+                            chartType = type
+                        } label: {
+                            Label(type.localizedTitle, systemImage: type.systemImage)
+                        }
+                    }
+                }
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.body)
+                .foregroundColor(.secondary)
+                .frame(width: 56, height: 50)
+        }
+        .tint(Color.primary)
+    }
+
+    private var dateRangeControls: some View {
+        HStack(spacing: Constants.step1) {
+            // Date range menu button
+            Menu {
+                StatsDateRangePickerMenu(selection: $dateRange, isShowingCustomRangePicker: $isShowingDatePicker)
+            } label: {
+                HStack(spacing: 6) {
+                    Image(systemName: "calendar")
+                        .font(.subheadline)
+                    Text(context.formatters.dateRange.string(from: dateRange.dateInterval))
+                        .font(.subheadline.weight(.medium))
+                }
+                .foregroundColor(.primary)
+                .padding(.horizontal, Constants.step1)
+                .padding(.vertical, 8)
+                .background(Color(.secondarySystemBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+            }
+            .tint(Color.primary)
+
+            Spacer()
+
+            // Navigation controls
+            HStack(spacing: 4) {
+                navigationButton(direction: .backward)
+                navigationButton(direction: .forward)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func navigationButton(direction: Calendar.NavigationDirection) -> some View {
+        Button {
+            dateRange = dateRange.navigate(direction)
+        } label: {
+            Image(systemName: direction == .backward ? "chevron.backward" : "chevron.forward")
+                .font(.subheadline.weight(.medium))
+                .foregroundColor(dateRange.canNavigate(in: direction) ? .primary : Color(.quaternaryLabel))
+                .frame(width: 36, height: 36)
+                .background(Color(.secondarySystemBackground))
+                .clipShape(RoundedRectangle(cornerRadius: 8))
+        }
+        .disabled(!dateRange.canNavigate(in: direction))
+    }
+}
+
+private func generateChartData(
+    dataPoints: [DataPoint],
+    dateRange: StatsDateRange,
+    metric: SiteMetric,
+    calendar: Calendar,
+    granularity: DateRangeGranularity
+) async -> ChartData {
+    let aggregator = StatsDataAggregator(calendar: calendar)
+
+    // Filter data points for current period
+    let currentDataPoints = dataPoints.filter { dataPoint in
+        dateRange.dateInterval.contains(dataPoint.date)
+    }
+
+    // Process current period
+    let currentPeriod = aggregator.processPeriod(
+        dataPoints: currentDataPoints,
+        dateInterval: dateRange.dateInterval,
+        granularity: granularity,
+        metric: metric
+    )
+
+    // Create previous period using calendar extension
+    let previousDateInterval = dateRange.effectiveComparisonInterval
+
+    // Filter data points for previous period
+    let previousDataPoints = dataPoints.filter { dataPoint in
+        previousDateInterval.contains(dataPoint.date)
+    }
+
+    let previousPeriod = aggregator.processPeriod(
+        dataPoints: previousDataPoints,
+        dateInterval: previousDateInterval,
+        granularity: granularity,
+        metric: metric
+    )
+
+    // Map previous data points to current period dates for overlay
+    let mappedPreviousData = DataPoint.mapDataPoints(
+        previousPeriod.dataPoints,
+        from: previousDateInterval,
+        to: dateRange.dateInterval,
+        component: dateRange.component,
+        calendar: calendar
+    )
+
+    return ChartData(
+        metric: metric,
+        granularity: granularity,
+        currentTotal: currentPeriod.total,
+        currentData: currentPeriod.dataPoints,
+        previousTotal: previousPeriod.total,
+        previousData: previousPeriod.dataPoints,
+        mappedPreviousData: mappedPreviousData
+    )
+}
+
+// MARK: - Preview
+
+#Preview {
+    struct PreviewWrapper: View {
+        @State private var chartType: ChartType = .line
+
+        var body: some View {
+            StandaloneChartCard(
+                dataPoints: generateMockDataPoints(days: 365),
+                metric: .views,
+                initialDateRange: Calendar.demo.makeDateRange(for: .last7Days),
+                chartType: $chartType
+            )
+        }
+    }
+
+    return PreviewWrapper()
+        .cardStyle()
+        .padding(8)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        .background(Color(.systemGroupedBackground))
+        .environment(\.context, StatsContext.demo)
+}
+
+// Helper function to generate mock data
+private func generateMockDataPoints(days: Int, valueRange: ClosedRange<Int> = 50...200) -> [DataPoint] {
+    let calendar = Calendar.demo
+    let today = Date()
+
+    return (0..<days).compactMap { dayOffset in
+        guard let date = calendar.date(byAdding: .day, value: -dayOffset, to: today) else { return nil }
+        let value = Int.random(in: valueRange)
+        return DataPoint(date: date, value: value)
+    }
+}

--- a/Modules/Sources/JetpackStats/Cards/TopListCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListCard.swift
@@ -1,0 +1,339 @@
+import SwiftUI
+
+struct TopListCard: View {
+    @ObservedObject private var viewModel: TopListViewModel
+
+    private let itemLimit: Int
+    private let reserveSpace: Bool
+    private let showMoreInline: Bool
+
+    @State private var isExpanded = false
+
+    @Environment(\.context) var context
+    @Environment(\.router) var router
+
+    init(
+        viewModel: TopListViewModel,
+        itemLimit: Int = 5,
+        reserveSpace: Bool = true,
+        showMoreInline: Bool = false
+    ) {
+        self.viewModel = viewModel
+        self.itemLimit = itemLimit
+        self.reserveSpace = reserveSpace
+        self.showMoreInline = showMoreInline
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            cardHeaderView
+                .padding(.horizontal, Constants.step3)
+
+            if viewModel.selection.item == .locations {
+                mapView
+                    .padding(.vertical, Constants.step2)
+                    .padding(.horizontal, Constants.step2)
+            }
+
+            listHeaderView
+                .padding(.horizontal, Constants.step3)
+                .dynamicTypeSize(...DynamicTypeSize.xxLarge)
+
+            listContentView
+        }
+        .dynamicTypeSize(...DynamicTypeSize.accessibility1)
+        .onAppear {
+            viewModel.onAppear()
+        }
+        .padding(.vertical, Constants.step2)
+        .overlay(alignment: .topTrailing) {
+            moreMenu
+        }
+        .cardStyle()
+        .onTapGesture {
+            if !showMoreInline {
+                navigateToTopListScreen()
+            }
+        }
+        .grayscale(viewModel.isStale ? 1 : 0)
+        .opacity(viewModel.isEditing ? 0.6 : 1)
+        .scaleEffect(viewModel.isEditing ? 0.95 : 1)
+        .animation(.smooth, value: viewModel.isStale)
+        .animation(.spring, value: viewModel.isEditing)
+        .accessibilityElement(children: .contain)
+        .animation(.spring, value: viewModel.data.map(ObjectIdentifier.init)) // placing is important
+        .sheet(isPresented: $viewModel.isEditing) {
+            NavigationStack {
+                TopListCardCustomizationView(viewModel: viewModel)
+                    .navigationTitle(Strings.AddChart.selectDataType)
+                    .navigationBarTitleDisplayMode(.inline)
+            }
+            .presentationDetents([.medium, .large])
+            .presentationDragIndicator(.visible)
+        }
+    }
+
+    private var cardHeaderView: some View {
+        HStack {
+            StatsCardTitleView(title: viewModel.selection.item == .locations ? "Countries" : viewModel.title)
+            Spacer(minLength: 44)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel(Strings.Accessibility.cardTitle(viewModel.selection.item == .locations ? "Countries" : viewModel.title))
+    }
+
+    private var mapView: some View {
+        CountriesMapView(
+            data: viewModel.cachedCountriesMapData ?? .init(metric: viewModel.selection.metric, locations: []),
+            primaryColor: Constants.Colors.uiColorBlue
+        )
+    }
+
+    private var listHeaderView: some View {
+        HStack {
+            if viewModel.items.count > 1 {
+                Menu {
+                    itemTypePicker
+                } label: {
+                    InlineValuePickerTitle(title: viewModel.selection.item.localizedTitle)
+                        .padding(.top, 6)
+                        .padding(.vertical, Constants.step0_5) // Increase tap area
+                }
+                .fixedSize()
+            } else {
+                Text(viewModel.selection.item.localizedTitle)
+                    .padding(.top, 6)
+                    .padding(.vertical, Constants.step0_5)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+            }
+
+            Spacer()
+
+            let metrics = getSupportedMetrics(for: viewModel.selection.item)
+            if metrics.count > 1 {
+                Menu {
+                    makeMetricPicker(with: metrics)
+                } label: {
+                    InlineValuePickerTitle(title: viewModel.selection.metric.localizedTitle)
+                        .padding(.top, 6)
+                        .padding(.vertical, Constants.step0_5)
+                }
+                .fixedSize()
+            } else {
+                Text(viewModel.selection.metric.localizedTitle)
+                    .padding(.top, 6)
+                    .padding(.vertical, Constants.step0_5)
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+            }
+        }
+    }
+
+    private func navigateToTopListScreen() {
+        let screen = TopListScreenView(
+            selection: viewModel.selection,
+            dateRange: viewModel.dateRange,
+            service: context.service,
+            context: context,
+            initialData: viewModel.data,
+            filter: viewModel.filter
+        )
+        .environment(\.context, context)
+        .environment(\.router, router)
+
+        router.navigate(to: screen, title: viewModel.selection.item.localizedTitle)
+    }
+
+    private var itemTypePicker: some View {
+        ForEach(Array(viewModel.groupedItems.enumerated()), id: \.offset) { _, items in
+            Section {
+                ForEach(items) { item in
+                    Button {
+                        var selection = viewModel.selection
+                        selection.item = item
+
+                        let supportedMetric = getSupportedMetrics(for: item)
+                        if !supportedMetric.contains(selection.metric),
+                           let metric = supportedMetric.first {
+                            selection.metric = metric
+                        }
+                        viewModel.selection = selection
+                    } label: {
+                        Label(item.localizedTitle, systemImage: item.systemImage)
+                    }
+                }
+            }
+        }
+        .tint(Color.primary)
+    }
+
+    private func makeMetricPicker(with metrics: [SiteMetric]) -> some View {
+        ForEach(metrics) { metric in
+            Button {
+                viewModel.selection.metric = metric
+            } label: {
+                Label(metric.localizedTitle, systemImage: metric.systemImage)
+            }
+        }
+        .tint(Color.primary)
+    }
+
+    private func getSupportedMetrics(for item: TopListItemType) -> [SiteMetric] {
+        context.service.getSupportedMetrics(for: item)
+    }
+
+    private var moreMenu: some View {
+        Menu {
+            moreMenuContent
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 17))
+                .foregroundColor(.secondary)
+                .frame(width: 56, height: 50)
+        }
+        .tint(Color.primary)
+    }
+
+    @ViewBuilder
+    private var moreMenuContent: some View {
+        Section {
+            if let documentationURL = viewModel.selection.item.documentationURL {
+                Link(destination: documentationURL) {
+                    Label(Strings.Buttons.learnMore, systemImage: "info.circle")
+                }
+            }
+        }
+        EditCardMenuContent(cardViewModel: viewModel)
+    }
+
+    @ViewBuilder
+    private var listContentView: some View {
+        Group {
+            if viewModel.isFirstLoad {
+                topListItemsView(data: mockData)
+                    .allowsHitTesting(false)
+                    .redacted(reason: .placeholder)
+                    .pulsating()
+            } else if let data = viewModel.data {
+                if data.items.isEmpty {
+                    makeEmptyStateView(message: Strings.Chart.empty)
+                } else {
+                    topListItemsView(data: data)
+                }
+            } else {
+                makeEmptyStateView(message: viewModel.loadingError?.localizedDescription ?? Strings.Errors.generic)
+            }
+        }
+    }
+
+    private func topListItemsView(data: TopListData) -> some View {
+        VStack(spacing: 0) {
+            TopListItemsView(
+                data: data,
+                itemLimit: showMoreInline && isExpanded ? data.items.count : itemLimit,
+                dateRange: viewModel.dateRange,
+                reserveSpace: reserveSpace
+            )
+            if showMoreInline && data.items.count > itemLimit {
+                showMoreInlineButton
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, Constants.step3)
+            } else if !showMoreInline {
+                showMoreButton
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, Constants.step3)
+            }
+        }
+    }
+
+    private var showMoreButton: some View {
+        Button {
+            navigateToTopListScreen()
+        } label: {
+            HStack(spacing: 4) {
+                Text(Strings.Buttons.showAll)
+                    .padding(.trailing, 4)
+                    .font(.callout)
+                    .foregroundColor(.primary)
+                Image(systemName: "chevron.forward")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(.secondary)
+            }
+            .font(.body)
+        }
+        .padding(.top, 16)
+        .tint(Color.secondary.opacity(0.8))
+        .dynamicTypeSize(...DynamicTypeSize.xLarge)
+    }
+
+    private var showMoreInlineButton: some View {
+        Button {
+            withAnimation(.spring) {
+                isExpanded.toggle()
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text(isExpanded ? Strings.Buttons.showLess : Strings.Buttons.showMore)
+                    .padding(.trailing, 4)
+                    .font(.callout)
+                    .foregroundColor(.primary)
+                Image(systemName: isExpanded ? "chevron.up" : "chevron.down")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(.secondary)
+            }
+            .font(.body)
+            .frame(maxWidth: .infinity, alignment: .center) // Expand tap area
+        }
+        .padding(.top, 16)
+        .tint(Color.secondary.opacity(0.8))
+        .dynamicTypeSize(...DynamicTypeSize.xLarge)
+    }
+
+    private func makeEmptyStateView(message: String) -> some View {
+        topListItemsView(data: .init(item: viewModel.selection.item, metric: viewModel.selection.metric, items: []))
+            .allowsHitTesting(false)
+            .redacted(reason: .placeholder)
+            .overlay {
+                SimpleErrorView(message: message)
+                    .offset(y: -18)
+            }
+    }
+
+    private var mockData: TopListData {
+        TopListData.mock(
+            for: viewModel.selection.item,
+            metric: viewModel.selection.metric,
+            itemCount: itemLimit
+        )
+    }
+}
+
+#Preview {
+    TopListCardPreview(item: .authors)
+}
+
+private struct TopListCardPreview: View {
+    let item: TopListItemType
+
+    @StateObject private var viewModel: TopListViewModel
+
+    init(item: TopListItemType) {
+        self.item = item
+        self._viewModel = StateObject(wrappedValue: TopListViewModel(
+            configuration: TopListCardConfiguration(
+                item: item,
+                metric: item == .fileDownloads ? .downloads : .views
+            ),
+            dateRange: Calendar.demo.makeDateRange(for: .last28Days),
+            service: MockStatsService(),
+            tracker: MockStatsTracker.shared
+        ))
+    }
+
+    var body: some View {
+        TopListCard(viewModel: viewModel)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Constants.Colors.background)
+    }
+}

--- a/Modules/Sources/JetpackStats/Cards/TopListCardConfiguration.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListCardConfiguration.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+struct TopListCardConfiguration: Codable {
+    let id: UUID
+    var item: TopListItemType
+    var metric: SiteMetric
+
+    init(id: UUID = UUID(), item: TopListItemType, metric: SiteMetric) {
+        self.id = id
+        self.item = item
+        self.metric = metric
+    }
+}

--- a/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
@@ -1,0 +1,265 @@
+import SwiftUI
+
+@MainActor
+final class TopListViewModel: ObservableObject, TrafficCardViewModel {
+    var id: UUID { configuration.id }
+    let items: [TopListItemType]
+    let groupedItems: [[TopListItemType]]
+
+    var title: String {
+        selection.item.getTitle(for: selection.metric)
+    }
+
+    @Published private(set) var configuration: TopListCardConfiguration {
+        didSet {
+            configurationDelegate?.saveConfiguration(for: self)
+            updateSelection()
+        }
+    }
+
+    @Published var selection: Selection {
+        didSet {
+            loadData()
+        }
+    }
+    @Published private(set) var data: TopListData?
+    @Published private(set) var isLoading = true
+    @Published private(set) var loadingError: Error?
+    @Published private(set) var isStale = false
+    @Published private(set) var cachedCountriesMapData: CountriesMapData?
+
+    @Published var isEditing = false
+
+    weak var configurationDelegate: CardConfigurationDelegate?
+
+    let filter: Filter?
+
+    private let service: any StatsServiceProtocol
+    let tracker: (any StatsTracker)?
+    private let fetchLimit: Int?
+
+    private var loadingTask: Task<Void, Never>?
+    private var loadRequestCount = 0
+    private var staleTimer: Task<Void, Never>?
+
+    var dateRange: StatsDateRange {
+        didSet { loadData() }
+    }
+
+    struct Selection: Equatable, Sendable {
+        var item: TopListItemType
+        var metric: SiteMetric
+    }
+
+    enum Filter: Equatable {
+        case author(userId: String)
+    }
+
+    var isFirstLoad: Bool { isLoading && data == nil }
+
+    private var isFirstAppear = true
+
+    init(
+        configuration: TopListCardConfiguration,
+        dateRange: StatsDateRange,
+        service: any StatsServiceProtocol,
+        tracker: (any StatsTracker)? = nil,
+        items: [TopListItemType]? = nil,
+        fetchLimit: Int? = 100,
+        filter: Filter? = nil,
+        initialData: TopListData? = nil
+    ) {
+        self.configuration = configuration
+        self.selection = Selection(item: configuration.item, metric: configuration.metric)
+        self.items = items ?? service.supportedItems
+        self.dateRange = dateRange
+        self.service = service
+        self.tracker = tracker
+        self.fetchLimit = fetchLimit
+        self.filter = filter
+        self.data = initialData
+        self.isLoading = initialData == nil
+
+        self.groupedItems = {
+            let primary = service.supportedItems.filter {
+                !TopListItemType.secondaryItems.contains($0)
+            }
+            let secondary = service.supportedItems.filter {
+                TopListItemType.secondaryItems.contains($0)
+            }
+            return [primary, secondary]
+        }()
+    }
+
+    func updateConfiguration(_ newConfiguration: TopListCardConfiguration) {
+        self.configuration = newConfiguration
+    }
+
+    private func updateSelection() {
+        selection = Selection(item: configuration.item, metric: configuration.metric)
+    }
+
+    func onAppear() {
+        guard isFirstAppear else { return }
+        isFirstAppear = false
+
+        // Track card shown event
+        tracker?.send(.cardShown, properties: [
+            "card_type": "top_list",
+            "configuration": "\(selection.item.analyticsName)_\(selection.metric.analyticsName)",
+            "item_type": selection.item.analyticsName,
+            "metric": selection.metric.analyticsName
+        ])
+
+        loadData()
+    }
+
+    private func loadData() {
+        loadingTask?.cancel()
+        staleTimer?.cancel()
+
+        // Increment request count to track if this is the first request
+        loadRequestCount += 1
+        let isFirstRequest = loadRequestCount == 1
+
+        // If we have data, start a timer to mark data as stale if there is
+        // no response in more than T seconds.
+        if data != nil {
+            staleTimer = Task { [weak self] in
+                try? await Task.sleep(for: .seconds(2))
+                guard !Task.isCancelled else { return }
+                self?.isStale = true
+            }
+        }
+
+        // Create a new loading task
+        loadingTask = Task { [selection, dateRange, weak self] in
+            guard let self else { return }
+
+            // Add delay for subsequent requests to avoid rapid API calls when
+            // the user quickly switches between data types or metrics.
+            if !isFirstRequest {
+                try? await Task.sleep(for: .milliseconds(250))
+            }
+
+            guard !Task.isCancelled else { return }
+            await self.actuallyLoadData(for: selection, dateRange: dateRange)
+        }
+    }
+
+    private func actuallyLoadData(for selection: Selection, dateRange: StatsDateRange) async {
+        isLoading = true
+        loadingError = nil
+
+        do {
+            try Task.checkCancellation()
+
+            let data = try await getTopListData(for: selection, dateRange: dateRange)
+
+            // Check for cancellation before updating the state
+            try Task.checkCancellation()
+
+            // Cancel stale timer and reset stale flag when data is successfully loaded
+            staleTimer?.cancel()
+            isStale = false
+            self.data = data
+
+            // Update cached CountriesMapData if locations are selected
+            if selection.item == .locations {
+                updateCountriesMapDataCache(from: data)
+            } else {
+                cachedCountriesMapData = nil
+            }
+        } catch is CancellationError {
+            return
+        } catch {
+            loadingError = error
+            data = nil
+            tracker?.trackError(error, screen: "top_list_card")
+        }
+
+        loadRequestCount = 0
+        isLoading = false
+    }
+
+    private func getTopListData(for selection: Selection, dateRange: StatsDateRange) async throws -> TopListData {
+        let granularity = dateRange.dateInterval.preferredGranularity
+
+        // When filter is set for author, we need to fetch authors data
+        let fetchItem: TopListItemType
+        if let filter, case .author = filter {
+            // We have to fake it as "Posts & Pages" does not support filtering
+            fetchItem = .authors
+        } else {
+            fetchItem = selection.item
+        }
+
+        // Fetch current data
+        async let currentTask = service.getTopListData(
+            fetchItem,
+            metric: selection.metric,
+            interval: dateRange.dateInterval,
+            granularity: granularity,
+            limit: fetchLimit
+        )
+
+        // Fetch previous data only for items that support it
+        async let previousTask: TopListResponse? = {
+            guard selection.item != .archive else { return nil }
+            return try await service.getTopListData(
+                fetchItem,
+                metric: selection.metric,
+                interval: dateRange.effectiveComparisonInterval,
+                granularity: granularity,
+                limit: fetchLimit
+            )
+        }()
+
+        let (current, previous) = try await (currentTask, previousTask)
+
+        let currentItems = filteredItems(current.items)
+        let previousItems = filteredItems(previous?.items ?? [])
+
+        // Build previous items dictionary
+        var previousItemsDict: [TopListItemID: any TopListItemProtocol] = [:]
+        for item in previousItems {
+            previousItemsDict[item.id] = item
+        }
+
+        // Calculate max value from filtered items based on selected metric
+        let metric = selection.metric
+
+        return TopListData(
+            item: selection.item,
+            metric: metric,
+            items: currentItems,
+            previousItems: previousItemsDict
+        )
+    }
+
+    private func filteredItems(_ items: [any TopListItemProtocol]) -> [any TopListItemProtocol] {
+        guard let filter else {
+            return items
+        }
+        switch filter {
+        case .author(let userId):
+            let authors = items.lazy.compactMap { $0 as? TopListItem.Author }
+            if let author = authors.first(where: { $0.userId == userId }),
+               let posts = author.posts {
+                return posts
+            }
+            return []
+        }
+    }
+
+    private func updateCountriesMapDataCache(from data: TopListData) {
+        let locations = data.items.compactMap { $0 as? TopListItem.Location }
+        let previousLocations = data.previousItems.compactMapValues { $0 as? TopListItem.Location }
+
+        cachedCountriesMapData = CountriesMapData(
+            metric: selection.metric,
+            locations: locations,
+            previousLocations: previousLocations
+        )
+    }
+ }

--- a/Modules/Sources/JetpackStats/Cards/TrafficCardConfiguration.swift
+++ b/Modules/Sources/JetpackStats/Cards/TrafficCardConfiguration.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+struct TrafficCardConfiguration: Codable {
+    var cards: [Card]
+
+    enum Card: Codable {
+        case chart(ChartCardConfiguration)
+        case topList(TopListCardConfiguration)
+
+        var id: UUID {
+            switch self {
+            case .chart(let config):
+                return config.id
+            case .topList(let config):
+                return config.id
+            }
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Screens/TopListScreenView.swift
+++ b/Modules/Sources/JetpackStats/Screens/TopListScreenView.swift
@@ -1,0 +1,246 @@
+import SwiftUI
+import DesignSystem
+import UniformTypeIdentifiers
+
+struct TopListScreenView: View {
+    @StateObject private var viewModel: TopListViewModel
+
+    @Environment(\.router) var router
+    @Environment(\.context) var context
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+
+    init(
+        selection: TopListViewModel.Selection,
+        dateRange: StatsDateRange,
+        service: any StatsServiceProtocol,
+        context: StatsContext,
+        initialData: TopListData? = nil,
+        filter: TopListViewModel.Filter? = nil,
+    ) {
+        let configuration = TopListCardConfiguration(
+            item: selection.item,
+            metric: selection.metric
+        )
+        self._viewModel = StateObject(wrappedValue: TopListViewModel(
+            configuration: configuration,
+            dateRange: dateRange,
+            service: service,
+            tracker: context.tracker,
+            fetchLimit: nil, // Get all items
+            filter: filter,
+            initialData: initialData
+        ))
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: Constants.step4) {
+                headerView
+                    .background(Color(.secondarySystemBackground).opacity(0.7))
+                    .cardStyle()
+                    .dynamicTypeSize(...DynamicTypeSize.xLarge)
+                    .accessibilityElement(children: .contain)
+                    .padding(.horizontal, Constants.step1)
+
+                VStack {
+                    listHeaderView
+                        .padding(.horizontal, Constants.step1)
+                        .dynamicTypeSize(...DynamicTypeSize.xLarge)
+                    listContentView
+                        .grayscale(viewModel.isStale ? 1 : 0)
+                        .animation(.smooth, value: viewModel.isStale)
+                }
+                .padding(.horizontal, Constants.cardHorizontalInset(for: horizontalSizeClass))
+            }
+            .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
+            .padding(.vertical, Constants.step2)
+            .frame(maxWidth: horizontalSizeClass == .regular ? Constants.maxHortizontalWidthPlainLists : .infinity)
+            .frame(maxWidth: .infinity)
+            .animation(.spring, value: viewModel.data.map(ObjectIdentifier.init))
+        }
+        .background(Color(.systemBackground))
+        .navigationTitle(viewModel.selection.item.localizedTitle)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItemGroup(placement: .navigationBarTrailing) {
+                if horizontalSizeClass == .regular {
+                    StatsDateRangeButtons(dateRange: $viewModel.dateRange)
+                }
+                Menu {
+                    if let data = viewModel.data, !data.items.isEmpty {
+                        ShareLink(
+                            item: CSVDataRepresentation(
+                                items: data.items,
+                                metric: viewModel.selection.metric,
+                                fileName: generateCSVFilename()
+                            ),
+                            preview: SharePreview(
+                                generateCSVFilename(),
+                                image: Image(systemName: "doc.text")
+                            )
+                        ) {
+                            Label(Strings.Buttons.downloadCSV, systemImage: "square.and.arrow.down")
+                        }
+                    } else {
+                        Button(action: {}) {
+                            Label(Strings.Buttons.downloadCSV, systemImage: "square.and.arrow.down")
+                        }
+                        .disabled(true)
+                    }
+                } label: {
+                    Image(systemName: "ellipsis")
+                }
+                .accessibilityLabel(Strings.Accessibility.moreOptions)
+            }
+        }
+        .onAppear {
+            viewModel.onAppear()
+        }
+        .safeAreaInset(edge: .bottom) {
+            if horizontalSizeClass == .compact {
+                LegacyFloatingDateControl(dateRange: $viewModel.dateRange)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var headerView: some View {
+        HStack(alignment: .center, spacing: Constants.step1) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(viewModel.selection.item.getTitle(for: viewModel.selection.metric))
+                    .font(.headline)
+                    .foregroundColor(.primary)
+                Text(context.formatters.dateRange.string(from: viewModel.dateRange.dateInterval))
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
+
+            // Always show the metrics view to preserve identity
+            metricsOverviewView(data: viewModel.data ?? mockData)
+                .redacted(reason: viewModel.isFirstLoad ? .placeholder : [])
+                .pulsating(viewModel.isFirstLoad)
+                .animation(.smooth, value: viewModel.isFirstLoad)
+        }
+        .padding(.vertical, Constants.step2)
+        .padding(.horizontal, Constants.step3)
+    }
+
+    private var listHeaderView: some View {
+        HStack {
+            Text(viewModel.selection.item.localizedTitle)
+                .font(.subheadline)
+                .fontWeight(.medium)
+
+            Spacer()
+
+            Text(viewModel.selection.metric.localizedTitle)
+                .font(.subheadline)
+                .fontWeight(.medium)
+        }
+    }
+
+    @ViewBuilder
+    private func metricsOverviewView(data: TopListData) -> some View {
+        let formattedValue = StatsValueFormatter(metric: data.metric)
+            .format(value: data.metrics.total)
+        let trend = TrendViewModel(
+            currentValue: data.metrics.total,
+            previousValue: data.metrics.previousTotal,
+            metric: data.metric
+        )
+
+        VStack(alignment: .trailing, spacing: 0) {
+            Text(formattedValue)
+                .contentTransition(.numericText())
+                .font(Font.make(.recoleta, textStyle: .title, weight: .medium))
+                .foregroundColor(.primary)
+                .lineLimit(1)
+                .animation(.spring, value: formattedValue)
+
+            Text(trend.formattedTrendShort2)
+                .font(.system(.subheadline, design: .rounded, weight: .medium)).tracking(-0.2)
+                .foregroundStyle(trend.sentiment.foregroundColor)
+                .padding(.top, -4)
+        }
+    }
+
+    @ViewBuilder
+    private var listContentView: some View {
+        if viewModel.isFirstLoad {
+            itemsListView(data: mockData)
+                .redacted(reason: .placeholder)
+                .pulsating()
+        } else if let data = viewModel.data {
+            if data.items.isEmpty {
+                makeEmptyStateView(message: Strings.Chart.empty)
+            } else {
+                itemsListView(data: data)
+            }
+        } else {
+            makeEmptyStateView(message: viewModel.loadingError?.localizedDescription ?? Strings.Errors.generic)
+        }
+    }
+
+    private func itemsListView(data: TopListData) -> some View {
+        VStack(spacing: Constants.step0_5) {
+            ForEach(data.items, id: \.id) { item in
+                TopListItemView(
+                    item: item,
+                    previousValue: data.previousItem(for: item)?.metrics[viewModel.selection.metric],
+                    metric: viewModel.selection.metric,
+                    maxValue: data.metrics.maxValue,
+                    dateRange: viewModel.dateRange
+                )
+                .frame(height: TopListItemView.defaultCellHeight)
+            }
+        }
+    }
+
+    private func makeEmptyStateView(message: String) -> some View {
+        itemsListView(data: mockData)
+            .redacted(reason: .placeholder)
+            .grayscale(1)
+            .opacity(0.25)
+            .overlay {
+                SimpleErrorView(message: message)
+            }
+    }
+
+    private var mockData: TopListData {
+        TopListData.mock(
+            for: viewModel.selection.item,
+            metric: viewModel.selection.metric,
+            itemCount: 10
+        )
+    }
+
+    // MARK: - CSV Export
+
+    private func generateCSVFilename() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        let dateString = dateFormatter.string(from: Date())
+
+        let itemName = viewModel.selection.item.localizedTitle
+            .replacingOccurrences(of: " ", with: "_")
+            .replacingOccurrences(of: "&", with: "and")
+
+        let metricName = viewModel.selection.metric.localizedTitle
+            .replacingOccurrences(of: " ", with: "_")
+
+        return "\(itemName)_\(metricName)_\(dateString).csv"
+    }
+}
+
+#Preview {
+    NavigationStack {
+        TopListScreenView(
+            selection: .init(item: .postsAndPages, metric: .views),
+            dateRange: Calendar.demo.makeDateRange(for: .last28Days),
+            service: MockStatsService(),
+            context: .demo
+        )
+    }
+}

--- a/Modules/Sources/JetpackStats/Views/Customization/ChartCardCustomizationView.swift
+++ b/Modules/Sources/JetpackStats/Views/Customization/ChartCardCustomizationView.swift
@@ -1,0 +1,120 @@
+import SwiftUI
+
+struct ChartCardCustomizationView: View {
+    let chartViewModel: ChartCardViewModel
+
+    @State private var selectedMetrics: Set<SiteMetric> = []
+    @State private var metrics: [SiteMetric] = []
+    @State private var editMode: EditMode = .active
+
+    @ScaledMetric private var iconWidth = 26
+
+    @Environment(\.context) var context
+    @Environment(\.dismiss) var dismiss
+
+    var body: some View {
+        List {
+            ForEach(metrics, id: \.self) { metric in
+                metricRow(metric: metric)
+            }
+            .onMove { from, to in
+                metrics.move(fromOffsets: from, toOffset: to)
+            }
+
+            // Reset Settings button at the bottom
+            Section {
+                Button(action: resetToDefaults) {
+                    Text(Strings.Buttons.resetSettings)
+                        .foregroundColor(.red)
+                        .frame(maxWidth: .infinity, alignment: .center)
+
+                }
+                .padding(.top, 12)
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+            }
+        }
+        .listStyle(.plain)
+        .environment(\.editMode, $editMode)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(Strings.Buttons.cancel) {
+                    chartViewModel.isEditing = false
+                    dismiss()
+                }
+            }
+
+            ToolbarItem(placement: .navigationBarTrailing) {
+                if !selectedMetrics.isEmpty {
+                    Button(Strings.Buttons.done) {
+                        // Convert selected metrics to array in the order they appear in metrics
+                        let orderedSelectedMetrics = metrics.filter { selectedMetrics.contains($0) }
+
+                            // Update existing chart configuration
+                        var updatedConfig = chartViewModel.configuration
+                        updatedConfig.metrics = orderedSelectedMetrics
+                        chartViewModel.updateConfiguration(updatedConfig)
+                        chartViewModel.isEditing = false
+
+                        dismiss()
+                    }
+                    .fontWeight(.semibold)
+                }
+            }
+        }
+        .onAppear {
+            metrics = context.service.supportedMetrics
+
+            // If editing existing chart, pre-select its current metrics
+            selectedMetrics = Set(chartViewModel.metrics)
+
+            // Reorder metrics to put selected ones first in their current order
+            let currentMetrics = chartViewModel.metrics
+            let otherMetrics = metrics.filter { !currentMetrics.contains($0) }
+            metrics = currentMetrics + otherMetrics
+        }
+    }
+
+    private func metricRow(metric: SiteMetric) -> some View {
+        Button(action: {
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                if selectedMetrics.contains(metric) {
+                    selectedMetrics.remove(metric)
+                } else {
+                    selectedMetrics.insert(metric)
+                }
+            }
+        }) {
+            HStack(spacing: Constants.step0_5) {
+                Image(systemName: selectedMetrics.contains(metric) ? "checkmark.circle.fill" : "circle")
+                    .font(.title3)
+                    .foregroundColor(selectedMetrics.contains(metric) ? .accentColor : Color(.tertiaryLabel))
+                    .padding(.trailing, 8)
+
+                Image(systemName: metric.systemImage)
+                    .font(.subheadline)
+                    .frame(width: iconWidth)
+
+                Text(metric.localizedTitle)
+                    .font(.body)
+                    .foregroundColor(.primary)
+
+                Spacer()
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func resetToDefaults() {
+        // Get default metrics from service (excluding downloads)
+        let defaultMetrics = context.service.supportedMetrics.filter { $0 != .downloads }
+
+        // Update selected metrics
+        selectedMetrics = Set(defaultMetrics)
+
+        // Update the metrics array order to show default metrics first
+        let otherMetrics = metrics.filter { !defaultMetrics.contains($0) }
+        metrics = defaultMetrics + otherMetrics
+    }
+}

--- a/Modules/Sources/JetpackStats/Views/Customization/TopListCardCustomizationView.swift
+++ b/Modules/Sources/JetpackStats/Views/Customization/TopListCardCustomizationView.swift
@@ -1,0 +1,103 @@
+import SwiftUI
+
+struct TopListCardCustomizationView: View {
+    let viewModel: TopListViewModel
+
+    @State private var selectedItem: TopListItemType?
+    @State private var searchText = ""
+    @State private var editMode: EditMode = .active
+
+    @ScaledMetric private var iconWidth = 26
+
+    @Environment(\.context) var context
+    @Environment(\.dismiss) var dismiss
+
+    init(viewModel: TopListViewModel) {
+        self.viewModel = viewModel
+        self._selectedItem = State(initialValue: viewModel.configuration.item)
+    }
+
+    var body: some View {
+        List {
+            if !searchText.isEmpty {
+                filteredItemsList
+            } else {
+                ForEach(viewModel.items) { item in
+                    itemRow(item: item)
+                }
+            }
+        }
+        .listStyle(.plain)
+        .environment(\.editMode, $editMode)
+        .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always))
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button(Strings.Buttons.cancel) {
+                    viewModel.isEditing = false
+                    dismiss()
+                }
+            }
+        }
+        .onChange(of: selectedItem) { newValue in
+            if let newValue {
+                updateConfiguration(with: newValue)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var filteredItemsList: some View {
+        let filteredItems = viewModel.items.filter { item in
+            item.localizedTitle.localizedCaseInsensitiveContains(searchText)
+        }
+
+        ForEach(filteredItems) { item in
+            itemRow(item: item)
+        }
+    }
+
+    private func itemRow(item: TopListItemType) -> some View {
+        Button(action: {
+            withAnimation(.spring(response: 0.3, dampingFraction: 0.7)) {
+                selectedItem = item
+            }
+        }) {
+            HStack(spacing: Constants.step0_5) {
+                Image(systemName: item.systemImage)
+                    .font(.subheadline)
+                    .frame(width: iconWidth)
+
+                Text(item.localizedTitle)
+                    .font(.body)
+                    .foregroundColor(.primary)
+
+                Spacer()
+
+                Image(systemName: selectedItem == item ? "checkmark.circle.fill" : "circle")
+                    .font(.title3)
+                    .foregroundColor(selectedItem == item ? .accentColor : Color(.tertiaryLabel))
+                    .padding(.trailing, 8)
+                    .opacity(selectedItem == item ? 1 : 0) // Reserve space
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func updateConfiguration(with item: TopListItemType) {
+        var updatedConfig = viewModel.configuration
+        updatedConfig.item = item
+
+        // Adjust metric if current metric is not supported for the new item
+        let supportedMetrics = context.service.getSupportedMetrics(for: item)
+        if !supportedMetrics.contains(updatedConfig.metric),
+           let firstMetric = supportedMetrics.first {
+            updatedConfig.metric = firstMetric
+        }
+
+        viewModel.updateConfiguration(updatedConfig)
+        viewModel.isEditing = false
+
+        dismiss()
+    }
+}

--- a/Modules/Sources/JetpackStats/Views/EditCardMenuContent.swift
+++ b/Modules/Sources/JetpackStats/Views/EditCardMenuContent.swift
@@ -1,0 +1,52 @@
+import SwiftUI
+
+struct EditCardMenuContent: View {
+    let cardViewModel: TrafficCardViewModel
+
+    var body: some View {
+        Section {
+            Menu {
+                ControlGroup {
+                    Button {
+                        cardViewModel.configurationDelegate?.moveCard(cardViewModel, direction: .up)
+                    } label: {
+                        Label(Strings.Buttons.moveUp, systemImage: "arrow.up")
+                    }
+
+                    Button {
+                        cardViewModel.configurationDelegate?.moveCard(cardViewModel, direction: .top)
+                    } label: {
+                        Label(Strings.Buttons.moveToTop, systemImage: "arrow.up.to.line")
+                    }
+                }
+
+                ControlGroup {
+                    Button {
+                        cardViewModel.configurationDelegate?.moveCard(cardViewModel, direction: .down)
+                    } label: {
+                        Label(Strings.Buttons.moveDown, systemImage: "arrow.down")
+                    }
+
+                    Button {
+                        cardViewModel.configurationDelegate?.moveCard(cardViewModel, direction: .bottom)
+                    } label: {
+                        Label(Strings.Buttons.moveToBottom, systemImage: "arrow.down.to.line")
+                    }
+                }
+            } label: {
+                Label(Strings.Buttons.moveCard, systemImage: "arrow.up.arrow.down")
+            }
+            Button {
+                cardViewModel.isEditing = true
+            } label: {
+                Label(Strings.Buttons.customize, systemImage: "widget.small")
+            }
+            Button(role: .destructive) {
+                cardViewModel.configurationDelegate?.deleteCard(cardViewModel)
+            } label: {
+                Label(Strings.Buttons.deleteWidget, systemImage: "trash")
+                    .tint(Color.red)
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds the actual cards. The cards load the data and manage its presentation. The more challenging bit was to get it to stagger the reloads in the case the user taps quickly on "backward" or "forward" button.

I put both charts in the same PR as there are many similarities between them.

This PR also contains `StandaloneChartCard` which is used on the `PostStatsView`. This component could be improved as there is likely something to reuse with the other cards.

I also included `TopListScreenView` that opened when you tap "Show All" on the "Top List" card:

<img width="380" alt="Screenshot 2025-08-05 at 11 24 37 AM" src="https://github.com/user-attachments/assets/49eb83e3-0c33-4a5d-a548-ca0b1a205bc4" />
