### PR TITLE
Fix how editor handles dependencies loading

### DIFF
--- a/WordPress/Classes/Services/BlockEditorCache.swift
+++ b/WordPress/Classes/Services/BlockEditorCache.swift
@@ -29,7 +29,12 @@ final actor BlockEditorCache {
         guard FileManager.default.fileExists(atPath: fileURL.path) else {
             return nil
         }
-        return try? Data(contentsOf: fileURL)
+        do {
+            return try Data(contentsOf: fileURL)
+        } catch {
+            wpAssertionFailure("BlockEditorCache failed to read cached data", userInfo: ["error": "\(error)"])
+            return nil
+        }
     }
 
     func deleteBlockSettings(for blogID: String) throws {

--- a/WordPress/Classes/Services/BlockEditorCache.swift
+++ b/WordPress/Classes/Services/BlockEditorCache.swift
@@ -24,14 +24,12 @@ final actor BlockEditorCache {
         try settings.write(to: fileURL)
     }
 
-    func getBlockSettings(for blogID: String) throws -> Data? {
+    func getBlockSettings(for blogID: String) -> Data? {
         let fileURL = makeBlockSettingsURL(for: blogID)
-
         guard FileManager.default.fileExists(atPath: fileURL.path) else {
             return nil
         }
-
-        return try Data(contentsOf: fileURL)
+        return try? Data(contentsOf: fileURL)
     }
 
     func deleteBlockSettings(for blogID: String) throws {

--- a/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
+++ b/WordPress/Classes/Services/RawBlockEditorSettingsService.swift
@@ -31,7 +31,7 @@ final class RawBlockEditorSettingsService {
     /// the network.
     func getSettings(allowingCachedResponse: Bool = true) async throws -> Data {
         // Return cached settings if available
-        if allowingCachedResponse, let cachedSettings = try await BlockEditorCache.shared.getBlockSettings(for: blogID) {
+        if allowingCachedResponse, let cachedSettings = await BlockEditorCache.shared.getBlockSettings(for: blogID) {
             return cachedSettings
         }
         return try await fetchSettingsFromAPI()

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -273,11 +273,13 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
-        if case .loadingDependencies(let task) = self.editorState {
-            task.cancel()
-        }
 
-        self.editorLoadingTask?.cancel()
+        if isBeingDismissedDirectlyOrByAncestor() {
+            if case .loadingDependencies(let task) = editorState {
+                task.cancel()
+            }
+            editorLoadingTask?.cancel()
+        }
     }
 
     private func setupEditorView() {

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -184,10 +184,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 //            DDLogError("Error syncing JETPACK: \(String(describing: error))")
 //        })
 
-        editorLoadingTask = Task { @MainActor in
-            await loadEditor()
-        }
-
+        loadEditor()
         onViewDidLoad()
     }
 
@@ -215,7 +212,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         setContentScrollView(editorViewController.webView.scrollView)
     }
 
-    // MARK: - Functions
+    // MARK: - Helpers
 
     private func configureNavigationBar() {
         navigationController?.navigationBar.accessibilityIdentifier = "Gutenberg Editor Navigation Bar"
@@ -277,29 +274,6 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     func logException(_ exception: GutenbergJSException, with callback: @escaping () -> Void) {
         DispatchQueue.main.async {
             WordPressAppDelegate.crashLogging?.logJavaScriptException(exception, callback: callback)
-        }
-    }
-
-    @MainActor
-    private func loadEditor() async {
-        showActivityIndicator()
-
-        do {
-            let dependencies = try await fetchEditorDependencies()
-
-            let configuration = editorViewController.configuration.toBuilder()
-                .apply(dependencies.settings) { $0.setEditorSettings($1) }
-                .setTitle(post.postTitle ?? "")
-                .setContent(post.content ?? "")
-                .build()
-
-            editorViewController.updateConfiguration(configuration)
-            editorViewController.startEditorSetup()
-
-            // Handles refreshing controls with state context after options screen is dismissed
-            editorContentWasUpdated()
-        } catch {
-            // TODO: handle errors
         }
     }
 
@@ -370,6 +344,45 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     }
 
     // MARK: - Editor Setup
+
+    private func loadEditor() {
+        editorLoadingTask = Task { @MainActor in
+            await actuallyLoadEditor()
+        }
+    }
+
+    @MainActor
+    private func actuallyLoadEditor() async {
+        showActivityIndicator()
+
+        do {
+            let dependencies = try await fetchEditorDependencies()
+            startEditor(dependencies: dependencies)
+        } catch {
+            hideActivityIndicator()
+
+            let host = UIHostingView(view: EmptyStateView.failure(error: error) { [weak self] in
+                self?.loadEditor()
+            })
+            view.addSubview(host)
+            host.pinEdges()
+        }
+    }
+
+    private func startEditor(dependencies: EditorDependencies) {
+        let configuration = editorViewController.configuration.toBuilder()
+            .apply(dependencies.settings) { $0.setEditorSettings($1) }
+            .setTitle(post.postTitle ?? "")
+            .setContent(post.content ?? "")
+            .build()
+
+        editorViewController.updateConfiguration(configuration)
+        editorViewController.startEditorSetup()
+
+        // Handles refreshing controls with state context after options screen is dismissed
+        editorContentWasUpdated()
+    }
+
     private func fetchEditorDependencies() async throws -> EditorDependencies {
         let settings: String?
         do {
@@ -424,7 +437,7 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
             // is still reflecting the actual startup time of the editor
             editorSession.start()
         }
-        self.hideActivityIndicator()
+        hideActivityIndicator()
     }
 
     func editor(_ viewContoller: GutenbergKit.EditorViewController, didDisplayInitialContent content: String) {

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -355,18 +355,8 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     private func actuallyLoadEditor() async {
         showActivityIndicator()
 
-        do {
-            let dependencies = try await fetchEditorDependencies()
-            startEditor(dependencies: dependencies)
-        } catch {
-            hideActivityIndicator()
-
-            let host = UIHostingView(view: EmptyStateView.failure(error: error) { [weak self] in
-                self?.loadEditor()
-            })
-            view.addSubview(host)
-            host.pinEdges()
-        }
+        let dependencies = await fetchEditorDependencies()
+        startEditor(dependencies: dependencies)
     }
 
     private func startEditor(dependencies: EditorDependencies) {
@@ -383,7 +373,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         editorContentWasUpdated()
     }
 
-    private func fetchEditorDependencies() async throws -> EditorDependencies {
+    private func fetchEditorDependencies() async -> EditorDependencies {
         let settings: String?
         do {
             settings = try await blockEditorSettingsService.getSettingsString(allowingCachedResponse: true)

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -10,46 +10,6 @@ import WebKit
 import CocoaLumberjackSwift
 
 class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor {
-
-    enum EditorLoadingState {
-        /// We haven't done anything with the editor yet
-        ///
-        /// Valid states to transition to:
-        /// - .loadingDependencies
-        case uninitialized
-
-        /// We're loading the editor's dependencies
-        ///
-        /// Valid states to transition to:
-        /// - .loadingCancelled
-        /// - .dependencyError
-        /// - .dependenciesReady
-        case loadingDependencies(_ task: Task<Void, Error>)
-
-        /// We cancelled loading the editor's dependencies
-        ///
-        /// Valid states to transition to:
-        /// - .loadingDependencies
-        case loadingCancelled
-
-        /// An error occured while fetching dependencies
-        ///
-        /// Valid states to transition to:
-        /// - .loadingDependencies
-        case dependencyError(Error)
-
-        /// All dependencies have been loaded, so we're ready to start the editor
-        ///
-        /// Valid states to transition to:
-        /// - .ready
-        case dependenciesReady(EditorDependencies)
-
-        /// The editor is fully loaded and we've passed all required configuration and data to it
-        ///
-        /// There are no valid transition states from `.started`
-        case started
-    }
-
     struct EditorDependencies {
         let settings: String?
         let didLoadCookies: Bool
@@ -125,9 +85,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
     private var suggestionViewBottomConstraint: NSLayoutConstraint?
     private var currentSuggestionsController: GutenbergSuggestionsViewController?
 
-    private var editorState: EditorLoadingState = .uninitialized
-    private var dependencyLoadingError: Error?
-    private var editorLoadingTask: Task<Void, Error>?
+    private var editorLoadingTask: Task<Void, Never>?
 
     // TODO: remove (none of these APIs are needed for the new editor)
     func prepopulateMediaItems(_ media: [Media]) {}
@@ -215,8 +173,6 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         configureNavigationBar()
         refreshInterface()
 
-        startLoadingDependencies()
-
         SiteSuggestionService.shared.prefetchSuggestionsIfNeeded(for: post.blog) {
             // Do nothing
         }
@@ -228,56 +184,17 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 //            DDLogError("Error syncing JETPACK: \(String(describing: error))")
 //        })
 
+        editorLoadingTask = Task { @MainActor in
+            await loadEditor()
+        }
+
         onViewDidLoad()
-    }
-
-    override func viewWillAppear(_ animated: Bool) {
-        super.viewWillAppear(animated)
-
-        if case .loadingDependencies = self.editorState {
-            self.showActivityIndicator()
-        }
-
-        if case .loadingCancelled = self.editorState {
-            startLoadingDependencies()
-        }
-    }
-
-    override func viewDidAppear(_ animated: Bool) {
-        super.viewDidAppear(animated)
-
-        if case .loadingCancelled = self.editorState {
-            preconditionFailure("Dependency loading should not be cancelled")
-        }
-
-        self.editorLoadingTask = Task { [weak self] in
-            guard let self else { return }
-            do {
-                while case .loadingDependencies = self.editorState {
-                    try await Task.sleep(nanoseconds: 1000)
-                }
-
-                switch self.editorState {
-                    case .uninitialized: preconditionFailure("Dependencies must be initialized")
-                    case .loadingDependencies: preconditionFailure("Dependencies should not still be loading")
-                    case .loadingCancelled: preconditionFailure("Dependency loading should not be cancelled")
-                    case .dependencyError(let error): self.showEditorError(error)
-                    case .dependenciesReady(let dependencies): try await self.startEditor(settings: dependencies.settings)
-                    case .started: preconditionFailure("The editor should not already be started")
-                }
-            } catch {
-                self.showEditorError(error)
-            }
-        }
     }
 
     override func viewWillDisappear(_ animated: Bool) {
         super.viewWillDisappear(animated)
 
         if isBeingDismissedDirectlyOrByAncestor() {
-            if case .loadingDependencies(let task) = editorState {
-                task.cancel()
-            }
             editorLoadingTask?.cancel()
         }
     }
@@ -363,49 +280,27 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
         }
     }
 
-    func startLoadingDependencies() {
-        switch self.editorState {
-        case .uninitialized:
-            break // This is fine – we're loading for the first time
-        case .loadingDependencies:
-            preconditionFailure("`startLoadingDependencies` should not be called while in the `.loadingDependencies` state")
-        case .loadingCancelled:
-            break // This is fine – we're loading after quickly switching posts
-        case .dependencyError:
-            break // We're retrying after an error
-        case .dependenciesReady:
-            preconditionFailure("`startLoadingDependencies` should not be called while in the `.dependenciesReady` state")
-        case .started:
-            preconditionFailure("`startLoadingDependencies` should not be called while in the `.started` state")
-        }
-
-        self.editorState = .loadingDependencies(Task {
-            do {
-                let dependencies = try await fetchEditorDependencies()
-                self.editorState = .dependenciesReady(dependencies)
-            } catch {
-                self.editorState = .dependencyError(error)
-            }
-        })
-    }
-
     @MainActor
-    func startEditor(settings: String?) async throws {
-        guard case .dependenciesReady = self.editorState else {
-            preconditionFailure("`startEditor` should only be called when the editor is in the `.dependenciesReady` state.")
+    private func loadEditor() async {
+        showActivityIndicator()
+
+        do {
+            let dependencies = try await fetchEditorDependencies()
+
+            let configuration = editorViewController.configuration.toBuilder()
+                .apply(dependencies.settings) { $0.setEditorSettings($1) }
+                .setTitle(post.postTitle ?? "")
+                .setContent(post.content ?? "")
+                .build()
+
+            editorViewController.updateConfiguration(configuration)
+            editorViewController.startEditorSetup()
+
+            // Handles refreshing controls with state context after options screen is dismissed
+            editorContentWasUpdated()
+        } catch {
+            // TODO: handle errors
         }
-
-        let updatedConfiguration = self.editorViewController.configuration.toBuilder()
-            .apply(settings) { $0.setEditorSettings($1) }
-            .setTitle(post.postTitle ?? "")
-            .setContent(post.content ?? "")
-            .build()
-
-        self.editorViewController.updateConfiguration(updatedConfiguration)
-        self.editorViewController.startEditorSetup()
-
-        // Handles refreshing controls with state context after options screen is dismissed
-        editorContentWasUpdated()
     }
 
     // MARK: - Keyboard Observers


### PR DESCRIPTION
## Changes 

- Fix an issues with editor cancelling loading if you open "Revisions"
- Remove code handling non-existing error scenarios
- Fix (potential) issue with `RawBlockEditorSettingsService` not proceeding with the request if cache read fails
- Remove busy-waiting for `editorState` happening every 1 microsecond

<hr/>

### Issue with "Revisions"

**Prerequisites**
- Clean install
- Add a delay when loading dependencies (using your preferred way)

**Steps**
- Open the editor for the first time
- Tap "More" / "Revisions"

**Observed Results**
- Editor never gets loaded

**RCA**

`viewWillDisappear` is called not only when you close the screen, but also when it temporary gets covered by a different screen being presented as fullscreen modal or being pushed into the navigation stack.

