### PR TITLE
Use the latest wprs

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "c8f4bbd2bbb91f7941c8931ee9488286b2131e9ccc3722f50f8f2300227d0fae",
+  "originHash" : "fd1580694e27e7fc47fd2b45665164aaba97a02cc23377bd4ed63de983c402f7",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -372,8 +372,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/wordpress-rs",
       "state" : {
-        "branch" : "alpha-20250901",
-        "revision" : "8fa6532ea087bbc7dca60e027da0a1e82ea5dee8"
+        "branch" : "alpha-20250925",
+        "revision" : "cb2695d92e3da01720c0573700e031a08c026842"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fd1580694e27e7fc47fd2b45665164aaba97a02cc23377bd4ed63de983c402f7",
+  "originHash" : "823f3eea52d91ecdcb8cdca12da87bee25dddd86ecab2995397fc7989d2a92e3",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -372,8 +372,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/wordpress-rs",
       "state" : {
-        "branch" : "alpha-20250925",
-        "revision" : "cb2695d92e3da01720c0573700e031a08c026842"
+        "branch" : "alpha-20250926",
+        "revision" : "13c6207d6beeeb66c21cd7c627e13817ca5fdcae"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -52,7 +52,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
-        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250925"),
+        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250926"),
         .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.8.1-alpha.2"),
         .package(
             url: "https://github.com/Automattic/color-studio",

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -52,8 +52,8 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
-        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250901"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.8.1"),
+        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250925"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.8.1-alpha.2"),
         .package(
             url: "https://github.com/Automattic/color-studio",
             revision: "bf141adc75e2769eb469a3e095bdc93dc30be8de"

--- a/Modules/Sources/WordPressCore/Extensions/Avatar.swift
+++ b/Modules/Sources/WordPressCore/Extensions/Avatar.swift
@@ -1,6 +1,5 @@
 import Foundation
 import WordPressAPI
-import WordPressAPIInternal
 
 extension Dictionary where Key == UserAvatarSize, Value == WpResponseString {
 

--- a/Modules/Sources/WordPressCore/Plugins/InstalledPlugin.swift
+++ b/Modules/Sources/WordPressCore/Plugins/InstalledPlugin.swift
@@ -1,6 +1,5 @@
 import Foundation
 import WordPressAPI
-import WordPressAPIInternal
 
 public struct InstalledPlugin: Equatable, Hashable, Identifiable, Sendable {
     public var slug: PluginSlug

--- a/Modules/Sources/WordPressCore/Plugins/PluginDirectoryDataStore.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginDirectoryDataStore.swift
@@ -1,6 +1,6 @@
 import Foundation
 import WordPressAPI
-import WordPressAPIInternal
+import WordPressAPIInternal // Required for `Sendable` conformance for multiple types
 
 // MARK: - DataStore for full plugin deatils
 

--- a/Modules/Sources/WordPressCore/Plugins/PluginService.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginService.swift
@@ -1,7 +1,6 @@
 import Foundation
 import UIKit
 import WordPressAPI
-@preconcurrency import WordPressAPIInternal
 
 public actor PluginService: PluginServiceProtocol {
     private let client: WordPressClient
@@ -103,7 +102,7 @@ public actor PluginService: PluginServiceProtocol {
         return installed
     }
 
-    public func fetchPluginsDirectory(category: WordPressOrgApiPluginDirectoryCategory) async throws {
+    public func fetchPluginsDirectory(category: PluginWpOrgDirectoryCategory) async throws {
         // Hard-code the pagination parameters for now. We can suface these parameters when the app needs pagination.
         let plugins = try await wpOrgClient.browsePlugins(category: category, page: 1, pageSize: 10).plugins
         try await pluginDirectoryBrowserDataStore.delete(query: .category(category))

--- a/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginServiceProtocol.swift
@@ -1,6 +1,5 @@
 import Foundation
 import WordPressAPI
-import WordPressAPIInternal
 
 public protocol PluginServiceProtocol: Actor {
 
@@ -21,7 +20,7 @@ public protocol PluginServiceProtocol: Actor {
     func uninstalledPlugin(slug: PluginSlug) async throws
     func installPlugin(slug: PluginWpOrgDirectorySlug) async throws -> InstalledPlugin
 
-    func fetchPluginsDirectory(category: WordPressOrgApiPluginDirectoryCategory) async throws
+    func fetchPluginsDirectory(category: PluginWpOrgDirectoryCategory) async throws
     func pluginDirectoryUpdates(query: CategorizedPluginInformationDataStoreQuery) async -> AsyncStream<Result<[CategorizedPluginInformation], Error>>
 
     func searchPluginsDirectory(input: String) async throws -> [PluginInformation]

--- a/Modules/Sources/WordPressCore/Plugins/PluginUpdateChecksDataStore.swift
+++ b/Modules/Sources/WordPressCore/Plugins/PluginUpdateChecksDataStore.swift
@@ -1,5 +1,5 @@
 import Foundation
-import WordPressAPIInternal
+import WordPressAPIInternal // Required for `UpdateCheckPluginInfo` Hashable conformance
 
 extension UpdateCheckPluginInfo: @retroactive Identifiable {
     public var id: PluginSlug { plugin }

--- a/Modules/Sources/WordPressCore/Users/DisplayUser.swift
+++ b/Modules/Sources/WordPressCore/Users/DisplayUser.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressAPI
 
 public struct DisplayUser: Identifiable, Codable, Hashable, Sendable {
     public let id: Int64
@@ -8,7 +9,7 @@ public struct DisplayUser: Identifiable, Codable, Hashable, Sendable {
     public let lastName: String
     public let displayName: String
     public let profilePhotoUrl: URL?
-    public let role: String
+    public let role: UserRole
 
     public let emailAddress: String
     public let websiteUrl: String?
@@ -23,7 +24,7 @@ public struct DisplayUser: Identifiable, Codable, Hashable, Sendable {
         lastName: String,
         displayName: String,
         profilePhotoUrl: URL?,
-        role: String,
+        role: UserRole,
         emailAddress: String,
         websiteUrl: String?,
         biography: String?
@@ -49,7 +50,7 @@ public struct DisplayUser: Identifiable, Codable, Hashable, Sendable {
         lastName: "Smith",
         displayName: "John Smith",
         profilePhotoUrl: URL(string: "https://gravatar.com/avatar/58fc51586c9a1f9895ac70e3ca60886e?size=256"),
-        role: "administrator",
+        role: .administrator,
         emailAddress: "john@example.com",
         websiteUrl: "https://example.com",
         biography: "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat."

--- a/Modules/Sources/WordPressCore/Users/User+Extensions.swift
+++ b/Modules/Sources/WordPressCore/Users/User+Extensions.swift
@@ -1,5 +1,5 @@
 import WordPressAPI
-import WordPressAPIInternal // Needed for `UserRole` Equatable conformance – it'd be nice to not need this.
+import WordPressAPIInternal // Required for `UserRole` Equatable conformance – it'd be nice to not need this.
 
 public extension UserRole {
     var displayString: String {

--- a/Modules/Sources/WordPressCore/Users/User+Extensions.swift
+++ b/Modules/Sources/WordPressCore/Users/User+Extensions.swift
@@ -3,7 +3,7 @@ import WordPressAPIInternal // Required for `UserRole` Equatable conformance –
 
 public extension UserRole {
     var displayString: String {
-        "" // TODO: This should use .rawValue
+        self.rawValue.capitalized
     }
 }
 
@@ -16,7 +16,7 @@ extension UserRole: @retroactive Codable {
 
     public func encode(to encoder: any Encoder) throws {
         var container = encoder.singleValueContainer()
-        try container.encode("") // TODO: Use `.rawValue` here
+        try container.encode(self.rawValue)
     }
 }
 

--- a/Modules/Sources/WordPressCore/Users/User+Extensions.swift
+++ b/Modules/Sources/WordPressCore/Users/User+Extensions.swift
@@ -1,0 +1,39 @@
+import WordPressAPI
+import WordPressAPIInternal // Needed for `UserRole` Equatable conformance – it'd be nice to not need this.
+
+public extension UserRole {
+    var displayString: String {
+        "" // TODO: This should use .rawValue
+    }
+}
+
+extension UserRole: @retroactive Codable {
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let string: String = try container.decode(String.self)
+        self = .custom(string)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode("") // TODO: Use `.rawValue` here
+    }
+}
+
+extension UserRole: @retroactive Comparable {
+
+    public static func < (lhs: UserRole, rhs: UserRole) -> Bool {
+        let lhsIndex = Self.order.firstIndex(of: lhs) ?? Int.max
+        let rhsIndex = Self.order.firstIndex(of: rhs) ?? Int.max
+        return lhsIndex < rhsIndex
+    }
+
+    private static let order: [UserRole] = [
+        .superAdmin,
+        .administrator,
+        .editor,
+        .author,
+        .contributor,
+        .subscriber
+    ]
+}

--- a/Modules/Sources/WordPressCore/Users/UserService.swift
+++ b/Modules/Sources/WordPressCore/Users/UserService.swift
@@ -36,7 +36,7 @@ public actor UserService: UserServiceProtocol {
         }
     }
 
-    public func isCurrentUserCapableOf(_ capability: String) async -> Bool {
+    public func isCurrentUserCapableOf(_ capability: UserCapability) async -> Bool {
         await currentUser?.capabilities.keys.contains(capability) == true
     }
 
@@ -79,7 +79,7 @@ private extension DisplayUser {
             return nil
         }
 
-        self.init(
+        self = DisplayUser(
             id: user.id,
             handle: user.slug,
             username: user.username,

--- a/Modules/Sources/WordPressCore/Users/UserServiceProtocol.swift
+++ b/Modules/Sources/WordPressCore/Users/UserServiceProtocol.swift
@@ -4,7 +4,7 @@ import WordPressAPI
 public protocol UserServiceProtocol: Actor {
     func fetchUsers() async throws
 
-    func isCurrentUserCapableOf(_ capability: String) async -> Bool
+    func isCurrentUserCapableOf(_ capability: UserCapability) async -> Bool
 
     func setNewPassword(id: UserId, newPassword: String) async throws
 

--- a/WordPress/Classes/Networking/WordPressClient.swift
+++ b/WordPress/Classes/Networking/WordPressClient.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Combine
 import WordPressAPI
-import WordPressAPIInternal
+import WordPressAPIInternal // Required for `WpAuthenticationProvider`
 import WordPressCore
 import WordPressData
 import WordPressShared
@@ -53,6 +53,7 @@ extension WordPressClient {
     }
 }
 
+// TODO: Remove this
 extension PluginWpOrgDirectorySlug: @retroactive ExpressibleByStringLiteral {
     public typealias StringLiteralType = String
 
@@ -98,7 +99,7 @@ private final class AutoUpdateAuthenticationProvider: @unchecked Sendable, WpDyn
         return authentication
     }
 
-    func auth() -> WordPressAPIInternal.WpAuthentication {
+    func auth() -> WpAuthentication {
         lock.lock()
         defer {
             lock.unlock()

--- a/WordPress/Classes/Networking/WordPressClient.swift
+++ b/WordPress/Classes/Networking/WordPressClient.swift
@@ -133,7 +133,7 @@ private class AppNotifier: @unchecked Sendable, WpAppNotifier {
         self.coreDataStack = coreDataStack
     }
 
-    func requestedWithInvalidAuthentication() async {
+    func requestedWithInvalidAuthentication(requestUrl: String) async {
         let blogId = site.blogId(in: coreDataStack)
         NotificationCenter.default.post(name: WordPressClient.requestedWithInvalidAuthenticationNotification, object: blogId)
     }

--- a/WordPress/Classes/Plugins/Views/AddNewPluginView.swift
+++ b/WordPress/Classes/Plugins/Views/AddNewPluginView.swift
@@ -2,7 +2,6 @@ import Foundation
 import SwiftUI
 import WordPressCore
 import WordPressAPI
-import WordPressAPIInternal
 
 struct AddNewPluginView: View {
     @Environment(\.dismiss) var dismiss
@@ -214,7 +213,7 @@ private class AddNewPluginViewModel: ObservableObject {
         case popular
         case recommended
 
-        var wpOrgCategory: WordPressOrgApiPluginDirectoryCategory {
+        var wpOrgCategory: PluginWpOrgDirectoryCategory {
             // TODO: Update the returned values to be the correct onces after updating the wordpress-rs library
             switch self {
             case .featured:

--- a/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
+++ b/WordPress/Classes/Plugins/Views/InstalledPluginsListView.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import AsyncImageKit
 import WordPressUI
 import WordPressAPI
-import WordPressAPIInternal
 import WordPressCore
 
 struct InstalledPluginsListView: View {

--- a/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginDetailsView.swift
@@ -1,8 +1,9 @@
 import Foundation
 import SwiftUI
 import AsyncImageKit
+import WordPressAPI
+import WordPressAPIInternal // Required for `Screenshot`, `Ratings`
 import WordPressCore
-import WordPressAPIInternal
 
 struct PluginDetailsView: View {
     private struct BasicPluginInfo {

--- a/WordPress/Classes/Plugins/Views/PluginIconView.swift
+++ b/WordPress/Classes/Plugins/Views/PluginIconView.swift
@@ -2,7 +2,6 @@ import Foundation
 import SwiftUI
 import AsyncImageKit
 import WordPressAPI
-import WordPressAPIInternal
 import WordPressCore
 
 struct PluginIconView: View {

--- a/WordPress/Classes/Services/CommentServiceRemoteCoreRESTAPI.swift
+++ b/WordPress/Classes/Services/CommentServiceRemoteCoreRESTAPI.swift
@@ -149,7 +149,7 @@ private extension RemoteComment {
         self.postID = NSNumber(value: comment.post)
 
         self.status = comment.status.commentStatusType?.description
-        self.type = comment.commentType.type
+        self.type = comment.commentType.rawValue
 
         if let ext = try? comment.additionalFields.parseWpcomCommentsExtension() {
             self.postTitle = ext.post?.title

--- a/WordPress/Classes/Services/CommentServiceRemoteCoreRESTAPI.swift
+++ b/WordPress/Classes/Services/CommentServiceRemoteCoreRESTAPI.swift
@@ -1,7 +1,7 @@
 import Foundation
 import WordPressCore
 import WordPressAPI
-import WordPressAPIInternal
+import WordPressAPIInternal // Required for `WpApiParamCommentsOrderBy`
 import WordPressKit
 import WordPressShared
 import WordPressData

--- a/WordPress/Classes/Services/MediaServiceRemoteCoreREST.swift
+++ b/WordPress/Classes/Services/MediaServiceRemoteCoreREST.swift
@@ -3,7 +3,6 @@ import Combine
 import WordPressCore
 import WordPressShared
 import WordPressAPI
-import WordPressAPIInternal
 import WordPressKit
 
 /// A `MediaServiceRemote` implementation that uses the WordPress core REST API (`/wp-json/wp/v2/media`).

--- a/WordPress/Classes/Services/TaxonomyServiceRemoteCoreREST.swift
+++ b/WordPress/Classes/Services/TaxonomyServiceRemoteCoreREST.swift
@@ -3,7 +3,6 @@ import WordPressKit
 import WordPressCore
 import WordPressData
 import WordPressAPI
-import WordPressAPIInternal
 
 @objc public class TaxonomyServiceRemoteCoreREST: NSObject, TaxonomyServiceRemote {
     let client: WordPressClient

--- a/WordPress/Classes/Services/TaxonomyServiceRemoteCoreREST.swift
+++ b/WordPress/Classes/Services/TaxonomyServiceRemoteCoreREST.swift
@@ -20,11 +20,11 @@ import WordPressAPI
     public func createCategory(_ category: RemotePostCategory, success: ((RemotePostCategory) -> Void)?, failure: ((any Error) -> Void)? = nil) {
         Task { @MainActor in
             do {
-                let params = CategoryCreateParams(
+                let params = TermCreateParams(
                     name: category.name ?? "",
                     parent: category.parentID?.int64Value
                 )
-                let response = try await client.api.categories.create(params: params)
+                let response = try await client.api.terms.create(termEndpointType: .categories, params: params)
                 let remoteCategory = RemotePostCategory(category: response.data)
                 success?(remoteCategory)
             } catch {
@@ -36,7 +36,10 @@ import WordPressAPI
     public func getCategoriesWithSuccess(_ success: @escaping ([RemotePostCategory]) -> Void, failure: ((any Error) -> Void)? = nil) {
         Task { @MainActor in
             do {
-                let sequence = await client.api.categories.sequenceWithEditContext(params: CategoryListParams(perPage: 100))
+                let sequence = await client.api.terms.sequenceWithEditContext(
+                    type: .categories,
+                    params: TermListParams(perPage: 100)
+                )
                 let categories: [RemotePostCategory] = try await sequence.reduce(into: []) {
                     let page = $1.map(RemotePostCategory.init(category:))
                     $0.append(contentsOf: page)
@@ -51,14 +54,17 @@ import WordPressAPI
     public func getCategoriesWith(_ paging: RemoteTaxonomyPaging, success: @escaping ([RemotePostCategory]) -> Void, failure: ((any Error) -> Void)? = nil) {
         Task { @MainActor in
             do {
-                let params = CategoryListParams(
+                let params = TermListParams(
                     page: paging.page?.uint32Value,
                     perPage: paging.number?.uint32Value,
                     offset: paging.offset?.uint32Value,
-                    order: .init(paging.order),
-                    orderby: .init(paging.orderBy)
+                    order: WpApiParamOrder(paging.order),
+                    orderby: WpApiParamTermsOrderBy(paging.orderBy)
                 )
-                let response = try await client.api.categories.listWithEditContext(params: params)
+                let response = try await client.api.terms.listWithEditContext(
+                    termEndpointType: .categories,
+                    params: params
+                )
                 let categories = response.data.map(RemotePostCategory.init(category:))
                 success(categories)
             } catch {
@@ -70,8 +76,11 @@ import WordPressAPI
     public func searchCategories(withName nameQuery: String, success: @escaping ([RemotePostCategory]) -> Void, failure: ((any Error) -> Void)? = nil) {
         Task { @MainActor in
             do {
-                let params = CategoryListParams(search: nameQuery)
-                let response = try await client.api.categories.listWithEditContext(params: params)
+                let params = TermListParams(search: nameQuery)
+                let response = try await client.api.terms.listWithEditContext(
+                    termEndpointType: .categories,
+                    params: params
+                )
                 let categories = response.data.map(RemotePostCategory.init(category:))
                 success(categories)
             } catch {
@@ -83,12 +92,15 @@ import WordPressAPI
     public func createTag(_ tag: RemotePostTag, success: ((RemotePostTag) -> Void)?, failure: ((any Error) -> Void)? = nil) {
         Task { @MainActor in
             do {
-                let params = TagCreateParams(
+                let params = TermCreateParams(
                     name: tag.name ?? "",
                     description: tag.tagDescription,
                     slug: tag.slug
                 )
-                let response = try await client.api.tags.create(params: params)
+                let response = try await client.api.terms.create(
+                    termEndpointType: .tags,
+                    params: params
+                )
                 let remoteTag = RemotePostTag(tag: response.data)
                 success?(remoteTag)
             } catch {
@@ -105,12 +117,16 @@ import WordPressAPI
 
         Task { @MainActor in
             do {
-                let params = TagUpdateParams(
+                let params = TermUpdateParams(
                     name: tag.name,
                     description: tag.tagDescription,
                     slug: tag.slug
                 )
-                let response = try await client.api.tags.update(tagId: TagId(tagID.int64Value), params: params)
+                let response = try await client.api.terms.update(
+                    termEndpointType: .tags,
+                    termId: tagID.int64Value,
+                    params: params
+                )
                 let remoteTag = RemotePostTag(tag: response.data)
                 success?(remoteTag)
             } catch {
@@ -127,7 +143,7 @@ import WordPressAPI
 
         Task { @MainActor in
             do {
-                let _ = try await client.api.tags.delete(tagId: TagId(tagID.int64Value))
+                let _ = try await client.api.terms.delete(termEndpointType: .tags, termId: tagID.int64Value)
                 success?()
             } catch {
                 failure?(error)
@@ -138,7 +154,10 @@ import WordPressAPI
     public func getTagsWithSuccess(_ success: @escaping ([RemotePostTag]) -> Void, failure: ((any Error) -> Void)? = nil) {
         Task { @MainActor in
             do {
-                let response = try await client.api.tags.listWithEditContext(params: TagListParams())
+                let response = try await client.api.terms.listWithEditContext(
+                    termEndpointType: .tags,
+                    params: TermListParams()
+                )
                 let tags = response.data.map(RemotePostTag.init(tag:))
                 success(tags)
             } catch {
@@ -150,14 +169,17 @@ import WordPressAPI
     public func getTagsWith(_ paging: RemoteTaxonomyPaging, success: @escaping ([RemotePostTag]) -> Void, failure: ((any Error) -> Void)? = nil) {
         Task { @MainActor in
             do {
-                let params = TagListParams(
+                let params = TermListParams(
                     page: paging.page?.uint32Value,
                     perPage: paging.number?.uint32Value,
                     offset: paging.offset?.uint32Value,
-                    order: .init(paging.order),
-                    orderby: .init(paging.orderBy)
+                    order: WpApiParamOrder(paging.order),
+                    orderby: WpApiParamTermsOrderBy(paging.orderBy)
                 )
-                let response = try await client.api.tags.listWithEditContext(params: params)
+                let response = try await client.api.terms.listWithEditContext(
+                    termEndpointType: .tags,
+                    params: params
+                )
                 let tags = response.data.map(RemotePostTag.init(tag:))
                 success(tags)
             } catch {
@@ -169,7 +191,10 @@ import WordPressAPI
     public func searchTags(withName nameQuery: String, success: @escaping ([RemotePostTag]) -> Void, failure: ((any Error) -> Void)? = nil) {
         Task { @MainActor in
             do {
-                let response = try await client.api.tags.listWithEditContext(params: TagListParams(search: nameQuery))
+                let response = try await client.api.terms.listWithEditContext(
+                    termEndpointType: .tags,
+                    params: TermListParams(search: nameQuery)
+                )
                 let tags = response.data.map(RemotePostTag.init(tag:))
                 success(tags)
             } catch {
@@ -180,16 +205,16 @@ import WordPressAPI
 }
 
 private extension RemotePostCategory {
-    convenience init(category: CategoryWithEditContext) {
+    convenience init(category: AnyTermWithEditContext) {
         self.init()
         self.categoryID = NSNumber(value: category.id)
         self.name = category.name
-        self.parentID = NSNumber(value: category.parent)
+        self.parentID = NSNumber(value: category.parent ?? 0)
     }
 }
 
 private extension RemotePostTag {
-    convenience init(tag: TagWithEditContext) {
+    convenience init(tag: AnyTermWithEditContext) {
         self.init()
         self.tagID = NSNumber(value: tag.id)
         self.name = tag.name
@@ -212,20 +237,7 @@ private extension WpApiParamOrder {
     }
 }
 
-private extension WpApiParamCategoriesOrderBy {
-    init(_ other: RemoteTaxonomyPagingResultsOrdering) {
-        switch other {
-        case .byName:
-            self = .name
-        case .byCount:
-            self = .count
-        @unknown default:
-            self = .name
-        }
-    }
-}
-
-private extension WpApiParamTagsOrderBy {
+private extension WpApiParamTermsOrderBy {
     init(_ other: RemoteTaxonomyPagingResultsOrdering) {
         switch other {
         case .byName:

--- a/WordPress/Classes/Users/UserProvider.swift
+++ b/WordPress/Classes/Users/UserProvider.swift
@@ -58,7 +58,7 @@ actor MockUserProvider: UserServiceProtocol {
         await userDataStore.listStream(query: .all)
     }
 
-    func isCurrentUserCapableOf(_ capability: String) async -> Bool {
+    func isCurrentUserCapableOf(_ capability: UserCapability) async -> Bool {
         true
     }
 

--- a/WordPress/Classes/Users/ViewModel/UserDetailViewModel.swift
+++ b/WordPress/Classes/Users/ViewModel/UserDetailViewModel.swift
@@ -19,6 +19,6 @@ class UserDetailViewModel: ObservableObject {
         isLoadingCurrentUser = true
         defer { isLoadingCurrentUser = false}
 
-        currentUserCanModifyUsers = await userService.isCurrentUserCapableOf("edit_users")
+        currentUserCanModifyUsers = await userService.isCurrentUserCapableOf(.editUsers)
     }
 }

--- a/WordPress/Classes/Users/ViewModel/UserListViewModel.swift
+++ b/WordPress/Classes/Users/ViewModel/UserListViewModel.swift
@@ -14,7 +14,7 @@ class UserListViewModel: ObservableObject {
 
     enum RoleSection: Hashable, Comparable {
         case me
-        case role(String)
+        case role(UserRole)
         case searchResult
 
         /// Order in the users list.
@@ -41,7 +41,7 @@ class UserListViewModel: ObservableObject {
             case .me:
                 return ""
             case let .role(role):
-                return role
+                return role.displayString
             case .searchResult:
                 return NSLocalizedString("userList.searchResults.header", value: "Search Results", comment: "Header text fo the search results section in the users list")
             }

--- a/WordPress/Classes/Users/Views/UserDetailsView.swift
+++ b/WordPress/Classes/Users/Views/UserDetailsView.swift
@@ -55,7 +55,7 @@ struct UserDetailsView: View {
             .listRowInsets(.zero)
 
             Section {
-                makeRow(title: Strings.roleFieldTitle, content: user.role)
+                makeRow(title: Strings.roleFieldTitle, content: user.role.displayString)
                 makeRow(title: Strings.emailAddressFieldTitle, content: user.emailAddress, link: user.emailAddress.asEmail())
                 if let website = user.websiteUrl, !website.isEmpty {
                     makeRow(title: Strings.websiteFieldTitle, content: website, link: URL(string: website))

--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackConnectionViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackConnectionViewModel.swift
@@ -3,7 +3,6 @@ import WordPressCore
 import WordPressData
 import WordPressShared
 import WordPressAPI
-import WordPressAPIInternal
 
 @MainActor
 class JetpackConnectionViewModel: ObservableObject {

--- a/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/JetpackLoginViewController.swift
@@ -4,7 +4,6 @@ import WordPressData
 import WordPressShared
 import WordPressAuthenticator
 import WordPressUI
-import WordPressAPIInternal
 
 protocol JetpackConnectionSupport: AnyObject {
     init?(blog: Blog)

--- a/WordPress/Classes/ViewRelated/Jetpack/Login/RESTAPIJetpackLoginViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Login/RESTAPIJetpackLoginViewController.swift
@@ -4,7 +4,6 @@ import SwiftUI
 import WordPressData
 import WordPressCore
 import WordPressShared
-import WordPressAPIInternal
 
 class RESTAPIJetpackLoginViewController: UIViewController, JetpackConnectionSupport {
 


### PR DESCRIPTION
## Description
Updates the WordPress RS library to the latest version, adopting its changes.

## Testing instructions
If CI is green, this should be good to go. This touches the REST-powered users, plugins, comments, media, tags/categories, and Jetpack connection functionality.
