### PR TITLE
perf: Warm GutenbergKit on site selection

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -170,14 +170,6 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         subscribeToModelChanges()
         subscribeToPostPublished()
         subscribeToWillEnterForeground()
-
-        if RemoteFeatureFlag.newGutenberg.enabled() {
-            if let blog {
-                warmUpEditorIfNeeded(for: blog)
-            } else {
-                GutenbergKit.EditorViewController.warmup(configuration: .default)
-            }
-        }
     }
 
     override func viewWillAppear(_ animated: Bool) {

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -33,6 +33,7 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
     }
 
     private var currentSection: Section = .dashboard
+    private static var lastWarmedUpBlogID: NSManagedObjectID?
 
     @objc
     private(set) lazy var scrollView: UIScrollView = {
@@ -171,9 +172,11 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         subscribeToWillEnterForeground()
 
         if RemoteFeatureFlag.newGutenberg.enabled() {
-            GutenbergKit.EditorViewController.warmup(
-                configuration: blog.flatMap { EditorConfiguration(blog: $0) } ?? .default
-            )
+            if let blog {
+                warmUpEditorIfNeeded(for: blog)
+            } else {
+                GutenbergKit.EditorViewController.warmup(configuration: .default)
+            }
         }
     }
 
@@ -346,6 +349,24 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         configureNavBarAppearance(animated: true)
     }
 
+    // MARK: - Editor Warmup
+
+    /// Warms up the editor for the given blog if it hasn't been warmed up already.
+    /// This avoids duplicative warmups when the site hasn't changed.
+    private func warmUpEditorIfNeeded(for blog: Blog) {
+        guard blog.objectID != Self.lastWarmedUpBlogID else {
+            // Editor already warmed up for this blog
+            return
+        }
+
+        Self.lastWarmedUpBlogID = blog.objectID
+
+        let configuration = EditorConfiguration(blog: blog)
+        GutenbergKit.EditorViewController.warmup(configuration: configuration)
+
+        RawBlockEditorSettingsService(blog: blog).prefetchSettings()
+    }
+
     // MARK: - Main Blog
 
     /// This VC is prepared to either show the details for a blog, or show a no-results VC configured to let the user know they have no blogs.
@@ -386,7 +407,7 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         }
 
         if RemoteFeatureFlag.newGutenberg.enabled() {
-            RawBlockEditorSettingsService(blog: blog).prefetchSettings()
+            warmUpEditorIfNeeded(for: blog)
         }
     }
 


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Warm GutenbergKit on site selection rather than view load. This ensures
GutenbergKit is warmed when changing sites. It also ensure we do not unnecessarily
warm the "default" editor configuration when a site can provide its
site-specific configuration.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
### 1. GutenbergKit warms on app launch
1. Monitor the device network activity.
1. Launch the app with the experimental editor feature enabled.
1. Verify GutenbergKit is warmed, with relevant network activity
   occurring--e.g., editor settings, editor assets.

### 2. GutenbergKit warms on site change
1. Monitor the device network activity.
1. Launch the app with the experimental editor feature enabled.
1. Verify GutenbergKit is warmed, with relevant network activity
   occurring--e.g., editor settings, editor assets.
1. Change the selected site.
1. Verify GutenbergKit is warmed, with relevant network activity
   occurring--e.g., editor settings, editor assets.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
