### PR TITLE
Add spacer at the end of title view

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -191,7 +191,8 @@ extension BlogDetailHeaderView {
             let stackView = UIStackView(arrangedSubviews: [
                 siteIconView,
                 titleStackView,
-                siteSwitcherButton
+                siteSwitcherButton,
+                UIView()
             ])
 
             stackView.alignment = .center


### PR DESCRIPTION
## Description

The site switcher button is too far away from the content, especially when the screen is wide.

This PR adds a flexible spacer at the right side of the title view, to keep the site switcher closer to the site title and address.

Here are some screenshots after the changes:
![IMG_8465](https://github.com/user-attachments/assets/416813fb-f02a-468c-abf5-536af24eb98d)
![IMG_8466](https://github.com/user-attachments/assets/0ba5e130-319b-4df3-bee6-85f6f5882cbf)
![IMG_8467](https://github.com/user-attachments/assets/5b0ef631-7818-4ed6-bfba-da03160c9109)
![IMG_8468](https://github.com/user-attachments/assets/0c158a91-2ccf-4e9f-8dd4-23f84c6bed01)



## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
