### PR TITLE
Fix double dismiss in PostSettings

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -13,7 +13,6 @@ extension PostEditor {
         let viewModel = PostSettingsViewModel(post: post)
         viewModel.onEditorPostSaved = { [weak self] in
             self?.didSavePostSettings(originalFeaturedImageID: originalFeaturedImageID)
-            self?.navigationController?.dismiss(animated: true)
         }
         let postSettingsVC = PostSettingsViewController(viewModel: viewModel)
         let navigation = UINavigationController(rootViewController: postSettingsVC)


### PR DESCRIPTION
Fixes a regression introduced in https://github.com/wordpress-mobile/WordPress-iOS/commit/618402c88b3e024cb3cc1d49f7b655c16ca94512 where both `PostSettingsViewModel` and `PostEditor` will calls dismiss when you confirm the changes made in "Post Settings" presented from the editor (`standalone = false`).

In the updated version, only the "Post Settings" screen itself manages its dismiss, so it's easier to understand.

**Steps 1:**

- Open a draft post for editing
- Open More / Post Settings
- Change something
- Tap “Confirm”
- **Verify** that you are returned to the editor

**Steps 2:**

- Open a draft post for editing
- Tap “Publish”
- Change someting in post settings
- Tap “Close”
- Tap “Save Changes”
- **Verify** that the publishing sheet is dismissed