### PR TITLE
Fix search for RSS feeds in Reader

### DIFF
--- a/Modules/Sources/AsyncImageKit/Helpers/FaviconService.swift
+++ b/Modules/Sources/AsyncImageKit/Helpers/FaviconService.swift
@@ -74,7 +74,7 @@ private final class FaviconCache: @unchecked Sendable {
 }
 
 private let regex: NSRegularExpression? = {
-    let pattern = "<link[^>]*rel=\"apple-touch-icon\"[^>]*href=\"([^\"]+)\"[^>]*>"
+    let pattern = "<link[^>]*rel=\"apple-touch-icon(?:-precomposed)\"[^>]*href=\"([^\"]+)\"[^>]*>"
     return try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
 }()
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,6 +15,7 @@
 * [*] Add permalink preview in the slug editor and make other improvements [#24949]
 * [*] Add two accessible font sizes to Reader display settings [#25013]
 * [*] Fix an issue with Reader failing to parse some search results [#25022]
+* [*] Fix search for RSS feeds in Reader [#25023]
 * [*] Add "Taxonomies" to Site Settings [#24955]
 * [*] Update "Categories" picker to indicate multiple selection [#24952]
 * [*] Fix overly long related post titles in Reader [#25011]

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderFeedCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderFeedCell.swift
@@ -4,10 +4,11 @@ import WordPressKit
 
 struct ReaderFeedCell: View {
     let feed: ReaderFeed
+    @State private var faviconURL: URL?
 
     var body: some View {
         HStack(alignment: .center, spacing: 16) {
-            SiteIconView(viewModel: .init(feed: feed))
+            SiteIconView(viewModel: .init(feed: feed, faviconURL: faviconURL))
                 .frame(width: 40, height: 40)
 
             VStack(alignment: .leading) {
@@ -22,6 +23,21 @@ struct ReaderFeedCell: View {
                         .lineLimit(2)
                 }
             }
+        }
+        .task {
+            await loadFaviconIfNeeded()
+        }
+    }
+
+    private func loadFaviconIfNeeded() async {
+        guard feed.blavatarURL == nil, let url = feed.url else {
+            return
+        }
+
+        if let cachedFavicon = FaviconService.shared.cachedFavicon(forURL: url) {
+            faviconURL = cachedFavicon
+        } else {
+            faviconURL = try? await FaviconService.shared.favicon(forURL: url)
         }
     }
 
@@ -41,10 +57,12 @@ struct ReaderFeedCell: View {
 }
 
 extension SiteIconViewModel {
-    init(feed: ReaderFeed, size: Size = .regular) {
+    init(feed: ReaderFeed, faviconURL: URL? = nil, size: Size = .regular) {
         self.init(size: size)
         if let iconURL = feed.blavatarURL {
             self.imageURL = SiteIconViewModel.optimizedURL(for: iconURL.absoluteString, imageSize: size.size)
+        } else if let faviconURL {
+            self.imageURL = faviconURL
         }
     }
 }


### PR DESCRIPTION
- Add `meta=feed` parameter to the search endpoint and update parsing to support `.feed` data. **Note**: I accidentally added this change to a commit in https://github.com/wordpress-mobile/WordPress-iOS/pull/25022/commits/2c8a7c5f6369500409d3855ad6669e6e87af2729 by amending it. It already got merged.
- Update `ReaderFeedCell` to use `FaviconService` when other icons are not available
- Update `FaviconService` to support `apple-touch-icon-precomposed` (an old HTML meta key still used on some sites)

Before / After

<img width="340"  alt="simulator_screenshot_AE7865CF-9663-4B3D-9CE5-C232033875C3" src="https://github.com/user-attachments/assets/4b837218-25fc-40c2-86c8-cbcaed819410" /> <img width="340"  alt="Screenshot 2025-11-26 at 5 07 35 PM" src="https://github.com/user-attachments/assets/f74d538a-0930-417a-a658-7cd1a4d80b1d" />
