### PR TITLE
Fix rendering mode for icons in the Create sheet

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/SheetActions.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/SheetActions.swift
@@ -11,7 +11,7 @@ struct PostAction: ActionSheetItem {
     func makeButton() -> ActionSheetButton {
         return ActionSheetButton(
             title: NSLocalizedString("Blog post", comment: "Create new Blog Post button title"),
-            image: UIImage(named: "wpl-posts") ?? .init(),
+            image: UIImage(named: "wpl-posts")?.withRenderingMode(.alwaysTemplate) ?? .init(),
             identifier: "blogPostButton",
             action: {
                 WPAnalytics.track(.createSheetActionTapped, properties: ["source": source, "action": action])
@@ -47,7 +47,7 @@ struct PageAction: ActionSheetItem {
     func makeButton() -> ActionSheetButton {
         return ActionSheetButton(
             title: NSLocalizedString("Site page", comment: "Create new Site Page button title"),
-            image: UIImage(named: "wpl-pages") ?? .init(),
+            image: UIImage(named: "wpl-pages")?.withRenderingMode(.alwaysTemplate) ?? .init(),
             identifier: "sitePageButton",
             action: {
                 WPAnalytics.track(.createSheetActionTapped, properties: ["source": source, "action": action])


### PR DESCRIPTION
Before:

<img width="320"  alt="Screenshot 2025-09-12 at 9 11 59 PM" src="https://github.com/user-attachments/assets/0dbdced7-d63d-461f-85b1-24208d1f9599" />

After 
<img width="320"  alt="Screenshot 2025-09-12 at 9 15 19 PM" src="https://github.com/user-attachments/assets/145b3d48-146d-47e5-9373-737a7b919fbf" />
