### PR TITLE
feat: GutenbergKit requires app password for public Atomic sites

### DIFF
--- a/WordPress/Classes/Utility/Editor/EditorFactory.swift
+++ b/WordPress/Classes/Utility/Editor/EditorFactory.swift
@@ -54,9 +54,15 @@ class EditorFactory {
             return false
         }
 
-        // Only require application password for non-WPCOM Simple sites (self-hosted sites)
         let blog = post.blog
-        guard !blog.isHostedAtWPcom && !blog.isAtomic() else {
+
+        // WPCOM Simple sites rely upon bearer tokens
+        if blog.isHostedAtWPcom {
+            return false
+        }
+
+        // Application passwords do not support private Atomic sites currently
+        if blog.isAtomic() && blog.isPrivate() {
             return false
         }
 


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Close CMM-772. Expands upon https://github.com/wordpress-mobile/WordPress-iOS/pull/24802. 

Ensure public Atomic sites leverage the remote editor with support for
WordPress.com/Jetpack blocks.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
1. Enable the _Experimental block editor_ feature.
1. Open the post editor for an WoW/Atomic site without an app password.
1. Verify you are prompted to create an application password or one is
   automatically created before revealing the editor.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
