### PR TITLE
Add missing `@dynamic` declaration

### DIFF
--- a/Sources/WordPressData/Objective-C/AbstractPost.m
+++ b/Sources/WordPressData/Objective-C/AbstractPost.m
@@ -25,6 +25,7 @@
 @dynamic order;
 @dynamic rawMetadata;
 @dynamic rawOtherTerms;
+@dynamic permalinkTemplateURL;
 @synthesize voiceContent;
 
 #pragma mark - Life Cycle Methods


### PR DESCRIPTION
## Description

Addresses the following warning:

> AbstractPost.m:9:17: Property 'permalinkTemplateURL' requires method 'permalinkTemplateURL' to be defined - use `@synthesize`, `@dynamic` or provide a method implementation in this class implementation

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
