### PR TITLE
Reader: Show error description when failing to load posts

### DIFF
--- a/Tests/KeystoneTests/Tests/Reader/ReaderDetailCoordinatorTests.swift
+++ b/Tests/KeystoneTests/Tests/Reader/ReaderDetailCoordinatorTests.swift
@@ -330,7 +330,7 @@ private class ReaderDetailViewMock: UIViewController, ReaderDetailView {
         didCallShowError = true
     }
 
-    func showErrorWithWebAction() {
+    func showErrorWithWebAction(error: String?) {
         didCallShowErrorWithWebAction = true
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -347,7 +347,7 @@ class ReaderDetailCoordinator {
                                         self?.post = post
                                         self?.renderPostAndBumpStats()
                                     }, failure: { [weak self] error in
-                                        self?.postURL == nil ? self?.showError(error: error) : self?.view?.showErrorWithWebAction()
+                                        self?.postURL == nil ? self?.showError(error: error) : self?.view?.showErrorWithWebAction(error: error?.localizedDescription)
                                         self?.reportPostLoadFailure()
                                     })
     }
@@ -363,7 +363,7 @@ class ReaderDetailCoordinator {
                                         self?.renderPostAndBumpStats()
                                     }, failure: { [weak self] error in
                                         DDLogError("Error fetching post for detail: \(String(describing: error?.localizedDescription))")
-                                        self?.postURL == nil ? self?.showError(error: error) : self?.view?.showErrorWithWebAction()
+                                        self?.postURL == nil ? self?.showError(error: error) : self?.view?.showErrorWithWebAction(error: error?.localizedDescription)
                                         self?.reportPostLoadFailure()
                                     })
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -14,7 +14,7 @@ protocol ReaderDetailView: AnyObject {
     func renderRelatedPosts(_ posts: [RemoteReaderSimplePost])
     func showLoading()
     func showError(subtitle: String?)
-    func showErrorWithWebAction()
+    func showErrorWithWebAction(error: String?)
     func scroll(to: String)
     func updateHeader()
     func updateLikesView(with viewModel: ReaderDetailLikesViewModel)
@@ -399,8 +399,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
     }
 
     /// Shown an error with a button to open the post on the browser
-    func showErrorWithWebAction() {
-        displayLoadingViewWithWebAction(title: LoadingText.errorLoadingTitle)
+    func showErrorWithWebAction(error: String?) {
+        displayLoadingViewWithWebAction(title: LoadingText.errorLoadingTitle, subtitle: error)
     }
 
     /// Scroll the content to a given #hash
@@ -1122,9 +1122,10 @@ private extension ReaderDetailViewController {
         showLoadingView()
     }
 
-    func displayLoadingViewWithWebAction(title: String, accessoryView: UIView? = nil) {
+    func displayLoadingViewWithWebAction(title: String, subtitle: String? = nil, accessoryView: UIView? = nil) {
         noResultsViewController.configure(title: title,
                                           buttonTitle: LoadingText.errorLoadingPostURLButtonTitle,
+                                          subtitle: subtitle,
                                           accessoryView: accessoryView)
         showLoadingView()
     }


### PR DESCRIPTION
## Description

Fixes https://linear.app/a8c/issue/CMM-815

After the fix:

<img width="300" src="https://github.com/user-attachments/assets/db8f097c-eb4e-473a-a4b4-87601247f755" />

## Testing instructions

Find a P2 that you are not a member of. Send a post link in that P2 to your test device. Open the link.

BTW, you don't need AutoProxxy to view posts from the app.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
