### PR TITLE
iOS 26: Fix buttons in Editor

### DIFF
--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -552,7 +552,6 @@ class AztecPostViewController: UIViewController, PostEditor {
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
 
-        configureDismissButton()
         startListeningToNotifications()
         verificationPromptHelper?.updateVerificationStatus()
     }
@@ -731,11 +730,6 @@ class AztecPostViewController: UIViewController, PostEditor {
         navigationController?.navigationBar.accessibilityIdentifier = "Azctec Editor Navigation Bar"
         navigationItem.leftBarButtonItems = navigationBarManager.leftBarButtonItems
         navigationItem.titleView = navigationBarManager.blogTitleViewLabel
-    }
-
-    func configureDismissButton() {
-        let image = isModal() ? Assets.closeButtonModalImage : Assets.closeButtonRegularImage
-        navigationBarManager.closeButton.setImage(image, for: .normal)
     }
 
     func configureView() {
@@ -3089,8 +3083,6 @@ extension AztecPostViewController {
     }
 
     struct Assets {
-        static let closeButtonModalImage = UIImage.gridicon(.cross)
-        static let closeButtonRegularImage = UIImage(systemName: "chevron.backward")
         static let defaultMissingImage = UIImage.gridicon(.image)
         static let linkPlaceholderImage = UIImage.gridicon(.pages)
     }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteDetailsSiteIconView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/SiteDetailsSiteIconView.swift
@@ -95,10 +95,6 @@ final class SiteDetailsSiteIconView: UIView {
     @objc func touchedButton() {
         tapped?()
     }
-
-    func removeButtonBorder() {
-        button.layer.borderWidth = 0
-    }
 }
 
 extension SiteDetailsSiteIconView: UIDropInteractionDelegate {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -439,11 +439,6 @@ class GutenbergViewController: UIViewController, PostEditor, PublishingEditor {
         navigationBarManager.moreButton.showsMenuAsPrimaryAction = true
     }
 
-    private func reloadBlogIconView() {
-        let viewModel = SiteIconViewModel(blog: post.blog, size: .small)
-        navigationBarManager.siteIconView.imageView.setIcon(with: viewModel)
-    }
-
     private func reloadEditorContents() {
         let content = post.content ?? String()
 
@@ -456,7 +451,6 @@ class GutenbergViewController: UIViewController, PostEditor, PublishingEditor {
     }
 
     private func refreshInterface() {
-        reloadBlogIconView()
         reloadEditorContents()
         reloadPublishButton()
         navigationItem.rightBarButtonItems = post.status == .trash ? [] : navigationBarManager.rightBarButtonItems

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -220,11 +220,6 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         navigationBarManager.moreButton.showsMenuAsPrimaryAction = true
     }
 
-    private func reloadBlogIconView() {
-        let viewModel = SiteIconViewModel(blog: post.blog, size: .small)
-        navigationBarManager.siteIconView.imageView.setIcon(with: viewModel)
-    }
-
     // TODO: this should not be called on viewDidLoad
     private func reloadEditorContents() {
         let content = post.content ?? String()
@@ -238,7 +233,6 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     }
 
     private func refreshInterface() {
-        reloadBlogIconView()
         reloadEditorContents()
         reloadPublishButton()
         navigationItem.rightBarButtonItems = post.status == .trash ? [] : navigationBarManager.rightBarButtonItems

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -90,7 +90,7 @@ extension PostEditor {
     }
 
     var alertBarButtonItem: UIBarButtonItem? {
-        return navigationBarManager.closeBarButtonItem
+        navigationBarManager.closeButton
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
@@ -78,15 +78,9 @@ class PostEditorNavigationBarManager {
     }()
 
     /// Publish Button
-    private(set) lazy var publishButton: UIButton = {
-        let button = UIButton(type: .system)
-        button.addTarget(self, action: #selector(publishButtonTapped(sender:)), for: .touchUpInside)
-        button.setTitle(delegate?.publishButtonText ?? "", for: .normal)
-        button.sizeToFit()
+    private(set) lazy var publishButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(title: delegate?.publishButtonText, style: .plain, target: self, action: #selector(publishButtonTapped))
         button.isEnabled = delegate?.isPublishButtonEnabled ?? false
-        button.setContentHuggingPriority(.required, for: .horizontal)
-        button.tintColor = UIColor(light: .black, dark: .white)
-        button.titleLabel?.font = UIFont.systemFont(ofSize: 17.0)
         return button
     }()
 
@@ -109,13 +103,6 @@ class PostEditorNavigationBarManager {
         let separator = UIBarButtonItem(barButtonSystemItem: .fixedSpace, target: nil, action: nil)
         separator.width = 16
         return separator
-    }()
-
-    /// Publish Button
-    private(set) lazy var publishBarButtonItem: UIBarButtonItem = {
-        let button = UIBarButtonItem(customView: self.publishButton)
-
-        return button
     }()
 
     /// NavigationBar's More Button
@@ -164,16 +151,15 @@ class PostEditorNavigationBarManager {
     var rightBarButtonItems: [UIBarButtonItem] {
         let undoButton = UIBarButtonItem(customView: self.undoButton)
         let redoButton = UIBarButtonItem(customView: self.redoButton)
-        return [publishBarButtonItem, separatorButtonItem, moreBarButtonItem, separatorButtonItem, redoButton, separatorButtonItem, undoButton]
+        return [publishButton, separatorButtonItem, moreBarButtonItem, separatorButtonItem, redoButton, separatorButtonItem, undoButton]
     }
 
     var rightBarButtonItemsAztec: [UIBarButtonItem] {
-        return [moreBarButtonItem, publishBarButtonItem, separatorButtonItem]
+        return [moreBarButtonItem, publishButton, separatorButtonItem]
     }
 
     func reloadPublishButton() {
-        publishButton.setTitle(delegate?.publishButtonText ?? "", for: .normal)
-        publishButton.sizeToFit()
+        publishButton.title = delegate?.publishButtonText
         publishButton.isEnabled = delegate?.isPublishButtonEnabled ?? true
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
@@ -15,23 +15,6 @@ protocol PostEditorNavigationBarManagerDelegate: AnyObject {
     func navigationBarManager(_ manager: PostEditorNavigationBarManager, displayCancelMediaUploads sender: UIButton)
 }
 
-class ExtendedTouchAreaButton: UIButton {
-    private var touchAreaPadding: CGFloat = 24.0
-
-    override var isHighlighted: Bool {
-        didSet {
-            UIView.animate(withDuration: 0.2) {
-                self.alpha = self.isHighlighted ? 0.5 : 1.0
-            }
-        }
-    }
-
-    override func point(inside point: CGPoint, with event: UIEvent?) -> Bool {
-        let extendedArea = bounds.insetBy(dx: -touchAreaPadding, dy: -touchAreaPadding)
-        return extendedArea.contains(point)
-    }
-}
-
 // A class to share the navigation bar UI of the Post Editor.
 // Currenly shared between Aztec and Gutenberg
 //
@@ -40,52 +23,10 @@ class PostEditorNavigationBarManager {
 
     // MARK: - Buttons
 
-    /// Dismiss Button
-    ///
-    let siteIconView: SiteDetailsSiteIconView = {
-        let siteIconView = SiteDetailsSiteIconView(frame: .zero)
-        siteIconView.translatesAutoresizingMaskIntoConstraints = false
-        siteIconView.imageView.sizeToFit()
-
-        let widthConstraint = siteIconView.widthAnchor.constraint(equalToConstant: 28)
-        let heightConstraint = siteIconView.heightAnchor.constraint(equalToConstant: 28)
-        NSLayoutConstraint.activate([widthConstraint, heightConstraint])
-        siteIconView.isUserInteractionEnabled = false
-        siteIconView.removeButtonBorder()
-        return siteIconView
-    }()
-
-    lazy var closeButton: UIButton = {
-        let button = UIButton(type: .system)
-        button.setImage(UIImage(systemName: "chevron.backward"), for: .normal)
-        button.sizeToFit()
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.configuration?.contentInsets = NSDirectionalEdgeInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
-        button.isUserInteractionEnabled = false
-        return button
-    }()
-
-    lazy var closeButtonContainer: ExtendedTouchAreaButton = {
-        let button = ExtendedTouchAreaButton(type: .custom)
-        button.translatesAutoresizingMaskIntoConstraints = false
-        button.accessibilityIdentifier = "editor-close-button"
+    private(set) lazy var closeButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(image: UIImage(systemName: "xmark"), style: .plain, target: self, action: #selector(closeWasPressed))
         button.accessibilityLabel = NSLocalizedString("Close", comment: "Action button to close the editor")
-
-        let tapGesture = UITapGestureRecognizer(target: self, action: #selector(closeWasPressed))
-        button.addGestureRecognizer(tapGesture)
-
-        button.addSubview(closeButton)
-        button.addSubview(siteIconView)
-
-        NSLayoutConstraint.activate([
-            closeButton.leadingAnchor.constraint(equalTo: button.leadingAnchor, constant: -8),
-            closeButton.centerYAnchor.constraint(equalTo: button.centerYAnchor),
-            siteIconView.leadingAnchor.constraint(equalTo: closeButton.trailingAnchor, constant: 0),
-            siteIconView.trailingAnchor.constraint(equalTo: button.trailingAnchor),
-            siteIconView.centerYAnchor.constraint(equalTo: button.centerYAnchor)
-        ])
-        button.isUserInteractionEnabled = true
-        button.frame = CGRect(x: 0, y: 0, width: 70, height: 28)
+        button.accessibilityIdentifier = "editor-close-button"
         return button
     }()
 
@@ -170,15 +111,6 @@ class PostEditorNavigationBarManager {
         return separator
     }()
 
-    /// NavigationBar's Close Button
-    ///
-    lazy var closeBarButtonItem: UIBarButtonItem = {
-        let cancelItem = UIBarButtonItem(customView: self.closeButtonContainer)
-        cancelItem.accessibilityLabel = NSLocalizedString("Close", comment: "Action button to close edior and cancel changes or insertion of post")
-        cancelItem.accessibilityIdentifier = "Close"
-        return cancelItem
-    }()
-
     /// Publish Button
     private(set) lazy var publishBarButtonItem: UIBarButtonItem = {
         let button = UIBarButtonItem(customView: self.publishButton)
@@ -222,7 +154,7 @@ class PostEditorNavigationBarManager {
     // MARK: - Public
 
     var leftBarButtonItems: [UIBarButtonItem] {
-        return [closeBarButtonItem]
+        return [closeButton]
     }
 
     var uploadingMediaTitleView: UIView {

--- a/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorNavigationBarManager.swift
@@ -30,7 +30,7 @@ class PostEditorNavigationBarManager {
         return button
     }()
 
-    lazy var undoButton: UIButton = {
+    private(set) lazy var undoButton: UIButton = {
         let isRTL = UIView.userInterfaceLayoutDirection(for: .unspecified) == .rightToLeft
         let undoImage = UIImage(named: "editor-undo")
         let button = UIButton(type: .system)
@@ -44,7 +44,7 @@ class PostEditorNavigationBarManager {
         return button
     }()
 
-    lazy var redoButton: UIButton = {
+    private(set)lazy var redoButton: UIButton = {
         let isRTL = UIView.userInterfaceLayoutDirection(for: .unspecified) == .rightToLeft
         let redoImage = UIImage(named: "editor-redo")
         let button = UIButton(type: .system)
@@ -58,7 +58,7 @@ class PostEditorNavigationBarManager {
         return button
     }()
 
-    lazy var moreButton: UIButton = {
+    private(set)lazy var moreButton: UIButton = {
         let image = UIImage(named: "editor-more")
         let button = UIButton(type: .system)
         button.setImage(image, for: .normal)
@@ -70,7 +70,7 @@ class PostEditorNavigationBarManager {
     }()
 
     /// Blog TitleView Label
-    lazy var blogTitleViewLabel: UILabel = {
+    private(set) lazy var blogTitleViewLabel: UILabel = {
         let label = UILabel()
         label.textColor = UIAppColor.appBarText
         label.font = Fonts.blogTitle
@@ -151,7 +151,11 @@ class PostEditorNavigationBarManager {
     var rightBarButtonItems: [UIBarButtonItem] {
         let undoButton = UIBarButtonItem(customView: self.undoButton)
         let redoButton = UIBarButtonItem(customView: self.redoButton)
-        return [publishButton, separatorButtonItem, moreBarButtonItem, separatorButtonItem, redoButton, separatorButtonItem, undoButton]
+        if #available(iOS 26, *) {
+            return [publishButton, separatorButtonItem, moreBarButtonItem, redoButton, undoButton]
+        } else {
+            return [publishButton, separatorButtonItem, moreBarButtonItem, separatorButtonItem, redoButton, separatorButtonItem, undoButton]
+        }
     }
 
     var rightBarButtonItemsAztec: [UIBarButtonItem] {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-473/fix-the-back-button-in-the-gbk-based-editor.

- Simplifies the close button – just show the "xmark" (standard behavior).
- Fixes the missing padding in the "Publish" button
- Show other controls in a single group.
<img width="360" alt="Screenshot 2025-08-29 at 2 44 15 PM" src="https://github.com/user-attachments/assets/859f51ee-1e3c-4af8-a6e4-18a5bfc6f0dd" />
<img width="360" alt="Screenshot 2025-08-29 at 2 44 32 PM" src="https://github.com/user-attachments/assets/e1f1abb4-e451-45d3-99ae-39de16a0d8e2" />
<img width="360" alt="Screenshot 2025-08-29 at 2 45 14 PM" src="https://github.com/user-attachments/assets/121108a9-d2c5-4ec6-958d-08ce1eb1e8cf" />
