### PR TITLE
Fix (potential) for popover crash

### DIFF
--- a/WordPress/Classes/ViewRelated/Tips/AppTips.swift
+++ b/WordPress/Classes/ViewRelated/Tips/AppTips.swift
@@ -113,11 +113,11 @@ extension UIViewController {
         _ tip: some Tip,
         sourceItem: any UIPopoverPresentationControllerSourceItem,
         arrowDirection: UIPopoverArrowDirection? = nil,
-        actionHandler: ((Tips.Action) -> Void)? = nil
+        actionHandler: (@MainActor @Sendable (Tips.Action) -> Void)? = nil
     ) -> TipObserver? {
-        let task = Task { @MainActor [weak self] in
+        let task = Task { @MainActor [weak self, weak sourceItem] in
             for await shouldDisplay in tip.shouldDisplayUpdates {
-                if shouldDisplay {
+                if shouldDisplay, let sourceItem {
                     let popoverController = TipUIPopoverViewController(tip, sourceItem: sourceItem, actionHandler: actionHandler ?? { _ in })
                     popoverController.view.tintColor = .secondaryLabel
                     if let arrowDirection {


### PR DESCRIPTION
Fixes (potentially) https://a8c.sentry.io/issues/4670561854/?project=5716771. I couldn't reproduce the crash, but I see visual issues when the tip popover is shown after you quickly tap away from Stats (it is shown partially off-screen). Worst case, it fixes the visual issue.

I have high confidence the TipKit is the root cause because:
- The crash was introduced at the same time as the TipKit in Stats
- The crash happen on iPhone too and not just iPad – TipKit uses popover even on iPhone
- The is Stats screen "disappear" event in the breadcrumbs

I'm not quote sure why I can't get it to crash locally, but this is likely the root cause.