### PR TITLE
Fix issue: the site switch buton is not responsive

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -299,15 +299,7 @@ extension BlogDetailHeaderView {
 
         fileprivate func configureLargeTitleMode() {
             siteIconView.setImageViewSize(50)
-
             siteIconView.transform = CGAffineTransform(translationX: 0, y: 2) // Visually center vertically
-
-            siteSwitcherButton.removeFromSuperview()
-            mainStackView.addSubview(siteSwitcherButton)
-            NSLayoutConstraint.activate([
-                siteSwitcherButton.lastBaselineAnchor.constraint(equalTo: titleButton.lastBaselineAnchor, constant: -2),
-                siteSwitcherButton.leadingAnchor.constraint(equalTo: titleButton.trailingAnchor, constant: 2)
-            ])
         }
 
         func set(url: String) {


### PR DESCRIPTION
## Description

The `siteSwicherButton` was placed outside of its parent stack view, which made it unresponsive to tap on iOS 26. This PR removes a couple of customized constraints to keep `siteSwicherButton` inside the `mainStackView` stack view.

I didn't keep the baseline constraint because the difference is super subtle. I'm not sure it's worth the complexity to mess with stack view and adding customized constraints.

| Before | After |
| ------ | ----- |
| ![before-clipped](https://github.com/user-attachments/assets/7d9cb600-d66f-483f-b457-f6566cc7cc72) | ![after-clipped](https://github.com/user-attachments/assets/54ed28b9-6a57-4d91-a6e6-8b0aede43f41) |


## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
