### PR TITLE
Enable Intelligence FF for Jetpack

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -85,7 +85,7 @@ public enum FeatureFlag: Int, CaseIterable {
             return false
         case .intelligence:
             let languageCode = Locale.current.languageCode
-            return (languageCode ?? "en").hasPrefix("en")
+            return (languageCode ?? "en").hasPrefix("en") && app == .jetpack
         }
     }
 


### PR DESCRIPTION
Let's start by rolling it out in the Jetpack app so we could take advantage of it in the marketing materials.