### PR TITLE
Remove an unnecessary dispatch-async

### DIFF
--- a/WordPress/Classes/System/WindowManager.swift
+++ b/WordPress/Classes/System/WindowManager.swift
@@ -104,10 +104,6 @@ class WindowManager: NSObject {
             completion: { _ in
                 completion?()
             })
-
-        DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(2)) {
-            self.window.rootViewController = viewController
-        }
     }
 
     // MARK: Temporary Overlaying Window


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-747.

## Description

This dispatch async was added in https://github.com/wordpress-mobile/WordPress-iOS/pull/24810. It does not look like a related change, but more like a code that's supposed to be deleted after debugging.


## Testing instructions

Verify that both WP.com and self-hosted site login show the correct screens.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
