### PR TITLE
[iOS 26] Fix layout issues on Media screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaSelectionTitleView.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaSelectionTitleView.swift
@@ -10,7 +10,7 @@ final class SiteMediaSelectionTitleView: UIView {
 
         addSubview(textLabel)
         textLabel.translatesAutoresizingMaskIntoConstraints = false
-        pinSubviewToAllEdges(textLabel)
+        textLabel.pinEdges(insets: UIEdgeInsets(.horizontal, 8))
 
         textLabel.font = WPStyleGuide.fontForTextStyle(.headline)
         textLabel.textAlignment = .center


### PR DESCRIPTION
The only issues I found was lack of spacing in "N images selected" at the bottom.

<img width="360" alt="Screenshot 2025-08-26 at 4 28 54 PM" src="https://github.com/user-attachments/assets/5bd0debb-26ea-4695-bc51-afa36f451f24" />