### PR TITLE
Fix Reader insets on iOS 26

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -468,13 +468,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     /// Apply view styles
     @MainActor private func applyStyles() {
-        guard let readableGuide = webView.superview?.readableContentGuide else {
-            return
-        }
-
         NSLayoutConstraint.activate([
-            webView.rightAnchor.constraint(equalTo: readableGuide.rightAnchor, constant: -Constants.margin),
-            webView.leftAnchor.constraint(equalTo: readableGuide.leftAnchor, constant: Constants.margin)
+            webView.rightAnchor.constraint(equalTo: view.readableContentGuide.rightAnchor, constant: -Constants.margin),
+            webView.leftAnchor.constraint(equalTo: view.readableContentGuide.leftAnchor, constant: Constants.margin)
         ])
 
         webView.translatesAutoresizingMaskIntoConstraints = false


### PR DESCRIPTION
I reverted too much in https://github.com/wordpress-mobile/WordPress-iOS/pull/24895. 
Pinning to `webView.superview?.readableContentGuide` (`scrollView`) is incorrect. It needs to pin to the `view`.

| Before  | After |
| ------------- | ------------- |
|  <img  alt="iPad Pro 11-inch (M4)-3-light-Reader" src="https://github.com/user-attachments/assets/979699f6-26aa-4e58-af37-ac8595093e73" /> |  <img  alt="Simulator Screenshot - iPad Pro 11-inch (M4) - 2025-10-06 at 19 45 52" src="https://github.com/user-attachments/assets/6ca91203-bd94-40f8-8516-a9e3570a5bc8" /> |
