### PR TITLE
fix: GutenbergKit allows empty editor settings

### DIFF
--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -51,7 +51,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     }
 
     struct EditorDependencies {
-        let settings: String
+        let settings: String?
         let didLoadCookies: Bool
     }
 
@@ -383,13 +383,13 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     }
 
     @MainActor
-    func startEditor(settings: String) async throws {
+    func startEditor(settings: String?) async throws {
         guard case .dependenciesReady = self.editorState else {
             preconditionFailure("`startEditor` should only be called when the editor is in the `.dependenciesReady` state.")
         }
 
         let updatedConfiguration = self.editorViewController.configuration.toBuilder()
-            .setEditorSettings(settings)
+            .apply(settings) { $0.setEditorSettings($1) }
             .setTitle(post.postTitle ?? "")
             .setContent(post.content ?? "")
             .build()
@@ -469,7 +469,14 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
     // MARK: - Editor Setup
     private func fetchEditorDependencies() async throws -> EditorDependencies {
-        let settings = try await blockEditorSettingsService.getSettingsString(allowingCachedResponse: true)
+        let settings: String?
+        do {
+            settings = try await blockEditorSettingsService.getSettingsString(allowingCachedResponse: true)
+        } catch {
+            DDLogError("Failed to fetch editor settings: \(error)")
+            settings = nil
+        }
+
         let loaded = await loadAuthenticationCookiesAsync()
 
         return EditorDependencies(settings: settings, didLoadCookies: loaded)


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Fix CMM-830.

Sites without GutenbergKit plugin do not have the editor settings REST
API endpoint. For these sites or missing settings due to other reasons,
we should allow the editor to open with empty editor settings.

This approach aligns with the original implementation:

https://github.com/wordpress-mobile/WordPress-iOS/commit/ac3ad4c5aea1bc54b0626b3532963f6fbf4498fe#diff-985e4813fea24c7bfb37425f15af08cda2f4ace0da805b3eecc249862fdca2d5L362-L367

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
1. Add a self-hosted site without the Gutenberg plugin.
1. Open the experimental editor.
1. Verify the editor loads.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
