### PR TITLE
fix: Avoid empty GutenbergKit media callbacks

### DIFF
--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -496,8 +496,7 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
         }
 
         mediaPickerHelper.presentSiteMediaPicker(filter: flags, allowMultipleSelection: config.multiple, initialSelection: initialSelectionArray) { [weak self] assets in
-            guard let self, let media = assets as? [Media] else {
-                self?.editorViewController.setMediaUploadAttachment("[]")
+            guard let self, let media = assets as? [Media], !media.isEmpty else {
                 return
             }
             let mediaInfos = media.map { item in


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Fix CMM-697.

Sending empty media attachments to third-party code leads to errors, as
the code often expects to receive an attachment if the callback is
invoked.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
1. Open the experimental editor.
1. Insert a Paragraph block.
1. Tap the formatting options button (downward chevron) in the block toolbar.
1. Tap Inline image.
1. Tap Cancel.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
