### PR TITLE
fix: GutenbergKit uses correct REST API domain for application passwords

### DIFF
--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -858,14 +858,16 @@ private extension NewGutenbergViewController {
 extension EditorConfiguration {
     init(blog: Blog) {
         let selfHostedApiUrl = blog.restApiRootURL ?? blog.url(withPath: "wp-json/")
-        let isWPComSite = blog.isHostedAtWPcom || blog.isAtomic()
         let applicationPassword = try? blog.getApplicationToken()
+        let shouldUseWPComRestApi = applicationPassword == nil &&
+            blog.isAccessibleThroughWPCom() &&
+            (blog.isHostedAtWPcom || blog.isAtomic())
 
         let siteApiRoot: String?
         if applicationPassword != nil {
             siteApiRoot = selfHostedApiUrl
         } else {
-            siteApiRoot = blog.isAccessibleThroughWPCom() && isWPComSite ? blog.wordPressComRestApi?.baseURL.absoluteString : selfHostedApiUrl
+            siteApiRoot = shouldUseWPComRestApi ? blog.wordPressComRestApi?.baseURL.absoluteString : selfHostedApiUrl
         }
 
         let siteId = blog.dotComID?.stringValue
@@ -883,7 +885,7 @@ extension EditorConfiguration {
 
         // Must provide both namespace forms to detect usages of both forms in third-party code
         var siteApiNamespace: [String] = []
-        if isWPComSite && applicationPassword == nil {
+        if shouldUseWPComRestApi {
             if let siteId {
                 siteApiNamespace.append("sites/\(siteId)/")
             }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -859,13 +859,19 @@ extension EditorConfiguration {
     init(blog: Blog) {
         let selfHostedApiUrl = blog.restApiRootURL ?? blog.url(withPath: "wp-json/")
         let isWPComSite = blog.isHostedAtWPcom || blog.isAtomic()
-        let siteApiRoot = blog.isAccessibleThroughWPCom() && isWPComSite ? blog.wordPressComRestApi?.baseURL.absoluteString : selfHostedApiUrl
+        let applicationPassword = try? blog.getApplicationToken()
+
+        let siteApiRoot: String?
+        if applicationPassword != nil {
+            siteApiRoot = selfHostedApiUrl
+        } else {
+            siteApiRoot = blog.isAccessibleThroughWPCom() && isWPComSite ? blog.wordPressComRestApi?.baseURL.absoluteString : selfHostedApiUrl
+        }
+
         let siteId = blog.dotComID?.stringValue
         let siteDomain = blog.primaryDomainAddress
         let authToken = blog.authToken ?? ""
         var authHeader = "Bearer \(authToken)"
-
-        let applicationPassword = try? blog.getApplicationToken()
 
         if let appPassword = applicationPassword, let username = blog.username {
             let credentials = "\(username):\(appPassword)"
@@ -877,7 +883,7 @@ extension EditorConfiguration {
 
         // Must provide both namespace forms to detect usages of both forms in third-party code
         var siteApiNamespace: [String] = []
-        if isWPComSite {
+        if isWPComSite && applicationPassword == nil {
             if let siteId {
                 siteApiNamespace.append("sites/\(siteId)/")
             }


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Fix CMM-679.

The existing logic preferred application passwords over bearer tokens,
but did not apply same preference when setting the `siteApiRoot` domain.
The authentication header and root domain must be a compatible match in
order for authentication to succeed.

Failed authentication resulted in missing editor features and failed
upload requests.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
1. Log into a WordPress.com account that includes an Atomic (WoW) site.
1. Navigate to _Me_ → _App Settings_ → _Experimental Features_.
1. Enable the following experimental features:
  1. Allow creating Application Passwords
  1. Experimental Block Editor
1. Open the editor.
1. Insert an Image block.
1. Verify the _Upload_ button is present and uploading media succeeds.
1. Navigate to _My Site_ → _More_ → _Application passwords_.
1. Allow an application password to be created for the site.
1. Repeat steps 4-6.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
