### PR TITLE
Move some functions in post models to Swift

### DIFF
--- a/Sources/WordPressData/Objective-C/AbstractPost.m
+++ b/Sources/WordPressData/Objective-C/AbstractPost.m
@@ -271,18 +271,6 @@
     return self.mt_excerpt;
 }
 
-- (NSString *)dateStringForDisplay
-{
-    if ([self originalIsDraft] || [self.status isEqualToString:PostStatusPending]) {
-        return [[self dateModified] mediumString];
-    } else if ([self isScheduled]) {
-        return [[self dateCreated] mediumStringWithTime];
-    } else if ([self shouldPublishImmediately]) {
-        return NSLocalizedString(@"Publish Immediately",@"A short phrase indicating a post is due to be immedately published.");
-    }
-    return [[self dateCreated] mediumString];
-}
-
 - (BOOL)isPrivateAtWPCom
 {
     return self.blog.isPrivateAtWPCom;

--- a/Sources/WordPressData/Objective-C/AbstractPost.m
+++ b/Sources/WordPressData/Objective-C/AbstractPost.m
@@ -256,11 +256,6 @@
     return [self originalIsDraft] && [self dateCreatedIsNilOrEqualToDateModified];
 }
 
-- (NSString *)authorNameForDisplay
-{
-    return [self.author makePlainText];
-}
-
 - (NSURL *)blogURL
 {
     return [NSURL URLWithString:self.blog.url];

--- a/Sources/WordPressData/Objective-C/AbstractPost.m
+++ b/Sources/WordPressData/Objective-C/AbstractPost.m
@@ -261,11 +261,6 @@
     return [NSURL URLWithString:self.blog.url];
 }
 
-- (NSString *)contentPreviewForDisplay
-{
-    return self.mt_excerpt;
-}
-
 - (BOOL)isPrivateAtWPCom
 {
     return self.blog.isPrivateAtWPCom;

--- a/Sources/WordPressData/Objective-C/BasePost.m
+++ b/Sources/WordPressData/Objective-C/BasePost.m
@@ -1,5 +1,6 @@
 #import "BasePost.h"
 #import "Media.h"
+#import "WordPressData-Swift.h"
 
 @import WordPressShared;
 
@@ -19,16 +20,6 @@
 @dynamic wp_slug;
 @dynamic suggested_slug;
 @dynamic pathForDisplayImage;
-
-- (NSDate *)dateCreated
-{
-    return self.date_created_gmt;
-}
-
-- (void)setDateCreated:(NSDate *)localDate
-{
-    self.date_created_gmt = localDate;
-}
 
 - (BOOL)hasContent
 {

--- a/Sources/WordPressData/Objective-C/ReaderPost.m
+++ b/Sources/WordPressData/Objective-C/ReaderPost.m
@@ -259,24 +259,6 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     return ([content rangeOfString:featuredImage].location != NSNotFound);
 }
 
-- (NSString *)sourceAuthorNameForDisplay
-{
-    return self.sourceAttribution.authorName;
-}
-
-- (NSURL *)sourceAvatarURLForDisplay
-{
-    if (!self.sourceAttribution) {
-        return nil;
-    }
-    return [NSURL URLWithString:self.sourceAttribution.avatarURL];
-}
-
-- (NSString *)sourceBlogNameForDisplay
-{
-    return self.sourceAttribution.blogName;
-}
-
 - (NSDictionary *)railcarDictionary
 {
     if (!self.railcar) {

--- a/Sources/WordPressData/Objective-C/ReaderPost.m
+++ b/Sources/WordPressData/Objective-C/ReaderPost.m
@@ -234,15 +234,6 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     return nil;
 }
 
-- (NSString *)authorString
-{
-    if ([self.authorDisplayName length] > 0) {
-        return self.authorDisplayName;
-    }
-
-    return self.author;
-}
-
 - (BOOL)contentIncludesFeaturedImage
 {
     NSURL *featuredImageURL = [self featuredImageURL];

--- a/Sources/WordPressData/Objective-C/ReaderPost.m
+++ b/Sources/WordPressData/Objective-C/ReaderPost.m
@@ -234,12 +234,6 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     return nil;
 }
 
-- (BOOL)isP2Type
-{
-    NSInteger orgID = [self.organizationID intValue];
-    return orgID == SiteOrganizationTypeP2 || orgID == SiteOrganizationTypeAutomattic;
-}
-
 - (NSString *)authorString
 {
     if ([self.authorDisplayName length] > 0) {

--- a/Sources/WordPressData/Objective-C/ReaderPost.m
+++ b/Sources/WordPressData/Objective-C/ReaderPost.m
@@ -234,11 +234,6 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     return nil;
 }
 
-- (BOOL)isCrossPost
-{
-    return self.crossPostMeta != nil;
-}
-
 - (BOOL)isP2Type
 {
     NSInteger orgID = [self.organizationID intValue];

--- a/Sources/WordPressData/Objective-C/ReaderPost.m
+++ b/Sources/WordPressData/Objective-C/ReaderPost.m
@@ -259,17 +259,6 @@ static NSString * const SourceAttributionStandardTaxonomy = @"standard-pick";
     return ([content rangeOfString:featuredImage].location != NSNotFound);
 }
 
-- (SourceAttributionStyle)sourceAttributionStyle
-{
-    if ([self.sourceAttribution.attributionType isEqualToString:SourcePostAttribution.post]) {
-        return SourceAttributionStylePost;
-    } else if ([self.sourceAttribution.attributionType isEqualToString:SourcePostAttribution.site]) {
-        return SourceAttributionStyleSite;
-    } else {
-        return SourceAttributionStyleNone;
-    }
-}
-
 - (NSString *)sourceAuthorNameForDisplay
 {
     return self.sourceAttribution.authorName;

--- a/Sources/WordPressData/Objective-C/include/AbstractPost.h
+++ b/Sources/WordPressData/Objective-C/include/AbstractPost.h
@@ -89,7 +89,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 #pragma mark - Conveniece Methods
 - (BOOL)shouldPublishImmediately;
 - (NSString *)authorNameForDisplay;
-- (NSString *)dateStringForDisplay;
 - (BOOL)isPrivateAtWPCom;
 
 

--- a/Sources/WordPressData/Objective-C/include/AbstractPost.h
+++ b/Sources/WordPressData/Objective-C/include/AbstractPost.h
@@ -88,7 +88,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 
 #pragma mark - Conveniece Methods
 - (BOOL)shouldPublishImmediately;
-- (NSString *)authorNameForDisplay;
 - (BOOL)isPrivateAtWPCom;
 
 

--- a/Sources/WordPressData/Objective-C/include/BasePost.h
+++ b/Sources/WordPressData/Objective-C/include/BasePost.h
@@ -27,9 +27,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong, nullable) NSString *pathForDisplayImage;
 
-//date conversion
-@property (nonatomic, strong, nullable) NSDate * dateCreated;
-
 // Returns true if title or content is non empty
 - (BOOL)hasContent;
 

--- a/Sources/WordPressData/Objective-C/include/ReaderPost.h
+++ b/Sources/WordPressData/Objective-C/include/ReaderPost.h
@@ -82,9 +82,6 @@ extern NSString * const ReaderPostStoredCommentTextKey;
 + (instancetype)createOrReplaceFromRemotePost:(RemoteReaderPost *)remotePost forTopic:(ReaderAbstractTopic *)topic context:(NSManagedObjectContext *) managedObjectContext;
 
 - (BOOL)contentIncludesFeaturedImage;
-- (NSString *)sourceAuthorNameForDisplay;
-- (NSURL *)sourceAvatarURLForDisplay;
-- (NSString *)sourceBlogNameForDisplay;
 - (NSDictionary *)railcarDictionary;
 
 @end

--- a/Sources/WordPressData/Objective-C/include/ReaderPost.h
+++ b/Sources/WordPressData/Objective-C/include/ReaderPost.h
@@ -81,7 +81,6 @@ extern NSString * const ReaderPostStoredCommentTextKey;
 
 + (instancetype)createOrReplaceFromRemotePost:(RemoteReaderPost *)remotePost forTopic:(ReaderAbstractTopic *)topic context:(NSManagedObjectContext *) managedObjectContext;
 
-- (NSString *)authorString;
 - (BOOL)contentIncludesFeaturedImage;
 - (SourceAttributionStyle)sourceAttributionStyle;
 - (NSString *)sourceAuthorNameForDisplay;

--- a/Sources/WordPressData/Objective-C/include/ReaderPost.h
+++ b/Sources/WordPressData/Objective-C/include/ReaderPost.h
@@ -81,7 +81,6 @@ extern NSString * const ReaderPostStoredCommentTextKey;
 
 + (instancetype)createOrReplaceFromRemotePost:(RemoteReaderPost *)remotePost forTopic:(ReaderAbstractTopic *)topic context:(NSManagedObjectContext *) managedObjectContext;
 
-- (BOOL)isCrossPost;
 - (BOOL)isP2Type;
 - (NSString *)authorString;
 - (BOOL)contentIncludesFeaturedImage;

--- a/Sources/WordPressData/Objective-C/include/ReaderPost.h
+++ b/Sources/WordPressData/Objective-C/include/ReaderPost.h
@@ -82,7 +82,6 @@ extern NSString * const ReaderPostStoredCommentTextKey;
 + (instancetype)createOrReplaceFromRemotePost:(RemoteReaderPost *)remotePost forTopic:(ReaderAbstractTopic *)topic context:(NSManagedObjectContext *) managedObjectContext;
 
 - (BOOL)contentIncludesFeaturedImage;
-- (SourceAttributionStyle)sourceAttributionStyle;
 - (NSString *)sourceAuthorNameForDisplay;
 - (NSURL *)sourceAvatarURLForDisplay;
 - (NSString *)sourceBlogNameForDisplay;

--- a/Sources/WordPressData/Objective-C/include/ReaderPost.h
+++ b/Sources/WordPressData/Objective-C/include/ReaderPost.h
@@ -81,7 +81,6 @@ extern NSString * const ReaderPostStoredCommentTextKey;
 
 + (instancetype)createOrReplaceFromRemotePost:(RemoteReaderPost *)remotePost forTopic:(ReaderAbstractTopic *)topic context:(NSManagedObjectContext *) managedObjectContext;
 
-- (BOOL)isP2Type;
 - (NSString *)authorString;
 - (BOOL)contentIncludesFeaturedImage;
 - (SourceAttributionStyle)sourceAttributionStyle;

--- a/Sources/WordPressData/Swift/AbstractPost.swift
+++ b/Sources/WordPressData/Swift/AbstractPost.swift
@@ -250,4 +250,8 @@ public extension AbstractPost {
         }
         return self.dateCreated?.toMediumString()
     }
+
+    override func contentPreviewForDisplay() -> String? {
+        mt_excerpt
+    }
 }

--- a/Sources/WordPressData/Swift/AbstractPost.swift
+++ b/Sources/WordPressData/Swift/AbstractPost.swift
@@ -239,4 +239,15 @@ public extension AbstractPost {
             revision.deleteRevision()
         }
     }
+
+    func dateStringForDisplay() -> String? {
+        if self.originalIsDraft() || self.status == .pending {
+            return dateModified?.toMediumString()
+        } else if self.isScheduled() {
+            return self.dateCreated?.mediumStringWithTime()
+        } else if self.shouldPublishImmediately() {
+            return NSLocalizedString("Publish Immediately", comment: "A short phrase indicating a post is due to be immedately published.")
+        }
+        return self.dateCreated?.toMediumString()
+    }
 }

--- a/Sources/WordPressData/Swift/BasePost.swift
+++ b/Sources/WordPressData/Swift/BasePost.swift
@@ -74,4 +74,13 @@ extension BasePost {
 
         return nil
     }
+
+    @objc public var dateCreated: Date? {
+        get {
+            date_created_gmt
+        }
+        set {
+            date_created_gmt = newValue
+        }
+    }
 }

--- a/Sources/WordPressData/Swift/ReaderPost+PostContentProvider.swift
+++ b/Sources/WordPressData/Swift/ReaderPost+PostContentProvider.swift
@@ -68,4 +68,18 @@ extension ReaderPost {
     public func avatarURLForDisplay() -> URL? {
         authorAvatarURL.flatMap(URL.init(string:))
     }
+    public func sourceAttributionStyle() -> SourceAttributionStyle {
+        guard let sourceAttribution else {
+            return .none
+        }
+
+        if sourceAttribution.attributionType == SourcePostAttribution.post {
+            return .post
+        } else if sourceAttribution.attributionType == SourcePostAttribution.site {
+            return .site
+        }
+
+        return .none
+    }
+
 }

--- a/Sources/WordPressData/Swift/ReaderPost+PostContentProvider.swift
+++ b/Sources/WordPressData/Swift/ReaderPost+PostContentProvider.swift
@@ -46,7 +46,11 @@ extension ReaderPost {
     }
 
     public func authorForDisplay() -> String? {
-        return authorString()
+        if let name = self.authorDisplayName, !name.isEmpty {
+            return name
+        }
+
+        return author
     }
 
     public func dateForDisplay() -> Date? {

--- a/Sources/WordPressData/Swift/ReaderPost+PostContentProvider.swift
+++ b/Sources/WordPressData/Swift/ReaderPost+PostContentProvider.swift
@@ -6,6 +6,11 @@ extension ReaderPost {
         crossPostMeta != nil
     }
 
+    public var isP2Type: Bool {
+        guard let id = organizationID?.intValue, let type = SiteOrganizationType(rawValue: id) else { return false }
+        return type == .p2 || type == .automattic
+    }
+
     @objc public override var featuredImageURL: URL? {
         if !self.featuredImage.isEmpty {
             return URL(string: self.featuredImage)

--- a/Sources/WordPressData/Swift/ReaderPost+PostContentProvider.swift
+++ b/Sources/WordPressData/Swift/ReaderPost+PostContentProvider.swift
@@ -68,6 +68,11 @@ extension ReaderPost {
     public func avatarURLForDisplay() -> URL? {
         authorAvatarURL.flatMap(URL.init(string:))
     }
+
+    public func sourceAuthorNameForDisplay() -> String? {
+        sourceAttribution?.authorName
+    }
+
     public func sourceAttributionStyle() -> SourceAttributionStyle {
         guard let sourceAttribution else {
             return .none
@@ -80,6 +85,14 @@ extension ReaderPost {
         }
 
         return .none
+    }
+
+    public func sourceAvatarURLForDisplay() -> URL? {
+        sourceAttribution?.avatarURL.flatMap(URL.init(string:))
+    }
+
+    public func sourceBlogNameForDisplay() -> String? {
+        return sourceAttribution?.blogName
     }
 
 }

--- a/Sources/WordPressData/Swift/ReaderPost+PostContentProvider.swift
+++ b/Sources/WordPressData/Swift/ReaderPost+PostContentProvider.swift
@@ -2,6 +2,9 @@ import Foundation
 import WordPressShared
 
 extension ReaderPost {
+    public var isCrossPost: Bool {
+        crossPostMeta != nil
+    }
 
     @objc public override var featuredImageURL: URL? {
         if !self.featuredImage.isEmpty {

--- a/WordPress/Classes/Models/ReaderPost+Swift.swift
+++ b/WordPress/Classes/Models/ReaderPost+Swift.swift
@@ -13,7 +13,7 @@ extension ReaderPost {
         if canSubscribeComments {
             return true
         }
-        if isP2Type() {
+        if isP2Type {
             return !((topic as? ReaderSiteTopic)?.emailSubscription?.sendComments ?? false)
         }
         return false

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -46,7 +46,7 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
     }
 
     var authorDisplayName: String {
-        settings.author?.displayName ?? post.authorNameForDisplay()
+        settings.author?.displayName ?? post.author?.makePlainText() ?? ""
     }
 
     var authorAvatarURL: URL? {

--- a/WordPress/Classes/ViewRelated/Post/Views/PostListItemViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PostListItemViewModel.swift
@@ -28,7 +28,7 @@ final class PostListItemViewModel {
 
 private func makeAccessibilityLabel(for post: Post, statusViewModel: PostCardStatusViewModel) -> String? {
     let titleAndDateChunk: String = {
-        return String(format: Strings.Accessibility.titleAndDateChunkFormat, post.titleForDisplay(), post.dateStringForDisplay())
+        return String(format: Strings.Accessibility.titleAndDateChunkFormat, post.titleForDisplay(), post.dateStringForDisplay() ?? "")
     }()
 
     let authorChunk: String? = {

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderStreamViewController.swift
@@ -1329,7 +1329,7 @@ extension ReaderStreamViewController: WPTableViewHandlerDelegate {
             return cell
         }
 
-        if post.isCross() {
+        if post.isCrossPost {
             let cell = tableConfiguration.crossPostCell(tableView)
             cell.isCompact = isCompact
             cell.isSeparatorHidden = !showsSeparator

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -554,7 +554,7 @@ class ReaderDetailCoordinator {
         let characterSet = CharacterSet(charactersIn: "/")
 
         guard let post,
-              post.isCross(),
+              post.isCrossPost,
               let crossPostMeta = post.crossPostMeta,
               let crossPostURL = URL(string: crossPostMeta.postURL.trimmingCharacters(in: characterSet)),
               let selectedURL = URL(string: url.absoluteString.trimmingCharacters(in: characterSet)) else {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -871,7 +871,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             post.sourceAttribution.postID != nil &&
             post.sourceAttribution.blogID != nil {
             return ReaderDetailViewController.controllerWithPostID(post.sourceAttribution.postID!, siteID: post.sourceAttribution.blogID!)
-        } else if post.isCross() {
+        } else if post.isCrossPost {
             return ReaderDetailViewController.controllerWithPostID(post.crossPostMeta.postID, siteID: post.crossPostMeta.siteID)
         } else {
             let controller = ReaderDetailViewController.loadFromStoryboard()

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -274,7 +274,7 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             webView.postURL = postURL
         }
 
-        webView.isP2 = post.isP2Type()
+        webView.isP2 = post.isP2Type
 
         if post.content?.hasSuffix("[…]") == true {
             let viewMoreView = ReaderReadMoreView(post: post)


### PR DESCRIPTION
## Description

No feature changes, just moving to Swift. It'd be easier to review commit by commit to compare the original Objective-C code and the new Swift code.

> [!Note]
> I'll merge this PR after https://github.com/wordpress-mobile/WordPress-iOS/pull/24999.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
