### PR TITLE
Fix undeclared variable `skip_user_confirmation`

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -84,7 +84,7 @@ platform :ios do
       release_notes_file_path: release_notes_source_path
     )
 
-    unless skip_user_confirmation || UI.confirm('Ready to push changes to remote to let the automation configure it on GitHub?')
+    unless skip_confirm || UI.confirm('Ready to push changes to remote to let the automation configure it on GitHub?')
       UI.message("Terminating as requested. Don't forget to run the remainder of this automation manually.")
       next
     end


### PR DESCRIPTION
The variable was removed in https://github.com/wordpress-mobile/WordPress-iOS/pull/24929.

## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
