### PR TITLE
Always load comment data when viewing comments from the notifications

### DIFF
--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
@@ -185,10 +185,6 @@ private extension NotificationCommentDetailViewController {
             }
 
             self.fetchParentCommentIfNeeded(completion: {
-                if let comment = self.loadCommentFromCache(self.commentID) {
-                    self.comment = comment
-                    return
-                }
                 self.fetchComment(self.commentID, completion: { comment in
                     guard let comment else {
                         self.showErrorView(title: NoResults.errorTitle, subtitle: NoResults.errorSubtitle)


### PR DESCRIPTION
## Description

Fix an issue where the comment details pages show incorrect data.

Steps to reproduce:
1. Sign in to a WP.com account.
2. Go to the Notifications tab and tap a comment notification. View the status.
3. Go back to the Notifications tab, swipe the same comment notification, and tap the "approve/unapprove" action.
4. Wait for a couple of seconds for the API request to complete.
5. Tap the same comment notification and view its details.

The comment status is expected to match the status after the "approve/unapprove" action.

## Testing instructions

Verify the issue is fixed.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
