### PR TITLE
Fix a crash in the notification service extension

### DIFF
--- a/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
+++ b/WordPress/WordPressNotificationServiceExtension/Sources/NotificationService.swift
@@ -16,7 +16,7 @@ class NotificationService: UNNotificationServiceExtension {
     // MARK: Properties
 
     /// Manages analytics calls via Tracks
-    private let tracks = Tracks()
+    private let tracks: Tracks
 
     /// The content handler received from the extension
     private var contentHandler: ((UNNotificationContent) -> Void)?
@@ -27,14 +27,16 @@ class NotificationService: UNNotificationServiceExtension {
     /// The service used to retrieve remote notifications
     private var notificationService: NotificationSyncServiceRemote?
 
-    private let configuration = BuildSettings.current.notificationServiceExtensionConfiguration
+    private let configuration: NotificationServiceExtensionConfiguration
 
-    private let appKeychainAccessGroup = BuildSettings.current.appKeychainAccessGroup
+    private let appKeychainAccessGroup: String
 
     override init() {
-        super.init()
-
         BuildSettings.configure(secrets: ApiCredentials.toSecrets())
+        tracks = Tracks()
+        configuration = BuildSettings.current.notificationServiceExtensionConfiguration
+        appKeychainAccessGroup = BuildSettings.current.appKeychainAccessGroup
+        super.init()
     }
 
     // MARK: UNNotificationServiceExtension


### PR DESCRIPTION
## Description

The cause is the same https://github.com/wordpress-mobile/WordPress-iOS/pull/24626.

## Testing instructions

The notification service extension adds details to notifications, like showing comment content in a "<someone> commented on <post>" notification.

To send a notification:
1. Sign in to a WP.com account from the Jetpack app.
2. Make sure the app notifications are turned on.
3. Go to the deivce's home screen.
4. Open a browser and post a comment on the site.
5. You should receive a notification on your device.
![notifications](https://github.com/user-attachments/assets/89f58ad5-c166-4f19-944d-11eb5aa338ab)


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
