### PR TITLE
Fix an issue with Top Posts not loading for some users

### DIFF
--- a/Modules/Sources/WordPressKit/StatsFileDownloadsTimeIntervalData.swift
+++ b/Modules/Sources/WordPressKit/StatsFileDownloadsTimeIntervalData.swift
@@ -44,7 +44,7 @@ extension StatsFileDownloadsTimeIntervalData: StatsTimeIntervalData {
     public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
         guard
             let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
-            let fileDownloadsDict = unwrappedDays["files"] as? [[String: AnyObject]]
+            let fileDownloadsDict = Bamboozled.parseArray(unwrappedDays["files"])
             else {
                 return nil
         }

--- a/Modules/Sources/WordPressKit/StatsSearchTermTimeIntervalData.swift
+++ b/Modules/Sources/WordPressKit/StatsSearchTermTimeIntervalData.swift
@@ -45,7 +45,7 @@ extension StatsSearchTermTimeIntervalData: StatsTimeIntervalData {
             let totalSearchTerms = unwrappedDays["total_search_terms"] as? Int,
             let hiddenSearchTerms = unwrappedDays["encrypted_search_terms"] as? Int,
             let otherSearchTerms = unwrappedDays["other_search_terms"] as? Int,
-            let searchTermsDict = unwrappedDays["search_terms"] as? [[String: AnyObject]]
+            let searchTermsDict = Bamboozled.parseArray(unwrappedDays["search_terms"])
             else {
                 return nil
         }

--- a/Modules/Sources/WordPressKit/StatsServiceRemoteV2.swift
+++ b/Modules/Sources/WordPressKit/StatsServiceRemoteV2.swift
@@ -444,7 +444,37 @@ extension StatsTimeIntervalData {
         }
         return nil
     }
+}
 
+enum Bamboozled {
+    /// Sometimes PHP returns a dictionary with numbers as keys instead of an
+    /// actual array. This fixes it.
+    static func parseArray(_ object: AnyObject?) -> [[String: AnyObject]]? {
+        guard let object else {
+            return nil
+        }
+        if let array = object as? [[String: AnyObject]] {
+            return array
+        }
+        if let dictionary = object as? [String: [String: AnyObject]] {
+            return dictionary.sorted { lhs, rhs in
+                if let lhs = Int(lhs.key), let rhs = Int(rhs.key) {
+                    return lhs < rhs
+                }
+                return lhs.key.compare(rhs.key, options: .numeric) == .orderedAscending
+            }.map {
+                $0.value
+            }
+        }
+        if let dictionary = object as? [Int: [String: AnyObject]] {
+            return dictionary.sorted { lhs, rhs in
+                lhs.key < rhs.key
+            }.map {
+                $0.value
+            }
+        }
+        return nil
+    }
 }
 
 // We'll bring `StatsPeriodUnit` into this file when the "old" `WPStatsServiceRemote` gets removed.

--- a/Modules/Sources/WordPressKit/StatsTopAuthorsTimeIntervalData.swift
+++ b/Modules/Sources/WordPressKit/StatsTopAuthorsTimeIntervalData.swift
@@ -70,7 +70,7 @@ extension StatsTopAuthorsTimeIntervalData: StatsTimeIntervalData {
     public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
         guard
             let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
-            let authors = unwrappedDays["authors"] as? [[String: AnyObject]]
+            let authors = Bamboozled.parseArray(unwrappedDays["authors"])
             else {
                 return nil
         }
@@ -87,7 +87,7 @@ extension StatsTopAuthor {
             let name = jsonDictionary["name"] as? String,
             let views = jsonDictionary["views"] as? Int,
             let avatar = jsonDictionary["avatar"] as? String,
-            let posts = jsonDictionary["posts"] as? [[String: AnyObject]]
+            let posts = Bamboozled.parseArray(jsonDictionary["posts"])
             else {
                 return nil
         }

--- a/Modules/Sources/WordPressKit/StatsTopClicksTimeIntervalData.swift
+++ b/Modules/Sources/WordPressKit/StatsTopClicksTimeIntervalData.swift
@@ -50,7 +50,7 @@ extension StatsTopClicksTimeIntervalData: StatsTimeIntervalData {
     public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
         guard
             let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
-            let clicks = unwrappedDays["clicks"] as? [[String: AnyObject]]
+            let clicks = Bamboozled.parseArray(unwrappedDays["clicks"])
             else {
                 return nil
         }

--- a/Modules/Sources/WordPressKit/StatsTopCountryTimeIntervalData.swift
+++ b/Modules/Sources/WordPressKit/StatsTopCountryTimeIntervalData.swift
@@ -43,7 +43,7 @@ extension StatsTopCountryTimeIntervalData: StatsTimeIntervalData {
     public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
         guard
             let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
-            let countriesViews = unwrappedDays["views"] as? [[String: AnyObject]]
+            let countriesViews = Bamboozled.parseArray(unwrappedDays["views"])
             else {
                 return nil
         }

--- a/Modules/Sources/WordPressKit/StatsTopPostsTimeIntervalData.swift
+++ b/Modules/Sources/WordPressKit/StatsTopPostsTimeIntervalData.swift
@@ -28,7 +28,7 @@ extension StatsTopPostsTimeIntervalData: StatsTimeIntervalData {
     public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
         guard
             let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
-            let posts = unwrappedDays["postviews"] as? [[String: AnyObject]]
+            let posts = Bamboozled.parseArray(unwrappedDays["postviews"])
             else {
                 return nil
         }

--- a/Modules/Sources/WordPressKit/StatsTopReferrersTimeIntervalData.swift
+++ b/Modules/Sources/WordPressKit/StatsTopReferrersTimeIntervalData.swift
@@ -51,7 +51,7 @@ extension StatsTopReferrersTimeIntervalData: StatsTimeIntervalData {
     public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
         guard
             let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
-            let referrers = unwrappedDays["groups"] as? [[String: AnyObject]]
+            let referrers = Bamboozled.parseArray(unwrappedDays["groups"])
             else {
                 return nil
         }

--- a/Modules/Sources/WordPressKit/StatsTopVideosTimeIntervalData.swift
+++ b/Modules/Sources/WordPressKit/StatsTopVideosTimeIntervalData.swift
@@ -48,7 +48,7 @@ extension StatsTopVideosTimeIntervalData: StatsTimeIntervalData {
             let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
             let totalPlayCount = unwrappedDays["total_plays"] as? Int,
             let otherPlays = unwrappedDays["other_plays"] as? Int,
-            let videos = unwrappedDays["plays"] as? [[String: AnyObject]]
+            let videos = Bamboozled.parseArray(unwrappedDays["plays"])
             else {
                 return nil
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,11 @@
 26.4
 -----
 
+26.3.1
+------
+* [*] Fix an issue with Top Posts not loading for some users [#24860]
+* [*] Fix crash in Reader Article view [#24857]
+* [*] Fix more minor visual glitches on iOS 26 [#24858]
 
 26.3
 -----


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-765/stats-in-new-ios-not-displaying-most-viewed-entries-and-pages.

**RCA**

In some cases, the API returns a dictionary with indices as keys instead of an array (thanks!).

```swift
	"postviews": {
			"1": {
				"id": 12265,
...
```
				

