### PR TITLE
Fix horizontal insets in Reader article view

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 26.6
 -----
+* [*] Fix horizontal insets in Reader article view [#25010]
 
 
 26.5

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -471,8 +471,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     /// Apply view styles
     @MainActor private func applyStyles() {
         NSLayoutConstraint.activate([
-            webView.rightAnchor.constraint(equalTo: view.readableContentGuide.rightAnchor, constant: -Constants.margin),
-            webView.leftAnchor.constraint(equalTo: view.readableContentGuide.leftAnchor, constant: Constants.margin)
+            webView.rightAnchor.constraint(equalTo: view.readableContentGuide.rightAnchor, constant: 0),
+            webView.leftAnchor.constraint(equalTo: view.readableContentGuide.leftAnchor, constant: 0)
         ])
 
         webView.translatesAutoresizingMaskIntoConstraints = false
@@ -884,7 +884,6 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
 
     private enum Constants {
         static let preferredArticleWidth: CGFloat = 680
-        static let margin: CGFloat = UIDevice.isPad() ? 0 : 8
     }
 
     // MARK: - Managed object observer


### PR DESCRIPTION
Fixes incorrect horizontal insets. AFAIR the extra padding was added for iOS 26 betas. In the production version, it is not needed. It results in invalid layout.

Before / After

<img width="360" alt="Screenshot 2025-11-24 at 3 33 05 PM" src="https://github.com/user-attachments/assets/4e6b5c20-c3a6-4625-90ce-dbbaefc93a89" /> <img width="360" alt="Screenshot 2025-11-24 at 3 34 53 PM" src="https://github.com/user-attachments/assets/fb86f11d-f671-4051-88ed-c7bb2c7426f3" />
