### PR TITLE
Add missing call to fetch/update Reader provisioning profile

### DIFF
--- a/fastlane/lanes/codesign.rb
+++ b/fastlane/lanes/codesign.rb
@@ -105,6 +105,7 @@ platform :ios do
   # @option [Boolean] readonly (default: true) Whether to only fetch existing certificates and profiles, without generating new ones.
   #
   lane :update_certs_and_profiles_app_store do |readonly: true|
+    update_certs_and_profiles_app_store_reader(readonly: readonly)
     update_certs_and_profiles_jetpack_app_store(readonly: readonly)
     update_certs_and_profiles_wordpress_app_store(readonly: readonly)
   end


### PR DESCRIPTION
Run into this while regenerating the distribution provisioning profiles, see https://linear.app/a8c/issue/AINFRA-1443

Noticed that the naming is inconsistent, and that Reader is missing from the grouped calls. Logged https://linear.app/a8c/issue/AINFRA-1552 to tidy this up later on.