### PR TITLE
Add new "Publishing" sheet

### DIFF
--- a/Modules/Sources/WordPressUI/Views/SiteIconView.swift
+++ b/Modules/Sources/WordPressUI/Views/SiteIconView.swift
@@ -17,7 +17,7 @@ public struct SiteIconView: View {
     }
 
     private var cornerRadius: CGFloat {
-        if #available(iOS 26, *) { 12 } else { 6 }
+        if #available(iOS 26, *) { 10 } else { 6 }
     }
 
     @ViewBuilder

--- a/Modules/Sources/WordPressUI/Views/SiteIconView.swift
+++ b/Modules/Sources/WordPressUI/Views/SiteIconView.swift
@@ -13,7 +13,11 @@ public struct SiteIconView: View {
 
     public var body: some View {
         contents
-            .clipShape(RoundedRectangle(cornerRadius: 6))
+            .clipShape(RoundedRectangle(cornerRadius: cornerRadius))
+    }
+
+    private var cornerRadius: CGFloat {
+        if #available(iOS 26, *) { 12 } else { 6 }
     }
 
     @ViewBuilder

--- a/Sources/WordPressData/Swift/PublicizeInfo+CoreDataClass.swift
+++ b/Sources/WordPressData/Swift/PublicizeInfo+CoreDataClass.swift
@@ -31,7 +31,7 @@ public class PublicizeInfo: NSManagedObject {
     }
 
     /// A value-type representation for Publicize auto-sharing usage.
-    public struct SharingLimit {
+    public struct SharingLimit: Hashable {
         /// The remaining shares available for use.
         public let remaining: Int
 

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -398,10 +398,10 @@ class MediaCoordinator: NSObject {
         // https://github.com/wordpress-mobile/WordPress-iOS/issues/20298#issuecomment-1465319707
         let service = self.mediaServiceFactory.create(coreDataStack.mainContext)
         var progress: Progress? = nil
-        service.uploadMedia(media, automatedRetry: automatedRetry, progress: &progress, success: success, failure: failure)
-        if let progress {
-            resultProgress.addChild(progress, withPendingUnitCount: resultProgress.totalUnitCount)
-        }
+//        service.uploadMedia(media, automatedRetry: automatedRetry, progress: &progress, success: success, failure: failure)
+//        if let progress {
+//            resultProgress.addChild(progress, withPendingUnitCount: resultProgress.totalUnitCount)
+//        }
 
         uploading(media, progress: resultProgress)
 

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -398,10 +398,10 @@ class MediaCoordinator: NSObject {
         // https://github.com/wordpress-mobile/WordPress-iOS/issues/20298#issuecomment-1465319707
         let service = self.mediaServiceFactory.create(coreDataStack.mainContext)
         var progress: Progress? = nil
-//        service.uploadMedia(media, automatedRetry: automatedRetry, progress: &progress, success: success, failure: failure)
-//        if let progress {
-//            resultProgress.addChild(progress, withPendingUnitCount: resultProgress.totalUnitCount)
-//        }
+        service.uploadMedia(media, automatedRetry: automatedRetry, progress: &progress, success: success, failure: failure)
+        if let progress {
+            resultProgress.addChild(progress, withPendingUnitCount: resultProgress.totalUnitCount)
+        }
 
         uploading(media, progress: resultProgress)
 

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -89,6 +89,9 @@ class PostCoordinator: NSObject {
     ///
     /// - warning: Before publishing, ensure that the media for the post got
     /// uploaded. Managing media is not the responsibility of `PostRepository.`
+    ///
+    /// - parameter changes: The set of changes apply to the post together
+    /// with the publishing options.
     @MainActor
     func publish(_ post: AbstractPost, options: PublishingOptions) async throws {
         wpAssert(post.isOriginal())
@@ -111,6 +114,43 @@ class PostCoordinator: NSObject {
         if let publishDate = options.publishDate {
             parameters.date = publishDate
         } else {
+            // If the post was previously scheduled for a different date,
+            // the app has to send a new value to override it.
+            parameters.date = post.shouldPublishImmediately() ? nil : Date()
+        }
+
+        do {
+            let repository = PostRepository(coreDataStack: coreDataStack)
+            try await repository.save(post, changes: parameters)
+            didPublish(post)
+            show(PostCoordinator.makeUploadSuccessNotice(for: post))
+        } catch {
+            trackError(error, operation: "post-publish", post: post)
+            handleError(error, for: post)
+            throw error
+        }
+    }
+
+    /// Publishes the post according to the current settings and user capabilities.
+    ///
+    /// - warning: Before publishing, ensure that the media for the post got
+    /// uploaded. Managing media is not the responsibility of `PostRepository.`
+    ///
+    /// - parameter changes: The set of changes apply to the post together
+    /// with the publishing options.
+    @MainActor
+    func publish_v2(_ post: AbstractPost, parameters: RemotePostUpdateParameters) async throws {
+        wpAssert(post.isOriginal())
+        wpAssert(post.isStatus(in: [.draft, .pending]))
+
+        await pauseSyncing(for: post)
+        defer { resumeSyncing(for: post) }
+
+        var parameters = parameters
+        if parameters.status == nil {
+            parameters.status = Post.Status.publish.rawValue
+        }
+        if parameters.date == nil {
             // If the post was previously scheduled for a different date,
             // the app has to send a new value to override it.
             parameters.date = post.shouldPublishImmediately() ? nil : Date()

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -89,9 +89,6 @@ class PostCoordinator: NSObject {
     ///
     /// - warning: Before publishing, ensure that the media for the post got
     /// uploaded. Managing media is not the responsibility of `PostRepository.`
-    ///
-    /// - parameter changes: The set of changes apply to the post together
-    /// with the publishing options.
     @MainActor
     func publish(_ post: AbstractPost, options: PublishingOptions) async throws {
         wpAssert(post.isOriginal())

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -84,7 +84,7 @@ public enum FeatureFlag: Int, CaseIterable {
         case .newStats:
             return false
         case .newPublishingSheet:
-            return true
+            return BuildConfiguration.current == .debug
         }
     }
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -84,7 +84,7 @@ public enum FeatureFlag: Int, CaseIterable {
         case .newStats:
             return false
         case .newPublishingSheet:
-            return BuildConfiguration.current == .debug
+            return false
         }
     }
 

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -26,6 +26,7 @@ public enum FeatureFlag: Int, CaseIterable {
     case pluginManagementOverhaul
     case newsletterSubscribers
     case newStats
+    case newPublishingSheet
 
     /// Returns a boolean indicating if the feature is enabled.
     ///
@@ -82,6 +83,8 @@ public enum FeatureFlag: Int, CaseIterable {
             return true
         case .newStats:
             return false
+        case .newPublishingSheet:
+            return true
         }
     }
 
@@ -125,6 +128,7 @@ extension FeatureFlag {
         case .readerGutenbergCommentComposer: "Gutenberg Comment Composer"
         case .newsletterSubscribers: "Newsletter Subscribers"
         case .newStats: "New Stats"
+        case .newPublishingSheet: "New Publishing Sheet"
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialNoConnectionView.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Social/JetpackSocialNoConnectionView.swift
@@ -5,7 +5,7 @@ import WordPressUI
 
 struct JetpackSocialNoConnectionView: View {
 
-    private let viewModel: JetpackSocialNoConnectionViewModel
+    let viewModel: JetpackSocialNoConnectionViewModel
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12.0) {

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
@@ -37,7 +37,7 @@ struct PostSettings: Hashable {
         excerpt = post.mt_excerpt ?? ""
         slug = post.wp_slug ?? ""
         status = post.status ?? .draft
-        publishDate = post.dateCreated
+        publishDate = post.shouldPublishImmediately() ? nil : post.dateCreated
         password = post.password
 
         if let authorID = post.authorID?.intValue, authorID > 0 {

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
@@ -191,13 +191,13 @@ extension PostSettings {
 
 /// A value-type representation of `PublicizeService` for the current blog that's simplified for the auto-sharing flow.
 struct PostSocialSharingSettings: Hashable {
-    let services: [Service]
-    let message: String
-    let sharingLimit: PublicizeInfo.SharingLimit?
+    var services: [Service]
+    var message: String
+    var sharingLimit: PublicizeInfo.SharingLimit?
 
     struct Service: Hashable {
         let name: PublicizeService.ServiceName
-        let connections: [Connection]
+        var connections: [Connection]
     }
 
     struct Connection: Hashable {

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
@@ -131,6 +131,22 @@ struct PostSettings: Hashable {
             if post.isStickyPost != isStickyPost {
                 post.isStickyPost = isStickyPost
             }
+
+            if let sharing {
+                for connection in sharing.services.flatMap(\.connections) {
+                    let keyringID = NSNumber(value: connection.keyringID)
+                    if !post.publicizeConnectionDisabledForKeyringID(keyringID) != connection.enabled {
+                        if connection.enabled {
+                            post.enablePublicizeConnectionWithKeyringID(keyringID)
+                        } else {
+                            post.disablePublicizeConnectionWithKeyringID(keyringID)
+                        }
+                    }
+                }
+                if post.publicizeMessage != sharing.message {
+                    post.publicizeMessage = sharing.message
+                }
+            }
         case let page as Page:
             if page.parentID?.intValue != parentPageID {
                 page.parentID = parentPageID.map { NSNumber(value: $0) }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
@@ -25,6 +25,7 @@ struct PostSettings: Hashable {
     // MARK: - Post-specific
     var postFormat: String?
     var isStickyPost = false
+    var sharing: PostSocialSharingSettings?
 
     // MARK: - Page-specific
     var parentPageID: Int?
@@ -57,6 +58,7 @@ struct PostSettings: Hashable {
             categoryIDs = Set((post.categories ?? []).compactMap {
                 $0.categoryID?.intValue
             })
+            sharing = PostSocialSharingSettings.make(for: post)
         case let page as Page:
             parentPageID = page.parentID?.intValue
         default:
@@ -184,5 +186,72 @@ extension PostSettings {
         return categoryIDs.compactMap { categories[$0] }
             .sorted { $0.localizedCaseInsensitiveCompare($1) == .orderedAscending }
             .map { $0.stringByDecodingXMLCharacters() }
+    }
+}
+
+/// A value-type representation of `PublicizeService` for the current blog that's simplified for the auto-sharing flow.
+struct PostSocialSharingSettings: Hashable {
+    let services: [Service]
+    let message: String
+    let sharingLimit: PublicizeInfo.SharingLimit?
+
+    struct Service: Hashable {
+        let name: PublicizeService.ServiceName
+        let connections: [Connection]
+    }
+
+    struct Connection: Hashable {
+        let account: String
+        let keyringID: Int
+        var enabled: Bool
+    }
+
+    static func make(for post: Post) -> PostSocialSharingSettings? {
+        guard let context = post.managedObjectContext else {
+            wpAssertionFailure("missing moc")
+            return nil
+        }
+
+        let connections = post.blog.sortedConnections
+
+        // first, build a dictionary to categorize the connections.
+        var connectionsMap = [PublicizeService.ServiceName: [PublicizeConnection]]()
+        connections.filter { !$0.requiresUserAction() }.forEach { connection in
+            let name = PublicizeService.ServiceName(rawValue: connection.service) ?? .unknown
+            var serviceConnections = connectionsMap[name] ?? []
+            serviceConnections.append(connection)
+            connectionsMap[name] = serviceConnections
+        }
+
+        let publicizeServices: [PublicizeService]
+        do {
+            publicizeServices = try PublicizeService.allPublicizeServices(in: context)
+        } catch {
+            wpAssertionFailure("failed to fetch services", userInfo: ["error": error.localizedDescription])
+            return nil
+        }
+
+        let services = publicizeServices.compactMap { service -> PostSocialSharingSettings.Service? in
+            // skip services without connections.
+            guard let serviceConnections = connectionsMap[service.name],
+                  !serviceConnections.isEmpty else {
+                return nil
+            }
+
+            return PostSocialSharingSettings.Service(
+                name: service.name,
+                connections: serviceConnections.map {
+                    .init(account: $0.externalDisplay,
+                          keyringID: $0.keyringConnectionID.intValue,
+                          enabled: !post.publicizeConnectionDisabledForKeyringID($0.keyringConnectionID))
+                }
+            )
+        }
+
+        return PostSocialSharingSettings(
+            services: services,
+            message: post.publicizeMessage ?? post.titleForDisplay(),
+            sharingLimit: post.blog.sharingLimit
+        )
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -209,7 +209,7 @@ struct PostSettingsFormContentView: View {
     private var generalSection: some View {
         Section {
             authorRow
-            if !viewModel.isDraftOrPending {
+            if !viewModel.isDraftOrPending || viewModel.context == .publishing {
                 publishDateRow
                 visibilityRow
             }
@@ -249,7 +249,7 @@ struct PostSettingsFormContentView: View {
                 }
             ))
         } label: {
-            SettingsRow(Strings.publishDateLabel, value: viewModel.publishDateText ?? "–")
+            SettingsRow(Strings.publishDateLabel, value: viewModel.publishDateText ?? Strings.immediately)
         }
     }
 
@@ -573,5 +573,11 @@ private enum Strings {
         "postSettings.postID.label",
         value: "ID",
         comment: "Label for the post ID field in Post Settings"
+    )
+
+    static let immediately = NSLocalizedString(
+        "postSettings.publishDateImmediately",
+        value: "Immediately",
+        comment: "Placeholder value for a publishing date in the prepublishing sheet when the date is not selected"
     )
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -126,18 +126,21 @@ struct PostSettingsFormContentView: View {
     @ObservedObject var viewModel: PostSettingsViewModel
 
     var body: some View {
-        if viewModel.context == .publishing {
-            publishingOptionsSection
+        Section {
+            BlogListSiteView(site: .init(blog: viewModel.post.blog))
+                .listRowBackground(Color.clear)
+                .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
+        } header: {
+            SectionHeader(Strings.readyToPublish)
         }
+
         featuredImageSection
         if viewModel.isPost {
             organizationSection
         }
         excerptSection
-        if viewModel.isPost, viewModel.context == .publishing {
-            socialSharingSection
-        }
         generalSection
+        socialSharingSection
         moreOptionsSection
         if viewModel.context != .publishing {
             infoSection
@@ -221,7 +224,7 @@ struct PostSettingsFormContentView: View {
     private var generalSection: some View {
         Section {
             authorRow
-            if !viewModel.isDraftOrPending {
+            if !viewModel.isDraftOrPending || viewModel.context == .publishing {
                 publishDateRow
                 visibilityRow
             }
@@ -254,7 +257,7 @@ struct PostSettingsFormContentView: View {
         NavigationLink {
             PublishDatePickerView(configuration: PublishDatePickerConfiguration(
                 date: viewModel.settings.publishDate,
-                isRequired: viewModel.isDraftOrPending,
+                isRequired: !viewModel.isDraftOrPending,
                 timeZone: viewModel.timeZone,
                 updated: { date in
                     viewModel.settings.publishDate = date
@@ -630,6 +633,12 @@ private enum Strings {
         "postSettings.publishDateImmediately",
         value: "Immediately",
         comment: "Placeholder value for a publishing date in the prepublishing sheet when the date is not selected"
+    )
+
+    static let readyToPublish = NSLocalizedString(
+        "postSettings.publishingSectionTitle",
+        value: "Ready to Publish?",
+        comment: "The title of the top section that shows the site your are publishing to. Default is 'Ready to Publish?'"
     )
 
     static let publishingTo = NSLocalizedString(

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -183,28 +183,16 @@ struct PostSettingsFormContentView: View {
     }
 
     private var categoriesRow: some View {
-        Button(action: viewModel.showCategoriesPicker) {
-            HStack {
-                PostSettingsCategoriesRow(categories: viewModel.displayedCategories)
-                Image(systemName: "chevron.forward")
-                    .font(.footnote.weight(.semibold))
-                    .foregroundColor(Color(.tertiaryLabel))
-            }
+        LegacyNavigationLinkRow(action: viewModel.showCategoriesPicker) {
+            PostSettingsCategoriesRow(categories: viewModel.displayedCategories)
         }
-        .tint(.primary)
         .accessibilityIdentifier("post_settings_categories")
     }
 
     private var tagsRow: some View {
-        Button(action: viewModel.showTagsPicker) {
-            HStack {
-                PostSettingsTagsRow(tags: viewModel.displayedTags)
-                Image(systemName: "chevron.forward")
-                    .font(.footnote.weight(.semibold))
-                    .foregroundColor(Color(.tertiaryLabel))
-            }
+        LegacyNavigationLinkRow(action: viewModel.showTagsPicker) {
+            PostSettingsTagsRow(tags: viewModel.displayedTags)
         }
-        .tint(.primary)
         .accessibilityIdentifier("post_settings_tags")
     }
 
@@ -300,8 +288,10 @@ struct PostSettingsFormContentView: View {
                 switch state {
                 case .setup(let viewModel):
                     JetpackSocialNoConnectionView(viewModel: viewModel)
-                case .connected:
-                    Text("Connected (not implemented)")
+                case .connected(let viewModel):
+                    LegacyNavigationLinkRow(action: self.viewModel.showSocialSharingOptions) {
+                        PrepublishingAutoSharingView(model: viewModel)
+                    }
                 }
             } header: {
                 SectionHeader(Strings.socialSharing)
@@ -469,6 +459,23 @@ private struct SettingsTextFieldView: View {
         .onAppear {
             isFocused = true
         }
+    }
+}
+
+private struct LegacyNavigationLinkRow<Content: View>: View {
+    let action: () -> Void
+    @ViewBuilder let label: () -> Content
+
+    var body: some View {
+        Button(action: action) {
+            HStack {
+                label()
+                Image(systemName: "chevron.forward")
+                    .font(.footnote.weight(.semibold))
+                    .foregroundColor(Color(.tertiaryLabel))
+            }
+        }
+        .tint(.primary)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -254,7 +254,7 @@ struct PostSettingsFormContentView: View {
         NavigationLink {
             PublishDatePickerView(configuration: PublishDatePickerConfiguration(
                 date: viewModel.settings.publishDate,
-                isRequired: true,
+                isRequired: viewModel.isDraftOrPending,
                 timeZone: viewModel.timeZone,
                 updated: { date in
                     viewModel.settings.publishDate = date

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -126,14 +126,6 @@ struct PostSettingsFormContentView: View {
     @ObservedObject var viewModel: PostSettingsViewModel
 
     var body: some View {
-        Section {
-            BlogListSiteView(site: .init(blog: viewModel.post.blog))
-                .listRowBackground(Color.clear)
-                .listRowInsets(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
-        } header: {
-            SectionHeader(Strings.readyToPublish)
-        }
-
         featuredImageSection
         if viewModel.isPost {
             organizationSection
@@ -626,18 +618,6 @@ private enum Strings {
         "postSettings.publishDateImmediately",
         value: "Immediately",
         comment: "Placeholder value for a publishing date in the prepublishing sheet when the date is not selected"
-    )
-
-    static let readyToPublish = NSLocalizedString(
-        "postSettings.publishingSectionTitle",
-        value: "Ready to Publish?",
-        comment: "The title of the top section that shows the site your are publishing to. Default is 'Ready to Publish?'"
-    )
-
-    static let publishingTo = NSLocalizedString(
-        "postSettings.publishingTo",
-        value: "Publishing to",
-        comment: "Label indicating which site you are publishing to"
     )
 
     static let socialSharing = NSLocalizedString(

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -125,11 +125,11 @@ struct PostSettingsFormContentView: View {
 
     var body: some View {
         featuredImageSection
-        generalSection
         if viewModel.isPost {
             organizationSection
         }
         excerptSection
+        generalSection
         moreOptionsSection
         infoSection
     }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -124,6 +124,9 @@ struct PostSettingsFormContentView: View {
     @ObservedObject var viewModel: PostSettingsViewModel
 
     var body: some View {
+        if viewModel.context == .publishing {
+            publishingOptionsSection
+        }
         featuredImageSection
         if viewModel.isPost {
             organizationSection
@@ -134,6 +137,17 @@ struct PostSettingsFormContentView: View {
         infoSection
     }
 
+    // MARK: - "Publishing Options" Section
+    @ViewBuilder
+    private var publishingOptionsSection: some View {
+        Section {
+            BlogListSiteView(site: .init(blog: viewModel.post.blog))
+            publishDateRow
+            visibilityRow
+        } header: {
+            SectionHeader(Strings.publishingOptionsHeader)
+        }
+    }
     // MARK: - "Featured Image" Section
 
     @ViewBuilder
@@ -209,7 +223,7 @@ struct PostSettingsFormContentView: View {
     private var generalSection: some View {
         Section {
             authorRow
-            if !viewModel.isDraftOrPending || viewModel.context == .publishing {
+            if !viewModel.isDraftOrPending {
                 publishDateRow
                 visibilityRow
             }
@@ -579,5 +593,20 @@ private enum Strings {
         "postSettings.publishDateImmediately",
         value: "Immediately",
         comment: "Placeholder value for a publishing date in the prepublishing sheet when the date is not selected"
+    )
+    static let publishingOptionsHeader = NSLocalizedString(
+        "postSettings.publishing.header",
+        value: "Publishing",
+        comment: "Section header for Publishing Options in Post Settings"
+    )
+    static let publishingTo = NSLocalizedString(
+        "postSettings.publishingTo",
+        value: "Publishing to",
+        comment: "Label indicating which site you are publishing to"
+    )
+    static let previewLabel = NSLocalizedString(
+        "postSettings.preview.label",
+        value: "Preview",
+        comment: "Label for the preview button in Post Settings"
     )
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -255,14 +255,7 @@ struct PostSettingsFormContentView: View {
 
     private var publishDateRow: some View {
         NavigationLink {
-            PublishDatePickerView(configuration: PublishDatePickerConfiguration(
-                date: viewModel.settings.publishDate,
-                isRequired: !viewModel.isDraftOrPending,
-                timeZone: viewModel.timeZone,
-                updated: { date in
-                    viewModel.settings.publishDate = date
-                }
-            ))
+            PostSettingsPublishDatePicker(viewModel: viewModel)
         } label: {
             SettingsRow(Strings.publishDateLabel, value: viewModel.publishDateText ?? Strings.immediately)
         }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -288,9 +288,9 @@ struct PostSettingsFormContentView: View {
                 switch state {
                 case .setup(let viewModel):
                     JetpackSocialNoConnectionView(viewModel: viewModel)
-                case .connected(let viewModel):
-                    LegacyNavigationLinkRow(action: self.viewModel.showSocialSharingOptions) {
-                        PrepublishingAutoSharingView(model: viewModel)
+                case .connected(let settings):
+                    LegacyNavigationLinkRow(action: viewModel.showSocialSharingOptions) {
+                        PrepublishingAutoSharingView(model: settings)
                     }
                 }
             } header: {

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -55,10 +55,21 @@ private struct PostSettingsView: View {
         .accessibilityIdentifier("post_settings_form")
         .disabled(viewModel.isSaving)
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
+            ToolbarItem(placement: .topBarLeading) {
                 buttonCancel
+                    .confirmationDialog(Strings.discardChangesTitle, isPresented: $isShowingDiscardChangesAlert) {
+                        Button(Strings.discardChangesButton, role: .destructive) {
+                            viewModel.buttonCancelTapped()
+                        }
+                        Button(SharedStrings.Button.cancel, role: .cancel) {
+                            // Do nothing - continue editing
+                        }
+                    } message: {
+                        Text(Strings.discardChangesMessage)
+                    }
             }
-            ToolbarItem(placement: .navigationBarTrailing) {
+
+            ToolbarItem(placement: .topBarTrailing) {
                 buttonSave
             }
         }
@@ -69,16 +80,6 @@ private struct PostSettingsView: View {
             }
         } message: {
             Text(viewModel.deletedAlertMessage)
-        }
-        .confirmationDialog(Strings.discardChangesTitle, isPresented: $isShowingDiscardChangesAlert) {
-            Button(Strings.discardChangesButton, role: .destructive) {
-                viewModel.buttonCancelTapped()
-            }
-            Button(SharedStrings.Button.cancel, role: .cancel) {
-                // Do nothing - continue editing
-            }
-        } message: {
-            Text(Strings.discardChangesMessage)
         }
     }
 
@@ -92,6 +93,7 @@ private struct PostSettingsView: View {
         }
         .tint(AppColor.tint)
         .accessibilityIdentifier("post_settings_cancel_button")
+
     }
 
     @ViewBuilder

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -632,22 +632,10 @@ private enum Strings {
         comment: "Placeholder value for a publishing date in the prepublishing sheet when the date is not selected"
     )
 
-    static let publishingOptionsHeader = NSLocalizedString(
-        "postSettings.publishing.header",
-        value: "Publishing",
-        comment: "Section header for Publishing Options in Post Settings"
-    )
-
     static let publishingTo = NSLocalizedString(
         "postSettings.publishingTo",
         value: "Publishing to",
         comment: "Label indicating which site you are publishing to"
-    )
-
-    static let previewLabel = NSLocalizedString(
-        "postSettings.preview.label",
-        value: "Preview",
-        comment: "Label for the preview button in Post Settings"
     )
 
     static let socialSharing = NSLocalizedString(

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -134,9 +134,14 @@ struct PostSettingsFormContentView: View {
             organizationSection
         }
         excerptSection
+        if viewModel.context == .publishing {
+            socialSharingSection
+        }
         generalSection
         moreOptionsSection
-        infoSection
+        if viewModel.context != .publishing {
+            infoSection
+        }
     }
 
     // MARK: - "Publishing Options" Section
@@ -144,10 +149,12 @@ struct PostSettingsFormContentView: View {
     @ViewBuilder
     private var publishingOptionsSection: some View {
         Section {
-            BlogListSiteView(site: .init(blog: viewModel.post.blog))
-                .listRowSeparator(.hidden, edges: .bottom)
             publishDateRow
             visibilityRow
+        } header: {
+            BlogListSiteView(site: .init(blog: viewModel.post.blog))
+                .padding(.bottom, 8)
+                .foregroundStyle(.primary)
         }
     }
 
@@ -281,6 +288,24 @@ struct PostSettingsFormContentView: View {
             )
         } label: {
             SettingsRow(Strings.visibilityLabel, value: viewModel.visibilityText)
+        }
+    }
+
+    // MARK: - "Social Sharing" Section
+
+    @ViewBuilder
+    private var socialSharingSection: some View {
+        if let state = viewModel.socialSharingState {
+            Section {
+                switch state {
+                case .setup(let viewModel):
+                    JetpackSocialNoConnectionView(viewModel: viewModel)
+                case .connected:
+                    Text("Connected (not implemented)")
+                }
+            } header: {
+                SectionHeader(Strings.socialSharing)
+            }
         }
     }
 
@@ -597,19 +622,28 @@ private enum Strings {
         value: "Immediately",
         comment: "Placeholder value for a publishing date in the prepublishing sheet when the date is not selected"
     )
+
     static let publishingOptionsHeader = NSLocalizedString(
         "postSettings.publishing.header",
         value: "Publishing",
         comment: "Section header for Publishing Options in Post Settings"
     )
+
     static let publishingTo = NSLocalizedString(
         "postSettings.publishingTo",
         value: "Publishing to",
         comment: "Label indicating which site you are publishing to"
     )
+
     static let previewLabel = NSLocalizedString(
         "postSettings.preview.label",
         value: "Preview",
+        comment: "Label for the preview button in Post Settings"
+    )
+
+    static let socialSharing = NSLocalizedString(
+        "postSettings.socialSharing.header",
+        value: "Social Sharing",
         comment: "Label for the preview button in Post Settings"
     )
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -51,6 +51,7 @@ private struct PostSettingsView: View {
     var body: some View {
         Form {
             PostSettingsFormContentView(viewModel: viewModel)
+            infoSection
         }
         .accessibilityIdentifier("post_settings_form")
         .disabled(viewModel.isSaving)
@@ -120,6 +121,22 @@ private struct PostSettingsView: View {
             .tint(AppColor.tint)
         }
     }
+
+    @ViewBuilder
+    private var infoSection: some View {
+        if viewModel.lastEditedText != nil || viewModel.postID != nil {
+            Section {
+                if let postID = viewModel.postID {
+                    SettingsRow(Strings.postIDLabel, value: String(postID))
+                }
+                if let lastEditedText = viewModel.lastEditedText {
+                    SettingsRow(Strings.lastEditedLabel, value: lastEditedText)
+                }
+            } header: {
+                SectionHeader(Strings.infoLabel)
+            }
+        }
+    }
 }
 
 struct PostSettingsFormContentView: View {
@@ -134,9 +151,6 @@ struct PostSettingsFormContentView: View {
         generalSection
         socialSharingSection
         moreOptionsSection
-        if viewModel.context != .publishing {
-            infoSection
-        }
     }
 
     // MARK: - "Publishing Options" Section
@@ -358,24 +372,6 @@ struct PostSettingsFormContentView: View {
     private var stickyPostRow: some View {
         Toggle(isOn: $viewModel.settings.isStickyPost) {
             Text(Strings.stickyPostLabel)
-        }
-    }
-
-    // MARK: - "Info" Section
-
-    @ViewBuilder
-    private var infoSection: some View {
-        if viewModel.lastEditedText != nil || viewModel.postID != nil {
-            Section {
-                if let postID = viewModel.postID {
-                    SettingsRow(Strings.postIDLabel, value: String(postID))
-                }
-                if let lastEditedText = viewModel.lastEditedText {
-                    SettingsRow(Strings.lastEditedLabel, value: lastEditedText)
-                }
-            } header: {
-                SectionHeader(Strings.infoLabel)
-            }
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -134,7 +134,7 @@ struct PostSettingsFormContentView: View {
             organizationSection
         }
         excerptSection
-        if viewModel.context == .publishing {
+        if viewModel.isPost, viewModel.context == .publishing {
             socialSharingSection
         }
         generalSection

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -50,14 +50,7 @@ private struct PostSettingsView: View {
 
     var body: some View {
         Form {
-            featuredImageSection
-            generalSection
-            if viewModel.isPost {
-                organizationSection
-            }
-            excerptSection
-            moreOptionsSection
-            infoSection
+            PostSettingsFormContentView(viewModel: viewModel)
         }
         .accessibilityIdentifier("post_settings_form")
         .disabled(viewModel.isSaving)
@@ -124,6 +117,21 @@ private struct PostSettingsView: View {
             .disabled(!viewModel.hasChanges)
             .tint(AppColor.tint)
         }
+    }
+}
+
+struct PostSettingsFormContentView: View {
+    @ObservedObject var viewModel: PostSettingsViewModel
+
+    var body: some View {
+        featuredImageSection
+        generalSection
+        if viewModel.isPost {
+            organizationSection
+        }
+        excerptSection
+        moreOptionsSection
+        infoSection
     }
 
     // MARK: - "Featured Image" Section

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -288,9 +288,11 @@ struct PostSettingsFormContentView: View {
                 switch state {
                 case .setup(let viewModel):
                     JetpackSocialNoConnectionView(viewModel: viewModel)
-                case .connected(let settings):
-                    LegacyNavigationLinkRow(action: viewModel.showSocialSharingOptions) {
-                        PrepublishingAutoSharingView(model: settings)
+                case .connected:
+                    if let settings = viewModel.settings.sharing {
+                        LegacyNavigationLinkRow(action: viewModel.showSocialSharingOptions) {
+                            PrepublishingAutoSharingView(model: settings)
+                        }
                     }
                 }
             } header: {

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -138,16 +138,17 @@ struct PostSettingsFormContentView: View {
     }
 
     // MARK: - "Publishing Options" Section
+
     @ViewBuilder
     private var publishingOptionsSection: some View {
         Section {
             BlogListSiteView(site: .init(blog: viewModel.post.blog))
+                .listRowSeparator(.hidden, edges: .bottom)
             publishDateRow
             visibilityRow
-        } header: {
-            SectionHeader(Strings.publishingOptionsHeader)
         }
     }
+
     // MARK: - "Featured Image" Section
 
     @ViewBuilder

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -94,7 +94,6 @@ private struct PostSettingsView: View {
         }
         .tint(AppColor.tint)
         .accessibilityIdentifier("post_settings_cancel_button")
-
     }
 
     @ViewBuilder

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -107,6 +107,7 @@ final class PostSettingsViewModel: ObservableObject {
 
     var onDismiss: (() -> Void)?
     var onEditorPostSaved: (() -> Void)?
+    var onPostPublished: (() -> Void)?
 
     /// Weak reference to the view controller for navigation.
     /// This is temporary until we can fully migrate to SwiftUI navigation.
@@ -240,6 +241,7 @@ final class PostSettingsViewModel: ObservableObject {
                 let coordinator = PostCoordinator.shared
                 let changes = settings.makeUpdateParameters(from: post)
                 try await coordinator.publish_v2(post.original(), parameters: changes)
+                onPostPublished?()
             } catch {
                 isSaving = false
                 // `PostCoordinator` handles errors by showing an alert when needed

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -8,6 +8,7 @@ import Combine
 final class PostSettingsViewModel: ObservableObject {
     let post: AbstractPost
     let isStandalone: Bool
+    let context: Context
     let featuredImageViewModel: PostSettingsFeaturedImageViewModel
 
     @Published var settings: PostSettings {
@@ -111,9 +112,19 @@ final class PostSettingsViewModel: ObservableObject {
     /// This is temporary until we can fully migrate to SwiftUI navigation.
     weak var viewController: UIViewController?
 
-    init(post: AbstractPost, isStandalone: Bool = false) {
+    enum Context {
+        case settings
+        case publishing
+    }
+
+    init(
+        post: AbstractPost,
+        isStandalone: Bool = false,
+        context: Context = .settings
+    ) {
         self.post = post
         self.isStandalone = isStandalone
+        self.context = context
 
         // Initialize settings from the post
         let initialSettings = PostSettings(from: post)

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import BuildSettingsKit
 import WordPressData
 import WordPressKit
 import WordPressShared
@@ -22,6 +23,7 @@ final class PostSettingsViewModel: ObservableObject {
     @Published private(set) var displayedCategories: [String] = []
     @Published private(set) var displayedTags: [String] = []
     @Published private(set) var parentPageText: String?
+    @Published private(set) var socialSharingState: SocialSharingRowState = .hidden
 
     @Published var isShowingDeletedAlert = false
 
@@ -102,7 +104,16 @@ final class PostSettingsViewModel: ObservableObject {
         return postID
     }
 
+    enum SocialSharingRowState {
+        /// The initial prompt to set up connections.
+        case setup
+        /// The site has existing connections.
+        case connected
+        case hidden
+    }
+
     private let originalSettings: PostSettings
+    private let preferences: UserPersistentRepository
     private var cancellables = Set<AnyCancellable>()
 
     var onDismiss: (() -> Void)?
@@ -121,11 +132,13 @@ final class PostSettingsViewModel: ObservableObject {
     init(
         post: AbstractPost,
         isStandalone: Bool = false,
-        context: Context = .settings
+        context: Context = .settings,
+        preferences: UserPersistentRepository = UserDefaults.standard
     ) {
         self.post = post
         self.isStandalone = isStandalone
         self.context = context
+        self.preferences = preferences
 
         // Initialize settings from the post
         let initialSettings = PostSettings(from: post)
@@ -144,9 +157,12 @@ final class PostSettingsViewModel: ObservableObject {
         refreshDisplayedCategories()
         refreshDisplayedTags()
         refreshParentPageText()
+        refreshSocialSharingState()
 
         WPAnalytics.track(.postSettingsShown)
     }
+
+    // MARK: - Refresh
 
     private func refresh(from old: PostSettings, to new: PostSettings) {
         hasChanges = getSettingsToSave(for: new) != originalSettings
@@ -179,6 +195,29 @@ final class PostSettingsViewModel: ObservableObject {
             parentPageText = nil
         }
     }
+
+    private func refreshSocialSharingState() {
+        guard BuildSettings.current.brand == .jetpack &&
+                RemoteFeatureFlag.jetpackSocialImprovements.enabled() &&
+                post.status != .publishPrivate &&
+                !getPublicizeServices().isEmpty &&
+                post.blog.supportsPublicize() else {
+            socialSharingState = .hidden
+            return
+        }
+
+        if (post.blog.connections ?? []).isEmpty &&  {
+            socialSharingState = isSocialConnectionSetupDismissed ? .hidden : .setup
+        } else {
+            socialSharingState = .connected
+        }
+    }
+
+    private func getPublicizeServices() -> [PublicizeService] {
+        try? PublicizeService.allPublicizeServices(in: ContextManager.shared.mainContext) ?? []
+    }
+
+    // MARK: - Actions
 
     func buttonCancelTapped() {
         onDismiss?()
@@ -343,6 +382,30 @@ final class PostSettingsViewModel: ObservableObject {
     private func track(_ event: WPAnalyticsEvent) {
         WPAnalytics.track(event, properties: ["via": "settings"])
     }
+
+    // MARK: - Helpers
+
+    /// Convenience variable representing whether the No Connection view has been dismissed.
+    /// Note: the value is stored per site.
+    private var isSocialConnectionSetupDismissed: Bool {
+        get {
+            guard let blogID = post.blog.dotComID?.intValue,
+                  let dictionary = preferences.dictionary(forKey: Constants.noConnectionKey) as? [String: Bool],
+                  let value = dictionary["\(blogID)"] else {
+                return false
+            }
+            return value
+        }
+
+        set {
+            guard let blogID = post.blog.dotComID?.intValue else {
+                return wpAssertionFailure("blogID missing")
+            }
+            var dictionary = (persistentStore.dictionary(forKey: Constants.noConnectionKey) as? [String: Bool]) ?? .init()
+            dictionary["\(postBlogID)"] = newValue
+            preferences.set(dictionary, forKey: Constants.noConnectionKey)
+        }
+    }
 }
 
 // MARK: - Localized Strings
@@ -383,4 +446,8 @@ private enum Strings {
         value: "This page has been deleted and can no longer be saved.",
         comment: "Message when trying to save a deleted page"
     )
+}
+
+private enum Constants {
+    static let noConnectionKey = "prepublishing-social-no-connection-view-hidden"
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -226,6 +226,27 @@ final class PostSettingsViewModel: ObservableObject {
         }
     }
 
+    func buttonPublishTapped() {
+        // Check if the post still exists
+        guard let context = post.managedObjectContext,
+              let _ = try? context.existingObject(with: post.objectID) else {
+            isShowingDeletedAlert = true
+            return
+        }
+
+        isSaving = true
+        Task {
+            do {
+                let coordinator = PostCoordinator.shared
+                let changes = settings.makeUpdateParameters(from: post)
+                try await coordinator.publish_v2(post.original(), parameters: changes)
+            } catch {
+                isSaving = false
+                // `PostCoordinator` handles errors by showing an alert when needed
+            }
+        }
+    }
+
     private func didSaveChanges() {
         trackChanges(from: originalSettings, to: settings)
     }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -109,7 +109,7 @@ final class PostSettingsViewModel: ObservableObject {
         /// The initial prompt to set up connections.
         case setup(JetpackSocialNoConnectionViewModel)
         /// The site has existing connections.
-        case connected(PrepublishingAutoSharingModel)
+        case connected(PostSocialSharingSettings)
     }
 
     private let originalSettings: PostSettings
@@ -379,7 +379,7 @@ final class PostSettingsViewModel: ObservableObject {
         }
     }
 
-    private func makeAutoSharingModel(for post: Post) -> PrepublishingAutoSharingModel {
+    private func makeAutoSharingModel(for post: Post) -> PostSocialSharingSettings {
         let connections = post.blog.sortedConnections
 
         // first, build a dictionary to categorize the connections.
@@ -391,14 +391,14 @@ final class PostSettingsViewModel: ObservableObject {
             connectionsMap[serviceName] = serviceConnections
         }
 
-        let services = getPublicizeServices().compactMap { service -> PrepublishingAutoSharingModel.Service? in
+        let services = getPublicizeServices().compactMap { service -> PostSocialSharingSettings.Service? in
             // skip services without connections.
             guard let serviceConnections = connectionsMap[service.name],
                   !serviceConnections.isEmpty else {
                 return nil
             }
 
-            return PrepublishingAutoSharingModel.Service(
+            return PostSocialSharingSettings.Service(
                 name: service.name,
                 connections: serviceConnections.map {
                     .init(account: $0.externalDisplay,

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -109,7 +109,7 @@ final class PostSettingsViewModel: ObservableObject {
         /// The initial prompt to set up connections.
         case setup(JetpackSocialNoConnectionViewModel)
         /// The site has existing connections.
-        case connected
+        case connected(PrepublishingAutoSharingModel)
     }
 
     private let originalSettings: PostSettings
@@ -308,7 +308,8 @@ final class PostSettingsViewModel: ObservableObject {
                 RemoteFeatureFlag.jetpackSocialImprovements.enabled() &&
                 post.status != .publishPrivate &&
                 !getPublicizeServices().isEmpty &&
-                post.blog.supportsPublicize() else {
+                post.blog.supportsPublicize(),
+                let post = post as? Post else {
             socialSharingState = nil
             return
         }
@@ -320,7 +321,7 @@ final class PostSettingsViewModel: ObservableObject {
                 socialSharingState = .setup(makeSocialSharingSetupViewModel())
             }
         } else {
-            socialSharingState = .connected
+            socialSharingState = .connected(makeAutoSharingModel(for: post))
         }
     }
 
@@ -376,6 +377,54 @@ final class PostSettingsViewModel: ObservableObject {
         withAnimation {
             socialSharingState = nil
         }
+    }
+
+    private func makeAutoSharingModel(for post: Post) -> PrepublishingAutoSharingModel {
+        let connections = post.blog.sortedConnections
+
+        // first, build a dictionary to categorize the connections.
+        var connectionsMap = [PublicizeService.ServiceName: [PublicizeConnection]]()
+        connections.filter { !$0.requiresUserAction() }.forEach { connection in
+            let serviceName = PublicizeService.ServiceName(rawValue: connection.service) ?? .unknown
+            var serviceConnections = connectionsMap[serviceName] ?? []
+            serviceConnections.append(connection)
+            connectionsMap[serviceName] = serviceConnections
+        }
+
+        let services = getPublicizeServices().compactMap { service -> PrepublishingAutoSharingModel.Service? in
+            // skip services without connections.
+            guard let serviceConnections = connectionsMap[service.name],
+                  !serviceConnections.isEmpty else {
+                return nil
+            }
+
+            return PrepublishingAutoSharingModel.Service(
+                name: service.name,
+                connections: serviceConnections.map {
+                    .init(account: $0.externalDisplay,
+                          keyringID: $0.keyringConnectionID.intValue,
+                          enabled: !post.publicizeConnectionDisabledForKeyringID($0.keyringConnectionID))
+                }
+            )
+        }
+
+        return .init(services: services, message: post.publicizeMessage ?? post.titleForDisplay(), sharingLimit: post.blog.sharingLimit)
+    }
+
+    func showSocialSharingOptions() {
+        guard let blogID = post.blog.dotComID?.intValue,
+              let post = post as? Post else {
+            return wpAssertionFailure("invalid context")
+        }
+        let delegate = PrepublishingSocialAccountsDelegateAdapter()
+        cancellables.insert(AnyCancellable { _ = delegate }) // Retain it
+        let optionsVC = PrepublishingSocialAccountsViewController(
+            blogID: blogID,
+            model: makeAutoSharingModel(for: post),
+            delegate: delegate,
+            coreDataStack: ContextManager.shared
+        )
+        viewController?.navigationController?.pushViewController(optionsVC, animated: true)
     }
 
     // MARK: - Navigation
@@ -450,6 +499,37 @@ final class PostSettingsViewModel: ObservableObject {
 extension PostSettingsViewModel: @MainActor SharingViewControllerDelegate {
     func didChangePublicizeServices() {
         refreshSocialSharingState()
+    }
+}
+
+private final class PrepublishingSocialAccountsDelegateAdapter: NSObject, @MainActor PrepublishingSocialAccountsDelegate {
+    func didUpdateSharingLimit(with newValue: PublicizeInfo.SharingLimit?) {
+//        reloadData()
+    }
+
+    func didFinish(with connectionChanges: [Int: Bool], message: String?) {
+//        DispatchQueue.main.async {
+//            self._didFinish(with: connectionChanges, message: message)
+//        }
+    }
+
+    private func _didFinish(with connectionChanges: [Int: Bool], message: String?) {
+//        guard let post = post as? Post else {
+//            wpAssertionFailure("invalid post type")
+//            return
+//        }
+//        connectionChanges.forEach { (keyringID, enabled) in
+//            if enabled {
+//                post.enablePublicizeConnectionWithKeyringID(NSNumber(value: keyringID))
+//            } else {
+//                post.disablePublicizeConnectionWithKeyringID(NSNumber(value: keyringID))
+//            }
+//        }
+//
+//        let isMessageEmpty = message?.isEmpty ?? true
+//        post.publicizeMessage = isMessageEmpty ? nil : message
+//
+//        reloadData()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -306,16 +306,10 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
     // MARK: - Social Sharing
 
     private func refreshSocialSharingState() {
-        guard BuildSettings.current.brand == .jetpack &&
-                RemoteFeatureFlag.jetpackSocialImprovements.enabled() &&
-                post.status != .publishPrivate &&
-                !getPublicizeServices().isEmpty &&
-                post.blog.supportsPublicize(),
-                let post = post as? Post else {
+        guard let post = post as? Post, isPostEligibleForSocialSharing(post) else {
             socialSharingState = nil
             return
         }
-
         if (post.blog.connections ?? []).isEmpty {
             if isSocialConnectionSetupDismissed {
                 socialSharingState = nil
@@ -325,6 +319,14 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
         } else {
             socialSharingState = .connected
         }
+    }
+
+    private func isPostEligibleForSocialSharing(_ post: Post) -> Bool {
+        BuildSettings.current.brand == .jetpack &&
+        RemoteFeatureFlag.jetpackSocialImprovements.enabled() &&
+        post.status != .publishPrivate &&
+        !getPublicizeServices().isEmpty &&
+        post.blog.supportsPublicize()
     }
 
     private func getPublicizeServices() -> [PublicizeService] {
@@ -343,7 +345,6 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
             }
             return value
         }
-
         set {
             guard let blogID = post.blog.dotComID?.intValue else {
                 return wpAssertionFailure("blogID missing")
@@ -375,7 +376,6 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
     private func didDismissSocialSharingSetupPrompt() {
         track(.jetpackSocialNoConnectionCardDismissed)
         isSocialConnectionSetupDismissed = true
-
         withAnimation {
             socialSharingState = nil
         }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -1,5 +1,6 @@
 import Foundation
 import BuildSettingsKit
+import SwiftUI
 import WordPressData
 import WordPressKit
 import WordPressShared
@@ -321,9 +322,6 @@ final class PostSettingsViewModel: ObservableObject {
         } else {
             socialSharingState = .connected
         }
-
-        // TEMP:
-        socialSharingState = .setup(makeSocialSharingSetupViewModel())
     }
 
     private func getPublicizeServices() -> [PublicizeService] {
@@ -357,54 +355,28 @@ final class PostSettingsViewModel: ObservableObject {
         JetpackSocialNoConnectionViewModel(
             services: getPublicizeServices(),
             padding: .zero,
-            onConnectTap: { [weak self] in
-                // TODO:
-            },
-            onNotNowTap: { [weak self] in
-                // TODO:
-            }
+            onConnectTap: { [weak self] in self?.showSocialSharingSetupScreen() },
+            onNotNowTap: { [weak self] in self?.didDismissSocialSharingSetupPrompt() }
         )
     }
 
-//    /// A closure to be executed when the Connect button is tapped in the No Connection view.
-//    func noConnectionConnectTapped() -> () -> Void {
-//        return { [weak self] in
-//            guard let self,
-//                  let controller = SharingViewController(blog: self.post.blog, delegate: self),
-//                  self.presentedViewController == nil else {
-//                return
-//            }
-//
-//            WPAnalytics.track(.jetpackSocialNoConnectionCTATapped, properties: ["source": Constants.trackingSource])
-//
-//            let navigationController = UINavigationController(rootViewController: controller)
-//            self.show(navigationController, sender: nil)
-//        }
-//    }
-//
-//    /// A closure to be executed when the "Not now" button is tapped in the No Connection view.
-//    func noConnectionDismissTapped() -> () -> Void {
-//        return { [weak self] in
-//            guard let self,
-//                  let autoSharingRowIndex = options.firstIndex(where: { $0.id == .autoSharing }) else {
-//                return
-//            }
-//
-//            WPAnalytics.track(.jetpackSocialNoConnectionCardDismissed, properties: ["source": Constants.trackingSource])
-//
-//            self.isNoConnectionDismissed = true
-//            self.refreshOptions()
-//
-//            // ensure that the `.autoSharing` identifier is truly removed to prevent table updates from crashing.
-//            guard options.firstIndex(where: { $0.id == .autoSharing }) == nil else {
-//                return
-//            }
-//
-//            self.tableView.performBatchUpdates {
-//                self.tableView.deleteRows(at: [.init(row: autoSharingRowIndex, section: .zero)], with: .fade)
-//            } completion: { _ in }
-//        }
-//    }
+    private func showSocialSharingSetupScreen() {
+        guard let sharingVC = SharingViewController(blog: post.blog, delegate: self) else {
+            return wpAssertionFailure("failed to instantiate SharingVC")
+        }
+        track(.jetpackSocialNoConnectionCTATapped)
+        let navigationVC = UINavigationController(rootViewController: sharingVC)
+        viewController?.present(navigationVC, animated: true)
+    }
+
+    private func didDismissSocialSharingSetupPrompt() {
+        track(.jetpackSocialNoConnectionCardDismissed)
+        isSocialConnectionSetupDismissed = true
+
+        withAnimation {
+            socialSharingState = nil
+        }
+    }
 
     // MARK: - Navigation
 
@@ -445,7 +417,7 @@ final class PostSettingsViewModel: ObservableObject {
         }
         if old.featuredImageID != new.featuredImageID {
             let action = new.featuredImageID == nil ? "removed" : "changed"
-            WPAnalytics.track(.editorPostFeaturedImageChanged, properties: ["via": "settings", "action": action])
+            WPAnalytics.track(.editorPostFeaturedImageChanged, properties: ["via": source, "action": action])
         }
         if old.excerpt != new.excerpt {
             track(.editorPostExcerptChanged)
@@ -464,7 +436,20 @@ final class PostSettingsViewModel: ObservableObject {
     }
 
     private func track(_ event: WPAnalyticsEvent) {
-        WPAnalytics.track(event, properties: ["via": "settings"])
+        WPAnalytics.track(event, properties: ["via": source])
+    }
+
+    private var source: String {
+        switch context {
+        case .settings: "post_settings"
+        case .publishing: "pre_publishing"
+        }
+    }
+}
+
+extension PostSettingsViewModel: @MainActor SharingViewControllerDelegate {
+    func didChangePublicizeServices() {
+        refreshSocialSharingState()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -7,7 +7,7 @@ import WordPressShared
 import Combine
 
 @MainActor
-final class PostSettingsViewModel: ObservableObject {
+final class PostSettingsViewModel: NSObject, ObservableObject {
     let post: AbstractPost
     let isStandalone: Bool
     let context: Context
@@ -109,7 +109,7 @@ final class PostSettingsViewModel: ObservableObject {
         /// The initial prompt to set up connections.
         case setup(JetpackSocialNoConnectionViewModel)
         /// The site has existing connections.
-        case connected(PostSocialSharingSettings)
+        case connected
     }
 
     private let originalSettings: PostSettings
@@ -147,6 +147,8 @@ final class PostSettingsViewModel: ObservableObject {
 
         // Initialize featured image view model
         self.featuredImageViewModel = PostSettingsFeaturedImageViewModel(post: post)
+
+        super.init()
 
         // Observe selection changes from featured image view model
         featuredImageViewModel.$selection.dropFirst().sink { [weak self] media in
@@ -320,10 +322,8 @@ final class PostSettingsViewModel: ObservableObject {
             } else {
                 socialSharingState = .setup(makeSocialSharingSetupViewModel())
             }
-        } else if let settings = settings.sharing {
-            socialSharingState = .connected(settings)
         } else {
-            socialSharingState = nil
+            socialSharingState = .connected
         }
     }
 
@@ -386,12 +386,10 @@ final class PostSettingsViewModel: ObservableObject {
               let settigns = settings.sharing else {
             return wpAssertionFailure("invalid context")
         }
-        let delegate = PrepublishingSocialAccountsDelegateAdapter()
-        cancellables.insert(AnyCancellable { _ = delegate }) // Retain it
         let optionsVC = PrepublishingSocialAccountsViewController(
             blogID: blogID,
             model: settigns,
-            delegate: delegate,
+            delegate: self,
             coreDataStack: ContextManager.shared
         )
         viewController?.navigationController?.pushViewController(optionsVC, animated: true)
@@ -472,34 +470,28 @@ extension PostSettingsViewModel: @MainActor SharingViewControllerDelegate {
     }
 }
 
-private final class PrepublishingSocialAccountsDelegateAdapter: NSObject, @MainActor PrepublishingSocialAccountsDelegate {
+extension PostSettingsViewModel: @MainActor PrepublishingSocialAccountsDelegate {
     func didUpdateSharingLimit(with newValue: PublicizeInfo.SharingLimit?) {
-//        reloadData()
+        settings.sharing?.sharingLimit = newValue
     }
 
     func didFinish(with connectionChanges: [Int: Bool], message: String?) {
-//        DispatchQueue.main.async {
-//            self._didFinish(with: connectionChanges, message: message)
-//        }
-    }
-
-    private func _didFinish(with connectionChanges: [Int: Bool], message: String?) {
-//        guard let post = post as? Post else {
-//            wpAssertionFailure("invalid post type")
-//            return
-//        }
-//        connectionChanges.forEach { (keyringID, enabled) in
-//            if enabled {
-//                post.enablePublicizeConnectionWithKeyringID(NSNumber(value: keyringID))
-//            } else {
-//                post.disablePublicizeConnectionWithKeyringID(NSNumber(value: keyringID))
-//            }
-//        }
-//
-//        let isMessageEmpty = message?.isEmpty ?? true
-//        post.publicizeMessage = isMessageEmpty ? nil : message
-//
-//        reloadData()
+        guard var settings = settings.sharing else {
+            return wpAssertionFailure("social sharing settings missing")
+        }
+        settings.services = settings.services.map {
+            var service = $0
+            service.connections = service.connections.map {
+                var connection = $0
+                if let isEnabled = connectionChanges[connection.keyringID] {
+                    connection.enabled = isEnabled
+                }
+                return connection
+            }
+            return service
+        }
+        settings.message = message ?? ""
+        self.settings.sharing = settings
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -23,7 +23,7 @@ final class PostSettingsViewModel: ObservableObject {
     @Published private(set) var displayedCategories: [String] = []
     @Published private(set) var displayedTags: [String] = []
     @Published private(set) var parentPageText: String?
-    @Published private(set) var socialSharingState: SocialSharingRowState = .hidden
+    @Published private(set) var socialSharingState: SocialSharingSectionState?
 
     @Published var isShowingDeletedAlert = false
 
@@ -104,12 +104,11 @@ final class PostSettingsViewModel: ObservableObject {
         return postID
     }
 
-    enum SocialSharingRowState {
+    enum SocialSharingSectionState {
         /// The initial prompt to set up connections.
-        case setup
+        case setup(JetpackSocialNoConnectionViewModel)
         /// The site has existing connections.
         case connected
-        case hidden
     }
 
     private let originalSettings: PostSettings
@@ -194,27 +193,6 @@ final class PostSettingsViewModel: ObservableObject {
         } else {
             parentPageText = nil
         }
-    }
-
-    private func refreshSocialSharingState() {
-        guard BuildSettings.current.brand == .jetpack &&
-                RemoteFeatureFlag.jetpackSocialImprovements.enabled() &&
-                post.status != .publishPrivate &&
-                !getPublicizeServices().isEmpty &&
-                post.blog.supportsPublicize() else {
-            socialSharingState = .hidden
-            return
-        }
-
-        if (post.blog.connections ?? []).isEmpty &&  {
-            socialSharingState = isSocialConnectionSetupDismissed ? .hidden : .setup
-        } else {
-            socialSharingState = .connected
-        }
-    }
-
-    private func getPublicizeServices() -> [PublicizeService] {
-        try? PublicizeService.allPublicizeServices(in: ContextManager.shared.mainContext) ?? []
     }
 
     // MARK: - Actions
@@ -322,6 +300,112 @@ final class PostSettingsViewModel: ObservableObject {
         settings.password = selection.password.isEmpty ? nil : selection.password
     }
 
+    // MARK: - Social Sharing
+
+    private func refreshSocialSharingState() {
+        guard BuildSettings.current.brand == .jetpack &&
+                RemoteFeatureFlag.jetpackSocialImprovements.enabled() &&
+                post.status != .publishPrivate &&
+                !getPublicizeServices().isEmpty &&
+                post.blog.supportsPublicize() else {
+            socialSharingState = nil
+            return
+        }
+
+        if (post.blog.connections ?? []).isEmpty {
+            if isSocialConnectionSetupDismissed {
+                socialSharingState = nil
+            } else {
+                socialSharingState = .setup(makeSocialSharingSetupViewModel())
+            }
+        } else {
+            socialSharingState = .connected
+        }
+
+        // TEMP:
+        socialSharingState = .setup(makeSocialSharingSetupViewModel())
+    }
+
+    private func getPublicizeServices() -> [PublicizeService] {
+        let context = ContextManager.shared.mainContext
+        return (try? PublicizeService.allPublicizeServices(in: context)) ?? []
+    }
+
+    /// Convenience variable representing whether the No Connection view has been dismissed.
+    /// Note: the value is stored per site.
+    private var isSocialConnectionSetupDismissed: Bool {
+        get {
+            guard let blogID = post.blog.dotComID?.intValue,
+                  let dictionary = preferences.dictionary(forKey: Constants.noConnectionKey) as? [String: Bool],
+                  let value = dictionary["\(blogID)"] else {
+                return false
+            }
+            return value
+        }
+
+        set {
+            guard let blogID = post.blog.dotComID?.intValue else {
+                return wpAssertionFailure("blogID missing")
+            }
+            var dictionary = (preferences.dictionary(forKey: Constants.noConnectionKey) as? [String: Bool]) ?? .init()
+            dictionary["\(blogID)"] = newValue
+            preferences.set(dictionary, forKey: Constants.noConnectionKey)
+        }
+    }
+
+    private func makeSocialSharingSetupViewModel() -> JetpackSocialNoConnectionViewModel {
+        JetpackSocialNoConnectionViewModel(
+            services: getPublicizeServices(),
+            padding: .zero,
+            onConnectTap: { [weak self] in
+                // TODO:
+            },
+            onNotNowTap: { [weak self] in
+                // TODO:
+            }
+        )
+    }
+
+//    /// A closure to be executed when the Connect button is tapped in the No Connection view.
+//    func noConnectionConnectTapped() -> () -> Void {
+//        return { [weak self] in
+//            guard let self,
+//                  let controller = SharingViewController(blog: self.post.blog, delegate: self),
+//                  self.presentedViewController == nil else {
+//                return
+//            }
+//
+//            WPAnalytics.track(.jetpackSocialNoConnectionCTATapped, properties: ["source": Constants.trackingSource])
+//
+//            let navigationController = UINavigationController(rootViewController: controller)
+//            self.show(navigationController, sender: nil)
+//        }
+//    }
+//
+//    /// A closure to be executed when the "Not now" button is tapped in the No Connection view.
+//    func noConnectionDismissTapped() -> () -> Void {
+//        return { [weak self] in
+//            guard let self,
+//                  let autoSharingRowIndex = options.firstIndex(where: { $0.id == .autoSharing }) else {
+//                return
+//            }
+//
+//            WPAnalytics.track(.jetpackSocialNoConnectionCardDismissed, properties: ["source": Constants.trackingSource])
+//
+//            self.isNoConnectionDismissed = true
+//            self.refreshOptions()
+//
+//            // ensure that the `.autoSharing` identifier is truly removed to prevent table updates from crashing.
+//            guard options.firstIndex(where: { $0.id == .autoSharing }) == nil else {
+//                return
+//            }
+//
+//            self.tableView.performBatchUpdates {
+//                self.tableView.deleteRows(at: [.init(row: autoSharingRowIndex, section: .zero)], with: .fade)
+//            } completion: { _ in }
+//        }
+//    }
+
     // MARK: - Navigation
 
     func showCategoriesPicker() {
@@ -381,30 +465,6 @@ final class PostSettingsViewModel: ObservableObject {
 
     private func track(_ event: WPAnalyticsEvent) {
         WPAnalytics.track(event, properties: ["via": "settings"])
-    }
-
-    // MARK: - Helpers
-
-    /// Convenience variable representing whether the No Connection view has been dismissed.
-    /// Note: the value is stored per site.
-    private var isSocialConnectionSetupDismissed: Bool {
-        get {
-            guard let blogID = post.blog.dotComID?.intValue,
-                  let dictionary = preferences.dictionary(forKey: Constants.noConnectionKey) as? [String: Bool],
-                  let value = dictionary["\(blogID)"] else {
-                return false
-            }
-            return value
-        }
-
-        set {
-            guard let blogID = post.blog.dotComID?.intValue else {
-                return wpAssertionFailure("blogID missing")
-            }
-            var dictionary = (persistentStore.dictionary(forKey: Constants.noConnectionKey) as? [String: Bool]) ?? .init()
-            dictionary["\(postBlogID)"] = newValue
-            preferences.set(dictionary, forKey: Constants.noConnectionKey)
-        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -149,7 +149,7 @@ final class PostSettingsViewModel: ObservableObject {
     }
 
     private func refresh(from old: PostSettings, to new: PostSettings) {
-        hasChanges = new != originalSettings
+        hasChanges = getSettingsToSave(for: new) != originalSettings
 
         if old.categoryIDs != new.categoryIDs {
             refreshDisplayedCategories()
@@ -209,6 +209,7 @@ final class PostSettingsViewModel: ObservableObject {
 
     private func actuallySave() async {
         do {
+            let settings = getSettingsToSave(for: self.settings)
             let coordinator = PostCoordinator.shared
             if coordinator.isSyncAllowed(for: post) {
                 let revision = post.createRevision()
@@ -225,6 +226,19 @@ final class PostSettingsViewModel: ObservableObject {
             isSaving = false
             // `PostCoordinator` handles errors by showing an alert when needed
         }
+    }
+
+    func getSettingsToSave(for settings: PostSettings) -> PostSettings {
+        var settings = settings
+        if context == .publishing {
+            // We don't support saving these changes on the "Publishing" sheet
+            // as it would trigger the change in status and publishing. We'll
+            // only save what we can without publishing: tags, categories, etc.
+            settings.status = originalSettings.status
+            settings.password = originalSettings.password
+            settings.publishDate = originalSettings.publishDate
+        }
+        return settings
     }
 
     func buttonPublishTapped() {

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -320,8 +320,10 @@ final class PostSettingsViewModel: ObservableObject {
             } else {
                 socialSharingState = .setup(makeSocialSharingSetupViewModel())
             }
+        } else if let settings = settings.sharing {
+            socialSharingState = .connected(settings)
         } else {
-            socialSharingState = .connected(makeAutoSharingModel(for: post))
+            socialSharingState = nil
         }
     }
 
@@ -379,48 +381,16 @@ final class PostSettingsViewModel: ObservableObject {
         }
     }
 
-    private func makeAutoSharingModel(for post: Post) -> PostSocialSharingSettings {
-        let connections = post.blog.sortedConnections
-
-        // first, build a dictionary to categorize the connections.
-        var connectionsMap = [PublicizeService.ServiceName: [PublicizeConnection]]()
-        connections.filter { !$0.requiresUserAction() }.forEach { connection in
-            let serviceName = PublicizeService.ServiceName(rawValue: connection.service) ?? .unknown
-            var serviceConnections = connectionsMap[serviceName] ?? []
-            serviceConnections.append(connection)
-            connectionsMap[serviceName] = serviceConnections
-        }
-
-        let services = getPublicizeServices().compactMap { service -> PostSocialSharingSettings.Service? in
-            // skip services without connections.
-            guard let serviceConnections = connectionsMap[service.name],
-                  !serviceConnections.isEmpty else {
-                return nil
-            }
-
-            return PostSocialSharingSettings.Service(
-                name: service.name,
-                connections: serviceConnections.map {
-                    .init(account: $0.externalDisplay,
-                          keyringID: $0.keyringConnectionID.intValue,
-                          enabled: !post.publicizeConnectionDisabledForKeyringID($0.keyringConnectionID))
-                }
-            )
-        }
-
-        return .init(services: services, message: post.publicizeMessage ?? post.titleForDisplay(), sharingLimit: post.blog.sharingLimit)
-    }
-
     func showSocialSharingOptions() {
         guard let blogID = post.blog.dotComID?.intValue,
-              let post = post as? Post else {
+              let settigns = settings.sharing else {
             return wpAssertionFailure("invalid context")
         }
         let delegate = PrepublishingSocialAccountsDelegateAdapter()
         cancellables.insert(AnyCancellable { _ = delegate }) // Retain it
         let optionsVC = PrepublishingSocialAccountsViewController(
             blogID: blogID,
-            model: makeAutoSharingModel(for: post),
+            model: settigns,
             delegate: delegate,
             coreDataStack: ContextManager.shared
         )

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostSettingsFeaturedImageRow.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostSettingsFeaturedImageRow.swift
@@ -8,7 +8,7 @@ struct PostSettingsFeaturedImageRow: View {
     @ObservedObject var viewModel: PostSettingsFeaturedImageViewModel
     @State private var presentedMedia: Media?
 
-    @ScaledMetric(relativeTo: .body) var height = 120
+    @ScaledMetric(relativeTo: .body) var height = 110
 
     var body: some View {
         Group {

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostSettingsFeaturedImageRow.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostSettingsFeaturedImageRow.swift
@@ -142,10 +142,6 @@ struct PostSettingsFeaturedImageRow: View {
             RoundedRectangle(cornerRadius: cornerRadius)
                 .fill(Color(UIColor.secondarySystemGroupedBackground))
 
-            // Very subtle accent tint
-            RoundedRectangle(cornerRadius: cornerRadius)
-                .fill(Color.accentColor.opacity(0.02))
-
             content()
 
             // Prominent border

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostSettingsPublishDatePicker.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostSettingsPublishDatePicker.swift
@@ -1,0 +1,17 @@
+import SwiftUI
+import WordPressUI
+
+struct PostSettingsPublishDatePicker: View {
+    @ObservedObject var viewModel: PostSettingsViewModel
+
+    var body: some View {
+        PublishDatePickerView(configuration: PublishDatePickerConfiguration(
+            date: viewModel.settings.publishDate,
+            isRequired: !viewModel.isDraftOrPending,
+            timeZone: viewModel.timeZone,
+            updated: { date in
+                viewModel.settings.publishDate = date
+            }
+        ))
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingAutoSharingView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingAutoSharingView.swift
@@ -3,7 +3,7 @@ import WordPressUI
 
 struct PrepublishingAutoSharingView: View {
 
-    let model: PrepublishingAutoSharingModel
+    let model: PostSocialSharingSettings
 
     @Environment(\.sizeCategory) private var sizeCategory
 
@@ -107,7 +107,7 @@ private extension PrepublishingAutoSharingView {
 
 // MARK: - PrepublishingAutoSharingModel Private Extensions
 
-private extension PrepublishingAutoSharingModel.Service {
+private extension PostSocialSharingSettings.Service {
     /// Whether the icon for this service should be opaque or transparent.
     /// If at least one account is enabled, an opaque version should be shown.
     var usesOpaqueIcon: Bool {
@@ -116,12 +116,12 @@ private extension PrepublishingAutoSharingModel.Service {
         }
     }
 
-    var enabledConnections: [PrepublishingAutoSharingModel.Connection] {
+    var enabledConnections: [PostSocialSharingSettings.Connection] {
         connections.filter { $0.enabled }
     }
 }
 
-private extension PrepublishingAutoSharingModel {
+private extension PostSocialSharingSettings {
     var enabledConnectionsCount: Int {
         services.reduce(0) { $0 + $1.enabledConnections.count }
     }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingSocialAccountsViewController.swift
@@ -84,7 +84,7 @@ class PrepublishingSocialAccountsViewController: UITableViewController {
     }
 
     init(blogID: Int,
-         model: PrepublishingAutoSharingModel,
+         model: PostSocialSharingSettings,
          delegate: PrepublishingSocialAccountsDelegate?,
          coreDataStack: CoreDataStackSwift = ContextManager.shared,
          blogService: BlogService? = nil) {
@@ -374,7 +374,7 @@ private extension PrepublishingSocialAccountsViewController {
 
 }
 
-private extension PrepublishingAutoSharingModel {
+private extension PostSocialSharingSettings {
     var enabledConnectionsCount: Int {
         services.flatMap { $0.connections }.filter { $0.enabled }.count
     }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
@@ -12,7 +12,7 @@ extension PrepublishingViewController {
             return
         }
 
-        let publishVC = PublishPostViewController(post: revision)
+        let publishVC = PublishPostViewController(post: revision, isStandalone: isStandalone)
         publishVC.onCompletion = completion
         publishVC.sheetPresentationController?.detents = [.medium(), .large()]
         presentingViewController.present(publishVC, animated: true)

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
@@ -17,7 +17,7 @@ extension PrepublishingViewController {
         // - warning: Has to be UIKit because some of the  `PostSettingsView` rows rely on it.
         let navigationVC = UINavigationController(rootViewController: publishVC)
         navigationVC.sheetPresentationController?.detents = [
-            .custom(identifier: .medium, resolver: { context in 456 }),
+            .custom(identifier: .medium, resolver: { context in 460 }),
             .large()
         ]
         presentingViewController.present(navigationVC, animated: true)

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
@@ -16,7 +16,10 @@ extension PrepublishingViewController {
         publishVC.onCompletion = completion
         // - warning: Has to be UIKit because some of the  `PostSettingsView` rows rely on it.
         let navigationVC = UINavigationController(rootViewController: publishVC)
-        navigationVC.sheetPresentationController?.detents = [.medium(), .large()]
+        navigationVC.sheetPresentationController?.detents = [
+            .custom(identifier: .medium, resolver: { context in 456 }),
+            .large()
+        ]
         presentingViewController.present(navigationVC, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
@@ -13,6 +13,7 @@ extension PrepublishingViewController {
         }
 
         let publishVC = PublishPostViewController(post: revision)
+        publishVC.onCompletion = completion
         publishVC.sheetPresentationController?.detents = [.medium(), .large()]
         presentingViewController.present(publishVC, animated: true)
     }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
@@ -14,7 +14,9 @@ extension PrepublishingViewController {
 
         let publishVC = PublishPostViewController(post: revision, isStandalone: isStandalone)
         publishVC.onCompletion = completion
-        publishVC.sheetPresentationController?.detents = [.medium(), .large()]
-        presentingViewController.present(publishVC, animated: true)
+        // - warning: Has to be UIKit because some of the  `PostSettingsView` rows rely on it.
+        let navigationVC = UINavigationController(rootViewController: publishVC)
+        navigationVC.sheetPresentationController?.detents = [.medium(), .large()]
+        presentingViewController.present(navigationVC, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+Helpers.swift
@@ -6,7 +6,14 @@ extension PrepublishingViewController {
         // End editing to avoid issues with accessibility
         presentingViewController.view.endEditing(true)
 
-        let viewController = PrepublishingViewController(post: revision, isStandalone: isStandalone, completion: completion)
-        viewController.presentAsSheet(from: presentingViewController)
+        guard FeatureFlag.newPublishingSheet.enabled else {
+            let viewController = PrepublishingViewController(post: revision, isStandalone: isStandalone, completion: completion)
+            viewController.presentAsSheet(from: presentingViewController)
+            return
+        }
+
+        let publishVC = PublishPostViewController(post: revision)
+        publishVC.sheetPresentationController?.detents = [.medium(), .large()]
+        presentingViewController.present(publishVC, animated: true)
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
@@ -195,7 +195,7 @@ private extension PrepublishingViewController {
 
     // MARK: - Model Creation
 
-    func makeAutoSharingModel() -> PrepublishingAutoSharingModel {
+    func makeAutoSharingModel() -> PostSocialSharingSettings {
         return coreDataStack.performQuery { [postObjectID = post.objectID] context in
             guard let post = (try? context.existingObject(with: postObjectID)) as? Post,
                   let supportedServices = try? PublicizeService.allSupportedServices(in: context) else {
@@ -213,14 +213,14 @@ private extension PrepublishingViewController {
             }
 
             // then, transform [PublicizeService] to [PrepublishingAutoSharingModel.Service].
-            let modelServices = supportedServices.compactMap { service -> PrepublishingAutoSharingModel.Service? in
+            let modelServices = supportedServices.compactMap { service -> PostSocialSharingSettings.Service? in
                 // skip services without connections.
                 guard let serviceConnections = connectionsMap[service.name],
                       !serviceConnections.isEmpty else {
                     return nil
                 }
 
-                return PrepublishingAutoSharingModel.Service(
+                return PostSocialSharingSettings.Service(
                     name: service.name,
                     connections: serviceConnections.map {
                         .init(account: $0.externalDisplay,
@@ -247,7 +247,7 @@ private extension PrepublishingViewController {
 // MARK: - Auto Sharing Model
 
 /// A value-type representation of `PublicizeService` for the current blog that's simplified for the auto-sharing flow.
-struct PrepublishingAutoSharingModel {
+struct PostSocialSharingSettings {
     let services: [Service]
     let message: String
     let sharingLimit: PublicizeInfo.SharingLimit?

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController+JetpackSocial.swift
@@ -244,26 +244,6 @@ private extension PrepublishingViewController {
     }
 }
 
-// MARK: - Auto Sharing Model
-
-/// A value-type representation of `PublicizeService` for the current blog that's simplified for the auto-sharing flow.
-struct PostSocialSharingSettings {
-    let services: [Service]
-    let message: String
-    let sharingLimit: PublicizeInfo.SharingLimit?
-
-    struct Service: Hashable {
-        let name: PublicizeService.ServiceName
-        let connections: [Connection]
-    }
-
-    struct Connection: Hashable {
-        let account: String
-        let keyringID: Int
-        var enabled: Bool
-    }
-}
-
 // MARK: - Sharing View Controller Delegate
 
 extension PrepublishingViewController: SharingViewControllerDelegate {

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/PrepublishingViewController.swift
@@ -567,21 +567,4 @@ private struct PrepublishingStackView: UIViewRepresentable {
     }
 }
 
-private enum Strings {
-    static let publish = NSLocalizedString("prepublishing.publish", value: "Publish", comment: "Primary button label in the pre-publishing sheet")
-    static let schedule = NSLocalizedString("prepublishing.schedule", value: "Schedule", comment: "Primary button label in the pre-publishing shee")
-    static let publishDate = NSLocalizedString("prepublishing.publishDate", value: "Publish Date", comment: "Label for a cell in the pre-publishing sheet")
-    static let visibility = NSLocalizedString("prepublishing.visibility", value: "Visibility", comment: "Label for a cell in the pre-publishing sheet")
-    static let categories = NSLocalizedString("prepublishing.categories", value: "Categories", comment: "Label for a cell in the pre-publishing sheet")
-    static let tags = NSLocalizedString("prepublishing.tags", value: "Tags", comment: "Label for a cell in the pre-publishing sheet")
-    static let jetpackSocial = NSLocalizedString("prepublishing.jetpackSocial", value: "Jetpack Social", comment: "Label for a cell in the pre-publishing sheet")
-    static let immediately = NSLocalizedString("prepublishing.publishDateImmediately", value: "Immediately", comment: "Placeholder value for a publishing date in the prepublishing sheet when the date is not selected")
-    static let uploadingMedia = NSLocalizedString("prepublishing.uploadingMedia", value: "Uploading media", comment: "Title for a publish button state in the pre-publishing sheet")
-    private static let uploadMediaOneItemRemaining = NSLocalizedString("prepublishing.uploadMediaOneItemRemaining", value: "%@ item remaining", comment: "Details label for a publish button state in the pre-publishing sheet")
-    private static let uploadMediaManyItemsRemaining = NSLocalizedString("prepublishing.uploadMediaManyItemsRemaining", value: "%@ items remaining", comment: "Details label for a publish button state in the pre-publishing sheet")
-    static func uploadMediaRemaining(count: Int) -> String {
-        String(format: count == 1 ? Strings.uploadMediaOneItemRemaining : Strings.uploadMediaManyItemsRemaining, count.description)
-    }
-    static let mediaUploadFailedTitle = NSLocalizedString("prepublishing.mediaUploadFailedTitle", value: "Failed to upload media", comment: "Title for a publish button state in the pre-publishing sheet")
-    static let mediaUploadFailedDetailsMultipleFailures = NSLocalizedString("prepublishing.mediaUploadFailedDetails", value: "%@ items failed to upload", comment: "Details for a publish button state in the pre-publishing sheet; count as a parameter")
-}
+private typealias Strings = PrepublishingSheetStrings

--- a/WordPress/Classes/ViewRelated/Post/Prepublishing/Views/PostMediaUploadsSnackbarView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Prepublishing/Views/PostMediaUploadsSnackbarView.swift
@@ -1,0 +1,58 @@
+import SwiftUI
+
+struct PostMediaUploadsSnackbarView: View {
+    let state: PostMediaUploadsSnackbarState
+
+    private let accessoryViewWidth: CGFloat = 20
+
+    var body: some View {
+        HStack(spacing: 10) {
+            switch state {
+            case let .uploading(title, details, progress):
+                if let progress {
+                    MediaUploadProgressView(progress: progress)
+                        .frame(width: accessoryViewWidth)
+                } else {
+                    ProgressView()
+                        .foregroundStyle(.secondary)
+                        .frame(width: accessoryViewWidth)
+                }
+                makeDetailsView(title: title, details: details)
+            case let .failed(title, details):
+                Image(systemName: "exclamationmark.triangle.fill")
+                    .foregroundStyle(Color.red)
+                    .frame(width: accessoryViewWidth)
+                makeDetailsView(title: title, details: details)
+            }
+        }
+    }
+
+    private func makeDetailsView(title: String, details: String?) -> some View {
+        VStack(alignment: .leading) {
+            Text(title)
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.primary)
+            if let details {
+                Text(details)
+                    .font(.footnote)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .tint(.primary)
+        .lineLimit(1)
+    }
+}
+
+enum PostMediaUploadsSnackbarState {
+    case uploading(title: String, details: String, progress: Double?)
+    case failed(title: String, details: String? = nil)
+}
+
+#Preview {
+    VStack(spacing: 16) {
+        PostMediaUploadsSnackbarView(state: .uploading(title: "Uploading media...", details: "2 items remaining", progress: 0.2))
+        PostMediaUploadsSnackbarView(state: .failed(title: "Failed to upload media"))
+        PostMediaUploadsSnackbarView(state: .failed(title: "Failed to upload media", details: "Not connected to Internet"))
+    }
+    .padding()
+}

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -36,12 +36,8 @@ struct PublishPostView: View {
         Form {
             PostSettingsFormContentView(viewModel: settingsViewModel)
         }
-        .navigationTitle(Strings.title)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .title) {
-                PublishingHeaderView(blog: post.blog)
-            }
             ToolbarItem(placement: .navigationBarLeading) {
                 buttonCancel
             }
@@ -86,32 +82,6 @@ struct PublishPostView: View {
             .buttonBorderShape(.capsule)
             .tint(AppColor.primary)
         }
-    }
-}
-
-private struct PublishingHeaderView: View {
-    let blog: Blog
-
-    var body: some View {
-//        HStack(alignment: .center, spacing: 12) {
-            VStack(alignment: .center, spacing: 3) {
-                Text(Strings.title)
-                    .font(.headline)
-
-                HStack(alignment: .center, spacing: 4) {
-                    SiteIconView(viewModel: SiteIconViewModel(blog: blog, size: .regular))
-                        .frame(width: 20, height: 20)
-                    Text(blog.title ?? "")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .lineLimit(1)
-                }
-            }
-
-//            Spacer()
-//        }
-//        .listRowBackground(Color.clear)
-//        .listRowInsets(EdgeInsets.zero)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -118,8 +118,7 @@ struct PublishPostView: View {
         if viewModel.isSaving {
             ProgressView()
         } else {
-            // TODO: change dyncam to "Schedule"
-            Button(Strings.publish) {
+            Button(viewModel.publishButtonTitle) {
                 viewModel.buttonPublishTapped()
             }
             .fontWeight(.medium)
@@ -127,6 +126,13 @@ struct PublishPostView: View {
             .buttonBorderShape(.capsule)
             .tint(AppColor.primary)
         }
+    }
+}
+
+private extension PostSettingsViewModel {
+    var publishButtonTitle: String {
+        let isScheduled = settings.publishDate.map { $0 > .now } ?? false
+        return isScheduled ? Strings.schedule : Strings.publish
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -22,13 +22,66 @@ final class PublishPostViewController: UIHostingController<NavigationView<Publis
     }
 }
 
-// TODO: add `PrepublishingSheetResult`
 struct PublishPostView: View {
     @ObservedObject var settingsViewModel: PostSettingsViewModel
 
+    var post: AbstractPost { settingsViewModel.post }
+
     var body: some View {
         Form {
+            PublishingHeaderView(blog: post.blog)
             PostSettingsFormContentView(viewModel: settingsViewModel)
         }
+        .navigationTitle(Strings.title)
+        .navigationBarTitleDisplayMode(.inline)
     }
 }
+
+private struct PublishingHeaderView: View {
+    let blog: Blog
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 12) {
+            SiteIconView(viewModel: SiteIconViewModel(blog: blog, size: .regular))
+                .frame(width: 40, height: 40)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(Strings.publishingTo.uppercased())
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
+                Text(blog.title ?? "")
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+            }
+
+            Spacer()
+        }
+        .listRowBackground(Color.clear)
+        .listRowInsets(EdgeInsets.zero)
+    }
+}
+
+private typealias Strings = PrepublishingSheetStrings
+
+enum PrepublishingSheetStrings {
+    static let title = NSLocalizedString("prepublishing.title", value: "Publishing", comment: "Navigation title")
+    static let publishingTo = NSLocalizedString("prepublishing.publishingTo", value: "Publishing to", comment: "Label in the header in the pre-publishing sheet")
+    static let publish = NSLocalizedString("prepublishing.publish", value: "Publish", comment: "Primary button label in the pre-publishing sheet")
+    static let schedule = NSLocalizedString("prepublishing.schedule", value: "Schedule", comment: "Primary button label in the pre-publishing shee")
+    static let publishDate = NSLocalizedString("prepublishing.publishDate", value: "Publish Date", comment: "Label for a cell in the pre-publishing sheet")
+    static let visibility = NSLocalizedString("prepublishing.visibility", value: "Visibility", comment: "Label for a cell in the pre-publishing sheet")
+    static let categories = NSLocalizedString("prepublishing.categories", value: "Categories", comment: "Label for a cell in the pre-publishing sheet")
+    static let tags = NSLocalizedString("prepublishing.tags", value: "Tags", comment: "Label for a cell in the pre-publishing sheet")
+    static let jetpackSocial = NSLocalizedString("prepublishing.jetpackSocial", value: "Jetpack Social", comment: "Label for a cell in the pre-publishing sheet")
+    static let immediately = NSLocalizedString("prepublishing.publishDateImmediately", value: "Immediately", comment: "Placeholder value for a publishing date in the prepublishing sheet when the date is not selected")
+    static let uploadingMedia = NSLocalizedString("prepublishing.uploadingMedia", value: "Uploading media", comment: "Title for a publish button state in the pre-publishing sheet")
+    private static let uploadMediaOneItemRemaining = NSLocalizedString("prepublishing.uploadMediaOneItemRemaining", value: "%@ item remaining", comment: "Details label for a publish button state in the pre-publishing sheet")
+    private static let uploadMediaManyItemsRemaining = NSLocalizedString("prepublishing.uploadMediaManyItemsRemaining", value: "%@ items remaining", comment: "Details label for a publish button state in the pre-publishing sheet")
+    static func uploadMediaRemaining(count: Int) -> String {
+        String(format: count == 1 ? Strings.uploadMediaOneItemRemaining : Strings.uploadMediaManyItemsRemaining, count.description)
+    }
+    static let mediaUploadFailedTitle = NSLocalizedString("prepublishing.mediaUploadFailedTitle", value: "Failed to upload media", comment: "Title for a publish button state in the pre-publishing sheet")
+    static let mediaUploadFailedDetailsMultipleFailures = NSLocalizedString("prepublishing.mediaUploadFailedDetails", value: "%@ items failed to upload", comment: "Details for a publish button state in the pre-publishing sheet; count as a parameter")
+}
+

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -59,6 +59,16 @@ struct PublishPostView: View {
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
                 buttonCancel
+                    .confirmationDialog(Strings.discardChangesTitle, isPresented: $isShowingDiscardChangesAlert) {
+                        Button(Strings.discardChangesButton, role: .destructive) {
+                            viewModel.buttonCancelTapped()
+                        }
+                        Button(SharedStrings.Button.save) {
+                            viewModel.buttonSaveTapped()
+                        }
+                    } message: {
+                        Text(Strings.discardChangesMessage)
+                    }
             }
             ToolbarItemGroup(placement: .topBarTrailing) {
                 Button {
@@ -76,16 +86,6 @@ struct PublishPostView: View {
             }
         } message: {
             Text(viewModel.deletedAlertMessage)
-        }
-        .confirmationDialog(Strings.discardChangesTitle, isPresented: $isShowingDiscardChangesAlert) {
-            Button(Strings.discardChangesButton, role: .destructive) {
-                viewModel.buttonCancelTapped()
-            }
-            Button(SharedStrings.Button.save, role: .cancel) {
-                viewModel.buttonSaveTapped()
-            }
-        } message: {
-            Text(Strings.discardChangesMessage)
         }
         .disabled(viewModel.isSaving)
     }

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -7,7 +7,7 @@ import WordPressUI
 
 /// A screen shown just before publishing the post and allows you to change
 /// the post settings along with some publishing options like the publish date.
-final class PublishPostViewController: UIHostingController<NavigationView<PublishPostView>> {
+final class PublishPostViewController: UIHostingController<PublishPostView> {
     private let viewModel: PostSettingsViewModel
 
     var onCompletion: ((PrepublishingSheetResult) -> Void)?
@@ -19,7 +19,7 @@ final class PublishPostViewController: UIHostingController<NavigationView<Publis
             context: .publishing
         )
         self.viewModel = viewModel
-        super.init(rootView: NavigationView { PublishPostView(viewModel: viewModel) })
+        super.init(rootView: PublishPostView(viewModel: viewModel))
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -72,13 +72,6 @@ struct PublishPostView: View {
                     }
             }
             ToolbarItem(placement: .topBarTrailing) {
-                Button {
-                    // TODO: (publish) show preview
-                } label: {
-                    Image(systemName: "safari")
-                }
-            }
-            ToolbarItem(placement: .topBarTrailing) {
                 buttonPublish
             }
         }

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -51,6 +51,11 @@ struct PublishPostView: View {
 
     var body: some View {
         Form {
+            Section {
+                BlogListSiteView(site: .init(blog: viewModel.post.blog))
+            } header: {
+                SectionHeader(Strings.readyToPublish)
+            }
             PostSettingsFormContentView(viewModel: viewModel)
         }
         .environment(\.defaultMinListHeaderHeight, 0) // Reduces top inset a bit
@@ -183,5 +188,11 @@ enum PrepublishingSheetStrings {
         "prepublishing.saveChanges.button",
         value: "Save Changes",
         comment: "Button to confirm discarding changes"
+    )
+
+    static let readyToPublish = NSLocalizedString(
+        "prepublishing.publishingSectionTitle",
+        value: "Ready to Publish?",
+        comment: "The title of the top section that shows the site your are publishing to. Default is 'Ready to Publish?'"
     )
 }

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -46,7 +46,6 @@ struct PublishPostView: View {
     @ObservedObject var viewModel: PostSettingsViewModel
 
     @State private var isShowingDiscardChangesAlert = false
-    @State private var isShowingDatePicker = false
 
     var post: AbstractPost { viewModel.post }
 
@@ -110,23 +109,10 @@ struct PublishPostView: View {
 
     @ViewBuilder
     private var buttonSchedule: some View {
-        Button {
-            isShowingDatePicker = true
+        NavigationLink {
+            PostSettingsPublishDatePicker(viewModel: viewModel)
         } label: {
             Image(systemName: "calendar")
-        }
-        .popover(isPresented: $isShowingDatePicker) {
-            NavigationView {
-                PublishDatePickerView(configuration: PublishDatePickerConfiguration(
-                    date: viewModel.settings.publishDate,
-                    isRequired: !viewModel.isDraftOrPending,
-                    timeZone: viewModel.timeZone,
-                    updated: { date in
-                        viewModel.settings.publishDate = date
-                    }
-                ))
-            }
-            .presentationDetents([.height(430), .large])
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -10,6 +10,8 @@ import WordPressUI
 final class PublishPostViewController: UIHostingController<NavigationView<PublishPostView>> {
     private let viewModel: PostSettingsViewModel
 
+    var onCompletion: ((PrepublishingSheetResult) -> Void)?
+
     // TODO: add isShowingDeletedAlert
     init(post: AbstractPost) {
         // TODO: add isStandalone support
@@ -29,6 +31,9 @@ final class PublishPostViewController: UIHostingController<NavigationView<Publis
     override func viewDidLoad() {
         super.viewDidLoad()
 
+        viewModel.onPostPublished = { [weak self] in
+            self?.onCompletion?(.published)
+        }
         viewModel.onDismiss = { [weak self] in
             self?.presentingViewController?.dismiss(animated: true)
         }

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -49,7 +49,6 @@ struct PublishPostView: View {
 
     var post: AbstractPost { viewModel.post }
 
-    // TODO: (publish) figure out the media upload situation
     var body: some View {
         Form {
             PostSettingsFormContentView(viewModel: viewModel)
@@ -72,12 +71,14 @@ struct PublishPostView: View {
                         Text(Strings.discardChangesMessage)
                     }
             }
-            ToolbarItemGroup(placement: .topBarTrailing) {
+            ToolbarItem(placement: .topBarTrailing) {
                 Button {
                     // TODO: (publish) show preview
                 } label: {
                     Image(systemName: "safari")
                 }
+            }
+            ToolbarItem(placement: .topBarTrailing) {
                 buttonPublish
             }
         }

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -46,6 +46,7 @@ struct PublishPostView: View {
     @ObservedObject var viewModel: PostSettingsViewModel
 
     @State private var isShowingDiscardChangesAlert = false
+    @State private var isShowingDatePicker = false
 
     var post: AbstractPost { viewModel.post }
 
@@ -71,7 +72,8 @@ struct PublishPostView: View {
                         Text(Strings.discardChangesMessage)
                     }
             }
-            ToolbarItem(placement: .topBarTrailing) {
+            ToolbarItemGroup(placement: .topBarTrailing) {
+                buttonSchedule
                 buttonPublish
             }
         }
@@ -103,6 +105,28 @@ struct PublishPostView: View {
             isShowingDiscardChangesAlert = true
         } else {
             viewModel.buttonCancelTapped()
+        }
+    }
+
+    @ViewBuilder
+    private var buttonSchedule: some View {
+        Button {
+            isShowingDatePicker = true
+        } label: {
+            Image(systemName: "calendar")
+        }
+        .popover(isPresented: $isShowingDatePicker) {
+            NavigationView {
+                PublishDatePickerView(configuration: PublishDatePickerConfiguration(
+                    date: viewModel.settings.publishDate,
+                    isRequired: !viewModel.isDraftOrPending,
+                    timeZone: viewModel.timeZone,
+                    updated: { date in
+                        viewModel.settings.publishDate = date
+                    }
+                ))
+            }
+            .presentationDetents([.height(430), .large])
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -60,11 +60,13 @@ struct PublishPostView: View {
             ToolbarItem(placement: .topBarLeading) {
                 buttonCancel
                     .confirmationDialog(Strings.discardChangesTitle, isPresented: $isShowingDiscardChangesAlert) {
+                        Button(Strings.saveChangesButton) {
+                            viewModel.buttonSaveTapped()
+                        }
+                        // - warning: It's important for the destructive button to
+                        // be at the bottom or "Save" will not be shown
                         Button(Strings.discardChangesButton, role: .destructive) {
                             viewModel.buttonCancelTapped()
-                        }
-                        Button(SharedStrings.Button.save) {
-                            viewModel.buttonSaveTapped()
                         }
                     } message: {
                         Text(Strings.discardChangesMessage)
@@ -164,6 +166,12 @@ enum PrepublishingSheetStrings {
     static let discardChangesButton = NSLocalizedString(
         "prepublishing.discardChanges.button",
         value: "Discard Changes",
+        comment: "Button to confirm discarding changes"
+    )
+
+    static let saveChangesButton = NSLocalizedString(
+        "prepublishing.saveChanges.button",
+        value: "Save Changes",
         comment: "Button to confirm discarding changes"
     )
 }

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -36,6 +36,7 @@ struct PublishPostView: View {
         Form {
             PostSettingsFormContentView(viewModel: settingsViewModel)
         }
+        .environment(\.defaultMinListHeaderHeight, 0) // Reduces top inset a bit
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .navigationBarLeading) {

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -43,6 +43,13 @@ struct PublishPostView: View {
                 buttonCancel
             }
             ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    // TODO: implement preview
+                } label: {
+                    Image(systemName: "safari")
+                }
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
                 buttonPublish
             }
         }

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -12,12 +12,10 @@ final class PublishPostViewController: UIHostingController<NavigationView<Publis
 
     var onCompletion: ((PrepublishingSheetResult) -> Void)?
 
-    // TODO: add isShowingDeletedAlert
-    init(post: AbstractPost) {
-        // TODO: add isStandalone support
+    init(post: AbstractPost, isStandalone: Bool) {
         let viewModel = PostSettingsViewModel(
             post: post,
-            isStandalone: true,
+            isStandalone: isStandalone,
             context: .publishing
         )
         self.viewModel = viewModel
@@ -46,6 +44,8 @@ final class PublishPostViewController: UIHostingController<NavigationView<Publis
 
 struct PublishPostView: View {
     @ObservedObject var viewModel: PostSettingsViewModel
+
+    @State private var isShowingDiscardChangesAlert = false
 
     var post: AbstractPost { viewModel.post }
 
@@ -77,6 +77,16 @@ struct PublishPostView: View {
         } message: {
             Text(viewModel.deletedAlertMessage)
         }
+        .confirmationDialog(Strings.discardChangesTitle, isPresented: $isShowingDiscardChangesAlert) {
+            Button(Strings.discardChangesButton, role: .destructive) {
+                viewModel.buttonCancelTapped()
+            }
+            Button(SharedStrings.Button.save, role: .cancel) {
+                viewModel.buttonSaveTapped()
+            }
+        } message: {
+            Text(Strings.discardChangesMessage)
+        }
         .disabled(viewModel.isSaving)
     }
 
@@ -84,7 +94,6 @@ struct PublishPostView: View {
 
     @ViewBuilder
     private var buttonCancel: some View {
-        // TODO: (publish) connect to actual hasChanges
         if #available(iOS 26, *) {
             Button(role: .cancel, action: buttonCancelTapped)
         } else {
@@ -95,8 +104,7 @@ struct PublishPostView: View {
 
     private func buttonCancelTapped() {
         if viewModel.hasChanges {
-            // TODO: implement isShowingDiscardChangesAlert
-//                isShowingDiscardChangesAlert = true
+            isShowingDiscardChangesAlert = true
         } else {
             viewModel.buttonCancelTapped()
         }
@@ -140,4 +148,22 @@ enum PrepublishingSheetStrings {
     }
     static let mediaUploadFailedTitle = NSLocalizedString("prepublishing.mediaUploadFailedTitle", value: "Failed to upload media", comment: "Title for a publish button state in the pre-publishing sheet")
     static let mediaUploadFailedDetailsMultipleFailures = NSLocalizedString("prepublishing.mediaUploadFailedDetails", value: "%@ items failed to upload", comment: "Details for a publish button state in the pre-publishing sheet; count as a parameter")
+
+    static let discardChangesTitle = NSLocalizedString(
+        "prepublishing.discardChanges.title",
+        value: "Discard Changes?",
+        comment: "Title for the discard changes confirmation dialog"
+    )
+
+    static let discardChangesMessage = NSLocalizedString(
+        "prepublishing.discardChanges.message",
+        value: "You have unsaved changes to the post settings. Are you sure you want to discard them?",
+        comment: "Message for the discard changes confirmation dialog"
+    )
+
+    static let discardChangesButton = NSLocalizedString(
+        "prepublishing.discardChanges.button",
+        value: "Discard Changes",
+        comment: "Button to confirm discarding changes"
+    )
 }

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -34,6 +34,43 @@ struct PublishPostView: View {
         }
         .navigationTitle(Strings.title)
         .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                buttonCancel
+            }
+            ToolbarItem(placement: .navigationBarTrailing) {
+                buttonPublish
+            }
+        }
+    }
+
+    private var buttonCancel: some View {
+        // TODO: connect to actual hasChanges
+        Button(SharedStrings.Button.cancel) {
+            if settingsViewModel.hasChanges {
+                // TODO: implement isShowingDiscardChangesAlert
+//                isShowingDiscardChangesAlert = true
+            } else {
+                settingsViewModel.buttonCancelTapped()
+            }
+        }
+        .tint(AppColor.tint)
+    }
+
+    @ViewBuilder
+    private var buttonPublish: some View {
+        // TODO: connect to actual isSaving and save
+        if settingsViewModel.isSaving {
+            ProgressView()
+        } else {
+            // TODO: change dyncam to "Schedule"
+            Button(Strings.publish) {
+                settingsViewModel.buttonSaveTapped()
+            }
+            .buttonStyle(.borderedProminent)
+            .buttonBorderShape(.capsule)
+            .tint(AppColor.tint)
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -9,6 +9,7 @@ import WordPressUI
 /// the post settings along with some publishing options like the publish date.
 final class PublishPostViewController: UIHostingController<PublishPostView> {
     private let viewModel: PostSettingsViewModel
+    private let uploadsViewModel: PostMediaUploadsViewModel
 
     var onCompletion: ((PrepublishingSheetResult) -> Void)?
 
@@ -19,7 +20,12 @@ final class PublishPostViewController: UIHostingController<PublishPostView> {
             context: .publishing
         )
         self.viewModel = viewModel
-        super.init(rootView: PublishPostView(viewModel: viewModel))
+
+        let uploadsViewModel = PostMediaUploadsViewModel(post: post)
+        self.uploadsViewModel = uploadsViewModel
+
+        let view = PublishPostView(viewModel: viewModel, uploadsViewModel: uploadsViewModel)
+        super.init(rootView: view)
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -44,6 +50,7 @@ final class PublishPostViewController: UIHostingController<PublishPostView> {
 
 struct PublishPostView: View {
     @ObservedObject var viewModel: PostSettingsViewModel
+    @ObservedObject var uploadsViewModel: PostMediaUploadsViewModel
 
     @State private var isShowingDiscardChangesAlert = false
 
@@ -52,6 +59,13 @@ struct PublishPostView: View {
     var body: some View {
         Form {
             Section {
+                if let state = uploadsViewModel.uploadingSnackbarState {
+                    NavigationLink {
+                        PostMediaUploadsView(viewModel: uploadsViewModel)
+                    } label: {
+                        PostMediaUploadsSnackbarView(state: state)
+                    }
+                }
                 BlogListSiteView(site: .init(blog: viewModel.post.blog))
             } header: {
                 SectionHeader(Strings.readyToPublish)
@@ -126,13 +140,16 @@ struct PublishPostView: View {
         if viewModel.isSaving {
             ProgressView()
         } else {
+            let isDisabled = !uploadsViewModel.isCompleted
+
             Button(viewModel.publishButtonTitle) {
                 viewModel.buttonPublishTapped()
             }
             .fontWeight(.medium)
             .buttonStyle(.borderedProminent)
             .buttonBorderShape(.capsule)
-            .tint(AppColor.primary)
+            .tint(isDisabled ? Color(.opaqueSeparator) : AppColor.primary)
+            .disabled(isDisabled)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -8,8 +8,13 @@ import WordPressUI
 /// A screen shown just before publishing the post and allows you to change
 /// the post settings along with some publishing options like the publish date.
 final class PublishPostViewController: UIHostingController<NavigationView<PublishPostView>> {
+    private let settingsViewModel: PostSettingsViewModel
+
     init(post: AbstractPost) {
-        super.init(rootView: NavigationView { PublishPostView() })
+        // TODO: add isStandalone support
+        let settingsViewModel = PostSettingsViewModel(post: post, isStandalone: true)
+        self.settingsViewModel = settingsViewModel
+        super.init(rootView: NavigationView { PublishPostView(settingsViewModel: settingsViewModel) })
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
@@ -17,10 +22,13 @@ final class PublishPostViewController: UIHostingController<NavigationView<Publis
     }
 }
 
-// TODO: add isStandalone support
 // TODO: add `PrepublishingSheetResult`
 struct PublishPostView: View {
+    @ObservedObject var settingsViewModel: PostSettingsViewModel
+
     var body: some View {
-        Text("Here")
+        Form {
+            PostSettingsFormContentView(viewModel: settingsViewModel)
+        }
     }
 }

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -31,7 +31,7 @@ struct PublishPostView: View {
 
     var post: AbstractPost { settingsViewModel.post }
 
-    // TODO: figure out the media upload situation
+    // TODO: (publish) figure out the media upload situation
     var body: some View {
         Form {
             PostSettingsFormContentView(viewModel: settingsViewModel)
@@ -39,17 +39,15 @@ struct PublishPostView: View {
         .environment(\.defaultMinListHeaderHeight, 0) // Reduces top inset a bit
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
-            ToolbarItem(placement: .navigationBarLeading) {
+            ToolbarItem(placement: .topBarLeading) {
                 buttonCancel
             }
-            ToolbarItem(placement: .navigationBarTrailing) {
+            ToolbarItemGroup(placement: .topBarTrailing) {
                 Button {
-                    // TODO: implement preview
+                    // TODO: (publish) show preview
                 } label: {
                     Image(systemName: "safari")
                 }
-            }
-            ToolbarItem(placement: .navigationBarTrailing) {
                 buttonPublish
             }
         }
@@ -57,7 +55,7 @@ struct PublishPostView: View {
 
     @ViewBuilder
     private var buttonCancel: some View {
-        // TODO: connect to actual hasChanges
+        // TODO: (publish) connect to actual hasChanges
         if #available(iOS 26, *) {
             Button(role: .cancel, action: buttonCancelTapped)
         } else {

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -12,7 +12,11 @@ final class PublishPostViewController: UIHostingController<NavigationView<Publis
 
     init(post: AbstractPost) {
         // TODO: add isStandalone support
-        let settingsViewModel = PostSettingsViewModel(post: post, isStandalone: true)
+        let settingsViewModel = PostSettingsViewModel(
+            post: post,
+            isStandalone: true,
+            context: .publishing
+        )
         self.settingsViewModel = settingsViewModel
         super.init(rootView: NavigationView { PublishPostView(settingsViewModel: settingsViewModel) })
     }
@@ -27,14 +31,17 @@ struct PublishPostView: View {
 
     var post: AbstractPost { settingsViewModel.post }
 
+    // TODO: figure out the media upload situation
     var body: some View {
         Form {
-            PublishingHeaderView(blog: post.blog)
             PostSettingsFormContentView(viewModel: settingsViewModel)
         }
         .navigationTitle(Strings.title)
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
+            ToolbarItem(placement: .title) {
+                PublishingHeaderView(blog: post.blog)
+            }
             ToolbarItem(placement: .navigationBarLeading) {
                 buttonCancel
             }
@@ -44,17 +51,24 @@ struct PublishPostView: View {
         }
     }
 
+    @ViewBuilder
     private var buttonCancel: some View {
         // TODO: connect to actual hasChanges
-        Button(SharedStrings.Button.cancel) {
-            if settingsViewModel.hasChanges {
-                // TODO: implement isShowingDiscardChangesAlert
-//                isShowingDiscardChangesAlert = true
-            } else {
-                settingsViewModel.buttonCancelTapped()
-            }
+        if #available(iOS 26, *) {
+            Button(role: .cancel, action: buttonCancelTapped)
+        } else {
+            Button(SharedStrings.Button.cancel, action: buttonCancelTapped)
+                .tint(AppColor.tint)
         }
-        .tint(AppColor.tint)
+    }
+
+    private func buttonCancelTapped() {
+        if settingsViewModel.hasChanges {
+            // TODO: implement isShowingDiscardChangesAlert
+//                isShowingDiscardChangesAlert = true
+        } else {
+            settingsViewModel.buttonCancelTapped()
+        }
     }
 
     @ViewBuilder
@@ -67,9 +81,10 @@ struct PublishPostView: View {
             Button(Strings.publish) {
                 settingsViewModel.buttonSaveTapped()
             }
+            .fontWeight(.medium)
             .buttonStyle(.borderedProminent)
             .buttonBorderShape(.capsule)
-            .tint(AppColor.tint)
+            .tint(AppColor.primary)
         }
     }
 }
@@ -78,24 +93,25 @@ private struct PublishingHeaderView: View {
     let blog: Blog
 
     var body: some View {
-        HStack(alignment: .center, spacing: 12) {
-            SiteIconView(viewModel: SiteIconViewModel(blog: blog, size: .regular))
-                .frame(width: 40, height: 40)
-
-            VStack(alignment: .leading, spacing: 2) {
-                Text(Strings.publishingTo.uppercased())
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-
-                Text(blog.title ?? "")
+//        HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .center, spacing: 3) {
+                Text(Strings.title)
                     .font(.headline)
-                    .foregroundStyle(.primary)
+
+                HStack(alignment: .center, spacing: 4) {
+                    SiteIconView(viewModel: SiteIconViewModel(blog: blog, size: .regular))
+                        .frame(width: 20, height: 20)
+                    Text(blog.title ?? "")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
             }
 
-            Spacer()
-        }
-        .listRowBackground(Color.clear)
-        .listRowInsets(EdgeInsets.zero)
+//            Spacer()
+//        }
+//        .listRowBackground(Color.clear)
+//        .listRowInsets(EdgeInsets.zero)
     }
 }
 
@@ -121,4 +137,3 @@ enum PrepublishingSheetStrings {
     static let mediaUploadFailedTitle = NSLocalizedString("prepublishing.mediaUploadFailedTitle", value: "Failed to upload media", comment: "Title for a publish button state in the pre-publishing sheet")
     static let mediaUploadFailedDetailsMultipleFailures = NSLocalizedString("prepublishing.mediaUploadFailedDetails", value: "%@ items failed to upload", comment: "Details for a publish button state in the pre-publishing sheet; count as a parameter")
 }
-

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -1,0 +1,26 @@
+import UIKit
+import Combine
+import SwiftUI
+import WordPressData
+import WordPressShared
+import WordPressUI
+
+/// A screen shown just before publishing the post and allows you to change
+/// the post settings along with some publishing options like the publish date.
+final class PublishPostViewController: UIHostingController<NavigationView<PublishPostView>> {
+    init(post: AbstractPost) {
+        super.init(rootView: NavigationView { PublishPostView() })
+    }
+
+    required dynamic init?(coder aDecoder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+// TODO: add isStandalone support
+// TODO: add `PrepublishingSheetResult`
+struct PublishPostView: View {
+    var body: some View {
+        Text("Here")
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -8,33 +8,46 @@ import WordPressUI
 /// A screen shown just before publishing the post and allows you to change
 /// the post settings along with some publishing options like the publish date.
 final class PublishPostViewController: UIHostingController<NavigationView<PublishPostView>> {
-    private let settingsViewModel: PostSettingsViewModel
+    private let viewModel: PostSettingsViewModel
 
+    // TODO: add isShowingDeletedAlert
     init(post: AbstractPost) {
         // TODO: add isStandalone support
-        let settingsViewModel = PostSettingsViewModel(
+        let viewModel = PostSettingsViewModel(
             post: post,
             isStandalone: true,
             context: .publishing
         )
-        self.settingsViewModel = settingsViewModel
-        super.init(rootView: NavigationView { PublishPostView(settingsViewModel: settingsViewModel) })
+        self.viewModel = viewModel
+        super.init(rootView: NavigationView { PublishPostView(viewModel: viewModel) })
     }
 
     required dynamic init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
     }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        viewModel.onDismiss = { [weak self] in
+            self?.presentingViewController?.dismiss(animated: true)
+        }
+
+        // Set the view controller reference for navigation
+        // This is temporary until we can fully migrate to SwiftUI navigation
+        viewModel.viewController = self
+    }
 }
 
 struct PublishPostView: View {
-    @ObservedObject var settingsViewModel: PostSettingsViewModel
+    @ObservedObject var viewModel: PostSettingsViewModel
 
-    var post: AbstractPost { settingsViewModel.post }
+    var post: AbstractPost { viewModel.post }
 
     // TODO: (publish) figure out the media upload situation
     var body: some View {
         Form {
-            PostSettingsFormContentView(viewModel: settingsViewModel)
+            PostSettingsFormContentView(viewModel: viewModel)
         }
         .environment(\.defaultMinListHeaderHeight, 0) // Reduces top inset a bit
         .navigationBarTitleDisplayMode(.inline)
@@ -51,7 +64,18 @@ struct PublishPostView: View {
                 buttonPublish
             }
         }
+        .interactiveDismissDisabled(viewModel.isSaving || viewModel.hasChanges)
+        .alert(viewModel.deletedAlertTitle, isPresented: $viewModel.isShowingDeletedAlert) {
+            Button(SharedStrings.Button.ok) {
+                viewModel.onDismiss?()
+            }
+        } message: {
+            Text(viewModel.deletedAlertMessage)
+        }
+        .disabled(viewModel.isSaving)
     }
+
+    // MARK: – Actions
 
     @ViewBuilder
     private var buttonCancel: some View {
@@ -65,23 +89,22 @@ struct PublishPostView: View {
     }
 
     private func buttonCancelTapped() {
-        if settingsViewModel.hasChanges {
+        if viewModel.hasChanges {
             // TODO: implement isShowingDiscardChangesAlert
 //                isShowingDiscardChangesAlert = true
         } else {
-            settingsViewModel.buttonCancelTapped()
+            viewModel.buttonCancelTapped()
         }
     }
 
     @ViewBuilder
     private var buttonPublish: some View {
-        // TODO: connect to actual isSaving and save
-        if settingsViewModel.isSaving {
+        if viewModel.isSaving {
             ProgressView()
         } else {
             // TODO: change dyncam to "Schedule"
             Button(Strings.publish) {
-                settingsViewModel.buttonSaveTapped()
+                viewModel.buttonPublishTapped()
             }
             .fontWeight(.medium)
             .buttonStyle(.borderedProminent)

--- a/WordPress/Classes/ViewRelated/Post/Views/PostMediaUploadsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PostMediaUploadsViewModel.swift
@@ -42,6 +42,24 @@ final class PostMediaUploadsViewModel: ObservableObject {
         }.store(in: &cancellables)
     }
 
+    /// - returns `nil` if upload is completed.
+    var uploadingSnackbarState: PostMediaUploadsSnackbarState? {
+        guard !isCompleted else {
+            return nil
+        }
+        typealias Strings = PrepublishingSheetStrings
+        let errors = uploads.compactMap(\.error)
+        if !errors.isEmpty {
+            let details = errors.count == 1 ? errors[0].localizedDescription : String(format: Strings.mediaUploadFailedDetailsMultipleFailures, errors.count.description)
+            return .failed(title: Strings.mediaUploadFailedTitle, details: details)
+        }
+        return .uploading(
+            title: Strings.uploadingMedia,
+            details: Strings.uploadMediaRemaining(count: uploads.count - completedUploadsCount),
+            progress: fractionCompleted
+        )
+    }
+
     private func didUpdateMedia(_ media: Set<Media>) {
         let remainingObjectIDs = Set(media.map(\.objectID))
         withAnimation {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-759/new-publishing-sheet. See the ticket for the rationale.

<img width="360" alt="Screenshot 2025-09-29 at 7 53 53 AM" src="https://github.com/user-attachments/assets/ec32ac7b-b919-4843-bcf6-bfc70899e511" />

## Changes:
- Move “Publish” to the nav bar, so it takes less vertical space
- Use standard “Close” button
- Add a “Preview” button
- Add a full list of “Post Settings” options, including “Featured Image” and “Excerpt” – stuff you would expect to be in this sheet. 
- When you close it, it now asks you whether you want to save the settings you fiddles with like added tags – prod will just discard without telling you.

In terms of tech, it now uses the existing `PostSettingsView` with minimum changes – only adding the header and the “publish” logic. Any change we add to “Post Settings” – like adding “Excerpt“ generator – is automatically reflected here. It even reuses the existing `SiteListRowView` now.

For simplicity, it’s just a variation of `PostSettingsViewModel` – it’s nearly identical, and in the future I plan to add the “Status” field to “Post Settings” to be consistent with the web an dot allow publishing from “Post Settings” by changing status.

## Recording


https://github.com/user-attachments/assets/53f574ea-70ef-4947-bdc3-1582a1553559


