### PR TITLE
[New Stats] Fix CMM-655: dark mode in range picker

### DIFF
--- a/Modules/Sources/JetpackStats/Views/CustomDateRangePicker.swift
+++ b/Modules/Sources/JetpackStats/Views/CustomDateRangePicker.swift
@@ -43,6 +43,7 @@ struct CustomDateRangePicker: View {
                         .buttonStyle(.borderedProminent)
                         .buttonBorderShape(.capsule)
                         .tint(Color.primary)
+                        .foregroundStyle(Color(.systemBackground))
                 }
             }
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 26.2
 -----
-
+ * [*] New Stats: Fix dark mode support in custom range picker [#24770]
 
 26.1
 -----


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-655/the-custom-range-selection-apply-button-in-dark-mode

<img width="360" alt="Screenshot 2025-08-27 at 4 47 25 PM" src="https://github.com/user-attachments/assets/ec6bc333-9bb8-4867-b236-dbfd1f0d0d8d" />
<img width="360"  alt="Screenshot 2025-08-27 at 4 47 33 PM" src="https://github.com/user-attachments/assets/d395b2f2-22d9-4356-819b-b72e93e47501" />
