### PR TITLE
Fix CMM-657: edit card menu shown in the wrong places

### DIFF
--- a/Modules/Sources/JetpackStats/Views/EditCardMenuContent.swift
+++ b/Modules/Sources/JetpackStats/Views/EditCardMenuContent.swift
@@ -4,49 +4,56 @@ struct EditCardMenuContent: View {
     let cardViewModel: TrafficCardViewModel
 
     var body: some View {
-        Section {
-            Menu {
-                ControlGroup {
-                    Button {
-                        cardViewModel.configurationDelegate?.moveCard(cardViewModel, direction: .up)
-                    } label: {
-                        Label(Strings.Buttons.moveUp, systemImage: "arrow.up")
-                    }
+        if cardViewModel.configurationDelegate != nil {
+            Section {
+                contents
+            }
+        }
+    }
 
-                    Button {
-                        cardViewModel.configurationDelegate?.moveCard(cardViewModel, direction: .top)
-                    } label: {
-                        Label(Strings.Buttons.moveToTop, systemImage: "arrow.up.to.line")
-                    }
+    @ViewBuilder
+    private var contents: some View {
+        Menu {
+            ControlGroup {
+                Button {
+                    cardViewModel.configurationDelegate?.moveCard(cardViewModel, direction: .up)
+                } label: {
+                    Label(Strings.Buttons.moveUp, systemImage: "arrow.up")
                 }
 
-                ControlGroup {
-                    Button {
-                        cardViewModel.configurationDelegate?.moveCard(cardViewModel, direction: .down)
-                    } label: {
-                        Label(Strings.Buttons.moveDown, systemImage: "arrow.down")
-                    }
-
-                    Button {
-                        cardViewModel.configurationDelegate?.moveCard(cardViewModel, direction: .bottom)
-                    } label: {
-                        Label(Strings.Buttons.moveToBottom, systemImage: "arrow.down.to.line")
-                    }
+                Button {
+                    cardViewModel.configurationDelegate?.moveCard(cardViewModel, direction: .top)
+                } label: {
+                    Label(Strings.Buttons.moveToTop, systemImage: "arrow.up.to.line")
                 }
-            } label: {
-                Label(Strings.Buttons.moveCard, systemImage: "arrow.up.arrow.down")
             }
-            Button {
-                cardViewModel.isEditing = true
-            } label: {
-                Label(Strings.Buttons.customize, systemImage: "widget.small")
+
+            ControlGroup {
+                Button {
+                    cardViewModel.configurationDelegate?.moveCard(cardViewModel, direction: .down)
+                } label: {
+                    Label(Strings.Buttons.moveDown, systemImage: "arrow.down")
+                }
+
+                Button {
+                    cardViewModel.configurationDelegate?.moveCard(cardViewModel, direction: .bottom)
+                } label: {
+                    Label(Strings.Buttons.moveToBottom, systemImage: "arrow.down.to.line")
+                }
             }
-            Button(role: .destructive) {
-                cardViewModel.configurationDelegate?.deleteCard(cardViewModel)
-            } label: {
-                Label(Strings.Buttons.deleteWidget, systemImage: "trash")
-                    .tint(Color.red)
-            }
+        } label: {
+            Label(Strings.Buttons.moveCard, systemImage: "arrow.up.arrow.down")
+        }
+        Button {
+            cardViewModel.isEditing = true
+        } label: {
+            Label(Strings.Buttons.customize, systemImage: "widget.small")
+        }
+        Button(role: .destructive) {
+            cardViewModel.configurationDelegate?.deleteCard(cardViewModel)
+        } label: {
+            Label(Strings.Buttons.deleteWidget, systemImage: "trash")
+                .tint(Color.red)
         }
     }
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] New Stats: Add support for "weeks" granularity [#24767]
 * [*] New Stats: Fix dark mode support in custom range picker [#24770]
+* [*] New Stats: Fix edit card menu shown in the wrong places [#24774]
 
 26.1
 -----


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-657/context-menu-does-not-apply-to-most-viewed-author-screen

### Screenshots 

<img width="1314" height="1010" alt="Screenshot 2025-08-28 at 9 36 26 AM" src="https://github.com/user-attachments/assets/a83c0268-2e04-4677-b5de-32ca96031c3f" />
