### PR TITLE
fix: Unsuccessful GutenbergKit requests with app passwords for private Atomic sites 

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "64f477c45e08ef3a190ac3cc35e9f1d654c709425d08a3b0baedb55035f3846b",
+  "originHash" : "7614131a234de35f382850028f543252dc1189158ae6f2c629f1615687925051",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,7 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "24ac4ca1313ed7b5e720ff44de9494ef56297acd"
+        "revision" : "bb530d3b3b4dfeb8057497a25835bd63fbcd7d1f",
+        "version" : "0.8.0-alpha.1"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d87ddff03ce84cd64257cffd1d6b8ec7d7275c707bf5bba8620aab719859da17",
+  "originHash" : "64f477c45e08ef3a190ac3cc35e9f1d654c709425d08a3b0baedb55035f3846b",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,8 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "9de6625fa92ebf83af0d1a1603ec3426a79a3ddf",
-        "version" : "0.8.0-alpha.0"
+        "revision" : "24ac4ca1313ed7b5e720ff44de9494ef56297acd"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250813"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "24ac4ca1313ed7b5e720ff44de9494ef56297acd"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.8.0-alpha.1"),
         .package(
             url: "https://github.com/Automattic/color-studio",
             revision: "bf141adc75e2769eb469a3e095bdc93dc30be8de"

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250813"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.8.0-alpha.0"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "24ac4ca1313ed7b5e720ff44de9494ef56297acd"),
         .package(
             url: "https://github.com/Automattic/color-studio",
             revision: "bf141adc75e2769eb469a3e095bdc93dc30be8de"


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Ref CMM-684.

Integrate https://github.com/wordpress-mobile/GutenbergKit/pull/166 so that private Atomic sites make successful requests with application passwords. 

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
1. Use a fresh app install. 
2. Connect a WP.com account that owns an Atomic site. 
3. Open the experimental GutenbergKit editor. 
4. Insert an Image block.
5. Note the Upload button is present. 
6. Navigate to My Site → More → Application Passwords and await the creation of an application password. 
7. In the WordPress.com site, change the Atomic site visibility to "private." 
8. In the app, switch to a different site and back to the Atomic site. 
9. Repeat steps 3-4. 
10. Verify the Upload button is absent.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
