### PR TITLE
Move post revision related functions to Swift

### DIFF
--- a/Sources/WordPressData/Objective-C/AbstractPost.m
+++ b/Sources/WordPressData/Objective-C/AbstractPost.m
@@ -38,16 +38,6 @@
 #pragma mark -
 #pragma mark Revision management
 
-- (BOOL)isRevision
-{
-    return (![self isOriginal]);
-}
-
-- (BOOL)isOriginal
-{
-    return ([self original] == nil);
-}
-
 - (AbstractPost *)latest
 {
     return [self hasRevision] ? [[self revision] latest] : self;

--- a/Sources/WordPressData/Objective-C/AbstractPost.m
+++ b/Sources/WordPressData/Objective-C/AbstractPost.m
@@ -38,13 +38,6 @@
 #pragma mark -
 #pragma mark Revision management
 
-- (void)applyRevision
-{
-    if ([self isOriginal]) {
-        [self cloneFrom:self.revision];
-    }
-}
-
 - (BOOL)isRevision
 {
     return (![self isOriginal]);

--- a/Sources/WordPressData/Objective-C/AbstractPost.m
+++ b/Sources/WordPressData/Objective-C/AbstractPost.m
@@ -38,11 +38,6 @@
 #pragma mark -
 #pragma mark Revision management
 
-- (AbstractPost *)latest
-{
-    return [self hasRevision] ? [[self revision] latest] : self;
-}
-
 - (AbstractPost *)revision
 {
     [self willAccessValueForKey:@"revision"];

--- a/Sources/WordPressData/Objective-C/AbstractPost.m
+++ b/Sources/WordPressData/Objective-C/AbstractPost.m
@@ -38,26 +38,6 @@
 #pragma mark -
 #pragma mark Revision management
 
-- (AbstractPost *)cloneFrom:(AbstractPost *)source
-{
-    for (NSString *key in [[[source entity] attributesByName] allKeys]) {
-        if (![key isEqualToString:@"permalink"]) {
-            [self setValue:[source valueForKey:key] forKey:key];
-        }
-    }
-    for (NSString *key in [[[source entity] relationshipsByName] allKeys]) {
-        if ([key isEqualToString:@"original"] || [key isEqualToString:@"revision"]) {
-            continue;
-        } else if ([key isEqualToString:@"comments"]) {
-            [self setComments:[source comments]];
-        } else {
-            [self setValue: [source valueForKey:key] forKey: key];
-        }
-    }
-
-    return self;
-}
-
 - (AbstractPost *)createRevision
 {
     NSParameterAssert(self.revision == nil);

--- a/Sources/WordPressData/Objective-C/AbstractPost.m
+++ b/Sources/WordPressData/Objective-C/AbstractPost.m
@@ -38,18 +38,6 @@
 #pragma mark -
 #pragma mark Revision management
 
-- (void)deleteRevision
-{
-    if (self.revision) {
-        [self.managedObjectContext performBlockAndWait :^{
-            [self.managedObjectContext deleteObject:self.revision];
-            [self willChangeValueForKey:@"revision"];
-            [self setPrimitiveValue:nil forKey:@"revision"];
-            [self didChangeValueForKey:@"revision"];
-        }];
-    }
-}
-
 - (void)applyRevision
 {
     if ([self isOriginal]) {

--- a/Sources/WordPressData/Objective-C/AbstractPost.m
+++ b/Sources/WordPressData/Objective-C/AbstractPost.m
@@ -112,11 +112,6 @@
     return NO;
 }
 
-- (BOOL)hasRevision
-{
-    return self.revision != nil;
-}
-
 - (BOOL)hasRemote
 {
     return ((self.postID != nil) && ([self.postID longLongValue] > 0));

--- a/Sources/WordPressData/Objective-C/AbstractPost.m
+++ b/Sources/WordPressData/Objective-C/AbstractPost.m
@@ -38,18 +38,6 @@
 #pragma mark -
 #pragma mark Revision management
 
-- (AbstractPost *)createRevision
-{
-    NSParameterAssert(self.revision == nil);
-
-    AbstractPost *post = [NSEntityDescription insertNewObjectForEntityForName:NSStringFromClass(self.class) inManagedObjectContext:self.managedObjectContext];
-    [post cloneFrom:self];
-    post.remoteStatus = AbstractPostRemoteStatusLocalRevision;
-    [post setValue:self forKey:@"original"];
-    [post setValue:nil forKey:@"revision"];
-    return post;
-}
-
 - (void)deleteRevision
 {
     if (self.revision) {

--- a/Sources/WordPressData/Objective-C/AbstractPost.m
+++ b/Sources/WordPressData/Objective-C/AbstractPost.m
@@ -69,19 +69,6 @@
     }
 }
 
-- (AbstractPost *)updatePostFrom:(AbstractPost *)revision
-{
-    for (NSString *key in [[[revision entity] attributesByName] allKeys]) {
-        if ([key isEqualToString:@"postTitle"] ||
-            [key isEqualToString:@"content"]) {
-            [self setValue:[revision valueForKey:key] forKey:key];
-        } else if ([key isEqualToString:@"dateModified"]) {
-            [self setValue:[NSDate date] forKey:key];
-        }
-    }
-    return self;
-}
-
 - (BOOL)isRevision
 {
     return (![self isOriginal]);

--- a/Sources/WordPressData/Objective-C/BasePost.m
+++ b/Sources/WordPressData/Objective-C/BasePost.m
@@ -21,18 +21,4 @@
 @dynamic suggested_slug;
 @dynamic pathForDisplayImage;
 
-- (BOOL)hasContent
-{
-    BOOL titleIsEmpty = self.postTitle ? self.postTitle.isEmpty : YES;
-    BOOL contentIsEmpty = [self isContentEmpty];
-
-    return !titleIsEmpty || !contentIsEmpty;
-}
-
-- (BOOL)isContentEmpty
-{
-    BOOL isContentAnEmptyGBParagraph = [self.content isEqualToString:@"<!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph -->"];
-    return  self.content ? (self.content.isEmpty || isContentAnEmptyGBParagraph) : YES;
-}
-
 @end

--- a/Sources/WordPressData/Objective-C/include/AbstractPost.h
+++ b/Sources/WordPressData/Objective-C/include/AbstractPost.h
@@ -63,7 +63,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 @property (nonatomic, strong, nullable) NSString *voiceContent;
 
 // Revision management
-- (void)deleteRevision;
 - (void)applyRevision;
 - (BOOL)isRevision;
 - (BOOL)isOriginal;

--- a/Sources/WordPressData/Objective-C/include/AbstractPost.h
+++ b/Sources/WordPressData/Objective-C/include/AbstractPost.h
@@ -66,7 +66,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 - (AbstractPost *)createRevision;
 - (void)deleteRevision;
 - (void)applyRevision;
-- (AbstractPost *)updatePostFrom:(AbstractPost *)revision;
 - (BOOL)isRevision;
 - (BOOL)isOriginal;
 

--- a/Sources/WordPressData/Objective-C/include/AbstractPost.h
+++ b/Sources/WordPressData/Objective-C/include/AbstractPost.h
@@ -71,12 +71,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 - (BOOL)hasCategories;
 - (BOOL)hasTags;
 
-/**
- *  @brief      Call this method to know whether this post has a revision or not.
- *
- *  @returns    YES if this post has a revision, NO otherwise.
- */
-- (BOOL)hasRevision;
 
 #pragma mark - Conveniece Methods
 - (BOOL)shouldPublishImmediately;

--- a/Sources/WordPressData/Objective-C/include/AbstractPost.h
+++ b/Sources/WordPressData/Objective-C/include/AbstractPost.h
@@ -73,7 +73,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 /// Returns the latest revision of a post.
 ///
 - (AbstractPost *)latest;
-- (AbstractPost *)cloneFrom:(AbstractPost *)source;
 - (BOOL)hasPhoto;
 - (BOOL)hasVideo;
 - (BOOL)hasCategories;

--- a/Sources/WordPressData/Objective-C/include/AbstractPost.h
+++ b/Sources/WordPressData/Objective-C/include/AbstractPost.h
@@ -62,9 +62,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 
 @property (nonatomic, strong, nullable) NSString *voiceContent;
 
-// Revision management
-- (BOOL)isRevision;
-- (BOOL)isOriginal;
 
 /// Returns the latest revision of a post.
 ///

--- a/Sources/WordPressData/Objective-C/include/AbstractPost.h
+++ b/Sources/WordPressData/Objective-C/include/AbstractPost.h
@@ -63,7 +63,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 @property (nonatomic, strong, nullable) NSString *voiceContent;
 
 // Revision management
-- (void)applyRevision;
 - (BOOL)isRevision;
 - (BOOL)isOriginal;
 

--- a/Sources/WordPressData/Objective-C/include/AbstractPost.h
+++ b/Sources/WordPressData/Objective-C/include/AbstractPost.h
@@ -63,7 +63,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 @property (nonatomic, strong, nullable) NSString *voiceContent;
 
 // Revision management
-- (AbstractPost *)createRevision;
 - (void)deleteRevision;
 - (void)applyRevision;
 - (BOOL)isRevision;

--- a/Sources/WordPressData/Objective-C/include/AbstractPost.h
+++ b/Sources/WordPressData/Objective-C/include/AbstractPost.h
@@ -62,10 +62,6 @@ typedef NS_ENUM(NSUInteger, AbstractPostRemoteStatus) {
 
 @property (nonatomic, strong, nullable) NSString *voiceContent;
 
-
-/// Returns the latest revision of a post.
-///
-- (AbstractPost *)latest;
 - (BOOL)hasPhoto;
 - (BOOL)hasVideo;
 - (BOOL)hasCategories;

--- a/Sources/WordPressData/Objective-C/include/BasePost.h
+++ b/Sources/WordPressData/Objective-C/include/BasePost.h
@@ -27,12 +27,6 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, strong, nullable) NSString *pathForDisplayImage;
 
-// Returns true if title or content is non empty
-- (BOOL)hasContent;
-
-// True if the content field is empty, independent of the title field.
-- (BOOL)isContentEmpty;
-
 @end
 
 NS_ASSUME_NONNULL_END

--- a/Sources/WordPressData/Swift/AbstractPost.swift
+++ b/Sources/WordPressData/Swift/AbstractPost.swift
@@ -273,4 +273,17 @@ public extension AbstractPost {
             }
         }
     }
+
+    @objc
+    func createRevision() -> AbstractPost {
+        precondition(managedObjectContext != nil)
+        precondition(revision == nil, "This post must not already have a revision")
+
+        let post = Self(context: managedObjectContext!)
+        post.clone(from: self)
+        post.remoteStatus = .localRevision
+        post.setValue(self, forKey: "original")
+        post.setValue(nil, forKey: "revision")
+        return post
+    }
 }

--- a/Sources/WordPressData/Swift/AbstractPost.swift
+++ b/Sources/WordPressData/Swift/AbstractPost.swift
@@ -300,4 +300,12 @@ public extension AbstractPost {
             didChangeValue(forKey: "revision")
         }
     }
+
+    @objc
+    func applyRevision() {
+        guard isOriginal(), let revision else {
+            return
+        }
+        clone(from: revision)
+    }
 }

--- a/Sources/WordPressData/Swift/AbstractPost.swift
+++ b/Sources/WordPressData/Swift/AbstractPost.swift
@@ -320,6 +320,11 @@ public extension AbstractPost {
     }
 
     @objc
+    func latest() -> AbstractPost {
+        revision?.latest() ?? self
+    }
+
+    @objc
     func hasRevision() -> Bool {
         revision != nil
     }

--- a/Sources/WordPressData/Swift/AbstractPost.swift
+++ b/Sources/WordPressData/Swift/AbstractPost.swift
@@ -254,4 +254,23 @@ public extension AbstractPost {
     override func contentPreviewForDisplay() -> String? {
         mt_excerpt
     }
+
+    @objc(cloneFrom:)
+    func clone(from source: AbstractPost) {
+        for key in source.entity.attributesByName.keys {
+            if key != "permalink" {
+                setValue(source.value(forKey: key), forKey: key)
+            }
+        }
+
+        for key in source.entity.relationshipsByName.keys {
+            if key == "original" || key == "revision" {
+                continue
+            } else if key == "comments" {
+                comments = source.comments
+            } else {
+                setValue(source.value(forKey: key), forKey: key)
+            }
+        }
+    }
 }

--- a/Sources/WordPressData/Swift/AbstractPost.swift
+++ b/Sources/WordPressData/Swift/AbstractPost.swift
@@ -286,4 +286,18 @@ public extension AbstractPost {
         post.setValue(nil, forKey: "revision")
         return post
     }
+
+    @objc
+    func deleteRevision() {
+        guard let revision, let context = managedObjectContext else {
+            return
+        }
+
+        context.performAndWait {
+            context.delete(revision)
+            willChangeValue(forKey: "revision")
+            setPrimitiveValue(nil, forKey: "revision")
+            didChangeValue(forKey: "revision")
+        }
+    }
 }

--- a/Sources/WordPressData/Swift/AbstractPost.swift
+++ b/Sources/WordPressData/Swift/AbstractPost.swift
@@ -319,4 +319,8 @@ public extension AbstractPost {
         original == nil
     }
 
+    @objc
+    func hasRevision() -> Bool {
+        revision != nil
+    }
 }

--- a/Sources/WordPressData/Swift/AbstractPost.swift
+++ b/Sources/WordPressData/Swift/AbstractPost.swift
@@ -308,4 +308,15 @@ public extension AbstractPost {
         }
         clone(from: revision)
     }
+
+    @objc
+    func isRevision() -> Bool {
+        !isOriginal()
+    }
+
+    @objc
+    func isOriginal() -> Bool {
+        original == nil
+    }
+
 }

--- a/Sources/WordPressData/Swift/BasePost.swift
+++ b/Sources/WordPressData/Swift/BasePost.swift
@@ -83,4 +83,16 @@ extension BasePost {
             date_created_gmt = newValue
         }
     }
+
+    /// Returns true if title or content is non empty
+    public func hasContent() -> Bool {
+        let titleIsEmpty = self.postTitle != nil ? self.postTitle!.isEmpty : true
+        return !titleIsEmpty || !isContentEmpty()
+    }
+
+    /// True if the content field is empty, independent of the title field.
+    public func isContentEmpty() -> Bool {
+        let isContentAnEmptyGBParagraph = self.content == "<!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph -->"
+        return self.content != nil ? (self.content!.isEmpty || isContentAnEmptyGBParagraph) : true
+    }
 }

--- a/Sources/WordPressData/Swift/BasePost.swift
+++ b/Sources/WordPressData/Swift/BasePost.swift
@@ -86,13 +86,18 @@ extension BasePost {
 
     /// Returns true if title or content is non empty
     public func hasContent() -> Bool {
-        let titleIsEmpty = self.postTitle != nil ? self.postTitle!.isEmpty : true
-        return !titleIsEmpty || !isContentEmpty()
+        if let postTitle, !postTitle.isEmpty {
+            return true
+        }
+
+        return !isContentEmpty()
     }
 
     /// True if the content field is empty, independent of the title field.
     public func isContentEmpty() -> Bool {
-        let isContentAnEmptyGBParagraph = self.content == "<!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph -->"
-        return self.content != nil ? (self.content!.isEmpty || isContentAnEmptyGBParagraph) : true
+        guard let content else { return true }
+
+        let emptyGBParagraph = "<!-- wp:paragraph -->\n<p></p>\n<!-- /wp:paragraph -->"
+        return content.isEmpty || content == emptyGBParagraph
     }
 }


### PR DESCRIPTION
> [!Note]
> This PR will be merged after https://github.com/wordpress-mobile/WordPress-iOS/pull/25008.

## Description

No feature changes, just translating ObjC to Swift. It's easier to review this PR commit by commit.


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
