### PR TITLE
[Tooling] Improve `new_hotfix_release` lane to work when there's no release tag

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -284,10 +284,10 @@ platform :ios do
     base_ref_for_hotfix = if git_tag_exists(tag: previous_version, remote: true)
                             previous_version
                           elsif Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: previous_release_branch)
-                            UI.message("ℹ️  Tag #{previous_version} not found. Using release branch #{previous_release_branch} as the base for hotfix instead.")
+                            UI.message("ℹ️  Tag '#{previous_version}' not found on the remote. Using release branch '#{previous_release_branch}' as the base for hotfix instead.")
                             previous_release_branch
                           else
-                            UI.user_error!("Neither tag #{previous_version} nor branch #{previous_release_branch} exists! A hotfix branch cannot be created.")
+                            UI.user_error!("Neither tag '#{previous_version}' nor branch '#{previous_release_branch}' exists on the remote! A hotfix branch cannot be created.")
                           end
 
     # Check versions

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -308,6 +308,9 @@ platform :ios do
     # Check tags
     UI.user_error!("Version '#{new_version}' already exists on the remote! Abort!") if git_tag_exists(tag: new_version, remote: true)
 
+    # Fetch the base ref to ensure it's available locally
+    sh('git', 'fetch', 'origin', base_ref_for_hotfix)
+
     # Create the hotfix branch
     UI.message("Creating hotfix branch from '#{base_ref_for_hotfix}'...")
     Fastlane::Helper::GitHelper.create_branch(compute_release_branch_name(options: options, version: new_version), from: base_ref_for_hotfix)

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -304,20 +304,20 @@ platform :ios do
     UI.user_error!('Aborted by user request') unless options[:skip_confirm] || UI.confirm('Do you want to continue?')
 
     # Check tags
-    UI.user_error!("Version #{new_version} already exists! Abort!") if git_tag_exists(tag: new_version)
+    UI.user_error!("Version '#{new_version}' already exists on the remote! Abort!") if git_tag_exists(tag: new_version, remote: true)
 
     # Create the hotfix branch
-    UI.message "Creating hotfix branch from #{base_ref_for_hotfix}..."
+    UI.message("Creating hotfix branch from '#{base_ref_for_hotfix}'...")
     Fastlane::Helper::GitHelper.create_branch(compute_release_branch_name(options: options, version: new_version), from: base_ref_for_hotfix)
-    UI.success "Done! New hotfix branch is: #{git_branch}"
+    UI.success("Done! New hotfix branch is: '#{git_branch}'")
 
     # Bump the hotfix version and build code and write it to the `xcconfig` file
-    UI.message 'Bumping hotfix version and build code...'
+    UI.message('Bumping hotfix version and build code...')
     PUBLIC_VERSION_FILE.write(
       version_short: new_version,
       version_long: build_code_hotfix
     )
-    UI.success "Done! New Release Version: #{release_version_current}. New Build Code: #{build_code_current}"
+    UI.success("Done! New Release Version: '#{release_version_current}'. New Build Code: '#{build_code_current}'")
 
     commit_version_and_build_files
 

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -277,6 +277,8 @@ platform :ios do
 
     # Parse the provided version into an AppVersion object
     parsed_version = VERSION_FORMATTER.parse(new_version)
+    # Validate that this is a hotfix version (must have a patch component > 0)
+    UI.user_error!("Invalid hotfix version '#{new_version}'. Must include a patch number.") unless parsed_version.patch.to_i.positive?
     previous_version = VERSION_FORMATTER.release_version(VERSION_CALCULATOR.previous_patch_version(version: parsed_version))
     previous_release_branch = compute_release_branch_name(options: options, version: previous_version)
 

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -281,7 +281,7 @@ platform :ios do
     previous_release_branch = compute_release_branch_name(options: options, version: previous_version)
 
     # Determine the base for the hotfix branch: either a tag or a release branch
-    base_ref_for_hotfix = if git_tag_exists(tag: previous_version)
+    base_ref_for_hotfix = if git_tag_exists(tag: previous_version, remote: true)
                             previous_version
                           elsif Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: previous_release_branch)
                             UI.message("ℹ️  Tag #{previous_version} not found. Using release branch #{previous_release_branch} as the base for hotfix instead.")

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -311,9 +311,12 @@ platform :ios do
     # Fetch the base ref to ensure it's available locally
     sh('git', 'fetch', 'origin', base_ref_for_hotfix)
 
+    hotfix_branch = compute_release_branch_name(options: options, version: new_version)
+    ensure_branch_does_not_exist!(hotfix_branch)
+
     # Create the hotfix branch
     UI.message("Creating hotfix branch from '#{base_ref_for_hotfix}'...")
-    Fastlane::Helper::GitHelper.create_branch(compute_release_branch_name(options: options, version: new_version), from: base_ref_for_hotfix)
+    Fastlane::Helper::GitHelper.create_branch(hotfix_branch, from: base_ref_for_hotfix)
     UI.success("Done! New hotfix branch is: '#{git_branch}'")
 
     # Bump the hotfix version and build code and write it to the `xcconfig` file

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -284,6 +284,7 @@ platform :ios do
     base_ref_for_hotfix = if git_tag_exists(tag: previous_version)
                             previous_version
                           elsif Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: previous_release_branch)
+                            UI.message("ℹ️  Tag #{previous_version} not found. Using release branch #{previous_release_branch} as the base for hotfix instead.")
                             previous_release_branch
                           else
                             UI.user_error!("Neither tag #{previous_version} nor branch #{previous_release_branch} exists! A hotfix branch cannot be created.")

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -278,6 +278,16 @@ platform :ios do
     # Parse the provided version into an AppVersion object
     parsed_version = VERSION_FORMATTER.parse(new_version)
     previous_version = VERSION_FORMATTER.release_version(VERSION_CALCULATOR.previous_patch_version(version: parsed_version))
+    previous_release_branch = compute_release_branch_name(options: options, version: previous_version)
+
+    # Determine the base for the hotfix branch: either a tag or a release branch
+    base_ref_for_hotfix = if git_tag_exists(tag: previous_version)
+                            previous_version
+                          elsif Fastlane::Helper::GitHelper.branch_exists_on_remote?(branch_name: previous_release_branch)
+                            previous_release_branch
+                          else
+                            UI.user_error!("Neither tag #{previous_version} nor branch #{previous_release_branch} exists! A hotfix branch cannot be created.")
+                          end
 
     # Check versions
     message = <<~MESSAGE
@@ -286,7 +296,7 @@ platform :ios do
       • Current release version and build code: #{release_version_current} (#{build_code_current}).
       • New release version and build code: #{new_version} (#{build_code_hotfix}).
 
-      Branching from tag: #{previous_version}
+      Branching from #{base_ref_for_hotfix}
     MESSAGE
 
     UI.important(message)
@@ -294,11 +304,10 @@ platform :ios do
 
     # Check tags
     UI.user_error!("Version #{new_version} already exists! Abort!") if git_tag_exists(tag: new_version)
-    UI.user_error!("Version #{previous_version} is not tagged! A hotfix branch cannot be created.") unless git_tag_exists(tag: previous_version)
 
     # Create the hotfix branch
-    UI.message 'Creating hotfix branch...'
-    Fastlane::Helper::GitHelper.create_branch(compute_release_branch_name(options: options, version: new_version), from: previous_version)
+    UI.message "Creating hotfix branch from #{base_ref_for_hotfix}..."
+    Fastlane::Helper::GitHelper.create_branch(compute_release_branch_name(options: options, version: new_version), from: base_ref_for_hotfix)
     UI.success "Done! New hotfix branch is: #{git_branch}"
 
     # Bump the hotfix version and build code and write it to the `xcconfig` file


### PR DESCRIPTION
Related to AINFRA-1518

## Description

This PR aims to add more robustness and require less manual intervention to the hotfix creation lane `new_hotfix_release`.

We have observed that sometimes it is possible that the release has been finalized but a release tag isn't present yet for some reason (likely due to the fact that the release hasn't been published yet), so release managers will get an error and require manual intervention.

This PR changes the code so that, if no release tag is present, we start the hotfix branch based on the corresponding release branch.


## Testing instructions

There are basically 3 test scenarios that can be simulated:
1. There is a release tag that can be used to create the hotfix branch
2. There's no tag, but there's still a release branch that can be used to create the hotfix branch
3. There's no tag or branch (error)

To test it, you can create test branches / tags (⚠️ delete them later or, even better, use [this technique](https://github.com/bloom/DayOne-Apple/pull/27670#issuecomment-3553138802) of pointing your working copy’s `origin` remote to a local bare repo instead ⚠️ ) and run `bundle exec fastlane new_hotfix_release skip_confirm:false version:"$VERSION"` and then answer `no` after the prompt so that the lane execution stops and check the printed values.

For example:
1. Create and push release branch `release/30.6` (which doesn't exist and has no corresponding tag for that version)
2. Run `bundle exec fastlane new_hotfix_release skip_confirm:false version:30.6.1`
3. It should use the `release/30.6` branch instead of trying to use a tag. It should print:
```
New Hotfix:

• Current release version and build code: 26.4.1 (26.4.1.1).
• New release version and build code: 30.6.1 (30.6.1.0).

Branching from release/30.6
```
