### PR TITLE
iOS 26: Updates Stats layout

### DIFF
--- a/Modules/Sources/JetpackStats/Constants.swift
+++ b/Modules/Sources/JetpackStats/Constants.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import ColorStudio
 
-enum Constants {
+public enum Constants {
     enum Colors {
         static let positiveChangeForeground = Color(UIColor(
             light: UIColor(red: 0.2, green: 0.6, blue: 0.2, alpha: 1.0),
@@ -69,7 +69,7 @@ enum Constants {
     static let cardHorizontalInsetCompact: CGFloat = step1
 
     /// Returns the appropriate horizontal card inset for the given size class
-    static func cardHorizontalInset(for sizeClass: UserInterfaceSizeClass?) -> CGFloat {
+    public static func cardHorizontalInset(for sizeClass: UserInterfaceSizeClass?) -> CGFloat {
         sizeClass == .regular ? cardHorizontalInsetRegular : cardHorizontalInsetCompact
     }
 

--- a/Modules/Sources/JetpackStats/Screens/TrafficTabView.swift
+++ b/Modules/Sources/JetpackStats/Screens/TrafficTabView.swift
@@ -25,7 +25,7 @@ struct TrafficTabView: View {
                     buttonAddChart
                     timeZoneInfo
                 }
-                .padding(.vertical, Constants.step2 + (horizontalSizeClass == .regular ? Constants.step1 : 0))
+                .padding(.vertical, Constants.step2)
                 .padding(.horizontal, Constants.cardHorizontalInset(for: horizontalSizeClass))
                 .padding(.top, topPadding)
                 .onReceive(viewModel.scrollToCardSubject) { cardID in

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsBaseTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsBaseTableViewController.swift
@@ -1,5 +1,7 @@
 import UIKit
+import SwiftUI
 import WordPressUI
+import JetpackStats
 
 /// Base class for site stats table view controllers
 ///
@@ -22,17 +24,29 @@ class SiteStatsBaseTableViewController: UIViewController {
     }
 
     func initTableView() {
-        tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.cellLayoutMarginsFollowReadableWidth = true
+
+        if #available(iOS 26, *) {
+            tableView.preservesSuperviewLayoutMargins = false
+        }
 
         view.addSubview(tableView)
         tableView.pinEdges()
 
         tableView.refreshControl = refreshControl
     }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if #available(iOS 26, *) {
+            let inset = JetpackStats.Constants.cardHorizontalInset(for: UserInterfaceSizeClass(traitCollection.horizontalSizeClass))
+            tableView.directionalLayoutMargins = .init(top: 0, leading: inset, bottom: 0, trailing: inset)
+        }
+    }
 }
 
-// MARK: - Tableview Datasource
+// MARK: - UITableViewDataSource
 
 // These methods aren't actually needed as the tableview is controlled by an instance of ImmuTableViewHandler.
 // However, ImmuTableViewHandler requires that the owner of the tableview is a data source and delegate.
@@ -47,14 +61,14 @@ extension SiteStatsBaseTableViewController: TableViewContainer, UITableViewDataS
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        return UITableViewCell()
+        UITableViewCell()
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return 16
+        if #available(iOS 26, *) { 30 } else { 16 }
     }
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {
-        return 0
+        0
     }
 }

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsBaseTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsBaseTableViewController.swift
@@ -1,21 +1,15 @@
 import UIKit
-import DesignSystem
+import WordPressUI
 
 /// Base class for site stats table view controllers
 ///
-
 class SiteStatsBaseTableViewController: UIViewController {
 
     let refreshControl = UIRefreshControl()
 
-    /// This property must be set before viewDidLoad is called - currently the classes that inherit are created from storyboards
-    /// When storyboard is removed it can be passed in as a parameter in an initializer
-    var tableStyle: UITableView.Style = .grouped
+    var tableStyle: UITableView.Style { .insetGrouped }
 
-    // MARK: - Properties
-    lazy var tableView: UITableView = {
-        UITableView(frame: .zero, style: tableStyle)
-    }()
+    private(set) lazy var tableView = UITableView(frame: .zero, style: tableStyle)
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -30,8 +24,9 @@ class SiteStatsBaseTableViewController: UIViewController {
     func initTableView() {
         tableView.translatesAutoresizingMaskIntoConstraints = false
         tableView.cellLayoutMarginsFollowReadableWidth = true
+
         view.addSubview(tableView)
-        view.pinSubviewToAllEdges(tableView)
+        tableView.pinEdges()
 
         tableView.refreshControl = refreshControl
     }
@@ -56,7 +51,7 @@ extension SiteStatsBaseTableViewController: TableViewContainer, UITableViewDataS
     }
 
     func tableView(_ tableView: UITableView, heightForHeaderInSection section: Int) -> CGFloat {
-        return .DS.Padding.double
+        return 16
     }
 
     func tableView(_ tableView: UITableView, heightForFooterInSection section: Int) -> CGFloat {

--- a/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Insights/SiteStatsInsightsTableViewController.swift
@@ -52,17 +52,6 @@ class SiteStatsInsightsTableViewController: SiteStatsBaseTableViewController {
         return ImmuTableDiffableViewHandler(takeOver: self, with: analyticsTracker)
     }()
 
-    // MARK: - Initialization
-
-    init() {
-        super.init(nibName: nil, bundle: nil)
-        tableStyle = .insetGrouped
-    }
-
-    required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
-    }
-
     // MARK: - View
 
     override func viewDidLoad() {

--- a/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Period Stats/SiteStatsPeriodTableViewController.swift
@@ -44,7 +44,6 @@ final class SiteStatsPeriodTableViewController: SiteStatsBaseTableViewController
         datePickerViewModel = StatsTrafficDatePickerViewModel(period: period, date: date)
         datePickerView = StatsTrafficDatePickerView(viewModel: datePickerViewModel)
         super.init(nibName: nil, bundle: nil)
-        tableStyle = .insetGrouped
     }
 
     required init?(coder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsInsightsDetailsTableViewController.swift
@@ -58,7 +58,6 @@ class SiteStatsInsightsDetailsTableViewController: SiteStatsBaseTableViewControl
         self.selectedDate = selectedDate ?? StatsDataHelper.currentDateForSite()
         self.selectedPeriod = selectedPeriod
         self.postID = postID
-        tableStyle = .insetGrouped
         title = statSection.detailsTitle
         initViewModel()
         updateHeader()

--- a/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Subscribers/StatsSubscribersViewController.swift
@@ -13,8 +13,6 @@ final class StatsSubscribersViewController: SiteStatsBaseTableViewController {
     init(viewModel: StatsSubscribersViewModel) {
         self.viewModel = viewModel
         super.init(nibName: nil, bundle: nil)
-
-        tableStyle = .insetGrouped
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-718/update-card-top-and-intersections-insets-for-ios-26

Updates the insets for cells to match new stats.

## Screenshots (iPhone)

<img width="320" alt="Screenshot 2025-09-04 at 9 05 55 AM" src="https://github.com/user-attachments/assets/dd9ec1e4-ab73-4874-96fa-01abe9f16569" />
<img width="320" alt="Screenshot 2025-09-04 at 9 05 56 AM" src="https://github.com/user-attachments/assets/723a89b0-c110-4016-9cff-4698901a6b1f" />
<img width="320" alt="Screenshot 2025-09-04 at 9 05 57 AM" src="https://github.com/user-attachments/assets/a5de2328-e062-4a0a-83d0-1e4b6b37b9e9" />

## Screenshots (iPad)

<img width="1316" height="1011" alt="Screenshot 2025-09-04 at 9 11 16 AM" src="https://github.com/user-attachments/assets/d8439c22-fc54-484c-ac4b-2ae01b5627a0" />
<img width="1316" height="1011" alt="Screenshot 2025-09-04 at 9 11 18 AM" src="https://github.com/user-attachments/assets/4b48fc34-d005-4bd0-8957-8e965126834f" />
