### PR TITLE
`PostContentProvider` functions all return nullable result

### DIFF
--- a/Sources/WordPressData/Objective-C/include/PostContentProvider.h
+++ b/Sources/WordPressData/Objective-C/include/PostContentProvider.h
@@ -1,16 +1,16 @@
 #import <Foundation/Foundation.h>
 
 @protocol PostContentProvider <NSObject>
-- (NSString *)titleForDisplay;
-- (NSString *)authorForDisplay;
-- (NSString *)contentForDisplay;
-- (NSString *)contentPreviewForDisplay;
-- (NSURL *)avatarURLForDisplay; // Some providers use a hardcoded URL or blavatar URL
-- (NSString *)gravatarEmailForDisplay;
-- (NSDate *)dateForDisplay;
+- (nullable NSString *)titleForDisplay;
+- (nullable NSString *)authorForDisplay;
+- (nullable NSString *)contentForDisplay;
+- (nullable NSString *)contentPreviewForDisplay;
+- (nullable NSURL *)avatarURLForDisplay; // Some providers use a hardcoded URL or blavatar URL
+- (nullable NSString *)gravatarEmailForDisplay;
+- (nullable NSDate *)dateForDisplay;
 @optional
-- (NSString *)blogNameForDisplay;
-- (NSURL *)featuredImageURLForDisplay;
-- (NSURL *)authorURL;
-- (NSArray <NSString *> *)tagsForDisplay;
+- (nullable NSString *)blogNameForDisplay;
+- (nullable NSURL *)featuredImageURLForDisplay;
+- (nullable NSURL *)authorURL;
+- (nullable NSArray <NSString *> *)tagsForDisplay;
 @end

--- a/Sources/WordPressData/Swift/AbstractPost+Searchable.swift
+++ b/Sources/WordPressData/Swift/AbstractPost+Searchable.swift
@@ -58,9 +58,9 @@ fileprivate extension AbstractPost {
         if let postTitle {
             // Try to generate some keywords from the title...
             keywords = postTitle.components(separatedBy: " ").map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
-        } else if !contentPreviewForDisplay().isEmpty {
+        } else if let content = contentPreviewForDisplay(), !content.isEmpty {
             // ...otherwise try to generate some keywords from the content preview
-            keywords = contentPreviewForDisplay().components(separatedBy: " ").map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
+            keywords = content.components(separatedBy: " ").map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
         }
         return keywords
     }

--- a/WordPress/Classes/Models/ReaderPost+Searchable.swift
+++ b/WordPress/Classes/Models/ReaderPost+Searchable.swift
@@ -28,7 +28,7 @@ extension ReaderPost: @retroactive SearchableItemConvertable {
         var title = titleForDisplay() ?? ""
         if title.isEmpty {
             // If titleForDisplay() happens to be empty, try using the content preview instead...
-            title = contentPreviewForDisplay()
+            title = contentPreviewForDisplay() ?? ""
         }
         return title
     }
@@ -58,9 +58,9 @@ fileprivate extension ReaderPost {
         if let postTitle {
             // Try to generate some keywords from the title...
             keywords = postTitle.components(separatedBy: " ").map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
-        } else if !contentPreviewForDisplay().isEmpty {
+        } else if let content = contentPreviewForDisplay(), !content.isEmpty {
             // ...otherwise try to generate some keywords from the content preview
-            keywords = contentPreviewForDisplay().components(separatedBy: " ").map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
+            keywords = content.components(separatedBy: " ").map({ $0.trimmingCharacters(in: .whitespacesAndNewlines) })
         }
         return keywords
     }

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderCrossPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderCrossPostCell.swift
@@ -143,7 +143,7 @@ private final class ReaderCrossPostView: UIView {
         }
         let template = meta.commentURL.isEmpty ? Strings.siteTemplate : Strings.commentTemplate
 
-        let authorName: NSString = post.authorForDisplay() as NSString
+        let authorName: NSString = (post.authorForDisplay() ?? "") as NSString
         let siteName = subdomainNameFromPath(post.blogURL)
         let originName = subdomainNameFromPath(meta.siteURL)
 

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsViewController.swift
@@ -141,7 +141,7 @@ final class ReaderCommentsViewController: UIViewController, WPContentSyncHelperD
             return nil
         }
         return CommentTableHeaderView(
-            title: post.titleForDisplay(),
+            title: post.titleForDisplay() ?? "",
             subtitle: .commentThread,
             showsDisclosureIndicator: allowsPushingPostDetails
         ) { [weak self] in

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -291,7 +291,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         }
 
         coordinator?.storeAuthenticationCookies(in: webView) { [weak self] in
-            self?.webView.loadHTMLString(post.contentForDisplay())
+            if let content = post.contentForDisplay() {
+                self?.webView.loadHTMLString(content)
+            }
         }
 
         navigateToCommentIfNecessary()


### PR DESCRIPTION
## Description

Fixes CMM-946.

`BasePost` implements the protocol based on its properties (author, content, etc), which are all declared as nullable.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
