### PR TITLE
Fix related posts not working

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -844,7 +844,11 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
         let controller = ReaderDetailViewController.loadFromStoryboard()
         let coordinator = ReaderDetailCoordinator(view: controller)
-        coordinator.postURL = url
+        coordinator.set(
+            postID: NSNumber(value: simplePost.postID),
+            siteID: NSNumber(value: simplePost.siteID),
+            isFeed: false
+        )
         coordinator.remoteSimplePost = simplePost
         controller.coordinator = coordinator
 


### PR DESCRIPTION
## Description
Some related posts didn't work correctly because they were referenced by URL instead of passing around the post ID and site ID.

## Testing instructions
Go to https://ma.tt/2025/11/bending-spoons/ in reader and try tapping a related post. Prior to this PR, it wouldn't work. After this PR, it does.