### PR TITLE
build: Fix invalid Claude settings file

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,7 @@
       "Bash(tail:*)",
       "Bash(wc:*)",
       "Bash(tree:*)",
-      "Bash(git:log,status,diff,branch)",
+      "Bash(git:log,status,diff,branch)"
     ],
     "deny": []
   }


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
The trailing comma is invalid JSON and results in an error when starting
Claude within the project:

```
Found invalid settings files. They will be ignored. Run /doctor for details.
```

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
1. In your terminal, run `claude` within the project directory.
1. Verify the error no longer occurs.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
