### PR TITLE
iOS 26: Fix "Done" and "Close" buttons usage

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/PostStatsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/PostStatsViewController.swift
@@ -22,6 +22,7 @@ final class PostStatsViewController: UIViewController {
         super.viewDidLoad()
 
         view.backgroundColor = .systemBackground
+        title = Strings.title
 
         setupStatsView()
         setupNavigationBar()
@@ -64,4 +65,8 @@ final class PostStatsViewController: UIViewController {
     @objc private func dismissViewController() {
         presentingViewController?.dismiss(animated: true)
     }
+}
+
+private enum Strings {
+    static let title = NSLocalizedString("postStats.title", value: "Post Stats", comment: "Navigation bar title")
 }

--- a/WordPress/Classes/ViewRelated/Stats/PostStatsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/PostStatsViewController.swift
@@ -53,8 +53,8 @@ final class PostStatsViewController: UIViewController {
 
     private func setupNavigationBar() {
         if presentingViewController != nil {
-            navigationItem.rightBarButtonItem = UIBarButtonItem(
-                barButtonSystemItem: .done,
+            navigationItem.leftBarButtonItem = UIBarButtonItem(
+                barButtonSystemItem: .close,
                 target: self,
                 action: #selector(dismissViewController)
             )

--- a/WordPress/Classes/ViewRelated/Stats/PostStatsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/PostStatsViewController.swift
@@ -68,5 +68,5 @@ final class PostStatsViewController: UIViewController {
 }
 
 private enum Strings {
-    static let title = NSLocalizedString("postStats.title", value: "Post Stats", comment: "Navigation bar title")
+    static let title = NSLocalizedString("postStats.title", value: "Post Stats", comment: "Navigation bar title of the Post Stats screen")
 }


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-721/update-close-and-done-buttons

## Screenshots

Before / After

<img width="340" alt="Screenshot 2025-09-03 at 4 11 37 PM" src="https://github.com/user-attachments/assets/800cb5eb-90fa-44be-bdc8-6601b5120a40" /> <img width="340" alt="Screenshot 2025-09-03 at 5 45 04 PM" src="https://github.com/user-attachments/assets/aad09d59-2147-46b3-933a-59cfd27844a6" />.

Note: I also added the missing title.