### PR TITLE
Replace UITextInteraction API with UITextItem ones

### DIFF
--- a/WordPress/Classes/ViewRelated/Activity/Details/ActivityFormattableContentView.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Details/ActivityFormattableContentView.swift
@@ -57,14 +57,28 @@ struct ActivityFormattableContentView: UIViewRepresentable {
             super.init()
         }
 
-        func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-            guard interaction == .invokeDefaultAction else {
-                return false
+        func textView(_ textView: UITextView, primaryActionFor textItem: UITextItem, defaultAction: UIAction) -> UIAction? {
+            guard case let .link(URL) = textItem.content else {
+                return nil
             }
 
+            return UIAction { [weak self] _ in
+                self?.routeTo(URL)
+            }
+        }
+
+        func textView(_ textView: UITextView, menuConfigurationFor textItem: UITextItem, defaultMenu: UIMenu) -> UITextItem.MenuConfiguration? {
+            if case .link = textItem.content {
+                return nil
+            }
+
+            return .init(menu: defaultMenu)
+        }
+
+        private func routeTo(_ URL: URL) {
             // Get the top view controller to create content coordinator
             guard let viewController = UIViewController.topViewController else {
-                return false
+                return
             }
 
             let contentCoordinator = DefaultContentCoordinator(
@@ -78,8 +92,6 @@ struct ActivityFormattableContentView: UIViewRepresentable {
             )
 
             router.routeTo(URL)
-
-            return false
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Cells/ExpandableCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/ExpandableCell.swift
@@ -76,15 +76,21 @@ class ExpandableCell: WPReusableTableViewCell, NibLoadable {
 }
 
 extension ExpandableCell: UITextViewDelegate {
-    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-        switch interaction {
-        case .invokeDefaultAction:
-            urlCallback?(URL)
-            return false
-        case .preview, .presentActions:
-            return true
-        @unknown default:
-            fatalError()
+    func textView(_ textView: UITextView, primaryActionFor textItem: UITextItem, defaultAction: UIAction) -> UIAction? {
+        guard case let .link(URL) = textItem.content else {
+            return defaultAction
         }
+
+        return UIAction { [weak self] _ in
+            self?.urlCallback?(URL)
+        }
+    }
+
+    func textView(_ textView: UITextView, menuConfigurationFor textItem: UITextItem, defaultMenu: UIMenu) -> UITextItem.MenuConfiguration? {
+        if case .link = textItem.content {
+            return nil
+        }
+
+        return .init(menu: defaultMenu)
     }
 }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockTextTableViewCell.swift
@@ -119,9 +119,22 @@ class NoteBlockTextTableViewCell: NoteBlockTableViewCell, RichTextViewDataSource
 
     // MARK: - RichTextView Data Source
 
-    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-        onUrlClick?(URL)
-        return false
+    func textView(_ textView: UITextView, primaryActionFor textItem: UITextItem, defaultAction: UIAction) -> UIAction? {
+        guard case let .link(URL) = textItem.content else {
+            return nil
+        }
+
+        return UIAction { [weak self] _ in
+            self?.onUrlClick?(URL)
+        }
+    }
+
+    func textView(_ textView: UITextView, menuConfigurationFor textItem: UITextItem, defaultMenu: UIMenu) -> UITextItem.MenuConfiguration? {
+        if case .link = textItem.content {
+            return nil
+        }
+
+        return .init(menu: defaultMenu)
     }
 
     func textView(_ textView: UITextView, didPressLink link: URL) {

--- a/WordPress/Classes/ViewRelated/Views/RichTextView/RichTextView.swift
+++ b/WordPress/Classes/ViewRelated/Views/RichTextView/RichTextView.swift
@@ -259,12 +259,12 @@ import UniformTypeIdentifiers
         delegate?.textViewDidChangeSelection?(textView)
     }
 
-    open func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-        return delegate?.textView?(textView, shouldInteractWith: URL, in: characterRange, interaction: interaction) ?? true
+    open func textView(_ textView: UITextView, primaryActionFor textItem: UITextItem, defaultAction: UIAction) -> UIAction? {
+        delegate?.textView?(textView, primaryActionFor: textItem, defaultAction: defaultAction)
     }
 
-    open func textView(_ textView: UITextView, shouldInteractWith textAttachment: NSTextAttachment, in characterRange: NSRange, interaction: UITextItemInteraction) -> Bool {
-        return delegate?.textView?(textView, shouldInteractWith: textAttachment, in: characterRange, interaction: interaction) ?? true
+    public func textView(_ textView: UITextView, menuConfigurationFor textItem: UITextItem, defaultMenu: UIMenu) -> UITextItem.MenuConfiguration? {
+        delegate?.textView?(textView, menuConfigurationFor: textItem, defaultMenu: defaultMenu)
     }
 
     // MARK: - Private Properites


### PR DESCRIPTION
> [!Note]
> This PR is built on top of https://github.com/wordpress-mobile/WordPress-iOS/pull/24871, and will be merged after that. 

## Description

My understanding is that the delegate function that uses `UITextItemInteraction` was split into two methods: the `primaryActionFor` one and the `menuConfigurationFor` one.

We need to return a `UIAction` in the `primaryActionFor` delegate method. And, where the original function returns false, we now need to return nil in the `menuConfigurationFor` delegate method.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
