### PR TITLE
refactor: Remove unused Jetpack global configuration

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7614131a234de35f382850028f543252dc1189158ae6f2c629f1615687925051",
+  "originHash" : "2136cebd694e04559a7781756465413329635640c32d6d27359361ae3b7f70a5",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,8 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "bb530d3b3b4dfeb8057497a25835bd63fbcd7d1f",
-        "version" : "0.8.0-alpha.1"
+        "revision" : "960519724e853ba705a6c6f87897ed597e602f50"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "2136cebd694e04559a7781756465413329635640c32d6d27359361ae3b7f70a5",
+  "originHash" : "1396327d3789af5733c132cafaa4207f7edf61aff25de530bf4bbada8e3605fe",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,7 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "960519724e853ba705a6c6f87897ed597e602f50"
+        "revision" : "2224ad2663302dfcf3f21499db3494d1da041f96",
+        "version" : "0.8.0-alpha.2"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250813"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.8.0-alpha.1"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "960519724e853ba705a6c6f87897ed597e602f50"),
         .package(
             url: "https://github.com/Automattic/color-studio",
             revision: "bf141adc75e2769eb469a3e095bdc93dc30be8de"

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250813"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "960519724e853ba705a6c6f87897ed597e602f50"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.8.0-alpha.2"),
         .package(
             url: "https://github.com/Automattic/color-studio",
             revision: "bf141adc75e2769eb469a3e095bdc93dc30be8de"

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -1057,18 +1057,6 @@ extension EditorConfiguration {
             }
         }
         self.locale = WordPressComLanguageDatabase().deviceLanguage.slug
-
-        if !blog.isSelfHosted {
-            let siteType: String = blog.isHostedAtWPcom ? "simple" : "atomic"
-            do {
-                self.webViewGlobals = [
-                    try WebViewGlobal(name: "_currentSiteType", value: .string(siteType))
-                ]
-            } catch {
-                wpAssertionFailure("Failed to create WebViewGlobal", userInfo: ["error": "\(error)"])
-                self.webViewGlobals = []
-            }
-        }
     }
 
     /// Returns true if the plugins should be enabled for the given blog.


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
This configuration is now unnecessary, as the relevant globals were replaced with new globals. The new globals are set via remote JavaScript loaded into the WebView rather than manually setting the globals via GutenbergKit configuration.

Related: 
- Configuration removal: https://github.com/wordpress-mobile/GutenbergKit/pull/172
- Globals removal: https://github.com/Automattic/jetpack/pull/44133
- New globals: https://github.com/Automattic/jetpack/pull/44077

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
1. Enable the experimental editor feature. 
2. Enable the experimental editor plugins feature. 
3. Open the editor. 
4. Insert the Jetpack AI Assistant block. 
5. Verify AI commands succeed—e.g., write a haiku. 
