### PR TITLE
iOS 26: Fix visual issues in Page Layout Picker

### DIFF
--- a/Modules/Sources/UITestsFoundation/Screens/Editor/ChooseLayoutScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Editor/ChooseLayoutScreen.swift
@@ -4,7 +4,7 @@ import XCTest
 public class ChooseLayoutScreen: ScreenObject {
 
     private let closeButtonGetter: (XCUIApplication) -> XCUIElement = {
-        $0.buttons["Close"]
+        $0.buttons["close-button"]
     }
 
     private let createBlankPageButtonGetter: (XCUIApplication) -> XCUIElement = {

--- a/WordPress/Classes/Services/PageCoordinator.swift
+++ b/WordPress/Classes/Services/PageCoordinator.swift
@@ -14,7 +14,12 @@ class PageCoordinator {
 
     private static func showLayoutPicker(from controller: UIViewController, forBlog blog: Blog, _ completion: @escaping TemplateSelectionCompletion) {
         let rootViewController = GutenbergLayoutPickerViewController(blog: blog, completion: completion)
-        let navigationController = GutenbergLightNavigationController(rootViewController: rootViewController)
+        let navigationController: UINavigationController
+        if #available(iOS 26, *) {
+            navigationController = UINavigationController(rootViewController: rootViewController)
+        } else {
+            navigationController = GutenbergLightNavigationController(rootViewController: rootViewController)
+        }
         navigationController.modalPresentationStyle = .pageSheet
 
         controller.present(navigationController, animated: true, completion: nil)

--- a/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Collapsable Header/CollapsableHeaderViewController.swift
@@ -166,23 +166,9 @@ class CollapsableHeaderViewController: UIViewController, NoResultsViewHost {
 
     // MARK: - Static Helpers
     public static func closeButton(target: Any?, action: Selector) -> UIBarButtonItem {
-        let closeButton = UIButton(frame: CGRect(x: 0, y: 0, width: 30, height: 30))
-        closeButton.layer.cornerRadius = 15
-        closeButton.accessibilityLabel = NSLocalizedString("Close", comment: "Dismisses the current screen")
+        let closeButton = UIBarButtonItem(barButtonSystemItem: .close, target: target, action: action)
         closeButton.accessibilityIdentifier = "close-button"
-        closeButton.setImage(UIImage.gridicon(.crossSmall), for: .normal)
-        closeButton.addTarget(target, action: action, for: .touchUpInside)
-
-        closeButton.tintColor = .secondaryLabel
-        closeButton.backgroundColor = UIColor { (traitCollection: UITraitCollection) -> UIColor in
-            if traitCollection.userInterfaceStyle == .dark {
-                return UIColor.systemFill
-            } else {
-                return UIColor.quaternarySystemFill
-            }
-        }
-
-        return UIBarButtonItem(customView: closeButton)
+        return closeButton
     }
 
     // MARK: - Initializers

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceSelectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewDeviceSelectionViewController.swift
@@ -86,8 +86,6 @@ class PreviewDeviceSelectionViewController: UIViewController {
 
         effectView.contentView.pinSubviewToAllEdges(tableView)
 
-        tableView.separatorEffect = UIVibrancyEffect(blurEffect: blurEffect)
-
         tableView.register(UITableViewCell.self, forCellReuseIdentifier: "Cell")
     }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -342,7 +342,12 @@ extension SiteDesignContentCollectionViewController: CategorySectionTableViewCel
             completion: completion
         )
 
-        let navController = GutenbergLightNavigationController(rootViewController: previewVC)
+        let navController: UINavigationController
+        if #available(iOS 26, *) {
+            navController = UINavigationController(rootViewController: previewVC)
+        } else {
+            navController = GutenbergLightNavigationController(rootViewController: previewVC)
+        }
         navController.modalPresentationStyle = .pageSheet
         navigationController?.present(navController, animated: true) {
             // deselect so no border is shown on dismissal of the preview

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/SheetActions.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/SheetActions.swift
@@ -10,7 +10,7 @@ struct PostAction: ActionSheetItem {
 
     func makeButton() -> ActionSheetButton {
         return ActionSheetButton(
-            title: NSLocalizedString("Blog post", comment: "Create new Blog Post button title"),
+            title: Strings.post,
             image: UIImage(named: "wpl-posts")?.withRenderingMode(.alwaysTemplate) ?? .init(),
             identifier: "blogPostButton",
             action: {
@@ -28,7 +28,7 @@ struct PostFromAudioAction: ActionSheetItem {
 
     func makeButton() -> ActionSheetButton {
         return ActionSheetButton(
-            title: NSLocalizedString("createFAB.postFromAudio", value: "Post from Audio", comment: "Create new Blog Post from Audio button title"),
+            title: Strings.postFromAudio,
             image: .gridicon(.microphone),
             identifier: "blogPostFromAudioButton",
             action: {
@@ -46,7 +46,7 @@ struct PageAction: ActionSheetItem {
 
     func makeButton() -> ActionSheetButton {
         return ActionSheetButton(
-            title: NSLocalizedString("Site page", comment: "Create new Site Page button title"),
+            title: Strings.page,
             image: UIImage(named: "wpl-pages")?.withRenderingMode(.alwaysTemplate) ?? .init(),
             identifier: "sitePageButton",
             action: {
@@ -54,4 +54,10 @@ struct PageAction: ActionSheetItem {
                 handler()
             })
     }
+}
+
+private enum Strings {
+    static let post = NSLocalizedString("createSheet.post", value: "Post", comment: "Create Sheet button title")
+    static let postFromAudio = NSLocalizedString("createSheet.postFromAudio", value: "Post from Audio", comment: "Create Sheet button title")
+    static let page = NSLocalizedString("createSheet.page", value: "Page", comment: "Create Sheet button title")
 }


### PR DESCRIPTION
### Before

<img width="456" height="972" alt="Screenshot 2025-09-19 at 9 32 31 AM" src="https://github.com/user-attachments/assets/3aec2385-1585-48bf-b41f-40078dd4025c" />
<img width="456" height="972" alt="Screenshot 2025-09-19 at 9 32 35 AM" src="https://github.com/user-attachments/assets/c935e3ed-94c8-4a43-a1d3-64c6120d98a0" />

### After

<img width="456" height="972" alt="Screenshot 2025-09-19 at 9 42 19 AM" src="https://github.com/user-attachments/assets/b402f2ef-a38b-4c02-99cd-29a15f0ff755" />
<img width="456" height="972" alt="Screenshot 2025-09-19 at 9 42 22 AM" src="https://github.com/user-attachments/assets/0f3074fe-1bf6-4f17-93e1-d6ec38e211ac" />

### More

I also simplified the titles in the "Create" sheet.

<img width="456" height="972" alt="Screenshot 2025-09-19 at 9 42 14 AM" src="https://github.com/user-attachments/assets/9d6177d6-adc8-4e87-9a1a-a3b4f280aaf2" />

