### PR TITLE
Remove a few functions in AbstractPosts

### DIFF
--- a/Sources/WordPressData/Objective-C/AbstractPost.m
+++ b/Sources/WordPressData/Objective-C/AbstractPost.m
@@ -35,14 +35,6 @@
     [[ContextManager sharedInstance] saveContext:self.managedObjectContext];
 }
 
-
-#pragma mark - Getters/Setters
-
-- (void)setDateCreated:(NSDate *)localDate
-{
-    self.date_created_gmt = localDate;
-}
-
 #pragma mark -
 #pragma mark Revision management
 

--- a/Sources/WordPressData/Objective-C/AbstractPost.m
+++ b/Sources/WordPressData/Objective-C/AbstractPost.m
@@ -38,22 +38,6 @@
 
 #pragma mark - Getters/Setters
 
-- (void)setRemoteStatusNumber:(NSNumber *)remoteStatusNumber
-{
-    NSString *key = @"remoteStatusNumber";
-    [self willChangeValueForKey:key];
-    [self setPrimitiveValue:remoteStatusNumber forKey:key];
-    [self didChangeValueForKey:key];
-}
-
-- (void)setDate_created_gmt:(NSDate *)date_created_gmt
-{
-    NSString *key = @"date_created_gmt";
-    [self willChangeValueForKey:key];
-    [self setPrimitiveValue:date_created_gmt forKey:key];
-    [self didChangeValueForKey:key];
-}
-
 - (void)setDateCreated:(NSDate *)localDate
 {
     self.date_created_gmt = localDate;


### PR DESCRIPTION
## Description

The `setRemoteStatusNumber` and `setDate_created_gmt` implementations are the same as the default Core Data implementation. The original implementation (see commit 32477e1045ecde5dbbb68f624760f625e00e79bf) needed to update another property in the setters, which is no longer the case.


The `AbstractPost.setDateCreated` does the same thing as the same function in the super class `BasePost`.


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
