### PR TITLE
Enable "New Stats" for fresh installs

### DIFF
--- a/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift
+++ b/WordPress/Classes/Stores/RemoteFeatureFlagStore.swift
@@ -27,6 +27,12 @@ class RemoteFeatureFlagStore {
         return deviceID
     }
 
+    /// Returns `true` if the store hasn't been updated yet. It uses the
+    /// presence of `deviceID` as an indicator of the previous install.
+    public var isFreshInstall: Bool {
+        persistenceStore.string(forKey: Constants.DeviceIdKey) == nil
+    }
+
     init(persistenceStore: UserPersistentRepository = UserDefaults.standard) {
         self.persistenceStore = persistenceStore
     }

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -533,6 +533,11 @@ extension WordPressAppDelegate {
             FeatureFlagOverrideStore().override(RemoteFeatureFlag.dotComWebLogin, withValue: true)
         }
 
+        /// - warning: must be called before the `update(using:then:)`.
+        if remoteFeatureFlagStore.isFreshInstall {
+            FeatureFlagOverrideStore().override(FeatureFlag.newStats, withValue: true)
+        }
+
         var api: WordPressComRestApi
         if let authToken {
             api = WordPressComRestApi.defaultV2Api(authToken: authToken)


### PR DESCRIPTION
The upcoming posts highlights "New Stats" as the primary new recent feature. There is going to be some influx of new installs. We want them to see the "New Stats" experience by default (still is opt-out).