### PR TITLE
Remove the 'nativeJetpackConnection' feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -24,7 +24,6 @@ public enum FeatureFlag: Int, CaseIterable {
     case selfHostedSiteUserManagement
     case readerGutenbergCommentComposer
     case pluginManagementOverhaul
-    case nativeJetpackConnection
     case newsletterSubscribers
 
     /// Returns a boolean indicating if the feature is enabled.
@@ -78,8 +77,6 @@ public enum FeatureFlag: Int, CaseIterable {
             return false
         case .pluginManagementOverhaul:
             return false
-        case .nativeJetpackConnection:
-            return BuildConfiguration.current == .debug
         case .newsletterSubscribers:
             return true
         }
@@ -123,7 +120,6 @@ extension FeatureFlag {
         case .selfHostedSiteUserManagement: "Self-hosted Site User Management"
         case .pluginManagementOverhaul: "Plugin Management Overhaul"
         case .readerGutenbergCommentComposer: "Gutenberg Comment Composer"
-        case .nativeJetpackConnection: "Native Jetpack Connection"
         case .newsletterSubscribers: "Newsletter Subscribers"
         }
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackConnectionViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackConnectionViewModel.swift
@@ -252,7 +252,7 @@ class JetpackConnectionService {
             }
         }
 
-        // Refresh the blog options, so that we can get the latest Jetpack related statues.
+        // Refresh the blog options, so that we can get the latest Jetpack related status.
         try await withCheckedThrowingContinuation { [blogId] (continuation: CheckedContinuation<Void, Error>) in
             DispatchQueue.main.async {
                 let blog: Blog

--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackConnectionViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackConnectionViewModel.swift
@@ -151,6 +151,7 @@ private enum JetpackConnectionError: LocalizedError {
 }
 
 class JetpackConnectionService {
+    private let blogId: TaggedManagedObjectID<Blog>
     private let client: WordPressClient
     private let jetpackConnectionClient: JetpackConnectionClient
 
@@ -174,6 +175,7 @@ class JetpackConnectionService {
             return nil
         }
 
+        self.blogId = TaggedManagedObjectID(blog)
         self.client = .init(site: site)
         self.jetpackConnectionClient = .init(
             apiRootUrl: apiRootURL,
@@ -246,6 +248,26 @@ class JetpackConnectionService {
                     isJetpackLogin: true,
                     onSuccess: { _ in continuation.resume(returning: ()) },
                     onFailure: { continuation.resume(throwing: $0) }
+                )
+            }
+        }
+
+        // Refresh the blog options, so that we can get the latest Jetpack related statues.
+        try await withCheckedThrowingContinuation { [blogId] (continuation: CheckedContinuation<Void, Error>) in
+            DispatchQueue.main.async {
+                let blog: Blog
+                do {
+                    blog = try ContextManager.shared.mainContext.existingObject(with: blogId)
+                } catch {
+                    continuation.resume(throwing: error)
+                    return
+                }
+
+                let service = BlogService(coreDataStack: ContextManager.shared)
+                service.syncBlog(
+                    blog,
+                    success: { continuation.resume(returning: ()) },
+                    failure: { continuation.resume(throwing: $0) }
                 )
             }
         }

--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackConnectionViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackConnectionViewModel.swift
@@ -160,11 +160,7 @@ class JetpackConnectionService {
         // - The site is authenticated with application password, and
         // - Jetpack is not installed, or the installed jetpack version is 14.2 or above.
 
-        guard FeatureFlag.nativeJetpackConnection.enabled else { return nil }
-
         guard blog.account == nil else { return nil }
-
-        guard (try? blog.getApplicationToken()) != nil else { return nil }
 
         if let jetpack = blog.jetpack, jetpack.isInstalled, let version = jetpack.version,
            // The `version` value is not a strict semantic version number.


### PR DESCRIPTION
## Description

Also fixed a bug where re-connecting a site to Jetpack does not immediately show the "Stats".

## Testing instructions

Turn on the "Allow creating application passwords" feature flag. Add a self-hosted site that is no connected to Jetpack yet. Go to "Stats". Verify that the new flow is used to connect the site.

<img width="400" src="https://github.com/user-attachments/assets/c27fa649-c066-46aa-86d2-47e07b93325d" />


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
