### PR TITLE
Fix an issue with posts duplicated in Discover

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,5 @@
 26.6
 -----
-* [*] Fix horizontal insets in Reader article view [#25010]
 
 
 26.5
@@ -11,6 +10,7 @@
 * [*] Add "Access" section to "Post Settings" [#24942]
 * [*] Add "Discussion" to "Post Settings" [#24948]
 * [*] Add "File Size" to Site Media Details [#24947]
+* [*] Fix an issue with posts duplicated in Discover [#25015]
 * [*] Add "Email to Subscribers" row to "Publishing" sheet [#24946]
 * [*] Add permalink preview in the slug editor and make other improvements [#24949]
 * [*] Add two accessible font sizes to Reader display settings [#25013]
@@ -18,6 +18,7 @@
 * [*] Update "Categories" picker to indicate multiple selection [#24952]
 * [*] Fix overly long related post titles in Reader [#25011]
 * [*] Increase number of lines for post tiles in Reader to three [#25019]
+* [*] Fix horizontal insets in Reader article view [#25010]
 
 26.4
 -----

--- a/Sources/WordPressData/Swift/ReaderCard+CoreDataClass.swift
+++ b/Sources/WordPressData/Swift/ReaderCard+CoreDataClass.swift
@@ -43,25 +43,47 @@ public class ReaderCard: NSManagedObject {
         sites?.array as? [ReaderSiteTopic] ?? []
     }
 
-    public convenience init?(context: NSManagedObjectContext, from remoteCard: RemoteReaderCard) {
+    public static func createOrReuse(context: NSManagedObjectContext, from remoteCard: RemoteReaderCard) -> ReaderCard? {
         guard remoteCard.type != .unknown else {
             return nil
         }
 
-        self.init(context: context)
-
         switch remoteCard.type {
         case .post:
-            post = ReaderPost.createOrReplace(fromRemotePost: remoteCard.post, for: nil, context: context)
+            let post = ReaderPost.createOrReplace(fromRemotePost: remoteCard.post, for: nil, context: context)
+
+            // Check if a card already exists with this post to prevent duplicates
+            if let existingCard = findExistingCard(with: post, context: context) {
+                return existingCard
+            }
+
+            let card = ReaderCard(context: context)
+            card.post = post
+            return card
+
         case .interests:
-            return nil // Disabled in v26.6
+            return nil // Disabled in v26.5
         case .sites:
-            sites = NSOrderedSet(array: remoteCard.sites?.prefix(3).map {
+            let card = ReaderCard(context: context)
+            card.sites = NSOrderedSet(array: remoteCard.sites?.prefix(3).map {
                 ReaderSiteTopic.createIfNeeded(from: $0, context: context)
             } ?? [])
+            return card
 
         default:
-            break
+            return nil
         }
+    }
+
+    private static func findExistingCard(with post: ReaderPost?, context: NSManagedObjectContext) -> ReaderCard? {
+        guard let post else {
+            return nil
+        }
+
+        let fetchRequest = ReaderCard.fetchRequest()
+        fetchRequest.predicate = NSPredicate(format: "post = %@", post)
+        fetchRequest.fetchLimit = 1
+
+        return try? context.fetch(fetchRequest).first
     }
 }

--- a/Tests/KeystoneTests/Tests/Models/ReaderCardTests.swift
+++ b/Tests/KeystoneTests/Tests/Models/ReaderCardTests.swift
@@ -11,7 +11,7 @@ class ReaderCardTests: CoreDataTestCase {
         let expectation = self.expectation(description: "Create a Reader Card of type post")
 
         remoteCard(ofType: .post) { remoteCard in
-            let card = ReaderCard(context: self.mainContext, from: remoteCard)
+            let card = ReaderCard.createOrReuse(context: self.mainContext, from: remoteCard)
 
             expect(card?.post).toNot(beNil())
             expect(card?.post?.postTitle).to(equal("Pats, Please"))
@@ -28,7 +28,7 @@ class ReaderCardTests: CoreDataTestCase {
         let expectation = self.expectation(description: "Create a Reader Card of type interests")
 
         remoteCard(ofType: .interests) { remoteCard in
-            let card = ReaderCard(context: self.mainContext, from: remoteCard)
+            let card = ReaderCard.createOrReuse(context: self.mainContext, from: remoteCard)
             let topics = card?.topicsArray
 
             // THEN return 0 as these were disabled in 26.5
@@ -45,7 +45,7 @@ class ReaderCardTests: CoreDataTestCase {
         let expectation = self.expectation(description: "Create a Reader Card of type sites")
 
         remoteCard(ofType: .sites) { remoteCard in
-            let card = ReaderCard(context: self.mainContext, from: remoteCard)
+            let card = ReaderCard.createOrReuse(context: self.mainContext, from: remoteCard)
             let topics = card?.sitesArray
 
             expect(topics?.count).to(equal(1))
@@ -63,7 +63,7 @@ class ReaderCardTests: CoreDataTestCase {
         let expectation = self.expectation(description: "Don't create a Reader Card")
 
         remoteCard(ofType: .unknown) { remoteCard in
-            let card = ReaderCard(context: self.mainContext, from: remoteCard)
+            let card = ReaderCard.createOrReuse(context: self.mainContext, from: remoteCard)
 
             expect(card).to(beNil())
             expectation.fulfill()

--- a/Tests/KeystoneTests/Tests/Services/ReaderCardServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/ReaderCardServiceTests.swift
@@ -26,7 +26,7 @@ class ReaderCardServiceTests: CoreDataTestCase {
 
         service.fetch(isFirstPage: true, success: { _, _ in
             let cards = try? self.mainContext.fetch(NSFetchRequest(entityName: ReaderCard.classNameWithoutNamespaces()))
-            expect(cards?.count).to(equal(10))
+            expect(cards?.count).to(equal(9))
             expectation.fulfill()
         }, failure: { _ in })
 
@@ -74,7 +74,7 @@ class ReaderCardServiceTests: CoreDataTestCase {
             // Fetch again, this time the 1st page
             service.fetch(isFirstPage: true, success: { _, _ in
                 let cards = try? self.mainContext.fetch(NSFetchRequest(entityName: ReaderCard.classNameWithoutNamespaces())) as? [ReaderCard]
-                expect(cards?.count).to(equal(10))
+                expect(cards?.count).to(equal(9))
                 expectation.fulfill()
             }, failure: { _ in })
         }, failure: {_ in })

--- a/WordPress/Classes/Services/ReaderCardService.swift
+++ b/WordPress/Classes/Services/ReaderCardService.swift
@@ -81,7 +81,7 @@ class ReaderCardService {
                     }
 
                     updatedCards.enumerated().forEach { index, remoteCard in
-                        let card = ReaderCard(context: context, from: remoteCard)
+                        let card = ReaderCard.createOrReuse(context: context, from: remoteCard)
 
                         // Assign each interest an endpoint
                         card?


### PR DESCRIPTION
## Description
Fixes [CMM-764: Reader: posts in Discover are duplicated](https://linear.app/a8c/issue/CMM-764/reader-posts-in-discover-are-duplicated)

## Testing instructions

I tested by duplicated a post in a mock response.

Before / After
<img width="340"  alt="Screenshot 2025-11-24 at 5 32 38 PM" src="https://github.com/user-attachments/assets/6c668ccb-87b4-40a5-a982-829003c7b9fe" /> <img width="340"  alt="Screenshot 2025-11-24 at 5 34 54 PM" src="https://github.com/user-attachments/assets/758d20bb-679d-44e9-9f24-98bad166572b" />

