### PR TITLE
Remove the "Remove unused items" action

### DIFF
--- a/WordPress/Classes/Services/MediaServiceRemoteCoreREST.swift
+++ b/WordPress/Classes/Services/MediaServiceRemoteCoreREST.swift
@@ -13,14 +13,6 @@ class MediaServiceRemoteCoreREST: NSObject, MediaServiceRemote {
         self.client = client
     }
 
-    func unattachedMediaItemCount() async throws -> Int? {
-        try await client.api.media
-            .listWithViewContext(params: .init(parent: [0]))
-            .headerMap
-            .wpTotal()
-            .flatMap(Int.init)
-    }
-
     func getMediaWithID(_ mediaID: NSNumber, success: ((RemoteMedia?) -> Void)?, failure: (((any Error)?) -> Void)?) {
         Task { @MainActor in
             do {


### PR DESCRIPTION
## Description

I misunderstood the meaning of "unattached" media items. There is no way to detect unused media items. We can't provide the "Remove unused items" action.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
