### PR TITLE
Add corner radius to Aspect Ratio grid

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Views/SiteMediaCollectionCell.swift
@@ -119,6 +119,9 @@ final class SiteMediaCollectionCell: UICollectionViewCell, Reusable {
             aspectRatioConstraint.isActive = true
             self.aspectRatioConstraint = aspectRatioConstraint
         }
+
+        imageContainerView.layer.cornerRadius = isAspectRatioModeEnabled ? 4 : 0
+        imageContainerView.layer.masksToBounds = true
     }
 
     // MARK: - Refresh


### PR DESCRIPTION
Apple added small corner radius to Photos with "Aspect Grid" on, so I've done the same in the "Site Media" – looks a tiny bit nicer. To enable it, tap the "More/Filters" button at the top. It's enabled by default on iPad.

<img width="456" height="972" alt="Screenshot 2025-10-29 at 8 10 16 AM" src="https://github.com/user-attachments/assets/3a185236-a994-4e5c-b446-80fa22b68a99" />
