### PR TITLE
[New Stats] Add a TipKit

### DIFF
--- a/Modules/Sources/JetpackStats/Strings.swift
+++ b/Modules/Sources/JetpackStats/Strings.swift
@@ -99,6 +99,11 @@ enum Strings {
         static let samePeriodLastYear = AppLocalizedString("jetpackStats.datePicker.lastYear", value: "Last Year", comment: "Compare with same period last year option")
     }
 
+    enum DateRangeTips {
+        static let title = AppLocalizedString("jetpackStats.dateRangeTip.title", value: "Navigate Through Time", comment: "Title for stats date range control tip")
+        static let message = AppLocalizedString("jetpackStats.dateRangeTip.message", value: "View recent days, weeks, months, years, or select custom date ranges.", comment: "Message explaining how to use the date range control")
+    }
+
     enum Chart {
         static let showData = AppLocalizedString("jetpackStats.chart.showData", value: "Show Data", comment: "Show chart data menu item")
         static let lineChart = AppLocalizedString("jetpackStats.chart.lineChart", value: "Lines", comment: "Line chart type")

--- a/Modules/Sources/JetpackStats/Views/LegacyFloatingDateControl.swift
+++ b/Modules/Sources/JetpackStats/Views/LegacyFloatingDateControl.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import TipKit
 
 /// A pre-Liquid Glass version.
 struct LegacyFloatingDateControl: View {
@@ -56,6 +57,7 @@ struct LegacyFloatingDateControl: View {
         .tint(Color.primary)
         .menuOrder(.fixed)
         .buttonStyle(.plain)
+        .modifier(DateRangeTipModifier())
     }
 
     private var dateRangeButtonContent: some View {
@@ -138,8 +140,38 @@ private struct FloatingStyle: ViewModifier {
     }
 }
 
+@available(iOS 17, *)
+private struct StatsDateRangeTip: Tip {
+    var title: Text {
+        Text(Strings.DateRangeTips.title)
+    }
+
+    var message: Text? {
+        Text(Strings.DateRangeTips.message)
+    }
+
+    var image: Image? {
+        Image(systemName: "calendar")
+    }
+
+    var options: [any TipOption] {
+        [Tips.MaxDisplayCount(1)]
+    }
+}
+
 private extension View {
     func floatingStyle(cornerRadius: CGFloat = 40) -> some View {
         modifier(FloatingStyle(cornerRadius: cornerRadius))
+    }
+}
+
+private struct DateRangeTipModifier: ViewModifier {
+    func body(content: Content) -> some View {
+        if #available(iOS 17, *) {
+            content
+                .popoverTip(StatsDateRangeTip(), arrowEdge: .bottom)
+        } else {
+            content
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Tips/AppTips.swift
+++ b/WordPress/Classes/ViewRelated/Tips/AppTips.swift
@@ -83,6 +83,27 @@ enum AppTips {
             MaxDisplayCount(1)
         }
     }
+
+    @available(iOS 17, *)
+    struct StatsDateRangeTip: Tip {
+        let id = "stats_date_range_tip"
+
+        var title: Text {
+            Text(NSLocalizedString("tips.statsDateRange.title", value: "Navigate Through Time", comment: "Title for stats date range control tip"))
+        }
+
+        var message: Text? {
+            Text(NSLocalizedString("tips.statsDateRange.message", value: "Use the calendar to select days, weeks, months, years, or choose custom date ranges to view your stats.", comment: "Message explaining how to use the date range control"))
+        }
+
+        var image: Image? {
+            Image(systemName: "calendar")
+        }
+
+        var options: [any TipOption] {
+            MaxDisplayCount(1)
+        }
+    }
 }
 
 extension UIViewController {


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/CMM-705/add-daysweeksmonthsyears-granularity-picker.

There's been some feedback about users confused about the change to the date pickers, so it seems worth it to add a tip to draw attention to the new control and explain what it's for.

<img width="360" alt="Screenshot 2025-08-27 at 4 34 22 PM" src="https://github.com/user-attachments/assets/7c7cecb9-db0f-4d89-94bb-42e14190f876" />
