### PR TITLE
iOS 26: Use color in the Me tab

### DIFF
--- a/WordPress/Classes/ViewRelated/System/WPTabBarController+MeTab.swift
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController+MeTab.swift
@@ -67,7 +67,11 @@ extension UITabBarItem {
 
     func configureGravatarImage(_ image: UIImage) {
         let gravatarIcon = image.gravatarIcon(size: 26.0)
-        self.image = gravatarIcon?.blackAndWhite?.withAlpha(0.36)
+        if #available(iOS 26, *) {
+            self.image = gravatarIcon
+        } else {
+            self.image = gravatarIcon?.blackAndWhite?.withAlpha(0.36)
+        }
         self.selectedImage = gravatarIcon
     }
 }


### PR DESCRIPTION
Before / After

<img width="360" alt="Screenshot 2025-09-19 at 7 57 56 AM" src="https://github.com/user-attachments/assets/0e17e4e1-792d-4d25-9b75-6242f7513346" />
<img width="360" alt="Screenshot 2025-09-19 at 7 59 57 AM" src="https://github.com/user-attachments/assets/5937c818-659d-4c57-8e73-4f97b6e3fe9f" />

I think it looks nicer _after_.
