### PR TITLE
Load all categories instead of just the first page

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "9a980b8a6fb8e8447784dc15711ebea95c0ed816e2b97797a31cc3035da386bc",
+  "originHash" : "1779107faa0c84b72d4643d5b28ad85b6723c3b458190041157b8e8ffc6699e7",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -372,8 +372,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/wordpress-rs",
       "state" : {
-        "branch" : "alpha-20250813",
-        "revision" : "c9cbf79d118b22fa97f96fd28f701cdad35d9910"
+        "branch" : "alpha-20250901",
+        "revision" : "8fa6532ea087bbc7dca60e027da0a1e82ea5dee8"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -54,7 +54,7 @@ let package = Package(
         ),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
-        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250813"),
+        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250901"),
         .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.8.0"),
         .package(
             url: "https://github.com/Automattic/color-studio",

--- a/WordPress/Classes/Services/MediaServiceRemoteCoreREST.swift
+++ b/WordPress/Classes/Services/MediaServiceRemoteCoreREST.swift
@@ -144,7 +144,7 @@ private extension RemoteMedia {
 
         self.mediaID = NSNumber(value: media.id)
         self.url = URL(string: media.sourceUrl)
-        self.guid = URL(string: media.guid.raw)
+        self.guid = media.guid.raw.flatMap(URL.init(string:))
         self.date = media.dateGmt
         self.postID = media.postId.map { NSNumber(value: $0) }
         self.mimeType = media.mimeType

--- a/WordPress/Classes/Services/TaxonomyServiceRemoteCoreREST.swift
+++ b/WordPress/Classes/Services/TaxonomyServiceRemoteCoreREST.swift
@@ -37,8 +37,11 @@ import WordPressAPIInternal
     public func getCategoriesWithSuccess(_ success: @escaping ([RemotePostCategory]) -> Void, failure: ((any Error) -> Void)? = nil) {
         Task { @MainActor in
             do {
-                let response = try await client.api.categories.listWithEditContext(params: CategoryListParams())
-                let categories = response.data.map(RemotePostCategory.init(category:))
+                let sequence = await client.api.categories.sequenceWithEditContext(params: CategoryListParams(perPage: 100))
+                let categories: [RemotePostCategory] = try await sequence.reduce(into: []) {
+                    let page = $1.map(RemotePostCategory.init(category:))
+                    $0.append(contentsOf: page)
+                }
                 success(categories)
             } catch {
                 failure?(error)


### PR DESCRIPTION
## Description

The `getCategoriesWithSuccess:failure:` function was implemented incorrectly. We are supposed to return all categories, but the implementation only returns the first page. This PR fixes that issue.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
