### PR TITLE
Fix flaky tests by replacing sleeps

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -100,7 +100,6 @@ steps:
         command: ".buildkite/commands/run-unit-tests.sh"
         depends_on: "build_wordpress"
         plugins: [$CI_TOOLKIT_PLUGIN]
-        matrix: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         artifact_paths:
           - "build/results/*"
         notify:

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -100,6 +100,7 @@ steps:
         command: ".buildkite/commands/run-unit-tests.sh"
         depends_on: "build_wordpress"
         plugins: [$CI_TOOLKIT_PLUGIN]
+        matrix: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
         artifact_paths:
           - "build/results/*"
         notify:

--- a/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
@@ -169,7 +169,7 @@ class ApplicationPasswordsRepositoryTests {
         let host = "\(uuid).example.com"
         let blog = try await createSelfHostedSite(host: host)
 
-        let monitor = Monitor(delay: 0.1)
+        let monitor = Monitor(delay: 0.5)
         stubApiDiscovery(siteHost: host)
         stubSelfHostedSiteWpV2GetUser()
         stubSelfHostedSiteCreateApplicationPassword(host: host, password: uuid, monitor: monitor)
@@ -203,7 +203,7 @@ class ApplicationPasswordsRepositoryTests {
         let host = "\(uuid).example.com"
         let blog = try await createSelfHostedSite(host: host)
 
-        let monitor = Monitor(delay: 0.1)
+        let monitor = Monitor(delay: 0.5)
         stubApiDiscovery(siteHost: host)
         stubSelfHostedSiteWpV2GetUser()
         stubSelfHostedSiteCreateApplicationPassword(host: host, password: uuid, monitor: monitor)

--- a/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
@@ -195,7 +195,7 @@ class ApplicationPasswordsRepositoryTests {
         #expect(password == uuid)
     }
 
-    @Test(arguments: [0, 1, 2, 3, 4])
+    @Test(arguments: [1, 2, 3, 4])
     func cancelConcurrentCall(nthTaskToBeCancelled: Int) async throws {
         defer { HTTPStubs.removeAllStubs()}
 

--- a/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/ApplicationPasswordsRepositoryTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 import Testing
 import WordPressData
 import WordPressAPI
@@ -176,7 +177,8 @@ class ApplicationPasswordsRepositoryTests {
         let repository = ApplicationPasswordRepository.forTesting(coreDataStack: coreDataStack, keychain: keychain)
 
         let first = Task { try await repository.createPasswordIfNeeded(for: blog) }
-        try await Task.sleep(for: .milliseconds(10))
+        await monitor.hasReceivedRequest()
+
         let second = Task { try await repository.createPasswordIfNeeded(for: blog) }
 
         first.cancel()
@@ -210,10 +212,20 @@ class ApplicationPasswordsRepositoryTests {
 
         let numberOfTasks = 5
         var tasks: [Task<Void, Error>] = []
+        // Start a few tasks and ensure they all have started at the end of the for-loop
         for _ in 0..<numberOfTasks {
-            tasks.append(Task { try await repository.createPasswordIfNeeded(for: blog) })
+            let started = CurrentValueSubject<_, Never>(false)
+            let task = Task {
+                started.value = true
+                try await repository.createPasswordIfNeeded(for: blog)
+            }
+            tasks.append(task)
+
+            _ = await started.values.first(where: { $0 })
             try await Task.sleep(for: .milliseconds(10))
         }
+
+        _ = await monitor.hasReceivedRequest()
 
         tasks[nthTaskToBeCancelled].cancel()
 
@@ -559,7 +571,11 @@ private extension ApplicationPasswordsRepositoryTests {
 
 private class Monitor {
     let delay: TimeInterval?
-    private(set) var numberOfRequests: Int = 0
+    let numberOfRequestsSubject = CurrentValueSubject<_, Never>(0)
+
+    var numberOfRequests: Int {
+        numberOfRequestsSubject.value
+    }
 
     private let lock = NSLock()
 
@@ -571,7 +587,11 @@ private class Monitor {
         lock.lock()
         defer { lock.unlock() }
 
-        numberOfRequests += 1
+        numberOfRequestsSubject.value += 1
+    }
+
+    func hasReceivedRequest() async {
+        _ = await numberOfRequestsSubject.values.first(where: { $0 > 0 })
     }
 }
 


### PR DESCRIPTION
## Description

I used `Task.sleep` to wait for the concurrent tasks to start, but this approach is not reliable on CI. This PR replaces them with actual signals that are sent out when certain things happen during tests (like a task has started, a request has been made).

I have created many unit test runs on [this CI job](https://buildkite.com/automattic/wordpress-ios/builds/28740), which all passed without flaky tests in `ApplicationPasswordRepositoryTests`. So, I think this PR improved the stability.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
