### PR TITLE
iOS 26: Update readable guide for Reader Article view

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -236,11 +236,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
         super.traitCollectionDidChange(previousTraitCollection)
 
-        if traitCollection.horizontalSizeClass != previousTraitCollection?.horizontalSizeClass {
-            let isCompact = traitCollection.horizontalSizeClass == .compact
-            headerContainerView.layer.cornerRadius = isCompact ? DesignConstants.radius(.large) : 0
-            headerContainerView.layer.maskedCorners = isCompact ? [.layerMaxXMinYCorner, .layerMinXMinYCorner] : []
-        }
+        let isCompact = traitCollection.horizontalSizeClass == .compact
+        headerContainerView.layer.cornerRadius = isCompact ? DesignConstants.radius(.large) : 0
+        headerContainerView.layer.maskedCorners = isCompact ? [.layerMaxXMinYCorner, .layerMinXMinYCorner] : []
     }
 
     func render(_ post: ReaderPost) {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -173,8 +173,6 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
             headerContainerView.clipsToBounds = true
             headerContainerView.backgroundColor = .systemBackground
-            headerContainerView.layer.cornerRadius = DesignConstants.radius(.large)
-            headerContainerView.layer.maskedCorners = [.layerMaxXMinYCorner, .layerMinXMinYCorner]
         }
 
         // Fixes swipe to go back not working when leftBarButtonItem is set
@@ -233,6 +231,16 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     override func contentScrollView(for edge: NSDirectionalRectEdge) -> UIScrollView? {
         scrollView
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        if traitCollection.horizontalSizeClass != previousTraitCollection?.horizontalSizeClass {
+            let isCompact = traitCollection.horizontalSizeClass == .compact
+            headerContainerView.layer.cornerRadius = isCompact ? DesignConstants.radius(.large) : 0
+            headerContainerView.layer.maskedCorners = isCompact ? [.layerMaxXMinYCorner, .layerMinXMinYCorner] : []
+        }
     }
 
     func render(_ post: ReaderPost) {
@@ -444,13 +452,10 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     /// Apply view styles
     @MainActor private func applyStyles() {
-        guard let readableGuide = webView.superview?.readableContentGuide else {
-            return
-        }
-
+        webView.pinEdges(.horizontal, to: view, insets: UIEdgeInsets(.horizontal, 16), priority: .init(950))
         NSLayoutConstraint.activate([
-            webView.rightAnchor.constraint(equalTo: readableGuide.rightAnchor, constant: -Constants.margin),
-            webView.leftAnchor.constraint(equalTo: readableGuide.leftAnchor, constant: Constants.margin)
+            webView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            webView.widthAnchor.constraint(lessThanOrEqualToConstant: UIFontMetrics(forTextStyle: .body).scaledValue(for: Constants.preferredArticleWidth))
         ])
 
         webView.translatesAutoresizingMaskIntoConstraints = false
@@ -853,7 +858,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     private enum Constants {
-        static let margin: CGFloat = UIDevice.isPad() ? 0 : 8
+        static let preferredArticleWidth: CGFloat = 680
     }
 
     // MARK: - Managed object observer

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -176,7 +176,7 @@ class ReaderDetailToolbar {
         // Set font
         configuration.titleTextAttributesTransformer = UIConfigurationTextAttributesTransformer { incoming in
             var outgoing = incoming
-            outgoing.font = .preferredFont(forTextStyle: .subheadline)
+            outgoing.font = .system(size: 15)
             return outgoing
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderHeroView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderHeroView.swift
@@ -69,8 +69,9 @@ final class ReaderHeroView: UIView {
         super.traitCollectionDidChange(previousTraitCollection)
 
         // Extend below the header of the article to support corner radius
-        if traitCollection.horizontalSizeClass != previousTraitCollection?.horizontalSizeClass {
-            bottomExtensionHeight = traitCollection.horizontalSizeClass == .compact ? DesignConstants.radius(.large) : 0
+        let newValue = traitCollection.horizontalSizeClass == .compact ? DesignConstants.radius(.large) : 0
+        if bottomExtensionHeight != newValue {
+            bottomExtensionHeight = newValue
             setNeedsLayout()
         }
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderHeroView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderHeroView.swift
@@ -12,7 +12,7 @@ final class ReaderHeroView: UIView {
         traitCollection.horizontalSizeClass == .compact ? 40 : 20
     }
 
-    let bottomExtensionHeight = DesignConstants.radius(.large)
+    private(set) var bottomExtensionHeight: CGFloat = 0
 
     var imageURL: URL?
 
@@ -62,6 +62,16 @@ final class ReaderHeroView: UIView {
 
         if imageViewFrame != imageView.frame {
             imageView.frame = imageViewFrame
+        }
+    }
+
+    override func traitCollectionDidChange(_ previousTraitCollection: UITraitCollection?) {
+        super.traitCollectionDidChange(previousTraitCollection)
+
+        // Extend below the header of the article to support corner radius
+        if traitCollection.horizontalSizeClass != previousTraitCollection?.horizontalSizeClass {
+            bottomExtensionHeight = traitCollection.horizontalSizeClass == .compact ? DesignConstants.radius(.large) : 0
+            setNeedsLayout()
         }
     }
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-708/readable-content-width-on-ipad-not-repsected-in-reader-and-other.

The readable guide changes on iOS 26 – it's now much larger by default. It doesn't work well for the article view, which I updated to use a hardcoded maximum width depending on the dynamic type. The width is the recommended size for reading.

I also disabled rounded corners in the header on iPad – they don't look good on a larger screen.



<img width="1316" height="1011" alt="Screenshot 2025-09-09 at 6 33 43 AM" src="https://github.com/user-attachments/assets/81bab253-24b2-46b1-83f1-114ebd09b79a" />
<img width="1316" height="1011" alt="Screenshot 2025-09-09 at 6 33 55 AM" src="https://github.com/user-attachments/assets/c5c35fb1-7b41-4189-83f8-7d08ef1829b0" />
<img width="1316" height="1011" alt="Screenshot 2025-09-09 at 6 44 33 AM" src="https://github.com/user-attachments/assets/080e51e5-6fb3-49ec-826a-23c0447c8cc1" />
