### PR TITLE
iOS 26: Update WebKitViewController

### DIFF
--- a/WordPress/Classes/Utility/WebViewController/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebViewController/WebKitViewController.swift
@@ -96,7 +96,6 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
     private var reachabilityObserver: Any?
     private var tapLocation = CGPoint(x: 0.0, y: 0.0)
     private var widthConstraint: NSLayoutConstraint?
-    private var stackViewBottomAnchor: NSLayoutConstraint?
     private var onClose: (() -> Void)?
 
     private var navBarTitleColor: UIColor {
@@ -172,36 +171,17 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        view.backgroundColor = UIColor(light: UIAppColor.gray(.shade0), dark: .systemBackground)
+        view.backgroundColor = .systemBackground
 
-        let stackView = UIStackView(arrangedSubviews: [
-            progressView,
-            webView
-        ])
-        stackView.axis = .vertical
-        stackView.translatesAutoresizingMaskIntoConstraints = false
+        let stackView = UIStackView(axis: .vertical, [progressView, webView])
         view.addSubview(stackView)
-
-        let edgeConstraints = [
-            view.leadingAnchor.constraint(equalTo: stackView.leadingAnchor),
-            view.trailingAnchor.constraint(equalTo: stackView.trailingAnchor),
-            view.topAnchor.constraint(equalTo: stackView.topAnchor),
-            view.bottomAnchor.constraint(equalTo: stackView.bottomAnchor),
-        ]
-        edgeConstraints.forEach({ $0.priority = UILayoutPriority(rawValue: UILayoutPriority.defaultHigh.rawValue - 1) })
-
-        NSLayoutConstraint.activate(edgeConstraints)
+        stackView.pinEdges()
 
         // we are pinning the top and bottom of the stack view to the safe area to prevent unintentionally hidden content/overlaps (ie cookie acceptance popup) then center the horizontal constraints vertically
         let safeArea = self.view.safeAreaLayoutGuide
 
         stackView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         stackView.topAnchor.constraint(equalTo: safeArea.topAnchor).isActive = true
-
-        // this constraint saved as a varible so it can be deactivated when the toolbar is hidden, to prevent unintended pinning to the safe area
-        let stackViewBottom = stackView.bottomAnchor.constraint(equalTo: safeArea.bottomAnchor)
-        stackViewBottomAnchor = stackViewBottom
-        NSLayoutConstraint.activate([stackViewBottom])
 
         let stackWidthConstraint = stackView.widthAnchor.constraint(equalToConstant: 0)
         stackWidthConstraint.priority = UILayoutPriority.defaultLow
@@ -308,8 +288,6 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
         navigationController?.isToolbarHidden = secureInteraction
 
         guard !secureInteraction else {
-            // if not a secure interaction/view, no toolbar is displayed, so deactivate constraint pinning stack view to safe area
-            stackViewBottomAnchor?.isActive = false
             return
         }
         configureToolbarButtons()

--- a/WordPress/Classes/Utility/WebViewController/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebViewController/WebKitViewController.swift
@@ -177,6 +177,10 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
         view.addSubview(stackView)
         stackView.pinEdges()
 
+        if #unavailable(iOS 26) {
+            WPStyleGuide.disableScrollEdgeAppearance(for: self)
+        }
+
         // we are pinning the top and bottom of the stack view to the safe area to prevent unintentionally hidden content/overlaps (ie cookie acceptance popup) then center the horizontal constraints vertically
         let safeArea = self.view.safeAreaLayoutGuide
 

--- a/WordPress/Classes/Utility/WebViewController/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebViewController/WebKitViewController.swift
@@ -297,17 +297,28 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
 
         let space = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
 
-        let items = [
-            backButton,
-            space,
-            forwardButton,
-            space,
-            shareButton,
-            space,
-            safariButton
-        ]
-        for item in items {
-            item.tintColor = UIAppColor.tint
+        let items: [UIBarButtonItem]
+        if #available(iOS 26, *) {
+            items = [
+               backButton,
+               forwardButton,
+               space,
+               shareButton,
+               safariButton
+           ]
+        } else {
+            items = [
+                backButton,
+                space,
+                forwardButton,
+                space,
+                shareButton,
+                space,
+                safariButton
+            ]
+            for item in items {
+                item.tintColor = UIAppColor.tint
+            }
         }
         setToolbarItems(items, animated: false)
     }


### PR DESCRIPTION
## Before 

(wrong background color and not extending beyond the bottom safe area)

<img width="340" alt="Screenshot 2025-09-23 at 4 57 11 PM" src="https://github.com/user-attachments/assets/ec422a60-8412-42a9-a4ef-cd016e024b38" />


## After

regular / "secure" (no toolbar)

<img width="340"  alt="Screenshot 2025-09-23 at 5 04 22 PM" src="https://github.com/user-attachments/assets/7a7367a7-ccc0-4eab-8ece-e3117a16729d" />
<img width="340"  alt="Screenshot 2025-09-23 at 5 05 25 PM" src="https://github.com/user-attachments/assets/bf98dd02-4cf6-4e76-9639-64787cb99b96" />

