### PR TITLE
Make sure the re-authentication flow is only for the current site

### DIFF
--- a/Sources/WordPressData/Swift/Blog+SelfHosted.swift
+++ b/Sources/WordPressData/Swift/Blog+SelfHosted.swift
@@ -226,4 +226,16 @@ public enum WordPressSite {
             return try context.existingObject(with: blogId)
         }
     }
+
+    public func blogId(in coreDataStack: CoreDataStack) -> TaggedManagedObjectID<Blog>? {
+        switch self {
+        case let .dotCom(siteId, _):
+            return coreDataStack.performQuery { context in
+                guard let blog = try? Blog.lookup(withID: siteId, in: context) else { return nil }
+                return TaggedManagedObjectID(blog)
+            }
+        case let .selfHosted(id, _, _, _):
+            return id
+        }
+    }
 }

--- a/WordPress/Classes/Networking/WordPressClient.swift
+++ b/WordPress/Classes/Networking/WordPressClient.swift
@@ -22,7 +22,7 @@ extension WordPressClient {
         // rather than using the shared one on disk).
         let session = URLSession(configuration: .ephemeral)
 
-        let notifier = AppNotifier()
+        let notifier = AppNotifier(site: site, coreDataStack: ContextManager.shared)
         let provider = WpAuthenticationProvider.dynamic(
             dynamicAuthenticationProvider: AutoUpdateAuthenticationProvider(site: site, coreDataStack: ContextManager.shared)
         )
@@ -42,7 +42,6 @@ extension WordPressClient {
             authenticationProvider: provider,
             appNotifier: notifier
         )
-        notifier.api = api
         self.init(api: api, rootUrl: apiRootURL)
     }
 
@@ -109,18 +108,7 @@ private final class AutoUpdateAuthenticationProvider: @unchecked Sendable, WpDyn
     }
 
     func refresh() async -> Bool {
-        let blogId: TaggedManagedObjectID<Blog>?
-        switch site {
-        case let .dotCom(siteId, _):
-            blogId = await coreDataStack.performQuery { context in
-                guard let blog = try? Blog.lookup(withID: siteId, in: context) else { return nil }
-                return TaggedManagedObjectID(blog)
-            }
-        case let .selfHosted(id, _, _, _):
-            blogId = id
-        }
-
-        guard let blogId else { return false }
+        guard let blogId = site.blogId(in: coreDataStack) else { return false }
 
         do {
             DDLogInfo("Create a new application password")
@@ -137,10 +125,17 @@ private final class AutoUpdateAuthenticationProvider: @unchecked Sendable, WpDyn
 }
 
 private class AppNotifier: @unchecked Sendable, WpAppNotifier {
-    weak var api: WordPressAPI?
+    let site: WordPressSite
+    let coreDataStack: CoreDataStack
+
+    init(site: WordPressSite, coreDataStack: CoreDataStack) {
+        self.site = site
+        self.coreDataStack = coreDataStack
+    }
 
     func requestedWithInvalidAuthentication() async {
-        NotificationCenter.default.post(name: WordPressClient.requestedWithInvalidAuthenticationNotification, object: api)
+        let blogId = site.blogId(in: coreDataStack)
+        NotificationCenter.default.post(name: WordPressClient.requestedWithInvalidAuthenticationNotification, object: blogId)
     }
 }
 


### PR DESCRIPTION
> [!Note]
> This PR is built on top of #24742.

## Description

We don't want to present a sign-in web view when the API to other sites fails.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
