### PR TITLE
Fix rare crash in Stats / Subscribers

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * [*] Fix an issue with Reader article rendering when iOS "Display Zoom" is enabled [#24895]
 * [*] Fix an issue with "Add Media" button not visible in "Media" under some scenarios [#24900]
 * [*] Fix performance issues with search in Reader Subscriptions [#24841]
+* [*] Fix rare crash in Stats / Subscribers [#24907]
 * [*] Improve performance and animations when showing a full Top List with a large number of items [#24868]
 * [*] Show the Top 10 and 50 items in the Top List screen in a dedicated section [#24868]
 

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/Stats Detail/SiteStatsDetailsViewModel.swift
@@ -876,11 +876,14 @@ private extension SiteStatsDetailsViewModel {
         let emailsSummaryPosts = subscribersStore.emailsSummary.value.data?.posts ?? []
 
         return emailsSummaryPosts.map {
-            StatsTotalRowData(name: $0.title,
-                              data: $0.opens.abbreviatedString(),
-                              secondData: $0.clicks.abbreviatedString(),
-                              multiline: false,
-                              statSection: .subscribersEmailsSummary)
+            StatsTotalRowData(
+                id: UUID(),
+                name: $0.title,
+                data: $0.opens.abbreviatedString(),
+                secondData: $0.clicks.abbreviatedString(),
+                multiline: false,
+                statSection: .subscribersEmailsSummary
+            )
         }
     }
 


### PR DESCRIPTION
Fixes https://a8c.sentry.io/issues/5504466344/events/81395481ca8342b198e94b6bbe32e9d0/.

**RCA:** evidently, sometimes the backend returns multiple "email" entries with the same data. This PR disables incremental reloads by assigning each item a unique ID. So, table view will just reload all rows when new data arrives – no harm done.