### PR TITLE
fix: Prevent GutenbergKit retain cycle

### DIFF
--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -113,8 +113,8 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     private var hasEditorStarted = false
     private var isModalDialogOpen = false
 
-    lazy var autosaver = Autosaver() {
-        self.performAutoSave()
+    lazy var autosaver = Autosaver() { [weak self] in
+        self?.performAutoSave()
     }
 
     // MARK: - Private Properties
@@ -197,6 +197,14 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
     deinit {
         tearDownKeyboardObservers()
+
+        // Cancel any pending tasks
+        editorLoadingTask?.cancel()
+
+        // Clean up child view controller
+        editorViewController.willMove(toParent: nil)
+        editorViewController.view.removeFromSuperview()
+        editorViewController.removeFromParent()
     }
 
     // MARK: - Lifecycle methods

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -250,7 +250,8 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
             preconditionFailure("Dependency loading should not be cancelled")
         }
 
-        self.editorLoadingTask = Task {
+        self.editorLoadingTask = Task { [weak self] in
+            guard let self else { return }
             do {
                 while case .loadingDependencies = self.editorState {
                     try await Task.sleep(nanoseconds: 1000)

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -200,11 +200,6 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
         // Cancel any pending tasks
         editorLoadingTask?.cancel()
-
-        // Clean up child view controller
-        editorViewController.willMove(toParent: nil)
-        editorViewController.view.removeFromSuperview()
-        editorViewController.removeFromParent()
     }
 
     // MARK: - Lifecycle methods


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Close CMM-834. 

It appears the strong `Autosaver` references and, possibly, lack of cleaning up asset loading tasks and view elements led to a retain cycle. The retain cycle prevented proper disposal of WebViews. The memory leak likely leads to performance degradations and crashes.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

### 1. Verify pending changes are persisted via autosave mechanism 
1. Open the GutenbergKit editor for a new or existing post. 
1. Make content changes—required to rigger autosaver. 
1. Attempt saving changes as well as closing the editor with pending changes.
1. Verify new changes are persisted as expected. 

### 2. Verify WebViews are disposed upon editor close
1. Open the GutenbergKit editor. 
1. Insert content—required to rigger autosaver. 
1. Close the editor and discard/save changes.
1. Repeat a few times. 
1. Attempt to inspect the WebView via Safari developer tools. 
1. Verify WebViews are not retained after the editor closes. 

<img width="517" height="336" alt="Screenshot 2025-10-10 at 08 31 09" src="https://github.com/user-attachments/assets/89abb31e-c880-4b0e-b111-6c90ce46116f" />


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
