### PR TITLE
Fix tint color for WPiOS

### DIFF
--- a/Modules/Sources/DesignSystem/Foundation/AppColor.swift
+++ b/Modules/Sources/DesignSystem/Foundation/AppColor.swift
@@ -5,14 +5,8 @@ import BuildSettingsKit
 
 public enum UIAppColor {
     /// A tint color used in places like navigation bars.
-    ///
-    /// - note: The Jetpack app uses
     public static var tint: UIColor {
-        switch AppBrand.current {
-        case .wordpress: primary
-        case .jetpack: UIColor.label
-        case .reader: primary
-        }
+        UIColor.label
     }
 
     public static var primary: UIColor {

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/SiteMediaViewController.swift
@@ -3,6 +3,7 @@ import PhotosUI
 import SVProgressHUD
 import WordPressData
 import WordPressShared
+import WordPressUI
 
 /// The main Site Media screen.
 final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewControllerDelegate {
@@ -83,6 +84,7 @@ final class SiteMediaViewController: UIViewController, SiteMediaCollectionViewCo
         let config = UIImage.SymbolConfiguration(textStyle: .body, scale: .large)
         let image = UIImage(systemName: "plus", withConfiguration: config) ?? .gridicon(.plus)
         button.setImage(image, for: .normal)
+        button.tintColor = UIAppColor.tint
         button.menu = buttonAddMediaMenuController.makeMenu(for: self)
         button.showsMenuAsPrimaryAction = true
         button.accessibilityLabel = Strings.addButtonAccessibilityLabel


### PR DESCRIPTION
With Apple discouraging the use of the tint color in the navigation bars, toolbars, and other areas, we can now make our life easier by unified the `tintColor` for all apps. It fixes the following issues (there could be more):

<img width="350" alt="IMG_5032" src="https://github.com/user-attachments/assets/d72afb8a-aea7-480c-ac58-81f089bcb57d" />

It will now be much easier testing this moving forward as the "actual" tint color will be applied to the same places in all apps.

**Note**: we need to remove or rename the `tintColor` property now – future PRs.
