### PR TITLE
Break a retain cycle between a UIAction and UIViewController

### DIFF
--- a/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaAddMediaMenuController.swift
+++ b/WordPress/Classes/ViewRelated/Media/SiteMedia/Controllers/SiteMediaAddMediaMenuController.swift
@@ -37,9 +37,14 @@ final class SiteMediaAddMediaMenuController: NSObject, PHPickerViewControllerDel
         }
         if blog.isHostedAtWPcom, blog.isQuotaAvailable {
             children += [
-                UIAction(title: Strings.viewUsage, subtitle: blog.quotaUsageShortDescription, image: UIImage(systemName: "opticaldiscdrive"), handler: { _ in
+                UIAction(
+                    title: Strings.viewUsage,
+                    subtitle: blog.quotaUsageShortDescription,
+                    image: UIImage(systemName: "opticaldiscdrive")
+                ) { [weak self, weak viewController] _ in
+                    guard let self, let viewController else { return }
                     self.showQuotaView(from: viewController)
-                })
+                }
             ]
         }
         return UIMenu(options: [.displayInline], children: children)


### PR DESCRIPTION
## Description

The retain cycle was introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/24982.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
