### PR TITLE
Fix an issue with duplicated subscriptions for Jetpack-connected sites

### DIFF
--- a/Modules/Sources/WordPressKit/ReaderFeed.swift
+++ b/Modules/Sources/WordPressKit/ReaderFeed.swift
@@ -10,9 +10,14 @@ import Foundation
 /// - External RSS feeds: Data in meta.data.feed, blog_ID is "0"
 ///
 public struct ReaderFeed: Decodable {
-    /// Feed ID from meta.data.feed
     public var feedID: String? {
-        feed?.feedID
+        let id = feed?.feedID ?? site?.feedID.map(String.init)
+        return id?.nonEmptyID
+    }
+
+    public var blogID: String? {
+        let id = feed?.blogID ?? site?.id.map(String.init)
+        return id?.nonEmptyID
     }
 
     /// Site/Feed URL with fallback: data.site → data.feed
@@ -32,13 +37,6 @@ public struct ReaderFeed: Decodable {
         site?.description ?? feed?.description
     }
 
-    /// Blog ID with fallback: data.feed.blog_ID → data.site.ID
-    /// Returns nil if "0" (external RSS feeds)
-    public var blogID: String? {
-        let id = feed?.blogID ?? site?.id.map(String.init)
-        return (id == "0") ? nil : id
-    }
-
     /// Site icon/avatar URL, prioritizing data.site.icon.img over data.feed.image
     public var iconURL: URL? {
         site?.iconURL ?? feed?.imageURL
@@ -56,6 +54,11 @@ public struct ReaderFeed: Decodable {
         let parsed = try ReaderFeedJSON(from: decoder)
         self.feed = parsed.meta?.data?.feed
         self.site = parsed.meta?.data?.site
+
+        // If feed data not found, try parsing inline data from root (WordPress.com format)
+        if self.feed == nil, let inlineData = try? InlineData(from: decoder) {
+            self.feed = FeedData(from: inlineData)
+        }
     }
 }
 
@@ -100,10 +103,20 @@ private struct FeedData: Decodable {
         description = try? container.decodeIfPresent(String.self, forKey: .description)
         imageURL = try? container.decodeIfPresent(URL.self, forKey: .imageURL)
     }
+
+    init(from inlineData: InlineData) {
+        self.feedID = inlineData.feedID
+        self.blogID = inlineData.blogID
+        self.name = inlineData.title
+        self.url = inlineData.url
+        self.description = nil
+        self.imageURL = nil
+    }
 }
 
 /// Represents site-specific data from meta.data.site
 private struct SiteData: Decodable {
+    let feedID: Int?
     let id: Int?
     let name: String?
     let url: URL?
@@ -111,6 +124,7 @@ private struct SiteData: Decodable {
     let iconURL: URL?
 
     private enum CodingKeys: String, CodingKey {
+        case feedID = "feed_ID"
         case id = "ID"
         case name = "name"
         case url = "URL"
@@ -125,6 +139,7 @@ private struct SiteData: Decodable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
+        feedID = try? container.decodeIfPresent(Int.self, forKey: .feedID)
         id = try? container.decodeIfPresent(Int.self, forKey: .id)
         name = try? container.decodeIfPresent(String.self, forKey: .name)
         url = try? container.decodeIfPresent(URL.self, forKey: .url)
@@ -136,5 +151,31 @@ private struct SiteData: Decodable {
         } else {
             iconURL = nil
         }
+    }
+}
+
+/// Represents inline feed data (WordPress.com sites)
+/// Used when feed data appears at root level instead of nested in meta.data.feed.
+/// In practice, it should never be necessary. It's a fallback.
+private struct InlineData: Decodable {
+    let feedID: String?
+    let blogID: String?
+    let title: String?
+    let url: URL?
+
+    private enum CodingKeys: String, CodingKey {
+        case feedID = "feed_ID"
+        case blogID = "blog_ID"
+        case title = "title"
+        case url = "URL"
+    }
+}
+
+private extension String {
+    var nonEmptyID: String? {
+        guard !isEmpty && self != "0" else {
+            return nil
+        }
+        return self
     }
 }

--- a/Modules/Sources/WordPressKit/ReaderFeed.swift
+++ b/Modules/Sources/WordPressKit/ReaderFeed.swift
@@ -4,20 +4,56 @@ import Foundation
 /// Encapsulates details of a single feed returned by the Reader feed search API
 /// (read/feed?q=query)
 ///
+/// The API returns different structures depending on the site type:
+/// - WordPress.com sites: Data at root level (URL, title, blog_ID)
+/// - Jetpack sites: Data in meta.data.feed
+/// - External RSS feeds: Data in meta.data.feed, blog_ID is "0"
+///
 public struct ReaderFeed: Decodable {
-    public let url: URL?
-    public let title: String?
-    public let feedDescription: String?
-    public let feedID: String?
-    public let blogID: String?
-    public let blavatarURL: URL?
+    /// Feed ID from meta.data.feed
+    public var feedID: String? {
+        feed?.feedID
+    }
 
-    private enum CodingKeys: String, CodingKey {
-        case url = "URL"
-        case title = "title"
-        case feedID = "feed_ID"
-        case blogID = "blog_ID"
-        case meta = "meta"
+    /// Site/Feed URL with fallback: data.site → data.feed
+    /// Prioritizes site URL over feed URL for canonical representation
+    public var url: URL? {
+        site?.url ?? feed?.url
+    }
+
+    /// Site/Feed title with fallback: data.site → data.feed
+    /// Prioritizes site name over feed name
+    public var title: String? {
+        site?.name ?? feed?.name
+    }
+
+    /// Feed description with fallback: data.site → data.feed
+    public var description: String? {
+        site?.description ?? feed?.description
+    }
+
+    /// Blog ID with fallback: data.feed.blog_ID → data.site.ID
+    /// Returns nil if "0" (external RSS feeds)
+    public var blogID: String? {
+        let id = feed?.blogID ?? site?.id.map(String.init)
+        return (id == "0") ? nil : id
+    }
+
+    /// Site icon/avatar URL, prioritizing data.site.icon.img over data.feed.image
+    public var iconURL: URL? {
+        site?.iconURL ?? feed?.imageURL
+    }
+
+    // MARK: - Decodable
+
+    /// Feed data from meta.data.feed
+    private var feed: FeedData?
+
+    /// Site data from meta.data.site
+    private var site: SiteData?
+
+    private enum CodingKeys: CodingKey {
+        case meta
     }
 
     private enum MetaKeys: CodingKey {
@@ -30,61 +66,52 @@ public struct ReaderFeed: Decodable {
     }
 
     public init(from decoder: Decoder) throws {
-        // We have to manually decode the feed from the JSON, for a couple of reasons:
-        // - Some feeds have no `icon` dictionary
-        // - Some feeds have no `data` dictionary
-        // - We want to decode whatever we can get, and not fail if neither of those exist
-        let rootContainer = try decoder.container(keyedBy: CodingKeys.self)
-
-        var feedURL = try? rootContainer.decodeIfPresent(URL.self, forKey: .url)
-        var title = try? rootContainer.decodeIfPresent(String.self, forKey: .title)
-        feedID = try? rootContainer.decode(String.self, forKey: .feedID)
-        blogID = try? rootContainer.decode(String.self, forKey: .blogID)
-
-        var feedDescription: String?
-        var blavatarURL: URL?
-
-        // Try to parse both site and feed data from meta.data
-        do {
-            let metaContainer = try rootContainer.nestedContainer(keyedBy: MetaKeys.self, forKey: .meta)
-            let dataContainer = try metaContainer.nestedContainer(keyedBy: DataKeys.self, forKey: .data)
-
-            let siteData = try? dataContainer.decode(SiteOrFeedData.self, forKey: .site)
-            let feedData = try? dataContainer.decode(SiteOrFeedData.self, forKey: .feed)
-
-            // Use data from either source, preferring site data when both are available
-            feedDescription = siteData?.description ?? feedData?.description
-            blavatarURL = siteData?.iconURL ?? feedData?.iconURL
-
-            // Fixes CMM-1002: in some cases, the backend fails to embed certain fields
-            // directly in the feed object
-            if feedURL == nil {
-                feedURL = siteData?.url ?? feedData?.url
-            }
-            if title == nil {
-                title = siteData?.title ?? feedData?.title
-            }
-        } catch {
+        let root = try decoder.container(keyedBy: CodingKeys.self)
+        if let meta = try? root.nestedContainer(keyedBy: MetaKeys.self, forKey: .meta),
+           let data = try? meta.nestedContainer(keyedBy: DataKeys.self, forKey: .data) {
+            self.feed = try? data.decode(FeedData.self, forKey: .feed)
+            self.site = try? data.decode(SiteData.self, forKey: .site)
         }
-
-        self.url = feedURL
-        self.title = title
-        self.feedDescription = feedDescription
-        self.blavatarURL = blavatarURL
     }
 }
 
-private struct SiteOrFeedData: Decodable {
-    var title: String?
-    var description: String?
-    var iconURL: URL?
-    var url: URL?
+// MARK: - Feed Data
 
-    enum CodingKeys: String, CodingKey {
-        case description
-        case icon
+/// Represents feed-specific data from meta.data.feed
+private struct FeedData: Decodable {
+    let feedID: String?
+    let blogID: String?
+    let name: String?
+    let url: URL?
+    let description: String?
+    let imageURL: URL?
+
+    private enum CodingKeys: String, CodingKey {
+        case feedID = "feed_ID"
+        case blogID = "blog_ID"
+        case name = "name"
         case url = "URL"
-        case name
+        case description = "description"
+        case imageURL = "image"
+    }
+}
+
+// MARK: - Site Data
+
+/// Represents site-specific data from meta.data.site
+private struct SiteData: Decodable {
+    let id: Int?
+    let name: String?
+    let url: URL?
+    let description: String?
+    let iconURL: URL?
+
+    private enum CodingKeys: String, CodingKey {
+        case id = "ID"
+        case name = "name"
+        case url = "URL"
+        case description = "description"
+        case icon = "icon"
     }
 
     private enum IconKeys: CodingKey {
@@ -94,19 +121,16 @@ private struct SiteOrFeedData: Decodable {
     init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
 
-        title = try? container.decodeIfPresent(String.self, forKey: .name)
-        description = try? container.decodeIfPresent(String.self, forKey: .description)
+        id = try? container.decodeIfPresent(Int.self, forKey: .id)
+        name = try? container.decodeIfPresent(String.self, forKey: .name)
         url = try? container.decodeIfPresent(URL.self, forKey: .url)
+        description = try? container.decodeIfPresent(String.self, forKey: .description)
 
-        // Try to decode the icon URL from the nested icon dictionary
+        // Decode icon.img if icon dictionary exists
         if let iconContainer = try? container.nestedContainer(keyedBy: IconKeys.self, forKey: .icon) {
             iconURL = try? iconContainer.decode(URL.self, forKey: .img)
+        } else {
+            iconURL = nil
         }
-    }
-}
-
-extension ReaderFeed: CustomStringConvertible {
-    public var description: String {
-        return "<Feed | URL: \(String(describing: url)), title: \(String(describing: title)), feedID: \(String(describing: feedID)), blogID: \(String(describing: blogID))>"
     }
 }

--- a/Modules/Sources/WordPressKit/ReaderFeed.swift
+++ b/Modules/Sources/WordPressKit/ReaderFeed.swift
@@ -52,30 +52,25 @@ public struct ReaderFeed: Decodable {
     /// Site data from meta.data.site
     private var site: SiteData?
 
-    private enum CodingKeys: CodingKey {
-        case meta
-    }
-
-    private enum MetaKeys: CodingKey {
-        case data
-    }
-
-    private enum DataKeys: CodingKey {
-        case site
-        case feed
-    }
-
     public init(from decoder: Decoder) throws {
-        let root = try decoder.container(keyedBy: CodingKeys.self)
-        if let meta = try? root.nestedContainer(keyedBy: MetaKeys.self, forKey: .meta),
-           let data = try? meta.nestedContainer(keyedBy: DataKeys.self, forKey: .data) {
-            self.feed = try? data.decode(FeedData.self, forKey: .feed)
-            self.site = try? data.decode(SiteData.self, forKey: .site)
-        }
+        let parsed = try ReaderFeedJSON(from: decoder)
+        self.feed = parsed.meta?.data?.feed
+        self.site = parsed.meta?.data?.site
     }
 }
 
-// MARK: - Feed Data
+private struct ReaderFeedJSON: Decodable {
+    struct Meta: Decodable {
+        struct Data: Decodable {
+            var feed: FeedData?
+            var site: SiteData?
+        }
+
+        var data: Data?
+    }
+
+    var meta: Meta?
+}
 
 /// Represents feed-specific data from meta.data.feed
 private struct FeedData: Decodable {
@@ -94,9 +89,18 @@ private struct FeedData: Decodable {
         case description = "description"
         case imageURL = "image"
     }
-}
 
-// MARK: - Site Data
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        feedID = try? container.decodeIfPresent(String.self, forKey: .feedID)
+        blogID = try? container.decodeIfPresent(String.self, forKey: .blogID)
+        name = try? container.decodeIfPresent(String.self, forKey: .name)
+        url = try? container.decodeIfPresent(URL.self, forKey: .url)
+        description = try? container.decodeIfPresent(String.self, forKey: .description)
+        imageURL = try? container.decodeIfPresent(URL.self, forKey: .imageURL)
+    }
+}
 
 /// Represents site-specific data from meta.data.site
 private struct SiteData: Decodable {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -23,6 +23,7 @@
 * [*] Fix overly long related post titles in Reader [#25011]
 * [*] Increase number of lines for post tiles in Reader to three [#25019]
 * [*] Fix horizontal insets in Reader article view [#25010]
+* [*] Fix an issue with duplicated subscriptions for Jetpack-connected sites [#25026]
 * [*] Fixed several reader bugs causing posts to load strangely, or not at all [#25016]
 
 26.4

--- a/Tests/WordPressKitTests/WordPressKitTests/Mock Data/Reader/reader-search-response-01.json
+++ b/Tests/WordPressKitTests/WordPressKitTests/Mock Data/Reader/reader-search-response-01.json
@@ -1,0 +1,133 @@
+{
+  "feeds": [
+    {
+      "subscribe_URL": "https://ma.tt/feed/",
+      "feed_ID": "188407",
+      "meta": {
+        "links": {
+          "feed": "https://public-api.wordpress.com/rest/v1.1/read/feed/188407",
+          "site": "https://public-api.wordpress.com/rest/v1.1/read/sites/1047865"
+        },
+        "data": {
+          "feed": {
+            "blog_ID": "1047865",
+            "feed_ID": "188407",
+            "blog_owner": {
+              "ID": 5,
+              "name": "Matt"
+            },
+            "name": "Matt Mullenweg",
+            "URL": "https://ma.tt/",
+            "feed_URL": "http://ma.tt/feed",
+            "subscribers_count": 4520,
+            "is_following": false,
+            "last_update": "2025-11-27T07:18:10+00:00",
+            "last_checked": "2025-11-27T19:04:42+00:00",
+            "marked_for_refresh": false,
+            "next_refresh_time": null,
+            "organization_id": 0,
+            "subscription_id": null,
+            "unseen_count": 0,
+            "meta": {
+              "links": {
+                "self": "https://public-api.wordpress.com/rest/v1.1/read/feed/188407",
+                "site": "https://public-api.wordpress.com/rest/v1.1/read/sites/1047865"
+              }
+            },
+            "resolved_feed_url": "https://ma.tt/feed/",
+            "image": "https://i0.wp.com/ma.tt/files/2024/01/cropped-matt-favicon.png?fit=32%2C32&amp;quality=80&amp;ssl=1",
+            "description": "Unlucky in Cards"
+          },
+          "site": {
+            "ID": 1047865,
+            "name": "Matt Mullenweg",
+            "description": "Unlucky in Cards",
+            "URL": "https://ma.tt",
+            "jetpack": true,
+            "jetpack_connection": true,
+            "post_count": 5600,
+            "subscribers_count": 4520,
+            "lang": "en-US",
+            "icon": {
+              "img": "https://ma.tt/files/2024/01/cropped-matt-favicon.png",
+              "ico": "https://ma.tt/files/2024/01/cropped-matt-favicon.png?w=16"
+            },
+            "logo": {
+              "id": 0,
+              "sizes": [],
+              "url": ""
+            },
+            "visible": true,
+            "is_private": false,
+            "is_coming_soon": false,
+            "is_following": false,
+            "organization_id": 0,
+            "meta": {
+              "links": {
+                "self": "https://public-api.wordpress.com/rest/v1.1/read/sites/1047865",
+                "help": "https://public-api.wordpress.com/rest/v1.1/read/sites/1047865/help",
+                "posts": "https://public-api.wordpress.com/rest/v1.1/read/sites/1047865/posts/",
+                "comments": "https://public-api.wordpress.com/rest/v1.1/sites/1047865/comments/",
+                "xmlrpc": "https://ma.tt/blog/xmlrpc.php"
+              }
+            },
+            "launch_status": false,
+            "site_migration": {
+              "is_complete": false,
+              "in_progress": false
+            },
+            "is_fse_active": false,
+            "is_fse_eligible": false,
+            "is_core_site_editor_enabled": false,
+            "is_wpcom_atomic": false,
+            "is_wpcom_staging_site": false,
+            "is_deleted": false,
+            "is_a4a_client": false,
+            "is_a4a_dev_site": false,
+            "is_wpcom_flex": false,
+            "capabilities": {
+              "edit_pages": false,
+              "edit_posts": false,
+              "edit_others_posts": false,
+              "edit_theme_options": false,
+              "list_users": false,
+              "manage_categories": false,
+              "manage_options": false,
+              "publish_posts": false,
+              "upload_files": false,
+              "view_stats": false
+            },
+            "is_multi_author": true,
+            "feed_ID": 188407,
+            "feed_URL": "http://ma.tt/feed",
+            "header_image": false,
+            "owner": {
+              "ID": 5,
+              "login": "matt",
+              "name": "Matt",
+              "first_name": "Matt",
+              "last_name": "Mullenweg",
+              "nice_name": "matt",
+              "URL": "https://matt.blog/",
+              "avatar_URL": "https://0.gravatar.com/avatar/33252cd1f33526af53580fcb1736172f06e6716f32afdd1be19ec3096d15dea5?s=96&d=retro&r=G",
+              "profile_URL": "https://gravatar.com/matt",
+              "ip_address": false,
+              "site_visible": true,
+              "has_avatar": true
+            },
+            "subscription": {
+              "delivery_methods": {
+                "email": null,
+                "notification": {
+                  "send_posts": false
+                }
+              }
+            },
+            "is_blocked": false,
+            "unseen_count": 0
+          }
+        }
+      }
+    }
+  ]
+}

--- a/Tests/WordPressKitTests/WordPressKitTests/Mock Data/Reader/reader-search-response-02.json
+++ b/Tests/WordPressKitTests/WordPressKitTests/Mock Data/Reader/reader-search-response-02.json
@@ -1,0 +1,151 @@
+{
+  "feeds": [
+    {
+      "URL": "http://veselin.blog",
+      "subscribe_URL": "http://veselin.blog",
+      "blog_ID": "125098293",
+      "title": "Veselin.blog",
+      "railcar": {
+        "railcar": "KkQSHUkMCD@Z",
+        "fetch_algo": "reader/manage/search:0",
+        "fetch_position": 0,
+        "rec_blog_id": 125098293,
+        "fetch_lang": "en",
+        "fetch_query": "Veselin.blog"
+      },
+      "meta": {
+        "links": {
+          "feed": "https://public-api.wordpress.com/rest/v1.1/read/feed/152023972",
+          "site": "https://public-api.wordpress.com/rest/v1.1/read/sites/125098293"
+        },
+        "data": {
+          "feed": {
+            "blog_ID": "125098293",
+            "feed_ID": "152023972",
+            "blog_owner": {
+              "ID": 217470,
+              "name": "Veselin"
+            },
+            "name": "Veselin.blog",
+            "URL": "http://veselin.blog/",
+            "feed_URL": "http://veselin.blog",
+            "subscribers_count": 534,
+            "is_following": true,
+            "last_update": "2025-11-26T22:19:29+00:00",
+            "last_checked": "2025-11-26T22:19:33+00:00",
+            "marked_for_refresh": false,
+            "next_refresh_time": null,
+            "organization_id": 0,
+            "subscription_id": "824304679",
+            "unseen_count": 0,
+            "meta": {
+              "links": {
+                "self": "https://public-api.wordpress.com/rest/v1.1/read/feed/152023972",
+                "site": "https://public-api.wordpress.com/rest/v1.1/read/sites/125098293"
+              }
+            },
+            "image": "https://veselinblogblog.files.wordpress.com/2024/04/cropped-avatar-18.jpg?w=32",
+            "description": "Cats, good books, AI, and religious walking in the city of Sofia"
+          },
+          "site": {
+            "ID": 125098293,
+            "name": "Veselin.blog",
+            "description": "Cats, good books, AI, and religious walking in the city of Sofia",
+            "URL": "http://veselin.blog",
+            "jetpack": false,
+            "jetpack_connection": false,
+            "post_count": 791,
+            "subscribers_count": 534,
+            "lang": "en",
+            "icon": {
+              "img": "https://veselinblogblog.wordpress.com/wp-content/uploads/2024/04/cropped-avatar-18.jpg?w=96",
+              "ico": "https://veselinblogblog.wordpress.com/wp-content/uploads/2024/04/cropped-avatar-18.jpg?w=96"
+            },
+            "logo": {
+              "id": 0,
+              "sizes": [],
+              "url": ""
+            },
+            "visible": true,
+            "is_private": false,
+            "is_coming_soon": false,
+            "is_following": true,
+            "organization_id": 0,
+            "meta": {
+              "links": {
+                "self": "https://public-api.wordpress.com/rest/v1.1/read/sites/125098293",
+                "help": "https://public-api.wordpress.com/rest/v1.1/read/sites/125098293/help",
+                "posts": "https://public-api.wordpress.com/rest/v1.1/read/sites/125098293/posts/",
+                "comments": "https://public-api.wordpress.com/rest/v1.1/sites/125098293/comments/",
+                "xmlrpc": "https://veselinblogblog.wordpress.com/xmlrpc.php"
+              }
+            },
+            "launch_status": false,
+            "site_migration": {
+              "is_complete": false,
+              "in_progress": false
+            },
+            "is_fse_active": false,
+            "is_fse_eligible": false,
+            "is_core_site_editor_enabled": false,
+            "is_wpcom_atomic": false,
+            "is_wpcom_staging_site": false,
+            "is_deleted": false,
+            "is_a4a_client": false,
+            "is_a4a_dev_site": false,
+            "is_wpcom_flex": false,
+            "capabilities": {
+              "edit_pages": false,
+              "edit_posts": false,
+              "edit_others_posts": false,
+              "edit_theme_options": false,
+              "list_users": false,
+              "manage_categories": false,
+              "manage_options": false,
+              "publish_posts": false,
+              "upload_files": false,
+              "view_stats": false
+            },
+            "is_multi_author": false,
+            "feed_ID": 152023972,
+            "feed_URL": "http://veselin.blog",
+            "header_image": false,
+            "owner": {
+              "ID": 217470,
+              "login": "dzver",
+              "name": "Veselin",
+              "first_name": "Veselin",
+              "last_name": "Nikolov",
+              "nice_name": "dzver",
+              "URL": "https://veselin.blog",
+              "avatar_URL": "https://2.gravatar.com/avatar/5f0ee9d86c04bc37653bb6adfeba93e6d5b57f2356d32c06fd2de25ad4adfbe6?s=96&d=identicon&r=G",
+              "profile_URL": "https://gravatar.com/dzver",
+              "ip_address": false,
+              "site_visible": true,
+              "has_avatar": true
+            },
+            "subscription": {
+              "delivery_methods": {
+                "email": {
+                  "send_posts": true,
+                  "send_comments": false,
+                  "post_delivery_frequency": "instantly",
+                  "date_subscribed": "2025-11-27 19:08:50"
+                },
+                "notification": {
+                  "send_posts": false
+                }
+              }
+            },
+            "is_blocked": false,
+            "unseen_count": 0
+          }
+        }
+      },
+      "feed_ID": "152023972",
+      "subscribers_count": 532
+    }
+  ],
+  "total": 1,
+  "algorithm": "reader/manage/search:0"
+}

--- a/Tests/WordPressKitTests/WordPressKitTests/Mock Data/Reader/reader-search-response-03.json
+++ b/Tests/WordPressKitTests/WordPressKitTests/Mock Data/Reader/reader-search-response-03.json
@@ -1,0 +1,39 @@
+{
+  "feeds": [
+    {
+      "subscribe_URL": "http://daringfireball.net/feeds/main",
+      "feed_ID": "20787116",
+      "meta": {
+        "links": {
+          "feed": "https://public-api.wordpress.com/rest/v1.1/read/feed/20787116"
+        },
+        "data": {
+          "feed": {
+            "blog_ID": "0",
+            "feed_ID": "20787116",
+            "blog_owner": null,
+            "name": "Daring Fireball",
+            "URL": "https://daringfireball.net/",
+            "feed_URL": "http://daringfireball.net/feeds/main",
+            "subscribers_count": 408,
+            "is_following": false,
+            "last_update": "2025-11-27T00:31:44+00:00",
+            "last_checked": "2025-11-27T15:47:03+00:00",
+            "marked_for_refresh": false,
+            "next_refresh_time": null,
+            "organization_id": 0,
+            "subscription_id": null,
+            "unseen_count": 0,
+            "meta": {
+              "links": {
+                "self": "https://public-api.wordpress.com/rest/v1.1/read/feed/20787116"
+              }
+            },
+            "resolved_feed_url": "https://daringfireball.net/feeds/main",
+            "description": "By John Gruber"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/Tests/WordPressKitTests/WordPressKitTests/Mock Data/reader-site-search-no-blog-or-feed-id.json
+++ b/Tests/WordPressKitTests/WordPressKitTests/Mock Data/reader-site-search-no-blog-or-feed-id.json
@@ -19,7 +19,6 @@
         },
         "data": {
           "site": {
-            "ID": 489937,
             "name": "The Daily Post",
             "description": "The Art and Craft of Blogging",
             "URL": "https://dailypost.wordpress.com",
@@ -60,7 +59,6 @@
               "view_stats": false
             },
             "is_multi_author": true,
-            "feed_ID": 27030,
             "feed_URL": "http://dailypost.wordpress.com",
             "header_image": false,
             "owner": {

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/ReaderSiteSearchServiceRemoteTests.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/ReaderSiteSearchServiceRemoteTests.swift
@@ -71,8 +71,8 @@ class ReaderSiteSearchServiceRemoteTests: RemoteTestCase, RESTTestable {
                                 XCTAssertEqual(feed.title, "The Daily Post")
                                 XCTAssertEqual(feed.feedID, "27030")
                                 XCTAssertEqual(feed.url, URL(string: "https://dailypost.wordpress.com")!)
-                                XCTAssertEqual(feed.feedDescription, "The Art and Craft of Blogging")
-                                XCTAssertNil(feed.blavatarURL)
+                                XCTAssertEqual(feed.description, "The Art and Craft of Blogging")
+                                XCTAssertNil(feed.iconURL)
 
                                 expect.fulfill()
         }, failure: { _ in
@@ -101,8 +101,8 @@ class ReaderSiteSearchServiceRemoteTests: RemoteTestCase, RESTTestable {
                                 XCTAssertEqual(feed.title, "The Daily Post")
                                 XCTAssertEqual(feed.feedID, "27030")
                                 XCTAssertEqual(feed.url, URL(string: "https://dailypost.wordpress.com")!)
-                                XCTAssertNil(feed.blavatarURL)
-                                XCTAssertNil(feed.feedDescription)
+                                XCTAssertNil(feed.iconURL)
+                                XCTAssertNil(feed.description)
 
                                 expect.fulfill()
 
@@ -167,7 +167,7 @@ class ReaderSiteSearchServiceRemoteTests: RemoteTestCase, RESTTestable {
                                 XCTAssertNil(feed.feedID)
                                 XCTAssertEqual(feed.blogID, "489937")
                                 XCTAssertEqual(feed.url, URL(string: "https://dailypost.wordpress.com")!)
-                                XCTAssertEqual(feed.feedDescription, "The Art and Craft of Blogging")
+                                XCTAssertEqual(feed.description, "The Art and Craft of Blogging")
 
                                 expect.fulfill()
         }, failure: { _ in
@@ -196,7 +196,7 @@ class ReaderSiteSearchServiceRemoteTests: RemoteTestCase, RESTTestable {
                                 XCTAssertEqual(feed.title, "Discover")
                                 XCTAssertEqual(feed.feedID, "41325786")
                                 XCTAssertEqual(feed.url, URL(string: "https://discover.wordpress.com")!)
-                                XCTAssertEqual(feed.feedDescription, "A daily selection of the best content published on WordPress, collected for you by humans who love to read.")
+                                XCTAssertEqual(feed.description, "A daily selection of the best content published on WordPress, collected for you by humans who love to read.")
 
                                 expect.fulfill()
         }, failure: { _ in

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/ReaderSiteSearchServiceRemoteTests.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/ReaderSiteSearchServiceRemoteTests.swift
@@ -164,7 +164,7 @@ class ReaderSiteSearchServiceRemoteTests: RemoteTestCase, RESTTestable {
                                 }
 
                                 XCTAssertEqual(feed.title, "The Daily Post")
-                                XCTAssertNil(feed.feedID)
+                                XCTAssertEqual(feed.feedID, "27030")
                                 XCTAssertEqual(feed.blogID, "489937")
                                 XCTAssertEqual(feed.url, URL(string: "https://dailypost.wordpress.com")!)
                                 XCTAssertEqual(feed.description, "The Art and Craft of Blogging")

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/ReederFeedTests.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/ReederFeedTests.swift
@@ -5,141 +5,105 @@ import Testing
 
 struct ReaderFeedTests {
 
-    @Test func decodesReaderFeedEnvelopeWithSiteFallbacks() throws {
-        // GIVEN: JSON response where URL and title are not embedded at root level
-        let jsonData = try #require(readerFeedJSON.data(using: .utf8))
+    // MARK: - Jetpack-connected Sites
+
+    /// Tests decoding a Jetpack-connected WordPress site feed where URL, title, and description
+    /// must fall back to meta.data.feed fields since they're not present at root level.
+    @Test func decodesJetpackConnectedSiteFeed() throws {
+        // GIVEN: Search response for a Jetpack site (ma.tt)
+        let jsonData = try loadMockJSON(filename: "reader-search-response-01")
 
         // WHEN: Decoding the envelope
         let decoder = JSONDecoder()
         let envelope = try decoder.decode(ReaderFeedEnvelope.self, from: jsonData)
 
-        // THEN: Envelope contains feeds array
+        // THEN: Envelope contains one feed with no total count
         #expect(envelope.feeds.count == 1)
+        #expect(envelope.total == nil)
 
         let feed = try #require(envelope.feeds.first)
 
-        // THEN: Feed ID is decoded from root level
+        // THEN: IDs are decoded correctly
         #expect(feed.feedID == "188407")
+        #expect(feed.blogID == "1047865")
 
-        // THEN: URL falls back to data.site.URL since not present at root
+        // THEN: Feed metadata falls back to meta.data.feed fields
         #expect(feed.url?.absoluteString == "https://ma.tt")
-
-        // THEN: Title falls back to data.site.name since not present at root
         #expect(feed.title == "Matt Mullenweg")
-
-        // THEN: Description is decoded from data.site.description
-        #expect(feed.feedDescription == "Unlucky in Cards")
-
-        // THEN: Blavatar URL is decoded from data.site.icon.img
-        #expect(feed.blavatarURL?.absoluteString == "https://ma.tt/files/2024/01/cropped-matt-favicon.png")
+        #expect(feed.description == "Unlucky in Cards")
+        #expect(feed.iconURL?.absoluteString == "https://ma.tt/files/2024/01/cropped-matt-favicon.png")
     }
-}
 
-// MARK: - Test Data
+    // MARK: - WordPress.com Sites
 
-private let readerFeedJSON = """
-{
-  "feeds": [
-    {
-      "subscribe_URL": "https://ma.tt/feed/",
-      "feed_ID": "188407",
-      "meta": {
-        "links": {
-          "feed": "https://public-api.wordpress.com/rest/v1.1/read/feed/188407",
-          "site": "https://public-api.wordpress.com/rest/v1.1/read/sites/1047865"
-        },
-        "data": {
-          "site": {
-            "ID": 1047865,
-            "name": "Matt Mullenweg",
-            "description": "Unlucky in Cards",
-            "URL": "https://ma.tt",
-            "jetpack": true,
-            "jetpack_connection": true,
-            "post_count": 5599,
-            "subscribers_count": 4520,
-            "lang": "en-US",
-            "icon": {
-              "img": "https://ma.tt/files/2024/01/cropped-matt-favicon.png",
-              "ico": "https://ma.tt/files/2024/01/cropped-matt-favicon.png?w=16"
-            },
-            "logo": {
-              "id": 0,
-              "sizes": [],
-              "url": ""
-            },
-            "visible": true,
-            "is_private": false,
-            "is_coming_soon": false,
-            "is_following": false,
-            "organization_id": 0,
-            "meta": {
-              "links": {
-                "self": "https://public-api.wordpress.com/rest/v1.1/read/sites/1047865",
-                "help": "https://public-api.wordpress.com/rest/v1.1/read/sites/1047865/help",
-                "posts": "https://public-api.wordpress.com/rest/v1.1/read/sites/1047865/posts/",
-                "comments": "https://public-api.wordpress.com/rest/v1.1/sites/1047865/comments/",
-                "xmlrpc": "https://ma.tt/blog/xmlrpc.php"
-              }
-            },
-            "launch_status": false,
-            "site_migration": {
-              "is_complete": false,
-              "in_progress": false
-            },
-            "is_fse_active": false,
-            "is_fse_eligible": false,
-            "is_core_site_editor_enabled": false,
-            "is_wpcom_atomic": false,
-            "is_wpcom_staging_site": false,
-            "is_deleted": false,
-            "is_a4a_client": false,
-            "is_a4a_dev_site": false,
-            "is_wpcom_flex": false,
-            "capabilities": {
-              "edit_pages": false,
-              "edit_posts": false,
-              "edit_others_posts": false,
-              "edit_theme_options": false,
-              "list_users": false,
-              "manage_categories": false,
-              "manage_options": false,
-              "publish_posts": false,
-              "upload_files": false,
-              "view_stats": false
-            },
-            "is_multi_author": true,
-            "feed_ID": 188407,
-            "feed_URL": "http://ma.tt/feed",
-            "header_image": false,
-            "owner": {
-              "ID": 5,
-              "login": "matt",
-              "name": "Matt",
-              "first_name": "Matt",
-              "last_name": "Mullenweg",
-              "nice_name": "matt",
-              "URL": "https://matt.blog/",
-              "avatar_URL": "https://0.gravatar.com/avatar/33252cd1f33526af53580fcb1736172f06e6716f32afdd1be19ec3096d15dea5?s=96&d=retro&r=G",
-              "profile_URL": "https://gravatar.com/matt",
-              "ip_address": false,
-              "site_visible": true,
-              "has_avatar": true
-            },
-            "subscription": {
-              "delivery_methods": {
-                "email": null,
-                "notification": {
-                  "send_posts": false
-                }
-              }
-            },
-            "is_blocked": false,
-            "unseen_count": 0
-          }
+    /// Tests decoding a WordPress.com site feed where URL and title are present at root level,
+    /// and the envelope includes a total count field.
+    @Test func decodesWordPressComSiteFeed() throws {
+        // GIVEN: Search response for a WordPress.com site (veselin.blog)
+        let jsonData = try loadMockJSON(filename: "reader-search-response-02")
+
+        // WHEN: Decoding the envelope
+        let decoder = JSONDecoder()
+        let envelope = try decoder.decode(ReaderFeedEnvelope.self, from: jsonData)
+
+        // THEN: Envelope contains one feed with total count
+        #expect(envelope.feeds.count == 1)
+        #expect(envelope.total == 1)
+
+        let feed = try #require(envelope.feeds.first)
+
+        // THEN: IDs are decoded from root level
+        #expect(feed.feedID == "152023972")
+        #expect(feed.blogID == "125098293")
+
+        // THEN: URL and title are at root level
+        #expect(feed.url?.absoluteString == "http://veselin.blog")
+        #expect(feed.title == "Veselin.blog")
+
+        // THEN: Description and icon fall back to meta.data fields
+        #expect(feed.description == "Cats, good books, AI, and religious walking in the city of Sofia")
+        #expect(feed.iconURL?.absoluteString == "https://veselinblogblog.wordpress.com/wp-content/uploads/2024/04/cropped-avatar-18.jpg?w=96")
+    }
+
+    // MARK: - External RSS Feeds
+
+    /// Tests decoding an external RSS feed (not a WordPress site) where blogID is "0"
+    /// and only feed metadata is available (no site data).
+    @Test func decodesExternalRSSFeed() throws {
+        // GIVEN: Search response for an external RSS feed (Daring Fireball)
+        let jsonData = try loadMockJSON(filename: "reader-search-response-03")
+
+        // WHEN: Decoding the envelope
+        let decoder = JSONDecoder()
+        let envelope = try decoder.decode(ReaderFeedEnvelope.self, from: jsonData)
+
+        // THEN: Envelope contains one feed with no total count
+        #expect(envelope.feeds.count == 1)
+        #expect(envelope.total == nil)
+
+        let feed = try #require(envelope.feeds.first)
+
+        // THEN: Feed ID is present but blog ID is "0" for external RSS feeds
+        #expect(feed.feedID == "20787116")
+        #expect(feed.blogID == nil)
+
+        // THEN: Feed metadata falls back to meta.data.feed fields
+        #expect(feed.url?.absoluteString == "https://daringfireball.net/")
+        #expect(feed.title == "Daring Fireball")
+        #expect(feed.description == "By John Gruber")
+
+        // THEN: No icon available for this external RSS feed
+        #expect(feed.iconURL == nil)
+    }
+
+    // MARK: - Helpers
+
+    private func loadMockJSON(filename: String) throws -> Data {
+        // Use the test bundle by referencing a class from the test target
+        let bundle = Bundle(for: RemoteTestCase.self)
+        guard let url = bundle.url(forResource: filename, withExtension: "json") else {
+            throw NSError(domain: "ReaderFeedTests", code: 1, userInfo: [NSLocalizedDescriptionKey: "Mock file not found: \(filename).json"])
         }
-      }
+        return try Data(contentsOf: url)
     }
-  ]
 }
-"""

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderFeedCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderFeedCell.swift
@@ -30,7 +30,7 @@ struct ReaderFeedCell: View {
     }
 
     private func loadFaviconIfNeeded() async {
-        guard feed.blavatarURL == nil, let url = feed.url else {
+        guard feed.iconURL == nil, let url = feed.url else {
             return
         }
 
@@ -49,7 +49,7 @@ struct ReaderFeedCell: View {
     }
 
     var subtitle: String? {
-        if let description = feed.feedDescription, !description.isEmpty {
+        if let description = feed.description, !description.isEmpty {
             return description.stringByDecodingXMLCharacters()
         }
         return feed.urlForDisplay
@@ -59,7 +59,7 @@ struct ReaderFeedCell: View {
 extension SiteIconViewModel {
     init(feed: ReaderFeed, faviconURL: URL? = nil, size: Size = .regular) {
         self.init(size: size)
-        if let iconURL = feed.blavatarURL {
+        if let iconURL = feed.iconURL {
             self.imageURL = SiteIconViewModel.optimizedURL(for: iconURL.absoluteString, imageSize: size.size)
         } else if let faviconURL {
             self.imageURL = faviconURL

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1244,6 +1244,18 @@
 		};
 /* End PBXFileSystemSynchronizedBuildFileExceptionSet section */
 
+/* Begin PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
+		0C798C582ED8DD2E0012F3E2 /* Exceptions for "WordPressKitTests" folder in "Compile Sources" phase from "WordPressKitTests" target */ = {
+			isa = PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet;
+			buildPhase = 4A8280F92E5FE9B60037E180 /* Sources */;
+			membershipExceptions = (
+				"WordPressKitTests/Mock Data/Reader/reader-search-response-01.json",
+				"WordPressKitTests/Mock Data/Reader/reader-search-response-02.json",
+				"WordPressKitTests/Mock Data/Reader/reader-search-response-03.json",
+			);
+		};
+/* End PBXFileSystemSynchronizedGroupBuildPhaseMembershipExceptionSet section */
+
 /* Begin PBXFileSystemSynchronizedRootGroup section */
 		0C1CB0CD2D95C63C00494A8C /* Sources */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
@@ -1363,6 +1375,9 @@
 		};
 		4A8280FE2E5FE9B60037E180 /* WordPressKitTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
+			exceptions = (
+				0C798C582ED8DD2E0012F3E2 /* Exceptions for "WordPressKitTests" folder in "Compile Sources" phase from "WordPressKitTests" target */,
+			);
 			path = WordPressKitTests;
 			sourceTree = "<group>";
 		};


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-1007/reader-subscriptions-to-jetpack-connected-sites-made-from-search-are (see ticket for RCA).

### Testing Instructions

- Open Reader / Search
- Find a blog you are looking for
- **Verify** that the title, description, and image are displayed in both the list and the full details page
- Subscribe
- Open Reader / Subscriptions
- **Verify** that subscriptions are not duplicated

Repeat the steps for an RSS feed, a Dotcom site, and a Jetpack-connected site. I covered all three scenarios with unit tests.

### Recording

https://github.com/user-attachments/assets/40feff80-f1c4-4e4f-881c-460e16ddc9c8

