### PR TITLE
Reader: Disable recommended tags in Discover

### DIFF
--- a/Sources/WordPressData/Swift/ReaderCard+CoreDataClass.swift
+++ b/Sources/WordPressData/Swift/ReaderCard+CoreDataClass.swift
@@ -54,9 +54,7 @@ public class ReaderCard: NSManagedObject {
         case .post:
             post = ReaderPost.createOrReplace(fromRemotePost: remoteCard.post, for: nil, context: context)
         case .interests:
-            topics = NSOrderedSet(array: remoteCard.interests?.prefix(5).map {
-                ReaderTagTopic.createOrUpdateIfNeeded(from: $0, context: context)
-            } ?? [])
+            return nil // Disabled in v26.6
         case .sites:
             sites = NSOrderedSet(array: remoteCard.sites?.prefix(3).map {
                 ReaderSiteTopic.createIfNeeded(from: $0, context: context)

--- a/Tests/KeystoneTests/Tests/Models/ReaderCardTests.swift
+++ b/Tests/KeystoneTests/Tests/Models/ReaderCardTests.swift
@@ -31,9 +31,8 @@ class ReaderCardTests: CoreDataTestCase {
             let card = ReaderCard(context: self.mainContext, from: remoteCard)
             let topics = card?.topicsArray
 
-            expect(topics?.count).to(equal(2))
-            expect(topics?.filter { $0.title == "Activism" }).toNot(beNil())
-            expect(topics?.filter { $0.slug == "activism" }).toNot(beNil())
+            // THEN return 0 as these were disabled in 26.5
+            expect(topics).to(beNil())
             expectation.fulfill()
         }
 

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderRecommendedTagsCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderRecommendedTagsCell.swift
@@ -3,6 +3,7 @@ import UIKit
 import WordPressData
 import WordPressUI
 
+/// - warning: The tags no longer gets shown since v26.6.
 final class ReaderRecommendedTagsCell: UITableViewCell {
     private let scrollView = UIScrollView()
     private let tagsStackView = UIStackView(axis: .horizontal, spacing: 8, insets: UIEdgeInsets(.vertical, 16), [])


### PR DESCRIPTION
Fixes [CMM-976: Be more selective about "You might like" topics](https://linear.app/a8c/issue/CMM-976/be-more-selective-about-you-might-like-topics) (see ticket for rationale)

I kept the presentation code because there are still cards on disk. The remaining files can be removed later.