### PR TITLE
iOS 26: When Reader is shown by default, the initial screen is not visible

### DIFF
--- a/WordPress/Classes/System/Root View/ReaderPresenter.swift
+++ b/WordPress/Classes/System/Root View/ReaderPresenter.swift
@@ -27,6 +27,8 @@ public final class ReaderPresenter: NSObject, SplitViewDisplayable {
         self.init(viewModel: ReaderSidebarViewModel())
     }
 
+    weak var splitViewController: UISplitViewController?
+
     init(viewModel: ReaderSidebarViewModel) {
         sidebarViewModel = viewModel
         secondary = UINavigationController()
@@ -219,10 +221,6 @@ public final class ReaderPresenter: NSObject, SplitViewDisplayable {
         } else {
             mainNavigationController.safePushViewController(viewController, animated: true)
         }
-    }
-
-    private var splitViewController: UISplitViewController? {
-        sidebar.splitViewController
     }
 
     // MARK: - Deep Links (ReaderNavigationPath)

--- a/WordPress/Classes/System/Root View/SplitViewRootPresenter.swift
+++ b/WordPress/Classes/System/Root View/SplitViewRootPresenter.swift
@@ -103,6 +103,8 @@ final class SplitViewRootPresenter: RootViewPresenter {
             content = notificationsContent
         case .reader:
             content = readerPresenter
+            readerPresenter.splitViewController = splitVC
+
         }
 
         display(content: content)


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-730/when-reader-is-the-default-screen-the-split-view-not-displaying