### PR TITLE
Update UI tests

### DIFF
--- a/WordPress/UITests/Tests/StatsTests.swift
+++ b/WordPress/UITests/Tests/StatsTests.swift
@@ -7,7 +7,10 @@ class StatsTests: XCTestCase {
 
     @MainActor
     override func setUpWithError() throws {
-        setUpTestSuite(selectWPComSite: WPUITestCredentials.testWPcomPaidSite)
+        setUpTestSuite(
+            arguments: ["-ff-override-New Stats", "false"],
+            selectWPComSite: WPUITestCredentials.testWPcomPaidSite
+        )
 
         try MySiteScreen()
             .goToMoreMenu()


### PR DESCRIPTION
With "New Stats" enabled for fresh installs in https://github.com/wordpress-mobile/WordPress-iOS/pull/24921, we need to update the UI tests to continue testing the production version of Stats (for now).