### PR TITLE
Hard-code the default Jetpack migration phase as 'static screens'

### DIFF
--- a/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Branding/Coordinator/JetpackFeaturesRemovalCoordinator.swift
@@ -101,7 +101,7 @@ public class JetpackFeaturesRemovalCoordinator: NSObject {
 
         if AccountHelper.noWordPressDotComAccount {
             let selfHostedRemoval = RemoteFeatureFlag.jetpackFeaturesRemovalPhaseSelfHosted.enabled(using: featureFlagStore)
-            return selfHostedRemoval ? .selfHosted : .normal
+            return selfHostedRemoval ? .selfHosted : .staticScreens
         }
         if RemoteFeatureFlag.jetpackFeaturesRemovalPhaseNewUsers.enabled(using: featureFlagStore) {
             return .newUsers
@@ -122,7 +122,7 @@ public class JetpackFeaturesRemovalCoordinator: NSObject {
             return .one
         }
 
-        return .normal
+        return .staticScreens
     }
 
     static func siteCreationPhase(featureFlagStore: RemoteFeatureFlagStore = RemoteFeatureFlagStore()) -> SiteCreationPhase {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-747.

## Description

The app has been on the 'static screens' / 'static poster' phase for a long time. I don't think we'd go back to previous phases.

## Testing instructions

See the Linear issue.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
