### PR TITLE
build: Integrate the latest GutenbergKit changes

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "0018852d4b5daf8ccfef53dba310fdb313c4511d7c5ade6fe3ef42fa2490ca4e",
+  "originHash" : "33b78b0c403a7a4c2e461dff99d86f18e7b060ddd2dfb2327b41e1406735762d",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,8 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "06a322f5fe222c4991abca407b7392f76bcff9d8",
-        "version" : "0.9.0"
+        "revision" : "3527195a557cdf28c589e1f75b76652e16eb9b2b"
       }
     },
     {
@@ -293,6 +292,15 @@
       "state" : {
         "revision" : "6b5f6d2ffc92c10d38cb9c716ae37b2832230c89",
         "version" : "8.0.4"
+      }
+    },
+    {
+      "identity" : "svgview",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/exyte/SVGView.git",
+      "state" : {
+        "revision" : "6465962facdd25cb96eaebc35603afa2f15d2c0d",
+        "version" : "1.0.6"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "67092cca4799694e12c471d9f94f11555fdc850008233d4e5550e58f35fbd89a",
+  "originHash" : "4c7d004ff26e92b4a1aced9ed653f925454fd22c6c582cddc07f1e7ef0611720",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,7 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "8e7f4e018da5afc55b5626548c5f2dcbe16ec89a"
+        "revision" : "4cc0684226c358a430f3d9bc81815883d71cfafa",
+        "version" : "0.10.0-alpha.0"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fea3bdea69d2569a3b51ceba0610b8794ab1d089a622a8330594206eedf5ca7e",
+  "originHash" : "67092cca4799694e12c471d9f94f11555fdc850008233d4e5550e58f35fbd89a",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "aa6264f4a39cd9289961980e3150f5f9840117d7"
+        "revision" : "8e7f4e018da5afc55b5626548c5f2dcbe16ec89a"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "33b78b0c403a7a4c2e461dff99d86f18e7b060ddd2dfb2327b41e1406735762d",
+  "originHash" : "fea3bdea69d2569a3b51ceba0610b8794ab1d089a622a8330594206eedf5ca7e",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "3527195a557cdf28c589e1f75b76652e16eb9b2b"
+        "revision" : "aa6264f4a39cd9289961980e3150f5f9840117d7"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "aa6264f4a39cd9289961980e3150f5f9840117d7"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "8e7f4e018da5afc55b5626548c5f2dcbe16ec89a"),
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20251101"),
         .package(
             url: "https://github.com/Automattic/color-studio",

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "8e7f4e018da5afc55b5626548c5f2dcbe16ec89a"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.10.0-alpha.0"),
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20251101"),
         .package(
             url: "https://github.com/Automattic/color-studio",

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "3527195a557cdf28c589e1f75b76652e16eb9b2b"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "aa6264f4a39cd9289961980e3150f5f9840117d7"),
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20251101"),
         .package(
             url: "https://github.com/Automattic/color-studio",

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -53,7 +53,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.9.0"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "3527195a557cdf28c589e1f75b76652e16eb9b2b"),
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20251101"),
         .package(
             url: "https://github.com/Automattic/color-studio",

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/Editor/CommentGutenbergEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/Editor/CommentGutenbergEditorViewController.swift
@@ -89,6 +89,10 @@ extension CommentGutenbergEditorViewController: GutenbergKit.EditorViewControlle
         // Do nothing
     }
 
+    func editor(_ viewController: GutenbergKit.EditorViewController, didLogMessage message: String, level: GutenbergKit.LogLevel) {
+        // Do nothing
+    }
+
     func editor(_ viewController: GutenbergKit.EditorViewController, didRequestMediaFromSiteMediaLibrary config: GutenbergKit.OpenMediaLibraryAction) {
         // Do nothing
     }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -565,8 +565,8 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
         }
     }
 
-    func editor(_ viewController: GutenbergKit.EditorViewController, performRequest: GutenbergKit.EditorNetworkRequest) async throws -> GutenbergKit.EditorNetworkResponse {
-        throw URLError(.unknown)
+    func editor(_ viewController: GutenbergKit.EditorViewController, didLogMessage message: String, level: GutenbergKit.LogLevel) {
+        // Do nothing
     }
 
     func editor(_ viewController: GutenbergKit.EditorViewController, didRequestMediaFromSiteMediaLibrary config: OpenMediaLibraryAction) {


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Integrate the latest GutenbergKit changes. Namely, https://github.com/wordpress-mobile/GutenbergKit/pull/209, where GutenbergKit's default editor supports plugins. 

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
See https://github.com/wordpress-mobile/GutenbergKit/pull/209

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
