### PR TITLE
Add two accessible font sizes to Reader display settings

### DIFF
--- a/Modules/Sources/WordPressReader/Settings/ReaderDisplaySettings.swift
+++ b/Modules/Sources/WordPressReader/Settings/ReaderDisplaySettings.swift
@@ -249,6 +249,8 @@ public struct ReaderDisplaySettings: Codable, Equatable, Hashable, Sendable {
         case normal
         case large
         case extraLarge
+        case extraExtraLarge
+        case extraExtraExtraLarge
 
         public var scale: Double {
             switch self {
@@ -262,6 +264,10 @@ public struct ReaderDisplaySettings: Codable, Equatable, Hashable, Sendable {
                 return 1.15
             case .extraLarge:
                 return 1.25
+            case .extraExtraLarge:
+                return 1.4
+            case .extraExtraExtraLarge:
+                return 1.6
             }
         }
 
@@ -297,6 +303,18 @@ public struct ReaderDisplaySettings: Codable, Equatable, Hashable, Sendable {
                     value: "Extra Large",
                     comment: "Accessibility label for the Extra Large size option, used in the Reader's reading preferences."
                 )
+            case .extraExtraLarge:
+                return NSLocalizedString(
+                    "reader.preferences.size.extraExtraLarge",
+                    value: "Extra Extra Large",
+                    comment: "Accessibility label for the Extra Extra Large size option, used in the Reader's reading preferences."
+                )
+            case .extraExtraExtraLarge:
+                return NSLocalizedString(
+                    "reader.preferences.size.extraExtraExtraLarge",
+                    value: "Extra Extra Extra Large",
+                    comment: "Accessibility label for the Extra Extra Extra Large size option, used in the Reader's reading preferences."
+                )
             }
         }
 
@@ -312,6 +330,10 @@ public struct ReaderDisplaySettings: Codable, Equatable, Hashable, Sendable {
                 return "large"
             case .extraLarge:
                 return "extra_large"
+            case .extraExtraLarge:
+                return "extra_extra_large"
+            case .extraExtraExtraLarge:
+                return "extra_extra_extra_large"
             }
         }
     }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,7 @@
 * [*] Add "File Size" to Site Media Details [#24947]
 * [*] Add "Email to Subscribers" row to "Publishing" sheet [#24946]
 * [*] Add permalink preview in the slug editor and make other improvements [#24949]
+* [*] Add two accessible font sizes to Reader display settings [#25013]
 * [*] Add "Taxonomies" to Site Settings [#24955]
 * [*] Update "Categories" picker to indicate multiple selection [#24952]
 

--- a/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Theme/ReaderDisplaySettingViewController.swift
@@ -411,7 +411,7 @@ extension ReaderDisplaySettingSelectionView {
 
         var sizeSelectionView: some View {
             Slider(value: $sliderValue,
-                   in: Double(ReaderDisplaySettings.Size.extraSmall.rawValue)...Double(ReaderDisplaySettings.Size.extraLarge.rawValue),
+                   in: Double(ReaderDisplaySettings.Size.extraSmall.rawValue)...Double(ReaderDisplaySettings.Size.extraExtraExtraLarge.rawValue),
                    step: 1) {
                 Text(Strings.sizeSliderLabel)
             } minimumValueLabel: {
@@ -420,7 +420,7 @@ extension ReaderDisplaySettingSelectionView {
                     .accessibilityHidden(true)
             } maximumValueLabel: {
                 Text("A")
-                    .font(Font(ReaderDisplaySettings.font(with: .sans, size: .extraLarge, textStyle: .body)))
+                    .font(Font(ReaderDisplaySettings.font(with: .sans, size: .extraExtraExtraLarge, textStyle: .body)))
                     .accessibilityHidden(true)
             } onEditingChanged: { _ in
                 let size = ReaderDisplaySettings.Size(rawValue: Int(sliderValue)) ?? .normal


### PR DESCRIPTION
## Description
Fixes [CMM-980: Reader: add larger font sizes in "Reader Preferences"](https://linear.app/a8c/issue/CMM-980/reader-add-larger-font-sizes-in-reader-preferences).

### Before 
<img width="340" alt="Screenshot 2025-11-24 at 4 13 24 PM" src="https://github.com/user-attachments/assets/c9f317c1-3609-4b9c-9a1e-ce2a3d0b2103" />

### After

<img width="340" alt="Screenshot 2025-11-24 at 4 30 38 PM" src="https://github.com/user-attachments/assets/283ae7db-7ecc-4be1-b99f-6276489f3495" /> <img width="340"  alt="Screenshot 2025-11-24 at 4 30 42 PM" src="https://github.com/user-attachments/assets/1c1c3ef0-a5b9-4edd-aa59-28c5f72f1c9c" />
