### PR TITLE
Add events for the new Jetpack connection flow

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -1793,21 +1793,21 @@ import WordPressShared
 
         // Jetpack Connection Flow
         case .jetpackConnectStarted:
-            return "jetpack_connect_started"
+            return "jetpack_rest_connect_started"
         case .jetpackConnectLogin:
-            return "jetpack_connect_login"
+            return "jetpack_rest_connect_login"
         case .jetpackConnectInstall:
-            return "jetpack_connect_install"
+            return "jetpack_rest_connect_install"
         case .jetpackConnectSiteConnection:
-            return "jetpack_connect_site_connection"
+            return "jetpack_rest_connect_site_connection"
         case .jetpackConnectUserConnection:
-            return "jetpack_connect_user_connection"
+            return "jetpack_rest_connect_user_connection"
         case .jetpackConnectFinalize:
-            return "jetpack_connect_finalize"
+            return "jetpack_rest_connect_finalize"
         case .jetpackConnectCompleted:
-            return "jetpack_connect_completed"
+            return "jetpack_rest_connect_completed"
         case .jetpackConnectStepRetried:
-            return "jetpack_connect_step_retried"
+            return "jetpack_rest_connect_step_retried"
         } // END OF SWITCH
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -659,6 +659,16 @@ import WordPressShared
     // Error Events
     case jetpackStatsErrorEncountered
 
+    // Jetpack Connection Flow
+    case jetpackConnectStarted
+    case jetpackConnectLogin
+    case jetpackConnectInstall
+    case jetpackConnectSiteConnection
+    case jetpackConnectUserConnection
+    case jetpackConnectFinalize
+    case jetpackConnectCompleted
+    case jetpackConnectStepRetried
+
     /// A String that represents the event
     var value: String {
         switch self {
@@ -1780,6 +1790,24 @@ import WordPressShared
         // Error Events
         case .jetpackStatsErrorEncountered:
             return "jetpack_stats_error_encountered"
+
+        // Jetpack Connection Flow
+        case .jetpackConnectStarted:
+            return "jetpack_connect_started"
+        case .jetpackConnectLogin:
+            return "jetpack_connect_login"
+        case .jetpackConnectInstall:
+            return "jetpack_connect_install"
+        case .jetpackConnectSiteConnection:
+            return "jetpack_connect_site_connection"
+        case .jetpackConnectUserConnection:
+            return "jetpack_connect_user_connection"
+        case .jetpackConnectFinalize:
+            return "jetpack_connect_finalize"
+        case .jetpackConnectCompleted:
+            return "jetpack_connect_completed"
+        case .jetpackConnectStepRetried:
+            return "jetpack_connect_step_retried"
         } // END OF SWITCH
     }
 

--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackConnectionViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackConnectionViewModel.swift
@@ -81,7 +81,7 @@ class JetpackConnectionViewModel: ObservableObject {
             WPAnalytics.track(currentStep.event, properties: [
                 "state": "failed",
                 "error_domain": (error as NSError).domain,
-                "error_code":  (error as NSError).code
+                "error_code": (error as NSError).code
             ])
         }
     }

--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackConnectionViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackConnectionViewModel.swift
@@ -34,6 +34,7 @@ class JetpackConnectionViewModel: ObservableObject {
     func connect() {
         guard !isConnecting else { return }
 
+        WPAnalytics.track(.jetpackConnectStarted)
         isConnecting = true
         Task {
             await processCurrentStep()
@@ -42,6 +43,10 @@ class JetpackConnectionViewModel: ObservableObject {
 
     private func processCurrentStep() async {
         stepStages[currentStep] = .processing
+
+        WPAnalytics.track(currentStep.event, properties: [
+            "state": "started"
+        ])
 
         do {
             switch currentStep {
@@ -59,14 +64,25 @@ class JetpackConnectionViewModel: ObservableObject {
 
             stepStages[currentStep] = .success
 
+            WPAnalytics.track(currentStep.event, properties: [
+                "state": "completed"
+            ])
+
             if let nextStep = self.nextStep() {
                 currentStep = nextStep
                 await processCurrentStep()
             } else {
                 isCompleted = true
+                WPAnalytics.track(.jetpackConnectCompleted)
             }
         } catch {
             stepStages[currentStep] = .error(error.localizedDescription)
+
+            WPAnalytics.track(currentStep.event, properties: [
+                "state": "failed",
+                "error_domain": (error as NSError).domain,
+                "error_code":  (error as NSError).code
+            ])
         }
     }
 
@@ -129,6 +145,9 @@ class JetpackConnectionViewModel: ObservableObject {
     }
 
     func retryCurrentStep() {
+        WPAnalytics.track(.jetpackConnectStepRetried, properties: [
+            "step": currentStep.event.value
+        ])
         stepStages[currentStep] = .pending
         Task {
             await processCurrentStep()
@@ -283,6 +302,21 @@ enum JetpackConnectionStep: Int, CaseIterable {
             Strings.stepUserConnectionTitle
         case .finalize:
             Strings.stepFinalizeTitle
+        }
+    }
+
+    var event: WPAnalyticsEvent {
+        switch self {
+        case .login:
+            return .jetpackConnectLogin
+        case .install:
+            return .jetpackConnectInstall
+        case .siteConnection:
+            return .jetpackConnectSiteConnection
+        case .userConnection:
+            return .jetpackConnectUserConnection
+        case .finalize:
+            return .jetpackConnectFinalize
         }
     }
 }


### PR DESCRIPTION
## Description

I only just noticed that I didn't add any events for the new connection flow. This PR adds some tracking.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
