### PR TITLE
Fix PostEditor dismissed twice

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -13,7 +13,6 @@ extension PostEditor {
         let viewModel = PostSettingsViewModel(post: post)
         viewModel.onEditorPostSaved = { [weak self] in
             self?.didSavePostSettings(originalFeaturedImageID: originalFeaturedImageID)
-            self?.navigationController?.dismiss(animated: true)
         }
         let postSettingsVC = PostSettingsViewController(viewModel: viewModel)
         let navigation = UINavigationController(rootViewController: postSettingsVC)


### PR DESCRIPTION
## Description

This PR cherry-picks [this commit](https://github.com/wordpress-mobile/WordPress-iOS/pull/24940/commits/a16b5cecf19cbb5e6ae4b8b37d323e131c83c40b) in the 26.4.0.3 build to the hotfix 26.4.1.

[The 26.4 tag is behind the 26.4.0.3 tag](https://github.com/wordpress-mobile/WordPress-iOS/compare/26.4...26.4.0.3). I'm not exactly sure what caused that.


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
