### PR TITLE
Ship the Media Library Storage view

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -21,6 +21,9 @@ import WordPressShared
 
     // Media
     case siteMediaShareTapped
+    case mediaStorageDetailsViewed
+    case mediaStorageDetailsActionTapped
+    case mediaStorageDetailsPurchaseCompleted
 
     // Settings and Prepublishing Nudges
     case editorPostPublishTap
@@ -720,6 +723,12 @@ import WordPressShared
             // Media
         case .siteMediaShareTapped:
             return "site_media_shared_tapped"
+        case .mediaStorageDetailsViewed:
+            return "media_storage_details_viewed"
+        case .mediaStorageDetailsActionTapped:
+            return "media_storage_details_action_tapped"
+        case .mediaStorageDetailsPurchaseCompleted:
+            return "media_storage_details_purchase_completed"
         // Editor
         case .editorPostPublishTap:
             return "editor_post_publish_tapped"

--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -24,7 +24,6 @@ public enum FeatureFlag: Int, CaseIterable {
     case readerGutenbergCommentComposer
     case pluginManagementOverhaul
     case newStats
-    case mediaQuotaView
     case intelligence
     case newSupport
     case nativeBlockInserter
@@ -80,8 +79,6 @@ public enum FeatureFlag: Int, CaseIterable {
             return false
         case .newStats:
             return false
-        case .mediaQuotaView:
-            return false
         case .intelligence:
             let languageCode = Locale.current.language.languageCode?.identifier
             return (languageCode ?? "en").hasPrefix("en")
@@ -130,7 +127,6 @@ extension FeatureFlag {
         case .pluginManagementOverhaul: "Plugin Management Overhaul"
         case .readerGutenbergCommentComposer: "Gutenberg Comment Composer"
         case .newStats: "New Stats"
-        case .mediaQuotaView: "Media Quota"
         case .intelligence: "Intelligence"
         case .newSupport: "New Support"
         case .nativeBlockInserter: "Native Block Inserter"

--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaAddMediaMenuController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaAddMediaMenuController.swift
@@ -35,18 +35,12 @@ final class SiteMediaAddMediaMenuController: NSObject, PHPickerViewControllerDel
                 UIMenu(options: [.displayInline], children: freeMediaActions)
             ]
         }
-        if let quotaUsageDescription = blog.quotaUsageDescription {
-            if FeatureFlag.mediaQuotaView.enabled {
-                children += [
-                    UIAction(title: Strings.viewUsage, subtitle: blog.quotaUsageShortDescription, image: UIImage(systemName: "opticaldiscdrive"), handler: { _ in
-                        self.showQuotaView(from: viewController)
-                    })
-                ]
-            } else {
-                children += [
-                    UIAction(subtitle: quotaUsageDescription, handler: { _ in })
-                ]
-            }
+        if blog.isHostedAtWPcom, blog.isQuotaAvailable {
+            children += [
+                UIAction(title: Strings.viewUsage, subtitle: blog.quotaUsageShortDescription, image: UIImage(systemName: "opticaldiscdrive"), handler: { _ in
+                    self.showQuotaView(from: viewController)
+                })
+            ]
         }
         return UIMenu(options: [.displayInline], children: children)
     }


### PR DESCRIPTION
## Description

This PR adds some analytic events and adds code to make sure the view is only accessible to WP.com sites.

## Testing instructions

The entry is at: Media -> + menu -> View Usage

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
