### PR TITLE
iOS 26: Fix table view separator colors

### DIFF
--- a/Modules/Sources/WordPressUI/Extensions/WPStyleGuide+Shared.swift
+++ b/Modules/Sources/WordPressUI/Extensions/WPStyleGuide+Shared.swift
@@ -22,7 +22,6 @@ extension WPStyleGuide {
         }
 
         tableView.backgroundColor = .systemGroupedBackground
-        tableView.separatorColor = UIAppColor.neutral(.shade10)
     }
 
     @objc


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-719/fix-separators-in-table-views

## Screenshots

<img width="456" height="972" alt="Screenshot 2025-09-03 at 10 41 02 AM" src="https://github.com/user-attachments/assets/caef1f6b-2a0e-476c-a6f7-bf3edce768bd" />
<img width="484" height="1030" alt="Screenshot 2025-09-03 at 10 43 23 AM" src="https://github.com/user-attachments/assets/f8cfbd23-e844-4dcb-985c-959062466ecc" />
