### PR TITLE
Stats: Fix an issue with BarChartView preventing scrolling

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 26.3
 -----
 * [*] Fix an issue with Notification Settings button not working in the Reader Subscriptions context menus for subscriptions [#24778]
+* [*] Fix an issue with tooltip in bar charts in Stats preventing scrolling [#24822]
 * [*] Fix rare crash in Reader when loading posts [#24815]
 
 26.2


### PR DESCRIPTION
In the simplified implementation, you can tap or you can drag. You can on longer long-press.

## Testing

- Verify that you can still tap on a chart to show the selected period
- Verify that you can drag horizontally to show the tooltips (long-press no longer works)

I'll do another pass on it when I have time, but I've spent a ton of time on it already. The new version prioritizes scrolling and tapping over annotations, which I assume is what most people would expect to work.