### PR TITLE
Set tag description to an empty string when nil

### DIFF
--- a/WordPress/Classes/ViewRelated/Tags/TagsService.swift
+++ b/WordPress/Classes/ViewRelated/Tags/TagsService.swift
@@ -100,6 +100,8 @@ class TagsService {
             throw TagsServiceError.noRemoteService
         }
 
+        tag.tagDescription = tag.tagDescription ?? ""
+
         return try await withCheckedThrowingContinuation { continuation in
             if tag.tagID == nil {
                 remote.createTag(tag, success: { savedTag in


### PR DESCRIPTION
When it's nil, the XMLRPC remote implementation crashes due to encoding a null value.
