### PR TITLE
iOS 26: Update search bar placemenet

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteSwitcherView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/SiteSwitcherView.swift
@@ -90,9 +90,17 @@ struct SiteSwitcherView: View {
                     SiteSwitcherToolbarView(viewModel: viewModel)
                 }
             }
-            .searchable(text: $viewModel.searchText, placement: .navigationBarDrawer(displayMode: .always))
+            .searchable(text: $viewModel.searchText, placement: searchPlacemenet)
             .navigationTitle(Strings.navigationTitle)
             .navigationBarTitleDisplayMode(.inline)
+    }
+
+    private var searchPlacemenet: SearchFieldPlacement {
+        if #available(iOS 26, *) {
+            .automatic
+        } else {
+            .navigationBarDrawer(displayMode: .always)
+        }
     }
 }
 
@@ -108,10 +116,17 @@ private struct SiteSwitcherToolbarView: View {
                 Spacer()
                 button
                     .padding(.trailing, 20)
-                    .padding(.bottom, UIDevice.current.userInterfaceIdiom == .pad ? 20 : 0)
+                    .padding(.bottom, bottomOffset)
                     .accessibilityIdentifier("add-site-button")
             }
         }
+    }
+
+    private var bottomOffset: CGFloat {
+        if #available(iOS 26, *) {
+            return 20
+        }
+        return UIDevice.current.userInterfaceIdiom == .pad ? 20 : 0
     }
 
     @ViewBuilder

--- a/WordPress/Classes/ViewRelated/Me/App Settings/Boolean User Defaults/BooleanUserDefaultsDebugView.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/Boolean User Defaults/BooleanUserDefaultsDebugView.swift
@@ -29,7 +29,7 @@ struct BooleanUserDefaultsDebugView: View {
             }
         }
         .navigationTitle(Strings.title)
-        .searchable(text: $viewModel.searchQuery, placement: .navigationBarDrawer(displayMode: .always))
+        .searchable(text: $viewModel.searchQuery)
         .onAppear {
             viewModel.load()
         }

--- a/WordPress/Classes/ViewRelated/Me/App Settings/DebugFeatureFlagsView.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/DebugFeatureFlagsView.swift
@@ -10,7 +10,7 @@ struct DebugFeatureFlagsView: View {
         }
         .tint(Color(UIAppColor.jetpackGreen))
         .listStyle(.plain)
-        .searchable(text: $viewModel.filterTerm, placement: .navigationBarDrawer(displayMode: .always))
+        .searchable(text: $viewModel.filterTerm)
         .navigationTitle(navigationTitle)
         .navigationBarTitleDisplayMode(.inline)
         .toolbarTitleMenu {

--- a/WordPress/Classes/ViewRelated/Me/App Settings/RemoteConfigDebugView.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/RemoteConfigDebugView.swift
@@ -8,7 +8,7 @@ struct RemoteConfigDebugView: View {
             listContent
         }
         .listStyle(.plain)
-        .searchable(text: $viewModel.searchText, placement: .navigationBarDrawer(displayMode: .always))
+        .searchable(text: $viewModel.searchText)
         .toolbar {
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button(Strings.reset, action: viewModel.resetAll)

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -91,6 +91,12 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
         didMove(toParent: parentViewController)
 
         parentViewController.navigationItem.searchController = searchController
+
+#if compiler(>=6.2)
+        if #available(iOS 26, *) {
+            parentViewController.navigationItem.preferredSearchBarPlacement = .integratedButton
+        }
+#endif
     }
 
     override func viewDidLoad() {

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -94,7 +94,7 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
 
 #if compiler(>=6.2)
         if #available(iOS 26, *) {
-            parentViewController.navigationItem.preferredSearchBarPlacement = .integratedButton
+            parentViewController.navigationItem.preferredSearchBarPlacement = traitCollection.horizontalSizeClass == .regular ? .integrated : .integratedButton
         }
 #endif
     }

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Helpers/SiteMediaFilterButtonView.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Helpers/SiteMediaFilterButtonView.swift
@@ -1,7 +1,7 @@
 import UIKit
 import WordPressData
 
-struct SiteMediaFilter {
+struct SiteMediaFilter: Equatable {
     let mediaType: MediaType?
     let title: String
     let imageName: String?
@@ -18,7 +18,7 @@ struct SiteMediaFilter {
 }
 
 private enum Strings {
-    static let filterAll = NSLocalizedString("mediaLibrary.filterAll", value: "All", comment: "The name of the media filter")
+    static let filterAll = NSLocalizedString("mediaLibrary.filterDefault", value: "Default (All)", comment: "The name of the media filter")
     static let filterImages = NSLocalizedString("mediaLibrary.filterImages", value: "Images", comment: "The name of the media filter")
     static let filterVideos = NSLocalizedString("mediaLibrary.filterVideos", value: "Videos", comment: "The name of the media filter")
     static let filterDocuments = NSLocalizedString("mediaLibrary.filterDocuments", value: "Documents", comment: "The name of the media filter")

--- a/WordPress/Classes/ViewRelated/Post/Controllers/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Controllers/AbstractPostListViewController.swift
@@ -202,7 +202,7 @@ class AbstractPostListViewController: UIViewController,
 
 #if compiler(>=6.2)
         if #available(iOS 26, *) {
-            navigationItem.preferredSearchBarPlacement = .integratedButton
+            navigationItem.preferredSearchBarPlacement = traitCollection.horizontalSizeClass == .regular ? .integrated : .integratedButton
         }
 #endif
 

--- a/WordPress/Classes/ViewRelated/Post/Controllers/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Controllers/AbstractPostListViewController.swift
@@ -200,6 +200,12 @@ class AbstractPostListViewController: UIViewController,
 
         searchResultsViewController.configure(searchController, self as? InteractivePostViewDelegate)
 
+#if compiler(>=6.2)
+        if #available(iOS 26, *) {
+            navigationItem.preferredSearchBarPlacement = .integratedButton
+        }
+#endif
+
         definesPresentationContext = true
         navigationItem.searchController = searchController
     }

--- a/WordPress/Classes/ViewRelated/Post/Views/AuthorFilterButton.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/AuthorFilterButton.swift
@@ -65,7 +65,7 @@ final class AuthorFilterButton: UIControl {
     private func commonInit() {
         addSubview(authorImageView)
         NSLayoutConstraint.activate([
-            authorImageView.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metrics.leadingPadding),
+            authorImageView.centerXAnchor.constraint(equalTo: centerXAnchor),
             authorImageView.centerYAnchor.constraint(equalTo: centerYAnchor),
             authorImageView.widthAnchor.constraint(equalToConstant: Metrics.gravatarSize.width),
             authorImageView.heightAnchor.constraint(equalToConstant: Metrics.gravatarSize.height),
@@ -82,7 +82,6 @@ final class AuthorFilterButton: UIControl {
     private enum Metrics {
         static let contentSize = CGSize(width: 44.0, height: 44.0)
         static let gravatarSize = CGSize(width: 28.0, height: 28.0)
-        static let leadingPadding: CGFloat = 12.0
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/Views/AuthorFilterViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/AuthorFilterViewController.swift
@@ -157,7 +157,7 @@ class AuthorFilterViewController: UITableViewController {
     }
 
     private enum Metrics {
-        static let rowHeight: CGFloat = 44.0
+        static let rowHeight: CGFloat = if #available(iOS 26, *) { 60.0 } else { 44.0 }
         static let preferredWidth: CGFloat = 220.0
         static let topinset: CGFloat = 13.0
     }

--- a/WordPress/Classes/ViewRelated/Tools/TimeZone/TimeZoneSelectorView.swift
+++ b/WordPress/Classes/ViewRelated/Tools/TimeZone/TimeZoneSelectorView.swift
@@ -25,7 +25,7 @@ struct TimeZoneSelectorView: View {
             }
         }
         .listStyle(.plain)
-        .searchable(text: $searchText, placement: .navigationBarDrawer(displayMode: .always))
+        .searchable(text: $searchText)
         .navigationTitle(Strings.title)
         .navigationBarTitleDisplayMode(.inline)
         .overlay {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-716/move-search-to-standard-position-bottom-where-applicable

## Screenshots

### Site List

Before / After
<img width="340" alt="Screenshot 2025-09-03 at 2 41 26 PM" src="https://github.com/user-attachments/assets/e025d824-c975-4a0f-a431-4c15703effbc" /> <img width="340" alt="Screenshot 2025-09-03 at 3 14 05 PM" src="https://github.com/user-attachments/assets/0ed541a3-f0cf-4ebb-99ee-899b12e70e4f" />

### Post List

Before, see video: 


https://github.com/user-attachments/assets/ec8fcc86-d0da-4607-b519-93ff2f474c85

After, it uses the new `integratedButton` placement. I also fixed the "authors" filter.

<img width="340" alt="Screenshot 2025-09-03 at 3 57 43 PM" src="https://github.com/user-attachments/assets/4e4fe5b3-d90c-442e-b87e-2bc8f9aa2e54" />


### Media

The "Media" screen also had problems with animations when showing search, so I updated it to be shown in the navigation bar. I also replaced the title-menu that Apple no longer seems to be using with a "filter" button that we used throughout the app.
<img width="340" alt="Screenshot 2025-09-03 at 5 04 34 PM" src="https://github.com/user-attachments/assets/fb9341a2-7e17-4f65-b1b1-50b74d98156f" />
<img width="1316" height="1011" alt="Screenshot 2025-09-03 at 5 28 22 PM" src="https://github.com/user-attachments/assets/7b616882-9e9a-4f9c-9189-cd0e9aa098e4" />

### Misc

I updated a couple of other screens including "Debug Flags" and more to use standard placement.

<img width="340" alt="Screenshot 2025-09-03 at 5 34 46 PM" src="https://github.com/user-attachments/assets/35871fca-b53e-4734-bfe1-a7f9db7ee591" />


