### PR TITLE
iOS 26: Larger quick actions

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Quick Actions/DashboardQuickActionCell.swift
@@ -43,7 +43,8 @@ final class DashboardQuickActionCell: UITableViewCell {
         stackView.isUserInteractionEnabled = false
 
         contentView.addSubview(stackView)
-        stackView.pinEdges(insets: UIEdgeInsets(horizontal: 16, vertical: 12))
+        let vertical: CGFloat = if #available(iOS 26, *) { 14 } else { 12 }
+        stackView.pinEdges(insets: UIEdgeInsets(horizontal: 16, vertical: vertical))
     }
 
     func configure(_ viewModel: DashboardQuickActionItemViewModel) {


### PR DESCRIPTION
Adjust to match the iOS 26 default increase heights for cells.

Before / After

<img width="350"  alt="Screenshot 2025-09-23 at 6 59 43 AM" src="https://github.com/user-attachments/assets/6f21795c-b797-4c71-9bce-294fc9b98e25" />
<img width="350" alt="Screenshot 2025-09-23 at 7 05 58 AM" src="https://github.com/user-attachments/assets/64a09257-27b7-422a-9e81-06e4fcdc787c" />
