### PR TITLE
iOS 26: The auto-hiding tab bar in New Stats becomes blurry after navigating to a details page

### DIFF
--- a/Modules/Sources/WordPressUI/Views/AdaptiveTabBarController.swift
+++ b/Modules/Sources/WordPressUI/Views/AdaptiveTabBarController.swift
@@ -30,7 +30,7 @@ public final class AdaptiveTabBarController<Item: AdaptiveTabBarItem> {
     }
 
     public let filterBar = AdaptiveTabBar()
-    private var filterBarContainer = UIView()
+    private var filterBarContainer = UIVisualEffectView(effect: UIBlurEffect(style: .regular))
 
     public let segmentedControl = UISegmentedControl()
 
@@ -51,8 +51,8 @@ public final class AdaptiveTabBarController<Item: AdaptiveTabBarItem> {
     }
 
     private func setupFilterBar() {
-        filterBarContainer.backgroundColor = .secondarySystemGroupedBackground
-        filterBarContainer.addSubview(filterBar)
+//        filterBarContainer.backgroundColor = .systemGroupedBackground // .secondarySystemGroupedBackground
+        filterBarContainer.contentView.addSubview(filterBar)
         filterBar.pinEdges(.top, to: filterBarContainer.safeAreaLayoutGuide, insets: UIEdgeInsets(.top, -filterBar.tabBarHeight))
         filterBar.pinEdges([.horizontal, .bottom])
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -462,13 +462,6 @@ private extension SiteStatsDashboardViewController {
         ])
 
         child.didMove(toParent: self)
-
-        // Delay for SwiftUI-based views that don't render immediatelly
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(100)) {
-            if let scrollView = child.contentScrollView(for: .top) {
-                self.filterBarController.enableAutomaticHiding(in: scrollView)
-            }
-        }
     }
 
     private func _removeChildViewController(_ child: UIViewController) {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-746/ios-26-the-tab-bar-in-stats-becomes-blurry-after-navigating-to-the and https://linear.app/a8c/issue/CMM-749/the-auto-hiding-tab-bar-in-the-production-version-of-stats-leaves.

I decided to disable it for now – better safe than sorry. I added blur so it doesn't look as sad.


https://github.com/user-attachments/assets/c1d10aca-27ea-4f7d-8586-53705c46c16e

