### PR TITLE
Stats Review: Add StatsMainView with its tabs (P13)

### DIFF
--- a/Modules/Sources/JetpackStats/Cards/RealtimeMetricsCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/RealtimeMetricsCard.swift
@@ -1,0 +1,128 @@
+import SwiftUI
+
+struct RealtimeMetricsCard: View {
+    @State private var activeVisitors = 420
+    @State private var visitorsLast30Min = 1280
+    @State private var viewsLast30Min = 3720
+    @State private var isPulsing = false
+
+    @ScaledMetric(relativeTo: .caption) private var pulseCircleSize: CGFloat = 6
+
+    let timer = Timer.publish(every: 3, on: .main, in: .common).autoconnect()
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 20) {
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(spacing: 0) {
+                    Text("Realtime")
+                        .font(.headline)
+                        .foregroundColor(.primary)
+                    Circle()
+                        .fill(Color.green)
+                        .frame(width: pulseCircleSize, height: pulseCircleSize)
+                        .scaleEffect(isPulsing ? 1.2 : 0.8)
+                        .opacity(isPulsing ? 0.4 : 0.8)
+                        .animation(.easeInOut(duration: 2.0).repeatForever(autoreverses: true), value: isPulsing)
+                        .padding(.leading, 8)
+
+                    Spacer()
+                }
+
+                Text("Last 30 minutes")
+                    .font(.subheadline.smallCaps()).fontWeight(.medium)
+                    .foregroundColor(.secondary)
+            }
+
+            HStack(spacing: 16) {
+                realtimeStatRow(
+                    systemImage: SiteMetric.views.systemImage,
+                    label: SiteMetric.views.localizedTitle,
+                    value: viewsLast30Min.formatted(.number.notation(.compactName))
+                )
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("\(SiteMetric.views.localizedTitle), \(viewsLast30Min.formatted())")
+
+                realtimeStatRow(
+                    systemImage: SiteMetric.visitors.systemImage,
+                    label: SiteMetric.visitors.localizedTitle,
+                    value: visitorsLast30Min.formatted(.number.notation(.compactName))
+                )
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("\(SiteMetric.visitors.localizedTitle), \(visitorsLast30Min.formatted())")
+
+                realtimeStatRow(
+                    systemImage: SiteMetric.visitors.systemImage,
+                    label: Strings.SiteMetrics.visitorsNow,
+                    value: activeVisitors.formatted(.number.notation(.compactName))
+                )
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel(Strings.Accessibility.visitorsNow(activeVisitors))
+            }
+        }
+        .padding()
+        .onAppear {
+            isPulsing = true
+        }
+        .onReceive(timer) { _ in
+            updateRealtimeStats()
+        }
+    }
+
+    private func realtimeStatRow(systemImage: String, label: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            VStack(alignment: .leading, spacing: 4) {
+                Image(systemName: systemImage)
+                    .font(.caption2.weight(.medium))
+                    .foregroundColor(.secondary)
+                    .accessibilityHidden(true)
+
+                Text(label.uppercased())
+                    .font(.caption.weight(.medium))
+                    .foregroundColor(.secondary)
+            }
+
+            Text(value)
+                .contentTransition(.numericText())
+                .animation(.spring, value: value)
+                .font(Font.make(.recoleta, textStyle: .title, weight: .medium))
+                .foregroundColor(.primary)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func updateRealtimeStats() {
+        withAnimation(.easeInOut(duration: 0.3)) {
+            // Active visitors: typically 300-600 with small variations
+            let activeVariation = Int.random(in: -30...30)
+            activeVisitors = max(100, min(800, activeVisitors + activeVariation))
+
+            // Visitors in last 30 min: typically 1000-2000, smoother changes
+            let visitorVariation = Int.random(in: -50...80)
+            visitorsLast30Min = max(500, min(3000, visitorsLast30Min + visitorVariation))
+
+            // Views in last 30 min: typically 3000-5000, more volatile
+            let viewsVariation = Int.random(in: -150...200)
+            viewsLast30Min = max(1000, min(8000, viewsLast30Min + viewsVariation))
+
+            // Occasionally simulate traffic spikes (5% chance)
+            if Int.random(in: 1...20) == 1 {
+                activeVisitors += Int.random(in: 50...150)
+                visitorsLast30Min += Int.random(in: 200...400)
+                viewsLast30Min += Int.random(in: 500...1000)
+            }
+
+            // Occasionally simulate traffic drops (5% chance)
+            if Int.random(in: 1...20) == 20 {
+                activeVisitors = max(100, activeVisitors - Int.random(in: 50...100))
+                visitorsLast30Min = max(500, visitorsLast30Min - Int.random(in: 100...300))
+                viewsLast30Min = max(1000, viewsLast30Min - Int.random(in: 300...600))
+            }
+        }
+    }
+}
+
+#Preview {
+    RealtimeMetricsCard()
+        .padding()
+        .background(Constants.Colors.background)
+}

--- a/Modules/Sources/JetpackStats/Cards/RealtimeTopListCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/RealtimeTopListCard.swift
@@ -1,0 +1,164 @@
+import SwiftUI
+
+struct RealtimeTopListCard: View {
+    let availableItems: [TopListItemType]
+
+    @StateObject private var viewModel: RealtimeTopListCardViewModel
+    @State private var selectedItem: TopListItemType
+
+    @Environment(\.context) var context
+
+    init(
+        availableDataTypes: [TopListItemType] = TopListItemType.allCases,
+        initialDataType: TopListItemType = .postsAndPages,
+        service: any StatsServiceProtocol
+    ) {
+        self.availableItems = availableDataTypes
+
+        let selectedItem = availableDataTypes.contains(initialDataType) ? initialDataType : availableDataTypes.first ?? .postsAndPages
+        self._selectedItem = State(initialValue: selectedItem)
+
+        let viewModel = RealtimeTopListCardViewModel(service: service)
+        self._viewModel = StateObject(wrappedValue: viewModel)
+
+        viewModel.loadData(for: selectedItem)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack {
+                StatsCardTitleView(title: selectedItem.getTitle(for: .views))
+                    .unredacted()
+                Spacer()
+            }
+            .padding(.horizontal, Constants.step2)
+
+            VStack(spacing: 12) {
+                headerView
+                    .padding(.horizontal, Constants.step2)
+                    .unredacted()
+                contentView
+            }
+        }
+        .padding(.vertical, Constants.step3)
+        .redacted(reason: viewModel.isFirstLoad ? .placeholder : [])
+        .onChange(of: selectedItem) { newValue in
+            viewModel.loadData(for: newValue)
+        }
+    }
+
+    private var headerView: some View {
+        HStack {
+            Menu {
+                ForEach(availableItems) { dataType in
+                    Button {
+                        // Temporarily solution while there are animation isseus with Menu on iOS 26
+                        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
+                            selectedItem = dataType
+                        }
+                    } label: {
+                        Label(dataType.localizedTitle, systemImage: dataType.systemImage)
+                    }
+                }
+                .tint(Color.primary)
+            } label: {
+                InlineValuePickerTitle(title: selectedItem.localizedTitle)
+            }
+            .fixedSize()
+
+            Spacer()
+
+            Text("Views")
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    @ViewBuilder
+    private var contentView: some View {
+        Group {
+            if viewModel.isFirstLoad {
+                loadingView
+            } else if let data = viewModel.topListData {
+                topListItemsView(data: data)
+            } else if let error = viewModel.loadingError {
+                loadingView
+                    .redacted(reason: .placeholder)
+                    .opacity(0.1)
+                    .overlay {
+                        SimpleErrorView(error: error)
+                    }
+            }
+        }
+        .animation(.spring, value: selectedItem)
+    }
+
+    private func topListItemsView(data: TopListResponse) -> some View {
+        let chartData = TopListData(
+            item: selectedItem,
+            metric: .views,
+            items: data.items,
+            previousItems: [:] // No previous data for realtime
+        )
+
+        return TopListItemsView(
+            data: chartData,
+            itemLimit: 6,
+            dateRange: context.calendar.makeDateRange(for: .today)
+        )
+    }
+
+    private var loadingView: some View {
+        topListItemsView(data: mockData)
+    }
+
+    private var mockData: TopListResponse {
+        let chartData = TopListData.mock(
+            for: selectedItem,
+            metric: .views,
+            itemCount: 6
+        )
+        return TopListResponse(items: chartData.items)
+    }
+
+}
+
+// MARK: - Preview
+
+#Preview {
+    ScrollView {
+        VStack(spacing: 20) {
+            // Posts & Pages
+            RealtimeTopListCard(
+                availableDataTypes: [.postsAndPages],
+                initialDataType: .postsAndPages,
+                service: MockStatsService()
+            )
+            .padding()
+            .background(Color(.systemBackground))
+            .cornerRadius(12)
+
+            // Referrers
+            RealtimeTopListCard(
+                availableDataTypes: [.referrers],
+                initialDataType: .referrers,
+                service: MockStatsService()
+            )
+            .padding()
+            .background(Color(.systemBackground))
+            .cornerRadius(12)
+
+            // Locations
+            RealtimeTopListCard(
+                availableDataTypes: [.locations],
+                initialDataType: .locations,
+                service: MockStatsService()
+            )
+            .padding()
+            .background(Color(.systemBackground))
+            .cornerRadius(12)
+        }
+        .padding()
+    }
+    .background(Color(.systemGroupedBackground))
+}

--- a/Modules/Sources/JetpackStats/Cards/RealtimeTopListCardViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/RealtimeTopListCardViewModel.swift
@@ -1,0 +1,60 @@
+import SwiftUI
+
+@MainActor
+final class RealtimeTopListCardViewModel: ObservableObject {
+    @Published var topListData: TopListResponse?
+    @Published var isLoading = true
+    @Published var loadingError: Error?
+
+    private let service: any StatsServiceProtocol
+    private var realtimeTimer: Task<Void, Never>?
+    private var currentDataType: TopListItemType?
+
+    var isFirstLoad: Bool { isLoading && topListData == nil }
+
+    init(service: any StatsServiceProtocol) {
+        self.service = service
+        startRealtimeUpdates()
+    }
+
+    deinit {
+        realtimeTimer?.cancel()
+    }
+
+    func loadData(for dataType: TopListItemType) {
+        currentDataType = dataType
+
+        Task {
+            await actuallyLoadData(dataType: dataType)
+        }
+    }
+
+    private func actuallyLoadData(dataType: TopListItemType) async {
+        isLoading = true
+        loadingError = nil
+
+        do {
+            let response = try await service.getRealtimeTopListData(dataType)
+            topListData = response
+        } catch {
+            loadingError = error
+            topListData = nil
+        }
+
+        isLoading = false
+    }
+
+    private func startRealtimeUpdates() {
+        realtimeTimer = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: .seconds(2))
+                guard let self, !Task.isCancelled else { break }
+
+                // Trigger a reload with the current state
+                if let dataType = self.currentDataType {
+                    await self.actuallyLoadData(dataType: dataType)
+                }
+            }
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Screens/InsightsTabView.swift
+++ b/Modules/Sources/JetpackStats/Screens/InsightsTabView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct InsightsTabView: View {
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                Text("Insights")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                    .padding(.top, 20)
+
+                Text("Coming Soon")
+                    .font(.headline)
+                    .foregroundColor(.secondary)
+
+                Spacer(minLength: 100)
+            }
+            .padding()
+        }
+    }
+}
+
+#Preview {
+    InsightsTabView()
+}

--- a/Modules/Sources/JetpackStats/Screens/RealtimeTabView.swift
+++ b/Modules/Sources/JetpackStats/Screens/RealtimeTabView.swift
@@ -1,0 +1,62 @@
+import SwiftUI
+
+struct RealtimeTabView: View {
+    @Environment(\.context) var context
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @ScaledMetric private var maxWidth = 720
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: Constants.step3) {
+                realtimeStatsCard
+                Text("Showing Mock Data")
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(.secondary)
+                    .frame(maxWidth: .infinity, alignment: .center)
+                realtimeTopPosts
+                realtimeTopReferrers
+                realtimeTopLocations
+            }
+            .padding(.horizontal, Constants.cardHorizontalInset(for: horizontalSizeClass))
+            .padding(.vertical, Constants.step2)
+            .frame(maxWidth: maxWidth, alignment: .center)
+            .frame(maxWidth: maxWidth)
+        }
+        .background(Constants.Colors.background)
+    }
+
+    private var realtimeStatsCard: some View {
+        RealtimeMetricsCard()
+            .cardStyle()
+    }
+
+    private var realtimeTopPosts: some View {
+        RealtimeTopListCard(
+            initialDataType: .postsAndPages,
+            service: context.service
+        )
+        .cardStyle()
+    }
+
+    private var realtimeTopReferrers: some View {
+        RealtimeTopListCard(
+            initialDataType: .referrers,
+            service: context.service
+        )
+        .cardStyle()
+    }
+
+    private var realtimeTopLocations: some View {
+        RealtimeTopListCard(
+            initialDataType: .locations,
+            service: context.service
+        )
+        .cardStyle()
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    RealtimeTabView()
+}

--- a/Modules/Sources/JetpackStats/Screens/StatsMainView.swift
+++ b/Modules/Sources/JetpackStats/Screens/StatsMainView.swift
@@ -1,0 +1,104 @@
+import SwiftUI
+
+public struct StatsMainView: View {
+    @StateObject private var viewModel: StatsViewModel
+
+    @State private var selectedTab = StatsTab.traffic
+    @State private var isTabBarBackgroundShown = true
+
+    private let context: StatsContext
+    private let router: StatsRouter
+    private let showTabs: Bool
+
+    public init(context: StatsContext, router: StatsRouter, showTabs: Bool = true) {
+        self.context = context
+        self.router = router
+        self.showTabs = showTabs
+
+        let viewModel = StatsViewModel(context: context)
+        self._viewModel = StateObject(wrappedValue: viewModel)
+    }
+
+    public var body: some View {
+        if showTabs {
+            tabContent
+                .id(selectedTab)
+                .trackScrollOffset(isScrolling: $isTabBarBackgroundShown)
+                .toolbarBackground(.hidden, for: .navigationBar)
+                .safeAreaInset(edge: .top) {
+                    StatsTabBar(selectedTab: $selectedTab, showBackground: isTabBarBackgroundShown)
+                }
+                .background(Constants.Colors.background)
+                .navigationTitle(Strings.stats)
+                .navigationBarTitleDisplayMode(.inline)
+                .environment(\.context, context)
+                .environment(\.router, router)
+                .onAppear {
+                    context.tracker?.send(.statsMainScreenShown)
+                }
+                .onChange(of: selectedTab) { newValue in
+                    trackTabChange(from: selectedTab, to: newValue)
+                }
+        } else {
+            // When tabs are hidden, show only traffic tab without the tab bar
+            TrafficTabView(viewModel: viewModel, topPadding: Constants.step1)
+                .background(Constants.Colors.background)
+                .environment(\.context, context)
+                .environment(\.router, router)
+                .onAppear {
+                    context.tracker?.send(.statsMainScreenShown)
+                }
+        }
+    }
+
+    @ViewBuilder
+    private var tabContent: some View {
+        switch selectedTab {
+        case .traffic:
+            TrafficTabView(viewModel: viewModel)
+                .onAppear {
+                    context.tracker?.send(.trafficTabShown)
+                }
+        case .realtime:
+            RealtimeTabView()
+                .onAppear {
+                    context.tracker?.send(.realtimeTabShown)
+                }
+        case .insights:
+            InsightsTabView()
+        case .subscribers:
+            SubscribersTabView()
+                .onAppear {
+                    context.tracker?.send(.subscribersTabShown)
+                }
+        }
+    }
+
+    private func trackTabChange(from oldTab: StatsTab, to newTab: StatsTab) {
+        context.tracker?.send(.statsTabSelected, properties: [
+            "tab_name": newTab.analyticsName,
+            "previous_tab": oldTab.analyticsName
+        ])
+    }
+}
+
+#Preview {
+    PreviewStatsMainView()
+        .ignoresSafeArea()
+}
+
+private struct PreviewStatsMainView: UIViewControllerRepresentable {
+
+    func makeUIViewController(context: Context) -> UINavigationController {
+        let navigationController = UINavigationController()
+        let router = StatsRouter(viewController: navigationController, factory: MockStatsRouterScreenFactory())
+        let view = StatsMainView(context: .demo, router: router)
+        let hostingController = UIHostingController(rootView: view)
+        navigationController.viewControllers = [hostingController]
+        return navigationController
+    }
+
+    func updateUIViewController(_ uiViewController: UINavigationController, context: Context) {
+        // No update needed
+    }
+}

--- a/Modules/Sources/JetpackStats/Screens/SubscribersTabView.swift
+++ b/Modules/Sources/JetpackStats/Screens/SubscribersTabView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct SubscribersTabView: View {
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 16) {
+                Text("Subscribers")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                    .padding(.top, 20)
+
+                Text("Coming Soon")
+                    .font(.headline)
+                    .foregroundColor(.secondary)
+
+                Spacer(minLength: 100)
+            }
+            .padding()
+        }
+    }
+}
+
+#Preview {
+    SubscribersTabView()
+}

--- a/Modules/Sources/JetpackStats/Screens/TrafficTabView.swift
+++ b/Modules/Sources/JetpackStats/Screens/TrafficTabView.swift
@@ -1,0 +1,157 @@
+import SwiftUI
+
+struct TrafficTabView: View {
+    @ObservedObject var viewModel: StatsViewModel
+
+    @State private var isShowingCustomRangePicker = false
+    @State private var isShowingAddCardSheet = false
+
+    @Environment(\.context) var context
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+
+    // Temporary workaround while we are still showing this in the existing UIKit screens.
+    private let topPadding: CGFloat
+
+    init(viewModel: StatsViewModel, topPadding: CGFloat = 0) {
+        self.viewModel = viewModel
+        self.topPadding = topPadding
+    }
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView {
+                VStack(spacing: Constants.step3) {
+                    cards
+                    buttonAddChart
+                    timeZoneInfo
+                }
+                .padding(.vertical, Constants.step2 + (horizontalSizeClass == .regular ? Constants.step1 : 0))
+                .padding(.horizontal, Constants.cardHorizontalInset(for: horizontalSizeClass))
+                .padding(.top, topPadding)
+                .onReceive(viewModel.scrollToCardSubject) { cardID in
+                    // Use a more elegant spring animation for scrolling
+                    withAnimation(.spring) {
+                        proxy.scrollTo(cardID, anchor: .top)
+                    }
+                }
+            }
+            .background(Constants.Colors.background)
+            .animation(.spring, value: viewModel.cards.map(\.id))
+            .listStyle(.plain)
+        }
+        .toolbar {
+            if horizontalSizeClass == .regular {
+                ToolbarItemGroup(placement: .navigationBarTrailing) {
+                    StatsDateRangeButtons(dateRange: $viewModel.dateRange)
+                }
+            }
+        }
+        .safeAreaInset(edge: .bottom) {
+            if horizontalSizeClass == .compact {
+                LegacyFloatingDateControl(dateRange: $viewModel.dateRange)
+            }
+        }
+        .sheet(isPresented: $isShowingCustomRangePicker) {
+            CustomDateRangePicker(dateRange: $viewModel.dateRange)
+        }
+    }
+
+    @ViewBuilder
+    private var cards: some View {
+        if horizontalSizeClass == .regular {
+            var cards = viewModel.cards
+            if let first = cards.first as? ChartCardViewModel {
+                let _ = cards.removeFirst()
+                cardView(for: first)
+            }
+            HStack(alignment: .top, spacing: Constants.step2) {
+                VStack(spacing: Constants.step3) {
+                    ForEach(Array(cards.enumerated()), id: \.element.id) { index, card in
+                        if index % 2 == 0 {
+                            cardView(for: card)
+                        }
+                    }
+                }
+                VStack(spacing: Constants.step3) {
+                    ForEach(Array(cards.enumerated()), id: \.element.id) { index, card in
+                        if index % 2 == 1 {
+                            cardView(for: card)
+                        }
+                    }
+                }
+            }
+        } else {
+            ForEach(viewModel.cards, id: \.id) { card in
+                cardView(for: card)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func makeItem(for viewModel: TrafficCardViewModel) -> some View {
+        switch viewModel {
+        case let viewModel as ChartCardViewModel:
+            ChartCard(viewModel: viewModel)
+        case let viewModel as TopListViewModel:
+            TopListCard(viewModel: viewModel)
+        default:
+            let _ = assertionFailure("Unsupported type: \(viewModel)")
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private func cardView(for card: TrafficCardViewModel) -> some View {
+        makeItem(for: card)
+            .id(card.id)
+            .transition(.asymmetric(
+                insertion: .push(from: .bottom).combined(with: .opacity),
+                removal: .scale.combined(with: .opacity)
+            ))
+    }
+
+    // MARK: - Misc
+
+    private var buttonAddChart: some View {
+        // Add Chart Button
+        Button(action: {
+            isShowingAddCardSheet = true
+        }) {
+            HStack(spacing: Constants.step1) {
+                Image(systemName: "plus")
+                    .font(.headline)
+                Text(Strings.Buttons.addCard)
+                    .font(.headline)
+            }
+            .foregroundColor(.secondary)
+            .padding(3)
+        }
+        .accessibilityLabel(Strings.Accessibility.addCardButton)
+        .dynamicTypeSize(...DynamicTypeSize.xLarge)
+        .buttonStyle(.bordered)
+        .buttonBorderShape(.capsule)
+        .popover(isPresented: $isShowingAddCardSheet) {
+            AddCardSheet { cardType in
+                viewModel.addCard(type: cardType)
+            }
+            .dynamicTypeSize(...DynamicTypeSize.xLarge)
+            .modifier(PopoverPresentationModifier())
+        }
+    }
+
+    private var timeZoneInfo: some View {
+        TimezoneInfoView()
+            .padding(.horizontal, Constants.step4)
+            .padding(.top, Constants.step2)
+            .padding(.bottom, Constants.step1)
+            .dynamicTypeSize(...DynamicTypeSize.xLarge)
+    }
+}
+
+#Preview {
+    NavigationView {
+        TrafficTabView(viewModel: StatsViewModel(context: .demo))
+    }
+    .environment(\.context, .demo)
+    .environment(\.router, StatsRouter(viewController: UINavigationController(), factory: MockStatsRouterScreenFactory()))
+}

--- a/Modules/Sources/JetpackStats/StatsViewModel.swift
+++ b/Modules/Sources/JetpackStats/StatsViewModel.swift
@@ -1,0 +1,285 @@
+import SwiftUI
+import Combine
+import UIKit
+
+@MainActor
+final class StatsViewModel: ObservableObject, CardConfigurationDelegate {
+    @Published var trafficCardConfiguration: TrafficCardConfiguration
+    @Published var dateRange: StatsDateRange {
+        didSet {
+            updateViewModelsDateRange()
+            saveSelectedDateRangePreset()
+        }
+    }
+    @Published private(set) var cards: [any TrafficCardViewModel] = []
+
+    let scrollToCardSubject = PassthroughSubject<UUID, Never>()
+
+    let context: StatsContext
+
+    private let userDefaults: UserDefaults
+    private let configurationKey = "JetpackStatsTrafficConfiguration"
+    private let dateRangePresetKey = "JetpackStatsSelectedDateRangePreset"
+
+    init(context: StatsContext, userDefaults: UserDefaults = .standard) {
+        self.context = context
+        self.userDefaults = userDefaults
+
+        // Try to load the saved preset, otherwise use the initial date range
+        if let savedPreset = Self.loadDateRangePreset(from: userDefaults, key: dateRangePresetKey) {
+            self.dateRange = context.calendar.makeDateRange(for: savedPreset)
+        } else {
+            self.dateRange = context.calendar.makeDateRange(for: .last7Days)
+        }
+
+        self.trafficCardConfiguration = Self.loadConfiguration(
+            from: userDefaults,
+            key: configurationKey,
+            context: context
+        )
+        configureCards()
+    }
+
+    func saveConfiguration() {
+        guard let data = try? JSONEncoder().encode(trafficCardConfiguration) else { return }
+        userDefaults.set(data, forKey: configurationKey)
+    }
+
+    func resetToDefault() {
+        trafficCardConfiguration = makeDefaultConfiguration()
+        userDefaults.removeObject(forKey: configurationKey)
+    }
+
+    private static func loadConfiguration(from userDefaults: UserDefaults, key: String, context: StatsContext) -> TrafficCardConfiguration {
+        guard let data = userDefaults.data(forKey: key),
+              let configuration = try? JSONDecoder().decode(TrafficCardConfiguration.self, from: data) else {
+            return makeDefaultConfiguration(context: context)
+        }
+        return configuration
+    }
+
+    private static func makeDefaultConfiguration(context: StatsContext) -> TrafficCardConfiguration {
+        // Get available metrics from service, excluding downloads
+        let availableMetrics = context.service.supportedMetrics
+
+        var cards: [TrafficCardConfiguration.Card] = [
+            .chart(ChartCardConfiguration(metrics: availableMetrics))
+        ]
+
+        if UIDevice.current.userInterfaceIdiom == .pad { // Has more space
+            cards += [
+                .topList(TopListCardConfiguration(item: .postsAndPages, metric: .views)),
+                .topList(TopListCardConfiguration(item: .referrers, metric: .views)),
+                .topList(TopListCardConfiguration(item: .searchTerms, metric: .views)),
+                .topList(TopListCardConfiguration(item: .locations, metric: .views)),
+                .topList(TopListCardConfiguration(item: .externalLinks, metric: .views)),
+                .topList(TopListCardConfiguration(item: .authors, metric: .views)),
+            ]
+        } else {
+            cards += [
+                .topList(TopListCardConfiguration(item: .postsAndPages, metric: .views)),
+                .topList(TopListCardConfiguration(item: .referrers, metric: .views)),
+                .topList(TopListCardConfiguration(item: .locations, metric: .views))
+            ]
+        }
+
+        return TrafficCardConfiguration(cards: cards)
+    }
+
+    private func makeDefaultConfiguration() -> TrafficCardConfiguration {
+        Self.makeDefaultConfiguration(context: context)
+    }
+
+    private func configureCards() {
+        cards = trafficCardConfiguration.cards.compactMap { card in
+            createViewModel(for: card)
+        }
+    }
+
+    private func createViewModel(for card: TrafficCardConfiguration.Card) -> TrafficCardViewModel? {
+        let viewModel: TrafficCardViewModel?
+
+        switch card {
+        case .chart(let configuration):
+            viewModel = ChartCardViewModel(
+                configuration: configuration,
+                dateRange: dateRange,
+                service: context.service,
+                tracker: context.tracker
+            )
+        case .topList(let configuration):
+            viewModel = TopListViewModel(
+                configuration: configuration,
+                dateRange: dateRange,
+                service: context.service,
+                tracker: context.tracker
+            )
+        }
+
+        viewModel?.configurationDelegate = self
+        return viewModel
+    }
+
+    private func updateViewModelsDateRange() {
+        for card in cards {
+            card.dateRange = dateRange
+        }
+    }
+
+    // MARK: - Adding Cards
+
+    func addCard(type: AddCardType) {
+        let card = makeCard(type: type)
+        trafficCardConfiguration.cards.append(card)
+        saveConfiguration()
+
+        // Track card added event
+        context.tracker?.send(.cardAdded, properties: ["card_type": cardType(for: card)])
+
+        // Create and append the view model
+        if let viewModel = createViewModel(for: card) {
+            cards.append(viewModel)
+
+            // Enable editing after a short delay to allow the card to be added and scrolled to
+            Task {
+                try? await Task.sleep(for: .milliseconds(500))
+                scrollToCardSubject.send(viewModel.id)
+                try? await Task.sleep(for: .milliseconds(500))
+                viewModel.isEditing = true
+            }
+        }
+    }
+
+    private func makeCard(type: AddCardType) -> TrafficCardConfiguration.Card {
+        switch type {
+        case .chart:
+            let configuration = ChartCardConfiguration(metrics: context.service.supportedMetrics)
+            return TrafficCardConfiguration.Card.chart(configuration)
+        case .topList:
+            let configuration = TopListCardConfiguration(item: .postsAndPages, metric: .views)
+            return TrafficCardConfiguration.Card.topList(configuration)
+        }
+    }
+
+    // MARK: - CardConfigurationDelegate
+
+    func saveConfiguration(for card: any TrafficCardViewModel) {
+        // Find the index of the card in configuration
+        guard let index = trafficCardConfiguration.cards.firstIndex(where: { $0.id == card.id }) else { return }
+
+        // Update the configuration based on the card type
+        switch card {
+        case let chartViewModel as ChartCardViewModel:
+            trafficCardConfiguration.cards[index] = .chart(chartViewModel.configuration)
+        case let topListViewModel as TopListViewModel:
+            trafficCardConfiguration.cards[index] = .topList(topListViewModel.configuration)
+        default:
+            assertionFailure("Unknown card type")
+        }
+
+        saveConfiguration()
+    }
+
+    func deleteCard(_ card: any TrafficCardViewModel) {
+        // Track card removed event
+        context.tracker?.send(.cardRemoved, properties: ["card_type": cardType(for: card)])
+
+        // Find and remove the card from configuration using the protocol's id property
+        trafficCardConfiguration.cards.removeAll { $0.id == card.id }
+
+        // Remove the card from the view models array
+        cards.removeAll { $0.id == card.id }
+
+        saveConfiguration()
+    }
+
+    func moveCard(_ card: any TrafficCardViewModel, direction: MoveDirection) {
+        // Find the index of the card in both arrays
+        guard let currentIndex = cards.firstIndex(where: { $0.id == card.id }),
+              let configIndex = trafficCardConfiguration.cards.firstIndex(where: { $0.id == card.id }) else {
+            return
+        }
+
+        let newIndex: Int
+        switch direction {
+        case .up:
+            newIndex = max(0, currentIndex - 1)
+        case .down:
+            newIndex = min(cards.count - 1, currentIndex + 1)
+        case .top:
+            newIndex = 0
+        case .bottom:
+            newIndex = cards.count - 1
+        }
+
+        // If the position hasn't changed, return early
+        if newIndex == currentIndex {
+            return
+        }
+
+        // Move in cards array
+        let movedCard = cards.remove(at: currentIndex)
+        cards.insert(movedCard, at: newIndex)
+
+        // Move in configuration array
+        let movedConfigCard = trafficCardConfiguration.cards.remove(at: configIndex)
+        trafficCardConfiguration.cards.insert(movedConfigCard, at: newIndex)
+
+        saveConfiguration()
+
+        // Scroll to the moved card after a short delay
+        Task {
+            try? await Task.sleep(for: .milliseconds(250))
+            scrollToCardSubject.send(card.id)
+        }
+    }
+
+    // MARK: - Date Range Persistence
+
+    private func saveSelectedDateRangePreset() {
+        if let preset = dateRange.preset {
+            userDefaults.set(preset.rawValue, forKey: dateRangePresetKey)
+        } else {
+            userDefaults.removeObject(forKey: dateRangePresetKey)
+        }
+    }
+
+    private static func loadDateRangePreset(from userDefaults: UserDefaults, key: String) -> DateIntervalPreset? {
+        guard let rawValue = userDefaults.string(forKey: key),
+              let preset = DateIntervalPreset(rawValue: rawValue) else {
+            return nil
+        }
+        return preset
+    }
+
+    // MARK: - Reset Settings
+
+    /// Resets all persistently stored settings including card configuration and date range preset
+    func resetAllSettings() {
+        // Reset card configuration
+        resetToDefault()
+
+        // Reset date range preset
+        userDefaults.removeObject(forKey: dateRangePresetKey)
+
+        // Reset date range to default
+        dateRange = context.calendar.makeDateRange(for: .last7Days)
+    }
+
+    // MARK: - Helper Methods
+
+    private func cardType(for card: TrafficCardConfiguration.Card) -> String {
+        switch card {
+        case .chart: return "chart"
+        case .topList: return "top_list"
+        }
+    }
+
+    private func cardType(for viewModel: any TrafficCardViewModel) -> String {
+        switch viewModel {
+        case is ChartCardViewModel: return "chart"
+        case is TopListViewModel: return "top_list"
+        default: return "unknown"
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Views/CustomDateRangePicker.swift
+++ b/Modules/Sources/JetpackStats/Views/CustomDateRangePicker.swift
@@ -1,0 +1,273 @@
+import SwiftUI
+
+struct CustomDateRangePicker: View {
+    @Binding var dateRange: StatsDateRange
+
+    @State private var startDate: Date
+    @State private var endDate: Date
+
+    @Environment(\.dismiss) private var dismiss
+    @Environment(\.context) private var context
+
+    init(dateRange: Binding<StatsDateRange>) {
+        self._dateRange = dateRange
+        let interval = dateRange.wrappedValue.dateInterval
+        self._startDate = State(initialValue: interval.start)
+        // The app uses inclusive date periods (e.g., Jan 1 00:00 to Jan 2 00:00 represents all of Jan 1).
+        // For DatePicker, we subtract 1 second to ensure the end date shows as the last day of the range
+        // (e.g., Jan 1 instead of Jan 2). The time component is irrelevant since we only pick dates.
+        self._endDate = State(initialValue: interval.end.addingTimeInterval(-1))
+    }
+
+    private var calendar: Calendar {
+        context.calendar
+    }
+
+    var body: some View {
+        NavigationView {
+            ScrollView {
+                contents
+            }
+            .background(Constants.Colors.background)
+            .navigationTitle(Strings.DatePicker.customRange)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(Strings.Buttons.cancel) { dismiss() }
+                        .tint(Color.primary)
+                }
+
+                ToolbarItem(placement: .confirmationAction) {
+                    Button(Strings.Buttons.apply) { buttonApplyTapped() }
+                        .fontWeight(.semibold)
+                        .buttonStyle(.borderedProminent)
+                        .buttonBorderShape(.capsule)
+                        .tint(Color.primary)
+                }
+            }
+        }
+        .presentationDetents([.medium, .large])
+        .presentationDragIndicator(.visible)
+    }
+
+    @ViewBuilder
+    private var contents: some View {
+        VStack(spacing: 16) {
+            VStack(spacing: 16) {
+                dateSelectionSection
+                currentSelectionHeader
+            }
+            .padding()
+            .cardStyle()
+            .padding(.horizontal, Constants.step1)
+
+            quickPeriodPicker
+                .padding()
+        }
+        .padding(.top, 16)
+        .dynamicTypeSize(...DynamicTypeSize.xLarge)
+    }
+
+    // MARK: - Actions
+
+    private func buttonApplyTapped() {
+        let interval = DateInterval(start: startDate, end: {
+            let date = calendar.startOfDay(for: endDate)
+            return calendar.date(byAdding: .day, value: 1, to: date) ?? date
+        }())
+        let component = calendar.determineNavigationComponent(for: interval) ?? .day
+        dateRange = StatsDateRange(interval: interval, component: component, comparison: dateRange.comparison, calendar: calendar)
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+
+        // Track custom date range selection
+        let dateFormatter = ISO8601DateFormatter()
+        dateFormatter.formatOptions = [.withFullDate]
+        context.tracker?.send(.customDateRangeSelected, properties: [
+            "start_date": dateFormatter.string(from: startDate),
+            "end_date": dateFormatter.string(from: endDate)
+        ])
+
+        dismiss()
+    }
+
+    // MARK: - View Components
+
+    private var currentSelectionHeader: some View {
+        VStack(spacing: 5) {
+            Text(formattedDateCount)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.secondary)
+                .contentTransition(.numericText())
+                .animation(.spring, value: formattedDateCount)
+            TimezoneInfoView()
+        }
+    }
+
+    private var formattedDateCount: String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.day]
+        formatter.unitsStyle = .full
+        formatter.calendar = calendar
+        formatter.maximumUnitCount = 1
+        return formatter.string(from: startDate, to: endDate.addingTimeInterval(1)) ?? ""
+    }
+
+    private var dateSelectionSection: some View {
+        HStack(alignment: .bottom, spacing: 0) {
+            datePickerColumn(label: Strings.DatePicker.from.uppercased(), selection: $startDate, alignment: .leading)
+                .onChange(of: startDate) { newValue in
+                    // If start date is after end date, adjust end date to be one day after start
+                    if newValue > endDate {
+                        endDate = calendar.date(byAdding: .day, value: 1, to: newValue) ?? newValue
+                    }
+                }
+
+            Spacer(minLength: 32)
+
+            datePickerColumn(label: Strings.DatePicker.to.uppercased(), selection: $endDate, alignment: .trailing)
+                .onChange(of: endDate) { newValue in
+                    // If end date is before start date, adjust start date to be one day before end
+                    if newValue < startDate {
+                        startDate = calendar.date(byAdding: .day, value: -1, to: newValue) ?? newValue
+                    }
+                }
+        }
+        .overlay(alignment: .bottom) {
+            Image(systemName: "arrow.forward")
+                .font(.headline.weight(.bold))
+                .foregroundColor(.secondary)
+                .padding(.bottom, 10)
+        }
+    }
+
+    private func datePickerColumn(label: String, selection: Binding<Date>, alignment: HorizontalAlignment) -> some View {
+        VStack(alignment: alignment, spacing: 8) {
+            Text(label)
+                .font(.caption)
+                .foregroundColor(.secondary)
+                .textCase(.uppercase)
+
+            DatePicker("", selection: selection, displayedComponents: .date)
+                .labelsHidden()
+                .datePickerStyle(.compact)
+                .fixedSize()
+                .environment(\.timeZone, context.timeZone)
+        }
+        .lineLimit(1)
+    }
+
+    // MARK: - Quick Periods
+
+    struct QuickPeriod: Identifiable {
+        var id: String { name }
+        let name: String
+        let action: () -> Void
+        let datePreview: String
+    }
+
+    private var quickPeriods: [QuickPeriod] {
+        return [
+            makeQuickPeriod(named: Strings.Calendar.week, component: .weekOfYear),
+            makeQuickPeriod(named: Strings.Calendar.month, component: .month),
+            makeQuickPeriod(named: Strings.Calendar.quarter, component: .quarter),
+            makeQuickPeriod(named: Strings.Calendar.year, component: .year),
+        ].compactMap { $0 }
+    }
+
+    private func makeQuickPeriod(named name: String, component: Calendar.Component) -> QuickPeriod? {
+        guard let interval = calendar.dateInterval(of: component, for: startDate) else {
+            return nil
+        }
+        return QuickPeriod(
+            name: name,
+            action: { selectQuickPeriod(component) },
+            datePreview: context.formatters.dateRange.string(from: interval)
+        )
+    }
+
+    private var quickPeriodPicker: some View {
+        VStack(spacing: 12) {
+            Text(Strings.DatePicker.quickPeriodsForStartDate)
+                .font(.footnote)
+                .foregroundColor(.secondary)
+
+            LazyVGrid(columns: [
+                GridItem(.flexible(), spacing: 12),
+                GridItem(.flexible(), spacing: 12)
+            ], spacing: 12) {
+                ForEach(quickPeriods) { period in
+                    QuickPeriodButtonView(period: period)
+                }
+            }
+        }
+    }
+
+    private func selectQuickPeriod(_ component: Calendar.Component) {
+        guard let interval = calendar.dateInterval(of: component, for: startDate) else {
+            assertionFailure("invalid interval")
+            return
+        }
+        startDate = interval.start
+        // Same adjustment as in init: subtract 1 second for DatePicker display
+        endDate = interval.end.addingTimeInterval(-1)
+    }
+}
+
+private struct QuickPeriodButtonView: View {
+    let period: CustomDateRangePicker.QuickPeriod
+
+    var body: some View {
+        Button {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            period.action()
+        } label: {
+            VStack(spacing: 4) {
+                Text(period.name)
+                    .font(.callout.weight(.medium))
+                Text(period.datePreview)
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+                    .contentTransition(.numericText())
+                    .animation(.spring, value: period.datePreview)
+            }
+            .lineLimit(1)
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 12)
+            .padding(.horizontal, 8)
+            .background(Color(.tertiarySystemFill))
+            .cornerRadius(12)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+#Preview {
+    struct PreviewContainer: View {
+        @State private var showingPicker = true
+        @State private var dateRange = Calendar.demo.makeDateRange(for: .today)
+
+        var body: some View {
+            ZStack {
+                Color(.systemBackground)
+                    .ignoresSafeArea()
+
+                VStack {
+                    Text("Main View")
+                        .font(.largeTitle)
+
+                    Button("Show Date Picker") {
+                        showingPicker = true
+                    }
+                    .buttonStyle(.borderedProminent)
+                }
+            }
+            .sheet(isPresented: $showingPicker) {
+                CustomDateRangePicker(dateRange: $dateRange)
+                    .presentationDetents([.medium, .large])
+                    .presentationDragIndicator(.visible)
+            }
+        }
+    }
+
+    return PreviewContainer()
+}

--- a/Modules/Sources/JetpackStats/Views/Customization/AddCardSheet.swift
+++ b/Modules/Sources/JetpackStats/Views/Customization/AddCardSheet.swift
@@ -1,0 +1,76 @@
+import SwiftUI
+
+enum AddCardType {
+    case chart
+    case topList
+}
+
+struct AddCardSheet: View {
+    let onCardTypeSelected: (AddCardType) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: Constants.step1) {
+            cardTypeSelection
+        }
+
+    }
+
+    private var cardTypeSelection: some View {
+        VStack(spacing: Constants.step0_5) {
+            cardTypeButton(
+                title: Strings.AddChart.chartOption,
+                subtitle: Strings.AddChart.chartDescription,
+                icon: "chart.line.uptrend.xyaxis",
+                color: Constants.Colors.blue,
+                action: {
+                    onCardTypeSelected(.chart)
+                    dismiss()
+                }
+            )
+
+            cardTypeButton(
+                title: Strings.AddChart.topListOption,
+                subtitle: Strings.AddChart.topListDescription,
+                icon: "list.number",
+                color: Constants.Colors.purple,
+                action: {
+                    onCardTypeSelected(.topList)
+                    dismiss()
+                }
+            )
+        }
+        .padding(Constants.step1)
+    }
+
+    private func cardTypeButton(title: String, subtitle: String, icon: String, color: Color, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            HStack(spacing: Constants.step1) {
+                ZStack {
+                    RoundedRectangle(cornerRadius: 10)
+                        .fill(color.opacity(0.1))
+                        .frame(width: 40, height: 40)
+
+                    Image(systemName: icon)
+                        .font(.body)
+                        .foregroundColor(color)
+                }
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(title)
+                        .font(.callout.weight(.semibold))
+                        .foregroundColor(.primary)
+                    Text(subtitle)
+                        .font(.caption2)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+            }
+            .padding(.horizontal, Constants.step1)
+            .padding(.vertical, Constants.step0_5)
+            .background(Color(UIColor.secondarySystemGroupedBackground))
+            .clipShape(RoundedRectangle(cornerRadius: 10))
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Views/LegacyFloatingDateControl.swift
+++ b/Modules/Sources/JetpackStats/Views/LegacyFloatingDateControl.swift
@@ -1,0 +1,145 @@
+import SwiftUI
+
+/// A pre-Liquid Glass version.
+struct LegacyFloatingDateControl: View {
+    @Binding var dateRange: StatsDateRange
+    @State private var isShowingCustomRangePicker = false
+
+    private var buttonHeight: CGFloat { min(_buttonHeight, 60) }
+    @ScaledMetric private var _buttonHeight = 50
+
+    @Environment(\.context) var context
+
+    // MARK: - Body
+
+    var body: some View {
+        HStack(spacing: 0) {
+            dateRangeButton
+            Spacer(minLength: 8)
+            navigationControls
+        }
+        .dynamicTypeSize(...DynamicTypeSize.xLarge)
+        .padding(.horizontal, 24)
+        .background {
+            LinearGradient(
+                gradient: Gradient(colors: [
+                    Color(uiColor: .systemBackground).opacity(0.1),
+                    Color(uiColor: .systemBackground).opacity(0.8),
+                    Color(uiColor: .systemBackground).opacity(1)
+                ]),
+                startPoint: .top,
+                endPoint: .bottom
+            )
+            .offset(y: buttonHeight / 4)
+            .frame(height: buttonHeight * 2 + buttonHeight / 4)
+            .ignoresSafeArea()
+        }
+        .sheet(isPresented: $isShowingCustomRangePicker) {
+            CustomDateRangePicker(dateRange: $dateRange)
+        }
+    }
+
+    // MARK: - Date Range Picker
+
+    private var dateRangeButton: some View {
+        Menu {
+            StatsDateRangePickerMenu(
+                selection: $dateRange,
+                isShowingCustomRangePicker: $isShowingCustomRangePicker
+            )
+        } label: {
+            dateRangeButtonContent
+                .contentShape(Rectangle())
+                .frame(height: buttonHeight)
+                .floatingStyle()
+        }
+        .tint(Color.primary)
+        .menuOrder(.fixed)
+        .buttonStyle(.plain)
+    }
+
+    private var dateRangeButtonContent: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "calendar")
+                .font(.headline.weight(.regular))
+                .foregroundStyle(.primary.opacity(0.8))
+
+            VStack(alignment: .leading, spacing: 0) {
+                Text(currentRangeText)
+                    .fontWeight(.medium)
+                    .allowsTightening(true)
+            }
+        }
+        .lineLimit(1)
+        .padding(.horizontal, 15)
+        .padding(.trailing, 2)
+    }
+
+    private var currentRangeText: String {
+        if let preset = dateRange.preset, !preset.prefersDateIntervalFormatting {
+            return preset.localizedString
+        }
+        return context.formatters.dateRange
+            .string(from: dateRange.dateInterval)
+    }
+
+    // MARK: - Navigation Controls
+
+    private var navigationControls: some View {
+        HStack(spacing: 8) {
+            makeNavigationButton(direction: .backward)
+            makeNavigationButton(direction: .forward)
+        }
+        .floatingStyle()
+    }
+
+    private func makeNavigationButton(direction: Calendar.NavigationDirection) -> some View {
+        let isDisabled = !dateRange.canNavigate(in: direction)
+        return Menu {
+            ForEach(dateRange.availableAdjacentPeriods(in: direction)) { period in
+                Button(period.displayText) {
+                    dateRange = period.range
+                }
+            }
+        } label: {
+            Image(systemName: direction.systemImage)
+                .font(.title3.weight(.medium))
+                .foregroundColor(isDisabled ? Color(.quaternaryLabel) : Color(.label))
+                .frame(width: 48)
+                .frame(height: buttonHeight)
+                .opacity(isDisabled ? 0.5 : 1.0)
+                .contentShape(Rectangle())
+        } primaryAction: {
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+            dateRange = dateRange.navigate(direction)
+        }
+        .disabled(isDisabled)
+    }
+}
+
+private struct FloatingStyle: ViewModifier {
+    let cornerRadius: CGFloat
+
+    init(cornerRadius: CGFloat = 40) {
+        self.cornerRadius = cornerRadius
+    }
+
+    func body(content: Content) -> some View {
+        content
+            .background(Color(.systemBackground).opacity(0.2))
+            .background(Material.thin)
+            .overlay {
+                RoundedRectangle(cornerRadius: cornerRadius)
+                    .stroke(Color(.separator).opacity(0.2), lineWidth: 1)
+            }
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+            .shadow(color: Constants.Colors.shadowColor, radius: 8, x: 0, y: 4)
+            .shadow(color: Constants.Colors.shadowColor.opacity(0.5), radius: 4, x: 0, y: 2)
+    }
+}
+
+private extension View {
+    func floatingStyle(cornerRadius: CGFloat = 40) -> some View {
+        modifier(FloatingStyle(cornerRadius: cornerRadius))
+    }
+}

--- a/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
+++ b/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
@@ -1,0 +1,170 @@
+import SwiftUI
+import WordPressUI
+
+/// A horizontal scrollable tab view displaying metric summaries with values and trends.
+///
+/// Each tab shows a metric's current value, percentage change, and visual selection indicator.
+struct MetricsOverviewTabView: View {
+    /// Data for a single metric tab
+    struct MetricData {
+        let metric: SiteMetric
+        let value: Int?
+        let previousValue: Int?
+    }
+
+    let data: [MetricData]
+    @Binding var selectedMetric: SiteMetric
+    var onMetricSelected: ((SiteMetric) -> Void)?
+
+    @ScaledMetric(relativeTo: .title) private var minTabWidth: CGFloat = 100
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
+
+    var body: some View {
+        ScrollViewReader { proxy in
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 0) {
+                    ForEach(data, id: \.metric) { item in
+                        makeItemView(for: item) {
+                            selectDataType(item.metric, proxy: proxy)
+                        }
+                    }
+                }
+                .padding(.trailing, Constants.step1) // A bit extra after the last item
+                .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
+            }
+        }
+    }
+
+    private func makeItemView(for item: MetricData, onTap: @escaping () -> Void) -> some View {
+        MetricItemView(data: item, isSelected: selectedMetric == item.metric, onTap: onTap)
+            .frame(minWidth: minTabWidth + (horizontalSizeClass == .compact ? 0 : 20))
+            .id(item.metric)
+    }
+
+    private func selectDataType(_ type: SiteMetric, proxy: ScrollViewProxy) {
+        withAnimation(.spring) {
+            selectedMetric = type
+            proxy.scrollTo(type, anchor: .center)
+        }
+        UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+        onMetricSelected?(type)
+    }
+}
+
+private struct MetricItemView: View {
+    let data: MetricsOverviewTabView.MetricData
+    let isSelected: Bool
+    let onTap: () -> Void
+
+    private var valueFormatter: StatsValueFormatter {
+        StatsValueFormatter(metric: data.metric)
+    }
+
+    private var formattedValue: String {
+        guard let value = data.value else { return "–" }
+        return valueFormatter.format(value: value, context: .compact)
+    }
+
+    private var trend: TrendViewModel? {
+        guard let value = data.value, let previousValue = data.previousValue else { return nil }
+        return TrendViewModel(currentValue: value, previousValue: previousValue, metric: data.metric)
+    }
+
+    var body: some View {
+        Button(action: onTap) {
+            VStack(alignment: .leading, spacing: 0) {
+                selectionIndicator
+                    .padding(.leading, Constants.step2)
+                    .padding(.trailing, Constants.step1)
+                tabContent
+                    .padding(.top, Constants.step1 + 3)
+                    .padding(.bottom, Constants.step2 + 2)
+                    .padding(.leading, Constants.step3)
+                    .animation(.spring, value: isSelected)
+            }
+        }
+        .buttonStyle(.plain)
+    }
+
+    // MARK: - Private Views
+
+    private var tabContent: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            headerView
+                .unredacted()
+            metricsView
+        }
+    }
+
+    private var headerView: some View {
+        HStack(spacing: 2) {
+            Image(systemName: data.metric.systemImage)
+                .font(.caption2.weight(.medium))
+                .scaleEffect(x: 0.9, y: 0.9)
+            Text(data.metric.localizedTitle.uppercased())
+                .font(.caption.weight(.medium))
+        }
+        .foregroundColor(isSelected ? .primary : .secondary)
+        .animation(.easeInOut(duration: 0.25), value: isSelected)
+        .padding(.trailing, 4) // Visually spacing matters less than for metricsView
+    }
+
+    private var metricsView: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(formattedValue)
+                .contentTransition(.numericText())
+                .font(Font.make(.recoleta, textStyle: .title, weight: .medium))
+                .foregroundColor(.primary)
+                .lineLimit(1)
+                .animation(.spring, value: formattedValue)
+
+            if let trend {
+                BadgeTrendIndicator(trend: trend)
+            } else {
+                // Placeholder for loading state
+                BadgeTrendIndicator(
+                    trend: TrendViewModel(currentValue: 125, previousValue: 100, metric: data.metric)
+                )
+                .grayscale(1)
+                .redacted(reason: .placeholder)
+            }
+        }
+        .padding(.trailing, 8)
+    }
+
+    private var selectionIndicator: some View {
+        Rectangle()
+            .fill(Color.primary)
+            .frame(height: 3)
+            .cornerRadius(1.5)
+            .opacity(isSelected ? 1 : 0)
+            .scaleEffect(x: isSelected ? 1 : 0.75, anchor: .center)
+            .animation(.spring, value: isSelected)
+    }
+}
+
+// MARK: - Preview Support
+
+#if DEBUG
+
+#Preview {
+    let mockData: [MetricsOverviewTabView.MetricData] = [
+        .init(metric: .views, value: 128400, previousValue: 142600),
+        .init(metric: .visitors, value: 49800, previousValue: 54200),
+        .init(metric: .likes, value: nil, previousValue: nil),
+        .init(metric: .comments, value: 210, previousValue: nil),
+        .init(metric: .timeOnSite, value: 165, previousValue: 148),
+        .init(metric: .bounceRate, value: nil, previousValue: 72)
+    ]
+
+    MetricsOverviewTabView(
+        data: mockData,
+        selectedMetric: .constant(.views)
+    )
+    .background(Color(.systemBackground))
+    .cardStyle()
+    .frame(maxHeight: .infinity, alignment: .center)
+    .background(Constants.Colors.background)
+}
+
+#endif

--- a/Modules/Sources/JetpackStats/Views/StatsCardTitleView.swift
+++ b/Modules/Sources/JetpackStats/Views/StatsCardTitleView.swift
@@ -1,0 +1,83 @@
+import SwiftUI
+
+struct StatsCardTitleView: View {
+    let title: String
+    let showChevron: Bool
+
+    init(title: String, showChevron: Bool = false) {
+        self.title = title
+        self.showChevron = showChevron
+    }
+
+    var body: some View {
+        HStack(alignment: .center) {
+            content
+        }
+        .tint(Color.primary)
+        .lineLimit(1)
+        .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        let title = Text(title)
+            .font(.headline)
+            .foregroundColor(.primary)
+        if showChevron {
+            // Note: had to do that to fix the animation issuse with Menu
+            // hiding the image.
+            title + Text(" ") + Text(Image(systemName: "chevron.up.chevron.down"))
+                .font(.footnote.weight(.semibold))
+                .foregroundColor(.secondary)
+                .baselineOffset(1)
+        } else {
+            title
+        }
+    }
+}
+
+struct InlineValuePickerTitle: View {
+    let title: String
+
+    init(title: String) {
+        self.title = title
+    }
+
+    var body: some View {
+        HStack(alignment: .center) {
+            content
+        }
+        .tint(Color.primary)
+        .lineLimit(1)
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        let title = Text(title)
+            .font(.subheadline)
+            .fontWeight(.medium)
+
+        // Note: had to do that to fix the animation issuse with Menu
+        // hiding the image.
+        title + Text(" ") + Text(Image(systemName: "chevron.up.chevron.down"))
+            .font(.footnote.weight(.semibold))
+            .foregroundColor(.secondary)
+            .baselineOffset(1)
+    }
+}
+
+#Preview {
+    VStack(spacing: 20) {
+        StatsCardTitleView(title: "Posts & Pages", showChevron: true)
+            .padding()
+            .background(Color(.systemBackground))
+            .cornerRadius(12)
+
+        StatsCardTitleView(title: "Referrers", showChevron: false)
+            .padding()
+            .background(Color(.systemBackground))
+            .cornerRadius(12)
+    }
+    .padding()
+    .background(Color(.systemGroupedBackground))
+}

--- a/Modules/Sources/JetpackStats/Views/StatsDateRangeButtons.swift
+++ b/Modules/Sources/JetpackStats/Views/StatsDateRangeButtons.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+struct StatsDateRangeButtons: View {
+    @Binding var dateRange: StatsDateRange
+    @State private var isShowingCustomRangePicker = false
+
+    var body: some View {
+        Group {
+            StatsDatePickerToolbarItem(
+                dateRange: $dateRange,
+                isShowingCustomRangePicker: $isShowingCustomRangePicker
+            )
+            .modifier(ProminentMenuModifier())
+            .popover(isPresented: $isShowingCustomRangePicker) {
+                CustomDateRangePicker(dateRange: $dateRange)
+                    .frame(idealWidth: 360)
+            }
+            StatsNavigationButton(dateRange: $dateRange, direction: .backward)
+                .modifier(ProminentMenuModifier())
+            StatsNavigationButton(dateRange: $dateRange, direction: .forward)
+                .modifier(ProminentMenuModifier())
+        }
+
+    }
+}
+
+struct StatsDatePickerToolbarItem: View {
+    @Binding var dateRange: StatsDateRange
+    @Binding var isShowingCustomRangePicker: Bool
+
+    @Environment(\.context) var context
+
+    var body: some View {
+        Menu {
+            StatsDateRangePickerMenu(
+                selection: $dateRange,
+                isShowingCustomRangePicker: $isShowingCustomRangePicker
+            )
+        } label: {
+            Label(
+                context.formatters.dateRange.string(from: dateRange.dateInterval),
+                systemImage: "calendar"
+            )
+        }
+        .labelStyle(.titleAndIcon)
+        .menuOrder(.fixed)
+        .accessibilityLabel(Strings.Accessibility.dateRangeSelected(context.formatters.dateRange.string(from: dateRange.dateInterval)))
+        .accessibilityHint(Strings.Accessibility.selectDateRange)
+    }
+}
+
+struct StatsNavigationButton: View {
+    @Binding var dateRange: StatsDateRange
+    let direction: Calendar.NavigationDirection
+
+    var body: some View {
+        let isDisabled = !dateRange.canNavigate(in: direction)
+
+        Menu {
+            ForEach(dateRange.availableAdjacentPeriods(in: direction)) { period in
+                Button(period.displayText) {
+                    dateRange = period.range
+                }
+            }
+        } label: {
+            Image(systemName: direction.systemImage)
+                .foregroundStyle(isDisabled ? Color(.tertiaryLabel) : Color.primary)
+        } primaryAction: {
+            dateRange = dateRange.navigate(direction)
+        }
+        .opacity(isDisabled ? 0.5 : 1.0)
+        .disabled(isDisabled)
+        .accessibilityLabel(direction == .forward ? Strings.Accessibility.nextPeriod : Strings.Accessibility.previousPeriod)
+        .accessibilityHint(direction == .forward ? Strings.Accessibility.navigateToNextDateRange : Strings.Accessibility.navigateToPreviousDateRange)
+    }
+}
+
+private struct ProminentMenuModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        content
+            .tint(Color(.tertiaryLabel))
+            .foregroundStyle(.primary)
+            .menuStyle(.button)
+            .buttonStyle(.bordered)
+            .buttonBorderShape(.capsule)
+    }
+}

--- a/Modules/Sources/JetpackStats/Views/StatsDateRangePickerMenu.swift
+++ b/Modules/Sources/JetpackStats/Views/StatsDateRangePickerMenu.swift
@@ -1,0 +1,87 @@
+import SwiftUI
+
+struct StatsDateRangePickerMenu: View {
+    @Binding var selection: StatsDateRange
+    @Binding var isShowingCustomRangePicker: Bool
+
+    @Environment(\.context) var context
+
+    var body: some View {
+        Section {
+            Button {
+                isShowingCustomRangePicker = true
+            } label: {
+                Label(Strings.DatePicker.customRangeMenu, systemImage: "calendar")
+            }
+            comparisonPeriodPicker
+        }
+        Section {
+            makePresetButtons(for: [
+                .last7Days,
+                .last30Days,
+                .last12Months,
+            ])
+            Menu {
+                Section {
+                    makePresetButtons(for: [
+                        .last28Days,
+                        .last90Days,
+                        .last6Months,
+                        .last3Years,
+                        .last10Years
+                    ])
+                }
+            } label: {
+                Text(Strings.DatePicker.morePeriods)
+            }
+        }
+        Section {
+            makePresetButtons(for: [
+                .today,
+                .thisWeek,
+                .thisMonth,
+                .thisYear
+            ])
+        }
+    }
+
+    private func makePresetButtons(for presents: [DateIntervalPreset]) -> some View {
+        ForEach(presents) { preset in
+            Button(preset.localizedString) {
+                selection.update(preset: preset)
+                UIImpactFeedbackGenerator(style: .light).impactOccurred()
+
+                // Track preset selection
+                context.tracker?.send(.dateRangePresetSelected, properties: [
+                    "selected_preset": preset.analyticsName
+                ])
+            }
+        }
+    }
+
+    private var comparisonPeriodPicker: some View {
+        Menu {
+            ForEach(DateRangeComparisonPeriod.allCases) { period in
+                Button(action: {
+                    selection.update(comparisonPeriod: period)
+                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
+                }) {
+                    Text(period.localizedTitle)
+                    Text(formattedComparisonRange(for: period))
+                    if selection.comparison == period {
+                        Image(systemName: "checkmark")
+                    }
+                }
+                .lineLimit(1)
+            }
+        } label: {
+            Label(Strings.DatePicker.compareWith, systemImage: "arrow.left.arrow.right")
+        }
+    }
+
+    private func formattedComparisonRange(for period: DateRangeComparisonPeriod) -> String {
+        var copy = selection
+        copy.update(comparisonPeriod: period)
+        return context.formatters.dateRange.string(from: copy.effectiveComparisonInterval)
+    }
+}

--- a/Modules/Sources/JetpackStats/Views/StatsTabBar.swift
+++ b/Modules/Sources/JetpackStats/Views/StatsTabBar.swift
@@ -1,0 +1,95 @@
+import SwiftUI
+
+enum StatsTab: CaseIterable {
+    case traffic
+    case realtime
+    case insights
+    case subscribers
+
+    var localizedTitle: String {
+        switch self {
+        case .traffic: return Strings.Tabs.traffic
+        case .realtime: return Strings.Tabs.realtime
+        case .insights: return Strings.Tabs.insights
+        case .subscribers: return Strings.Tabs.subscribers
+        }
+    }
+
+    var analyticsName: String {
+        switch self {
+        case .traffic: return "traffic"
+        case .realtime: return "realtime"
+        case .insights: return "insights"
+        case .subscribers: return "subscribers"
+        }
+    }
+}
+
+struct StatsTabBar: View {
+    @Binding var selectedTab: StatsTab
+    var showBackground: Bool = true
+
+    var body: some View {
+        VStack(spacing: 0) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 18) {
+                    ForEach(StatsTab.allCases, id: \.self) { tab in
+                        tabButton(for: tab)
+                    }
+                }
+                .padding(.horizontal, Constants.step4)
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel(Strings.Accessibility.statsTabBar)
+            Divider()
+        }
+        .dynamicTypeSize(...DynamicTypeSize.xxLarge)
+        .padding(.top, 8)
+        .background {
+            backgroundView
+        }
+    }
+
+    @ViewBuilder
+    private func tabButton(for tab: StatsTab) -> some View {
+        Button(action: {
+            selectedTab = tab
+            UIImpactFeedbackGenerator(style: .soft).impactOccurred()
+            UIAccessibility.post(notification: .announcement, argument: Strings.Accessibility.tabSelected(tab.localizedTitle))
+        }) {
+            VStack(spacing: 8) {
+                ZStack {
+                    // Reserver enough space for the semibold version
+                    Text(tab.localizedTitle)
+                        .font(.headline.weight(.semibold))
+                        .foregroundColor(.primary)
+                        .opacity(selectedTab == tab ? 1 : 0)
+
+                    Text(tab.localizedTitle)
+                        .font(.headline.weight(.regular))
+                        .foregroundColor(.secondary)
+                        .opacity(selectedTab == tab ? 0 : 1)
+                }
+
+                Rectangle()
+                    .fill(selectedTab == tab ? Color.primary : Color.clear)
+                    .frame(height: 2)
+                    .cornerRadius(1.5)
+            }
+            .animation(.smooth, value: selectedTab)
+        }
+        .accessibilityLabel(tab.localizedTitle)
+        .accessibilityHint(Strings.Accessibility.selectTab(tab.localizedTitle))
+        .accessibilityAddTraits(selectedTab == tab ? [.isSelected] : [])
+    }
+
+    private var backgroundView: some View {
+        Rectangle()
+            .fill(Material.ultraThin)
+            .ignoresSafeArea(edges: .top)
+            .frame(maxHeight: .infinity)
+            .offset(y: -100)
+            .padding(.bottom, -100)
+            .opacity(showBackground ? 1 : 0)
+    }
+}


### PR DESCRIPTION
This PR adds `StatsMainView` and its tabs. It also includes some additional controls like the ones for date period selection.

**Note**: in the future, we will use `.toolbar` to show date period controls on iOS 26. It was not possible because `UIPageViewController` in the legacy `StatsViewController` breaks it.