### PR TITLE
Fix Display Zoom issue in Reader

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [*] Fix a few minor visual issues on iOS 26 [#24863], [#24863], [#24865], [#24866], [#24867], [#24890]
 * [*] [Intelligence] Add support for generating excerpts for posts [#24852]
 * [*] Fix an issue with themes in Reader [#24881]
+* [*] Fix an issue with Reader article rendering when iOS "Display Zoom" is enabled [#24895]
 * [*] Fix performance issues with search in Reader Subscriptions [#24841]
 * [*] Improve performance and animations when showing a full Top List with a large number of items [#24868]
 * [*] Show the Top 10 and 50 items in the Top List screen in a dedicated section [#24868]

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -468,10 +468,13 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     /// Apply view styles
     @MainActor private func applyStyles() {
-        webView.pinEdges(.horizontal, to: view, insets: UIEdgeInsets(.horizontal, 16), priority: .init(950))
+        guard let readableGuide = webView.superview?.readableContentGuide else {
+            return
+        }
+
         NSLayoutConstraint.activate([
-            webView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
-            webView.widthAnchor.constraint(lessThanOrEqualToConstant: UIFontMetrics(forTextStyle: .body).scaledValue(for: Constants.preferredArticleWidth))
+            webView.rightAnchor.constraint(equalTo: readableGuide.rightAnchor, constant: -Constants.margin),
+            webView.leftAnchor.constraint(equalTo: readableGuide.leftAnchor, constant: Constants.margin)
         ])
 
         webView.translatesAutoresizingMaskIntoConstraints = false
@@ -879,6 +882,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     private enum Constants {
         static let preferredArticleWidth: CGFloat = 680
+        static let margin: CGFloat = UIDevice.isPad() ? 0 : 8
     }
 
     // MARK: - Managed object observer


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-787/in-some-scenarios-articles-in-reader-get-cropped-on-the-right-side (see steps).

Reverted the changes made in 26.3. As a result, on iPad, the article will now appear slightly larger as Apple changed how `readableContentGuide` works on iOS 26, which I think is acceptable. We can enhance iPad later.
<img width="360" alt="Screenshot 2025-09-26 at 3 14 47 PM" src="https://github.com/user-attachments/assets/bcfc8361-b77c-46e0-bb2d-e571bbeeab30" />
