### PR TITLE
Fix a couple of bugs in managing terms

### DIFF
--- a/WordPress/Classes/ViewRelated/Tags/EditTagView.swift
+++ b/WordPress/Classes/ViewRelated/Tags/EditTagView.swift
@@ -54,12 +54,30 @@ struct EditTagView: View {
 
             if viewModel.isExistingTag {
                 Section {
-                    Button(action: {
+                    Button(role: .destructive) {
                         viewModel.showDeleteConfirmation = true
-                    }) {
+                    } label: {
                         Text(SharedStrings.Button.delete)
                             .foregroundColor(.red)
                     }
+                    .frame(maxWidth: .infinity)
+                }
+                .confirmationDialog(
+                    Strings.deleteConfirmationTitle,
+                    isPresented: $viewModel.showDeleteConfirmation,
+                    titleVisibility: .visible
+                ) {
+                    Button(SharedStrings.Button.delete, role: .destructive) {
+                        Task {
+                            let success = await viewModel.deleteTag()
+                            if success {
+                                dismiss()
+                            }
+                        }
+                    }
+                    Button(SharedStrings.Button.cancel, role: .cancel) { }
+                } message: {
+                    Text(Strings.deleteConfirmationMessage)
                 }
             }
         }
@@ -77,23 +95,6 @@ struct EditTagView: View {
                 }
                 .disabled(viewModel.tagName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
             }
-        }
-        .confirmationDialog(
-            Strings.deleteConfirmationTitle,
-            isPresented: $viewModel.showDeleteConfirmation,
-            titleVisibility: .visible
-        ) {
-            Button(SharedStrings.Button.delete, role: .destructive) {
-                Task {
-                    let success = await viewModel.deleteTag()
-                    if success {
-                        dismiss()
-                    }
-                }
-            }
-            Button(SharedStrings.Button.cancel, role: .cancel) { }
-        } message: {
-            Text(Strings.deleteConfirmationMessage)
         }
         .alert(SharedStrings.Error.generic, isPresented: $viewModel.showError) {
             Button(SharedStrings.Button.ok) { }

--- a/WordPress/Classes/ViewRelated/Tags/SiteTagsView.swift
+++ b/WordPress/Classes/ViewRelated/Tags/SiteTagsView.swift
@@ -55,13 +55,7 @@ private struct TagsListView: View {
         .listStyle(.plain)
         .overlay {
             if let response = viewModel.response {
-                if response.isEmpty {
-                    EmptyStateView(
-                        viewModel.labels.empty,
-                        systemImage: "tag",
-                        description: viewModel.labels.emptyDescription
-                    )
-                }
+                NoTermView(viewModel: viewModel, response: response)
             } else if viewModel.isLoading {
                 ProgressView()
             } else if let error = viewModel.error {
@@ -72,6 +66,21 @@ private struct TagsListView: View {
         }
         .onAppear {
             viewModel.onAppear()
+        }
+    }
+}
+
+private struct NoTermView: View {
+    @ObservedObject var viewModel: TagsViewModel
+    @ObservedObject var response: TagsPaginatedResponse
+
+    var body: some View {
+        if response.isEmpty {
+            EmptyStateView(
+                viewModel.labels.empty,
+                systemImage: "tag",
+                description: viewModel.labels.emptyDescription
+            )
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes https://linear.app/a8c/issue/CMM-877 and https://linear.app/a8c/issue/CMM-876

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
