### PR TITLE
Fix visual issues on SDK 26.1

### DIFF
--- a/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/System/Action Sheet/BloggingPromptsHeaderView.swift
@@ -84,6 +84,7 @@ private extension BloggingPromptsHeaderView {
         shareButton.titleLabel?.adjustsFontSizeToFitWidth = true
         shareButton.setTitleColor(WPStyleGuide.BloggingPrompts.buttonTitleColor, for: .normal)
         attributionLabel.adjustsFontForContentSizeCategory = true
+        backgroundColor = .clear
     }
 
     func configureConstraints() {

--- a/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/System/Floating Create Button/CreateButtonCoordinator.swift
@@ -17,16 +17,14 @@ final class CreateButtonCoordinator: NSObject {
     var button: UIButton = {
         let button: UIButton
         if #available(iOS 26, *) {
-            var configuration = UIButton.Configuration.prominentClearGlass()
+            var configuration = UIButton.Configuration.prominentGlass()
             configuration.image = UIImage(systemName: "plus")
             configuration.contentInsets = .init(top: 12, leading: 12, bottom: 12, trailing: 12)
             configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(
                 font: .systemFont(ofSize: 20, weight: .semibold)
             )
-            configuration.baseForegroundColor = .systemBackground
-            configuration.baseBackgroundColor = .label.withAlphaComponent(0.8)
-
             button = UIButton(configuration: configuration, primaryAction: nil)
+            button.tintColor = .label.withAlphaComponent(0.9)
         } else {
             button = FloatingActionButton(image: .gridicon(.plus))
         }


### PR DESCRIPTION
There appear to be a couple of new visual issues when compiled under SDK 26.1, especially in dark mode.

Before / After
<img width="340" alt="Screenshot 2025-11-26 at 9 35 56 AM" src="https://github.com/user-attachments/assets/69a66be4-a256-4dd3-91b6-b573bc715cc9" /> <img width="340" alt="Screenshot 2025-11-26 at 10 00 06 AM" src="https://github.com/user-attachments/assets/2d875ff9-7171-486f-9c70-3e7a7fd18748" />

<img width="340" alt="Screenshot 2025-11-26 at 9 52 34 AM" src="https://github.com/user-attachments/assets/395824f7-a4de-49bb-af12-9cd0d1ec9ad1" /> <img width="340" alt="Screenshot 2025-11-26 at 9 57 07 AM" src="https://github.com/user-attachments/assets/bcb526c1-97a0-4077-bab5-c87effbd4d46" />
