### PR TITLE
Display the same blog in expanded and collapsed mode

### DIFF
--- a/WordPress/Classes/System/Root View/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/Root View/SplitViewRootPresenter.swift
@@ -312,6 +312,11 @@ extension SplitViewRootPresenter: UISplitViewControllerDelegate {
 
     // TODO: refactor this
     func splitViewControllerDidCollapse(_ svc: UISplitViewController) {
+        // Make sure the tab bar controller (displayed in compact mode) shows the same blog as the one in split view.
+        if let blog = siteContent?.blog, tabBarVC.mySitesCoordinator.currentBlog != siteContent?.blog {
+            tabBarVC.mySitesCoordinator.showBlogDetails(for: blog)
+        }
+
         switch sidebarViewModel.selection {
         case .blog:
             break
@@ -338,6 +343,15 @@ extension SplitViewRootPresenter: UISplitViewControllerDelegate {
             tabBarVC.showNotificationsTab()
         default:
             break
+        }
+    }
+
+    func splitViewControllerDidExpand(_ svc: UISplitViewController) {
+        // Make sure the split view shows the same blog as the tab bar controller (displayed in the compact mode)
+        if let blog = tabBarVC.mySitesCoordinator.currentBlog,
+           case let .blog(blogID) = sidebarViewModel.selection,
+           blog.objectID != blogID.objectID {
+            sidebarViewModel.selection = .blog(TaggedManagedObjectID(blog))
         }
     }
 }


### PR DESCRIPTION
## Description

The "root split view" on iPad has two completely separated view controller stacks for expanded and collapsed mode. They can display two different blogs when switching between them. Before iOS 26, the switch could only happen when the app was side-by-side with other apps, but iOS 26's resizing window feature makes it super easy to make the app switch between expanded and collapsed modes.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
