### PR TITLE
feat: Enable GutenbergKit remote editor for Jetpack-connected sites

### DIFF
--- a/Tests/KeystoneTests/Tests/Features/Gutenberg/EditorConfigurationPluginsTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Gutenberg/EditorConfigurationPluginsTests.swift
@@ -1,0 +1,135 @@
+import Testing
+import Foundation
+import CoreData
+import WordPressData
+import GutenbergKit
+
+@testable import WordPress
+
+@Suite("EditorConfiguration.shouldEnablePlugins Tests")
+final class EditorConfigurationPluginsTests {
+    private let contextManager = ContextManager.forTesting()
+    private let keychain = TestKeychain()
+    private let featureFlags = FeatureFlagOverrideStore()
+
+    private var context: NSManagedObjectContext {
+        contextManager.mainContext
+    }
+
+    init() {
+        featureFlags.override(RemoteFeatureFlag.newGutenbergPlugins, withValue: true)
+    }
+
+    func tearDown() {
+        featureFlags.override(RemoteFeatureFlag.newGutenbergPlugins, withValue: RemoteFeatureFlag.newGutenbergPlugins.originalValue)
+    }
+
+    @Test("Should disable plugins for non-Jetpack-connected sites without app password")
+    func disablesPluginsForNonJetpackSitesWithoutAppPassword() async throws {
+        let blog = BlogBuilder(context)
+            .with(atomic: false)
+            .isNotHostedAtWPcom()
+            .with(username: "selfhosted")
+            .with(url: "https://self-hosted.org")
+            .build()
+
+        let result = EditorConfiguration.shouldEnablePlugins(for: blog, appPassword: nil)
+
+        #expect(result == false, "Should return false for non-Jetpack sites without app password")
+    }
+
+    @Test("Should enable plugins for Simple WP.com sites")
+    func enablesPluginsForSimpleSites() async throws {
+        let blog = BlogBuilder(context)
+            .with(atomic: false)
+            .isHostedAtWPcom()
+            .withAnAccount(username: "simpleuser", authToken: "token")
+            .with(dotComID: 12345)
+            .build()
+
+        let result = EditorConfiguration.shouldEnablePlugins(for: blog, appPassword: nil)
+
+        #expect(result == true, "Should return true for Simple WP.com sites")
+    }
+
+    @Test("Should enable plugins for Atomic sites with app password")
+    func enablesPluginsForAtomicSitesWithAppPassword() async throws {
+        let blog = BlogBuilder(context)
+            .with(atomic: true)
+            .isNotHostedAtWPcom()
+            .withAnAccount(username: "atomicuser", authToken: "token")
+            .with(dotComID: 67890)
+            .with(url: "https://atomic.com")
+            .build()
+
+        let result = EditorConfiguration.shouldEnablePlugins(for: blog, appPassword: "app-password-123")
+
+        #expect(result == true, "Should return true for Atomic sites with app password")
+    }
+
+    @Test("Should disable plugins for Atomic sites without app password")
+    func disablesPluginsForAtomicSitesWithoutAppPassword() async throws {
+        let blog = BlogBuilder(context)
+            .with(atomic: true)
+            .isNotHostedAtWPcom()
+            .withAnAccount(username: "atomicuser", authToken: "token")
+            .with(dotComID: 67890)
+            .with(url: "https://atomic.com")
+            .build()
+
+        let result = EditorConfiguration.shouldEnablePlugins(for: blog, appPassword: nil)
+
+        #expect(result == false, "Should return false for Atomic sites without app password")
+    }
+
+    @Test("Should enable plugins for Jetpack-connected sites with app password")
+    func enablesPluginsForJetpackSitesWithAppPassword() async throws {
+        let blog = BlogBuilder(context)
+            .with(atomic: false)
+            .isNotHostedAtWPcom()
+            .withAnAccount(username: "jetpackuser", authToken: "token")
+            .withJetpack(version: "13.0")
+            .with(dotComID: 99999)
+            .with(url: "https://jetpack-site.org")
+            .build()
+
+        let result = EditorConfiguration.shouldEnablePlugins(for: blog, appPassword: "jetpack-app-password")
+
+        #expect(result == true, "Should return true for Jetpack sites with app password")
+    }
+
+    @Test("Should disable plugins for Jetpack-connected sites without app password")
+    func disablesPluginsForJetpackSitesWithoutAppPassword() async throws {
+        let blog = BlogBuilder(context)
+            .with(atomic: false)
+            .isNotHostedAtWPcom()
+            .withAnAccount(username: "jetpackuser", authToken: "token")
+            .withJetpack(version: "13.0")
+            .with(dotComID: 99999)
+            .with(url: "https://jetpack-site.org")
+            .build()
+
+        let result = EditorConfiguration.shouldEnablePlugins(for: blog, appPassword: nil)
+
+        #expect(result == false, "Should return false for Jetpack sites without app password")
+    }
+
+    @Test("Should use default remote flag implementation when not provided")
+    func usesDefaultRemoteFlagImplementation() async throws {
+        let blog = BlogBuilder(context)
+            .with(atomic: false)
+            .isHostedAtWPcom()
+            .withAnAccount(username: "user", authToken: "token")
+            .with(dotComID: 12345)
+            .build()
+
+        let result = EditorConfiguration.shouldEnablePlugins(for: blog)
+
+        let expectedResult = RemoteFeatureFlag.newGutenbergPlugins.enabled() &&
+                           blog.isAccessibleThroughWPCom() &&
+                           blog.isHostedAtWPcom
+
+        #expect(result == expectedResult,
+                "Should use RemoteFeatureFlag.newGutenbergPlugins.enabled() when not provided")
+    }
+}


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Close CMM-672. 

Enable the remote editor (non-core block support) for all Jetpack-connected sites that either (A) are a WP.com Simple site or (B) have an application password. A Jetpack connection is required until the editor assets endpoint is available in WordPress Core. A WP.com Simple site or application password is required for authenticating all REST API requests, including those originating from non-core blocks. 

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
> [!tip]
> Use a fresh app install to avoid lingering application passwords. 

### 1. Plugins disabled for unsupported site types
1. Enable the _Experimental Block Editor_ experimental features toggle. 
2. Enable the _Experimental Block Editor Plugins_ debug feature flag. 
3. Use an Atomic (WoW) site **without an application password.** 
4. Open the editor. 
5. Verify non-core blocks are unavailable. 
6. Repeat steps 3–4 for a Jetpack-connected, self-hosted site (e.g., JN site) **without an application password.** 

### 2. Plugins enabled for supported site types
1. Enable the _Experimental Block Editor_ experimental features toggle. 
2. Enable the _Experimental Block Editor Plugins_ debug feature flag. 
3. Use an Atomic (WoW) site. 
4. Create an application password for the site. 
5. Open the editor. 
6. Verify non-core blocks are available. 
7. Repeat steps 3–4 for a Jetpack-connected, self-hosted site (e.g., JN site). 

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->

