### PR TITLE
Fix regex for apple-touch-icon

### DIFF
--- a/Modules/Sources/AsyncImageKit/Helpers/FaviconService.swift
+++ b/Modules/Sources/AsyncImageKit/Helpers/FaviconService.swift
@@ -32,7 +32,7 @@ public actor FaviconService {
         let task = tasks[siteURL] ?? FaviconTask { [session] in
             let (data, response) = try await session.data(from: siteURL)
             try validate(response: response)
-            return await makeFavicon(from: data, siteURL: siteURL)
+            return FaviconService.makeFavicon(from: data, siteURL: siteURL)
         }
         let subscriptionID = UUID()
         task.subscriptions.insert(subscriptionID)
@@ -54,6 +54,20 @@ public actor FaviconService {
         }
         task.task.cancel()
         tasks[key] = nil
+    }
+
+    /// Parses HTML data to extract the apple-touch-icon URL or falls back to /favicon.icon
+    public static func makeFavicon(from data: Data, siteURL: URL) -> URL {
+        let html = String(data: data, encoding: .utf8) ?? ""
+        let range = NSRange(location: 0, length: html.utf16.count)
+        if let match = regex?.firstMatch(in: html, options: [], range: range),
+           let matchRange = Range(match.range(at: 1), in: html),
+            let faviconURL = URL(string: String(html[matchRange]), relativeTo: siteURL) {
+            return faviconURL
+        }
+        // Fallback to standard favicon path. It has low quality, but
+        // it's better than nothing.
+        return siteURL.appendingPathComponent("favicon.icon")
     }
 }
 
@@ -77,19 +91,6 @@ private let regex: NSRegularExpression? = {
     let pattern = "<link[^>]*rel=\"apple-touch-icon(?:-precomposed)?\"[^>]*href=\"([^\"]+)\"[^>]*>"
     return try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
 }()
-
-private func makeFavicon(from data: Data, siteURL: URL) async -> URL {
-    let html = String(data: data, encoding: .utf8) ?? ""
-    let range = NSRange(location: 0, length: html.utf16.count)
-    if let match = regex?.firstMatch(in: html, options: [], range: range),
-       let matchRange = Range(match.range(at: 1), in: html),
-        let faviconURL = URL(string: String(html[matchRange]), relativeTo: siteURL) {
-        return faviconURL
-    }
-    // Fallback to standard favicon path. It has low quality, but
-    // it's better than nothing.
-    return siteURL.appendingPathComponent("favicon.icon")
-}
 
 private func validate(response: URLResponse) throws {
     guard let response = response as? HTTPURLResponse else {

--- a/Modules/Sources/AsyncImageKit/Helpers/FaviconService.swift
+++ b/Modules/Sources/AsyncImageKit/Helpers/FaviconService.swift
@@ -74,7 +74,7 @@ private final class FaviconCache: @unchecked Sendable {
 }
 
 private let regex: NSRegularExpression? = {
-    let pattern = "<link[^>]*rel=\"apple-touch-icon(?:-precomposed)\"[^>]*href=\"([^\"]+)\"[^>]*>"
+    let pattern = "<link[^>]*rel=\"apple-touch-icon(?:-precomposed)?\"[^>]*href=\"([^\"]+)\"[^>]*>"
     return try? NSRegularExpression(pattern: pattern, options: .caseInsensitive)
 }()
 

--- a/Modules/Tests/AsyncImageKitTests/FaviconServiceTests.swift
+++ b/Modules/Tests/AsyncImageKitTests/FaviconServiceTests.swift
@@ -1,0 +1,235 @@
+import UIKit
+import Testing
+import AsyncImageKit
+
+@Suite final class FaviconServiceTests {
+    @Test func appleTouchIcon() throws {
+        // GIVEN
+        let siteURL = try #require(URL(string: "https://example.com"))
+        let html = """
+        <html>
+        <head>
+            <link rel="apple-touch-icon" href="/apple-icon.png">
+        </head>
+        </html>
+        """
+        let data = Data(html.utf8)
+
+        // WHEN
+        let faviconURL = FaviconService.makeFavicon(from: data, siteURL: siteURL)
+
+        // THEN
+        #expect(faviconURL.absoluteString == "https://example.com/apple-icon.png")
+    }
+
+    @Test func appleTouchIconPrecomposed() throws {
+        // GIVEN
+        let siteURL = try #require(URL(string: "https://example.com"))
+        let html = """
+        <html>
+        <head>
+            <link rel="apple-touch-icon-precomposed" href="/apple-icon-precomposed.png">
+        </head>
+        </html>
+        """
+        let data = Data(html.utf8)
+
+        // WHEN
+        let faviconURL = FaviconService.makeFavicon(from: data, siteURL: siteURL)
+
+        // THEN
+        #expect(faviconURL.absoluteString == "https://example.com/apple-icon-precomposed.png")
+    }
+
+    @Test func appleTouchIconWithAbsoluteURL() throws {
+        // GIVEN
+        let siteURL = try #require(URL(string: "https://example.com"))
+        let html = """
+        <html>
+        <head>
+            <link rel="apple-touch-icon" href="https://cdn.example.com/icon.png">
+        </head>
+        </html>
+        """
+        let data = Data(html.utf8)
+
+        // WHEN
+        let faviconURL = FaviconService.makeFavicon(from: data, siteURL: siteURL)
+
+        // THEN
+        #expect(faviconURL.absoluteString == "https://cdn.example.com/icon.png")
+    }
+
+    @Test func appleTouchIconWithRelativePath() throws {
+        // GIVEN
+        let siteURL = try #require(URL(string: "https://example.com"))
+        let html = """
+        <html>
+        <head>
+            <link rel="apple-touch-icon" href="assets/icon.png">
+        </head>
+        </html>
+        """
+        let data = Data(html.utf8)
+
+        // WHEN
+        let faviconURL = FaviconService.makeFavicon(from: data, siteURL: siteURL)
+
+        // THEN
+        #expect(faviconURL.absoluteString == "https://example.com/assets/icon.png")
+    }
+
+    @Test func appleTouchIconWithAdditionalAttributes() throws {
+        // GIVEN
+        let siteURL = try #require(URL(string: "https://example.com"))
+        let html = """
+        <html>
+        <head>
+            <link rel="apple-touch-icon" sizes="180x180" href="/apple-icon-180x180.png">
+        </head>
+        </html>
+        """
+        let data = Data(html.utf8)
+
+        // WHEN
+        let faviconURL = FaviconService.makeFavicon(from: data, siteURL: siteURL)
+
+        // THEN
+        #expect(faviconURL.absoluteString == "https://example.com/apple-icon-180x180.png")
+    }
+
+    @Test func appleTouchIconPrecomposedWithSizes() throws {
+        // GIVEN
+        let siteURL = try #require(URL(string: "https://example.com"))
+        let html = """
+        <html>
+        <head>
+            <link rel="apple-touch-icon-precomposed" sizes="152x152" href="/apple-icon-precomposed-152.png">
+        </head>
+        </html>
+        """
+        let data = Data(html.utf8)
+
+        // WHEN
+        let faviconURL = FaviconService.makeFavicon(from: data, siteURL: siteURL)
+
+        // THEN
+        #expect(faviconURL.absoluteString == "https://example.com/apple-icon-precomposed-152.png")
+    }
+
+    @Test func fallbackToFaviconIcon() throws {
+        // GIVEN
+        let siteURL = try #require(URL(string: "https://example.com"))
+        let html = """
+        <html>
+        <head>
+            <link rel="icon" href="/favicon.ico">
+        </head>
+        </html>
+        """
+        let data = Data(html.utf8)
+
+        // WHEN
+        let faviconURL = FaviconService.makeFavicon(from: data, siteURL: siteURL)
+
+        // THEN
+        #expect(faviconURL.absoluteString == "https://example.com/favicon.icon")
+    }
+
+    @Test func fallbackWhenNoFaviconFound() throws {
+        // GIVEN
+        let siteURL = try #require(URL(string: "https://example.com"))
+        let html = "<html><head></head></html>"
+        let data = Data(html.utf8)
+
+        // WHEN
+        let faviconURL = FaviconService.makeFavicon(from: data, siteURL: siteURL)
+
+        // THEN
+        #expect(faviconURL.absoluteString == "https://example.com/favicon.icon")
+    }
+
+    @Test func appleTouchIconCaseInsensitive() throws {
+        // GIVEN
+        let siteURL = try #require(URL(string: "https://example.com"))
+        let html = """
+        <html>
+        <head>
+            <link rel="APPLE-TOUCH-ICON" href="/apple-icon.png">
+        </head>
+        </html>
+        """
+        let data = Data(html.utf8)
+
+        // WHEN
+        let faviconURL = FaviconService.makeFavicon(from: data, siteURL: siteURL)
+
+        // THEN
+        #expect(faviconURL.absoluteString == "https://example.com/apple-icon.png")
+    }
+
+    @Test func multipleAppleTouchIconsUsesFirst() throws {
+        // GIVEN
+        let siteURL = try #require(URL(string: "https://example.com"))
+        let html = """
+        <html>
+        <head>
+            <link rel="apple-touch-icon" sizes="180x180" href="/apple-icon-180.png">
+            <link rel="apple-touch-icon" sizes="152x152" href="/apple-icon-152.png">
+            <link rel="apple-touch-icon-precomposed" href="/apple-icon-precomposed.png">
+        </head>
+        </html>
+        """
+        let data = Data(html.utf8)
+
+        // WHEN
+        let faviconURL = FaviconService.makeFavicon(from: data, siteURL: siteURL)
+
+        // THEN - Uses the first match
+        #expect(faviconURL.absoluteString == "https://example.com/apple-icon-180.png")
+    }
+
+    @Test func emptyData() throws {
+        // GIVEN
+        let siteURL = try #require(URL(string: "https://example.com"))
+        let data = Data()
+
+        // WHEN
+        let faviconURL = FaviconService.makeFavicon(from: data, siteURL: siteURL)
+
+        // THEN - Falls back to standard favicon path
+        #expect(faviconURL.absoluteString == "https://example.com/favicon.icon")
+    }
+
+    @Test func siteURLWithPath() throws {
+        // GIVEN
+        let siteURL = try #require(URL(string: "https://example.com/blog"))
+        let html = """
+        <html>
+        <head>
+            <link rel="apple-touch-icon" href="/apple-icon.png">
+        </head>
+        </html>
+        """
+        let data = Data(html.utf8)
+
+        // WHEN
+        let faviconURL = FaviconService.makeFavicon(from: data, siteURL: siteURL)
+
+        // THEN
+        #expect(faviconURL.absoluteString == "https://example.com/apple-icon.png")
+    }
+
+    @Test func siteURLWithPathFallback() throws {
+        // GIVEN
+        let siteURL = try #require(URL(string: "https://example.com/blog"))
+        let html = "<html><head></head></html>"
+        let data = Data(html.utf8)
+
+        // WHEN
+        let faviconURL = FaviconService.makeFavicon(from: data, siteURL: siteURL)
+
+        // THEN
+        #expect(faviconURL.absoluteString == "https://example.com/blog/favicon.icon")
+    }
+}


### PR DESCRIPTION
Fixes regression introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/25023. I should not have trusted AI to write regex.

**Notes**:

- Yes, it should probably not use regex in the first place
-  I'm looking into the root cause – why do some dotcom sites not have an icon in some responses while they do in others

<img width="300"  alt="Screenshot 2025-11-27 at 12 56 21 PM" src="https://github.com/user-attachments/assets/d03010bf-35b6-4a13-bd1b-d2b25df8ce6e" />

Before:

<img width="816" height="234" alt="Screenshot 2025-11-27 at 12 53 43 PM" src="https://github.com/user-attachments/assets/3ae9ac3f-9367-4495-b89e-1652c4535777" />

After (making the group actually optional):

<img width="807" height="257" alt="Screenshot 2025-11-27 at 12 53 47 PM" src="https://github.com/user-attachments/assets/ff4f1bc7-a881-4681-aec9-16c588abc44a" />
