### PR TITLE
Disable NSAssert statements in WordPressKit targets release builds

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -173,7 +173,12 @@ let package = Package(
             resources: [.process("Resources")],
             swiftSettings: [.swiftLanguageMode(.v5)]
         ),
-        .target(name: "WordPressKitObjCUtils"),
+        .target(
+            name: "WordPressKitObjCUtils",
+            cSettings: [
+                .define("NS_BLOCK_ASSERTIONS", to: "1", .when(configuration: .release))
+            ]
+        ),
         .target(
             name: "WordPressKitModels",
             dependencies: [
@@ -189,7 +194,10 @@ let package = Package(
                 "WordPressKitModels",
                 "WordPressKitObjCUtils",
             ],
-            publicHeadersPath: "include"
+            publicHeadersPath: "include",
+            cSettings: [
+                .define("NS_BLOCK_ASSERTIONS", to: "1", .when(configuration: .release))
+            ],
         ),
         .target(
             name: "WordPressKit",


### PR DESCRIPTION
## Description

I ran into a crash at [this `NSParameterAssert` statement here](https://github.com/wordpress-mobile/WordPress-iOS/blob/91c8c2d9ed137be3a55c01819e46584a023ec00f/Modules/Sources/WordPressKitObjC/ServiceRemoteWordPressXMLRPC.m#L17) on a Test Flight build. These statements were disabled when WordPressKit was built as an xcframework, and we should do the same on the new SPM targets.

<img width="763" height="324" alt="Screenshot 2025-09-14 at 9 44 15 PM" src="https://github.com/user-attachments/assets/31da40cb-587f-4c65-8135-b04944a79a4a" />


## Testing instructions

Add an assertion to WordPressKit Objective-C code. Something like this:

```diff
diff --git a/Modules/Sources/WordPressKitObjC/ServiceRemoteWordPressXMLRPC.m b/Modules/Sources/WordPressKitObjC/ServiceRemoteWordPressXMLRPC.m
index dd8673a6c5..ff2cd9fe81 100644
--- a/Modules/Sources/WordPressKitObjC/ServiceRemoteWordPressXMLRPC.m
+++ b/Modules/Sources/WordPressKitObjC/ServiceRemoteWordPressXMLRPC.m
@@ -12,6 +12,7 @@ @implementation ServiceRemoteWordPressXMLRPC
 
 - (id)initWithApi:(id<WordPressOrgXMLRPCApiInterfacing>)api username:(NSString *)username password:(NSString *)password
 {
+    NSParameterAssert(false);
     NSParameterAssert(api != nil);
     NSParameterAssert(username != nil);
     NSParameterAssert(password != nil);
diff --git a/WordPress/Classes/System/WordPressAppDelegate.swift b/WordPress/Classes/System/WordPressAppDelegate.swift
index ba09debecf..29bdcffd7c 100644
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -114,6 +114,7 @@ public class WordPressAppDelegate: UIResponder, UIApplicationDelegate {
     }
 
     public func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]? = nil) -> Bool {
+        _ = BlogServiceRemoteXMLRPC(api: WordPressOrgXMLRPCApi(endpoint: URL(string: "https://apple.com")!), username: "", password: "")
         DDLogInfo("didFinishLaunchingWithOptions state: \(application.applicationState)")
 
         ABTest.start()

```

Launching from Xcode should cause a crash.

Edit the Xcode scheme, set the build configuration from Debug to Release, and launch from Xcode again. No crash should happen this time.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
