### PR TITLE
iOS 26: Minor visual fixes

### DIFF
--- a/Modules/Sources/JetpackStats/Screens/ChartDataListView.swift
+++ b/Modules/Sources/JetpackStats/Screens/ChartDataListView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import WordPressUI
 import UniformTypeIdentifiers
 
 struct ChartDataListView: View {
@@ -33,8 +34,14 @@ struct ChartDataListView: View {
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {
             ToolbarItem(placement: .topBarLeading) {
-                Button(Strings.Buttons.done) {
-                    dismiss()
+                if #available(iOS 26, *) {
+                    SwiftUI.Button(role: .close) {
+                        dismiss()
+                    }
+                } else {
+                    SwiftUI.Button(Strings.Buttons.cancel) {
+                        dismiss()
+                    }
                 }
             }
             ToolbarItem(placement: .topBarTrailing) {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 26.4
 -----
-* [*] Fix a few minor visual issues on iOS 26 [#24863], [#24863], [#24865], [#24866], [#24867]
+* [*] Fix a few minor visual issues on iOS 26 [#24863], [#24863], [#24865], [#24866], [#24867], [#24890]
 * [*] [Intelligence] Add support for generating excerpts for posts [#24852]
 * [*] Fix performance issues with search in Reader Subscriptions [#24841]
 * [*] Improve performance and animations when showing a full Top List with a large number of items [#24868]

--- a/WordPress/Classes/Utility/Button+Extensions.swift
+++ b/WordPress/Classes/Utility/Button+Extensions.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 extension Button where Label == Text {
     @ViewBuilder
-    public static func make(role: BackportButtonRole, _ action: @escaping () -> Void) -> some View {
+    public static func make(role: BackportButtonRole, action: @escaping () -> Void) -> some View {
         if #available(iOS 26, *) {
             SwiftUI.Button(role: ButtonRole(role), action: action)
         } else {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/BlogDashboardViewController.swift
@@ -238,8 +238,12 @@ extension BlogDashboardViewController {
     private enum Constants {
         static let estimatedHeight: CGFloat = 44
         static let horizontalSectionInset: CGFloat = 12
-        static let verticalSectionInset: CGFloat = 20
-        static let cellSpacing: CGFloat = 20
+        static let verticalSectionInset: CGFloat = verticalInset
+        static let cellSpacing: CGFloat = verticalInset
+
+        static var verticalInset: CGFloat {
+            if #available(iOS 26, *) { 28 } else { 20 }
+        }
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -289,7 +289,6 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
     private func setupNavigationItem() {
         navigationItem.largeTitleDisplayMode = .never
         navigationItem.title = Strings.mySite
-        navigationItem.backButtonTitle = Strings.mySite
 
         // Set the nav bar
         navigationController?.navigationBar.accessibilityIdentifier = "my-site-navigation-bar"

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -458,11 +458,6 @@ private extension NotificationsViewController {
             navigationController?.navigationBar.prefersLargeTitles = false
             navigationItem.largeTitleDisplayMode = .never
         }
-
-        // Don't show 'Notifications' in the next-view back button
-        // we are using a space character because we need a non-empty string to ensure a smooth
-        // transition back, with large titles enabled.
-        navigationItem.backBarButtonItem = UIBarButtonItem(title: " ", style: .plain, target: nil, action: nil)
         navigationItem.title = NSLocalizedString("Notifications", comment: "Notifications View Controller title")
     }
 

--- a/WordPress/Classes/ViewRelated/Post/Categories/PostCategoryCreateView.swift
+++ b/WordPress/Classes/ViewRelated/Post/Categories/PostCategoryCreateView.swift
@@ -20,7 +20,7 @@ struct PostCategoryCreateView: View {
         }
         .toolbar {
             ToolbarItem(placement: .cancellationAction) {
-                Button(SharedStrings.Button.cancel) {
+                Button.make(role: .cancel) {
                     dismiss()
                 }
             }
@@ -28,7 +28,7 @@ struct PostCategoryCreateView: View {
                 if isSaving {
                     ProgressView()
                 } else {
-                    Button(SharedStrings.Button.save, action: buttonSaveTapped)
+                    Button.make(role: .confirm, action: buttonSaveTapped)
                         .disabled(title.trimmingCharacters(in: .whitespaces).isEmpty)
                 }
             }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -85,7 +85,7 @@ private struct PostSettingsView: View {
     }
 
     private var buttonCancel: some View {
-        Button(SharedStrings.Button.cancel) {
+        Button.make(role: .cancel) {
             if viewModel.hasChanges {
                 isShowingDiscardChangesAlert = true
             } else {
@@ -101,19 +101,8 @@ private struct PostSettingsView: View {
         if viewModel.isSaving {
             ProgressView()
         } else {
-            Group {
-                if viewModel.isStandalone {
-                    Button(SharedStrings.Button.save) {
-                        viewModel.buttonSaveTapped()
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .buttonBorderShape(.capsule)
-                } else {
-                    Button(SharedStrings.Button.done) {
-                        viewModel.buttonSaveTapped()
-                    }
-                    .fontWeight(.medium)
-                }
+            Button.make(role: .confirm) {
+                viewModel.buttonSaveTapped()
             }
             .accessibilityIdentifier("post_settings_save_button")
             .disabled(!viewModel.hasChanges)


### PR DESCRIPTION
See the individual commit message for changes: slightly larger spacing, fixing unwanted back button titles, integrating native "done" buttons, etc.

### Screenshots

An issue with an empty space in the notifications:

<img width="320" alt="Screenshot 2025-09-25 at 3 36 55 PM" src="https://github.com/user-attachments/assets/ef2c3a2c-d923-4c27-ba45-955e60507cb5" />

New native done buttons in "Post Settings" (grayed out inactive on screenshot)

<img width="320" alt="Screenshot 2025-09-25 at 3 44 01 PM" src="https://github.com/user-attachments/assets/a119b08a-a4dd-4fb1-89cd-5959057869f7" />

Slightly more breezing room on dashboard.

<img width="320" alt="Screenshot 2025-09-25 at 3 55 06 PM" src="https://github.com/user-attachments/assets/23236c80-0f6a-4941-a191-2721d982e638" />

