### PR TITLE
Fix crash in the Share App extension

### DIFF
--- a/WordPress/Classes/Utility/Sharing/ShareExtensionSessionManager.swift
+++ b/WordPress/Classes/Utility/Sharing/ShareExtensionSessionManager.swift
@@ -26,7 +26,7 @@ import WordPressKit
     fileprivate lazy var backgroundSession: URLSession = {
         let configuration = URLSessionConfiguration.background(withIdentifier: self.backgroundSessionIdentifier)
         configuration.sharedContainerIdentifier = self.appGroup
-        let session = URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+        let session = URLSession(configuration: configuration, delegate: self, delegateQueue: OperationQueue.main)
         return session
     }()
 

--- a/WordPress/WordPressShareExtension/Sources/UI/ShareExtensionEditorViewController.swift
+++ b/WordPress/WordPressShareExtension/Sources/UI/ShareExtensionEditorViewController.swift
@@ -254,6 +254,10 @@ class ShareExtensionEditorViewController: ShareExtensionAbstractViewController {
     // MARK: - Title and Title placeholder position methods
 
     func refreshTitlePosition() {
+        guard titleTopConstraint != nil && textPlaceholderTopConstraint != nil else {
+            return
+        }
+
         let referenceView: UITextView = richTextView
         titleTopConstraint.constant = -(referenceView.contentOffset.y + referenceView.contentInset.top)
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-753/ios-26-crash-in-the-share-app-extension.

<img width="603" height="1311" alt="View recent photos" src="https://github.com/user-attachments/assets/bd8f9ed8-9198-4e32-803a-3822ff4bbaf6" />
