### PR TITLE
Reader: Increase number of lines for post tiles

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] Fix horizontal insets in Reader article view [#25010]
 
+
 26.5
 -----
 * [*] Add "Status" field to the "Post Settings" screen to make it easier to move posts from one state to another [#24939]
@@ -16,6 +17,7 @@
 * [*] Add "Taxonomies" to Site Settings [#24955]
 * [*] Update "Categories" picker to indicate multiple selection [#24952]
 * [*] Fix overly long related post titles in Reader [#25011]
+* [*] Increase number of lines for post tiles in Reader to three [#25019]
 
 26.4
 -----

--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -199,7 +199,7 @@ private final class ReaderPostCellView: UIView {
     }
 
     private func configureLayout(isCompact: Bool) {
-        titleLabel.numberOfLines = 2
+        titleLabel.numberOfLines = 3
         detailsLabel.numberOfLines = isCompact ? 3 : 5
 
         postPreview.axis = isCompact ? .vertical : .horizontal


### PR DESCRIPTION
2 → 3 as there is a substantial number of posts where 2 is not enough, and 3 still looks great.

<img width="360" alt="Screenshot 2025-11-25 at 7 38 51 AM" src="https://github.com/user-attachments/assets/81b1bc23-87bc-4779-9ce1-0a5eeb15fb2d" />
