### PR TITLE
iOS 26: Fix featured image corner radius

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostSettingsFeaturedImageRow.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostSettingsFeaturedImageRow.swift
@@ -139,19 +139,23 @@ struct PostSettingsFeaturedImageRow: View {
     private func makeWithProminentBackground<Content: View>(@ViewBuilder content: @escaping () -> Content) -> some View {
         ZStack {
             // System background that adapts to dark mode
-            RoundedRectangle(cornerRadius: 12)
+            RoundedRectangle(cornerRadius: cornerRadius)
                 .fill(Color(UIColor.secondarySystemGroupedBackground))
 
             // Very subtle accent tint
-            RoundedRectangle(cornerRadius: 12)
+            RoundedRectangle(cornerRadius: cornerRadius)
                 .fill(Color.accentColor.opacity(0.02))
 
             content()
 
             // Prominent border
-            RoundedRectangle(cornerRadius: 12)
+            RoundedRectangle(cornerRadius: cornerRadius)
                 .strokeBorder(Color.accentColor.opacity(0.3), lineWidth: 1)
         }
+    }
+
+    private var cornerRadius: CGFloat {
+        if #available(iOS 26, *) { 26 } else { 12 }
     }
 
     private func makeMediaPicker<Content: View>(@ViewBuilder content: @escaping () -> Content) -> some View {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-717/fix-featured-images-corner-radius-in-post-settings

<img width="1316" height="1011" alt="Screenshot 2025-09-04 at 9 21 11 AM" src="https://github.com/user-attachments/assets/822b55a4-3b4b-414e-9373-958326e9fae5" />