### PR TITLE
iOS 26: Fix visual issues in the Site Creation flow

### DIFF
--- a/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+Search.swift
+++ b/WordPress/Classes/Extensions/Colors and Styles/WPStyleGuide+Search.swift
@@ -8,9 +8,13 @@ extension WPStyleGuide {
         searchBar.accessibilityIdentifier = "Search"
         searchBar.autocapitalizationType = .none
         searchBar.autocorrectionType = .no
-        searchBar.isTranslucent = true
-        searchBar.backgroundImage = UIImage()
-        searchBar.backgroundColor = backgroundColor
+        if #available(iOS 26, *) {
+            searchBar.searchBarStyle = .minimal // Removes borders
+        } else {
+            searchBar.isTranslucent = true
+            searchBar.backgroundImage = UIImage()
+            searchBar.backgroundColor = backgroundColor
+        }
         searchBar.returnKeyType = returnKeyType
     }
 

--- a/WordPress/Classes/ViewRelated/Domains/DomainSelectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Domains/DomainSelectionViewController.swift
@@ -419,10 +419,7 @@ final class DomainSelectionViewController: CollapsableHeaderViewController {
         searchTextField.delegate = self
         searchTextField.accessibilityTraits = .searchField
 
-        let placeholderText = Strings.searchPlaceholder
-        let attributes = WPStyleGuide.defaultSearchBarTextAttributesSwifted(.placeholderText)
-        let attributedPlaceholder = NSAttributedString(string: placeholderText, attributes: attributes)
-        searchTextField.attributedPlaceholder = attributedPlaceholder
+        searchBar.placeholder = Strings.searchPlaceholder
         searchTextField.accessibilityHint = Strings.searchAccessibility
 
         view.addSubview(noResultsLabel)

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -17,7 +17,7 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
     let secondaryActionTitle: String?
     let defaultActionTitle: String?
     open var accessoryBarHeight: CGFloat {
-        return 44
+        if #available(iOS 26, *) { 64 + 16 } else { 44 }
     }
 
     open var separatorStyle: SeparatorStyle {
@@ -96,7 +96,11 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
     @IBOutlet var visualEffects: [UIVisualEffectView]! {
         didSet {
             visualEffects.forEach { (visualEffect) in
-                visualEffect.effect = UIBlurEffect.init(style: .systemChromeMaterial)
+                if #available(iOS 26, *) {
+                    visualEffect.effect = UIBlurEffect(style: .regular)
+                } else {
+                    visualEffect.effect = UIBlurEffect(style: .systemChromeMaterial)
+                }
                 // Allow touches to pass through to the scroll view behind the header.
                 visualEffect.contentView.isUserInteractionEnabled = false
             }

--- a/WordPress/Classes/ViewRelated/Reader/Style/WPStyleGuide+ReaderComments.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Style/WPStyleGuide+ReaderComments.swift
@@ -3,26 +3,6 @@ import WordPressShared
 import WordPressUI
 
 extension WPStyleGuide {
-
-    @objc class func defaultSearchBarTextAttributes(_ color: UIColor) -> [String: Any] {
-        let attributes = defaultSearchBarTextAttributesSwifted(color)
-        return NSAttributedString.Key.convertToRaw(attributes: attributes)
-    }
-
-    class func defaultSearchBarTextAttributesSwifted() -> [NSAttributedString.Key: Any] {
-        return [
-            .font: WPStyleGuide.fixedFont(for: .body)
-        ]
-    }
-
-    class func defaultSearchBarTextAttributesSwifted(_ color: UIColor) -> [NSAttributedString.Key: Any] {
-        var attributes = defaultSearchBarTextAttributesSwifted()
-
-        attributes[.foregroundColor] = color
-
-        return attributes
-    }
-
     public struct ReaderCommentsNotificationSheet {
         static let textColor = UIColor.label
         static let descriptionLabelFont = fontForTextStyle(.subheadline)
@@ -31,19 +11,5 @@ extension WPStyleGuide {
         static let buttonBorderColor = UIColor.systemGray3
         static let switchOnTintColor = UIColor.systemGreen
         static let switchInProgressTintColor = UIAppColor.primary
-    }
-}
-
-private extension NSAttributedString.Key {
-    /// Converts a collection of NSAttributedString Attributes, with 'NSAttributedStringKey' instances as 'Keys', into an
-    /// equivalent collection that uses regular 'String' instances as keys.
-    ///
-    static func convertToRaw(attributes: [NSAttributedString.Key: Any]) -> [String: Any] {
-        var output = [String: Any]()
-        for (key, value) in attributes {
-            output[key.rawValue] = value
-        }
-
-        return output
     }
 }

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -215,7 +215,7 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
     }
 
     private func configureSkipButton() {
-        let skip = UIBarButtonItem(title: TextContent.skipButtonTitle, style: .done, target: self, action: #selector(skipButtonTapped))
+        let skip = UIBarButtonItem(title: TextContent.skipButtonTitle, style: .plain, target: self, action: #selector(skipButtonTapped))
         navigationItem.rightBarButtonItem = skip
     }
 
@@ -224,7 +224,7 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
             return
         }
 
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: TextContent.cancelButtonTitle, style: .done, target: self, action: #selector(closeButtonTapped))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(closeButtonTapped))
     }
 
     @objc
@@ -253,8 +253,6 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
                                                        comment: "Shortened version of the main title to be used in back navigation.")
         static let skipButtonTitle = NSLocalizedString("Skip",
                                                        comment: "Continue without making a selection.")
-        static let cancelButtonTitle = NSLocalizedString("Cancel",
-                                                         comment: "Cancel site creation.")
         static let errorTitle = NSLocalizedString("Unable to load this content right now.",
                                                   comment: "Informing the user that a network request failed because the device wasn't able to establish a network connection.")
         static let errorSubtitle = NSLocalizedString("Check your network connection and try again.",

--- a/WordPress/Classes/ViewRelated/Site Creation/Site Intent/IntentCell.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Site Intent/IntentCell.swift
@@ -28,7 +28,11 @@ final class IntentCell: UITableViewCell, ModelSettableCell, NibLoadable {
     }
 
     private func commonInit() {
-        selectedBackgroundView?.backgroundColor = .clear
+        if #available(iOS 26, *) {
+            selectionStyle = .none
+        } else {
+            selectedBackgroundView?.backgroundColor = .clear
+        }
 
         accessibilityTraits = .button
         accessibilityHint = NSLocalizedString("Selects this topic as the intent for your site.",

--- a/WordPress/Classes/ViewRelated/Site Creation/Site Intent/SiteIntentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Site Intent/SiteIntentViewController.swift
@@ -15,7 +15,9 @@ class SiteIntentViewController: CollapsableHeaderViewController {
         let searchBar = UISearchBar()
         searchBar.translatesAutoresizingMaskIntoConstraints = false
         WPStyleGuide.configureSearchBar(searchBar, backgroundColor: .clear, returnKeyType: .search)
-        searchBar.setImage(UIImage(), for: .search, state: .normal)
+        if #unavailable(iOS 26) {
+            searchBar.setImage(UIImage(), for: .search, state: .normal)
+        }
         return searchBar
     }()
 
@@ -78,15 +80,9 @@ class SiteIntentViewController: CollapsableHeaderViewController {
         // Title
         navigationItem.backButtonTitle = Strings.backButtonTitle
         // Skip button
-        navigationItem.rightBarButtonItem = UIBarButtonItem(title: Strings.skipButtonTitle,
-                                                            style: .done,
-                                                            target: self,
-                                                            action: #selector(skipButtonTapped))
+        navigationItem.rightBarButtonItem = UIBarButtonItem(title: Strings.skipButtonTitle, style: .plain, target: self, action: #selector(skipButtonTapped))
         // Cancel button
-        navigationItem.leftBarButtonItem = UIBarButtonItem(title: Strings.cancelButtonTitle,
-                                                           style: .done,
-                                                           target: self,
-                                                           action: #selector(closeButtonTapped))
+        navigationItem.leftBarButtonItem = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(closeButtonTapped))
         navigationItem.leftBarButtonItem?.accessibilityIdentifier = "site-intent-cancel-button"
     }
 
@@ -132,8 +128,6 @@ extension SiteIntentViewController {
                                                        comment: "Shortened version of the main title to be used in back navigation")
         static let skipButtonTitle = NSLocalizedString("Skip",
                                                        comment: "Continue without making a selection")
-        static let cancelButtonTitle = NSLocalizedString("Cancel",
-                                                         comment: "Cancel site creation")
         static let searchTextFieldPlaceholder = NSLocalizedString("E.g. Fashion, Poetry, Politics", comment: "Placeholder text for the search field int the Site Intent screen.")
         static let continueButtonTitle = NSLocalizedString("Continue", comment: "Title of the continue button for the Site Intent screen.")
     }


### PR DESCRIPTION
### Before 

<img width="456" height="972" alt="Screenshot 2025-09-19 at 8 04 20 AM" src="https://github.com/user-attachments/assets/bea4eb66-d48f-428d-9969-6254351ffd5a" />

https://github.com/user-attachments/assets/0fd8be7e-4e56-4907-9556-355f8674229f

### After (iOS 26)

**Note**: the search bar shadow is still not ideal, but I ran out of time today. I need to switch to the other projects. It fixes the main issues.

<img width="456" height="972" alt="Screenshot 2025-09-19 at 9 17 10 AM" src="https://github.com/user-attachments/assets/2b5407f8-bcc9-4abc-95ca-4e0a1c39a371" />
<img width="456" height="972" alt="Screenshot 2025-09-19 at 9 17 14 AM" src="https://github.com/user-attachments/assets/653914c2-6d9d-4d0a-8292-8110faafea9c" />
<img width="456" height="972" alt="Screenshot 2025-09-19 at 9 17 28 AM" src="https://github.com/user-attachments/assets/e8612572-6271-4a5b-83ba-6a3ea63681ca" />
<img width="456" height="972" alt="Screenshot 2025-09-19 at 9 20 57 AM" src="https://github.com/user-attachments/assets/de8dd897-d784-4639-9184-9f673bc8905d" />

### After (iOS 18)

<img width="456" height="972" alt="Screenshot 2025-09-19 at 8 47 42 AM" src="https://github.com/user-attachments/assets/78b7a7f1-45b5-45ff-a8dc-f9ce9ed3d3d4" />
