### PR TITLE
feat: Disable header navigation when GutenbergKit opens dialogs

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f2f962bfcc2fe1a8aa488a8ff1b6e9f473241efe8f14317b383021f42551316d",
+  "originHash" : "c33cba27b92a7c9ad551b1485c7e3cdd56cdd5ec529e0f8f1e12fef742736199",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,7 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "0675c3b995fa3e3260862d854e06195d9f35d093"
+        "revision" : "06a322f5fe222c4991abca407b7392f76bcff9d8",
+        "version" : "0.9.0"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "f2f962bfcc2fe1a8aa488a8ff1b6e9f473241efe8f14317b383021f42551316d",
+  "originHash" : "d3bc89b16cb8e29c83845b61b4bcff3961b043b6510981ea0cf91d56df2e5f31",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "0675c3b995fa3e3260862d854e06195d9f35d093"
+        "revision" : "bd8f3c08d493ee2fcee53bb9efeb7f4cf5e2bf17"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "823f3eea52d91ecdcb8cdca12da87bee25dddd86ecab2995397fc7989d2a92e3",
+  "originHash" : "f2f962bfcc2fe1a8aa488a8ff1b6e9f473241efe8f14317b383021f42551316d",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,8 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "c0960ce1297c16dc386abb9bb3335b8a29833e4a",
-        "version" : "0.8.1"
+        "revision" : "0675c3b995fa3e3260862d854e06195d9f35d093"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d3bc89b16cb8e29c83845b61b4bcff3961b043b6510981ea0cf91d56df2e5f31",
+  "originHash" : "f2f962bfcc2fe1a8aa488a8ff1b6e9f473241efe8f14317b383021f42551316d",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "bd8f3c08d493ee2fcee53bb9efeb7f4cf5e2bf17"
+        "revision" : "0675c3b995fa3e3260862d854e06195d9f35d093"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250926"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.8.1-alpha.2"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "0675c3b995fa3e3260862d854e06195d9f35d093"),
         .package(
             url: "https://github.com/Automattic/color-studio",
             revision: "bf141adc75e2769eb469a3e095bdc93dc30be8de"

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250926"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "0675c3b995fa3e3260862d854e06195d9f35d093"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.9.0"),
         .package(
             url: "https://github.com/Automattic/color-studio",
             revision: "bf141adc75e2769eb469a3e095bdc93dc30be8de"

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250926"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "bd8f3c08d493ee2fcee53bb9efeb7f4cf5e2bf17"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "0675c3b995fa3e3260862d854e06195d9f35d093"),
         .package(
             url: "https://github.com/Automattic/color-studio",
             revision: "bf141adc75e2769eb469a3e095bdc93dc30be8de"

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20250926"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "0675c3b995fa3e3260862d854e06195d9f35d093"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "bd8f3c08d493ee2fcee53bb9efeb7f4cf5e2bf17"),
         .package(
             url: "https://github.com/Automattic/color-studio",
             revision: "bf141adc75e2769eb469a3e095bdc93dc30be8de"

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/Editor/CommentGutenbergEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/Editor/CommentGutenbergEditorViewController.swift
@@ -96,4 +96,12 @@ extension CommentGutenbergEditorViewController: GutenbergKit.EditorViewControlle
     func editor(_ viewController: GutenbergKit.EditorViewController, didTriggerAutocompleter type: String) {
         // Do nothing
     }
+
+    func editor(_ viewController: GutenbergKit.EditorViewController, didOpenModalDialog dialogType: String) {
+        // Do nothing
+    }
+
+    func editor(_ viewController: GutenbergKit.EditorViewController, didCloseModalDialog dialogType: String) {
+        // Do nothing
+    }
 }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -111,6 +111,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     private var editorViewController: GutenbergKit.EditorViewController
     private var activityIndicator: UIActivityIndicatorView?
     private var hasEditorStarted = false
+    private var isModalDialogOpen = false
 
     lazy var autosaver = Autosaver() {
         self.performAutoSave()
@@ -496,6 +497,14 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
             }
         }
     }
+
+    private func setNavigationItemsEnabled(_ enabled: Bool) {
+        navigationBarManager.closeButton.isEnabled = enabled
+        navigationBarManager.moreButton.isEnabled = enabled
+        navigationBarManager.publishButton.isEnabled = enabled
+        navigationBarManager.undoButton.isEnabled = enabled
+        navigationBarManager.redoButton.isEnabled = enabled
+    }
 }
 
 extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate {
@@ -606,6 +615,16 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
         default:
             DDLogError("Unknown autocompleter type: \(type)")
         }
+    }
+
+    func editor(_ viewController: GutenbergKit.EditorViewController, didOpenModalDialog dialogType: String) {
+        isModalDialogOpen = true
+        setNavigationItemsEnabled(false)
+    }
+
+    func editor(_ viewController: GutenbergKit.EditorViewController, didCloseModalDialog dialogType: String) {
+        isModalDialogOpen = false
+        setNavigationItemsEnabled(true)
     }
 
     private func convertMediaInfoArrayToJSONString(_ mediaInfoArray: [MediaInfo]) -> String? {


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Close CMM-823. Integrates https://github.com/wordpress-mobile/GutenbergKit/pull/186. 

Disabling the native header navigation respects GutenbergKit's web-based
modal dialogs, where focus should remain on the dialog to mitigate
confusion from surrounding UI elements.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
1. Open the experimental editor.
1. Type some text. 
1. Open the block inserter.
1. Verify all native header navigation UI is disabled.
1. Close the block inserter.
1. Verify all native header navigation UI is enabled.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
