### PR TITLE
Fix an issue with Enable New Stats prompt not shown

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -297,12 +297,10 @@ public class SiteStatsDashboardViewController: UIViewController {
 
     @available(iOS 17, *)
     private func showNewStatsTip() {
-        guard let button = parent?.navigationItem.rightBarButtonItem else { return }
-
         tipObserver?.cancel()
         tipObserver = registerTipPopover(
             AppTips.NewStatsTip(),
-            sourceItem: button,
+            sourceItem: statsMenuButton,
             arrowDirection: .up
         ) { [weak self] action in
             guard let self else { return }


### PR DESCRIPTION
<img width="340" alt="Screenshot 2025-09-12 at 8 43 25 AM" src="https://github.com/user-attachments/assets/035dc1d9-0196-46b6-8f9b-0aed58908195" />
<img width="340"  alt="Screenshot 2025-09-12 at 8 43 34 AM" src="https://github.com/user-attachments/assets/4d69482a-e521-4064-a3ec-79806803cad7" />