### PR TITLE
fix: Expand GutenbergKit REST API configuration

### DIFF
--- a/Tests/KeystoneTests/Helpers/BlogBuilder.swift
+++ b/Tests/KeystoneTests/Helpers/BlogBuilder.swift
@@ -2,6 +2,7 @@ import CoreData
 import Foundation
 import XCTest
 import WordPressData
+import WordPressShared
 
 @testable import WordPress
 
@@ -99,12 +100,12 @@ final class BlogBuilder {
         return self
     }
 
-    func withAnAccount(username: String = "test_user") -> Self {
+    func withAnAccount(username: String = "test_user", authToken: String = "authtoken") -> Self {
         // Add Account
         let account = NSEntityDescription.insertNewObject(forEntityName: WPAccount.entityName(), into: context) as! WPAccount
         account.displayName = "displayName"
         account.username = username
-        account.authToken = "authtoken"
+        account.authToken = authToken
         blog.account = account
 
         return self
@@ -221,6 +222,21 @@ final class BlogBuilder {
 
     func with(postFormats: [String: String]) -> Self {
         blog.postFormats = postFormats
+
+        return self
+    }
+
+    func withApplicationPassword(_ password: String, using keychain: KeychainAccessible = KeychainUtils()) -> Self {
+        do {
+            try blog.setApplicationToken(password, using: keychain)
+        } catch {
+            XCTFail("Failed to set application password: \(error)")
+        }
+        return self
+    }
+
+    func with(restApiRootURL: String) -> Self {
+        blog.restApiRootURL = restApiRootURL
 
         return self
     }

--- a/Tests/KeystoneTests/Tests/Features/Gutenberg/EditorConfigurationTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Gutenberg/EditorConfigurationTests.swift
@@ -1,0 +1,118 @@
+import Testing
+import Foundation
+import CoreData
+import XCTest
+import WordPressData
+import GutenbergKit
+
+@testable import WordPress
+
+@Suite("EditorConfiguration Authentication Tests")
+struct EditorConfigurationTests {
+    private let contextManager = ContextManager.forTesting()
+    private let keychain = TestKeychain()
+
+    private var context: NSManagedObjectContext {
+        contextManager.mainContext
+    }
+
+    @Test("Simple site uses WP.com REST API")
+    func simpleSiteUses() async throws {
+        let context = self.context
+
+        let blog = BlogBuilder(context)
+            .with(atomic: false)
+            .isHostedAtWPcom()
+            .withAnAccount(username: "simpleuser", authToken: "simple-bearer-token")
+            .with(dotComID: 12345)
+            .build()
+
+        let config = EditorConfiguration(blog: blog)
+
+        #expect(config.siteApiRoot == "https://public-api.wordpress.com/", "Should use WP.com API root")
+        #expect(config.authHeader == "Bearer simple-bearer-token", "Should use Bearer authentication from account")
+    }
+
+    @Test("Atomic site uses WP.com REST API")
+    func atomicSiteUsesWPcomRestApi() async throws {
+        let context = self.context
+
+        let blog = BlogBuilder(context)
+            .with(atomic: true)
+            .isNotHostedAtWPcom()
+            .withAnAccount(username: "atomicuser", authToken: "atomic-bearer-token")
+            .with(username: "atomicuser")
+            .with(dotComID: 67890)
+            .with(url: "https://atomic.com")
+            .build()
+
+        let config = EditorConfiguration(blog: blog)
+
+        #expect(config.siteApiRoot == "https://public-api.wordpress.com/", "Should use WP.com API root")
+        #expect(config.authHeader == "Bearer atomic-bearer-token", "Should use Bearer authentication")
+        #expect(config.siteApiNamespace.contains("sites/67890/"), "Should include site ID namespace")
+    }
+
+    @Test("Atomic site with application password uses self-hosted REST API")
+    func atomicSiteWithAppPasswordUsesSelfHostedRestApi() async throws {
+        let context = self.context
+
+        let blog = BlogBuilder(context, dotComID: 67890)
+            .with(atomic: true)
+            .isNotHostedAtWPcom()
+            .withAnAccount(username: "atomicuser", authToken: "atomic-bearer-token")
+            .with(username: "atomicuser")
+            .withApplicationPassword("test-app-password-1234", using: keychain)
+            .build()
+
+        let config = EditorConfiguration(blog: blog, keychain: keychain)
+        let base64Credentials = "YXRvbWljdXNlcjp0ZXN0LWFwcC1wYXNzd29yZC0xMjM0" // Base64 encoding of "atomicuser:test-app-password-1234"
+
+        #expect(config.siteApiRoot == "https://67890.example.com/wp-json/", "Should use self-hosted API URL")
+        #expect(config.authHeader == "Basic \(base64Credentials)", "Should use Basic authentication")
+        #expect(config.siteApiNamespace.isEmpty, "Should not have WP.com API namespace")
+    }
+
+    @Test("Self-hosted site uses self-hosted REST API")
+    func selfHostedSiteUsesSelfHostedAPI() async throws {
+        let context = self.context
+
+        let blog = BlogBuilder(context)
+            .with(atomic: false)
+            .isNotHostedAtWPcom()
+            .with(username: "selfhosteduser")
+            .with(url: "https://self-hosted.org")
+            .withApplicationPassword("test-app-password-1234", using: keychain)
+            .with(restApiRootURL: "https://self-hosted.org/wp-json/")
+            .build()
+
+        let config = EditorConfiguration(blog: blog, keychain: keychain)
+        let base64Credentials = "c2VsZmhvc3RlZHVzZXI6dGVzdC1hcHAtcGFzc3dvcmQtMTIzNA==" // Base64 encoding of "selfhosteduser:test-app-password-1234"
+
+        #expect(config.siteApiRoot == "https://self-hosted.org/wp-json/", "Should use self-hosted API URL")
+        #expect(config.authHeader == "Basic \(base64Credentials)", "Should use Basic authentication")
+        #expect(config.siteApiNamespace.isEmpty, "Should not have WP.com API namespace")
+    }
+
+    @Test("Self-hosted site with Jetpack connection and application password uses self-hosted REST API")
+    func selfHostedSiteWithJetpackAndAppPasswordUsesWPcomRestApi() async throws {
+        let context = self.context
+
+        let blog = BlogBuilder(context, dotComID: 12345)
+            .with(atomic: false)
+            .isNotHostedAtWPcom()
+            .withAnAccount(username: "selfhosteduser", authToken: "self-hosted-bearer-token")
+            .with(username: "selfhosteduser")
+            .with(url: "https://self-hosted.org")
+            .withApplicationPassword("test-app-password-1234", using: keychain)
+            .with(restApiRootURL: "https://self-hosted.org/wp-json/")
+            .build()
+
+        let config = EditorConfiguration(blog: blog, keychain: keychain)
+        let base64Credentials = "c2VsZmhvc3RlZHVzZXI6dGVzdC1hcHAtcGFzc3dvcmQtMTIzNA==" // Base64 encoding of "selfhosteduser:test-app-password-1234"
+
+        #expect(config.siteApiRoot == "https://self-hosted.org/wp-json/", "Should use self-hosted API URL")
+        #expect(config.authHeader == "Basic \(base64Credentials)", "Should use Basic authentication")
+        #expect(config.siteApiNamespace.isEmpty, "Should not have WP.com API namespace")
+    }
+}

--- a/Tests/KeystoneTests/Tests/Features/Gutenberg/EditorConfigurationTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Gutenberg/EditorConfigurationTests.swift
@@ -94,6 +94,25 @@ struct EditorConfigurationTests {
         #expect(config.siteApiNamespace.isEmpty, "Should not have WP.com API namespace")
     }
 
+    @Test("Self-hosted site with Jetpack connection uses WP.com REST API")
+    func selfHostedSiteWithJetpackUsesWPcomRestApi() async throws {
+        let context = self.context
+
+        let blog = BlogBuilder(context, dotComID: 12345)
+            .with(atomic: false)
+            .isNotHostedAtWPcom()
+            .withAnAccount(username: "selfhosteduser", authToken: "self-hosted-bearer-token")
+            .with(username: "selfhosteduser")
+            .with(url: "https://self-hosted.org")
+            .build()
+
+        let config = EditorConfiguration(blog: blog, keychain: keychain)
+
+        #expect(config.siteApiRoot == "https://public-api.wordpress.com/", "Should use WP.com API root")
+        #expect(config.authHeader == "Bearer self-hosted-bearer-token", "Should use Bearer authentication")
+        #expect(config.siteApiNamespace.contains("sites/12345/"), "Should include site ID namespace")
+    }
+
     @Test("Self-hosted site with Jetpack connection and application password uses self-hosted REST API")
     func selfHostedSiteWithJetpackAndAppPasswordUsesWPcomRestApi() async throws {
         let context = self.context

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -172,7 +172,7 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
 
         if RemoteFeatureFlag.newGutenberg.enabled() {
             GutenbergKit.EditorViewController.warmup(
-                configuration: blog.flatMap(EditorConfiguration.init(blog:)) ?? .default
+                configuration: blog.flatMap({ EditorConfiguration.init(blog: $0) }) ?? .default
             )
         }
     }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -859,9 +859,7 @@ extension EditorConfiguration {
     init(blog: Blog, keychain: KeychainAccessible = KeychainUtils()) {
         let selfHostedApiUrl = blog.restApiRootURL ?? blog.url(withPath: "wp-json/")
         let applicationPassword = try? blog.getApplicationToken(using: keychain)
-        let shouldUseWPComRestApi = applicationPassword == nil &&
-            blog.isAccessibleThroughWPCom() &&
-            (blog.isHostedAtWPcom || blog.isAtomic())
+        let shouldUseWPComRestApi = applicationPassword == nil && blog.isAccessibleThroughWPCom()
 
         let siteApiRoot: String?
         if applicationPassword != nil {

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -856,9 +856,9 @@ private extension NewGutenbergViewController {
 }
 
 extension EditorConfiguration {
-    init(blog: Blog) {
+    init(blog: Blog, keychain: KeychainAccessible = KeychainUtils()) {
         let selfHostedApiUrl = blog.restApiRootURL ?? blog.url(withPath: "wp-json/")
-        let applicationPassword = try? blog.getApplicationToken()
+        let applicationPassword = try? blog.getApplicationToken(using: keychain)
         let shouldUseWPComRestApi = applicationPassword == nil &&
             blog.isAccessibleThroughWPCom() &&
             (blog.isHostedAtWPcom || blog.isAtomic())


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Add automated unit tests for various editor REST API configurations to address https://github.com/wordpress-mobile/WordPress-iOS/pull/24738#issuecomment-3177217005. 

Address an additional failing scenario for Jetpack-connected, self-hosted sites without an application password, which should rely upon the WP.com REST API (mirrors Gutenberg Mobile).

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
> [!important]
> * Enable the _Experimental Block Editor_ experimental feature before testing. 
> * Quite the Jetpack app between the following two test cases to avoid lingering cookie caches. 


### 1: Self-hosted sites _transition_ to application passwords 
1. Add a self-hosted site _without_ Jetpack. 
1. Open the editor.
1. Insert an Image block.
1. Note the _Upload_ button is absent. 
1. Enable the _Allow creating Application Passwords_  experimental feature. 
1. Navigate to _My Site_ → _Application Passwords_ and await the successful password creation. 
1. Repeat steps 2-3. 
1. Verify the _Upload_ button is present and uploading media succeeds.

### 2: Self-hosted, Jetpack-connected sites without an application password 
1. Connect a self-hosted site to the app via Jetpack. 
1. Open the editor.
1. Insert an Image block.
1. Verify the _Upload_ button is present and uploading media succeeds.

<details><summary>Optional test cases</summary>
<p>

_I tested these to avoid regressions, but there likely isn't a need to repeat testing them as they already work in the latest release._

Image block uploads for self-hosted sites with: 
| Auth Type | Outcome |
| - | - |
| User credentials | ❌ Fails[^1] |
| App password | ✅ Passes |
| App password + Jetpack | ✅ Passes | 

Image block uploads for Atomic sites with: 

| Auth Type | Outcome |
| - | - |
| Bearer token | ✅ Passes |
| App password | ✅ Passes[^2] |

[^2]: An edge case exists for private Atomic sites: CMM-684. 

Image block uploads for Simple sites with: 

| Auth Type | Outcome |
| - | - |
| Bearer token | ✅ Passes |

[^1]: GutenbergKit does not support self-hosted sites without a Jetpack connection or application password. 

</p>
</details> 

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
