### PR TITLE
Add "Email to Subscribers" row to "Publishing" sheet

### DIFF
--- a/Modules/Sources/WordPressKit/RemotePostParameters.swift
+++ b/Modules/Sources/WordPressKit/RemotePostParameters.swift
@@ -233,26 +233,6 @@ struct RemotePostCreateParametersWordPressComEncoder: Encodable {
             try container.encode(parameters.isSticky, forKey: .isSticky)
         }
     }
-
-    // - warning: fixme
-    static func encodeMetadata(_ metadata: Set<RemotePostMetadataItem>) -> [[String: Any]] {
-        metadata.map { item in
-            var operation = "update"
-            if item.key == nil {
-                if item.id != nil && item.value == nil {
-                    operation = "delete"
-                } else if item.id == nil && item.value != nil {
-                    operation = "add"
-                }
-            }
-            var dictionary: [String: Any] = [:]
-            if let id = item.id { dictionary["id"] = id }
-            if let value = item.value { dictionary["value"] = value }
-            if let key = item.key { dictionary["key"] = key }
-            dictionary["operation"] = operation
-            return dictionary
-        }
-    }
 }
 
 struct RemotePostUpdateParametersWordPressComMetadata: Encodable {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 26.5
 -----
 * [*] Add "Access" section to "Post Settings" [#24942]
+* [*] Add "Email to Subscribers" row to "Publishing" sheet [#24946]
 
 26.4
 -----

--- a/Sources/WordPressData/Swift/PostHelper+Metadata.swift
+++ b/Sources/WordPressData/Swift/PostHelper+Metadata.swift
@@ -23,10 +23,14 @@ extension PostHelper {
 
     public static func mapDictionaryToMetadataItems(_ dictionary: [String: Any]) -> RemotePostMetadataItem? {
         let id = dictionary["id"]
+        let value = dictionary["value"]
+        if let value {
+            wpAssert(value is String, "only strings are currently supported by WordPressKit")
+        }
         return RemotePostMetadataItem(
             id: (id as? String) ?? (id as? NSNumber)?.stringValue,
             key: dictionary["key"] as? String,
-            value: dictionary["value"] as? String
+            value: value as? String
         )
     }
 

--- a/Sources/WordPressData/Swift/PostMetadata.swift
+++ b/Sources/WordPressData/Swift/PostMetadata.swift
@@ -177,8 +177,8 @@ public struct PostMetadata {
 // MARK: - PostMetadata (Jetpack)
 
 extension PostMetadata.Key {
-    /// Jetpack Newsletter access level metadata key
     public static let jetpackNewsletterAccess: PostMetadata.Key = "_jetpack_newsletter_access"
+    public static let jetpackNewsletterEmailDisabled: PostMetadata.Key = "_jetpack_dont_email_post_to_subs"
 }
 
 extension PostMetadata {
@@ -193,6 +193,22 @@ extension PostMetadata {
                 setValue(newValue.rawValue, for: .jetpackNewsletterAccess)
             } else {
                 removeValue(for: .jetpackNewsletterAccess)
+            }
+        }
+    }
+
+    /// Returns `true` if the post is configured to _not_ be sent in an email
+    /// to subscribers.
+    public var isJetpackNewsletterEmailDisabled: Bool {
+        get {
+            guard let value = getString(for: .jetpackNewsletterEmailDisabled) else { return false }
+            return (value as NSString).boolValue
+        }
+        set {
+            if newValue {
+                setValue("1", for: .jetpackNewsletterEmailDisabled)
+            } else {
+                removeValue(for: .jetpackNewsletterEmailDisabled)
             }
         }
     }

--- a/Sources/WordPressData/Swift/PostMetadata.swift
+++ b/Sources/WordPressData/Swift/PostMetadata.swift
@@ -28,7 +28,7 @@ public struct PostMetadata: Hashable {
             container.accessLevel = accessLevel
         }
         if previous.isJetpackNewsletterEmailDisabled != isJetpackNewsletterEmailDisabled {
-            container.setValue(isJetpackNewsletterEmailDisabled, for: .jetpackNewsletterEmailDisabled)
+            container.setValue(String(describing: isJetpackNewsletterEmailDisabled), for: .jetpackNewsletterEmailDisabled)
         }
     }
 

--- a/Sources/WordPressData/Swift/PostMetadata.swift
+++ b/Sources/WordPressData/Swift/PostMetadata.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+/// Metadata used by the app.
+public struct PostMetadata: Hashable {
+    /// Gets or sets the Jetpack Newsletter access level as a PostAccessLevel enum
+    public var accessLevel: JetpackPostAccessLevel?
+
+    /// Returns `true` if the post is configured to _not_ be sent in an email
+    /// to subscribers.
+    public var isJetpackNewsletterEmailDisabled: Bool
+
+    public init(from container: PostMetadataContainer) {
+        self.accessLevel = container.accessLevel
+        self.isJetpackNewsletterEmailDisabled = container.getAdaptiveBool(for: .jetpackNewsletterEmailDisabled)
+    }
+
+    /// Applies the metadata values to the container and returns them
+    /// as metadata values.
+    public func encode(in container: inout PostMetadataContainer) {
+        let previous = PostMetadata(from: container)
+        if previous.accessLevel != accessLevel {
+            container.accessLevel = accessLevel
+        }
+        if previous.isJetpackNewsletterEmailDisabled != isJetpackNewsletterEmailDisabled {
+            container.setValue(isJetpackNewsletterEmailDisabled, for: .jetpackNewsletterEmailDisabled)
+        }
+    }
+
+    /// Returns all metadata values encoded in `PostMetadataContainer` as
+    /// WordPress metadata fields.
+    ///
+    /// - note: It returns _only_ the fields managed by the app so that we
+    /// don't send more than needed to the server when updating it.
+    public static func entries(in container: PostMetadataContainer) -> [[String: Any]] {
+        PostMetadata.allKeys.compactMap(container.entry)
+    }
+
+    /// Returns all keys managed by the app.
+    public static let allKeys: [PostMetadataContainer.Key] = [
+        .jetpackNewsletterAccess,
+        .jetpackNewsletterEmailDisabled
+    ]
+}
+
+/// Valid access levels for Jetpack Newsletter
+public enum JetpackPostAccessLevel: String, CaseIterable, Hashable, Codable {
+    case everybody = "everybody"
+    case subscribers = "subscribers"
+    case paidSubscribers = "paid_subscribers"
+}
+
+private extension PostMetadataContainer {
+    var accessLevel: JetpackPostAccessLevel? {
+        get {
+            guard let value = getString(for: .jetpackNewsletterAccess) else { return nil }
+            return JetpackPostAccessLevel(rawValue: value)
+        }
+        set {
+            if let newValue {
+                setValue(newValue.rawValue, for: .jetpackNewsletterAccess)
+            } else {
+                removeValue(for: .jetpackNewsletterAccess)
+            }
+        }
+    }
+}
+
+extension PostMetadataContainer.Key {
+    static let jetpackNewsletterAccess: PostMetadataContainer.Key = "_jetpack_newsletter_access"
+    static let jetpackNewsletterEmailDisabled: PostMetadataContainer.Key = "_jetpack_dont_email_post_to_subs"
+}

--- a/Sources/WordPressData/Swift/PostMetadata.swift
+++ b/Sources/WordPressData/Swift/PostMetadata.swift
@@ -1,4 +1,5 @@
 import Foundation
+import WordPressShared
 
 /// Metadata used by the app.
 public struct PostMetadata: Hashable {
@@ -8,6 +9,11 @@ public struct PostMetadata: Hashable {
     /// Returns `true` if the post is configured to _not_ be sent in an email
     /// to subscribers.
     public var isJetpackNewsletterEmailDisabled: Bool
+
+    /// Initialized metadata with the given post.
+    public init(_ post: AbstractPost) {
+        self = PostMetadata(from: PostMetadataContainer(post))
+    }
 
     public init(from container: PostMetadataContainer) {
         self.accessLevel = container.accessLevel

--- a/Sources/WordPressData/Swift/PostMetadataContainer.swift
+++ b/Sources/WordPressData/Swift/PostMetadataContainer.swift
@@ -28,7 +28,7 @@ import WordPressShared
 ///   }
 /// ]
 /// ```
-public struct PostMetadata {
+public struct PostMetadataContainer {
     public struct Key: ExpressibleByStringLiteral, Hashable {
         public let rawValue: String
 
@@ -58,13 +58,13 @@ public struct PostMetadata {
         if let data = post.rawMetadata {
             do {
                 let metadata = try JSONSerialization.jsonObject(with: data) as? [[String: Any]] ?? []
-                self = PostMetadata(metadata: metadata)
+                self = PostMetadataContainer(metadata: metadata)
             } catch {
                 wpAssertionFailure("Failed to decode metadata JSON", userInfo: ["error": error.localizedDescription])
-                self = PostMetadata()
+                self = PostMetadataContainer()
             }
         } else {
-            self = PostMetadata()
+            self = PostMetadataContainer()
         }
     }
 
@@ -77,7 +77,7 @@ public struct PostMetadata {
         guard let dictionary = metadata as? [[String: Any]] else {
             throw Error.invalidData
         }
-        self = PostMetadata(metadata: dictionary)
+        self = PostMetadataContainer(metadata: dictionary)
     }
 
     /// Initialize with raw metadata array (same format as JSON data)
@@ -176,12 +176,12 @@ public struct PostMetadata {
 
 // MARK: - PostMetadata (Jetpack)
 
-extension PostMetadata.Key {
-    public static let jetpackNewsletterAccess: PostMetadata.Key = "_jetpack_newsletter_access"
-    public static let jetpackNewsletterEmailDisabled: PostMetadata.Key = "_jetpack_dont_email_post_to_subs"
+extension PostMetadataContainer.Key {
+    public static let jetpackNewsletterAccess: PostMetadataContainer.Key = "_jetpack_newsletter_access"
+    public static let jetpackNewsletterEmailDisabled: PostMetadataContainer.Key = "_jetpack_dont_email_post_to_subs"
 }
 
-extension PostMetadata {
+extension PostMetadataContainer {
     /// Gets or sets the Jetpack Newsletter access level as a PostAccessLevel enum
     public var accessLevel: JetpackPostAccessLevel? {
         get {

--- a/Sources/WordPressData/Swift/PostMetadataContainer.swift
+++ b/Sources/WordPressData/Swift/PostMetadataContainer.swift
@@ -111,16 +111,22 @@ public struct PostMetadataContainer {
     ///   - key: The metadata key to search for
     /// - Returns: The value cast to the specified type if found and compatible, nil otherwise
     public func getValue<T>(_ expectedType: T.Type, forKey key: Key) -> T? {
-        guard let dict = items[key], let value = dict["value"] else { return nil }
+        guard let value = _getValue(forKey: key) else {
+            return nil
+        }
         guard let value = value as? T else {
             wpAssertionFailure("unexpected value", userInfo: [
                 "key": key.rawValue,
-                "actual_type": String(describing: expectedType),
-                "expected_type": String(describing: type(of: value))
+                "actual_type": String(describing: type(of: _getValue)),
+                "expected_type": String(describing: expectedType)
             ])
             return nil
         }
         return value
+    }
+
+    private func _getValue(forKey key: Key) -> Any? {
+        items[key]?["value"]
     }
 
     /// Retrieves a metadata value by key as String (convenience method)
@@ -128,6 +134,23 @@ public struct PostMetadataContainer {
     /// - Returns: The value as String if found and convertible, nil otherwise
     public func getString(for key: Key) -> String? {
         getValue(String.self, forKey: key)
+    }
+
+    /// Gets a bool, regardless of how it's encoded.
+    public func getAdaptiveBool(for key: Key) -> Bool {
+        guard let value = _getValue(forKey: key) else {
+            return false
+        }
+        switch value {
+        case let value as Bool:
+            return value
+        case let value as NSNumber:
+            return value.boolValue
+        case let value as NSString:
+            return value.boolValue
+        default:
+            return false
+        }
     }
 
     /// Sets or updates a metadata item with any JSON-compatible value
@@ -170,53 +193,6 @@ public struct PostMetadataContainer {
     /// - Parameter key: The metadata key to retrieve
     /// - Returns: The complete metadata dictionary containing "key", "value", and optional "id", or nil if not found
     public func entry(forKey key: Key) -> [String: Any]? {
-        return items[key]
+        items[key]
     }
-}
-
-// MARK: - PostMetadata (Jetpack)
-
-extension PostMetadataContainer.Key {
-    public static let jetpackNewsletterAccess: PostMetadataContainer.Key = "_jetpack_newsletter_access"
-    public static let jetpackNewsletterEmailDisabled: PostMetadataContainer.Key = "_jetpack_dont_email_post_to_subs"
-}
-
-extension PostMetadataContainer {
-    /// Gets or sets the Jetpack Newsletter access level as a PostAccessLevel enum
-    public var accessLevel: JetpackPostAccessLevel? {
-        get {
-            guard let value = getString(for: .jetpackNewsletterAccess) else { return nil }
-            return JetpackPostAccessLevel(rawValue: value)
-        }
-        set {
-            if let newValue {
-                setValue(newValue.rawValue, for: .jetpackNewsletterAccess)
-            } else {
-                removeValue(for: .jetpackNewsletterAccess)
-            }
-        }
-    }
-
-    /// Returns `true` if the post is configured to _not_ be sent in an email
-    /// to subscribers.
-    public var isJetpackNewsletterEmailDisabled: Bool {
-        get {
-            guard let value = getString(for: .jetpackNewsletterEmailDisabled) else { return false }
-            return (value as NSString).boolValue
-        }
-        set {
-            if newValue {
-                setValue("1", for: .jetpackNewsletterEmailDisabled)
-            } else {
-                removeValue(for: .jetpackNewsletterEmailDisabled)
-            }
-        }
-    }
-}
-
-/// Valid access levels for Jetpack Newsletter
-public enum JetpackPostAccessLevel: String, CaseIterable, Hashable, Codable {
-    case everybody = "everybody"
-    case subscribers = "subscribers"
-    case paidSubscribers = "paid_subscribers"
 }

--- a/Sources/WordPressData/Swift/RemotePostCreateParameters+Helpers.swift
+++ b/Sources/WordPressData/Swift/RemotePostCreateParameters+Helpers.swift
@@ -49,7 +49,7 @@ private extension RemotePostCreateParameters {
         var output = PostHelper.remoteMetadata(for: post) as? [[String: Any]] ?? []
 
         // Add Jetpack Newsletter access level metadata
-        let metadata = PostMetadata(post)
+        let metadata = PostMetadataContainer(post)
         if let entry = metadata.entry(forKey: .jetpackNewsletterAccess) {
             output.append(entry)
         }

--- a/Sources/WordPressData/Swift/RemotePostCreateParameters+Helpers.swift
+++ b/Sources/WordPressData/Swift/RemotePostCreateParameters+Helpers.swift
@@ -47,12 +47,8 @@ private extension RemotePostCreateParameters {
     static func generateRemoteMetadata(for post: Post) -> [[String: Any]] {
         // Start with existing metadata from PostHelper
         var output = PostHelper.remoteMetadata(for: post) as? [[String: Any]] ?? []
-
-        // Add Jetpack Newsletter access level metadata
-        let metadata = PostMetadataContainer(post)
-        if let entry = metadata.entry(forKey: .jetpackNewsletterAccess) {
-            output.append(entry)
-        }
+        // Add metadata mananged using `PostMetadata`
+        output += PostMetadata.entries(in: PostMetadataContainer(post))
         return output
     }
 }

--- a/Tests/WordPressDataTests/PostMetadataContainerTests.swift
+++ b/Tests/WordPressDataTests/PostMetadataContainerTests.swift
@@ -1,0 +1,193 @@
+import Testing
+@testable import WordPressData
+
+@Suite("PostMetadataContainer Tests")
+struct PostMetadataContainerTests {
+
+    private let contextManager = ContextManager.forTesting()
+    private var mainContext: NSManagedObjectContext { contextManager.mainContext }
+
+    // MARK: - Initialization Tests
+
+    @Test("Initialization with mock data")
+    func initializationWithMockData() throws {
+        let metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
+
+        #expect(!metadata.values.isEmpty)
+        #expect(metadata.values.count == 12)
+    }
+
+    @Test("Initialization with metadata array")
+    func initializationWithMetadataArray() {
+        let metadataArray = [
+            ["key": "key1", "value": "value1"],
+            ["key": "key2", "value": "value2"]
+        ]
+        let metadata = PostMetadataContainer(metadata: metadataArray)
+
+        #expect(metadata.values.count == 2)
+        #expect(metadata.getValue(String.self, forKey: "key1") == "value1")
+        #expect(metadata.getValue(String.self, forKey: "key2") == "value2")
+    }
+
+    @Test("Empty initialization")
+    func emptyInitialization() {
+        let metadata = PostMetadataContainer()
+
+        #expect(metadata.values.isEmpty)
+        #expect(metadata.values.count == 0)
+    }
+
+    // MARK: - CRUD
+
+    @Test("Get value from mock data")
+    func getValueFromMockData() throws {
+        let metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
+
+        #expect(metadata.getValue(String.self, forKey: .jetpackNewsletterAccess) == "subscribers")
+        #expect(metadata.getValue(String.self, forKey: "wp_jp_foreign_id") == "95199E7F-EEF2-46B0-BC89-898AE817CEAD")
+        #expect(metadata.getValue(String.self, forKey: "_wpas_feature_enabled") == "1")
+
+        let nilValue: String? = metadata.getValue(String.self, forKey: "nonexistent_key")
+        #expect(nilValue == nil)
+    }
+
+    @Test("Get string value from mock data")
+    func getStringFromMockData() throws {
+        let metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
+
+        #expect(metadata.getString(for: .jetpackNewsletterAccess) == "subscribers")
+        #expect(metadata.getString(for: "wp_jp_foreign_id") == "95199E7F-EEF2-46B0-BC89-898AE817CEAD")
+        #expect(metadata.getString(for: "_wpas_feature_enabled") == "1")
+        #expect(metadata.getString(for: "nonexistent_key") == nil)
+    }
+
+    @Test("Set value")
+    func setValue() {
+        var metadata = PostMetadataContainer()
+
+        metadata.setValue("test_value", for: "test_key", id: "123")
+
+        #expect(metadata.values.count == 1)
+        #expect(metadata.getValue(String.self, forKey: "test_key") == "test_value")
+    }
+
+    @Test("Set value with Key type")
+    func setValueWithKeyType() {
+        var metadata = PostMetadataContainer()
+
+        metadata.setValue("test_value", for: .jetpackNewsletterAccess)
+
+        #expect(metadata.values.count == 1)
+        #expect(metadata.getValue(String.self, forKey: .jetpackNewsletterAccess) == "test_value")
+    }
+
+    @Test("Set value updates existing")
+    func setValueUpdatesExisting() throws {
+        var metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
+        let originalCount = metadata.values.count
+
+        metadata.setValue("new_value", for: .jetpackNewsletterAccess)
+
+        #expect(metadata.values.count == originalCount) // Count should remain same
+        #expect(metadata.getValue(String.self, forKey: .jetpackNewsletterAccess) == "new_value")
+    }
+
+    @Test("Remove value")
+    func removeValue() throws {
+        var metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
+        let originalCount = metadata.values.count
+
+        let removed = metadata.removeValue(for: .jetpackNewsletterAccess)
+
+        #expect(removed)
+        #expect(metadata.values.count == originalCount - 1)
+        #expect(metadata.getValue(String.self, forKey: .jetpackNewsletterAccess) == nil)
+
+        // Try to remove non-existent key
+        let notRemoved = metadata.removeValue(for: "nonexistent_key")
+        #expect(!notRemoved)
+    }
+
+    @Test("Clear all metadata")
+    func clear() throws {
+        var metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
+
+        metadata.clear()
+
+        #expect(metadata.values.isEmpty)
+        #expect(metadata.values.count == 0)
+    }
+
+    // MARK: - Encoding Tests
+
+    @Test("Encode and decode round trip")
+    func encodeAndDecodeRoundTrip() throws {
+        let originalMetadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
+
+        let encodedData = try #require(try originalMetadata.encode(), "Failed to encode metadata")
+
+        let decodedMetadata = try PostMetadataContainer(data: encodedData)
+
+        #expect(originalMetadata.values.count == decodedMetadata.values.count)
+
+        // Verify specific values are preserved
+        #expect(originalMetadata.getValue(String.self, forKey: .jetpackNewsletterAccess) ==
+                decodedMetadata.getValue(String.self, forKey: .jetpackNewsletterAccess))
+        #expect(originalMetadata.getValue(String.self, forKey: "wp_jp_foreign_id") ==
+                decodedMetadata.getValue(String.self, forKey: "wp_jp_foreign_id"))
+    }
+
+    // MARK: - Edge Cases and Error Handling
+
+    @Test("Invalid JSON handling")
+    func invalidJSONHandling() throws {
+        let invalidJSON = "invalid json".data(using: .utf8)!
+
+        #expect(throws: Error.self) {
+            _ = try try PostMetadataContainer(data: invalidJSON)
+        }
+    }
+
+    @Test("Malformed metadata item handling")
+    func malformedMetadataItemHandling() throws {
+        let malformedData: [[String: Any]] = [
+            ["key": "valid_key", "value": "valid_value"], // Valid item
+            ["value": "missing_key"], // Missing key
+            ["id": "123"] // Missing both key and value
+        ]
+
+        let jsonData = try JSONSerialization.data(withJSONObject: malformedData, options: [])
+        let metadata = try PostMetadataContainer(data: jsonData)
+
+        #expect(metadata.values.count == 1) // Only the valid item should be parsed
+        #expect(metadata.getValue(String.self, forKey: "valid_key") == "valid_value")
+    }
+
+    @Test("Key type string literal")
+    func keyTypeStringLiteral() {
+        let key: PostMetadataContainer.Key = "custom_key"
+        #expect(key.rawValue == "custom_key")
+    }
+
+    @Test("Key type raw value init")
+    func keyTypeRawValueInit() {
+        let key = PostMetadataContainer.Key(rawValue: "another_key")
+        #expect(key.rawValue == "another_key")
+    }
+
+    @Test("Mixed key types")
+    func mixedKeyTypes() {
+        var metadata = PostMetadataContainer()
+
+        // Set using Key type
+        metadata.setValue("key_value", for: .jetpackNewsletterAccess)
+
+        // Set using string (for methods that still accept strings)
+        metadata.setValue("string_value", for: "string_key")
+
+        // Both should work
+        #expect(metadata.getString(for: .jetpackNewsletterAccess) == "key_value")
+        #expect(metadata.getValue(String.self, forKey: "string_key") == "string_value")
+    }
+}

--- a/Tests/WordPressDataTests/PostMetadataTests.swift
+++ b/Tests/WordPressDataTests/PostMetadataTests.swift
@@ -11,7 +11,7 @@ struct PostMetadataTests {
 
     @Test("Initialization with mock data")
     func initializationWithMockData() throws {
-        let metadata = try PostMetadata(data: Self.mockMetadataJSON)
+        let metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
 
         #expect(!metadata.values.isEmpty)
         #expect(metadata.values.count == 12)
@@ -23,7 +23,7 @@ struct PostMetadataTests {
             ["key": "key1", "value": "value1"],
             ["key": "key2", "value": "value2"]
         ]
-        let metadata = PostMetadata(metadata: metadataArray)
+        let metadata = PostMetadataContainer(metadata: metadataArray)
 
         #expect(metadata.values.count == 2)
         #expect(metadata.getValue(String.self, forKey: "key1") == "value1")
@@ -32,7 +32,7 @@ struct PostMetadataTests {
 
     @Test("Empty initialization")
     func emptyInitialization() {
-        let metadata = PostMetadata()
+        let metadata = PostMetadataContainer()
 
         #expect(metadata.values.isEmpty)
         #expect(metadata.values.count == 0)
@@ -42,7 +42,7 @@ struct PostMetadataTests {
 
     @Test("Get value from mock data")
     func getValueFromMockData() throws {
-        let metadata = try PostMetadata(data: Self.mockMetadataJSON)
+        let metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
 
         #expect(metadata.getValue(String.self, forKey: .jetpackNewsletterAccess) == "subscribers")
         #expect(metadata.getValue(String.self, forKey: "wp_jp_foreign_id") == "95199E7F-EEF2-46B0-BC89-898AE817CEAD")
@@ -54,7 +54,7 @@ struct PostMetadataTests {
 
     @Test("Get string value from mock data")
     func getStringFromMockData() throws {
-        let metadata = try PostMetadata(data: Self.mockMetadataJSON)
+        let metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
 
         #expect(metadata.getString(for: .jetpackNewsletterAccess) == "subscribers")
         #expect(metadata.getString(for: "wp_jp_foreign_id") == "95199E7F-EEF2-46B0-BC89-898AE817CEAD")
@@ -64,7 +64,7 @@ struct PostMetadataTests {
 
     @Test("Set value")
     func setValue() {
-        var metadata = PostMetadata()
+        var metadata = PostMetadataContainer()
 
         metadata.setValue("test_value", for: "test_key", id: "123")
 
@@ -74,7 +74,7 @@ struct PostMetadataTests {
 
     @Test("Set value with Key type")
     func setValueWithKeyType() {
-        var metadata = PostMetadata()
+        var metadata = PostMetadataContainer()
 
         metadata.setValue("test_value", for: .jetpackNewsletterAccess)
 
@@ -84,7 +84,7 @@ struct PostMetadataTests {
 
     @Test("Set value updates existing")
     func setValueUpdatesExisting() throws {
-        var metadata = try PostMetadata(data: Self.mockMetadataJSON)
+        var metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
         let originalCount = metadata.values.count
 
         metadata.setValue("new_value", for: .jetpackNewsletterAccess)
@@ -95,7 +95,7 @@ struct PostMetadataTests {
 
     @Test("Remove value")
     func removeValue() throws {
-        var metadata = try PostMetadata(data: Self.mockMetadataJSON)
+        var metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
         let originalCount = metadata.values.count
 
         let removed = metadata.removeValue(for: .jetpackNewsletterAccess)
@@ -111,7 +111,7 @@ struct PostMetadataTests {
 
     @Test("Clear all metadata")
     func clear() throws {
-        var metadata = try PostMetadata(data: Self.mockMetadataJSON)
+        var metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
 
         metadata.clear()
 
@@ -123,14 +123,14 @@ struct PostMetadataTests {
 
     @Test("Access level from mock data")
     func accessLevelFromMockData() throws {
-        let metadata = try PostMetadata(data: Self.mockMetadataJSON)
+        let metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
 
         #expect(metadata.accessLevel == .subscribers)
     }
 
     @Test("Set access level")
     func setAccessLevel() {
-        var metadata = PostMetadata()
+        var metadata = PostMetadataContainer()
 
         metadata.accessLevel = .everybody
 
@@ -140,7 +140,7 @@ struct PostMetadataTests {
 
     @Test("Remove access level")
     func removeAccessLevel() throws {
-        var metadata = try PostMetadata(data: Self.mockMetadataJSON)
+        var metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
 
         #expect(metadata.accessLevel != nil)
 
@@ -154,11 +154,11 @@ struct PostMetadataTests {
 
     @Test("Encode and decode round trip")
     func encodeAndDecodeRoundTrip() throws {
-        let originalMetadata = try PostMetadata(data: Self.mockMetadataJSON)
+        let originalMetadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
 
         let encodedData = try #require(try originalMetadata.encode(), "Failed to encode metadata")
 
-        let decodedMetadata = try PostMetadata(data: encodedData)
+        let decodedMetadata = try PostMetadataContainer(data: encodedData)
 
         #expect(originalMetadata.values.count == decodedMetadata.values.count)
 
@@ -176,7 +176,7 @@ struct PostMetadataTests {
         let invalidJSON = "invalid json".data(using: .utf8)!
 
         #expect(throws: Error.self) {
-            _ = try try PostMetadata(data: invalidJSON)
+            _ = try try PostMetadataContainer(data: invalidJSON)
         }
     }
 
@@ -189,7 +189,7 @@ struct PostMetadataTests {
         ]
 
         let jsonData = try JSONSerialization.data(withJSONObject: malformedData, options: [])
-        let metadata = try PostMetadata(data: jsonData)
+        let metadata = try PostMetadataContainer(data: jsonData)
 
         #expect(metadata.values.count == 1) // Only the valid item should be parsed
         #expect(metadata.getValue(String.self, forKey: "valid_key") == "valid_value")
@@ -197,19 +197,19 @@ struct PostMetadataTests {
 
     @Test("Key type string literal")
     func keyTypeStringLiteral() {
-        let key: PostMetadata.Key = "custom_key"
+        let key: PostMetadataContainer.Key = "custom_key"
         #expect(key.rawValue == "custom_key")
     }
 
     @Test("Key type raw value init")
     func keyTypeRawValueInit() {
-        let key = PostMetadata.Key(rawValue: "another_key")
+        let key = PostMetadataContainer.Key(rawValue: "another_key")
         #expect(key.rawValue == "another_key")
     }
 
     @Test("Mixed key types")
     func mixedKeyTypes() {
-        var metadata = PostMetadata()
+        var metadata = PostMetadataContainer()
 
         // Set using Key type
         metadata.setValue("key_value", for: .jetpackNewsletterAccess)
@@ -226,7 +226,7 @@ struct PostMetadataTests {
 
     @Test
     func jetpackNewsletterEmailDisabled() {
-        var metadata = PostMetadata()
+        var metadata = PostMetadataContainer()
 
         #expect(metadata.isJetpackNewsletterEmailDisabled == false)
 

--- a/Tests/WordPressDataTests/PostMetadataTests.swift
+++ b/Tests/WordPressDataTests/PostMetadataTests.swift
@@ -221,6 +221,24 @@ struct PostMetadataTests {
         #expect(metadata.getString(for: .jetpackNewsletterAccess) == "key_value")
         #expect(metadata.getValue(String.self, forKey: "string_key") == "string_value")
     }
+
+    // MARK: - Extensions (JetpackNewsletterEmailDisabled)
+
+    @Test
+    func jetpackNewsletterEmailDisabled() {
+        var metadata = PostMetadata()
+
+        #expect(metadata.isJetpackNewsletterEmailDisabled == false)
+
+        metadata.setValue("", for: .jetpackNewsletterEmailDisabled)
+        #expect(metadata.isJetpackNewsletterEmailDisabled == false)
+
+        metadata.setValue("true", for: .jetpackNewsletterEmailDisabled)
+        #expect(metadata.isJetpackNewsletterEmailDisabled == true)
+
+        metadata.setValue("1", for: .jetpackNewsletterEmailDisabled)
+        #expect(metadata.isJetpackNewsletterEmailDisabled == true)
+    }
 }
 
 // MARK: - Mock Data

--- a/Tests/WordPressDataTests/PostMetadataTests.swift
+++ b/Tests/WordPressDataTests/PostMetadataTests.swift
@@ -4,246 +4,92 @@ import Testing
 @Suite("PostMetadata Tests")
 struct PostMetadataTests {
 
-    private let contextManager = ContextManager.forTesting()
-    private var mainContext: NSManagedObjectContext { contextManager.mainContext }
-
-    // MARK: - Initialization Tests
-
-    @Test("Initialization with mock data")
-    func initializationWithMockData() throws {
-        let metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
-
-        #expect(!metadata.values.isEmpty)
-        #expect(metadata.values.count == 12)
-    }
-
-    @Test("Initialization with metadata array")
-    func initializationWithMetadataArray() {
-        let metadataArray = [
-            ["key": "key1", "value": "value1"],
-            ["key": "key2", "value": "value2"]
-        ]
-        let metadata = PostMetadataContainer(metadata: metadataArray)
-
-        #expect(metadata.values.count == 2)
-        #expect(metadata.getValue(String.self, forKey: "key1") == "value1")
-        #expect(metadata.getValue(String.self, forKey: "key2") == "value2")
-    }
-
-    @Test("Empty initialization")
-    func emptyInitialization() {
-        let metadata = PostMetadataContainer()
-
-        #expect(metadata.values.isEmpty)
-        #expect(metadata.values.count == 0)
-    }
-
-    // MARK: - CRUD
-
-    @Test("Get value from mock data")
-    func getValueFromMockData() throws {
-        let metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
-
-        #expect(metadata.getValue(String.self, forKey: .jetpackNewsletterAccess) == "subscribers")
-        #expect(metadata.getValue(String.self, forKey: "wp_jp_foreign_id") == "95199E7F-EEF2-46B0-BC89-898AE817CEAD")
-        #expect(metadata.getValue(String.self, forKey: "_wpas_feature_enabled") == "1")
-
-        let nilValue: String? = metadata.getValue(String.self, forKey: "nonexistent_key")
-        #expect(nilValue == nil)
-    }
-
-    @Test("Get string value from mock data")
-    func getStringFromMockData() throws {
-        let metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
-
-        #expect(metadata.getString(for: .jetpackNewsletterAccess) == "subscribers")
-        #expect(metadata.getString(for: "wp_jp_foreign_id") == "95199E7F-EEF2-46B0-BC89-898AE817CEAD")
-        #expect(metadata.getString(for: "_wpas_feature_enabled") == "1")
-        #expect(metadata.getString(for: "nonexistent_key") == nil)
-    }
-
-    @Test("Set value")
-    func setValue() {
-        var metadata = PostMetadataContainer()
-
-        metadata.setValue("test_value", for: "test_key", id: "123")
-
-        #expect(metadata.values.count == 1)
-        #expect(metadata.getValue(String.self, forKey: "test_key") == "test_value")
-    }
-
-    @Test("Set value with Key type")
-    func setValueWithKeyType() {
-        var metadata = PostMetadataContainer()
-
-        metadata.setValue("test_value", for: .jetpackNewsletterAccess)
-
-        #expect(metadata.values.count == 1)
-        #expect(metadata.getValue(String.self, forKey: .jetpackNewsletterAccess) == "test_value")
-    }
-
-    @Test("Set value updates existing")
-    func setValueUpdatesExisting() throws {
-        var metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
-        let originalCount = metadata.values.count
-
-        metadata.setValue("new_value", for: .jetpackNewsletterAccess)
-
-        #expect(metadata.values.count == originalCount) // Count should remain same
-        #expect(metadata.getValue(String.self, forKey: .jetpackNewsletterAccess) == "new_value")
-    }
-
-    @Test("Remove value")
-    func removeValue() throws {
-        var metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
-        let originalCount = metadata.values.count
-
-        let removed = metadata.removeValue(for: .jetpackNewsletterAccess)
-
-        #expect(removed)
-        #expect(metadata.values.count == originalCount - 1)
-        #expect(metadata.getValue(String.self, forKey: .jetpackNewsletterAccess) == nil)
-
-        // Try to remove non-existent key
-        let notRemoved = metadata.removeValue(for: "nonexistent_key")
-        #expect(!notRemoved)
-    }
-
-    @Test("Clear all metadata")
-    func clear() throws {
-        var metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
-
-        metadata.clear()
-
-        #expect(metadata.values.isEmpty)
-        #expect(metadata.values.count == 0)
-    }
-
-    // MARK: - Extensions (JetpackPostAccessLevel)
+    // MARK: accessLevel
 
     @Test("Access level from mock data")
     func accessLevelFromMockData() throws {
-        let metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
+        let metadata = try PostMetadata(data: PostMetadataContainerTests.mockMetadataJSON)
 
         #expect(metadata.accessLevel == .subscribers)
     }
 
     @Test("Set access level")
-    func setAccessLevel() {
-        var metadata = PostMetadataContainer()
+    func setEncodeAccessLevel() {
+        // GIVEN
+        var container = PostMetadataContainer()
+        var metadata = PostMetadata(from: container)
 
+        // WHEN
         metadata.accessLevel = .everybody
+        metadata.encode(in: &container)
 
-        #expect(metadata.accessLevel == .everybody)
-        #expect(metadata.getValue(String.self, forKey: .jetpackNewsletterAccess) == "everybody")
+        // THEN
+        #expect(container.getValue(String.self, forKey: .jetpackNewsletterAccess) == "everybody")
     }
 
     @Test("Remove access level")
     func removeAccessLevel() throws {
-        var metadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
-
+        // GIVEN
+        var metadata = try PostMetadata(data: PostMetadataContainerTests.mockMetadataJSON)
         #expect(metadata.accessLevel != nil)
 
+        // WHEN
         metadata.accessLevel = nil
+        var container = PostMetadataContainer()
+        metadata.encode(in: &container)
 
-        #expect(metadata.accessLevel == nil)
-        #expect(metadata.getValue(String.self, forKey: .jetpackNewsletterAccess) == nil)
+        // THEN
+        #expect(container.getValue(String.self, forKey: .jetpackNewsletterAccess) == nil)
     }
 
-    // MARK: - Encoding Tests
-
-    @Test("Encode and decode round trip")
-    func encodeAndDecodeRoundTrip() throws {
-        let originalMetadata = try PostMetadataContainer(data: Self.mockMetadataJSON)
-
-        let encodedData = try #require(try originalMetadata.encode(), "Failed to encode metadata")
-
-        let decodedMetadata = try PostMetadataContainer(data: encodedData)
-
-        #expect(originalMetadata.values.count == decodedMetadata.values.count)
-
-        // Verify specific values are preserved
-        #expect(originalMetadata.getValue(String.self, forKey: .jetpackNewsletterAccess) ==
-                decodedMetadata.getValue(String.self, forKey: .jetpackNewsletterAccess))
-        #expect(originalMetadata.getValue(String.self, forKey: "wp_jp_foreign_id") ==
-                decodedMetadata.getValue(String.self, forKey: "wp_jp_foreign_id"))
-    }
-
-    // MARK: - Edge Cases and Error Handling
-
-    @Test("Invalid JSON handling")
-    func invalidJSONHandling() throws {
-        let invalidJSON = "invalid json".data(using: .utf8)!
-
-        #expect(throws: Error.self) {
-            _ = try try PostMetadataContainer(data: invalidJSON)
-        }
-    }
-
-    @Test("Malformed metadata item handling")
-    func malformedMetadataItemHandling() throws {
-        let malformedData: [[String: Any]] = [
-            ["key": "valid_key", "value": "valid_value"], // Valid item
-            ["value": "missing_key"], // Missing key
-            ["id": "123"] // Missing both key and value
-        ]
-
-        let jsonData = try JSONSerialization.data(withJSONObject: malformedData, options: [])
-        let metadata = try PostMetadataContainer(data: jsonData)
-
-        #expect(metadata.values.count == 1) // Only the valid item should be parsed
-        #expect(metadata.getValue(String.self, forKey: "valid_key") == "valid_value")
-    }
-
-    @Test("Key type string literal")
-    func keyTypeStringLiteral() {
-        let key: PostMetadataContainer.Key = "custom_key"
-        #expect(key.rawValue == "custom_key")
-    }
-
-    @Test("Key type raw value init")
-    func keyTypeRawValueInit() {
-        let key = PostMetadataContainer.Key(rawValue: "another_key")
-        #expect(key.rawValue == "another_key")
-    }
-
-    @Test("Mixed key types")
-    func mixedKeyTypes() {
-        var metadata = PostMetadataContainer()
-
-        // Set using Key type
-        metadata.setValue("key_value", for: .jetpackNewsletterAccess)
-
-        // Set using string (for methods that still accept strings)
-        metadata.setValue("string_value", for: "string_key")
-
-        // Both should work
-        #expect(metadata.getString(for: .jetpackNewsletterAccess) == "key_value")
-        #expect(metadata.getValue(String.self, forKey: "string_key") == "string_value")
-    }
-
-    // MARK: - Extensions (JetpackNewsletterEmailDisabled)
+    // MARK: isJetpackNewsletterEmailDisabled
 
     @Test
     func jetpackNewsletterEmailDisabled() {
-        var metadata = PostMetadataContainer()
+        var container = PostMetadataContainer()
 
-        #expect(metadata.isJetpackNewsletterEmailDisabled == false)
+        #expect(PostMetadata(from: container).isJetpackNewsletterEmailDisabled == false)
 
-        metadata.setValue("", for: .jetpackNewsletterEmailDisabled)
-        #expect(metadata.isJetpackNewsletterEmailDisabled == false)
+        container.setValue("", for: .jetpackNewsletterEmailDisabled)
+        #expect(PostMetadata(from: container).isJetpackNewsletterEmailDisabled == false)
 
-        metadata.setValue("true", for: .jetpackNewsletterEmailDisabled)
-        #expect(metadata.isJetpackNewsletterEmailDisabled == true)
+        container.setValue("true", for: .jetpackNewsletterEmailDisabled)
+        #expect(PostMetadata(from: container).isJetpackNewsletterEmailDisabled == true)
 
-        metadata.setValue("1", for: .jetpackNewsletterEmailDisabled)
-        #expect(metadata.isJetpackNewsletterEmailDisabled == true)
+        container.setValue("1", for: .jetpackNewsletterEmailDisabled)
+        #expect(PostMetadata(from: container).isJetpackNewsletterEmailDisabled == true)
+
+        container.setValue(1, for: .jetpackNewsletterEmailDisabled)
+        #expect(PostMetadata(from: container).isJetpackNewsletterEmailDisabled == true)
+
+        container.setValue(true, for: .jetpackNewsletterEmailDisabled)
+        #expect(PostMetadata(from: container).isJetpackNewsletterEmailDisabled == true)
+    }
+
+    @Test
+    func settingExistingValueIsNoop() {
+        // GIVEN
+        var container = PostMetadataContainer()
+        container.setValue("", for: .jetpackNewsletterEmailDisabled)
+
+        // WHEN
+        var metadata = PostMetadata(from: container)
+        metadata.isJetpackNewsletterEmailDisabled = false
+        metadata.encode(in: &container)
+
+        // THEN
+        #expect(container.getString(for: .jetpackNewsletterEmailDisabled) == "")
     }
 }
 
-// MARK: - Mock Data
+private extension PostMetadata {
+    init(data: Data) throws {
+        let container = try PostMetadataContainer(data: data)
+        self = PostMetadata(from: container)
+    }
+}
 
-extension PostMetadataTests {
+extension PostMetadataContainerTests {
     static var mockMetadataJSON: Data {
         let mockData: [[String: Any]] = [
             [

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
@@ -51,7 +51,7 @@ struct PostSettings: Hashable {
 
         featuredImageID = post.featuredImage?.mediaID?.intValue
 
-        let metadata = PostMetadata(post)
+        let metadata = PostMetadataContainer(post)
 
         switch post {
         case let post as Post:
@@ -153,7 +153,7 @@ struct PostSettings: Hashable {
             }
 
             /// Update metadata
-            var metadata = PostMetadata(post)
+            var metadata = PostMetadataContainer(post)
             if metadata.accessLevel != accessLevel {
                 metadata.accessLevel = accessLevel
                 do {

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
@@ -21,12 +21,12 @@ struct PostSettings: Hashable {
     var categoryIDs: Set<Int> = []
     var tags: String = ""
     var featuredImageID: Int?
+    var metadata: PostMetadata
 
     // MARK: - Post-specific
     var postFormat: String?
     var isStickyPost = false
     var sharing: PostSocialSharingSettings?
-    var accessLevel: JetpackPostAccessLevel?
 
     // MARK: - Page-specific
     var parentPageID: Int?
@@ -51,7 +51,7 @@ struct PostSettings: Hashable {
 
         featuredImageID = post.featuredImage?.mediaID?.intValue
 
-        let metadata = PostMetadataContainer(post)
+        metadata = PostMetadata(post)
 
         switch post {
         case let post as Post:
@@ -61,8 +61,6 @@ struct PostSettings: Hashable {
             categoryIDs = Set((post.categories ?? []).compactMap {
                 $0.categoryID?.intValue
             })
-            sharing = PostSocialSharingSettings.make(for: post)
-            accessLevel = metadata.accessLevel ?? .everybody
         case let page as Page:
             parentPageID = page.parentID?.intValue
         default:
@@ -103,6 +101,16 @@ struct PostSettings: Hashable {
             }
         } else {
             post.featuredImage = nil
+        }
+
+        var postMetadataContainer = PostMetadataContainer(post)
+        if PostMetadata(from: postMetadataContainer) != metadata {
+            metadata.encode(in: &postMetadataContainer)
+            do {
+                post.rawMetadata = try postMetadataContainer.encode()
+            } catch {
+                wpAssertionFailure("failed to encode metadata")
+            }
         }
 
         switch post {
@@ -149,17 +157,6 @@ struct PostSettings: Hashable {
                 }
                 if post.publicizeMessage != sharing.message {
                     post.publicizeMessage = sharing.message
-                }
-            }
-
-            /// Update metadata
-            var metadata = PostMetadataContainer(post)
-            if metadata.accessLevel != accessLevel {
-                metadata.accessLevel = accessLevel
-                do {
-                    post.rawMetadata = try metadata.encode()
-                } catch {
-                    wpAssertionFailure("failed to encode metadata")
                 }
             }
         case let page as Page:

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -669,7 +669,7 @@ private enum Strings {
     )
 
     static let newsletterLabel = NSLocalizedString(
-        "postSettings.sendNewsletter",
+        "postSettings.emailToSubscribers.label",
         value: "Email to Subscribers",
         comment: "Label for the checkbox that lets you send a post to newsletter subscribers"
     )

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -345,8 +345,8 @@ struct PostSettingsFormContentView: View {
     private var moreOptionsSection: some View {
         Section {
             if viewModel.shouldShow(.jetpackNewsletterEmailOptions) {
-                Toggle(isOn: $viewModel.settings.metadata.isJetpackNewsletterEmailDisabled) {
-                    Text(Strings.newsletterLabel)
+                Toggle(isOn: $viewModel.emailToSubscribers) {
+                    Text(Strings.emailToSubscribers)
                 }
             }
             if viewModel.shouldShowStickyOption {
@@ -668,7 +668,7 @@ private enum Strings {
         comment: "Label for the preview button in Post Settings"
     )
 
-    static let newsletterLabel = NSLocalizedString(
+    static let emailToSubscribers = NSLocalizedString(
         "postSettings.emailToSubscribers.label",
         value: "Email to Subscribers",
         comment: "Label for the checkbox that lets you send a post to newsletter subscribers"

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -287,7 +287,7 @@ struct PostSettingsFormContentView: View {
             Section {
                 SettingsPicker(
                     title: Strings.accessHeader,
-                    selection: $viewModel.settings.accessLevel,
+                    selection: $viewModel.settings.metadata.accessLevel,
                     values: JetpackPostAccessLevel.allCases.map { level in
                         SettingsPickerValue(
                             title: level.localizedTitle,

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -344,6 +344,11 @@ struct PostSettingsFormContentView: View {
     @ViewBuilder
     private var moreOptionsSection: some View {
         Section {
+            if viewModel.shouldShow(.jetpackNewsletterEmailOptions) {
+                Toggle(isOn: $viewModel.settings.metadata.isJetpackNewsletterEmailDisabled) {
+                    Text(Strings.newsletterLabel)
+                }
+            }
             if viewModel.shouldShowStickyOption {
                 stickyPostRow
             }
@@ -661,6 +666,12 @@ private enum Strings {
         "postSettings.socialSharing.header",
         value: "Social Sharing",
         comment: "Label for the preview button in Post Settings"
+    )
+
+    static let newsletterLabel = NSLocalizedString(
+        "postSettings.sendNewsletter",
+        value: "Email to Subscribers",
+        comment: "Label for the checkbox that lets you send a post to newsletter subscribers"
     )
 
     static let readyToPublish = NSLocalizedString(

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -49,6 +49,11 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
         settings.author?.avatarURL
     }
 
+    var emailToSubscribers: Bool {
+        get { !settings.metadata.isJetpackNewsletterEmailDisabled }
+        set { settings.metadata.isJetpackNewsletterEmailDisabled = !newValue }
+    }
+
     var publishDateText: String? {
         guard let date = settings.publishDate else {
             return nil

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -115,6 +115,7 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
 
     enum Row {
         case jetpackAccessLevel
+        case jetpackNewsletterEmailOptions
     }
 
     private let originalSettings: PostSettings
@@ -178,6 +179,8 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
         switch row {
         case .jetpackAccessLevel:
             post.blog.supports(.wpComRESTAPI)
+        case .jetpackNewsletterEmailOptions:
+            post.blog.supports(.wpComRESTAPI) && context == .publishing
         }
     }
 


### PR DESCRIPTION
Closes https://linear.app/a8c/issue/CMM-831/add-support-for-setting-article-permission-for-newsletters

## Screenshots

<img width="360" alt="Screenshot 2025-10-14 at 6 52 33 PM" src="https://github.com/user-attachments/assets/2138d69a-ef0b-4534-be82-a083f637746a" />

## Testing

- Publish post A with the toggle on
- **Verify** that it gets delivered to your subscribers that opted-in into emails (should be the default)
- Publish post B with the toggle off
- **Verify** that it does not get sent in an email

I tested it end-to-end. Here's the JSON we send when the toggle is off:

```json
{
  "slug": "",
  "format": "standard",
  "status": "publish",
  "content": "",
  "title": "Test Variant D",
  "author": 255064965,
  "excerpt": "",
  "metadata": [
    {
      "value": "3DC2C067-E1E6-4557-936D-59D74C0105E3",
      "key": "wp_jp_foreign_id",
      "operation": "update"
    },
    {
      "value": "true",
      "key": "_jetpack_dont_email_post_to_subs",
      "operation": "update"
    }
  ],
  "type": "post"
}
```

**Note**: I send `true` as a string because that's the only option we currently support in WordPressKit.

I sent "Variant D" with emails disabled (see the JSON).

<img width="405" height="138" alt="Screenshot 2025-10-14 at 6 59 09 PM" src="https://github.com/user-attachments/assets/51784e27-ba6a-43f4-8dd9-d9ea5e95d3c0" />




