### PR TITLE
Fix search bar placement in WPiOS

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaCollectionViewController.swift
@@ -94,7 +94,7 @@ final class SiteMediaCollectionViewController: UIViewController, NSFetchedResult
 
 #if compiler(>=6.2)
         if #available(iOS 26, *) {
-            parentViewController.navigationItem.preferredSearchBarPlacement = traitCollection.horizontalSizeClass == .regular ? .integrated : .integratedButton
+            parentViewController.navigationItem.preferredSearchBarPlacement = .integrated
         }
 #endif
     }

--- a/WordPress/Classes/ViewRelated/Post/Controllers/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Controllers/AbstractPostListViewController.swift
@@ -199,7 +199,7 @@ class AbstractPostListViewController: UIViewController,
 
 #if compiler(>=6.2)
         if #available(iOS 26, *) {
-            navigationItem.preferredSearchBarPlacement = traitCollection.horizontalSizeClass == .regular ? .integrated : .integratedButton
+            navigationItem.preferredSearchBarPlacement = .integrated
         }
 #endif
 


### PR DESCRIPTION
### Before

<img width="360"  alt="IMG_5029" src="https://github.com/user-attachments/assets/230fb2ed-f1de-448d-b430-d1e70c517b37" />

### After

<img width="360"  alt="IMG_5030" src="https://github.com/user-attachments/assets/9faa880c-3571-4df7-acb2-1062012503ef" />

### JPiOS (still works as a button)

<img width="360"  alt="IMG_5031" src="https://github.com/user-attachments/assets/35a4ca6f-1205-4da1-b8d2-bfea63e375f1" />

