### PR TITLE
Fix CMM-810: stats layout not adapting for resizing windows

### DIFF
--- a/Modules/Sources/JetpackStats/Screens/TrafficTabView.swift
+++ b/Modules/Sources/JetpackStats/Screens/TrafficTabView.swift
@@ -5,6 +5,7 @@ struct TrafficTabView: View {
 
     @State private var isShowingCustomRangePicker = false
     @State private var isShowingAddCardSheet = false
+    @State private var isShowingColumns = false
 
     @Environment(\.context) var context
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
@@ -39,6 +40,11 @@ struct TrafficTabView: View {
             .animation(.spring, value: viewModel.cards.map(\.id))
             .listStyle(.plain)
         }
+        .onGeometryChange(for: Bool.self, of: { proxy in
+            proxy.size.width > 680
+        }, action: {
+            isShowingColumns = $0
+        })
         .toolbar {
             if horizontalSizeClass == .regular {
                 ToolbarItemGroup(placement: .navigationBarTrailing) {
@@ -58,7 +64,7 @@ struct TrafficTabView: View {
 
     @ViewBuilder
     private var cards: some View {
-        if horizontalSizeClass == .regular {
+        if isShowingColumns {
             var cards = viewModel.cards
             if let first = cards.first as? ChartCardViewModel {
                 let _ = cards.removeFirst()

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,7 @@
 * [*] Fix an issue with Reader article rendering when iOS "Display Zoom" is enabled [#24895]
 * [*] Fix an issue with "Add Media" button not visible in "Media" under some scenarios [#24900]
 * [*] Fix performance issues with search in Reader Subscriptions [#24841]
+* [*] Fix New Ststs layout not adapting for resizing windows [#24908]
 * [*] Improve performance and animations when showing a full Top List with a large number of items [#24868]
 * [*] Show the Top 10 and 50 items in the Top List screen in a dedicated section [#24868]
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-810/the-layout-in-new-stats-doesnt-adapt-to-screen-size


https://github.com/user-attachments/assets/04eb7d78-33b9-4f2d-aa99-fa618bea8e39

