### PR TITLE
Fix date controls showing multiple in standalone charts

### DIFF
--- a/Modules/Sources/JetpackStats/Cards/StandaloneChartCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/StandaloneChartCard.swift
@@ -197,7 +197,7 @@ struct StandaloneChartCard: View {
     }
 
     private var dateRangeControls: some View {
-        HStack(spacing: Constants.step1) {
+        HStack {
             // Date range menu button
             Menu {
                 StatsDateRangePickerMenu(selection: $dateRange, isShowingCustomRangePicker: $isShowingDatePicker)
@@ -216,7 +216,7 @@ struct StandaloneChartCard: View {
             }
             .tint(Color.primary)
 
-            Spacer()
+            Spacer(minLength: Constants.step1)
 
             // Navigation controls
             HStack(spacing: 4) {
@@ -224,6 +224,7 @@ struct StandaloneChartCard: View {
                 navigationButton(direction: .forward)
             }
         }
+        .lineLimit(1)
     }
 
     @ViewBuilder


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-750/new-stats-the-date-picker-in-post-details-displays-more-than-one-line

<img width="456" height="972" alt="Screenshot 2025-09-12 at 8 56 03 AM" src="https://github.com/user-attachments/assets/44ec2b78-41f4-4886-a6a9-1d54b2bf08aa" />
