### PR TITLE
Fix an issue with the notification badge not disappearing

### DIFF
--- a/Tests/KeystoneTests/Tests/Features/Notifications/NotificationsViewControllerTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Notifications/NotificationsViewControllerTests.swift
@@ -1,6 +1,5 @@
 import XCTest
 import WordPressData
-import UserNotifications
 @testable import WordPress
 
 final class NotificationsViewControllerTests: XCTestCase {
@@ -47,7 +46,7 @@ final class NotificationsViewControllerTests: XCTestCase {
     func testResetApplicationBadgeWhenAccountChange() throws {
         // Give
         let newUnreadCount = 1
-        UNUserNotificationCenter.current().setBadgeCount(0)
+        UIApplication.shared.applicationIconBadgeNumber = 0
         ZendeskUtils.unreadNotificationsCount = newUnreadCount
 
         // When

--- a/WordPress/Classes/Utility/Notifications/PushNotificationsManager.swift
+++ b/WordPress/Classes/Utility/Notifications/PushNotificationsManager.swift
@@ -75,7 +75,7 @@ public final class PushNotificationsManager: NSObject {
             sharedApplication.registerForRemoteNotifications()
         }
         sharedApplication.unregisterForRemoteNotifications()
-        UNUserNotificationCenter.current().setBadgeCount(0)
+        sharedApplication.applicationIconBadgeNumber = 0
         didRegisterForRemoteNotifications = false
     }
 
@@ -187,7 +187,7 @@ public final class PushNotificationsManager: NSObject {
 
         // Badge: Update
         if let badgeCountNumber = userInfo.number(forKeyPath: Notification.badgePath)?.intValue {
-            UNUserNotificationCenter.current().setBadgeCount(badgeCountNumber)
+            sharedApplication.applicationIconBadgeNumber = badgeCountNumber
         }
 
         // Badge: Reset

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -307,7 +307,7 @@ class ZendeskUtils: NSObject, ZendeskUtilsProtocol {
     /// - post an NSNotification so the various indicators can be cleared.
     ///
     static func pushNotificationRead() {
-        UNUserNotificationCenter.current().setBadgeCount(UIApplication.shared.applicationIconBadgeNumber - unreadNotificationsCount)
+        UIApplication.shared.applicationIconBadgeNumber -= unreadNotificationsCount
         unreadNotificationsCount = 0
         saveUnreadCount()
         postNotificationRead()

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationsViewController/NotificationsViewController.swift
@@ -8,7 +8,6 @@ import Gridicons
 import UIKit
 import WordPressUI
 import SwiftUI
-import UserNotifications
 
 /// The purpose of this class is to render the collection of Notifications, associated to the main
 /// WordPress.com account.
@@ -1716,7 +1715,7 @@ private extension NotificationsViewController {
     func resetApplicationBadge() {
         // These notifications are cleared, so we just need to take Zendesk unread notifications
         // into account when setting the app icon count.
-        UNUserNotificationCenter.current().setBadgeCount(ZendeskUtils.unreadNotificationsCount)
+        UIApplication.shared.applicationIconBadgeNumber = ZendeskUtils.unreadNotificationsCount
     }
 }
 

--- a/WordPress/Classes/ViewRelated/System/WPTabBarController.m
+++ b/WordPress/Classes/ViewRelated/System/WPTabBarController.m
@@ -356,11 +356,7 @@ static NSInteger const WPTabBarIconOffsetiPhone = 5;
     }
 
     // Discount Zendesk unread notifications when determining if we need to show the notificationsTabBarImageUnread.
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdeprecated-declarations"
     NSInteger count = [[UIApplication sharedApplication] applicationIconBadgeNumber] - ObjCBridge.unreadNotificationsCount;
-#pragma clang diagnostic pop
-
     if (count > 0 || ![self welcomeNotificationSeen]) {
         notificationsTabBarItem.image = self.notificationsTabBarImageUnread;
         notificationsTabBarItem.accessibilityLabel = NSLocalizedString(@"Notifications Unread", @"Notifications tab bar item accessibility label, unread notifications state");


### PR DESCRIPTION
Reverts https://github.com/wordpress-mobile/WordPress-iOS/pull/24877

https://github.com/user-attachments/assets/5aee1dbf-174f-4421-910f-d4515c7d05cf

