### PR TITLE
Do not use wp/v2 endpoints to load categories

### DIFF
--- a/WordPress/Classes/Services/PostCategoryService.m
+++ b/WordPress/Classes/Services/PostCategoryService.m
@@ -180,11 +180,6 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 - (nullable id<TaxonomyServiceRemote>)remoteForBlog:(Blog *)blog {
-    TaxonomyServiceRemoteCoreREST *instance = [[TaxonomyServiceRemoteCoreREST alloc] initWithBlog:blog];
-    if (instance != nil) {
-        return instance;
-    }
-
     if ([blog supports:BlogFeatureWPComRESTAPI]) {
         if (blog.wordPressComRestApi) {
             return [[TaxonomyServiceRemoteREST alloc] initWithWordPressComRestApi:blog.wordPressComRestApi siteID:blog.dotComID];


### PR DESCRIPTION
## Description

Fixes #24750.

Root cause: The `TaxonomyServiceRemoteCoreREST.getCategories` function does not return all categories.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
