### PR TITLE
Remove delay when handling deep links

### DIFF
--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -456,52 +456,13 @@ extension WordPressAppDelegate {
             return
         }
 
-        // Don't try to resolve `apps.wordpress.com` URLs
-        if url.host == "apps.wordpress.com" {
-            UniversalLinkRouter.shared.handle(url: url)
-            return
-        }
-
-        // WordPress.com News links (i.e. http://en.blog.wordpress.com/2025/11/24/managed-vs-shared-wordpress-hosting/),
-        // which can be parsed by the app, redirect to links (i.e. https://wordpress.com/blog/2025/11/24/managed-vs-shared-wordpress-hosting/)
-        // that are not parsable by the app.
-        // Since we can handle post links in blog.wordpress.com, we don't need to resolve them.
-        if url.host?.hasSuffix("blog.wordpress.com") == true, UniversalLinkRouter.shared.canHandle(url: url) {
-            UniversalLinkRouter.shared.handle(url: url)
-            return
-        }
-
-        trackDeepLink(for: url) { url in
-            DispatchQueue.main.async {
-                UniversalLinkRouter.shared.handle(url: url)
-            }
-        }
+        UniversalLinkRouter.shared.handle(url: url)
     }
 
     @objc func configureWordPressComApi() {
         if let baseUrl = UserPersistentStoreFactory.instance().string(forKey: "wpcom-api-base-url"), let url = URL(string: baseUrl) {
             AppEnvironment.replaceEnvironment(wordPressComApiBase: url)
         }
-    }
-}
-
-// MARK: - Deep Link Handling
-
-extension WordPressAppDelegate {
-
-    private func trackDeepLink(for url: URL, completion: @escaping ((URL) -> Void)) {
-        let task = URLSession.shared.dataTask(with: url) { _, response, error in
-            guard let url = response?.url else {
-                wpAssertionFailure(
-                    "Received a deep link response without URL attached.",
-                    userInfo: ["response": response ?? "no response"]
-                )
-                return
-            }
-
-            completion(url)
-        }
-        task.resume()
     }
 }
 


### PR DESCRIPTION
Removes delay when handling deep links.

If I understood it correctly:

- In 2020, `links.wp.a8cmail.com` support was added. The app will need to call `URLSession.shared.dataTask(with: url)` to track those before opening the actual link.
- In 2025, the reference to this domain was removed in https://github.com/wordpress-mobile/WordPress-iOS/pull/24487/files, but seemingly incorrectly the call `URLSession.shared.dataTask(with: url)`  was extended to now run on _every_ link