### PR TITLE
Add "Today" card

### DIFF
--- a/Modules/Sources/JetpackStats/Analytics/StatsEvent.swift
+++ b/Modules/Sources/JetpackStats/Analytics/StatsEvent.swift
@@ -95,6 +95,10 @@ public enum StatsEvent {
     ///   - "value": The value of the selected bar
     case chartBarSelected
 
+    // MARK: - Today
+
+    case todayCardTapped
+
     // MARK: - List Events
 
     /// Top list item tapped

--- a/Modules/Sources/JetpackStats/Cards/CardViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/CardViewModel.swift
@@ -3,7 +3,13 @@ import Foundation
 @MainActor
 protocol TrafficCardViewModel: AnyObject {
     var id: UUID { get }
+    var cardType: CardType { get }
     var dateRange: StatsDateRange { get set }
     var isEditing: Bool { get set }
+    var isEditable: Bool { get }
     var configurationDelegate: CardConfigurationDelegate? { get set }
+}
+
+extension TrafficCardViewModel {
+    var isEditable: Bool { true }
 }

--- a/Modules/Sources/JetpackStats/Cards/ChartCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/ChartCard.swift
@@ -5,8 +5,6 @@ struct ChartCard: View {
     @ObservedObject private var viewModel: ChartCardViewModel
 
     private var onDateRangeSelected: ((StatsDateRange) -> Void)?
-    private var backButtonTitle: String?
-    private var backButtonAction: (() -> Void)?
 
     private var dateRange: StatsDateRange { viewModel.dateRange }
     private var metrics: [SiteMetric] { viewModel.metrics }
@@ -23,7 +21,7 @@ struct ChartCard: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            VStack(spacing: Constants.step1) {
+            VStack(spacing: Constants.step0_5) {
                 headerView(for: selectedMetric)
                     .unredacted()
                 contentView
@@ -41,10 +39,7 @@ struct ChartCard: View {
             viewModel.onAppear()
         }
         .overlay(alignment: .topTrailing) {
-            HStack(alignment: .center, spacing: 0) {
-                backButton
-                moreMenu
-            }
+            moreMenu
         }
         .cardStyle()
         .grayscale(viewModel.isStale ? 1 : 0)
@@ -57,7 +52,7 @@ struct ChartCard: View {
         .sheet(isPresented: $viewModel.isEditing) {
             NavigationStack {
                 ChartCardCustomizationView(chartViewModel: viewModel)
-                    .navigationTitle(Strings.AddChart.selectMetric)
+                    .navigationTitle(Strings.Cards.selectMetric)
                     .navigationBarTitleDisplayMode(.inline)
             }
             .presentationDetents([.medium, .large])
@@ -77,31 +72,13 @@ struct ChartCard: View {
             StatsCardTitleView(title: metric.localizedTitle, showChevron: false)
             Spacer(minLength: 0)
         }
-        .animation(.spring, value: backButtonTitle)
         .accessibilityElement(children: .combine)
         .accessibilityLabel(Strings.Accessibility.cardTitle(metric.localizedTitle))
     }
 
     @ViewBuilder
-    private var backButton: some View {
-        if let title = backButtonTitle, let action = backButtonAction {
-            Button(action: action) {
-                HStack(spacing: 4) {
-                    Image(systemName: "chevron.backward")
-                        .font(.system(size: 12, weight: .bold))
-                    Text(title)
-                        .font(.system(size: 14, weight: .medium))
-                }
-                .foregroundColor(Constants.Colors.blue)
-            }
-            .buttonStyle(.plain)
-            .transition(.scale(scale: 0.9).combined(with: .opacity))
-        }
-    }
-
-    @ViewBuilder
     private var contentView: some View {
-        VStack(spacing: Constants.step0_5) {
+        VStack(spacing: 4) {
             chartHeaderView
                 .padding(.trailing, -Constants.step0_5)
             chartContentView
@@ -271,14 +248,6 @@ struct ChartCard: View {
         )
         onDateRangeSelected?(newDateRange)
         viewModel.tracker?.send(.chartBarSelected)
-    }
-
-    /// Configures the back button for navigation history
-    func backButton(title: String?, action: (() -> Void)?) -> ChartCard {
-        var copy = self
-        copy.backButtonTitle = title
-        copy.backButtonAction = action
-        return copy
     }
 
     /// Configures the action when a bar is tapped for drill-down navigation

--- a/Modules/Sources/JetpackStats/Cards/ChartCardViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/ChartCardViewModel.swift
@@ -4,6 +4,7 @@ import SwiftUI
 final class ChartCardViewModel: ObservableObject, TrafficCardViewModel {
     var id: UUID { configuration.id }
     var metrics: [SiteMetric] { configuration.metrics }
+    let cardType: CardType = .chart
 
     @Published private(set) var configuration: ChartCardConfiguration
     @Published private(set) var chartData: [SiteMetric: ChartData] = [:]
@@ -75,7 +76,7 @@ final class ChartCardViewModel: ObservableObject, TrafficCardViewModel {
 
         // Track card shown event
         tracker?.send(.cardShown, properties: [
-            "card_type": "chart",
+            "card_type": CardType.chart.rawValue,
             "configuration": metrics.map { $0.analyticsName }.joined(separator: "_"),
             "chart_type": selectedChartType.rawValue
         ])

--- a/Modules/Sources/JetpackStats/Cards/TodayCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TodayCard.swift
@@ -64,7 +64,7 @@ struct TodayCard: View {
                 .font(.caption.weight(.medium))
         }
         .foregroundStyle(Color.secondary)
-        .offset(y: 9) // Get it close to the value
+        .offset(y: 7) // Get it close to the value
         .dynamicTypeSize(...DynamicTypeSize.large)
     }
 

--- a/Modules/Sources/JetpackStats/Cards/TodayCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TodayCard.swift
@@ -1,0 +1,370 @@
+import SwiftUI
+import Charts
+import WordPressUI
+
+struct TodayCard: View {
+    @ObservedObject private var viewModel: TodayCardViewModel
+
+    @ScaledMetric(relativeTo: .title)
+    private var sparklineHeight: CGFloat = 52
+
+    private var isChevronHidden = false
+
+    init(viewModel: TodayCardViewModel) {
+        self.viewModel = viewModel
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 32) {
+                VStack(alignment: .leading, spacing: 0) {
+                    headerView
+                    Spacer()
+                    prominentMetricLabel
+                }
+                sparklineView
+                    .padding(.trailing, 16)
+            }
+            .frame(height: sparklineHeight)
+
+            metricsView
+        }
+        .padding(.vertical, Constants.step2)
+        .padding(.horizontal, Constants.step3)
+        .dynamicTypeSize(...DynamicTypeSize.xxLarge)
+        .onAppear {
+            viewModel.onAppear()
+        }
+        .overlay(alignment: .topTrailing) {
+            moreMenu
+        }
+        .cardStyle()
+        .animation(.spring, value: viewModel.data?.id)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(Strings.Accessibility.chartContainer)
+    }
+
+    private var headerView: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            StatsCardTitleView(title: Strings.Today.title)
+            Text(currentDateText)
+                .font(.system(.caption, design: .rounded, weight: .medium))
+                .foregroundStyle(Color.secondary)
+        }
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(Strings.Today.title), \(currentDateText)")
+    }
+
+    private var prominentMetricLabel: some View {
+        HStack(spacing: 2) {
+            Image(systemName: SiteMetric.views.systemImage)
+                .font(.caption2.weight(.medium))
+                .scaleEffect(x: 0.9, y: 0.9)
+            Text(SiteMetric.views.localizedTitle.uppercased())
+                .font(.caption.weight(.medium))
+        }
+        .foregroundStyle(Color.secondary)
+        .offset(y: 9) // Get it close to the value
+        .dynamicTypeSize(...DynamicTypeSize.large)
+    }
+
+    private var currentDateText: String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEEE, MMM d"
+        return formatter.string(from: Date())
+    }
+
+    func chevronHidden(_ isHidden: Bool = true) -> TodayCard {
+        var copy = self
+        copy.isChevronHidden = isHidden
+        return copy
+    }
+
+    // MARK: - Content Views
+
+    @ViewBuilder
+    private var metricsView: some View {
+        if let data = viewModel.data {
+            makeMetricsView(with: data.metrics)
+        } else if viewModel.isLoading {
+            makeMetricsView(with: placeholderData.metrics)
+                .redacted(reason: .placeholder)
+                .opacity(0.66)
+                .pulsating()
+        } else {
+            makeMetricsView(with: SiteMetricsSet())
+                .grayscale(1).opacity(0.33)
+        }
+    }
+
+    private func makeMetricsView(with metrics: SiteMetricsSet) -> some View {
+        HStack(alignment: .bottom, spacing: 20) {
+            ForEach(viewModel.configuration.metrics) { metric in
+                if metric == .views {
+                    TodayCardProminentMetricView(value: metrics[metric], metric: metric)
+                        .offset(y: 6.5) // Compensate for the larger line height
+                } else {
+                    TodayCardMetricView(metric: metric, value: metrics[metric])
+                }
+            }
+            .layoutPriority(2)
+
+            if !isChevronHidden {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundStyle(Color.secondary.opacity(0.4))
+                    .frame(maxWidth: .infinity, alignment: .trailing)
+                    .offset(x: 8, y: -3)
+                    .unredacted()
+                    .layoutPriority(1)
+            }
+        }
+        .lineLimit(1)
+    }
+
+    @ViewBuilder
+    private var sparklineView: some View {
+        if let data = viewModel.data {
+            makeSparklineView(data)
+        } else {
+            let placeholder = makeSparklineView(placeholderData)
+                .redacted(reason: .placeholder)
+            if viewModel.isLoading {
+                placeholder.pulsating().opacity(0.33)
+            } else {
+                placeholder.grayscale(1).opacity(0.25)
+            }
+        }
+    }
+
+    private func makeSparklineView(_ data: TodayCardData) -> some View {
+        SparklineChart(
+            dataPoints: data.hourlyViews,
+            previousDataPoints: data.previousHourlyViews ?? [],
+            metric: .views
+        )
+        .frame(maxWidth: .infinity)
+        .padding(.trailing, 32)
+        .padding(.vertical, 2)
+        .transition(.opacity.combined(with: .scale(scale: 0.97)))
+    }
+
+    // MARK: - Placeholder Data
+
+    private var placeholderData: TodayCardData {
+        // Generate hourly data points with a realistic curve peaking mid-day
+        let hourlyViews = (0..<12).map { hour in
+            let normalizedHour = Double(hour)
+            // Create a bell curve centered around hour 14 (2 PM)
+            let peakHour = 14.0
+            let spread = 4.5  // Reduced spread for sharper peak
+            let amplitude = 300.0  // Increased amplitude for higher peak
+            let baseline = 20.0  // Lower baseline to increase contrast
+
+            let bellCurve = amplitude * exp(-pow(normalizedHour - peakHour, 2) / (2 * pow(spread, 2))) + baseline
+            let noise = Double.random(in: -30...30)
+            let value = Int(bellCurve + noise)
+
+            return (hour: hour, value: max(15, value))
+        }
+
+        let previousHourlyViews = (0..<24).map { hour in
+            let normalizedHour = Double(hour)
+            // Similar curve but slightly different for comparison
+            let peakHour = 12.0
+            let spread = 3.0  // Reduced spread for sharper peak
+            let amplitude = 280.0  // Increased amplitude for higher peak
+            let baseline = 18.0  // Lower baseline to increase contrast
+
+            let bellCurve = amplitude * exp(-pow(normalizedHour - peakHour, 2) / (2 * pow(spread, 2))) + baseline
+            let noise = Double.random(in: -30...30)
+            let value = Int(bellCurve + noise)
+
+            return (hour: hour, value: max(12, value))
+        }
+
+        var metricsSet = SiteMetricsSet()
+        metricsSet[.views] = 1234
+        metricsSet[.visitors] = 567
+        metricsSet[.likes] = 89
+        metricsSet[.comments] = 12
+
+        return TodayCardData(
+            hourlyViews: hourlyViews,
+            previousHourlyViews: previousHourlyViews,
+            metrics: metricsSet
+        )
+    }
+
+    // MARK: - More Menu
+
+    private var moreMenu: some View {
+        Menu {
+            moreMenuContent
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 16))
+                .foregroundColor(.secondary)
+                .frame(width: 44, height: 44)
+        }
+        .tint(Color.primary)
+    }
+
+    @ViewBuilder
+    private var moreMenuContent: some View {
+        Section {
+            Link(destination: URL(string: "https://wordpress.com/support/stats/understand-your-sites-traffic/")!) {
+                Label(Strings.Buttons.learnMore, systemImage: "info.circle")
+            }
+        }
+        EditCardMenuContent(cardViewModel: viewModel)
+    }
+}
+
+private struct SparklineChart: View {
+    let dataPoints: [(hour: Int, value: Int)]
+    let previousDataPoints: [(hour: Int, value: Int)]
+    let metric: SiteMetric
+
+    @Environment(\.colorScheme) var colorScheme
+
+    var body: some View {
+        Chart {
+            current
+            previous
+        }
+        .chartXAxis(.hidden)
+        .chartYAxis(.hidden)
+    }
+
+    // Current day's data (colored area + line)
+    private var current: some ChartContent {
+        ForEach(dataPoints, id: \.hour) { hour, value in
+            AreaMark(
+                x: .value("Hour", hour),
+                y: .value("Current", value),
+                series: .value("Series", "Current")
+            )
+            .foregroundStyle(
+                LinearGradient(
+                    colors: [
+                        metric.primaryColor.opacity(colorScheme == .light ? 0.15 : 0.25),
+                        metric.primaryColor.opacity(0.0)
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+            .interpolationMethod(.linear)
+
+            LineMark(
+                x: .value("Hour", hour),
+                y: .value("Current", value),
+                series: .value("Series", "Current")
+            )
+            .foregroundStyle(metric.primaryColor)
+            .lineStyle(StrokeStyle(
+                lineWidth: 2.5,
+                lineCap: .round,
+                lineJoin: .round
+            ))
+            .interpolationMethod(.linear)
+        }
+    }
+
+    // Previous day's data (gray dashed line)
+    private var previous: some ChartContent {
+        ForEach(previousDataPoints, id: \.hour) { hour, value in
+            AreaMark(
+                x: .value("Hour", hour),
+                y: .value("Previous", value),
+                series: .value("Series", "Previous")
+            )
+            .foregroundStyle(Color.clear)
+            .interpolationMethod(.linear)
+
+            LineMark(
+                x: .value("Hour", hour),
+                y: .value("Previous", value),
+                series: .value("Series", "Previous")
+            )
+            .foregroundStyle(Color.secondary.opacity(0.5))
+            .lineStyle(StrokeStyle(
+                lineWidth: 1.5,
+                lineCap: .round,
+                lineJoin: .round,
+                dash: [4, 4]
+            ))
+            .interpolationMethod(.linear)
+        }
+    }
+}
+
+private struct TodayCardProminentMetricView: View {
+    let value: Int?
+    let metric: SiteMetric
+
+    private var formattedValue: String {
+        guard let value else { return "–" }
+        return StatsValueFormatter(metric: metric)
+            .format(value: value, context: .regular)
+    }
+
+    var body: some View {
+        Text(formattedValue)
+            .contentTransition(.numericText())
+            .font(Font.make(.recoleta, textStyle: .title, weight: .medium))
+            .foregroundColor(.primary)
+            .lineLimit(1)
+            .animation(.spring, value: value)
+            .dynamicTypeSize(...DynamicTypeSize.xLarge)
+    }
+}
+
+private struct TodayCardMetricView: View {
+    let metric: SiteMetric
+    let value: Int?
+
+    @Environment(\.colorScheme) var colorScheme
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Image(systemName: metric.systemImage)
+                .font(.caption.weight(.medium))
+                .foregroundColor(.secondary.opacity(0.8))
+            Text(formattedValue)
+                .contentTransition(.numericText())
+                .font(.system(.headline, design: .rounded, weight: .medium))
+                .tracking(-0.33)
+                .foregroundStyle(Color.primary.opacity(0.9))
+        }
+    }
+
+    private var formattedValue: String {
+        guard let value else { return "–" }
+        return StatsValueFormatter(metric: metric).format(value: value, context: .compact)
+    }
+}
+
+#Preview {
+    ScrollView {
+        VStack(spacing: 20) {
+            TodayCardPreview()
+        }
+        .padding()
+    }
+    .background(Color(.systemGroupedBackground))
+}
+
+private struct TodayCardPreview: View {
+    @StateObject var viewModel = TodayCardViewModel(
+        configuration: TodayCardConfiguration(metrics: [.views, .visitors, .likes, .comments]),
+        dateRange: Calendar.demo.makeDateRange(for: .today),
+        context: .demo
+    )
+
+    var body: some View {
+        TodayCard(viewModel: viewModel)
+            .cardStyle()
+    }
+}

--- a/Modules/Sources/JetpackStats/Cards/TodayCardConfiguration.swift
+++ b/Modules/Sources/JetpackStats/Cards/TodayCardConfiguration.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+struct TodayCardConfiguration: Codable {
+    let id: UUID
+    var metrics: [SiteMetric]
+
+    init(id: UUID = UUID(), metrics: [SiteMetric]) {
+        self.id = id
+        self.metrics = metrics
+    }
+
+    init(supportedMetrics: Set<SiteMetric>) {
+        // We have only so much space
+        let preferredMetrics: [SiteMetric] = [.views, .visitors, .likes, .comments]
+        self.id = UUID()
+        self.metrics = preferredMetrics.filter(supportedMetrics.contains)
+    }
+}

--- a/Modules/Sources/JetpackStats/Cards/TodayCardViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/TodayCardViewModel.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+
+@MainActor
+final class TodayCardViewModel: ObservableObject, TrafficCardViewModel {
+    var id: UUID { configuration.id }
+    let cardType: CardType = .today
+
+    @Published private(set) var configuration: TodayCardConfiguration
+    @Published private(set) var data: TodayCardData?
+    @Published private(set) var isLoading = true
+    @Published private(set) var loadingError: Error?
+    @Published var isEditing = false
+
+    let isEditable = false
+
+    weak var configurationDelegate: CardConfigurationDelegate?
+
+    var dateRange: StatsDateRange {
+        didSet {
+            loadData(for: dateRange.updating(preset: .today))
+        }
+    }
+
+    var isFirstLoad: Bool { isLoading && data == nil }
+
+    private let service: any StatsServiceProtocol
+    let tracker: (any StatsTracker)?
+
+    private var loadingTask: Task<Void, Never>?
+    private var isFirstAppear = true
+
+    init(
+        configuration: TodayCardConfiguration,
+        dateRange: StatsDateRange,
+        context: StatsContext,
+    ) {
+        self.configuration = configuration
+        self.dateRange = dateRange.updating(preset: .today)
+        self.service = context.service
+        self.tracker = context.tracker
+    }
+
+    func updateConfiguration(_ newConfiguration: TodayCardConfiguration) {
+        self.configuration = newConfiguration
+        configurationDelegate?.saveConfiguration(for: self)
+        loadData(for: dateRange)
+    }
+
+    func onAppear() {
+        guard isFirstAppear else { return }
+        isFirstAppear = false
+
+        tracker?.send(.cardShown, properties: [
+            "card_type": CardType.today.rawValue,
+            "configuration": configuration.metrics.map(\.analyticsName).joined(separator: "_")
+        ])
+
+        loadData(for: dateRange)
+    }
+
+    private func loadData(for dateRange: StatsDateRange) {
+        loadingTask?.cancel()
+
+        // Create a new loading task
+        loadingTask = Task { [weak self] in
+            guard let self else { return }
+            await self.actuallyLoadData(dateRange: dateRange)
+        }
+    }
+
+    private func actuallyLoadData(dateRange: StatsDateRange) async {
+        isLoading = true
+        loadingError = nil
+
+        do {
+            let loadedData = try await getSiteStats(dateRange: dateRange)
+
+            try Task.checkCancellation()
+
+            data = loadedData
+        } catch is CancellationError {
+            return
+        } catch {
+            loadingError = error
+            tracker?.trackError(error, screen: "today_card")
+        }
+
+        isLoading = false
+    }
+
+    private func getSiteStats(dateRange: StatsDateRange) async throws -> TodayCardData {
+        let granularity = dateRange.dateInterval.preferredGranularity
+
+        async let currentResponseTask = service.getSiteStats(
+            interval: dateRange.dateInterval,
+            granularity: granularity
+        )
+        async let previousResponseTask = service.getSiteStats(
+            interval: dateRange.effectiveComparisonInterval,
+            granularity: granularity
+        )
+
+        let currentResponse = try await currentResponseTask
+        let previousResponse = try? await previousResponseTask
+
+        // Extract hourly views data and convert to simple tuples
+        let calendar = dateRange.calendar
+        let hourlyViews = (currentResponse.metrics[.views] ?? []).map { dataPoint in
+            (hour: calendar.component(.hour, from: dataPoint.date), value: dataPoint.value)
+        }
+        let previousHourlyViews = previousResponse?.metrics[.views]?.map { dataPoint in
+            (hour: calendar.component(.hour, from: dataPoint.date), value: dataPoint.value)
+        }
+
+        var metricsSet = SiteMetricsSet()
+        for metric in configuration.metrics {
+            metricsSet[metric] = currentResponse.total[metric]
+        }
+
+        return TodayCardData(
+            hourlyViews: hourlyViews,
+            previousHourlyViews: previousHourlyViews,
+            metrics: metricsSet
+        )
+    }
+}
+
+struct TodayCardData {
+    let id = UUID()
+    let hourlyViews: [(hour: Int, value: Int)]
+    let previousHourlyViews: [(hour: Int, value: Int)]?
+    let metrics: SiteMetricsSet
+}

--- a/Modules/Sources/JetpackStats/Cards/TopListCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListCard.swift
@@ -65,7 +65,7 @@ struct TopListCard: View {
         .sheet(isPresented: $viewModel.isEditing) {
             NavigationStack {
                 TopListCardCustomizationView(viewModel: viewModel)
-                    .navigationTitle(Strings.AddChart.selectDataType)
+                    .navigationTitle(Strings.Cards.selectDataType)
                     .navigationBarTitleDisplayMode(.inline)
             }
             .presentationDetents([.medium, .large])

--- a/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
@@ -3,6 +3,7 @@ import SwiftUI
 @MainActor
 final class TopListViewModel: ObservableObject, TrafficCardViewModel {
     var id: UUID { configuration.id }
+    let cardType: CardType = .topList
     let items: [TopListItemType]
     let groupedItems: [[TopListItemType]]
 
@@ -105,7 +106,7 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
 
         // Track card shown event
         tracker?.send(.cardShown, properties: [
-            "card_type": "top_list",
+            "card_type": CardType.topList.rawValue,
             "configuration": "\(selection.item.analyticsName)_\(selection.metric.analyticsName)",
             "item_type": selection.item.analyticsName,
             "metric": selection.metric.analyticsName

--- a/Modules/Sources/JetpackStats/Cards/TrafficCardConfiguration.swift
+++ b/Modules/Sources/JetpackStats/Cards/TrafficCardConfiguration.swift
@@ -1,19 +1,68 @@
 import Foundation
+import SwiftUI
 
 struct TrafficCardConfiguration: Codable {
     var cards: [Card]
 
     enum Card: Codable {
+        case today(TodayCardConfiguration)
         case chart(ChartCardConfiguration)
         case topList(TopListCardConfiguration)
 
         var id: UUID {
             switch self {
-            case .chart(let config):
-                return config.id
-            case .topList(let config):
-                return config.id
+            case .today(let config): config.id
+            case .chart(let config): config.id
+            case .topList(let config): config.id
             }
+        }
+
+        var type: CardType {
+            switch self {
+            case .today: .today
+            case .chart: .chart
+            case .topList: .topList
+            }
+        }
+    }
+}
+
+enum CardType: String, CaseIterable, Identifiable {
+    case chart = "chart"
+    case topList = "top_list"
+    case today = "today"
+
+    var id: CardType { self }
+
+    var systemImage: String {
+        switch self {
+        case .today: "sun.horizon"
+        case .chart: "chart.line.uptrend.xyaxis"
+        case .topList: "list.number"
+        }
+    }
+
+    var localizedTitle: String {
+        switch self {
+        case .chart: Strings.Cards.chart
+        case .topList: Strings.Cards.topList
+        case .today: Strings.Cards.today
+        }
+    }
+
+    var localizedDescription: String {
+        switch self {
+        case .chart: Strings.Cards.chartDescription
+        case .topList: Strings.Cards.topListDescription
+        case .today: Strings.Cards.todayDescription
+        }
+    }
+
+    var tint: Color {
+        switch self {
+        case .chart: Constants.Colors.blue
+        case .topList: Constants.Colors.purple
+        case .today: Constants.Colors.orange
         }
     }
 }

--- a/Modules/Sources/JetpackStats/Screens/StatsMainView.swift
+++ b/Modules/Sources/JetpackStats/Screens/StatsMainView.swift
@@ -41,7 +41,7 @@ public struct StatsMainView: View {
                 }
         } else {
             // When tabs are hidden, show only traffic tab without the tab bar
-            TrafficTabView(viewModel: viewModel, topPadding: Constants.step1)
+            TrafficTabView(viewModel: viewModel, topPadding: Constants.step0_5)
                 .background(Constants.Colors.background)
                 .environment(\.context, context)
                 .environment(\.router, router)

--- a/Modules/Sources/JetpackStats/Screens/TrafficTabView.swift
+++ b/Modules/Sources/JetpackStats/Screens/TrafficTabView.swift
@@ -39,6 +39,12 @@ struct TrafficTabView: View {
             .background(Constants.Colors.background)
             .animation(.spring, value: viewModel.cards.map(\.id))
             .listStyle(.plain)
+            .refreshable {
+                for card in viewModel.cards {
+                    card.dateRange = viewModel.dateRange
+                }
+                try? await Task.sleep(for: .seconds(1))
+            }
         }
         .onGeometryChange(for: Bool.self, of: { proxy in
             proxy.size.width > 680
@@ -94,35 +100,6 @@ struct TrafficTabView: View {
     }
 
     @ViewBuilder
-    private func makeItem(for viewModel: TrafficCardViewModel) -> some View {
-        switch viewModel {
-        case let viewModel as ChartCardViewModel:
-            ChartCard(viewModel: viewModel)
-                .onDateRangeSelected { dateRange in
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                    self.viewModel.pushDateRange(dateRange)
-                }
-                .backButton(title: getBackButtonTitle()) {
-                    UIImpactFeedbackGenerator(style: .light).impactOccurred()
-                    self.viewModel.popDateRange()
-                }
-        case let viewModel as TopListViewModel:
-            TopListCard(viewModel: viewModel)
-        default:
-            let _ = assertionFailure("Unsupported type: \(viewModel)")
-            EmptyView()
-        }
-    }
-
-    private func getBackButtonTitle() -> String? {
-        guard let range = viewModel.dateRangeNavigationStack.last else {
-            return nil
-        }
-        let formatter = StatsDateRangeFormatter(timeZone: context.timeZone)
-        return formatter.string(from: range.dateInterval)
-    }
-
-    @ViewBuilder
     private func cardView(for card: TrafficCardViewModel) -> some View {
         makeItem(for: card)
             .id(card.id)
@@ -130,12 +107,92 @@ struct TrafficTabView: View {
                 insertion: .push(from: .bottom).combined(with: .opacity),
                 removal: .scale.combined(with: .opacity)
             ))
+            .overlay(alignment: .top) {
+                // Display it on top of the first `.chart` card if present
+                if let other = viewModel.cards.prefix(2).first(where: { $0.cardType == .chart }) {
+                    if card.id == other.id {
+                        popButton
+                    }
+                } else if card.id == viewModel.cards.first?.id {
+                    // Or the first available card
+                    popButton
+                }
+            }
+    }
+
+    @ViewBuilder
+    private func makeItem(for viewModel: TrafficCardViewModel) -> some View {
+        switch viewModel {
+        case let viewModel as ChartCardViewModel:
+            ChartCard(viewModel: viewModel)
+                .onDateRangeSelected(pushDateRange)
+        case let viewModel as TopListViewModel:
+            TopListCard(viewModel: viewModel)
+        case let viewModel as TodayCardViewModel:
+            let isToday = self.viewModel.dateRange.preset == .today
+            Button {
+                guard !isToday else { return }
+                context.tracker?.send(.todayCardTapped)
+                pushDateRange(self.viewModel.dateRange.updating(preset: .today))
+            } label: {
+                TodayCard(viewModel: viewModel)
+                    .chevronHidden(isToday)
+            }
+             .buttonStyle(.plain)
+        default:
+            let _ = assertionFailure("Unsupported type: \(viewModel)")
+            EmptyView()
+        }
+    }
+
+    // MARK: - Push/Pop
+
+    private func pushDateRange(_ dateRange: StatsDateRange) {
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        withAnimation(.spring) {
+            self.viewModel.pushDateRange(dateRange)
+        }
+    }
+
+    private func popDateRange() {
+        UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        withAnimation(.spring) {
+            self.viewModel.popDateRange()
+        }
+    }
+
+    @ViewBuilder
+    private var popButton: some View {
+        if let range = viewModel.dateRangeNavigationStack.last {
+            let button = Button {
+                popDateRange()
+            } label: {
+                HStack(spacing: 5) {
+                    Image(systemName: "chevron.backward")
+                    Text(context.formatters.dateRange.string(from: range))
+                }
+                .padding(.vertical, 2)
+                .font(.subheadline.weight(.medium))
+            }
+                .transition(.scale(0.8).combined(with: .opacity).combined(with: .offset(y: 12)))
+                .dynamicTypeSize(...DynamicTypeSize.xLarge)
+            if #available(iOS 26, *) {
+                button
+                    .buttonStyle(.glass)
+                    .padding(.top, -8)
+            } else {
+                button
+                    .buttonStyle(.bordered)
+                    .buttonBorderShape(.capsule)
+                    .foregroundStyle(Color.primary)
+                    .padding(.top, 6)
+            }
+        }
     }
 
     // MARK: - Misc
 
     private var buttonAddChart: some View {
-        // Add Chart Button
         Button(action: {
             isShowingAddCardSheet = true
         }) {
@@ -166,7 +223,6 @@ struct TrafficTabView: View {
             .padding(.horizontal, Constants.step4)
             .padding(.top, Constants.step2)
             .padding(.bottom, Constants.step1)
-            .dynamicTypeSize(...DynamicTypeSize.xLarge)
     }
 }
 

--- a/Modules/Sources/JetpackStats/StatsViewModel.swift
+++ b/Modules/Sources/JetpackStats/StatsViewModel.swift
@@ -9,7 +9,9 @@ final class StatsViewModel: ObservableObject, CardConfigurationDelegate {
     @Published var dateRange: StatsDateRange {
         didSet {
             updateViewModelsDateRange()
-            saveSelectedDateRangePreset()
+            if !isNavigationStackLocked {
+                saveSelectedDateRangePreset()
+            }
             if !dateRange.isAdjacent(to: oldValue) {
                 clearNavigationStack()
             }
@@ -17,6 +19,7 @@ final class StatsViewModel: ObservableObject, CardConfigurationDelegate {
     }
 
     private var isNavigationStackLocked = false
+
     @Published private(set) var cards: [any TrafficCardViewModel] = []
     @Published private(set) var dateRangeNavigationStack: [StatsDateRange] = []
 
@@ -25,68 +28,81 @@ final class StatsViewModel: ObservableObject, CardConfigurationDelegate {
     let context: StatsContext
 
     private let userDefaults: UserDefaults
-    private let configurationKey = "JetpackStatsTrafficConfiguration"
-    private let dateRangePresetKey = "JetpackStatsSelectedDateRangePreset"
+    private static let configurationKey = "JetpackStatsTrafficConfiguration"
+    private static let dateRangePresetKey = "JetpackStatsSelectedDateRangePreset"
+    private static let versionKey = "JetpackStatsVersionKey"
 
     init(context: StatsContext, userDefaults: UserDefaults = .standard) {
         self.context = context
         self.userDefaults = userDefaults
 
-        let preset = Self.loadDateRangePreset(from: userDefaults, key: dateRangePresetKey)
+        Self.performMigrations(userDefaults: userDefaults, context: context)
+
+        let preset = Self.loadDateRangePreset(from: userDefaults) {
         self.dateRange = context.calendar.makeDateRange(for: preset ?? .last7Days)
 
-        self.trafficCardConfiguration = Self.loadConfiguration(
-            from: userDefaults,
-            key: configurationKey,
-            context: context
-        )
+        let configuraiton = Self.getConfiguration(from: userDefaults)
+        self.trafficCardConfiguration = configuraiton ?? Self.makeDefaultConfiguration(context: context)
+
         configureCards()
     }
 
-    func saveConfiguration() {
-        guard let data = try? JSONEncoder().encode(trafficCardConfiguration) else { return }
-        userDefaults.set(data, forKey: configurationKey)
+    private static func performMigrations(userDefaults: UserDefaults, context: StatsContext) {
+        if userDefaults.integer(forKey: Self.versionKey) == 0 {
+            userDefaults.set(1, forKey: Self.versionKey)
+
+            if var configuration = Self.getConfiguration(from: userDefaults) {
+                let metrics = Set(context.service.supportedMetrics)
+                let index = (UIDevice.current.userInterfaceIdiom == .pad && !configuration.cards.isEmpty) ? 1 : 0
+                configuration.cards.insert(.today(.init(supportedMetrics: metrics)), at: index)
+                Self.saveConfiguration(configuration, in: userDefaults)
+            }
+        }
+    }
+
+    private func saveConfiguration() {
+        Self.saveConfiguration(trafficCardConfiguration, in: userDefaults)
     }
 
     func resetToDefault() {
         trafficCardConfiguration = makeDefaultConfiguration()
-        userDefaults.removeObject(forKey: configurationKey)
+        userDefaults.removeObject(forKey: Self.configurationKey)
     }
 
-    private static func loadConfiguration(from userDefaults: UserDefaults, key: String, context: StatsContext) -> TrafficCardConfiguration {
-        guard let data = userDefaults.data(forKey: key),
-              let configuration = try? JSONDecoder().decode(TrafficCardConfiguration.self, from: data) else {
-            return makeDefaultConfiguration(context: context)
-        }
-        return configuration
+    private static func saveConfiguration(_ configuration: TrafficCardConfiguration, in userDefaults: UserDefaults) {
+        guard let data = try? JSONEncoder().encode(configuration) else { return }
+        userDefaults.set(data, forKey: Self.configurationKey)
+    }
+
+    private static func getConfiguration(from userDefaults: UserDefaults) -> TrafficCardConfiguration? {
+        guard let data = userDefaults.data(forKey: Self.configurationKey) else { return nil}
+        return try? JSONDecoder().decode(TrafficCardConfiguration.self, from: data)
     }
 
     private static func makeDefaultConfiguration(context: StatsContext) -> TrafficCardConfiguration {
-        // Get available metrics from service, excluding downloads
         let availableMetrics = context.service.supportedMetrics
 
-        var cards: [TrafficCardConfiguration.Card] = [
-            .chart(ChartCardConfiguration(metrics: availableMetrics))
-        ]
-
-        if UIDevice.current.userInterfaceIdiom == .pad { // Has more space
-            cards += [
-                .topList(TopListCardConfiguration(item: .postsAndPages, metric: .views)),
-                .topList(TopListCardConfiguration(item: .referrers, metric: .views)),
-                .topList(TopListCardConfiguration(item: .searchTerms, metric: .views)),
-                .topList(TopListCardConfiguration(item: .locations, metric: .views)),
-                .topList(TopListCardConfiguration(item: .externalLinks, metric: .views)),
-                .topList(TopListCardConfiguration(item: .authors, metric: .views)),
-            ]
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            // The iPad vesrion has more space, to it's OK to add more advanced cards.
+            return TrafficCardConfiguration(cards: [
+                .chart(.init(metrics: availableMetrics)),
+                .today(.init(supportedMetrics: Set(availableMetrics))),
+                .topList(.init(item: .postsAndPages, metric: .views)),
+                .topList(.init(item: .referrers, metric: .views)),
+                .topList(.init(item: .searchTerms, metric: .views)),
+                .topList(.init(item: .locations, metric: .views)),
+                .topList(.init(item: .externalLinks, metric: .views)),
+                .topList(.init(item: .authors, metric: .views)),
+            ])
         } else {
-            cards += [
-                .topList(TopListCardConfiguration(item: .postsAndPages, metric: .views)),
-                .topList(TopListCardConfiguration(item: .referrers, metric: .views)),
-                .topList(TopListCardConfiguration(item: .locations, metric: .views))
-            ]
+            return TrafficCardConfiguration(cards: [
+                .today(.init(supportedMetrics: Set(availableMetrics))),
+                .chart(.init(metrics: availableMetrics)),
+                .topList(.init(item: .postsAndPages, metric: .views)),
+                .topList(.init(item: .referrers, metric: .views)),
+                .topList(.init(item: .locations, metric: .views))
+            ])
         }
-
-        return TrafficCardConfiguration(cards: cards)
     }
 
     private func makeDefaultConfiguration() -> TrafficCardConfiguration {
@@ -94,15 +110,19 @@ final class StatsViewModel: ObservableObject, CardConfigurationDelegate {
     }
 
     private func configureCards() {
-        cards = trafficCardConfiguration.cards.compactMap { card in
-            createViewModel(for: card)
-        }
+        cards = trafficCardConfiguration.cards.map(createViewModel)
     }
 
-    private func createViewModel(for card: TrafficCardConfiguration.Card) -> TrafficCardViewModel? {
-        let viewModel: TrafficCardViewModel?
+    private func createViewModel(for card: TrafficCardConfiguration.Card) -> TrafficCardViewModel {
+        let viewModel: TrafficCardViewModel
 
         switch card {
+        case .today(let configuration):
+            viewModel = TodayCardViewModel(
+                configuration: configuration,
+                dateRange: dateRange,
+                context: context
+            )
         case .chart(let configuration):
             viewModel = ChartCardViewModel(
                 configuration: configuration,
@@ -119,7 +139,7 @@ final class StatsViewModel: ObservableObject, CardConfigurationDelegate {
             )
         }
 
-        viewModel?.configurationDelegate = self
+        viewModel.configurationDelegate = self
         return viewModel
     }
 
@@ -157,36 +177,41 @@ final class StatsViewModel: ObservableObject, CardConfigurationDelegate {
 
     // MARK: - Adding Cards
 
-    func addCard(type: AddCardType) {
+    func addCard(type: CardType) {
         let card = makeCard(type: type)
         trafficCardConfiguration.cards.append(card)
         saveConfiguration()
 
         // Track card added event
-        context.tracker?.send(.cardAdded, properties: ["card_type": cardType(for: card)])
+        context.tracker?.send(.cardAdded, properties: ["card_type": type.rawValue])
 
         // Create and append the view model
-        if let viewModel = createViewModel(for: card) {
-            cards.append(viewModel)
+        let viewModel = createViewModel(for: card)
+        cards.append(viewModel)
 
-            // Enable editing after a short delay to allow the card to be added and scrolled to
-            Task {
-                try? await Task.sleep(for: .milliseconds(500))
-                scrollToCardSubject.send(viewModel.id)
-                try? await Task.sleep(for: .milliseconds(500))
-                viewModel.isEditing = true
-            }
+        // Enable editing after a short delay to allow the card to be added and scrolled to
+        Task {
+            try? await Task.sleep(for: .milliseconds(500))
+            scrollToCardSubject.send(viewModel.id)
+            try? await Task.sleep(for: .milliseconds(500))
+            viewModel.isEditing = true
         }
     }
 
-    private func makeCard(type: AddCardType) -> TrafficCardConfiguration.Card {
+    private func makeCard(type: CardType) -> TrafficCardConfiguration.Card {
         switch type {
+        case .today:
+            let supported = Set(context.service.supportedMetrics)
+            let metrics = [SiteMetric.views, .visitors, .likes, .comments]
+                .filter(supported.contains)
+            let configuration = TodayCardConfiguration(metrics: metrics)
+            return .today(configuration)
         case .chart:
             let configuration = ChartCardConfiguration(metrics: context.service.supportedMetrics)
-            return TrafficCardConfiguration.Card.chart(configuration)
+            return .chart(configuration)
         case .topList:
             let configuration = TopListCardConfiguration(item: .postsAndPages, metric: .views)
-            return TrafficCardConfiguration.Card.topList(configuration)
+            return .topList(configuration)
         }
     }
 
@@ -211,7 +236,7 @@ final class StatsViewModel: ObservableObject, CardConfigurationDelegate {
 
     func deleteCard(_ card: any TrafficCardViewModel) {
         // Track card removed event
-        context.tracker?.send(.cardRemoved, properties: ["card_type": cardType(for: card)])
+        context.tracker?.send(.cardRemoved, properties: ["card_type": card.cardType.rawValue])
 
         // Find and remove the card from configuration using the protocol's id property
         trafficCardConfiguration.cards.removeAll { $0.id == card.id }
@@ -267,14 +292,14 @@ final class StatsViewModel: ObservableObject, CardConfigurationDelegate {
 
     private func saveSelectedDateRangePreset() {
         if let preset = dateRange.preset {
-            userDefaults.set(preset.rawValue, forKey: dateRangePresetKey)
+            userDefaults.set(preset.rawValue, forKey: Self.dateRangePresetKey)
         } else {
             // Do nothing – remember last used preset-based period
         }
     }
 
-    private static func loadDateRangePreset(from userDefaults: UserDefaults, key: String) -> DateIntervalPreset? {
-        guard let rawValue = userDefaults.string(forKey: key),
+    private static func loadDateRangePreset(from userDefaults: UserDefaults) -> DateIntervalPreset? {
+        guard let rawValue = userDefaults.string(forKey: Self.dateRangePresetKey),
               let preset = DateIntervalPreset(rawValue: rawValue) else {
             return nil
         }
@@ -289,26 +314,9 @@ final class StatsViewModel: ObservableObject, CardConfigurationDelegate {
         resetToDefault()
 
         // Reset date range preset
-        userDefaults.removeObject(forKey: dateRangePresetKey)
+        userDefaults.removeObject(forKey: Self.dateRangePresetKey)
 
         // Reset date range to default
         dateRange = context.calendar.makeDateRange(for: .last7Days)
-    }
-
-    // MARK: - Helper Methods
-
-    private func cardType(for card: TrafficCardConfiguration.Card) -> String {
-        switch card {
-        case .chart: return "chart"
-        case .topList: return "top_list"
-        }
-    }
-
-    private func cardType(for viewModel: any TrafficCardViewModel) -> String {
-        switch viewModel {
-        case is ChartCardViewModel: return "chart"
-        case is TopListViewModel: return "top_list"
-        default: return "unknown"
-        }
     }
 }

--- a/Modules/Sources/JetpackStats/StatsViewModel.swift
+++ b/Modules/Sources/JetpackStats/StatsViewModel.swift
@@ -38,7 +38,7 @@ final class StatsViewModel: ObservableObject, CardConfigurationDelegate {
 
         Self.performMigrations(userDefaults: userDefaults, context: context)
 
-        let preset = Self.loadDateRangePreset(from: userDefaults) {
+        let preset = Self.loadDateRangePreset(from: userDefaults)
         self.dateRange = context.calendar.makeDateRange(for: preset ?? .last7Days)
 
         let configuraiton = Self.getConfiguration(from: userDefaults)

--- a/Modules/Sources/JetpackStats/Strings.swift
+++ b/Modules/Sources/JetpackStats/Strings.swift
@@ -229,13 +229,19 @@ enum Strings {
         static let section = AppLocalizedString("jetpackStats.csv.section", value: "Section", comment: "CSV header for section column")
     }
 
-    enum AddChart {
-        static let chartOption = AppLocalizedString("jetpackStats.addChart.chartOption", value: "Chart", comment: "Chart option title")
+    enum Cards {
+        static let chart = AppLocalizedString("jetpackStats.addChart.chartOption", value: "Chart", comment: "Chart option title")
         static let chartDescription = AppLocalizedString("jetpackStats.addChart.chartDescription", value: "Visualize trends over time", comment: "Chart option description")
-        static let topListOption = AppLocalizedString("jetpackStats.addChart.topListOption", value: "Top List", comment: "Top list option title")
+        static let topList = AppLocalizedString("jetpackStats.addChart.topListOption", value: "Top List", comment: "Top list option title")
         static let topListDescription = AppLocalizedString("jetpackStats.addChart.topListDescription", value: "See your top performing content", comment: "Top list option description")
+        static let today = AppLocalizedString("jetpackStats.addChart.today", value: "Today", comment: "Today chart title")
+        static let todayDescription = AppLocalizedString("jetpackStats.addChart.topListDescription", value: "See today's metrics", comment: "Today option description")
         static let selectMetric = AppLocalizedString("jetpackStats.addChart.selectMetric", value: "Select Metrics", comment: "Title for metric selection")
         static let selectDataType = AppLocalizedString("jetpackStats.addChart.selectDataType", value: "Select Data Type", comment: "Title for data type selection")
+    }
+
+    enum Today {
+        static let title = AppLocalizedString("jetpackStats.todayCard.title", value: "Today", comment: "Today card title")
     }
 
     enum Accessibility {

--- a/Modules/Sources/JetpackStats/Utilities/Formatters/StatsDateRangeFormatter.swift
+++ b/Modules/Sources/JetpackStats/Utilities/Formatters/StatsDateRangeFormatter.swift
@@ -45,6 +45,15 @@ struct StatsDateRangeFormatter {
         dateIntervalFormatter.timeStyle = .none
     }
 
+    /// Returns a preset name or a formatted date interval depending on what's
+    /// optimial for presentation.
+    func string(from dateRange: StatsDateRange) -> String {
+        if let preset = dateRange.preset, !preset.prefersDateIntervalFormatting {
+            return preset.localizedString
+        }
+        return string(from: dateRange.dateInterval)
+    }
+
     func string(from interval: DateInterval, now: Date = Date()) -> String {
         var calendar = Calendar.current
         calendar.timeZone = timeZone

--- a/Modules/Sources/JetpackStats/Utilities/Modifiers/PulseAnimationModifier.swift
+++ b/Modules/Sources/JetpackStats/Utilities/Modifiers/PulseAnimationModifier.swift
@@ -4,31 +4,28 @@ struct PulseAnimationModifier: ViewModifier {
     let isEnabled: Bool
 
     func body(content: Content) -> some View {
-        if isEnabled {
-            content
-                .mask {
-                    PulsingMask()
+        content
+            .overlay {
+                if isEnabled {
+                    PulsingOverlay()
+                        .padding(-8) // Temporary workaround to cover charts properly
                 }
-        } else {
-            content
-        }
+            }
     }
 }
 
-private struct PulsingMask: View {
-    @State private var opacity: Double = 0.5
+private struct PulsingOverlay: View {
+    @State private var opacity: Double = 0.1
 
     var body: some View {
         Constants.Colors.secondaryBackground
             .opacity(opacity)
             .onAppear {
-                withAnimation(
-                    .easeInOut(duration: 1.5)
-                    .repeatForever(autoreverses: true)
-                ) {
-                    opacity = 0.9
+                withAnimation(.easeInOut(duration: 1.5) .repeatForever(autoreverses: true)) {
+                    opacity = 0.6
                 }
             }
+            .allowsHitTesting(false)
     }
 }
 

--- a/Modules/Sources/JetpackStats/Utilities/StatsDateRange.swift
+++ b/Modules/Sources/JetpackStats/Utilities/StatsDateRange.swift
@@ -44,6 +44,12 @@ struct StatsDateRange: Equatable, Sendable {
         refreshEffectiveComparisonPeriodInterval()
     }
 
+    func updating(preset: DateIntervalPreset) -> StatsDateRange {
+        var copy = self
+        copy.update(preset: preset)
+        return copy
+    }
+
     mutating func update(comparisonPeriod: DateRangeComparisonPeriod) {
         self.comparison = comparisonPeriod
         refreshEffectiveComparisonPeriodInterval()

--- a/Modules/Sources/JetpackStats/Views/Customization/AddCardSheet.swift
+++ b/Modules/Sources/JetpackStats/Views/Customization/AddCardSheet.swift
@@ -1,75 +1,48 @@
 import SwiftUI
 
-enum AddCardType {
-    case chart
-    case topList
-}
-
 struct AddCardSheet: View {
-    let onCardTypeSelected: (AddCardType) -> Void
+    let onCardTypeSelected: (CardType) -> Void
     @Environment(\.dismiss) private var dismiss
 
     var body: some View {
-        VStack(spacing: Constants.step1) {
-            cardTypeSelection
-        }
-
-    }
-
-    private var cardTypeSelection: some View {
         VStack(spacing: Constants.step0_5) {
-            cardTypeButton(
-                title: Strings.AddChart.chartOption,
-                subtitle: Strings.AddChart.chartDescription,
-                icon: "chart.line.uptrend.xyaxis",
-                color: Constants.Colors.blue,
-                action: {
-                    onCardTypeSelected(.chart)
+            ForEach(CardType.allCases) { card in
+                Button {
+                    onCardTypeSelected(card)
                     dismiss()
+                } label: {
+                    makeLabel(for: card)
                 }
-            )
-
-            cardTypeButton(
-                title: Strings.AddChart.topListOption,
-                subtitle: Strings.AddChart.topListDescription,
-                icon: "list.number",
-                color: Constants.Colors.purple,
-                action: {
-                    onCardTypeSelected(.topList)
-                    dismiss()
-                }
-            )
+            }
         }
         .padding(Constants.step1)
     }
 
-    private func cardTypeButton(title: String, subtitle: String, icon: String, color: Color, action: @escaping () -> Void) -> some View {
-        Button(action: action) {
-            HStack(spacing: Constants.step1) {
-                ZStack {
-                    RoundedRectangle(cornerRadius: 10)
-                        .fill(color.opacity(0.1))
-                        .frame(width: 40, height: 40)
+    private func makeLabel(for card: CardType) -> some View {
+        HStack(spacing: Constants.step1) {
+            ZStack {
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(card.tint.opacity(0.1))
+                    .frame(width: 40, height: 40)
 
-                    Image(systemName: icon)
-                        .font(.body)
-                        .foregroundColor(color)
-                }
-
-                VStack(alignment: .leading, spacing: 1) {
-                    Text(title)
-                        .font(.callout.weight(.semibold))
-                        .foregroundColor(.primary)
-                    Text(subtitle)
-                        .font(.caption2)
-                        .foregroundColor(.secondary)
-                }
-
-                Spacer()
+                Image(systemName: card.systemImage)
+                    .font(.body)
+                    .foregroundColor(card.tint)
             }
-            .padding(.horizontal, Constants.step1)
-            .padding(.vertical, Constants.step0_5)
-            .clipShape(RoundedRectangle(cornerRadius: 10))
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(card.localizedTitle)
+                    .font(.callout.weight(.semibold))
+                    .foregroundColor(.primary)
+                Text(card.localizedDescription)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer()
         }
+        .padding(.horizontal, Constants.step1)
+        .padding(.vertical, Constants.step0_5)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
     }
 }

--- a/Modules/Sources/JetpackStats/Views/EditCardMenuContent.swift
+++ b/Modules/Sources/JetpackStats/Views/EditCardMenuContent.swift
@@ -44,10 +44,12 @@ struct EditCardMenuContent: View {
         } label: {
             Label(Strings.Buttons.moveCard, systemImage: "arrow.up.arrow.down")
         }
-        Button {
-            cardViewModel.isEditing = true
-        } label: {
-            Label(Strings.Buttons.customize, systemImage: "widget.small")
+        if cardViewModel.isEditable {
+            Button {
+                cardViewModel.isEditing = true
+            } label: {
+                Label(Strings.Buttons.customize, systemImage: "widget.small")
+            }
         }
         Button(role: .destructive) {
             cardViewModel.configurationDelegate?.deleteCard(cardViewModel)

--- a/Modules/Sources/JetpackStats/Views/LegacyFloatingDateControl.swift
+++ b/Modules/Sources/JetpackStats/Views/LegacyFloatingDateControl.swift
@@ -78,11 +78,7 @@ struct LegacyFloatingDateControl: View {
     }
 
     private var currentRangeText: String {
-        if let preset = dateRange.preset, !preset.prefersDateIntervalFormatting {
-            return preset.localizedString
-        }
-        return context.formatters.dateRange
-            .string(from: dateRange.dateInterval)
+        context.formatters.dateRange.string(from: dateRange)
     }
 
     // MARK: - Navigation Controls

--- a/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
+++ b/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
@@ -17,7 +17,6 @@ struct MetricsOverviewTabView: View {
     var onMetricSelected: ((SiteMetric) -> Void)?
 
     @ScaledMetric(relativeTo: .title) private var minTabWidth: CGFloat = 100
-    @Environment(\.horizontalSizeClass) var horizontalSizeClass
 
     var body: some View {
         ScrollViewReader { proxy in
@@ -37,7 +36,7 @@ struct MetricsOverviewTabView: View {
 
     private func makeItemView(for item: MetricData, onTap: @escaping () -> Void) -> some View {
         MetricItemView(data: item, isSelected: selectedMetric == item.metric, onTap: onTap)
-            .frame(minWidth: minTabWidth + (horizontalSizeClass == .compact ? 0 : 20))
+            .frame(minWidth: minTabWidth)
             .id(item.metric)
     }
 
@@ -77,8 +76,8 @@ private struct MetricItemView: View {
                     .padding(.leading, Constants.step2)
                     .padding(.trailing, Constants.step1)
                 tabContent
-                    .padding(.top, Constants.step1 + 3)
-                    .padding(.bottom, Constants.step2 + 2)
+                    .padding(.top, Constants.step1 + 1)
+                    .padding(.bottom, Constants.step2)
                     .padding(.leading, Constants.step3)
                     .animation(.spring, value: isSelected)
             }

--- a/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
+++ b/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
@@ -88,7 +88,7 @@ private struct MetricItemView: View {
     // MARK: - Private Views
 
     private var tabContent: some View {
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: -2) {
             headerView
                 .unredacted()
             metricsView

--- a/Modules/Sources/JetpackStats/Views/TimezoneInfoView.swift
+++ b/Modules/Sources/JetpackStats/Views/TimezoneInfoView.swift
@@ -23,6 +23,7 @@ struct TimezoneInfoView: View {
         .popover(isPresented: $showingTimezoneInfo) {
             timezoneInfoContent
         }
+        .dynamicTypeSize(...DynamicTypeSize.xLarge)
     }
 
     private var formattedTimeZone: String {

--- a/Modules/Sources/WordPressUI/Views/AdaptiveTabBar.swift
+++ b/Modules/Sources/WordPressUI/Views/AdaptiveTabBar.swift
@@ -58,7 +58,7 @@ public class AdaptiveTabBar: UIControl {
     private var indicatorCenterXConstraint: NSLayoutConstraint?
     private var previousWidth: CGFloat?
 
-    public let tabBarHeight: CGFloat = 44
+    public let tabBarHeight: CGFloat = 40
 
     // MARK: - Initialization
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,9 @@
 -----
 * [*] Fix a few minor visual issues on iOS 26 [#24863], [#24863], [#24901], [#24865], [#24866], [#24867], [#24890], [#24899]
 * [*] Fix an issue with "Homepage" not shown in Top List in New Stats [#24902]
+* [*] Fix a few minor visual issues on iOS 26 [#24863], [#24863], [#24901], [#24865], [#24866], [#24867], [#24890]
+* [**] [New Stats] Add "Today" card [#24898]
+* [*] Fix a few minor visual issues on iOS 26 [#24863], [#24863], [#24865], [#24866], [#24867], [#24890]
 * [*] [Intelligence] Add support for generating excerpts for posts [#24852]
 * [*] [Intelligence] Add auto-suggested tags for posts [#24886]
 * [*] [Intelligence] Add "Summarize Post" features in Reader [#24892]
@@ -14,6 +17,7 @@
 * [*] Improve performance and animations when showing a full Top List with a large number of items [#24868]
 * [*] Fix an issue with New Stats resetting the preferred preset after selecting a custom range [#24899]
 * [*] Show the Top 10 and 50 items in the Top List screen in a dedicated section [#24868]
+* [*] Add pull-to-refresh to the new Traffic tab [#24898]
 
 26.3.1
 ------

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,13 +1,11 @@
 26.4
 -----
+* [**] [New Stats] Add "Today" card [#24898]
+* [**] [Intelligence] Add support for generating excerpts for posts [#24852]
+* [**] [Intelligence] Add auto-suggested tags for posts [#24886]
+* [**] [Intelligence] Add "Summarize Post" features in Reader [#24892]
 * [*] Fix a few minor visual issues on iOS 26 [#24863], [#24863], [#24901], [#24865], [#24866], [#24867], [#24890], [#24899]
 * [*] Fix an issue with "Homepage" not shown in Top List in New Stats [#24902]
-* [*] Fix a few minor visual issues on iOS 26 [#24863], [#24863], [#24901], [#24865], [#24866], [#24867], [#24890]
-* [**] [New Stats] Add "Today" card [#24898]
-* [*] Fix a few minor visual issues on iOS 26 [#24863], [#24863], [#24865], [#24866], [#24867], [#24890]
-* [*] [Intelligence] Add support for generating excerpts for posts [#24852]
-* [*] [Intelligence] Add auto-suggested tags for posts [#24886]
-* [*] [Intelligence] Add "Summarize Post" features in Reader [#24892]
 * [*] Fix an issue with themes in Reader [#24881]
 * [*] Fix an issue with Reader article rendering when iOS "Display Zoom" is enabled [#24895]
 * [*] Fix an issue with "Add Media" button not visible in "Media" under some scenarios [#24900]

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent+JetpackStats.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent+JetpackStats.swift
@@ -22,6 +22,7 @@ extension StatsEvent {
         case .chartTypeChanged: .jetpackStatsChartTypeChanged
         case .chartMetricSelected: .jetpackStatsChartMetricSelected
         case .chartBarSelected: .jetpackStatsChartBarSelected
+        case .todayCardTapped: .jetpackStatsTodayCardTapped
         case .topListItemTapped: .jetpackStatsTopListItemTapped
         case .statsTabSelected: .jetpackStatsTabSelected
         case .errorEncountered: .jetpackStatsErrorEncountered

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -649,6 +649,9 @@ import WordPressShared
     case jetpackStatsChartMetricSelected
     case jetpackStatsChartBarSelected
 
+    // Today
+    case jetpackStatsTodayCardTapped
+
     // List Events
     case jetpackStatsTopListItemTapped
 
@@ -1787,6 +1790,10 @@ import WordPressShared
             return "jetpack_stats_chart_metric_selected"
         case .jetpackStatsChartBarSelected:
             return "jetpack_stats_chart_bar_selected"
+
+        // Today
+        case .jetpackStatsTodayCardTapped:
+            return "jetpack_stats_today_card_tapped"
 
         // List Events
         case .jetpackStatsTopListItemTapped:


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-789/ios-difficulty-accessing-daily-stats-hourly-breakdown-with-new-layout

## Changes

- Add a new "Today" card to the top of the new "Traffic" tab. You can tap it to view the today's stats. The card is displayed at the top, following natural reading patterns. It helps that this request is usually the fast.
- Add pull-to-refresh support.

## Screenshots

<img width="360"  alt="today-card" src="https://github.com/user-attachments/assets/83d551bf-685e-4260-b5c6-047162ad6eef" />

On iPad, I decided to put at on the second place.

<img width="1043" height="1137" alt="Screenshot 2025-09-29 at 7 03 59 AM" src="https://github.com/user-attachments/assets/bd1569c2-d93c-4a3f-b249-e54b3a32e559" />

## Recording

https://github.com/user-attachments/assets/23323e44-7c35-4ff3-98ce-92b709e9ad08

