### PR TITLE
[Tooling] Use ReleasesV2 version as the source of truth during Code Freeze

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -128,15 +128,14 @@ end
 
 # Returns the build code of the app for the code freeze. It is the release version name plus sets the build number to 0
 #
-def build_code_code_freeze
+def build_code_code_freeze(version_short: nil)
+  version_short ||= PUBLIC_VERSION_FILE.read_release_version
   # Read the current build code from the .xcconfig file and parse it into an AppVersion object
   # The AppVersion is used because WP/JPiOS uses the four part (1.2.3.4) build code format, so the version
   # calculator can be used to calculate the next four-part version
-  release_version_current = VERSION_FORMATTER.parse(PUBLIC_VERSION_FILE.read_release_version)
-  # Calculate the next release version, which will be used as the basis of the new build code
-  build_code_code_freeze = VERSION_CALCULATOR.next_release_version(version: release_version_current)
+  release_version_current = VERSION_FORMATTER.parse(version_short)
   # Return the formatted build code
-  BUILD_CODE_FORMATTER.build_code(version: build_code_code_freeze)
+  BUILD_CODE_FORMATTER.build_code(version: release_version_current)
 end
 
 # Returns the build code of the app for the code freeze. It is the hotfix version name plus sets the build number to 0

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -126,15 +126,15 @@ def build_code_current
   BUILD_CODE_FORMATTER.build_code(version: version)
 end
 
-# Returns the build code of the app for the code freeze. It is the release version name plus sets the build number to 0
+# Returns the initial build code for a code freeze (e.g., "1.2.3.0" for release version "1.2.3")
+# Takes the release version and formats it as a four-part build code with the build number set to 0
 #
 def build_code_code_freeze(version_short: nil)
+  # Use provided version or read the current release version from the .xcconfig file
   version_short ||= PUBLIC_VERSION_FILE.read_release_version
-  # Read the current build code from the .xcconfig file and parse it into an AppVersion object
-  # The AppVersion is used because WP/JPiOS uses the four part (1.2.3.4) build code format, so the version
-  # calculator can be used to calculate the next four-part version
+  # Parse the release version string (e.g., "1.2.3") into an AppVersion object
   release_version_current = VERSION_FORMATTER.parse(version_short)
-  # Return the formatted build code
+  # Format as four-part build code (e.g., "1.2.3.0")
   BUILD_CODE_FORMATTER.build_code(version: release_version_current)
 end
 

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -19,35 +19,23 @@ platform :ios do
     # Check out the up-to-date default branch, the designated starting point for the code freeze
     Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)
 
-    # Use provided version from release tool, or fall back to computed version
-    computed_version = release_version_next
-    provided_version = version
-    new_version = provided_version || computed_version
+    # If a new version is passed, use it as source of truth from now on
+    new_version = version || release_version_next
+    release_branch_name = compute_release_branch_name(options: { version: new_version, skip_confirm: skip_confirm }, version: new_version)
+    new_build_code = build_code_code_freeze(version_short: new_version)
 
-    # Fail if provided version differs from computed version
-    if provided_version && provided_version != computed_version
-      error_message = <<~ERROR
-        ❌ Version mismatch detected!
-
-        The explicitly-provided version from the release tool is '#{provided_version}' but the computed version from the codebase is '#{computed_version}'.
-
-        This mismatch must be resolved before proceeding with the code freeze. Please investigate and ensure the versions are aligned.
-      ERROR
-      buildkite_annotate(style: 'error', context: 'code-freeze-version-mismatch', message: error_message) if is_ci
-      UI.user_error!(error_message)
-    end
-
-    release_branch_name = compute_release_branch_name(options: { version: version, skip_confirm: skip_confirm }, version: new_version)
     ensure_branch_does_not_exist!(release_branch_name)
 
     # The `release_version_next` is used as the `new internal release version` value because the external and internal
     # release versions are always the same.
     message = <<~MESSAGE
+
       Code Freeze:
       • New release branch from #{DEFAULT_BRANCH}: #{release_branch_name}
 
       • Current release version and build code: #{release_version_current} (#{build_code_current}).
-      • New release version and build code: #{new_version} (#{build_code_code_freeze}).
+      • New release version and build code: #{new_version} (#{new_build_code}).
+
     MESSAGE
 
     UI.important(message)
@@ -61,8 +49,8 @@ platform :ios do
     # Bump the release version and build code and write it to the `xcconfig` file
     UI.message 'Bumping release version and build code...'
     PUBLIC_VERSION_FILE.write(
-      version_short: release_version_next,
-      version_long: build_code_code_freeze
+      version_short: new_version,
+      version_long: new_build_code
     )
     UI.success "Done! New Release Version: #{release_version_current}. New Build Code: #{build_code_current}"
 

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -24,15 +24,17 @@ platform :ios do
     provided_version = version
     new_version = provided_version || computed_version
 
-    # Warn if provided version differs from computed version
+    # Fail if provided version differs from computed version
     if provided_version && provided_version != computed_version
-      warning_message = <<~WARNING
-        ⚠️ Version mismatch: The explicitly-provided version was '#{provided_version}' while new computed version would have been '#{computed_version}'.
-        If this is unexpected, you might want to investigate the discrepency.
-        Continuing with the explicitly-provided verison '#{provided_version}'.
-      WARNING
-      UI.important(warning_message)
-      buildkite_annotate(style: 'warning', context: 'code-freeze-version-mismatch', message: warning_message) if is_ci
+      error_message = <<~ERROR
+        ❌ Version mismatch detected!
+
+        The explicitly-provided version from the release tool is '#{provided_version}' but the computed version from the codebase is '#{computed_version}'.
+
+        This mismatch must be resolved before proceeding with the code freeze. Please investigate and ensure the versions are aligned.
+      ERROR
+      buildkite_annotate(style: 'error', context: 'code-freeze-version-mismatch', message: error_message) if is_ci
+      UI.user_error!(error_message)
     end
 
     release_branch_name = compute_release_branch_name(options: { version: version, skip_confirm: skip_confirm }, version: new_version)


### PR DESCRIPTION
See AINFRA-1478

## Description

This PR enhances the version handling added in the previous iteration to assume the version received by the code freeze lane as the source of truth, ignoring potential mismatches between the ReleasesV2 version and the project's computed version.

## Testing

You can make sure the calculated release branch, current version and the next version are correctly shown in the "Continue" prompt. Just **remember to answer `N` when asked to continue**, to cancel the actual code freeze.

To avoid unexpected results, comment out the lines doing `ensure_git_status_clean` and `Fastlane::Helper::GitHelper.checkout_and_pull(DEFAULT_BRANCH)` at the beginning of the lane.

You can run the `code_freeze` lane, with and without the version parameters:
- Run `bundle exec fastlane code_freeze ` 
- Run `bundle exec fastlane code_freeze version:30.6`

This will be fully tested in the next release cycle during code freeze.