### PR TITLE
Add fallback for subscription title for JN sites

### DIFF
--- a/Sources/WordPressData/Swift/ReaderSiteTopic+Lookup.swift
+++ b/Sources/WordPressData/Swift/ReaderSiteTopic+Lookup.swift
@@ -3,6 +3,15 @@ import Foundation
 
 public extension ReaderSiteTopic {
 
+    /// The preferred display title for the site.
+    /// Returns the site title if not empty, otherwise returns the site host, or "–" if unavailable.
+    var preferredDisplayTitle: String {
+        if !title.isEmpty {
+            return title
+        }
+        return URL(string: siteURL)?.host ?? "–"
+    }
+
     /// Find a site topic by its site id
     ///
     /// - Parameter siteID: The site id of the topic

--- a/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Sidebar/ReaderSidebarSubscriptionsSection.swift
@@ -36,7 +36,7 @@ struct ReaderSidebarSubscriptionCell: View {
     var body: some View {
         HStack {
             Label {
-                Text(site.title)
+                Text(site.preferredDisplayTitle)
             } icon: {
                 ReaderSiteIconView(site: site, size: .small)
             }

--- a/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Subscriptions/ReaderSubscriptionCell.swift
@@ -27,7 +27,7 @@ struct ReaderSubscriptionCell: View {
 
                 VStack(alignment: .leading, spacing: 3) {
                     HStack(alignment: .firstTextBaseline, spacing: 8) {
-                        Text(site.title)
+                        Text(site.preferredDisplayTitle)
                             .font(.body.weight(.medium))
                     }
                     Text(details)


### PR DESCRIPTION
Fixes [CMM-1003: iOS: Subscriptions' section is corrupted](https://linear.app/a8c/issue/CMM-1003/ios-subscriptions-section-is-corrupted). 


(see favorable-fruit...)
<img width="456" height="972" alt="Screenshot 2025-11-27 at 4 14 14 PM" src="https://github.com/user-attachments/assets/b59626b2-b22c-4334-8199-f8aca656c239" />
