### PR TITLE
Fix 'Home' is not displayed upon app launch

### DIFF
--- a/WordPress/Classes/System/Root View/SplitViewRootPresenter+Site.swift
+++ b/WordPress/Classes/System/Root View/SplitViewRootPresenter+Site.swift
@@ -7,6 +7,8 @@ class SiteSplitViewContent: SiteMenuViewControllerDelegate, SplitViewDisplayable
     let supplementary: UINavigationController
     var secondary: UINavigationController
 
+    private weak var splitViewController: UISplitViewController?
+
     var blog: Blog {
         siteMenuVC.blog
     }
@@ -21,13 +23,21 @@ class SiteSplitViewContent: SiteMenuViewControllerDelegate, SplitViewDisplayable
     }
 
     func displayed(in splitVC: UISplitViewController) {
+        splitViewController = splitVC
+
         RecentSitesService().touch(blog: blog)
 
         _ = siteMenuVC.view
     }
 
     func siteMenuViewController(_ siteMenuViewController: SiteMenuViewController, showDetailsViewController viewController: UIViewController) {
-        guard siteMenuVC === siteMenuViewController, let splitVC = siteMenuViewController.splitViewController else { return }
+        // There is an issue on iOS 26 where the 'Home' tab of 'My Site' is selected, but the view controller is not displayed.
+        //
+        // The root cause is that during the app launch process, the `siteMenuVC.splitViewController` is nil (a.k.a. the `splitVC` variable
+        // in the guard statement below), even though `siteMenuVC` is set as the supplementary view controller.
+        //
+        // The workaround here is keeping the `UISplitViewController` reference and using it as the backup option.
+        guard siteMenuVC === siteMenuViewController, let splitVC = siteMenuViewController.splitViewController ?? splitViewController else { return }
 
         if viewController is UINavigationController ||
             viewController is UISplitViewController {


### PR DESCRIPTION
## Description

See the code comment about the issue and the fix.

## Testing instructions

Sign in to WP.com app. Kill the app. Launch the app again. The 'Home' (dashboard) content is displayed on screen.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
