### PR TITLE
Fix a crash caused by implicity unwraping

### DIFF
--- a/Sources/WordPressData/Swift/ReaderPost+PostContentProvider.swift
+++ b/Sources/WordPressData/Swift/ReaderPost+PostContentProvider.swift
@@ -12,8 +12,8 @@ extension ReaderPost {
     }
 
     @objc public override var featuredImageURL: URL? {
-        if !self.featuredImage.isEmpty {
-            return URL(string: self.featuredImage)
+        if let featuredImage, !featuredImage.isEmpty {
+            return URL(string: featuredImage)
         }
         return nil
     }


### PR DESCRIPTION
## Description

<img width="718" height="100" alt="image" src="https://github.com/user-attachments/assets/90b78b92-7edf-4191-b440-cb136e430cb9" />

`self.featuredImage` is an Objective-C property without a nullability annotation, which gets turned into `String!` in Swift.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
