### PR TITLE
Fix overly long related post titles

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,6 @@
 26.6
 -----
 
-
 26.5
 -----
 * [*] Add "Status" field to the "Post Settings" screen to make it easier to move posts from one state to another [#24939]
@@ -14,6 +13,7 @@
 * [*] Add permalink preview in the slug editor and make other improvements [#24949]
 * [*] Add "Taxonomies" to Site Settings [#24955]
 * [*] Update "Categories" picker to indicate multiple selection [#24952]
+* [*] Fix overly long related post titles in Reader [#25011]
 
 26.4
 -----

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderRelatedPostsCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderRelatedPostsCell.swift
@@ -19,7 +19,7 @@ class ReaderRelatedPostsCell: UITableViewCell, NibReusable {
         featuredImageView.contentMode = .scaleAspectFill
         featuredImageView.backgroundColor = .placeholderText
 
-        titleLabel.numberOfLines = 0
+        titleLabel.numberOfLines = 3
         titleLabel.font = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
         titleLabel.textColor = .label
 
@@ -61,6 +61,6 @@ class ReaderRelatedPostsCell: UITableViewCell, NibReusable {
     }
 
     private enum Constants {
-        static let cornerRadius: CGFloat = 4
+        static let cornerRadius: CGFloat = 6
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderRelatedPostsCell.xib
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderRelatedPostsCell.xib
@@ -1,9 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="17506" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="24412" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="24405"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -21,23 +20,23 @@
                         <rect key="frame" x="0.0" y="8" width="320" height="100"/>
                         <subviews>
                             <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="GT5-Ba-NHj">
-                                <rect key="frame" x="0.0" y="0.0" width="142" height="80"/>
+                                <rect key="frame" x="0.0" y="0.0" width="106.5" height="60"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="GT5-Ba-NHj" secondAttribute="height" multiplier="16:9" id="Fdq-E8-B0g"/>
-                                    <constraint firstAttribute="height" constant="80" id="OVJ-LX-8yx"/>
+                                    <constraint firstAttribute="height" constant="60" id="OVJ-LX-8yx"/>
                                 </constraints>
                             </imageView>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" spacing="8" translatesAutoresizingMaskIntoConstraints="NO" id="DBq-yS-yFy">
-                                <rect key="frame" x="158" y="0.0" width="162" height="49"/>
+                                <rect key="frame" x="122.5" y="0.0" width="197.5" height="49"/>
                                 <subviews>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="TUE-Aq-2F6">
-                                        <rect key="frame" x="0.0" y="0.0" width="162" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="197.5" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>
                                     </label>
                                     <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="FoT-uQ-Ghm">
-                                        <rect key="frame" x="0.0" y="28.5" width="162" height="20.5"/>
+                                        <rect key="frame" x="0.0" y="28.5" width="197.5" height="20.5"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                         <nil key="textColor"/>
                                         <nil key="highlightedColor"/>

--- a/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Select Interests/ReaderInterestsStyleGuide.swift
@@ -15,11 +15,11 @@ class ReaderInterestsStyleGuide {
 
         static let latest = Metrics(
             interestsLabelMargin: 16.0,
-            cellCornerRadius: 5.0,
+            cellCornerRadius: 8.0,
             cellSpacing: 8.0,
             cellHeight: 34.0,
             maxCellWidthMultiplier: 0.8,
-            borderWidth: 1.0,
+            borderWidth: 0.5,
             borderColor: .separator
         )
     }


### PR DESCRIPTION
## Description
Fix [CMM-983: Very long titles can be abused to show unwanted content on people's sites](https://linear.app/a8c/issue/CMM-983/very-long-titles-can-be-abused-to-show-unwanted-content-on-peoples)

Before / After

<img width="360" alt="Screenshot 2025-11-24 at 3 47 49 PM" src="https://github.com/user-attachments/assets/647fcdff-4922-4401-8c5d-63669e97f66e" /> <img width="360" alt="Screenshot 2025-11-24 at 3 50 57 PM" src="https://github.com/user-attachments/assets/c3aa3a0c-d1ed-4457-9b5e-94447f2ada1e" />
