### PR TITLE
iOS 26: Update toolbar items in web views

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 26.4
 -----
-* [*] Fix a few minor visual issues on iOS 26 [#24863], [#24863], [#24865], [#24866], [#24867], [#24890]
+* [*] Fix a few minor visual issues on iOS 26 [#24863], [#24863], [#24901], [#24865], [#24866], [#24867], [#24890]
 * [*] [Intelligence] Add support for generating excerpts for posts [#24852]
 * [*] Fix an issue with themes in Reader [#24881]
 * [*] Fix an issue with Reader article rendering when iOS "Display Zoom" is enabled [#24895]

--- a/WordPress/Classes/Utility/WebViewController/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebViewController/WebKitViewController.swift
@@ -316,18 +316,28 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
     func configureToolbarButtons() {
 
         let space = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
-
-        let items = [
-            backButton,
-            space,
-            forwardButton,
-            space,
-            shareButton,
-            space,
-            safariButton
-        ]
-        for item in items {
-            item.tintColor = UIAppColor.tint
+        let items: [UIBarButtonItem]
+        if #available(iOS 26, *) {
+            items = [
+                backButton,
+                forwardButton,
+                space,
+                shareButton,
+                safariButton
+            ]
+        } else {
+            items = [
+                backButton,
+                space,
+                forwardButton,
+                space,
+                shareButton,
+                space,
+                safariButton
+            ]
+            for item in items {
+                item.tintColor = UIAppColor.tint
+            }
         }
         setToolbarItems(items, animated: false)
     }

--- a/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Preview/PreviewWebKitViewController.swift
@@ -122,19 +122,23 @@ class PreviewWebKitViewController: WebKitViewController {
     func toolbarItems(linkBehavior: LinkBehavior) -> [UIBarButtonItem] {
         let space = UIBarButtonItem(barButtonSystemItem: .flexibleSpace, target: nil, action: nil)
 
-        let items: [UIBarButtonItem]
+        var adaptiveSpace: UIBarButtonItem? {
+            if #available(iOS 26, *) { nil } else { space }
+        }
+
+        let items: [UIBarButtonItem?]
 
         switch linkBehavior {
         case .all:
             items = [
                 backButton,
-                space,
+                adaptiveSpace,
                 forwardButton,
                 space,
                 shareButton,
-                space,
+                adaptiveSpace,
                 safariButton,
-                space,
+                adaptiveSpace,
                 previewButton
             ]
         case .withBaseURLOnly:
@@ -143,7 +147,7 @@ class PreviewWebKitViewController: WebKitViewController {
             if canPublish {
                 items = [
                     backButton,
-                    space,
+                    adaptiveSpace,
                     forwardButton,
                     space,
                     previewButton
@@ -151,13 +155,13 @@ class PreviewWebKitViewController: WebKitViewController {
             } else {
                 items = [
                     backButton,
-                    space,
+                    adaptiveSpace,
                     forwardButton,
                     space,
                     shareButton,
-                    space,
+                    adaptiveSpace,
                     safariButton,
-                    space,
+                    adaptiveSpace,
                     previewButton
                 ]
             }
@@ -165,11 +169,11 @@ class PreviewWebKitViewController: WebKitViewController {
             if canPublish {
                 items = [space, previewButton]
             } else {
-                items = [shareButton, space, safariButton, space, previewButton]
+                items = [shareButton, adaptiveSpace, safariButton, space, previewButton]
             }
         }
 
-        return items
+        return items.compactMap { $0 }
     }
 
     // MARK: Button Actions


### PR DESCRIPTION
This change ensures the buttons are grouped together on iOS 26.

Before / After

<img width="340"  alt="Screenshot 2025-09-29 at 2 34 23 PM" src="https://github.com/user-attachments/assets/2ee1d378-a8c1-45e9-96d9-16afb4439436" />
<img width="340" alt="Screenshot 2025-09-29 at 2 37 17 PM" src="https://github.com/user-attachments/assets/552211ba-8cff-4576-bf76-37d2e9f51b0b" />
