### PR TITLE
Fix an iPadOS 26 issue where status bar overlaps with navigation bar

### DIFF
--- a/Sources/Jetpack/Info.plist
+++ b/Sources/Jetpack/Info.plist
@@ -635,7 +635,7 @@
 	<key>UIRequiresFullScreen</key>
 	<false/>
 	<key>UIStatusBarHidden</key>
-	<true/>
+	<false/>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleBlackOpaque</string>
 	<key>UISupportedInterfaceOrientations</key>

--- a/Sources/WordPress/Info.plist
+++ b/Sources/WordPress/Info.plist
@@ -560,7 +560,7 @@
 	<key>UIRequiresFullScreen</key>
 	<false/>
 	<key>UIStatusBarHidden</key>
-	<true/>
+	<false/>
 	<key>UIStatusBarStyle</key>
 	<string>UIStatusBarStyleBlackOpaque</string>
 	<key>UISupportedInterfaceOrientations</key>


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-729/ipad-opens-with-a-status-bar-overlapping-the-navigation-bar

## Description

On iPad OS 26, the status bar overlaps with the navigation bar. The fix is changing the "Status bar is initially hidden" configuration from yes to no.

I think the root cause is a regression in iPad OS, which may be fixed in later releases. But I think showing the status bar on launch is okay too.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
