### PR TITLE
[iOS 26] Update Dashboard

### DIFF
--- a/Modules/Sources/DesignSystem/Foundation/DesignConstants.swift
+++ b/Modules/Sources/DesignSystem/Foundation/DesignConstants.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+public enum DesignConstants {
+    public enum Radius {
+        /// Radius applicable for large components like cards that take full
+        /// screen width
+        case large
+    }
+
+    public static func radius(_ radius: Radius) -> CGFloat {
+        if #available(iOS 26, *) {
+            return 26
+        } else {
+            return 10
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -208,7 +208,7 @@ extension BlogDashboardViewController {
         let horizontalInset = Constants.horizontalSectionInset
         let isLast = (sectionIndex == collectionView.numberOfSections - 1)
         // More on .compact to match the FAB.
-        let bottomInset = (isLast && traitCollection.horizontalSizeClass == .compact) ? 86 : 20
+        let bottomInset = (isLast && traitCollection.horizontalSizeClass == .compact) ? 86 : 0
         section.contentInsets = NSDirectionalEdgeInsets(
             top: Constants.verticalSectionInset,
             leading: horizontalInset,

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/BlogDashboardPersonalizeCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/BlogDashboardPersonalizeCardCell.swift
@@ -2,6 +2,7 @@ import UIKit
 import SwiftUI
 import WordPressData
 import WordPressShared
+import WordPressUI
 
 final class BlogDashboardPersonalizeCardCell: DashboardCollectionViewCell {
     private var blog: Blog?
@@ -31,12 +32,7 @@ final class BlogDashboardPersonalizeCardCell: DashboardCollectionViewCell {
         let imageView = UIImageView(image: UIImage(named: "personalize")?.withRenderingMode(.alwaysTemplate))
         imageView.tintColor = .label
 
-        let spacer = UIView()
-        spacer.translatesAutoresizingMaskIntoConstraints = false
-        spacer.widthAnchor.constraint(greaterThanOrEqualToConstant: 8).isActive = true
-
-        let contents = UIStackView(arrangedSubviews: [titleLabel, spacer, imageView])
-        contents.alignment = .center
+        let contents = UIStackView(alignment: .center, spacing: 8, [titleLabel, imageView])
         contents.isUserInteractionEnabled = false
 
         personalizeButton.accessibilityLabel = Strings.buttonTitle
@@ -44,25 +40,22 @@ final class BlogDashboardPersonalizeCardCell: DashboardCollectionViewCell {
         personalizeButton.addTarget(self, action: #selector(buttonTapped), for: .touchUpInside)
 
         let container = UIView()
-        container.layer.cornerRadius = 10
+        container.layer.cornerRadius = DesignConstants.radius(.large)
         container.addSubview(personalizeButton)
         container.addSubview(contents)
-
-        personalizeButton.translatesAutoresizingMaskIntoConstraints = false
-        container.pinSubviewToAllEdges(personalizeButton)
-
-        contents.translatesAutoresizingMaskIntoConstraints = false
-        container.pinSubviewToAllEdges(contents, insets: UIEdgeInsets(.all, 16))
+        personalizeButton.pinEdges()
+        contents.pinEdges(insets: UIEdgeInsets(.all, 16))
 
         contentView.addSubview(container)
-        container.translatesAutoresizingMaskIntoConstraints = false
-        contentView.pinSubviewToAllEdges(container)
+        container.pinEdges(.horizontal, relation: .lessThanOrEqual)
+        container.pinEdges(.vertical)
+        container.pinCenter()
     }
 
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        personalizeButton.setBackgroundImage(.renderBackgroundImage(fill: .tertiarySystemFill), for: .normal)
+        personalizeButton.setBackgroundImage(.renderBackgroundImage(fill: .tertiarySystemFill, cornerRadius: DesignConstants.radius(.large)), for: .normal)
     }
 
     // MARK: - BlogDashboardCardConfigurable

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -1,4 +1,5 @@
 import UIKit
+import DesignSystem
 import WordPressUI
 
 /// A view that consists of the frame of a Dashboard card
@@ -30,7 +31,7 @@ class BlogDashboardCardFrameView: UIView {
         let titleLabel = UILabel()
         titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
         titleLabel.adjustsFontForContentSizeCategory = true
-        titleLabel.font = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .semibold)
+        titleLabel.font = .preferredFont(forTextStyle: .subheadline).withWeight(.semibold)
         titleLabel.accessibilityTraits = .button
         titleLabel.numberOfLines = 0
         return titleLabel
@@ -127,6 +128,10 @@ class BlogDashboardCardFrameView: UIView {
 
         if !ellipsisButton.isHidden {
             mainStackViewTrailingConstraint?.constant = -Constants.mainStackViewTrailingPadding
+            if #available(iOS 26, *) {
+                buttonContainerStackView.layoutMargins = UIEdgeInsets(.top, 5)
+                buttonContainerStackView.isLayoutMarginsRelativeArrangement = true
+            }
         }
     }
 
@@ -161,6 +166,11 @@ class BlogDashboardCardFrameView: UIView {
             mainStackView.leadingAnchor.constraint(equalTo: leadingAnchor),
             trailingConstraint
         ])
+
+        if #available(iOS 26, *) {
+            mainStackView.layoutMargins = .init(top: 5, left: 0, bottom: 5, right: 0)
+            mainStackView.isLayoutMarginsRelativeArrangement = true
+        }
 
         mainStackView.addArrangedSubview(headerStackView)
         headerStackView.addArrangedSubviews([titleLabel, ellipsisButton])
@@ -258,7 +268,7 @@ class BlogDashboardCardFrameView: UIView {
         static let headerPaddingWithEllipsisButtonHidden = UIEdgeInsets(top: 12, left: 16, bottom: 8, right: 16)
         static let headerPaddingWithEllipsisButtonShown = UIEdgeInsets(top: 12, left: 16, bottom: 8, right: 8)
         static let headerHorizontalSpacing: CGFloat = 5
-        static let cornerRadius: CGFloat = 10
+        static let cornerRadius = DesignConstants.radius(.large)
         static let buttonContainerStackViewPadding: CGFloat = 8
         static let mainStackViewTrailingPadding: CGFloat = 32
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Posts/BlogDashboardCardFrameView.swift
@@ -39,10 +39,13 @@ class BlogDashboardCardFrameView: UIView {
     /// Ellipsis Button displayed on the top right corner of the view.
     /// Displayed only when an associated action is set
     private(set) lazy var ellipsisButton: UIButton = {
-        let button = UIButton(type: .custom)
-        button.setImage(UIImage(named: "more-horizontal-mobile"), for: .normal)
+        var configuration = UIButton.Configuration.plain()
+        configuration.image = UIImage(systemName: "ellipsis")
+        configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(font: .systemFont(ofSize: 13))
+        configuration.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 8, bottom: 0, trailing: 8)
+
+        let button = UIButton(configuration: configuration, primaryAction: nil)
         button.tintColor = UIColor.secondaryLabel
-        button.contentEdgeInsets = Constants.ellipsisButtonPadding
         button.isAccessibilityElement = true
         button.accessibilityLabel = Strings.ellipsisButtonAccessibilityLabel
         button.accessibilityTraits = .button
@@ -256,7 +259,6 @@ class BlogDashboardCardFrameView: UIView {
         static let headerPaddingWithEllipsisButtonShown = UIEdgeInsets(top: 12, left: 16, bottom: 8, right: 8)
         static let headerHorizontalSpacing: CGFloat = 5
         static let cornerRadius: CGFloat = 10
-        static let ellipsisButtonPadding = UIEdgeInsets(top: 0, left: 8, bottom: 0, right: 8)
         static let buttonContainerStackViewPadding: CGFloat = 8
         static let mainStackViewTrailingPadding: CGFloat = 32
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionsCardCell.swift
@@ -4,6 +4,7 @@ import WordPressData
 import WordPressShared
 import SwiftUI
 import WordPressAPI
+import WordPressUI
 
 final class DashboardQuickActionsCardCell: UICollectionViewCell, Reusable, UITableViewDataSource, UITableViewDelegate {
 
@@ -14,7 +15,7 @@ final class DashboardQuickActionsCardCell: UICollectionViewCell, Reusable, UITab
         tableView.isScrollEnabled = false
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.clipsToBounds = true
-        tableView.layer.cornerRadius = 10
+        tableView.layer.cornerRadius = DesignConstants.radius(.large)
         tableView.backgroundColor = .secondarySystemGroupedBackground
         tableView.register(DashboardQuickActionCell.self, forCellReuseIdentifier: Constants.cellReuseID)
         return tableView


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-704/update-dashboard-design

- Add `DesignConstants` (will by adopting these gradually)
- Make "Personalize" button look more like button
- Use larger corner radius (like everywhere on iOS 26)
- Fix iOS 16 deprecation warnings (`UIButton.Configuration`)
- Remove bottom spacing from the quick actions (top menu) to make it more symmetrical)

<img width="360"  alt="ios-26-dashboard1" src="https://github.com/user-attachments/assets/dee1fd6d-2534-4d91-a28f-37f8dc28628c" />
<img width="360"  alt="ios-26-dashboard2" src="https://github.com/user-attachments/assets/72909fcd-eee9-4c45-b629-2f704ac167d2" />

