### PR TITLE
[Tooling] Don't fail lint on strings not in base language

### DIFF
--- a/WordPress/JetpackDraftActionExtension/bg.lproj/InfoPlist.strings
+++ b/WordPress/JetpackDraftActionExtension/bg.lproj/InfoPlist.strings
@@ -2,5 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!--Warning: Auto-generated file, do not edit.-->
 <plist version="1.0">
-  <dict/>
+  <dict>
+    <key>CFBundleDisplayName</key>
+    <string>Запазване като чернова</string>
+    <key>CFBundleName</key>
+    <string>Запазване като чернова</string>
+  </dict>
 </plist>

--- a/WordPress/JetpackIntents/bg.lproj/Sites.strings
+++ b/WordPress/JetpackIntents/bg.lproj/Sites.strings
@@ -3,8 +3,16 @@
 <!--Warning: Auto-generated file, do not edit.-->
 <plist version="1.0">
   <dict>
+    <key>BOl9KQ</key>
+    <string>Има  ${count}, съвпадащи с ‘${site}’.</string>
+    <key>ILcGmf</key>
+    <string>Сайт</string>
+    <key>cyajMn</key>
+    <string>Сайт</string>
     <key>gpCwrM</key>
     <string>Select Site</string>
+    <key>s4dJhx</key>
+    <string>Само да потвърдим, искате ‘${site}’?</string>
     <key>tVvJ9c</key>
     <string>Select Site Intent</string>
   </dict>

--- a/WordPress/Resources/ar.lproj/Localizable.strings
+++ b/WordPress/Resources/ar.lproj/Localizable.strings
@@ -1,6 +1,6 @@
-/* Translation-Revision-Date: 2025-10-06 16:54:08+0000 */
+/* Translation-Revision-Date: 2025-11-24 16:54:10+0000 */
 /* Plural-Forms: nplurals=6; plural=(n == 0) ? 0 : ((n == 1) ? 1 : ((n == 2) ? 2 : ((n % 100 >= 3 && n % 100 <= 10) ? 3 : ((n % 100 >= 11 && n % 100 <= 99) ? 4 : 5)))); */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: ar */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -581,8 +581,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "تقريبًا هناك! يرجى إدخال رمز التحقق من تطبيق الموثق الخاص بك.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "النص البديل";
 
 /* No comment provided by engineer. */
@@ -725,9 +724,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "هل تريد بالتأكيد قطع اتصال Jetpack عن هذا الموقع؟";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "هل تريد بالتأكيد حذف هذا العنصر نهائيًا؟";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "هل تريد بالتأكيد إزالة %1$@ من %2$@؟";
@@ -1082,7 +1078,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "إلغاء";
@@ -1110,8 +1105,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "ألا يمكنك التحديد؟ يمكنك تغيير القالب في أي وقت.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "كلمات توضيحية";
 
 /* Alert title. */
@@ -1777,8 +1771,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "الافتراضي";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "التصنيف الافتراضي";
 
 /* Label for selecting the default post format
@@ -1787,9 +1780,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "الإعدادات الافتراضية للمقالات الجديدة";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "حذف";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "حذف القائمة";
@@ -1808,14 +1798,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "حذف القائمة";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "محذوف!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "جاري حذف الموقع…";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "جاري الحذف...";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "رفض";
@@ -1823,8 +1807,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "صف غرض الصورة. اترك ذلك الحقل فارغًا إذا كان للزخرفة.";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "الوصف";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1842,9 +1825,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "ألم تقصد إنشاء حساب جديد؟ العودة للخلف لإعادة إدخال عنوان بريدك الإلكتروني.";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "الأبعاد";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "تعطيل";
@@ -2121,7 +2101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "سيؤدي تحرير ملف GIF هذا إلى إزالة الرسوم المتحركة الخاصة به.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "المحرّر";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2463,11 +2443,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "إعدادات مكوّن ملف";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "اسم الملف";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "نوع الملف";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "نوع الملف غير مدعوم كملف وسائط.";
@@ -2781,6 +2758,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post content used in the login prologue screens. */
 "I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next" = "لقد ألهمتني أعمال المصور كاميرون كارستن للغاية. سأجرِّب هذه التقنيات في المحاولة التالية";
 
+/* Text on the support form to refer to what area the user has problem with. */
+"I need help with" = "أحتاج إلى المساعدة في";
+
 /* Describes the IP address section in the comment detail screen. */
 "IP address" = "عنوان IP";
 
@@ -2826,9 +2806,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "وصف الصورة";
 
-/* Hint for image description on image settings. */
-"Image Description" = "وصف الصورة";
-
 /* Hint for image link on image settings. */
 "Image Link" = "رابط صورة";
 
@@ -2840,9 +2817,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "لم يتم العثور على ملف الصورة.";
-
-/* Hint for image title on image settings. */
-"Image title" = "عنوان الصورة";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "بكلمات قليلة، اكتب نبذة قصيرة عن الموقع.";
@@ -3205,6 +3179,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the button that will dismiss this view. */
 "Let me know when finished!" = "أخبرني عند الانتهاء!";
 
+/* Message info on the support screen. */
+"Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon." = "أطلعنا على عنوان الموقع الخاص بك (عنوان الموقع URL) وقدم لنا أكبر قدر ممكن من التفاصيل حول المشكلة، وسنتواصل معك قريبًا.";
+
+/* Title to let the user know what do we want on the support screen. */
+"Let’s get this sorted" = "لِنقم بترتيب الأمور";
+
 /* Lifestyle site intent topic */
 "Lifestyle" = "نمط الحياة";
 
@@ -3405,6 +3385,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Main Navigation" = "التنقل الرئيسي";
+
+/* Explanation for the option to enable theme styles */
+"Make the block editor look like your theme." = "أجعل محرر المكونات يعكس مظهر قالبك.";
 
 /* No comment provided by engineer. */
 "Make your content stand out by adding images, gifs, videos, and embedded media to your pages." = "اجعل محتواك مميزًا عن طريق إضافة صور وصورgif ومقاطع فيديو ووسائط مضمنة إلى صفحاتك.";
@@ -3747,9 +3730,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "لم يتم العثور على أي حسابات";
-
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "بدون تصنيف";
 
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "لا يوجد اتصال";
@@ -4191,9 +4171,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "ترقيم الصفحات";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "التصنيف الأب";
-
 /* Parenting site intent topic */
 "Parenting" = "الأبوة والأمومة";
 
@@ -4411,9 +4388,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "مقالة";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "تصنيفات المقالة";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "إعدادات المقالة";
@@ -4722,9 +4696,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "يقوم بإزالة بيانات تعرييف الموقع من الصور قبل رفعها على موقعك.";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "تؤدي إزالة المتابعين إلى توقفهم عن استقبال تحديثات من موقعك. إذا اختاروا ذلك، فسيظل بإمكانهم زيارة موقعك ومتابعته مرة أخرى.";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "استبدال المكوِّن الحالي";
@@ -5561,6 +5532,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "الشعار";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "وسوم";
 
@@ -5657,6 +5629,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint, informing user the button can be used to visit the Gravatar website. */
 "Tap to visit the Gravatar website in an external browser" = "النقر لزيارة موقع جرافتار على الويب في متصفح خارجي";
+
+/* Label for viewing the custom taxonomies */
+"Taxonomies" = "الفئات";
 
 /* Technology site intent topic */
 "Technology" = "التكنولوجيا";
@@ -5946,9 +5921,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "لقد انتهت صلاحية رمز تسجيل الدخول هذا. يرجى الضغط على زر المسح الضوئي مرة أخرى لإعادة مسح الرمز ضوئيًا.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "تم حذف عنصر الوسائط هذا.";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "يتعذر إغلاق حساب المستخدم هذا إذا كانت هناك عمليات رد مبالغ مدفوعة لم يتم حلها.";
 
@@ -6017,7 +5989,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "العنوان";
@@ -6111,8 +6082,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "تحويل المكوِّن…";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "سلة المهملات";
 
@@ -6209,9 +6179,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "تعذر إنشاء روابط دعوة جديدة.";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "يتعذر حذف عنصر الوسائط.";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "تعذر تعطيل روابط الدعوة.";
 
@@ -6242,9 +6209,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "يتعذر تحميل هذا المحتوى حاليًا.";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "يتعذر رفع مقطع الفيديو.";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "يتعذر تشغيل الفيديو";
 
@@ -6253,9 +6217,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "غير قادر على استعادة موقعك";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "يتعذر حفظ عنصر الوسائط.";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "تعذرت مشاركة الرابط";
@@ -6412,9 +6373,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "فشل الرفع";
 
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "تم الرفع";
-
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "تم رفع مسودة مقالة واحدة، و%ld من الملفات";
 
@@ -6456,6 +6414,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The button title text for logging in with WP.com password instead of magic link. */
 "Use password to sign in" = "استخدام كلمة المرور لتسجيل الدخول";
+
+/* Option to enable theme styles in the block editor */
+"Use theme styles" = "استخدام أنماط القالب";
 
 /* A placeholder for the twitter username
    Accessibility label for the username text field in the self-hosted login page.
@@ -6906,7 +6867,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "تُظهر خريطة العالم المشاهدات حسب البلد.";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "ألا تزال تريد إزالة هذا الشخص؟";
 
 /* Button title. Opens the editor to write a new post.
@@ -7377,14 +7338,19 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Description for the prompt to upgrade to Application Passwords. The first argument is the name of the feature that requires Application Passwords. */
 "applicationPasswordRequired.description" = "كلمات مرور التطبيقات هي طريقة أكثر أمانًا للاتصال بموقعك المستضاف ذاتيًا، وتمكين الدعم لميزات، مثل: %@.";
 
+/* Feature name for managing application passwords in the app */
+"applicationPasswordRequired.feature.applicationPasswords" = "إدارة كلمات مرور التطبيق";
+
 /* Feature name for the block editor in application password required prompt */
 "applicationPasswordRequired.feature.blockEditor" = "محرِّر المكوِّنات";
+
+/* Feature name for managing terms and taxonomies in the app */
+"applicationPasswordRequired.feature.customTaxonomies" = "إدارة الفئات";
 
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "إدارة الإضافة";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "إدارة المستخدم";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -7610,6 +7576,285 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 
 /* Post Editor / Button in the 'More' menu */
 "classicEditor.moreMenu.saveDraft" = "حفظ المسودة";
+
+/* Button to add more screenshots */
+"com.jetpack.support.addMoreScreenshots" = "إضافة المزيد من لقطات الشاشة";
+
+/* Button to add screenshots */
+"com.jetpack.support.addScreenshots" = "إضافة لقطات الشاشة";
+
+/* Header for application logs section */
+"com.jetpack.support.applicationLogs" = "سجلات التطبيق";
+
+/* Description explaining why including logs is helpful */
+"com.jetpack.support.applicationLogsDescription" = "يمكن أن يساعد تضمين السجلات فريقنا في التحقيق في المشكلات. قد تحتوي السجلات على نشاط التطبيق الأخير.";
+
+/* Navigation title for application logs screen */
+"com.jetpack.support.applicationLogsTitle" = "سجلات التطبيق";
+
+/* Format string for attachment identifier */
+"com.jetpack.support.attachment" = "المرفق %@";
+
+/* Format string for attachment size limit. %1$@ is current size, %2$@ is maximum size */
+"com.jetpack.support.attachmentLimit" = "حد المرفقات: %1$@ \/ %2$@";
+
+/* Bot greeting message. %1$@ is the user's name */
+"com.jetpack.support.botGreeting" = "مرحبًا %1$@!";
+
+/* Bot introduction message explaining its purpose */
+"com.jetpack.support.botIntroduction" = "أنا مساعد الذكاء الاصطناعي الشخصي الخاص بك. يمكنني مساعدتك في الإجابة عن أي أسئلة متعلقة بموقعك أو حسابك.";
+
+/* Format string for cache file count and size. %1$d is the number of files, %2$@ is the formatted size. The system will pluralize 'files' based on the number – please specify it as the largest plural value */
+"com.jetpack.support.cacheFiles" = "⁦%1$d⁩ ملفات مخزنة مؤقتًا (%2$@)";
+
+/* Message shown when cache has no files */
+"com.jetpack.support.cacheIsEmpty" = "ذاكرة التخزين المؤقت فارغة";
+
+/* Button to cancel current action */
+"com.jetpack.support.cancel" = "إلغاء";
+
+/* Warning message that deleted logs cannot be recovered */
+"com.jetpack.support.cannotRecoverLogs" = "لن تتمكن من استعادتها.";
+
+/* Button to clear all activity logs */
+"com.jetpack.support.clearAllActivityLogs" = "مسح جميع سجلات النشاط";
+
+/* Button to clear disk cache */
+"com.jetpack.support.clearDiskCache" = "مسح ذاكرة التخزين المؤقت للقرص";
+
+/* Description explaining the purpose of clearing disk cache */
+"com.jetpack.support.clearDiskCacheDescription" = "إزالة الملفات المؤقتة لتحرير مساحة أو حل المشكلات.";
+
+/* Progress text while clearing cache */
+"com.jetpack.support.clearing" = "جارٍ المسح...";
+
+/* Message shown when cache clearing is complete */
+"com.jetpack.support.complete" = "مكتمل";
+
+/* Confirmation message when canceling a draft */
+"com.jetpack.support.confirmCancelMessage" = "هل أنت متأكد من رغبتك في إلغاء هذه الرسالة؟ ستفقد أي بيانات قمت بإدخالها";
+
+/* Title for alert confirming cancellation */
+"com.jetpack.support.confirmCancellation" = "تأكيد الإلغاء";
+
+/* Confirmation dialog title when deleting all logs */
+"com.jetpack.support.confirmDeleteAllLogs" = "هل أنت متأكد من رغبتك في حذف كل السجلات؟";
+
+/* Section title for contact information */
+"com.jetpack.support.contactInformation" = "معلومات جهة الاتصال";
+
+/* Button to continue editing a message */
+"com.jetpack.support.continueWriting" = "مواصلة الكتابة";
+
+/* Message shown at end of closed support conversation */
+"com.jetpack.support.conversationEnded" = "نهاية المحادثة. لا يمكن إضافة المزيد من الردود.";
+
+/* Navigation title for bot conversations list */
+"com.jetpack.support.conversations" = "المحادثات";
+
+/* Button to delete all log files */
+"com.jetpack.support.deleteAllLogs" = "حذف جميع السجلات";
+
+/* Description text for diagnostics screen */
+"com.jetpack.support.diagnosticsDescription" = "تنفيذ مهام الصيانة وحل المشكلات الشائعة.";
+
+/* Navigation title for diagnostics screen */
+"com.jetpack.support.diagnosticsTitle" = "التشخيصات";
+
+/* Button to discard changes in a draft message */
+"com.jetpack.support.discardChanges" = "تجاهل التغييرات";
+
+/* Notice explaining where support will send email responses */
+"com.jetpack.support.emailNotice" = "سنرسل إليك رسالة عبر البريد الإلكتروني على هذا العنوان.";
+
+/* Error title when logs fail to load */
+"com.jetpack.support.errorLoadingLogs" = "حدث خطأ أثناء تحميل السجلات";
+
+/* Error message when support conversations fail to load */
+"com.jetpack.support.errorLoadingSupportConversations" = "حدث خطأ أثناء تحميل محادثات فريق الدعم";
+
+/* Title for error alerts */
+"com.jetpack.support.errorTitle" = "خطأ";
+
+/* Option to export log as a file */
+"com.jetpack.support.exportAsFile" = "التصدير كملف";
+
+/* Button to dismiss alerts. */
+"com.jetpack.support.gotIt" = "فهمت";
+
+/* Text on the support form to refer to what area the user has problem with. */
+"com.jetpack.support.iNeedHelp" = "أحتاج المساعدة في";
+
+/* Toggle label to include application logs in the support request */
+"com.jetpack.support.includeApplicationLogs" = "تضمين سجلات التطبيق";
+
+/* Section title for issue details */
+"com.jetpack.support.issueDetails" = "تفاصيل المشكلة";
+
+/* Format string for when conversation was last updated */
+"com.jetpack.support.lastUpdated" = "آخر تحديث في %@";
+
+/* Progress message while loading conversation messages */
+"com.jetpack.support.loadingBotConversationMessages" = "تحميل الرسائل";
+
+/* Progress message while loading bot conversations */
+"com.jetpack.support.loadingBotConversations" = "جارٍ تحميل محادثات الروبوتات";
+
+/* Progress text while loading support conversations */
+"com.jetpack.support.loadingConversations" = "جارٍ تحميل المحادثات";
+
+/* Progress message while loading disk usage information */
+"com.jetpack.support.loadingDiskUsage" = "جارٍ تحميل استخدام القرص";
+
+/* Progress message while loading an image attachment */
+"com.jetpack.support.loadingImage" = "جارٍ تحميل الصور";
+
+/* Progress message shown in overlay while refreshing content */
+"com.jetpack.support.loadingLatestContent" = "جارٍ تحميل أحدث محتوى";
+
+/* Progress message while loading application log content */
+"com.jetpack.support.loadingLogContent" = "جارٍ تحميل محتوى السجل...";
+
+/* Progress message while loading log files */
+"com.jetpack.support.loadingLogs" = "جارٍ تحميل السجلات...";
+
+/* Progress text while loading conversation messages */
+"com.jetpack.support.loadingMessages" = "جارٍ تحميل الرسائل";
+
+/* Progress message while loading a video attachment */
+"com.jetpack.support.loadingVideo" = "جارٍ تحميل الفيديو";
+
+/* Section header for log files sorted by date */
+"com.jetpack.support.logFilesByDate" = "تسجيل الملفات حسب تاريخ إنشائها";
+
+/* Text indicating which log files will be included in the support request */
+"com.jetpack.support.logFilesToUpload" = "سيتم رفع ملفات السجل التالية:";
+
+/* Footer text explaining log retention policy */
+"com.jetpack.support.logRetentionNotice" = "يجري حفظ سجلات لمدّة تصل إلى سبعة أيام.";
+
+/* Section header for message text input */
+"com.jetpack.support.message" = "الرسالة";
+
+/* Success message when reply is sent successfully */
+"com.jetpack.support.messageSent" = "اكتمل إرسال الرسالة";
+
+/* Format string for number of messages in conversation */
+"com.jetpack.support.messagesCount" = "الرسائل %d";
+
+/* The title of a new bot chat in the support area of the app */
+"com.jetpack.support.new-bot-chat" = "محادثة روبوت جديدة";
+
+/* Option to create a new support ticket */
+"com.jetpack.support.newSupportTicket" = "بطاقة دعم جديدة";
+
+/* Label shown when there are no bot conversations */
+"com.jetpack.support.noConversations" = "لا توجد محادثات";
+
+/* Description shown when no log files are available */
+"com.jetpack.support.noLogsAvailable" = "لا توجد أي سجلات نشاط متاحة";
+
+/* Label shown when no log files are available */
+"com.jetpack.support.noLogsFound" = "تعذر العثور على أي سجلات";
+
+/* Button to open a support ticket */
+"com.jetpack.support.openSupportTicket" = "إنشاء بطاقة دعم";
+
+/* Text indicating a field is optional */
+"com.jetpack.support.optional" = "(اختياري)";
+
+/* Navigation title for replying to a support conversation */
+"com.jetpack.support.reply" = "رد";
+
+/* Description for saving log as a file */
+"com.jetpack.support.saveAsFile" = "حفظ كملف للمشاركة أو التخزين";
+
+/* Label for screenshots section */
+"com.jetpack.support.screenshots" = "لقطات الشاشة";
+
+/* Description for screenshots section */
+"com.jetpack.support.screenshotsDescription" = "يمكن أن تساعدنا إضافة لقطات الشاشة على فهم مشكلتك وحلها بشكل أسرع.";
+
+/* Button to send a message or reply */
+"com.jetpack.support.send" = "إرسال";
+
+/* Description for sending logs to support */
+"com.jetpack.support.sendLogsToSupport" = "إرسال السجلات مباشرة إلى فريق الدعم";
+
+/* Progress text while sending a message */
+"com.jetpack.support.sending" = "جارٍ الإرسال";
+
+/* Progress message shown while sending a message */
+"com.jetpack.support.sendingMessage" = "جارٍ إرسال الرسالة";
+
+/* Button to share content */
+"com.jetpack.support.share" = "مشاركة";
+
+/* Navigation title for sharing activity log */
+"com.jetpack.support.shareActivityLog" = "مشاركة سجل النشاط";
+
+/* Message shown when sharing log with support */
+"com.jetpack.support.sharingWithSupport" = "المشاركة مع فريق الدعم!";
+
+/* Site Address title on the support form */
+"com.jetpack.support.siteAddress" = "عنوان الموقع";
+
+/* Description encouraging user to start a new conversation */
+"com.jetpack.support.startNewConversation" = "بدء محادثة جديدة باستخدام الزر أعلاه";
+
+/* Subject title on the support form */
+"com.jetpack.support.subject" = "الموضوع";
+
+/* Placeholder for subject field */
+"com.jetpack.support.subjectPlaceholder" = "ملخص لمشكلتك";
+
+/* Button title to submit a support request. */
+"com.jetpack.support.submitRequest" = "إرسال طلب فريق الدعم";
+
+/* Navigation title for the support conversations list */
+"com.jetpack.support.supportConversations" = "محادثات فريق الدعم";
+
+/* Title for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSent" = "اكتمل إرسال الطلب!";
+
+/* Message for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSentMessage" = "اكتمل إرسال طلب فريق الدعم بنجاح. سنرد عبر رسالة على البريد الإلكتروني بأسرع ما يمكننا.";
+
+/* Progress message shown while bot is thinking */
+"com.jetpack.support.thinking" = "جارٍ التفكير...";
+
+/* Title of the view for contacting support. */
+"com.jetpack.support.title" = "الاتصال بفريق الدعم";
+
+/* Button to retry a failed operation */
+"com.jetpack.support.tryAgain" = "المحاولة مجددًا";
+
+/* Error title when log deletion fails */
+"com.jetpack.support.unableToDeleteLogs" = "تعذر حذف السجلات.";
+
+/* Error message when conversation cannot be displayed */
+"com.jetpack.support.unableToDisplayConversation" = "تعذر عرض المحادثة";
+
+/* Error title when video cannot be loaded or played */
+"com.jetpack.support.unableToDisplayVideo" = "تعذر عرض الفيديو";
+
+/* Error message when application logs cannot be loaded */
+"com.jetpack.support.unableToLoadApplicationLogs" = "يتعذر تحميل سجلات التطبيق";
+
+/* Error title when bot conversations fail to load */
+"com.jetpack.support.unableToLoadConversations" = "تعذر تحميل المحادثات";
+
+/* Error title when messages fail to load */
+"com.jetpack.support.unableToLoadMessages" = "تعذر تحميل الرسائل";
+
+/* Error title when message sending fails */
+"com.jetpack.support.unableToSendMessage" = "تعذر إرسال الرسالة.";
+
+/* Button to view an attachment */
+"com.jetpack.support.view" = "عرض";
+
+/* Progress message shown during cache clearing operation */
+"com.jetpack.support.working" = "جارٍ العمل…";
 
 /* Displayed in the confirmation alert when marking comment notifications as read. */
 "comment" = "التعليق";
@@ -7873,6 +8118,9 @@ Example: Reply to Pamela Nguyen */
 /* Weekly Roundup debug menu item */
 "debugMenu.weeklyRoundup" = "موجز أسبوعي";
 
+/* Title for selecting a default category for a post */
+"defaultCategory.title" = "التصنيف الافتراضي";
+
 /* Error tilte */
 "discussionSettings.saveErrorTitle" = "فشل حفظ الإعدادات";
 
@@ -8012,10 +8260,10 @@ Example: Reply to Pamela Nguyen */
 "double-tap to change unit" = "أنقر نقرًا مزدوجًا لتغيير الوحدة";
 
 /* Message for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.message" = "هل أنت متأكد من رغبتك في حذف هذا الوسم؟";
+"edit.tag.delete.confirmation.message" = "هل أنت متأكد من رغبتك في حذف هذا؟";
 
-/* Title for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.title" = "حذف الوسم";
+/* Title for delete a term confirmation dialog */
+"edit.tag.delete.confirmation.title" = "حذف";
 
 /* Placeholder text for tag description field */
 "edit.tag.description.placeholder" = "إضافة وصف...";
@@ -8030,7 +8278,37 @@ Example: Reply to Pamela Nguyen */
 "edit.tag.section.description" = "الوصف";
 
 /* Section header for tag name in edit tag view */
-"edit.tag.section.tag" = "الوسم";
+"edit.tag.section.tag" = "الاسم";
+
+/* Context menu action to insert a block */
+"editor.blockInserter.insertBlock" = "إدراج المكوِّن";
+
+/* Placeholder text for block search field */
+"editor.blockInserter.search" = "البحث";
+
+/* Button title to collapse and show fewer blocks */
+"editor.blockInserter.showLess" = "عرض الأقل";
+
+/* Button title to expand and show more blocks */
+"editor.blockInserter.showMore" = "عرض المزيد";
+
+/* Error message when media insertion fails */
+"editor.media.failedToInsert" = "فشل في إدراج الوسائط";
+
+/* Category name for section showing all patterns */
+"editor.patterns.all" = "الكل";
+
+/* Context menu action to insert a pattern */
+"editor.patterns.insertPattern" = "إدراج النمط";
+
+/* Title shown when no patterns match the search */
+"editor.patterns.noPatternsFound" = "تعذر العثور على أنماط";
+
+/* Navigation title for patterns view */
+"editor.patterns.title" = "الأنماط";
+
+/* Category name for patterns without a category */
+"editor.patterns.uncategorized" = "غير مصنف";
 
 /* Register Domain - Address information field Number placeholder */
 "eg. 1122334455" = "على سبيل المثال 1122334455";
@@ -8578,6 +8856,24 @@ Example: Reply to Pamela Nguyen */
 
 /* Write a blog prompt for the jetpack prologue */
 "jetpack.prologue.prompt.writeBlog" = "كتابة مدونة";
+
+/* Description for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.description" = "يمكن للجميع عرض هذه التدوينة";
+
+/* Title for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.title" = "الجميع";
+
+/* Description for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.description" = "لا يمكن عرض هذه التدوينة إلا للمشتركين في الباقات المدفوعة.";
+
+/* Title for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.title" = "المشتركون في الباقات المدفوعة";
+
+/* Description for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.description" = "التدوينة مرئية لجميع المشتركين، بما فيها المشتركون في الباقات المجانية";
+
+/* Title for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.title" = "جميع المشتركين";
 
 /* Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account */
 "jetpackSite.connectToDefaultAccount" = "يتعين عليك تسجيل الدخول باستخدام %@ لاستخدام الإحصاءات والتنبيهات.";
@@ -9297,17 +9593,23 @@ Example: Reply to Pamela Nguyen */
 /* Message about buying storage add-on */
 "mediaLibrary.storageDetails.buyStorage.message" = "قم بشراء وظائف إضافية للتخزين";
 
-/* Message shown when all media items are attached */
-"mediaLibrary.storageDetails.cleanup.allAttached" = "تم إرفاق كل العناصر الموجودة في مكتبة الوسائط.";
+/* Label for audio media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.audio" = "الصوت";
 
-/* Message shown while loading unattached media count */
-"mediaLibrary.storageDetails.cleanup.loading" = "جارٍ اكتشاف ما إذا كانت هناك أي عناصر وسائط غير مرفقة أم لا...";
+/* Label for document media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.document" = "الوثائق";
 
-/* Message about unattached media that can be cleaned up. %1$d is the count of unattached media. */
-"mediaLibrary.storageDetails.cleanup.message" = "تم إلغاء إرفاق ⁦%1$d⁩ من العناصر. قم بإزالتها لتوفير بعض المساحة.";
+/* Label for image media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.image" = "الصور";
 
-/* Title for cleanup section */
-"mediaLibrary.storageDetails.cleanup.title" = "إزالة العناصر غير المستخدمة";
+/* Label for other/unknown media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.other" = "أخرى";
+
+/* Label for PowerPoint/presentation media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.powerpoint" = "العروض التقديمية";
+
+/* Label for video media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.video" = "مقاطع الفيديو";
 
 /* Success message shown after upgrading plan */
 "mediaLibrary.storageDetails.purchase.plan.success" = "تمت ترقية خطة الموقع الخاصة بك!";
@@ -9693,6 +9995,12 @@ Example: Reply to Pamela Nguyen */
 /* Menu option for filtering posts by me */
 "pagesList.pagesByMe" = "الصفحات بواسطتي";
 
+/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
+"parentCategory.noCategory" = "من دون تصنيف";
+
+/* Title for selecting parent category of a category */
+"parentCategory.title" = "التصنيف الأصل";
+
 /* Title for the parent page picker screen */
 "parentPagePicker.title" = "الصفحة الأصل";
 
@@ -9848,6 +10156,27 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the post author selection screen */
 "postAuthorPicker.title" = "المؤلف";
+
+/* Title for selecting categories for a post or a page */
+"postCategories.title" = "التصنيفات";
+
+/* Toggle label for allowing comments on post */
+"postDiscussion.allowComments.label" = "السماح بالتعليقات";
+
+/* Toggle label for allowing pings/trackbacks on post */
+"postDiscussion.allowPings.label" = "السماح بالتنبيهات";
+
+/* Footer text when comments are disabled */
+"postDiscussion.comments.disabled.footer" = "يتعذر على الزائرين إضافة تعليقات أو ردود جديدة. تظل التعليقات الموجودة مرئية.";
+
+/* Footer text when comments are enabled */
+"postDiscussion.comments.enabled.footer" = "يمكن للزائرين إضافة تعليقات وردود جديدة.";
+
+/* Link text for learning more about pingbacks and trackbacks */
+"postDiscussion.pingbacks.learnMore.text" = "معرفة المزيد حول التنبيهات والتعقيبات";
+
+/* Navigation title for post discussion settings */
+"postDiscussion.title" = "المناقشة";
 
 /* Button in an alert confirming discaring changes */
 "postEditor.closeConfirmationAlert.discardChanges" = "تجاهل التغييرات";
@@ -10080,6 +10409,9 @@ Example: Reply to Pamela Nguyen */
 /* A default value for an post without a title */
 "postSaveErrorMessage.postUntitled" = "من دون عنوان";
 
+/* Section header for Access settings in Post Settings */
+"postSettings.access.header" = "الوصول";
+
 /* Label for the author field in Post Settings */
 "postSettings.author.label" = "المؤلف";
 
@@ -10098,6 +10430,18 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the discard changes confirmation dialog */
 "postSettings.discardChanges.title" = "تجاهل التغييرات؟";
+
+/* Status text when discussion (comments) is disabled */
+"postSettings.discussion.closed" = "مغلق";
+
+/* Label for the discussion settings field in Post Settings */
+"postSettings.discussion.label" = "المناقشة";
+
+/* Status text when discussion (comments) is enabled */
+"postSettings.discussion.open" = "فتح";
+
+/* Label for the checkbox that lets you send a post to newsletter subscribers */
+"postSettings.emailToSubscribers.label" = "إرسال بريد إلكتروني للمشتركين";
 
 /* Character count for excerpt. %1$d is the number of characters. */
 "postSettings.excerpt.characterCount" = "⁦%1$d⁩ من الأحرف";
@@ -10198,6 +10542,21 @@ Example: Reply to Pamela Nguyen */
 /* Cell title for the Top Level option case */
 "postSettings.parentPage.topLevel" = "أعلى مستوى";
 
+/* Accessibility label for hide password button */
+"postSettings.passwordEntry.hidePassword" = "إخفاء كلمة المرور";
+
+/* Instructions for password entry */
+"postSettings.passwordEntry.instructions" = "إدخال كلمة مرور لحماية هذه التدوينة لن يتمكّن من عرضه إلا المستخدمون الذين يملكون كلمة المرور.";
+
+/* Navigation title for password entry screen */
+"postSettings.passwordEntry.navigationTitle" = "إدخال كلمة المرور";
+
+/* Placeholder for password field */
+"postSettings.passwordEntry.placeholder" = "إدخال كلمة المرور";
+
+/* Accessibility label for show password button */
+"postSettings.passwordEntry.showPassword" = "عرض كلمة المرور";
+
 /* Label for the permalink field in Post Settings */
 "postSettings.permalink.label" = "رابط دائم";
 
@@ -10222,17 +10581,59 @@ Example: Reply to Pamela Nguyen */
 /* Section header for General settings in Post Settings */
 "postSettings.section.general" = "عام";
 
+/* Description text explaining what the slug editor does */
+"postSettings.slug.customizeDescription" = "تخصيص الجزء الأخير من الرابط الدائم.";
+
 /* Hint text for the slug field. Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso. */
 "postSettings.slug.hint" = "الاسم اللطيف هو إصدار عنوان المقالة المألوف لعنوان الموقع.";
 
 /* Label for the slug field. Should be the same as WP core. */
 "postSettings.slug.label" = "الاسم اللطيف";
 
+/* Button text to learn more about permalinks */
+"postSettings.slug.learnMore" = "تعرَّف على المزيد";
+
+/* Label for the slug field. Should be the same as WP core. */
+"postSettings.slug.navigationTitle" = "الاسم اللطيف";
+
+/* Notice shown when the post doesn't have a remote and permalink template is missing */
+"postSettings.slug.permalinkDraftNotice" = "سيظهر الرابط الدائم المقترح عند حفظ المسودة على الخادم";
+
+/* Label for the permalink preview */
+"postSettings.slug.permalinkLabel" = "الرابط الدائم";
+
+/* Section title for the permalink preview */
+"postSettings.slug.permalinkSection" = "الرابط الدائم";
+
 /* Placeholder for the slug field */
 "postSettings.slug.placeholder" = "أدخل اسمًا لطيفًا";
 
 /* Label for the preview button in Post Settings */
 "postSettings.socialSharing.header" = "المشاركة عبر وسائل التواصل الاجتماعي";
+
+/* Label for the status field in Post Settings */
+"postSettings.status.label" = "الحالة";
+
+/* Navigation title for status picker */
+"postSettings.statusPicker.navigationTitle" = "الحالة والظهور";
+
+/* Label showing the current password */
+"postSettings.statusPicker.passwordLabel" = "كلمة المرور";
+
+/* Toggle label for password protection */
+"postSettings.statusPicker.passwordProtected" = "محمي بكلمة مرور";
+
+/* Subtitle for password protected toggle */
+"postSettings.statusPicker.passwordProtectedSubtitle" = "لا يظهر المحتوى إلا لمن يعرف كلمة المرور";
+
+/* Label for schedule date row */
+"postSettings.statusPicker.scheduleDate" = "التاريخ";
+
+/* Toggle label for sticky posts */
+"postSettings.statusPicker.sticky" = "مثبّت";
+
+/* Subtitle for sticky toggle */
+"postSettings.statusPicker.stickySubtitle" = "تثبيت هذه التدوينة في الجزء العلوي من المدونة";
 
 /* Label for the sticky post toggle. Sticky posts are displayed at the top of the blog. */
 "postSettings.stickyPost.label" = "مثبّت";
@@ -10252,14 +10653,50 @@ Example: Reply to Pamela Nguyen */
 /* Navigation bar title of the Post Stats screen */
 "postStats.title" = "إحصاءات التدوينات";
 
-/* Button to add a new tag. %1$@ is the tag name. */
-"postTags.addTag" = "إضافة وسم";
+/* Post status title */
+"postStatus.deleted.details" = "اكتمل الحذف بشكل دائم.";
 
-/* Placeholder text for the tag search field */
-"postTags.searchOrAdd.placeholder" = "البحث عن وسوم أو إضافتها";
+/* Post status title */
+"postStatus.deleted.title" = "اكتمل الحذف";
 
-/* Title for the tags screen */
-"postTags.title" = "الوسوم";
+/* Post status details */
+"postStatus.draft.details" = "غير جاهز للنشر";
+
+/* Post status title */
+"postStatus.draft.title" = "مسودة";
+
+/* Post status details */
+"postStatus.pending.details" = "في انتظار المراجعة قبل النشر";
+
+/* Post status title */
+"postStatus.pending.title" = "معلق";
+
+/* Post status details */
+"postStatus.private.details" = "يظهر فقط لمشرفي الموقع والمحررين";
+
+/* Post status title */
+"postStatus.private.title" = "خاص";
+
+/* Post status details */
+"postStatus.published.details" = "ظاهر للجميع";
+
+/* Post status title */
+"postStatus.published.title" = "اكتمل النشر";
+
+/* Post status details */
+"postStatus.scheduled.details" = "النشر تلقائيًا في تاريخ محدد";
+
+/* Post status title */
+"postStatus.scheduled.title" = "مجدول";
+
+/* Post status title */
+"postStatus.trash.details" = "في سلة المهملات، ولم يُحذف بعد";
+
+/* Post status title */
+"postStatus.trash.title" = "في سلة المهملات";
+
+/* Button to add a new taxonomy term. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.addTag" = "إضافة %1$@";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "إلغاء";
@@ -10335,9 +10772,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "التصنيفات";
-
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "إغلاق";
 
 /* Button to confirm discarding changes */
 "prepublishing.discardChanges.button" = "تجاهل التغييرات";
@@ -10426,12 +10860,17 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "تحذير";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "رسالة";
+
+/* Placeholder text for the message field in Social Sharing */
+"prepublishing.socialAccounts.messagePlaceholder" = "اكتب رسالة موجزة لمشاركتها على شبكات التواصل الاجتماعي إلى جانب التدوينة";
 
 /* The navigation title for the pre-publishing social accounts screen. */
 "prepublishing.socialAccounts.navigationTitle" = "اجتماعي";
+
+/* Table section title */
+"prepublishing.socialAccounts.servicesSectionTitle" = "الخدمات";
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.tags" = "الوسوم";
@@ -11369,6 +11808,18 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Button to progress to the next step after selecting domain in Site Creation */
 "siteCreation.domains.buttons.selectDomain" = "تحديد نطاق";
 
+/* Default text for adding a new item when no label is provided */
+"siteCustomTaxonomies.defaultAddNew" = "إضافة";
+
+/* Description for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.description" = "تساعدك الفئات على تنظيم المحتوى بما يتجاوز التصنيفات ووسوم المقالات.";
+
+/* Title for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.title" = "لا توجد فئات مخصصة";
+
+/* Navigation title for the custom taxonomies screen */
+"siteCustomTaxonomies.navigationTitle" = "الفئات";
+
 /* Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio. */
 "siteMedia.accessibilityLabelAudio" = "الصوت، %@";
 
@@ -11387,8 +11838,77 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Accessibility hint for actions when displaying media items. */
 "siteMedia.cellAccessibilityHint" = "حدِّد الوسائط.";
 
+/* Label for the alt for a media asset (image) */
+"siteMedia.details.altText" = "النص البديل";
+
+/* Verb. Button title. Tapping cancels an action. */
+"siteMedia.details.cancel" = "إلغاء";
+
+/* Noun. Label for the caption for a media asset (image / video) */
+"siteMedia.details.caption" = "كلمات توضيحية";
+
+/* Title for button that permanently deletes a media item (photo / video) */
+"siteMedia.details.delete" = "حذف";
+
+/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
+"siteMedia.details.deleteConfirmation" = "هل أنت متأكد من رغبتك في حذف هذا العنصر نهائيًا؟";
+
+/* Text displayed in HUD after successfully deleting a media item */
+"siteMedia.details.deleted" = "اكتمل الحذف!";
+
+/* Text displayed in HUD while a media item is being deleted. */
+"siteMedia.details.deleting" = "جارٍ الحذف...";
+
+/* Label for the description for a media asset (image / video) */
+"siteMedia.details.description" = "الوصف";
+
+/* Label for the dimensions in pixels for a media asset (image / video) */
+"siteMedia.details.dimensions" = "الأبعاد";
+
+/* Label for the file name for a media asset (image / video) */
+"siteMedia.details.fileName" = "اسم الملف";
+
+/* Label for the file size for a media asset (image / video) */
+"siteMedia.details.fileSize" = "حجم الملف";
+
+/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
+"siteMedia.details.fileType" = "نوع الملف";
+
+/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
+"siteMedia.details.mediaDeleted" = "اكتمل حذف عنصر الوسائط هذا بنجاح.";
+
+/* Noun. Label for the title of a media asset (image / video) */
+"siteMedia.details.title" = "العنوان";
+
+/* Accessibility label for trash buttons in nav bars */
+"siteMedia.details.trash" = "سلة المهملات";
+
+/* Text displayed in HUD if there was an error attempting to delete a media item. */
+"siteMedia.details.unableToDeleteMedia" = "يتعذر حذف عنصر الوسائط.";
+
+/* Error shown when the app fails to load a video from the user's media library. */
+"siteMedia.details.unableToLoadVideo" = "يتعذر تحميل الفيديو.";
+
+/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
+"siteMedia.details.unableToSaveMedia" = "يتعذر حفظ عنصر الوسائط.";
+
+/* Label for the date a media asset (image / video) was uploaded */
+"siteMedia.details.uploaded" = "اكتمل الرفع";
+
 /* Title for the URL field */
 "siteMedia.details.url" = "عنوان الموقع";
+
+/* Hint for image alt on image settings. */
+"siteMedia.hints.imageAlt" = "النص البديل للصورة";
+
+/* Hint for image caption on image settings. */
+"siteMedia.hints.imageCaption" = "تسمية توضيحية للصورة.";
+
+/* Hint for image description on image settings. */
+"siteMedia.hints.imageDescription" = "وصف الصورة";
+
+/* Hint for image title on image settings. */
+"siteMedia.hints.imageTitle" = "عنوان الصورة";
 
 /* Accessibility hint for media item preview for user's viewing an item in their media library */
 "siteMediaItem.contentViewAccessibilityHint" = "النقر لعرض الوسائط في وضع الشاشة الكاملة";
@@ -11486,6 +12006,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "الخصوصية";
+
+/* Format string for adding a new taxonomy term. %1$@ is the taxonomy name. */
+"siteTaxonomy.addNew.format" = "إضافة %1$@";
 
 /* Hint for users when hidden privacy setting is set */
 "siteVisibility.hidden.hint" = "تم إخفاء موقعك عن الزوار خلف ملاحظة \"قريبًا\" حتى يصبح جاهزًا لمشاهدته.";
@@ -12054,7 +12577,8 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Subject of new Zendesk ticket. */
 "support.zendesk.readerAppTicketSubject" = "قارئ لدعم نظام iOS";
 
-/* Description for empty state when there are no tags */
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
 "tags.empty.description" = "الوسوم تساعد على تنظيم محتواك وتسهل على القراء العثور على التدوينات ذات الصلة.";
 
 /* Title for empty state when there are no tags */
@@ -12131,9 +12655,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "غير مقروء";
-
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "المشترك بالموقع";
 
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "مستخدم الموقع";
@@ -12219,9 +12740,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* The heading at the top of the user list */
 "userlist.title" = "المستخدمون";
-
-/* Site Subscribers */
-"users.list.title.subscribers" = "المشتركون";
 
 /* Screen title */
 "users.title" = "المستخدمون";

--- a/WordPress/Resources/bg.lproj/InfoPlist.strings
+++ b/WordPress/Resources/bg.lproj/InfoPlist.strings
@@ -2,5 +2,16 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!--Warning: Auto-generated file, do not edit.-->
 <plist version="1.0">
-  <dict/>
+  <dict>
+    <key>NSCameraUsageDescription</key>
+    <string>За да заснемате снимки или видео клипове за вашите публикации.</string>
+    <key>NSLocationUsageDescription</key>
+    <string>WordPress иска да добавя данни за местоположение към публикациите на сайтове, в които сте включили геотагинг.</string>
+    <key>NSLocationWhenInUseUsageDescription</key>
+    <string>WordPress иска да добавя данни за местоположение към публикациите на сайтове, в които сте включили геотагинг.</string>
+    <key>NSMicrophoneUsageDescription</key>
+    <string>Позволете достъп до микрофона, за да записвате звук във вашите видеа.</string>
+    <key>NSPhotoLibraryUsageDescription</key>
+    <string>Да добавяте снимки или видео към публикациите си.</string>
+  </dict>
 </plist>

--- a/WordPress/Resources/bg.lproj/Localizable.strings
+++ b/WordPress/Resources/bg.lproj/Localizable.strings
@@ -1,13 +1,84 @@
-/* Translation-Revision-Date: 2022-05-03 21:52:57+0000 */
+/* Translation-Revision-Date: 2025-11-27 18:06:49+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: bg */
+
+/* Message to ask the user to send us an email to clear their content. */
+"\nPlease send us an email to have your content cleared out." = "\nМоля изпратете ни имейл, за да изчистим Вашето съдържание.";
+
+/* Notice shown on the Edit Comment view when the author is a registered user. */
+"\nThis user is registered. Their name, web address, and email address cannot be edited." = "\nПотребителят е регистриран. Тяхното име, уеб адрес и имейл не могат да се редактират.";
+
+/* Message of Delete Site confirmation alert; substitution is site's host. */
+"\nTo confirm, please re-enter your site's address before deleting.\n\n" = "\nЗа да потвърдите, въведете повторно адреса на сайта си.\n";
+
+/* Message of Close Account confirmation alert */
+"\nTo confirm, please re-enter your username before closing.\n\n" = "\nЗа потвърждение, моля въведете вашето потребителско име, преди затваряне.\n";
 
 /* Title of a list of buttons used for sharing content to other services. These buttons appear when the user taps a `More` button. */
 "\"More\" Button" = "Бутон \"Още\"";
 
+/* Description for the restore action. $1$@ is a placeholder for the selected date. */
+"%1$@ is the selected point for your restore." = "%1$@ е избраната дата, от която се за възстановява";
+
+/* Description for the download backup action. $1$@ is a placeholder for the selected date. */
+"%1$@ is the selected point to create a downloadable backup." = "%1$@ е избраната дата, към която се създава бекъп за изтегляне.";
+
 /* Label displaying the author and post title for a Comment. %1$@ is a placeholder for the author. %2$@ is a placeholder for the post title. */
 "%1$@ on %2$@" = "%1$@ за %2$@";
+
+/* Error message displayed when restoring a site fails due to credentials not being configured. %1$@ is a placeholder for the string 'Enter your server credentials'. */
+"%1$@ to enable one click site restores from backups." = "%1$@ за включване на възстановяванията с едно докосване от бекъп.";
+
+/* Title for button when a site is missing server credentials. %1$@ is a placeholder for the string 'Enter your server credentials'. */
+"%1$@ to fix this threat." = "%1$@ за да отстраните заплахата.";
+
+/* Title for button when a site is missing server credentials. %1$@ is a placeholder for the string 'Enter your server credentials'. */
+"%1$@ to fix threats." = "%1$@ за да отстраните заплахите.";
+
+/* Singular label displaying number of comments. %1$d is a placeholder for the number of Comments. */
+"%1$d Comment" = "%1$d Коментар";
+
+/* Plural label displaying number of comments. %1$d is a placeholder for the number of Comments. */
+"%1$d Comments" = "%1$d Коментара";
+
+/* Singular button title to Like a comment. %1$d is a placeholder for the number of Likes.
+   Singular format string for view title displaying the number of post likes. %1$d is the number of likes. */
+"%1$d Like" = "%1$d Харесване";
+
+/* Plural button title to Like a comment. %1$d is a placeholder for the number of Likes.
+   Plural format string for view title displaying the number of post likes. %1$d is the number of likes. */
+"%1$d Likes" = "%1$d Харесвания";
+
+/* Singular format string for displaying the number of users that answered the blogging prompt. */
+"%1$d answer" = "%1$d отговор";
+
+/* Plural format string for displaying the number of users that answered the blogging prompt. */
+"%1$d answers" = "%1$d отговора";
+
+/* translators: 1: From block title, e.g. Paragraph. 2: To block title, e.g. Header. */
+"%1$s transformed to %2$s" = "%1$s е превърнат в %2$s";
+
+/* translators: accessibility text. Inform about current value. %1$s: Control label %2$s: setting label (example: width), %3$s: Current value. %4$s: value measurement unit (example: pixels) */
+"%1$s. %2$s is %3$s %4$s." = "%1$s. %2$s е %3$s %4$s.";
+
+/* translators:  %1$s: Select control button label e.g. \"Button width\". %2$s: Select control option value e.g: \"Auto, 25%\". */
+"%1$s. Currently selected: %2$s" = "%1$s. Избрано: %2$s";
+
+/* Post Stats label for week date range. Ex: Mar 25 - Mar 31, 2019 */
+"%@ - %@, %@" = "%1$@ - %2$@, %3$@";
+
+/* Accessibility identifier for buttons. */
+"%@ Button" = "%@ Бутон";
+
+/* The number of tags in the writting settings. Singular. %@ is a placeholder for the number */
+"%@ Tag" = "%@ Етикет";
+
+/* The number of tags in the writting settings. Plural. %@ is a placeholder for the number */
+"%@ Tags" = "%@ Етикета";
+
+/* Accessibility label for value in billions. Ex: 66.6 billion. */
+"%@ billion" = "%@ милиард";
 
 /* Number of Comments per Page */
 "%@ comments" = "%@ коментара";
@@ -22,8 +93,56 @@
 /* Number of Links */
 "%@ links" = "%@ връзки";
 
+/* Accessibility label for value in millions. Ex: 66.6 million. */
+"%@ million" = "%@ милион";
+
+/* Amount of disk quota being used. First argument is the total percentage being used second argument is total quota allowed in GB.Ex: 33% of 14 GB on your site. */
+"%@ of %@ on your site" = "%1$@ от %2$@ на вашия сайт";
+
+/* Accessibility label for value in quadrillion. Ex: 66.6 quadrillion. */
+"%@ quadrillion" = "%@ квадрилион";
+
+/* Accessibility label for value in quintillions. Ex: 66.6 quintillion. */
+"%@ quintillion" = "%@ квинтилиона";
+
+/* Accessibility label for value in thousands. Ex: 66.6 thousand. */
+"%@ thousand" = "%@ хиляди";
+
+/* Accessibility label for value in trillions. Ex: 66.6 trillion. */
+"%@ trillion" = "%@ трилион";
+
 /* Let's the user know that a third party sharing service was reconnected. The %@ is a placeholder for the service name. */
 "%@ was reconnected." = "%@ се свърза отново.";
+
+/* Accessibility value for a Stats' Posting Activity Month if the user selected a day with posts. The first parameter is day (e.g. November 2019). The second parameter is the number of posts. */
+"%@. %d posts." = "%1$@. %2$d публикации.";
+
+/* Accessibility value for a Stats' Posting Activity Month if the user selected a day with posts. The first parameter is day (e.g. November 2019). */
+"%@. 1 post." = "%@. 1 публикация.";
+
+/* Label displaying value in billions. Ex: 66.6B. */
+"%@B" = "%@ милиарда";
+
+/* Label displaying value in quintillions. Ex: 66.6E. */
+"%@E" = "%@E";
+
+/* Label displaying value in thousands. Ex: 66.6K. */
+"%@K" = "%@ хил.";
+
+/* Label displaying value in millions. Ex: 66.6M. */
+"%@M" = "%@ мил.";
+
+/* Label displaying value in quadrillions. Ex: 66.6P. */
+"%@P" = "%@P";
+
+/* Label displaying value in trillions. Ex: 66.6T. */
+"%@T" = "%@T";
+
+/* Number of posts displayed in Posting Activity when a day is selected. %d will contain the actual number (singular). */
+"%d Post" = "%d Публикация";
+
+/* Number of posts displayed in Posting Activity when a day is selected. %d will contain the actual number (plural). */
+"%d Posts" = "%d Публикации";
 
 /* Age between dates over one day.
    Number of days */
@@ -37,6 +156,12 @@
 
 /* Sepoken image size in pixels (e.g. 300 pixels) */
 "%d pixels" = "%d пиксела";
+
+/* Number of posts */
+"%d posts" = "%d публикации";
+
+/* Message for a notice informing the user their scan completed and %d threats were found */
+"%d potential threats found" = "%d потенциални заплахи";
 
 /* Age between dates over one year. */
 "%d years" = "%d години";
@@ -53,14 +178,96 @@
 /* The number of menus on the site and area. */
 "%i menus available" = "%i менюта са налични";
 
+/* Alert displayed to the user when multiple media items have failed to upload. */
+"%ld files not uploaded" = "%ld файла не бяха качени";
+
+/* System notification displayed to the user when multiple media items have uploaded successfully. */
+"%ld files successfully uploaded" = "%ld файла бяха качени";
+
+/* Displays the number of words and characters in text */
+"%li words, %li characters" = "%1$li думи, %2$li символа";
+
+/* translators: Block name. %s: The localized block name
+translators: %s: Block name e.g. \"Image block\" */
+"%s block" = "%s блок";
+
+/* translators: %s: block title e.g: \"Paragraph\". */
+"%s block options" = "Опции за блока %s";
+
+/* translators: Newly available block name. %s: The localized block name */
+"%s block, newly available" = "%s блок, новодобавен";
+
+/* translators: accessibility text for the media block empty state. %s: media type */
+"%s block. Empty" = "%s блок. Празен";
+
+/* translators: accessibility text for blocks with invalid content. %d: localized block title */
+"%s block. This block has invalid content" = "%s блок. Този блок има невалидно съдържание";
+
+/* translators: %s: name of the synced block */
+"%s detached" = "%s разкачен";
+
+/* translators: %s: embed block variant's label e.g: \"Twitter\". */
+"%s embed block previews are coming soon" = "Прегледите на вградения блок %s ще бъдат налични скоро";
+
+/* translators: %s: social link name e.g: \"Instagram\". */
+"%s has URL set" = "%s има избран адрес";
+
+/* translators: %s: social link name e.g: \"Instagram\". */
+"%s has no URL set" = "%s няма избран адрес";
+
+/* translators: %s: embed block variant's label e.g: \"Twitter\". */
+"%s link" = "%s връзка";
+
+/* translators: %s: embed block variant's label e.g: \"Twitter\". */
+"%s previews not yet available" = "%s прегледи не са налични";
+
+/* translators: %s: social link name e.g: \"Instagram\". */
+"%s social icon" = "%s социална икона";
+
+/* translators: displayed right after the classic block is converted to blocks. %s: The localized classic block name */
+"'%s' block converted to blocks" = "Блокът '%s' е конвертиран към блок";
+
+/* translators: Missing block alert title. %s: The localized block name */
+"'%s' is not fully-supported" = "'%s' не се поддържа изцяло";
+
 /* Empty Post Title */
 "(No Title)" = "(Без заглавие)";
 
 /* Menus title label text for a post that has no set title. */
 "(Untitled)" = "(Без заглавие)";
 
+/* Example Comment notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
+"*Johann Brandt* responded to your post" = "*Johann Brandt* отговори на вашата публикация";
+
+/* Example Like notification displayed in the prologue carousel of the app. Username should be marked with * characters and will be displayed as bold text. */
+"*Madison Ruiz* liked your post" = "*Madison Ruiz* хареса вашата публикация";
+
 /* Menus button text for adding a new menu to a site. */
 "+ Add new menu" = "+ Добавяне на ново меню";
+
+/* Register Domain - Address information field add new address line */
+"+ Address line %@" = "+ Адрес ред %@";
+
+/* Local notification displayed to the user when a single draft post has been successfully uploaded. */
+"1 draft post uploaded" = "1 чернова е качена";
+
+/* Alert displayed to the user when a single media item has failed to upload. */
+"1 file not uploaded" = "1 файл не е качен";
+
+/* System notification displayed to the user when a single media item has uploaded successfully. */
+"1 file successfully uploaded" = "1 файл е качен успешно";
+
+/* Alert displayed to the user when a single post has been successfully uploaded. */
+"1 post uploaded" = "1 публикация е качена";
+
+/* Alert displayed to the user when multiple media items attached to a post have failed to upload. */
+"1 post, %ld files not uploaded" = "1 публикация, %ld файлове не са качени";
+
+/* Alert displayed to the user when a single media item attached to a post has failed to upload. */
+"1 post, 1 file not uploaded" = "1 публикация, 1 файл не са качени";
+
+/* Message for a notice informing the user their scan completed and 1 threat was found */
+"1 potential threat found" = "1 потенциална заплаха";
 
 /* Indicates a video will be resized to Full HD 1920x1080 when uploaded. */
 "1080p" = "1080p";
@@ -74,8 +281,38 @@
 /* Indicates a video will be resized to HD 1280x720 when uploaded. */
 "720p" = "720p";
 
+/* Age between dates less than one hour. */
+"< 1 hour" = "<1 час";
+
+/* A short description of how many times a week the user will receive a blogging reminder. The '%d' placeholder will be populated with a count of the number of times a week they'll be reminded, and should be surrounded by <strong> HTML tags. */
+"<strong>%d<\/strong> times a week" = "<strong>%d<\/strong> пъти седмично";
+
+/* A short description of how many times a week the user will receive a blogging reminder. The '%d' placeholder will be populated with a count of the number of times a week they'll be reminded, and should be surrounded by <strong> HTML tags. */
+"<strong>%d<\/strong> times a week at %@" = "<strong>%1$d<\/strong> пъти седмично в %2$@";
+
+/* Short title telling the user they will receive a blogging reminder once per week. The word for 'once' should be surrounded by <strong> HTML tags. */
+"<strong>Once<\/strong> a week" = "<strong>Веднъж<\/strong> седмично";
+
+/* Short title telling the user they will receive a blogging reminder once per week. The word for 'once' should be surrounded by <strong> HTML tags. */
+"<strong>Once<\/strong> a week at %@" = "<strong>Веднъж<\/strong> седмично в %@";
+
+/* Short title telling the user they will receive a blogging reminder two times a week. The word for 'twice' should be surrounded by <strong> HTML tags. */
+"<strong>Twice<\/strong> a week" = "<strong>Два пъти<\/strong> седмично";
+
+/* Short title telling the user they will receive a blogging reminder two times a week. The word for 'twice' should be surrounded by <strong> HTML tags. */
+"<strong>Twice<\/strong> a week at %@" = "<strong>Два пъти<\/strong> седмично в %@";
+
+/* Label displaying the user's username preceeded by an '@' symbol. %1$@ is a placeholder for the username. */
+"@%1$@" = "@%1$@";
+
 /* A short description of what the 'More' button is and how it works. */
 "A \"more\" button contains a dropdown which displays sharing buttons" = "Бутонът \"още\" съдържа падащо меню с бутони за споделяне";
+
+/* Instruction text to explain magic link login step. */
+"A WordPress.com account is connected to your store credentials. To continue, we will send a verification link to the email address above." = "Профил в WordPress.com е свързан с идентификационните данни на вашия магазин. За да продължите, ще изпратим връзка за потвърждение на посочения по-горе имейл адрес.";
+
+/* Title for a threat */
+"A file contains a malicious code pattern" = "Файл съдържа злонамерен код";
 
 /* Placeholder text for the title of a site */
 "A title for the site" = "Заглавие на сайта";
@@ -83,21 +320,65 @@
 /* An error message. */
 "A valid email address is needed to mail an authentication link. Please return to the previous screen and provide a valid email address." = "Изисква се валиден имейл адрес, за да изпратим връзка за автентикация. Върнете се на предишния екран и задайте валиден имейл адрес.";
 
+/* Shown when a user types a non-number into the two factor field. */
+"A verification code will only contain numbers." = "Кодът за верификация съдържа само цифри.";
+
 /* Label for active Theme browser cell */
 "ACTIVE" = "АКТИВНИ";
+
+/* No comment provided by engineer. */
+"ADD BLOCK HERE" = "Добавете блок тук";
+
+/* No comment provided by engineer. */
+"ADD MEDIA" = "Добавяне на файл";
+
+/* Register Domain - Address information field section header title */
+"ADDRESS" = "АДРЕС";
+
+/* Link to About screen for Jetpack for iOS */
+"About Jetpack for iOS" = "Относно Jetpack за iOS";
+
+/* Link to About screen for Jetpack for iOS */
+"About Reader for iOS" = "Относно Reader за iOS";
+
+/* Link to About screen for WordPress for iOS */
+"About WordPress" = "За WordPress";
+
+/* Label for selecting the Accelerated Mobile Pages (AMP) Blog Traffic Setting */
+"Accelerated Mobile Pages (AMP)" = "Ускорени мобилни страници (AMP)";
+
+/* No comment provided by engineer. */
+"Access this Paywall block on your web browser for advanced settings." = "Заредете блока за платена стена в браузър, за повече настройки.";
 
 /* Title for the account section in site settings screen */
 "Account" = "Профил";
 
+/* Header for account details, shown after signing up. */
+"Account Details" = "Подробности за профила";
+
+/* Accessibility description for account information after logging in. */
+"Account Information. %@. %@." = "Информация за профила. %1$@. %2$@.";
+
 /* Account Settings Title
    Link to Account Settings section */
 "Account Settings" = "Настройки на профила";
+
+/* Overlay message displayed when account successfully closed */
+"Account closed" = "Профилът е затворен";
+
+/* Title of button that displays the App's acknowledgements */
+"Acknowledgements" = "Благодарности";
 
 /* Theme Activate action title */
 "Activate" = "Активиране";
 
 /* Title of alert when theme activation fails */
 "Activation Error" = "Грешка при активацията";
+
+/* Describes a status of a plugin
+   Label for active Theme
+   Whether a plugin is active on a site */
+"Active" = "Активен";
 
 /* The plugin is active on the site and has not enabled automatic updates */
 "Active, Autoupdates off" = "Активирано, автоматичните обновления са изключени";
@@ -109,8 +390,68 @@
    Noun. Name of the Activity Log feature */
 "Activity" = "Дейност";
 
+/* Noun. Links to a blog's Activity screen. */
+"Activity Log" = "Дневник на дейността";
+
+/* No comment provided by engineer. */
+"Add Block After" = "Добавяне на блок след";
+
+/* No comment provided by engineer. */
+"Add Block Before" = "Добавяне на блок преди";
+
+/* Alert option to add document contents into a blog post. */
+"Add Contents to Post" = "Добавяне на съдържание към публикацията";
+
+/* No comment provided by engineer. */
+"Add To Beginning" = "Добавяне в началото";
+
+/* No comment provided by engineer. */
+"Add To End" = "Добавяне в края";
+
+/* No comment provided by engineer. */
+"Add URL" = "Добавяне на адрес";
+
+/* Label of the button that starts the purchase of an additional redirected domain in the Domains Dashboard. */
+"Add a domain" = "Добавяне на домейн";
+
+/* No comment provided by engineer. */
+"Add a new block at any time by tapping on the + icon in the toolbar on the bottom left." = "Добавете нов блок, като докоснете иконата + в лентата с инструменти в долния ляв ъгъл.";
+
+/* No comment provided by engineer. */
+"Add a shortcode…" = "Добавяне на кратък код...";
+
+/* Accessibility description for adding an image to a new user account. Tapping this initiates that flow. */
+"Add account image." = "Добавяне на изображение на профила.";
+
 /* No comment provided by engineer. */
 "Add alt text" = "Добавете описателен текст";
+
+/* No comment provided by engineer. */
+"Add audio" = "Добавяне на аудио";
+
+/* No comment provided by engineer. */
+"Add blocks" = "Добавяне на блокове";
+
+/* No comment provided by engineer. */
+"Add button text" = "Текст на бутона за добавяне";
+
+/* No comment provided by engineer. */
+"Add description" = "Добавяне на описание";
+
+/* No comment provided by engineer. */
+"Add image" = "Добавяне на изображение";
+
+/* No comment provided by engineer. */
+"Add image or video" = "Добавяне на изображение или видео";
+
+/* Accessibility hint text for adding an image to a new user account. */
+"Add image, or avatar, to represent this new account." = "Добавяне на изображение или аватар за този нов профил";
+
+/* No comment provided by engineer. */
+"Add link text" = "Добавяне на текст към връзката";
+
+/* translators: %s: social link name e.g: \"Instagram\". */
+"Add link to %s" = "Добавяне на връзка към %s";
 
 /* No comment provided by engineer. */
 "Add menu item above" = "Добавяне на елемент в менюто отгоре";
@@ -121,12 +462,58 @@
 /* No comment provided by engineer. */
 "Add menu item to children" = "Добавяне на дъщерен елемент в менюто";
 
+/* Screen reader text for Menus button that adds a new menu to a site. */
+"Add new menu" = "Добавяне на меню";
+
+/* Screen reader text for button that adds a menu item */
+"Add new menu item" = "Добавяне на елемент от менюто";
+
+/* No comment provided by engineer. */
+"Add paragraph block" = "Добавяне на блок за параграф";
+
+/* Button title displayed when the user has removed all Insights from display.
+   Label for action to add a new Insight. */
+"Add stats card" = "Добавя карта за статистика";
+
+/* Placeholder text for tags module in share extension. */
+"Add tags" = "Добавяне на етикети";
+
+/* No comment provided by engineer. */
+"Add this email link" = "Добавяне на имейл връзка";
+
+/* No comment provided by engineer. */
+"Add this link" = "Добавяне на връзка";
+
+/* No comment provided by engineer. */
+"Add this telephone link" = "Добавяне на телефонна връзка";
+
+/* No comment provided by engineer. */
+"Add title" = "Добавете заглавие";
+
+/* No comment provided by engineer. */
+"Add video" = "Добавяне на видео";
+
+/* User-facing string, presented to reflect that site assembly is underway. */
+"Adding site features" = "Добавяне на функции";
+
 /* Label for url blog setting
    Register Domain - Address information field placeholder for Address line */
 "Address" = "Адрес";
 
+/* No comment provided by engineer. */
+"Address Settings" = "Настройка на адрес";
+
+/* Register Domain - Address information field Address line */
+"Address line %@" = "Адрес, ред %@";
+
 /* Title for the advanced section in site settings screen */
 "Advanced" = "Разширени";
+
+/* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
+"After %@" = "След %@";
+
+/* Option to select the Airmail app when logging in with magic links */
+"Airmail" = "Airmail";
 
 /* Image alignment option title.
    Title of the screen for choosing an image's alignment. */
@@ -141,14 +528,32 @@
    Title of the drafts filter. This filter shows a list of draft posts. */
 "All" = "Всички";
 
+/* Information about redeeming domain credit on site dashboard. */
+"All WordPress.com annual plans include a custom domain name. Register your free domain now." = "Всички годишни WordPress.com планове включват домейн. Ригистрирайте своя безплатен домейн сега.";
+
 /* An option in a list. Automatically approve all comments */
 "All comments" = "Всички коментари";
 
 /* Section title for All Languages */
 "All languages" = "Всички езици";
 
+/* Description for the Jetpack Backup Restore message. %1$@ is a placeholder for the selected date. */
+"All of your selected items are now restored back to %1$@." = "Всички избрани елементи са възстановени към %1$@.";
+
+/* Title of the completion screen of the Blogging Reminders Settings screen. */
+"All set!" = "Готово!";
+
+/* Insights 'All-Time' header */
+"All-Time" = "За всички времена";
+
 /* Settings: Comments Enabled */
 "Allow Comments" = "Включване на коментарите";
+
+/* Title for a cell with switch control that allows to enable or disable notifications */
+"Allow Notifications" = "Позволяване на известията";
+
+/* Suggests the user allow push notifications. Appears within app settings. */
+"Allow WordPress to send you push notifications" = "Позволяване на WordPress да изпраща пуш нотификации";
 
 /* Jetpack Settings: Allow WordPress.com login */
 "Allow WordPress.com login" = "Позволяване на влизане с WordPress.com регистрация.";
@@ -156,16 +561,68 @@
 /* A short description of the comment like sharing setting. */
 "Allow all comments to be Liked by you and your readers" = "Позволяване на коментарите да бъдат харесвани от вас и читателите ви";
 
+/* Allow button title shown in alert preparing users to grant permission for us to send them push notifications.
+   Button label for approving our request to allow push notifications */
+"Allow notifications" = "Позволяване на известията";
+
+/* Allow button title shown in alert preparing users to grant permission for us to send them push notifications.
+   Shown to the user in settings when they haven't yet allowed or denied push notifications */
+"Allow push notifications" = "Позволяване на пуш нотификации";
+
 /* No comment provided by engineer. */
 "Allow this connection to be used by all admins and users of your site." = "Позволяване тази връзка да бъде използвана от всички администратори и потребители на вашия сайт.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Allowlisted IP Addresses Title */
+"Allowlisted IP Addresses" = "Одобрени IP адреси";
+
+/* Jetpack Settings: Allowlisted IP addresses */
+"Allowlisted IP addresses" = "Одобрени IP адреси";
+
+/* Instructions for users with two-factor authentication enabled. */
+"Almost there! Please enter the verification code from your authenticator app." = "Почти сме готови! Моля въведете кодът за верификация от приложението за двуфакторно удостоверяване.";
+
+/* Image alt attribute option title. */
 "Alt Text" = "Описателен текст";
+
+/* No comment provided by engineer. */
+"Alternatively, you can convert the content to blocks." = "Алтернативно, може да конвертирате съдържанието в блокове.";
+
+/* No comment provided by engineer. */
+"Alternatively, you can detach and edit this block separately by tapping “Detach”." = "Алтернативно, може да разкачите и редактирате този блок отделно, като докоснете \"Разкачане\".";
+
+/* translators: Alternative option included in a warning related to having blocks deeply nested. */
+"Alternatively, you can flatten the content by ungrouping the block." = "Алтернативно, може да изравните съдържанието, като премахнете групирането на блока.";
+
+/* Instruction text to explain to help users type their password instead of using magic link login option. */
+"Alternatively, you may enter the password for this account." = "Алтернативно, може да въведете паролата за профила.";
+
+/* String displayed before offering alternative login methods */
+"Alternatively:" = "Алтернативно:";
+
+/* Title of a row displayed on the debug screen used to indicate whether crash logs should be forced to send, even if they otherwise wouldn't */
+"Always Send Crash Logs" = "Винаги да се пращат краш дневници";
+
+/* A failure reason for when an error HTTP status code was returned from the site, with the specific error code. */
+"An HTTP error code %i was returned." = "Върнат е HTTP код за грешка %i.";
+
+/* A failure reason for when an error HTTP status code was returned from the site. */
+"An HTTP error code was returned." = "Върнат е HTTP код за грешка.";
+
+/* Error message shown when trying to scan a log in code without an active internet connection. */
+"An active internet connection is required to scan log in codes" = "Активна Интернет връзка е нужна за сканиране на кодове за влизане";
+
+/* Error message shown when trying to view the scan status and there is no internet connection. */
+"An active internet connection is required to view Jetpack Scan" = "Изисква се връзка с Интернет, за да видите Jetpack Scan";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
    Error message when the user tries to visualize a plugin without internet connection */
 "An active internet connection is required to view plugins" = "За преглеждането на разширения е нужна връзка с интернет";
+
+/* Error message shown when trying to view the Scan History feature and there is no internet connection. */
+"An active internet connection is required to view the history" = "Изисква се връзка с Интернет, за да видите историята";
+
+/* Default error message displayed when unable to close user account. */
+"An error occured while closing account." = "Възникна грешка при затваряне на профила.";
 
 /* An error description explaining that a Menu could not be created. */
 "An error occurred creating the Menu." = "Възникна грешка при създаване на менюто.";
@@ -191,10 +648,54 @@
 /* Error recorded when all of the media associated with a post fail to be attached to the post on the server. */
 "An error occurred when attempting to attach uploaded media to the post." = "Възникна грешка при закачането на отдалечен медиен файл към публикацията.";
 
+/* Used when a remote response doesn't have a specific message for a specific request */
+"An error occurred while processing your request: " = "Възникна грешка при обработка на заявката ви: ";
+
+/* Text displayed when a stat section failed to load. */
+"An error occurred." = "Възникна грешка";
+
+/* A failure reason for when the error that occured wasn't able to be determined. */
+"An unknown error occurred." = "Възникна неочаквана грешка.";
+
+/* Error message shown when a media upload fails for unknown reason and the user should try again. */
+"An unknown error occurred. Please try again." = "Възникна неизвестна грешка. Моля опитайте отново.";
+
+/* Insights 'This Year' details view header */
+"Annual Site Stats" = "Годишна статистика";
+
+/* Verb. Opens the editor to answer the blogging prompt. */
+"Answer" = "Отговор";
+
+/* Title for a call-to-action button in the create new bottom action sheet.
+   Title for a call-to-action button on the prompts card. */
+"Answer Prompt" = "Отговор на предизвикателството";
+
+/* Title of answered Blogging Prompts filter. */
+"Answered" = "Отговорено";
+
+/* Navigates to picker screen to change the app's icon
+   Title of screen to change the app's icon */
+"App Icon" = "Икона на приложението";
+
 /* App Settings Title
    Link to App Settings section
    Title of the 'App Settings' screen within the 'Me' tab - used for spotlight indexing on iOS. */
 "App Settings" = "Настройки на приложението";
+
+/* The title of the app appearance settings screen */
+"Appearance" = "Изглед";
+
+/* Message shown when Apple authentication fails. */
+"Apple authentication failed.\nPlease make sure you are signed in to iCloud with an Apple ID that uses two-factor authentication." = "Удостоверяването с Apple е неуспешно.\nМоля, първо влезте с iCloud с Apple ID, което ползва двуфакторна автентикация.";
+
+/* Link to Application Passwords section */
+"Application Passwords" = "Пароли на приложения";
+
+/* No comment provided by engineer. */
+"Applies the setting" = "Прилага настройката";
+
+/* Apply action on the app extension tags picker screen. Saves the selected tags for the post. */
+"Apply" = "Прилагане";
 
 /* Approve action. Verb
    Approve comment (verb)
@@ -202,9 +703,15 @@
    Verb. Approves a 2fa authentication challenge, and logs in a user. */
 "Approve" = "Одобряване";
 
+/* Approves a Comment */
+"Approve Comment" = "Одобряване на коментара";
+
 /* Button title for Approved comment state.
    Title of approved Comments filter. */
 "Approved" = "Одобрен";
+
+/* VoiceOver accessibility hint, informing the user the button can be used to approve a comment */
+"Approves the Comment." = "Одобрява коментара.";
 
 /* Menus alert message for alerting the user to unsaved changes while trying back out of Menus. */
 "Are you sure you want to cancel and discard changes?" = "Сигурни ли сте, че искате да отхвърлите промените?";
@@ -218,8 +725,55 @@
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "Сигурни ли сте, че искате да прекратите връзката на Jetpack със сайта?";
 
+/* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
+"Are you sure you want to remove %1$@ from %2$@?" = "Сигурни ли сте, че искате да премахнете %1$@ от %2$@?";
+
+/* Text for the alert to confirm a plugin removal. %1$@ is the plugin name. */
+"Are you sure you want to remove %1$@?" = "Сигурни ли сте, че искате да премахнете %1$@?";
+
+/* Description for the confirm restore action. %1$@ is a placeholder for the selected date. */
+"Are you sure you want to restore your site back to %1$@? This will remove content and options created or changed since then." = "Сигурни ли сте, че искате да възстановите сайта си към %1$@? Това ще премахне съдържанието и настройките, създадени или променени след тази дата.";
+
+/* Title that asks the user if they are the trying to login.  %1$@ is a placeholder for the browser name (Chrome/Firefox), %2$@ is a placeholder for the users location */
+"Are you trying to log in to %1$@ near %2$@?" = "Опитвате ли се да влезете в %1$@ близо до %2$@?";
+
+/* Title that asks the user if they are the trying to log in.  %1$@ is a placeholder for the users location */
+"Are you trying to log in to your web browser near %1$@?" = "Опитвате ли се да влезете с уеб браузър близо до %1$@?";
+
+/* No comment provided by engineer. */
+"Arrange your content into columns, add Call to Action buttons, and overlay images with text." = "Подредете съдържанието си в колони, добавете бутони за действие и поставяйте текст върху изображения.";
+
+/* No comment provided by engineer. */
+"Arrow buttons" = "Бутони със стрелки";
+
+/* An example tag used in the login prologue screens.
+   Art site intent topic */
+"Art" = "Изкуство";
+
+/* Message shown to users who have an old publicize connection to a facebook profile. */
+"As of August 1, 2018, Facebook no longer allows direct sharing of posts to Facebook Profiles. Connections to Facebook Pages remain unchanged." = "След 1-ви август 2018 г., Facebook вече не позволява директно споделяне на публикации във Facebook профили. Връзките към страници продължават да работят.";
+
+/* Alert option to embed a doc link into a blog post. */
+"Attach File as Link" = "Закачане на файл като връзка";
+
+/* No comment provided by engineer. */
+"Audio Player" = "Аудио плейър";
+
+/* translators: accessibility text. %s: Audio caption. */
+"Audio caption. %s" = "Кратко описание на аудиото. %s";
+
+/* translators: accessibility text. Empty Audio caption. */
+"Audio caption. Empty" = "Кратко описание на аудиото. Празно";
+
 /* No comment provided by engineer. */
 "Authenticating" = "Разрешаване";
+
+/* Title for the error view when the authentication failed for any reason */
+"Authentication Failed" = "Грешка при удостоверяване";
+
+/* Accessibility label for the 2FA text field.
+   Placeholder for the 2FA code textfield. */
+"Authentication code" = "Код за идентификация";
 
 /* Popup title to ask for user credentials. */
 "Authentication required for host: %@" = "Изисква се автентикация за хост: %@";
@@ -228,9 +782,18 @@
    Title for a badge displayed beside the comment writer's name. Shown when the comment is written by the post author. */
 "Author" = "Автор";
 
+/* Voiceover description of a button that allows the user to filter posts by author. */
+"Author Filter" = "Филтриране по автор";
+
 /* Label for comments by author
    Period Stats 'Authors' header */
 "Authors" = "Автори";
+
+/* Describes a status of a plugin */
+"Auto-managed" = "Автоматично-управлявано";
+
+/* The plugin can not be manually updated or deactivated */
+"Auto-managed on this site" = "Автоматично-управлявано в този сайт";
 
 /* Discussion Settings Title
    Settings: Comments Approval settings */
@@ -248,8 +811,32 @@
 /* Discussion Settings: Comments Auto-close */
 "Automatically close comments on content after a certain number of days." = "Автоматично затваряне на дискусията след определен брой дни.";
 
+/* Title of button that displays information about the other apps available from Automattic */
+"Automattic Family" = "Семейството на Automattic";
+
+/* Automotive site intent topic */
+"Automotive" = "Автомобили";
+
+/* No comment provided by engineer. */
+"Autoplay may cause usability issues for some users." = "Автоматичното пускане може да причини неудобство за някои потребители.";
+
+/* Whether a plugin has enabled automatic updates */
+"Autoupdates" = "Автоматични актуализации";
+
 /* No comment provided by engineer. */
 "Available to all users" = "Наличен за всички потребители";
+
+/* 'This Year' label for average comments per post. */
+"Avg Comments \/ Post" = "Средно коментари\/публикация";
+
+/* 'This Year' label for average likes per post. */
+"Avg Likes \/ Post" = "Средно харесвания\/публикация";
+
+/* 'This Year' label for average words per post. */
+"Avg Words \/ Post" = "Средно думи\/публикация";
+
+/* Post Stats average views per day header. */
+"Avg. Views Per Day" = "Средно прегледи за ден";
 
 /* Back action on share extension site picker screen. Takes the user to the share extension editor screen.
    Back button title.
@@ -257,31 +844,187 @@
    Previous web page */
 "Back" = "Обратно";
 
+/* Title for the Background Color section */
+"Background Color" = "Цвят на фона";
+
+/* Noun. Links to a blog's Jetpack Backups screen.
+   Noun. Name of the Backup feature
+   Title for Jetpack Backup Complete screen
+   Title for Jetpack Backup Status screen
+   Title for Jetpack Backup Update Status Failed screen */
+"Backup" = "Бекъп";
+
+/* Title for error displayed when preparing a backup fails. */
+"Backup failed" = "Създаването на бекъп е неуспешно";
+
+/* This description is used to set the accessibility label for the Period chart, with Comments selected. */
+"Bar Chart depicting Comments for the selected period." = "Графиката показва коментарите за избрания период.";
+
+/* This description is used to set the accessibility label for the Period chart, with Likes selected. */
+"Bar Chart depicting Likes for the selected period." = "Графиката показва харесванията за избрания период.";
+
+/* This description is used to set the accessibility label for the Period chart, with Views selected. */
+"Bar Chart depicting Views for selected period, Visitors superimposed" = "Графиката показва прегледите за избрания период, посетителите за сравнение";
+
+/* This description is used to set the accessibility label for the Period chart, with Visitors selected. */
+"Bar Chart depicting Visitors for the selected period." = "Графиката показва посетителите за избрания период.";
+
+/* This description is used to set the accessibility label for the chart in the Post Stats view. */
+"Bar Chart depicting visitors for this post" = "Графикта показва посетителите за тази публикация";
+
+/* This description is used to set the accessibility label for the chart in the Insights view. */
+"Bar Chart depicting visitors for your latest post" = "Графиката показва посетителите за последната публикация";
+
+/* Title for button on the post details page when there are no comments. */
+"Be the first to comment" = "Коментирайте първи";
+
+/* Beauty site intent topic */
+"Beauty" = "Красота";
+
+/* Screen reader text expressing the menu item is before another menu item. Argument is a name for another menu item. */
+"Before %@" = "Преди %@";
+
+/* 'Best Day' label for Most Popular stat. */
+"Best Day" = "Най-добър ден";
+
+/* 'Best Hour' label for Most Popular stat. */
+"Best Hour" = "Най-добър час";
+
+/* Title for a section of recommended site designs. The %@ will be replaced with the related site intent topic, such as Food or Blogging. */
+"Best for %@" = "Най-добър за %@";
+
+/* All Time Stats 'Best views ever' label */
+"Best views ever" = "Най-много прегледи";
+
+/* Noun. Links to a blog's Blaze screen. */
+"Blaze" = "Blaze";
+
 /* Accessibility label for block quote button on formatting toolbar.
    Discoverability title for block quote keyboard shortcut. */
 "Block Quote" = "Цитат";
 
+/* No comment provided by engineer. */
+"Block cannot be rendered because it is deeply nested. Tap here for more details." = "Блокът не може да се покаже, защото е дълбоко вложен. Докоснете за подробности.";
+
+/* translators: displayed right after the block is copied. */
+"Block copied" = "Блокът е копиран";
+
+/* translators: displayed right after the block is cut. */
+"Block cut" = "Блокът е изрязан";
+
+/* translators: displayed right after the block is duplicated. */
+"Block duplicated" = "Блокът е дублиран";
+
+/* translators: displayed right after the block is grouped */
+"Block grouped" = "Блокът е групиран";
+
 /* Jetpack Settings: Block malicious login attempts */
 "Block malicious login attempts" = "Блокиране на злонамерени опити за вписване";
 
+/* translators: displayed right after the block is pasted. */
+"Block pasted" = "Блокът е поставен";
+
+/* translators: displayed right after the block is removed. */
+"Block removed" = "Блокът е премахнат";
+
+/* No comment provided by engineer. */
+"Block settings" = "Настройки на блока";
+
+/* translators: displayed right after the block is ungrouped. */
+"Block ungrouped" = "Блокът е разгрупиран";
+
+/* Notice title when blocking a user succeeds. */
+"Blocked user" = "Блокиран потребител";
+
+/* Blocklist Title
+   Settings: Comments Blocklist */
+"Blocklist" = "Черен списък";
+
+/* No comment provided by engineer. */
+"Blocks allow you to focus on writing your content, knowing that all the formatting tools you need are there to help you get your message across." = "Блоковете позволяват да се фокусирате върху съдържанието, като знаете, че всички средства за форматиране са вече налични, за да ви помогнат да се изразите.";
+
+/* No comment provided by engineer. */
+"Blocks are pieces of content that you can insert, rearrange, and style without needing to know how to code. Blocks are an easy and modern way for you to create beautiful layouts." = "Блоковете са части от съдржание, които може да поставяте, подреждате и стилизирате без да променяте код. Блоковете са лесен и модерен начин за създаване на оформления.";
+
+/* No comment provided by engineer. */
+"Blocks menu" = "Меню за блокове";
+
+/* translators: Warning related to having blocks deeply nested. %d: The deepest nesting level. */
+"Blocks nested deeper than %d levels may not render properly in the mobile editor." = "Блокове, вградени един в друг повече от %d нива, може да не се покажат правилно в мобилния редактор.";
+
 /* Title of a button that displays the WordPress.com blog */
 "Blog" = "Блог";
+
+/* Title for the blogging section in site settings screen */
+"Blogging" = "Блогване";
+
+/* Label for the blogging reminders setting */
+"Blogging Reminders" = "Напомняния за блогване";
 
 /* Accessibility label for bold button on formatting toolbar.
    Discoverability title for bold formatting keyboard shortcut. */
 "Bold" = "Удебеляване";
 
+/* Books site intent topic */
+"Books" = "Книги";
+
+/* No comment provided by engineer. */
+"Border Radius" = "Радиус на рамката";
+
+/* No comment provided by engineer. */
+"Border Settings" = "Настройки за рамката";
+
 /* Text snippet summarizing what comment paging does. */
 "Break comment threads into multiple pages." = "Разделяне на коментарите на страници.";
+
+/* No comment provided by engineer. */
+"Briefly describe the link to help screen reader user" = "Опишете кратко връзката за подпомагане на екрани четци";
+
+/* Jetpack Settings: Brute Force Attack Protection Section */
+"Brute Force Attack Protection" = "Защита от брутфорс атаки";
+
+/* No comment provided by engineer. */
+"Build layouts" = "Създаване на оформления";
 
 /* Discoverability title for bullet list keyboard shortcut. */
 "Bullet List" = "Неподреден списък";
 
+/* Business site intent topic */
+"Business" = "Бизнес";
+
 /* Title of a prompt letting the user know that they must wait until the current aciton completes. */
 "Busy" = "Изчакайте";
 
+/* No comment provided by engineer. */
+"Button Link URL" = "Адрес на връзката";
+
 /* Title for a list of different button styles. */
 "Button Style" = "Стил на бутона";
+
+/* No comment provided by engineer. */
+"Button position" = "Позиция на бутона";
+
+/* No comment provided by engineer. */
+"Button to copy error details" = "Бутон за копиране на грешката";
+
+/* No comment provided by engineer. */
+"Button to copy post text" = "Бутон за копиране на публикацията";
+
+/* Legal disclaimer for logging in. The underscores _..._ denote underline. */
+"By continuing, you agree to our _Terms of Service_." = "Като продължавате, се съгласявате на нашите _условия за ползване_.";
+
+/* Terms of Service link displayed when a user is registering domain. Text inside <a> tags will be highlighted. */
+"By registering this domain you agree to our <a>Terms&nbsp;and&nbsp;Conditions<\/a>." = "Като регистрирате домейн се съгласявате с нашите <a>условия на ползване<\/a>.";
+
+/* Title of the button which opens the Jetpack terms and conditions page. The sentence is composed by 2 lines separated by a line break 
+. Also there is a placeholder %@ which is: Terms and Conditions */
+"By setting up Jetpack you agree to our\n%@" = "Чрез настройване на Jetpack, вие се съгласявате на нашите\n%@";
+
+/* Legal disclaimer for signup buttons, the underscores _..._ denote underline */
+"By signing up, you agree to our _Terms of Service_." = "Като се регистрирате, вие се съгласявате с нашите условия за използване.";
+
+/* No comment provided by engineer. */
+"CUSTOMIZE" = "НАСТРОЙКА";
 
 /* Label for size of media while it's being calculated. */
 "Calculating..." = "Пресмятане...";
@@ -289,8 +1032,17 @@
 /* Accessibility label for taking an image or video with the camera on formatting toolbar. */
 "Camera" = "Камера";
 
+/* Title of an alert informing the user the camera permission for the app is disabled and its needed to proceed */
+"Camera access needed to scan login codes" = "Нужен е достъп до камерата, за да се сканират кодове за влизане";
+
 /* Title of an alert letting the user know */
 "Can Not Request Link" = "Неуспешно изискване на връзка";
+
+/* Alert message that is shown when trying to publish empty page */
+"Can't publish an empty page" = "Не можете да публикувате празна страница";
+
+/* Alert message that is shown when trying to publish empty post */
+"Can't publish an empty post" = "Не можете да публикувате празна публикация";
 
 /* Alert dismissal title
    Button label that dismisses the qr log in flow and returns the user back to the previous screen
@@ -326,7 +1078,6 @@
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Отказ";
@@ -339,12 +1090,29 @@
 /* Dialog box title for when the user is canceling an upload. */
 "Cancel media uploads" = "Отмяна на качването";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* No comment provided by engineer. */
+"Cancel search" = "Отмяна на търсенето";
+
+/* Share extension dialog dismiss button label - displayed when user is missing a login token. */
+"Cancel sharing" = "Отмяна на споделянето";
+
+/* A short message that informs the user the share extension is being canceled. */
+"Canceling..." = "Отмяна...";
+
+/* Error message shown when the input URL does not point to an existing site. */
+"Cannot access the site at this address. Please double-check and try again." = "Не може да се достъпи този адрес. Моля, проверете и пробвайте пак.";
+
+/* Helper text that appears at the bottom of the design screen. */
+"Can’t decide? You can change the theme at any time." = "Не можете да решите? Може да промените темата по всяко време.";
+
+/* Image caption field label (for editing) */
 "Caption" = "Надпис";
 
 /* Alert title. */
 "Careful!" = "Внимание!";
+
+/* Example prompt for the Prompts card in Feature Introduction. */
+"Cast the movie of your life." = "Играйте в киното на живота.";
 
 /* Category menu item in share extension. */
 "Category" = "Категория";
@@ -355,17 +1123,162 @@
 /* Popup title for wrong SSL certificate. */
 "Certificate error" = "Грешка със сертификата";
 
+/* Account Settings Change password label
+   Main title */
+"Change Password" = "Смяна на паролата";
+
+/* Change Username title. */
+"Change Username" = "Промяна на потребителско име";
+
+/* No comment provided by engineer. */
+"Change block position" = "Промяна на позицията на блока";
+
 /* Message to show when Publicize globally shared setting failed */
 "Change failed" = "Промяната е неуспешна";
+
+/* Accessibility hint for web preview device switching button */
+"Change the device type used for preview" = "Изберете вид устройство, което да се ползва за преглед";
 
 /* Instructions for editing the sharing label. */
 "Change the text of the sharing buttons' label. This text won't appear until you add at least one sharing button." = "Промяна на текста на бутоните за споделяне. Този текст няма да се появи преди да добавите поне един бутон за споделяне.";
 
+/* Change button. */
+"Change username" = "Промяна на потребителя";
+
+/* No comment provided by engineer. */
+"Changes to featured image will not be affected by the undo\/redo buttons." = "Промените на основното изображение няма да бъдат засегнати от бутоните отмяна\/повторение.";
+
+/* Shown while the app waits for the display name changing web service to return. */
+"Changing display name" = "Промяна на публичното име";
+
+/* Loader title displayed by the loading view while the password is changing
+   Shown while the app waits for the password changing web service to return. */
+"Changing password" = "Промяна на паролата";
+
+/* Shown while the app waits for the username changing web service to return. */
+"Changing username" = "Промяна на потребителско име";
+
 /* Title of alert when getting purchases fails */
 "Check Purchases Error" = "Грешка при изтегляне на покупките";
 
+/* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
+"Check out our top tips to increase your views and traffic" = "Проверете нашите съвети за увеличаване на прегледите и трафика";
+
+/* The title text on the magic link requested screen. */
+"Check your email on this device!" = "Проверете имейла на това устройство!";
+
+/* Instruction text after a login Magic Link was requested. */
+"Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Проверете имейла на това устройство и посетете връзката в имейла, който имате от WordPress.com.";
+
+/* Instructional text on how to open the email containing a magic link. */
+"Check your email on this device, and tap the link in the email you received from WordPress.com.\n\nNot seeing the email? Check your Spam or Junk Mail folder." = "Проверете имейла си на това устройство и заредете връзката в имейла от WordPress.com.\n\nАко не виждате такъв имейл, проверете си спам или junk папката.";
+
+/* Alert title for check your email during logIn/signUp. */
+"Check your email!" = "Проверете си имейла!";
+
+/* Subtitle shown on the dashboard when it fails to load */
+"Check your internet connection and pull to refresh." = "Проверете Интернет връзката и дръпнете за презареждане.";
+
+/* Default subtitle for no-results when there is no connection with a prompt to create a new page instead. */
+"Check your network connection and try again or create a blank page." = "Проверете Интернет връзката и пробвайте да създадете празна страница.";
+
+/* Default subtitle for no-results when there is no connection
+   Default subtitle for no-results when there is no connection. */
+"Check your network connection and try again." = "Проверете Интернет връзката и пробвайте отново.";
+
+/* Subtitle for No results full page screen displayed from pages list when there is no connection */
+"Check your network connection and try again. Or draft a page." = "Проверете Интернет връзката и пробвайте отново. Или създайте чернова.";
+
+/* Subtitle for No results full page screen displayed from post list when there is no connection */
+"Check your network connection and try again. Or draft a post." = "Проверете Интернет връзката си и пробвайте пак или създайте чернова.";
+
 /* Overlay message displayed while checking if site has premium purchases */
 "Checking purchases…" = "Изтегляне на покупките...";
+
+/* Screen reader text expressing the menu item is a child of another menu item. Argument is a name for another menu item. */
+"Child of %@" = "Дете на %@";
+
+/* Title for the button to progress with the selected site homepage design
+   Title for the button to progress with the selected site homepage design. */
+"Choose" = "Избор";
+
+/* Title for selecting a new homepage */
+"Choose Homepage" = "Избор на начална страница";
+
+/* Title for settings section which allows user to select their home page and posts page */
+"Choose Pages" = "Изберете страница";
+
+/* Title for selecting a new posts page */
+"Choose Posts Page" = "Избор на страница с публикации";
+
+/* Title for the screen to pick a template for a page */
+"Choose a Layout" = "Избор на оформление";
+
+/* Select domain name. Title */
+"Choose a domain" = "Избор на домейн";
+
+/* No comment provided by engineer. */
+"Choose a file" = "Изберете файл";
+
+/* OK Button title shown in alert informing users about the Reader Save for Later feature. */
+"Choose a new app icon" = "Избор на нова икона на приложението";
+
+/* Title for the screen to pick a theme and homepage for a site. */
+"Choose a theme" = "Избор на тема";
+
+/* Select the site's intent. Subtitle */
+"Choose a topic from the list below or type your own." = "Изберете тема от списъка по-долу или въведете своя.";
+
+/* No comment provided by engineer. */
+"Choose audio" = "Избор на аудио";
+
+/* No comment provided by engineer. */
+"Choose file" = "Избор на файл";
+
+/* Explanatory text for Homepage Settings homepage type selection. */
+"Choose from a homepage that displays your latest posts (classic blog) or a fixed \/ static page." = "Изберете между начална страница с последните публикации (блог) или статична страница.";
+
+/* No comment provided by engineer. */
+"Choose from device" = "Избор от устройството";
+
+/* No comment provided by engineer. */
+"Choose image" = "Избор на изображение";
+
+/* No comment provided by engineer. */
+"Choose image or video" = "Избор на изображение или видео";
+
+/* No comment provided by engineer. */
+"Choose images" = "Избор на изображения";
+
+/* Shortened version of the main title to be used in back navigation */
+"Choose layout" = "Избор на оформление";
+
+/* Downloadable items: general section title */
+"Choose the items to download" = "Избор на елементи за изтегляне";
+
+/* Restorable items: general section title */
+"Choose the items to restore" = "Избор на елементи за възстановяване";
+
+/* No comment provided by engineer. */
+"Choose video" = "Избор на видео";
+
+/* Register Domain - Address information field City */
+"City" = "Град";
+
+/* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
+"Claim your free domain" = "Вземете безплатен домейн";
+
+/* Label for button that clears all media cache. */
+"Clear Device Media Cache" = "Изчистване на кешираните файлове.";
+
+/* Label for button that clears the spotlight index on device. */
+"Clear Spotlight Index" = "Изчистване на Spotlight индекса";
+
+/* No comment provided by engineer. */
+"Clear search" = "Изчистване на търсенето";
+
+/* No comment provided by engineer. */
+"Clear selected color" = "Изчистване на избрания цвят";
 
 /* Label for size of media while it's being cleared. */
 "Clearing..." = "Изчистване...";
@@ -377,14 +1290,44 @@
 /* Action button to close the editor */
 "Close" = "Затваряне";
 
+/* Close account action label */
+"Close Account" = "Закриване на профила";
+
 /* Settings: Close comments after X period */
 "Close Commenting" = "Затваряне на дискусията";
+
+/* Accessibility label for button that closes the media picker on formatting toolbar */
+"Close Media Picker" = "Затвори избора на медия";
 
 /* Close comments after a given number of days */
 "Close after" = "Затваряне след";
 
 /* Close Comments Title */
 "Close commenting" = "Затваряне на дискусията";
+
+/* Overlay message displayed while closing account */
+"Closing account…" = "Закриване на профила...";
+
+/* Accessibility label for selecting code style button on the formatting toolbar. */
+"Code" = "Код";
+
+/* Accessibility hint */
+"Collapsed. Tap to expand." = "Събрано. Докоснете за разгръщане.";
+
+/* Label for switch to turn on/off sending app usage data */
+"Collect information" = "Събиране на информация";
+
+/* Title displayed for selection of custom app icons that have colorful backgrounds. */
+"Colorful backgrounds" = "Цветни фонове";
+
+/* translators: %d: column index. */
+"Column %d" = "Колона %d";
+
+/* No comment provided by engineer. */
+"Column Settings" = "Настройки на колоната";
+
+/* No comment provided by engineer. */
+"Columns Settings" = "Настройки за колоните";
 
 /* Header for a comment's content, shown when editing a comment.
    Text for the 'comment' when there is 1 or 0 comments */
@@ -393,11 +1336,39 @@
 /* Title for the `comment likes` setting */
 "Comment Likes" = "Харесвания на коментари";
 
+/* Message displayed when approving a comment succeeds. */
+"Comment approved." = "Коментарът бе одобрен.";
+
+/* Message displayed when deleting a comment succeeds. */
+"Comment deleted." = "Коментарът е изтрит.";
+
 /* Displayed when a Comment is deleted */
 "Comment has been deleted" = "Коментарът бе изтрит";
 
 /* Displayed when a Comment is spammed */
 "Comment has been marked as Spam" = "Коментарът бе маркиран като спам";
+
+/* Message displayed when spamming a comment succeeds. */
+"Comment marked as spam." = "Коментарът е маркиран като спам.";
+
+/* Message displayed when trashing a comment succeeds. */
+"Comment moved to trash." = "Коментарът е преместен в кошчето.";
+
+/* Provides hint that the current screen displays a comment on a post. The title of the post will displayed below this string. Example: Comment on 
+ My First Post */
+"Comment on" = "Коментар на";
+
+/* Message displayed when approving a comment succeeds. */
+"Comment set to approved." = "Коментарът е одобрен.";
+
+/* Message displayed when pending a comment succeeds. */
+"Comment set to pending." = "Коментарът сега е изчакващ.";
+
+/* Hint for users to grow their audience by commenting on other blogs. */
+"Comment to start making connections." = "Коментирайте, за да създадете контакти.";
+
+/* A tip displayed to the user in the stats section to help them gain more followers. */
+"Commenting on other blogs is a great way to build attention and followers for your new site." = "Коментирането на други блогове е добър начин за да откриете последователи.";
 
 /* Comments table header label.
    Filters Comments Notifications
@@ -410,6 +1381,9 @@
    Title for the Blog's Comments Section View
    Today's Stats 'Comments' label */
 "Comments" = "Коментари";
+
+/* Displayed on the post details page when there are no post comments and commenting is closed. */
+"Comments are closed" = "Коментарите са затворени";
 
 /* Sentence fragment. The full phrase is 'Comments on' followed by the title of a post on a separate line. */
 "Comments on" = "Коментари на";
@@ -426,17 +1400,32 @@
 /* Setting: WordPress.com Community */
 "Community" = "Общност";
 
+/* Community & Non-Profit site intent topic */
+"Community & Non-Profit" = "Организация с нестопанска цел";
+
 /* Section title for the configure table section in the blog details screen */
 "Configure" = "Конфигуриране";
 
 /* Verb. Title for Jetpack Restore confirm button. */
 "Confirm" = "Потвърждаване";
 
+/* Close Account alert title */
+"Confirm Close Account" = "Потвърдете закриването на профила";
+
 /* Title of Delete Site confirmation alert */
 "Confirm Delete Site" = "Потвърдете, че искате да изтриете този сайт";
 
 /* Instructional text about the Sharing feature. */
 "Confirm this is the account you would like to authorize. Note that your posts will be automatically shared to this account." = "Потвърдете, че това е потребителя, който искате да оторизирате. Имайте предвид, че вашите публикации ще бъдат споделени с този потребител.";
+
+/* Alert text field placeholder. */
+"Confirm username" = "Потвърждаване на потребителя";
+
+/* Title of alert prompting users to verify their accounts while attempting to publish */
+"Confirm your email first" = "Моля потвърдете първо Вашият email";
+
+/* Title of domain name purchase success screen */
+"Congratulations on your purchase!" = "Поздравления за покупката!";
 
 /* Verb. Tapping connects an account to Publicize.
    Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
@@ -457,6 +1446,9 @@
 /* Noun. Title. Title for the list of accounts for third party sharing services. */
 "Connected Accounts" = "Свързани профили";
 
+/* Title shown when a user logs in with Google but no matching WordPress.com account is found */
+"Connected But…" = "Свързан но...";
+
 /* Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name
    Connecting is a verb. Title of Publicize account selection. The %@ is a placeholder for the service's name. */
 "Connecting %@" = "Свързване на %@";
@@ -469,6 +1461,10 @@
 
 /* Verb. Text label. Allows the user to connect to a third-party sharing service like Facebook or Twitter. */
 "Connecting..." = "Свързване...";
+
+/* Message to show when Publicize authorization is canceled
+   Message to show when Publicize connection is canceled by the user. */
+"Connection canceled" = "Връзката бе отменена";
 
 /* Message to show when Publicize authorization failed
    Message to show when Publicize connect failed */
@@ -485,6 +1481,9 @@
 /* Button label for contacting support */
 "Contact support" = "Връзка с отдела по поддръжка";
 
+/* Alert title for contact us alert, placeholder for help email address, inserted at run time. */
+"Contact us at %@" = "Свържете се с нас на %@";
+
 /* Apply changes localy to single block edition in the web block editor
    Button to progress to the next step
    The button title text when there is a next step for logging in or signing up.
@@ -494,11 +1493,56 @@
    Title of the continue button for the Site Intent screen. */
 "Continue" = "Напред";
 
+/* Button title. Takes the user to the login with WordPress.com flow. */
+"Continue With WordPress.com" = "Продължаване с WordPress.com";
+
 /* Menus alert button title to continue making changes. */
 "Continue Working" = "Продължаване";
 
 /* Part of a prompt suggesting that there is more content for the user to read. */
 "Continue reading" = "Продължете да четете";
+
+/* Button title. Tapping begins log in using Apple. */
+"Continue with Apple" = "Продължаване с Apple";
+
+/* Button title. Tapping begins log in using Google. */
+"Continue with Google" = "Продължаване с Google";
+
+/* Shown while logging in with Apple and the app waits for the site creation process to complete. */
+"Continuing with Apple" = "Продължаване с Apple";
+
+/* Title of button that displays the WordPress.org contributor page */
+"Contribute" = "Допринасяне";
+
+/* No comment provided by engineer. */
+"Convert to link" = "Превръщане във връзка";
+
+/* An example tag used in the login prologue screens. */
+"Cooking" = "Готварство";
+
+/* No comment provided by engineer. */
+"Copied block" = "Блокът е копиран";
+
+/* Copy link to oomment button title */
+"Copy Link to Comment" = "Копиране на връзка към коментара";
+
+/* translators: Copy URL from the clipboard, https://sample.url */
+"Copy URL from the clipboard, %s" = "Копирайте адреса от междинната памет, %s";
+
+/* No comment provided by engineer. */
+"Copy error details" = "Копиране на грешката";
+
+/* No comment provided by engineer. */
+"Copy file URL" = "Копиране на адреса на файла";
+
+/* No comment provided by engineer. */
+"Copy post text" = "Копиране на текста на публикацията";
+
+/* Title of a prompt informing the user there was a probem unsubscribing from a topic in the reader. */
+"Could Not Follow Topic" = "Неуспешно последване на тема";
+
+/* Title of a prompt informing the user there was a probem unsubscribing from a topic in the reader. */
+"Could Not Remove Topic" = "Неуспешно премахване на тема";
 
 /* Title of an prompt letting the user know there was a problem saving. */
 "Could Not Save Changes" = "Промените не бяха запазени";
@@ -506,17 +1550,74 @@
 /* Message shown when site purchases API failed */
 "Could not check site purchases." = "Неуспешно изтегляне на покупките.";
 
+/* The app failed to disable notifications for the subscription */
+"Could not disable notifications" = "Неуспешно изключване на известията";
+
+/* The app failed to enable notifications for the subscription */
+"Could not enable notifications" = "Неуспешно включване на известията";
+
 /* Error message informing the user that there was a problem subscribing to a site or feed. */
 "Could not follow the site at the address specified." = "Не може да се отабонирате от сайта на указания адрес";
+
+/* Error message shown when the user scanned an expired log in code. */
+"Could not log you in using this log in code. Please tap the Scan Again button to rescan the code." = "Неуспешен вход с кода за влизане. Моля, сканирайте отново кода.";
+
+/* Title of a prompt. */
+"Could not remove post from Saved for Later" = "Неуспешно премахване на публикацията от Запомнени за после";
+
+/* Title of a prompt. */
+"Could not save post for later" = "Неуспешно запазване на публикацията за после";
+
+/* The app failed to subscribe to the comments for the post */
+"Could not subscribe to comments" = "Неуспешно абониране за коментари";
 
 /* An error description explaining that Follow could not be toggled due to a missing blogURL attribute. */
 "Could not toggle Follow: missing blogURL attribute" = "Неуспешна промяна на следването: липсва атрибута blogURL";
 
+/* An error description explaining that Seen could not be toggled due to a missing feedItemID. */
+"Could not toggle Seen: missing feedItemID." = "Неуспешно променяне на Видяно: липсва feedItemID";
+
+/* An error description explaining that Seen could not be toggled due to a missing postID. */
+"Could not toggle Seen: missing postID." = "Неуспешно променяне на Видяно: липсва postID";
+
 /* Error message informing the user that there was a problem unsubscribing to a site or feed. */
 "Could not unfollow the site at the address specified." = "Неуспешно отабонриане на сайта от посочения адрес.";
 
+/* The app failed to unsubscribe from the comments for the post */
+"Could not unsubscribe from comments" = "Неуспешно премахване на абонамент за коментари";
+
+/* Title for the error view when the user scanned an invalid log in code */
+"Could not validate the log in code" = "Неуспешно валидиране на кода за влизане";
+
 /* This is the text we display to the user when we ask them for a review and they've indicated they don't like the app */
 "Could you tell us how we could improve?" = "С какво можем да бъдем по-добри?";
+
+/* Error message shown a URL points to a valid site but not a WordPress site. */
+"Couldn't connect to the WordPress site. There is no valid WordPress site at this address. Check the site address (URL) you entered." = "Неуспешно свързване с WordPress сайта. На този адрес няма валиден WordPress. Проверете въведения адрес (URL).";
+
+/* Message to show to user when he tries to add a self-hosted site with RSD link present, but xmlrpc is missing. */
+"Couldn't connect. Required XML-RPC methods are missing on the server. Please contact your hosting provider to solve this problem." = "Неуспешна връзка. Изискваните XML-RPC методи не са налични. Моля, свържете се с хостинг доставчика си.";
+
+/* Message to show to user when he tries to add a self-hosted site but the host returned a 403 error, meaning that the access to the /xmlrpc.php file is forbidden. */
+"Couldn't connect. We received a 403 error when trying to access your site's XMLRPC endpoint. The app needs that in order to communicate with your site. Please contact your hosting provider to solve this problem." = "Неуспешно свързване. Получихме грешка 403 при опит за достъп до XMLRPC края на вашия сайт. Приложението се нуждае от него, за да комуникира с вашия сайт. Моля, свържете се с вашия хостинг, за да решите този проблем.";
+
+/* Message to show to user when he tries to add a self-hosted site but the host returned a 405 error, meaning that the host is blocking POST requests on /xmlrpc.php file. */
+"Couldn't connect. Your host is blocking POST requests, and the app needs that in order to communicate with your site. Please contact your hosting provider to solve this problem." = "Неуспешно свързване. Вашият хост блокира POST заявки, а приложението се нуждае от тях, за да комуникира с вашия сайт. Моля, свържете се с вашия хостинг, за да решите проблема.";
+
+/* Content show when the dashboard fails to load */
+"Couldn't load data. Please refresh again later." = "Неуспешно зареждане. Опитайте отново по-късно.";
+
+/* Error message when tag loading failed */
+"Couldn't load tags. Tap to retry." = "Неуспешно зареждане на етикети. Докоснете за повторно зареждане.";
+
+/* Indicating that referrer couldn't be marked as spam */
+"Couldn't mark as spam" = "Неуспешно маркиране като спам";
+
+/* Indicating that referrer couldn't be unmarked as spam */
+"Couldn't unmark as spam" = "Неуспешно отмаркиране от спам";
+
+/* Error title displayed when unable to close user account. */
+"Couldn’t close account automatically" = "Неуспешно затваряне на профила";
 
 /* Period Stats 'Countries' header */
 "Countries" = "Държава";
@@ -525,36 +1626,152 @@
    Register Domain - Domain contact information field Country */
 "Country" = "Страна";
 
+/* Register Domain - Address information field Country Code */
+"Country Code" = "Код на държавата";
+
+/* Label for switch to turn on/off sending crashes info */
+"Crash reports" = "Краш доклади";
+
+/* Accessibility label for create floating action button */
+"Create" = "Създаване";
+
 /* The button title text for creating a new account. */
 "Create Account" = "Създаване на профил";
+
+/* Title for button to make a blank page */
+"Create Blank Page" = "Създаване на празна страница";
+
+/* Create New header text */
+"Create New" = "Създаване на нов";
+
+/* Button for selecting the current page template.
+   Title for button to make a page with the contents of the selected layout */
+"Create Page" = "Създаване на страница";
 
 /* Button to progress to the next step
    Site creation. Step 1. Screen title
    Title for the button to progress with creating the site with the selected design. */
 "Create Site" = "Създаване на сайт";
 
+/* Button allowing the user to create a site icon by choosing an emoji character */
+"Create With Emoji" = "Създаване с емотикони";
+
+/* Displayed in the Notifications Tab as a button title, when the Unread Filter shows no notifications */
+"Create a Post" = "Създаване на публикация";
+
+/* Navigates to a new flow for site creation. */
+"Create a Site" = "Създаване на сайт";
+
+/* Title for the Site Icon Picker */
+"Create a site icon" = "Създаване на икона на сайта";
+
+/* Label that describes the download backup action */
+"Create downloadable backup" = "Създаване на бекъп за изтегляне";
+
+/* Button title for download backup action */
+"Create downloadable file" = "Създаване на файл за изтегляне";
+
+/* No comment provided by engineer. */
+"Create embed" = "Създаване на вграждане";
+
+/* No comment provided by engineer. */
+"Create link" = "Създаване на връзка";
+
 /* Menus alert message for alerting the user to unsaved changes while trying to create a new menu. */
 "Creating a new menu will discard changes you've made to the current menu. Are you sure you want to continue?" = "Създаването на ново меню ще отмени промените които сте направили към текущото меню. Сигурни ли сте, че искате да продължите?";
 
+/* User-facing string, presented to reflect that site assembly is underway. */
+"Creating dashboard" = "Създаване на табло";
+
+/* No comment provided by engineer. */
+"Crosspost" = "Кроспост";
+
 /* Current Theme text that appears in Theme Browser Header */
 "Current Theme" = "Настояща тема";
+
+/* Period Accessibility label. Prefix the current selected period. Ex. Current period: 2019 */
+"Current period: %@" = "Текущ период: %@";
+
+/* Week Period Accessibility label. Prefix the current selected period. Ex. Current period: Jan 6 to Jan 12. */
+"Current period: %@ to %@" = "Текущ период: от %1$@ до %2$@";
+
+/* No comment provided by engineer. */
+"Current placeholder text is" = "Текущият временен текст е";
+
+/* translators: accessibility text. Inform about current unit value. %s: Current unit value. */
+"Current unit is %s" = "Текущата мярка е %s";
+
+/* translators: %s: current cell value. */
+"Current value is %s" = "Текущата стойност е %s";
+
+/* Title for the Jetpack Backup Status message. */
+"Currently creating a downloadable backup of your site" = "Създава се бекъп, подходящ за изтегляне";
+
+/* Title for the Jetpack Restore Status message. */
+"Currently restoring site" = "В момента се възстановява сайта";
+
+/* Description of the current entry being restored. %1$@ is a placeholder for the specific entry being restored. */
+"Currently restoring: %1$@" = "В момента се възстановява: %1$@";
+
+/* No comment provided by engineer. */
+"Custom URL" = "Адрес по избор";
+
+/* Placeholder for Invite People message field. */
+"Custom message…" = "Персонализирано съобщение...";
 
 /* Customize button that appears in Theme Browser Header
    Theme Customize action title */
 "Customize" = "Персонализиране";
 
+/* No comment provided by engineer. */
+"Customize Gradient" = "Персонализиране на преливане";
+
+/* No comment provided by engineer. */
+"Customize blocks" = "Персонализация на блокове";
+
 /* Notification Settings for your own blogs */
 "Customize your site settings for Likes, Comments, Follows, and more." = "Задаване на настройки за харесвания, коментари, абонаменти и други.";
 
+/* No comment provided by engineer. */
+"Cut block" = "Изрязване на блок";
+
+/* DIY site intent topic */
+"DIY" = "Направи си сам";
+
+/* Title for the app appearance setting for dark mode */
+"Dark" = "Тъмно";
+
 /* Action title. Noun. Opens the user's WordPress.com dashboard in an external browser. */
 "Dashboard" = "Табло";
+
+/* Title for a threat that includes the number of database rows affected */
+"Database %1$d threats" = "Заплаха за базата данни %1$d";
+
+/* Title for a threat */
+"Database threat" = "Заплаха в базата данни";
+
+/* Blog Writing Settings: Date Format
+   Writing Date Format Settings Title */
+"Date Format" = "Формат на датата";
+
+/* Label for selecting the date and time settings section
+   Title for the Date and Time Format Settings Screen */
+"Date and Time Format" = "Формат на дата и час";
+
+/* Navigates to debug menu only available in development builds */
+"Debug" = "Дебъг";
+
+/* Only December needs to be translated */
+"December 17, 2017" = "17-ти декември, 2017";
+
+/* No comment provided by engineer. */
+"Deeply nested block" = "Дълбоко вложен блок";
 
 /* Description of the default paragraph formatting style in the editor.
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "По подразбиране";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Категория по подразбиране";
 
 /* Label for selecting the default post format
@@ -563,9 +1780,6 @@
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "По подразбиране за нови публикации";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Изтриване";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Изтриване на менюто";
@@ -581,25 +1795,43 @@
 /* Title of alert when site deletion fails */
 "Delete Site Error" = "Грешка при изтриване на сайта";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Изтрито!";
+/* Screen Reader: Button that deletes a menu. */
+"Delete menu" = "Изтриване на менюто";
 
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Изтриване на сайт...";
 
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Изтриване...";
+/* Verb. Denies a 2fa authentication challenge. */
+"Deny" = "Отказ";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* No comment provided by engineer. */
+"Describe the purpose of the image. Leave empty if decorative." = "Опишете целта на изображението. Оставете празно, ако е декоративно.";
+
+/* Title of section that contains plugins' description */
 "Description" = "Описание";
+
+/* Shortened version of the main title to be used in back navigation. */
+"Design" = "Дизайн";
+
+/* Navigates to design system gallery only available in development builds */
+"Design System" = "Дизайн система";
+
+/* Title for the desktop web preview */
+"Desktop" = "Компютър";
 
 /* Details button that appears in the Theme Browser Header
    Theme Details action title */
 "Details" = "Детайли";
 
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Размери";
+/* Instructions after a Magic Link was sent, but email is incorrect. */
+"Didn't mean to create a new account? Go back to re-enter your email address." = "Не искахте да създадете нов профил? Върнете се и въведете вашия имейл.";
+
+/* Title. Title of a button that will disable group invite links when tapped. */
+"Disable" = "Изключване";
+
+/* Title. A call to action to disable invite links.
+   Title. Title of a prompt to disable group invite links. */
+"Disable invite link" = "Деактивиране на връзката за покана";
 
 /* Adjective. Comment threading is disabled. */
 "Disabled" = "Изключено";
@@ -642,12 +1874,27 @@
    Accessibility label for the transparent space above the signup dialog which acts as a button to dismiss the dialog. */
 "Dismiss" = "Премахване";
 
+/* Accessibility hint for the continue button in the Feature Announcements screen. */
+"Dismiss announcements" = "Скриване на анонсите";
+
+/* Accessibility hint for a done button that dismisses the current modal screen */
+"Dismiss screen" = "Затваряне на екрана";
+
 /* Display Name label text.
    User's Display Name */
 "Display Name" = "Публично име";
 
+/* Register Domain - Domain contact information section header title */
+"Domain contact information" = "Информация за контакт на домейна";
+
+/* Register Domain - Privacy Protection section header description */
+"Domain owners have to share contact information in a public database of all domains. With Privacy Protection, we publish our own information instead of yours and privately forward any communication to you." = "Собствениците на домейни трябва да споделят информация за контакт в публична база данни. Със защита на поверителността, ние ще публикуваме наша информация, вместо вашата, и ще ви препращаме комуникацията към вас.";
+
 /* Noun. Title. Links to the Domains screen. */
 "Domains" = "Домейни";
+
+/* Label for button to log in using your site address. The underscores _..._ denote underline */
+"Don't have an account? _Sign up_" = "Нямате профил? _Регистрация_";
 
 /* A done button
    Button text on site creation epilogue page to proceed to My Sites.
@@ -661,6 +1908,138 @@
    Title for the button that will dismiss this view. */
 "Done" = "Готово";
 
+/* Title for label when there are no threats on the users site */
+"Don’t worry about a thing" = "Не се тревожете за нищо";
+
+/* No comment provided by engineer. */
+"Double tap and hold to edit" = "Двойно докосване и задържане за промяна";
+
+/* Screen reader hint for button that will move the menu item */
+"Double tap and hold to move this menu item up or down. Move horizontally to change hierarchy." = "Докоснете два пъти и преместете този елемент нагоре или надолу. Преместете хоризонтално, за да смените йерархията.";
+
+/* No comment provided by engineer. */
+"Double tap to add a block" = "Двойно докосване за добавяне на блок";
+
+/* No comment provided by engineer. */
+"Double tap to add a link." = "Двойно докосване за добавяне на връзка.";
+
+/* Voiceover accessibility hint informing the user they can double tap a modal alert to dismiss it */
+"Double tap to dismiss" = "Натиснете два пъти, за да изчезне";
+
+/* No comment provided by engineer. */
+"Double tap to edit button text" = "Двойно докосване за редакция на бутона";
+
+/* No comment provided by engineer. */
+"Double tap to edit label text" = "Двойно докосване за редакция на етикета";
+
+/* No comment provided by engineer. */
+"Double tap to edit placeholder text" = "Двойно докосване за редакция на примерния текст";
+
+/* translators: accessibility text */
+"Double tap to edit this value" = "Двойно докосване за промяна на стойността";
+
+/* translators: accessibility text (hint for moving to color settings) */
+"Double tap to go to color settings" = "Двойно докосване за настройки на цветовете";
+
+/* No comment provided by engineer. */
+"Double tap to listen the audio file" = "Двойно докосване, за слушане на аудио";
+
+/* No comment provided by engineer. */
+"Double tap to move the block down" = "Двойно докосване за преместване на блока надолу";
+
+/* No comment provided by engineer. */
+"Double tap to move the block to the left" = "Двойно докосване за преместване на блока в ляво";
+
+/* No comment provided by engineer. */
+"Double tap to move the block to the right" = "Двойно докосване за преместване на блока в дясно";
+
+/* No comment provided by engineer. */
+"Double tap to move the block up" = "Двойно докосване за преместване на блока нагоре";
+
+/* No comment provided by engineer. */
+"Double tap to open Action Sheet to add image or video" = "Двойно докосване за отваряне на панела за добавяне на видео или изображение";
+
+/* No comment provided by engineer. */
+"Double tap to open Action Sheet to edit, replace, or clear the image" = "Двойно докосване за отваряне на панела за редактиране, замяна или премахване на изображението";
+
+/* No comment provided by engineer. */
+"Double tap to open Action Sheet with available options" = "Двойно докосване за отваряне на панела с налични опции";
+
+/* No comment provided by engineer. */
+"Double tap to open Bottom Sheet to add image or video" = "Двойно докосване за отваряне на долния панел за добавяне на изображение или видео";
+
+/* No comment provided by engineer. */
+"Double tap to open Bottom Sheet to edit, replace, or clear the image" = "Двойно докосване за отваряне на долния панел за редактиране, замяна или премахване на изображението";
+
+/* No comment provided by engineer. */
+"Double tap to open Bottom Sheet with available options" = "Двойно докосване за отваряне на долния панел с налични опции";
+
+/* No comment provided by engineer. */
+"Double tap to preview page." = "Двойно докосване за преглед на страницата.";
+
+/* No comment provided by engineer. */
+"Double tap to preview post." = "Двойно докосване за преглед на публикацията.";
+
+/* No comment provided by engineer. */
+"Double tap to select" = "Двойно докосване за избор";
+
+/* No comment provided by engineer. */
+"Double tap to select a video" = "Двойно докосване за избор на видео";
+
+/* No comment provided by engineer. */
+"Double tap to select an audio file" = "Двойно докосване, за избор на аудио файл";
+
+/* No comment provided by engineer. */
+"Double tap to select an image" = "Двойно докосване за избор на изображение";
+
+/* No comment provided by engineer. */
+"Double tap to select default font size" = "Двойно докосване за избор на размер шрифт по подразбиране";
+
+/* No comment provided by engineer. */
+"Double tap to select font size" = "Двойно докосване за избор на размер шрифт";
+
+/* translators: accessibility text (hint for selecting option) */
+"Double tap to select the option" = "Двойно докосване за избор на опция";
+
+/* translators: accessibility text (hint for switches) */
+"Double tap to toggle setting" = "Двойно докосване за промяна на настройки";
+
+/* No comment provided by engineer. */
+"Double tap to view embed options." = "Двойно докосване за настройки за вграждане.";
+
+/* Title for the Jetpack Download Backup Site Screen */
+"Download Backup" = "Изтегляне на бекъп";
+
+/* Title for the button that will download the backup file. */
+"Download file" = "Изтегляне на файла";
+
+/* Label for number of file downloads. */
+"Downloads" = "Изтегляния";
+
+/* Title of the drafts filter.  This filter shows a list of draft posts. */
+"Drafts" = "Чернови";
+
+/* No comment provided by engineer. */
+"Drag & drop" = "Влачене и пускане";
+
+/* No comment provided by engineer. */
+"Drag & drop makes rearranging blocks a breeze. Press and hold on a block, then drag it to its new location and release." = "Влаченето и пускането прави подреждането на блокове лесно. Натиснете и задръжте върху блок, после го довлачете до новото му място и пуснете.";
+
+/* No comment provided by engineer. */
+"Drag to adjust focal point" = "Плъзнете за да настроите фокусната точка";
+
+/* No comment provided by engineer. */
+"Duplicate block" = "Дублиране на блок";
+
+/* No comment provided by engineer. */
+"Dynamic" = "Динамично";
+
+/* Placeholder text for the search field int the Site Intent screen. */
+"E.g. Fashion, Poetry, Politics" = "Например мода, поезия, политика";
+
+/* No comment provided by engineer. */
+"Each block has its own settings. To find them, tap on a block. Its settings will appear on the toolbar at the bottom of the screen." = "Всеки блок има настройки. За да ги откриете, докоснете блока. Настройките ще се появят в лентата с инструменти в дъното на екрана.";
+
 /* Editing GIF alert default action button.
    Edits a Comment
    Edits the comment
@@ -669,6 +2048,9 @@
 
 /* Title for the edit more button section */
 "Edit \"More\" button" = "Редактиране на бутона \"Още\"";
+
+/* Blocklist Keyword Edition Title */
+"Edit Blocklist Word" = "Редактиране на дума в черния списък";
 
 /* View title when editing a comment. */
 "Edit Comment" = "Редактиране на коментар";
@@ -686,11 +2068,50 @@
 /* Accessibility label for button to edit a comment from a notification */
 "Edit comment" = "Редактиране";
 
+/* No comment provided by engineer. */
+"Edit cover media" = "Редактиране на заглавното изображение";
+
+/* No comment provided by engineer. */
+"Edit file" = "Редактиране на файл";
+
+/* No comment provided by engineer. */
+"Edit focal point" = "Редакция на фокусната точка";
+
+/* No comment provided by engineer. */
+"Edit media" = "Редакция на файл";
+
+/* Explanation for the option to enable the block editor */
+"Edit new posts and pages with the block editor." = "Редактиране на новите публикации и страници с блоковия редактор.";
+
 /* Title for the edit sharing buttons section */
 "Edit sharing buttons" = "Редактиране на бутоните за споделяне";
 
-/* Title for the editor settings section */
+/* No comment provided by engineer. */
+"Edit using web editor" = "Редакция с уеб редактор";
+
+/* No comment provided by engineer. */
+"Edit video" = "Редактиране на видеото";
+
+/* translators: %s: name of the host app (e.g. WordPress) */
+"Editing synced patterns is not yet supported on %s for Android" = "Editing synced patterns is not yet supported on %s за Андроид";
+
+/* translators: %s: name of the host app (e.g. WordPress) */
+"Editing synced patterns is not yet supported on %s for iOS" = "Редакция на синхронизирани макети още не се поддържа в %s за iOS";
+
+/* Editing GIF alert message. */
+"Editing this GIF will remove its animation." = "Редактирането на GIF-а ще премахне анимацията.";
+
+/* Title for the editor section in site settings screen */
 "Editor" = "Редактор";
+
+/* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
+"Edits the comment." = "Редактира коментара.";
+
+/* Screen reader hint for button to edit a menu item */
+"Edits this menu item" = "Редакция на елемента";
+
+/* Education site intent topic */
+"Education" = "Образование";
 
 /* Accessibility label for the Email text field.
    Account Settings Email label
@@ -704,23 +2125,115 @@
 /* Header for a comment author's email address, shown when editing a comment. */
 "Email Address" = "Имейл адрес";
 
+/* Accessibility label for the email address text field.
+   Describes the email address section in the comment detail screen.
+   Placeholder for a textfield. The user may enter their email address.
+   Placeholder for the email address textfield. */
+"Email address" = "Имейл адрес";
+
 /* Notification Settings Channel */
 "Email from WordPress.com" = "Имейл от WordPress.com";
+
+/* Noun. The title of an item in a list. */
+"Email me new comments" = "Пращане на нови коментари на имейл";
+
+/* The title of an item in a list. */
+"Email me new posts" = "Пращане на нови публикации на имейл";
 
 /* Username Placeholder */
 "Email or Username of the person that should receive your invitation." = "Имейл или потребителско име на потребителя, който да получи вашата покана.";
 
+/* A placeholder for the username textfield.
+   Invite Username Placeholder */
+"Email or Username…" = "Имейл или потребителско име...";
+
 /* Overlay message displayed when export content started */
 "Email sent!" = "Имейлът бе изпратен!";
+
+/* No comment provided by engineer. */
+"Embed block previews are coming soon" = "Прегледите на вградените блокове ще бъдат налични скоро";
+
+/* translators: accessibility text. %s: Embed caption. */
+"Embed caption. %s" = "Кракто описание на вграждането. %s";
+
+/* translators: accessibility text. Empty Embed caption. */
+"Embed caption. Empty" = "Кратко описание на вграждането. Празно";
+
+/* No comment provided by engineer. */
+"Embed media" = "Влагане на файл";
+
+/* No comment provided by engineer. */
+"Embed options" = "Опции за вграждане";
+
+/* Title for the Emoji section */
+"Emoji" = "Емотикони";
+
+/* Accessibility value presented in the signup epilogue for an empty value.
+   Label for size of media when the cache is empty. */
+"Empty" = "Празно";
 
 /* Message to show to user when he tries to add a self-hosted site that is an empty URL. */
 "Empty URL" = "Празен адрес";
 
+/* Button title for the enable site notifications action.
+   Title of button to enable publicize. */
+"Enable" = "Включване";
+
+/* Title of button that enables push notifications when tapped */
+"Enable Notifications" = "Включване на известията";
+
+/* Title of the view, asking the user if they want to enable notifications. */
+"Enable Notifications?" = "Включване на известията?";
+
+/* Text shown when the site doesn't have the Publicize module enabled. */
+"Enable Publicize" = "Активирайте споделяне";
+
+/* Title for the button that will enable the site stats module. */
+"Enable Site Stats" = "Включване на статистиките";
+
+/* Describes a switch component that toggles in-app notifications for a followed post. */
+"Enable in-app notifications" = "Включване на известията";
+
+/* Error message shown when trying to view Stats and the stats module is disabled. */
+"Enable site stats to see detailed information about your traffic, likes, comments, and subscribers." = "Включете статистиките, за да видите подробна информация за вашия трафик, харесвания, коментари и абонати.";
+
+/* Text displayed while activating the site stats module. */
+"Enabling Site Stats..." = "Включване на статистики...";
+
+/* Title of a row displayed on the debug screen used to display a screen that shows a list of encrypted logs */
+"Encrypted Logs" = "Криптирани дневници";
+
+/* Enter a custom value */
+"Enter a custom value" = "Въвеждане на собствена стойност";
+
 /* (placeholder) Help enter WordPress password */
 "Enter password" = "Въвеждане на парола";
 
+/* Instruction text on the login's site addresss screen.
+   Label for button to log in using your site address. */
+"Enter the address of the WordPress site you'd like to connect." = "Въведете адреса на WordPress сайта, който искате да свържете.";
+
+/* Instructional text shown when requesting the user's password for login. */
+"Enter the password for your WordPress.com account." = "Въведете паролата за Вашият WordPress.com акаунт.";
+
 /* (placeholder) Help enter WordPress username */
 "Enter username" = "Потребителско име";
+
+/* Enter your account information for {site url}. Asks the user to enter a username and password for their self-hosted site. */
+"Enter your account information for %@." = "Въведете входна информация за %@.";
+
+/* Instruction text on the initial email address entry screen. */
+"Enter your email address to log in or create a WordPress.com account." = "Въведете имейл адрес за вход или създаване на WordPress.com профил.";
+
+/* Button title. Takes the user to the login by site address flow. */
+"Enter your existing site address" = "Въведете съществуващ адрес на ваш сайт";
+
+/* Title of a button on the magic link screen.
+   Title of a button. */
+"Enter your password instead." = "Вместо това въведете Вашата парола.";
+
+/* Error message displayed when site credentials aren't configured. */
+"Enter your server credentials" = "Въведете данни за достъп до сървъра";
 
 /* Generic error alert title */
 "Error" = "Грешка";
@@ -734,14 +2247,122 @@
 /* Menus error title for a menu that received an error while trying to save a menu. */
 "Error Saving Menu" = "Грешка при запазване на менюто";
 
+/* There was an error activating a plugin, placeholder is the plugin name */
+"Error activating %@." = "Грешка при включване на %@.";
+
+/* Message displayed when approving a comment fails. */
+"Error approving comment." = "Грешка при одобряването на коментара.";
+
+/* This secondary message is displayed if a user encounters a general error. */
+"Error communicating with the server, please try again" = "Грешка в комуникацията със сървъра, опитайте отново";
+
+/* There was an error deactivating a plugin, placeholder is the plugin name */
+"Error deactivating %@." = "Грешка при изключване на %@.";
+
+/* Message displayed when deleting a comment fails. */
+"Error deleting comment." = "Грешка при изтриването на коментара.";
+
+/* There was an error disabling autoupdates for a plugin, placeholder is the plugin name */
+"Error disabling autoupdates for %@." = "Грешка при изключване на автоматичното обновяване на %@.";
+
 /* Title of error dialog when disconnecting jetpack fails. */
 "Error disconnecting Jetpack" = "Грешка при прекратяване на връзката на Jetpack";
+
+/* There was an error enabling autoupdates for a plugin, placeholder is the plugin name */
+"Error enabling autoupdates for %@." = "Грешка при включване на автоматичното обновяване на %@.";
+
+/* Error displayed when fixing a threat fails. */
+"Error fixing threat. Please contact our support." = "Грешка при отстраняването на заплаха. Свържете се с поддръжката.";
+
+/* Error displayed when ignoring a threat fails. */
+"Error ignoring threat. Please contact our support." = "Грешка при пренебрегване на заплаха. Свържете се с поддръжката.";
+
+/* Notice displayed after attempt to install a plugin fails. */
+"Error installing %@." = "Грешка при инсталиране на %@.";
+
+/* Text displayed when there is a failure loading notification likes. */
+"Error loading likes" = "Неуспешно зареждане на харесванията";
+
+/* Messaged displayed when fetching plugins failed. */
+"Error loading plugins" = "Неуспешно зареждане на разширения";
+
+/* Text displayed when there is a failure loading a blogging prompt. */
+"Error loading prompt" = "Грешка при зареждане предизвикателството";
+
+/* Text displayed when there is a failure loading notification comments. */
+"Error loading the comment" = "Грешка при зареждането на коментар";
+
+/* Message displayed when spamming a comment fails. */
+"Error marking comment as spam." = "Грешка при отбелязването на коментара като спам.";
+
+/* Message displayed when trashing a comment fails. */
+"Error moving comment to trash." = "Грешка при преместването на коментара в кошчето.";
+
+/* Register Domain - Domain contact information error message shown to indicate an error during fetching domain contact information */
+"Error occurred fetching domain contact information" = "Грешка при зареждане на контактна информация за домейна";
+
+/* Register Domain - Domain contact information error message shown to indicate an error during fetching list of states */
+"Error occurred fetching states" = "Грешка при зареждане на щати";
 
 /* Title of error dialog when removing a site owner fails. */
 "Error removing %@" = "Грешка при премахване на %@";
 
+/* There was an error removing a plugin, placeholder is the plugin name */
+"Error removing %@." = "Грешка при премахване на %@.";
+
+/* Message shown when there was an error trying to re-send email verification and we suspect the user has already verified in the meantime */
+"Error sending verification email. Are you already verified?" = "Грешка при изпращане на email за верификация. Не сте ли вече потвърдили Вашият email?";
+
+/* Generic message shown when there was an error trying to re-send email verification. */
+"Error sending verification email. Check your connection and try again." = "Грешка при изпращане на email за верификация. Моля проверете Вашата връзка и опитайте отново.";
+
+/* Message displayed when approving a comment fails. */
+"Error setting comment to approved." = "Грешка при одобряването на коментара";
+
+/* Message displayed when pending a comment fails. */
+"Error setting comment to pending." = "Грешка при отбелязването на коментар като изчакващ.";
+
+/* There was an error updating a plugin, placeholder is the plugin name */
+"Error updating %@." = "Грешка в обновяването на %@.";
+
 /* Title of error dialog when updating jetpack settins fail. */
 "Error updating Jetpack settings" = "Грешкa при обновяването на настройките на Jetpack";
+
+/* Error message informing the user that their site's title could not be changed */
+"Error updating site title" = "Грешка при обновяване на заглавието";
+
+/* Title of error dialog when updating speed up site settings fail. */
+"Error updating speed up site settings" = "Грешка при обновяването на настройките.";
+
+/* Short title telling the user they will receive a blogging reminder every day of the week. */
+"Every day" = "Всеки ден";
+
+/* Short title telling the user they will receive a blogging reminder every day of the week. */
+"Every day at %@" = "Всеки ден в %@";
+
+/* No comment provided by engineer. */
+"Excerpt length (words)" = "Дължина на откъса (думи)";
+
+/* Downloadable/Restorable items: content section footer text */
+"Excludes themes, plugins, and uploads" = "Изключва теми, разширения и качвания";
+
+/* Screen reader text to represent the expanded state of a UI control */
+"Expanded" = "Разгърнато";
+
+/* Accessibility hint */
+"Expanded. Tap to collapse." = "Разгърнато. Докоснете за свиване.";
+
+/* Screen reader hint (non-imperative) about what does the site menu selector button do. */
+"Expands to select a different menu" = "Разширява за да се избере друго меню";
+
+/* Screen reader hint (non-imperative) about what does the site menu area selector button do. */
+"Expands to select a different menu area" = "Разширява за да се избере различна област от менюто";
+
+/* Title for the error view when the user scanned an expired log in code */
+"Expired log in code" = "Изтекъл код за влизане";
+
+/* Title. Indicates an expiration date. */
+"Expires on" = "Изтича на";
 
 /* Placeholder text for the tagline of a site */
 "Explain what this site is about." = "Описание на сайта.";
@@ -759,8 +2380,44 @@
 /* Overlay message displayed while starting content export */
 "Exporting content…" = "Експортиране на съдържанието...";
 
+/* Section title for the external table section in the blog details screen */
+"External" = "Външен";
+
+/* Message for mark all as read success notice */
+"Failed marking Notifications as read" = "Неуспешно отбелязване на известията като прочетени";
+
+/* No comment provided by engineer. */
+"Failed to insert audio file. Please tap for options." = "Неуспешно поставяне на аудио. Докоснете за опции.";
+
+/* Error message to show to use when media insertion on a post fails */
+"Failed to insert media.\n Please tap for options." = "Неуспех при вмъкването на файл.\n Моля натиснете за опции.";
+
+/* No comment provided by engineer. */
+"Failed to insert media.\nTap for more info." = "Неуспешно влагане на файл.\nДокоснете за информация.";
+
+/* A message indicating that we couldn't load the user's settings. */
+"Failed to load settings" = "Неуспешно зареждане на настройките";
+
+/* No comment provided by engineer. */
+"Failed to save files.\nPlease tap for options." = "Неуспешно записване на файлове.\nМоля, докоснете за опции.";
+
 /* Error message to show when wrong URL format is used to access the REST API */
 "Failed to serialize request to the REST API." = "Грешка при сериализацията на данните към REST API.";
+
+/* The app failed to unsubscribe from the comments for the post */
+"Failed to unfollow conversation" = "Неуспешно прекратяване на следването";
+
+/* No comment provided by engineer. */
+"Failed to upload files.\nPlease tap for options." = "Неуспешно качване на файлове.\nМоля, докоснете за опции.";
+
+/* Fashion site intent topic */
+"Fashion" = "Мода";
+
+/* Option to select the Fastmail app when logging in with magic links */
+"Fastmail" = "Fastmail";
+
+/* Header of section in Plugin Directory showing featured plugins */
+"Featured" = "На фокус";
 
 /* Text displayed while fetching themes */
 "Fetching Themes..." = "Изтегляне на темите...";
@@ -768,18 +2425,72 @@
 /* A brief prompt shown when the comment list is empty, letting the user know the app is currently fetching new comments. */
 "Fetching comments..." = "Изтегляне на коментарите...";
 
+/* Title displayed whilst fetching media from the user's media library */
+"Fetching media..." = "Подготване на медия...";
+
 /* A short message to inform the user data for their sites are being fetched. */
 "Fetching sites..." = "Изтегляне на сайтовете...";
 
-/* Label for the file name for a media asset (image / video) */
+/* Label for the posting activity legend. */
+"Fewer Posts" = "По-малко публикации";
+
+/* Label for list of file downloads. */
+"File" = "Файл";
+
+/* Period Stats 'File Downloads' header */
+"File Downloads" = "Изтегляния на файлове";
+
+/* No comment provided by engineer. */
+"File block settings" = "Настройки на файловия блок";
+
+/* No comment provided by engineer. */
 "File name" = "Име на файла";
 
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Файлов тип";
+/* No comment provided by engineer. */
+"File type not supported as a media file." = "Видът файл не се поддържа.";
+
+/* Film & Television site intent topic */
+"Film & Television" = "Филми и телевизия";
+
+/* Finance site intent topic */
+"Finance" = "Финанси";
+
+/* Title for the find out more button in the What's New page. */
+"Find out more" = "Още информация";
+
+/* The hint button's title text to help users find their site address. */
+"Find your site address" = "Открийте адреса на сайта";
 
 /* Register Domain - Domain contact information field First name
    User's First Name */
 "First Name" = "Собствено име";
+
+/* Fitness & Exercise site intent topic */
+"Fitness & Exercise" = "Фитнес";
+
+/* Button title that attempts to fix all fixable threats */
+"Fix All" = "Оправяне на всички";
+
+/* Button title, confirm fixing all threats */
+"Fix all threats" = "Отстраняване на всички заплахи";
+
+/* Title for button that will fix the threat */
+"Fix threat" = "Отстраняване на заплахата";
+
+/* Displays the fixed threats */
+"Fixed" = "Отстранени";
+
+/* Subtitle displayed while the server is fixing threats */
+"Fixing Threats" = "Отстаряване на заплахите";
+
+/* Button title. Follow the comments on a post. */
+"Follow Conversation" = "Следване на дискусията";
+
+/* Screen title. Reader select interests title label text. */
+"Follow topics" = "Следване на теми";
+
+/* Guide for users to follow topics. */
+"Follow topics you're interested in and we'll find some blogs you might like." = "Следвайте теми, които са ви интересни и ще откриете блогове, които харесвате.";
 
 /* User role badge */
 "Follower" = "Последовател";
@@ -787,24 +2498,142 @@
 /* Label for number of followers. */
 "Followers" = "Последователи";
 
+/* Label displayed to the user while loading their selected interests */
+"Following new topics..." = "Следване на нови теми...";
+
+/* The app successfully subscribed to the comments for the post */
+"Following this conversation" = "Следване на дискусията";
+
+/* No comment provided by engineer. */
+"Font Size" = "Размер на шрифта";
+
+/* translators: %1$s: Font size name e.g. Small */
+"Font Size, %1$s" = "Размер на шрифта, %1$s";
+
+/* Food site intent topic */
+"Food" = "Храна";
+
+/* An example tag used in the login prologue screens. */
+"Football" = "Футбол";
+
+/* translators: Recommendation included in a warning related to having blocks deeply nested. */
+"For this reason, we recommend editing the block using the web editor." = "По тази причина, препоръчваме редактирането на блока чрез уеб браузър.";
+
+/* translators: Recommendation included in a warning related to having blocks deeply nested. */
+"For this reason, we recommend editing the block using your web browser." = "По тази причина, препоръчваме редактирането на блока през уеб браузър.";
+
+/* Register Domain - Domain contact information section header description */
+"For your convenience, we have pre-filled your WordPress.com contact information. Please review to be sure it’s the correct information you want to use for this domain." = "Въвели сме данните от WordPress.com за ваше удобство. Моля, проверете дали информацията е вярна и искате да я използвате с този домейн.";
+
 /* Next web page */
 "Forward" = "Напред";
+
+/* No comment provided by engineer. */
+"Four" = "Четири";
 
 /* Browse free themes selection title */
 "Free" = "Безплатни";
 
+/* One of the options when selecting More in the Post Editor's format bar */
+"Free GIF Library" = "Безплатна библиотека с GIF-ове";
+
+/* One of the options when selecting More in the Post Editor's format bar */
+"Free Photo Library" = "Безплатна фото библиотека";
+
+/* Explanatory text for clearing device media cache. */
+"Free up storage space on this device by deleting temporary media files. This will not affect the media on your site." = "Освободете пространство чрез изтриване на временни файлове. Няма да засегне файловете на сайта ви.";
+
+/* Title of section that contains plugins' FAQ */
+"Frequently Asked Questions" = "Често задавани въпроси";
+
+/* Format for blogging prompts attribution. %1$@ is the attribution source. */
+"From %1$@" = "От %1$@";
+
+/* No comment provided by engineer. */
+"From clipboard" = "От междинната памет";
+
 /* Full size image. (default). Should be the same as in core WP. */
 "Full Size" = "Пълен размер";
+
+/* Badge title displayed on GIF images in the editor. */
+"GIF" = "GIF";
+
+/* translators: accessibility text. %s: gallery caption. */
+"Gallery caption. %s" = "Кратко описание на галерията. %s";
+
+/* No comment provided by engineer. */
+"Gallery style" = "Стил галерия";
+
+/* Gaming site intent topic */
+"Gaming" = "Гейминг";
+
+/* An example tag used in the login prologue screens. */
+"Gardening" = "Градинарство";
 
 /* Title for the general section in site settings screen */
 "General" = "Основни";
 
+/* Title. A call to action to generate a new invite link. */
+"Generate new link" = "Създаване на нова връзка";
+
+/* View title for initial auth views. */
+"Get Started" = "Първи стъпки";
+
+/* The button title for a secondary call-to-action button. When the user wants to try sending a magic link instead of entering a password. */
+"Get a login link by email" = "Вземете връзка за вход чрез имейл";
+
+/* Displayed in the Notifications Tab as a message, when there are no notifications */
+"Get active! Comment on posts from blogs you follow." = "Бъдете активни! Коментирайте публикациите на блоговете, които следвате.";
+
+/* Accessibility hint for the find out more button in the Feature Announcements screen. */
+"Get more details for this release" = "Повече информация за тази версия";
+
+/* Displayed in the Notifications Tab as a message, when the Follow Filter shows no notifications */
+"Get noticed: comment on posts you've read." = "Бъдете забелязани: публикувайте коментари под публикациите.";
+
+/* Prompt for the screen to pick a template for a page */
+"Get started by choosing from a wide variety of pre-made page layouts. Or just start with a blank page." = "Започнете чрез избор на оформление на страницата. Или стартирайте с празна страница.";
+
+/* No comment provided by engineer. */
+"Get support" = "Получете поддръжка";
+
+/* Title of the second alert preparing users to grant permission for us to send them push notifications. */
+"Get your notifications faster" = "Получаване на известията по-бързо";
+
+/* Example post title used in the login prologue screens. */
+"Getting Inspired" = "Вдъхновяване";
+
 /* Alerts the user that wpcom account information is being retrieved. */
 "Getting account information" = "Генериране на информацията за профила";
+
+/* No comment provided by engineer. */
+"Give it a try by adding a few blocks to your post or page!" = "Опитайте, като добавите няколко блока във вашата страница или публикация!";
+
+/* Option to select the Gmail app when logging in with magic links */
+"Gmail" = "Gmail";
+
+/* Displayed in the Notifications Tab as a button title, when there are no notifications */
+"Go to Reader" = "Към Читател";
+
+/* Instruction telling the user how to enable notifications in their device's system Settings app. The section names here should match those in Settings. */
+"Go to Settings → Notifications → WordPress, and toggle Allow Notifications." = "Идете в Settings → Notifications → WordPress, и изберете Allow Notifications.";
 
 /* Button label for going to settings to approve push notifications
    Opens WPiOS Settings.app Section */
 "Go to iOS Settings" = "Към настройки на iOS";
+
+/* Message shown on screen after the Google sign up process failed. */
+"Google sign up failed." = "Входът в Google е неуспешен.";
+
+/* Button title on the blogging prompt's feature introduction view to dismiss the view.
+   Title for the continue button in the dashboard's custom What's New page. */
+"Got it" = "Ясно";
+
+/* User-facing string, presented to reflect that site assembly is underway. */
+"Grabbing site URL" = "Взимане на адреса на сайта";
+
+/* No comment provided by engineer. */
+"Gradient Type" = "Вид на преливане";
 
 /* This is the text we display to the user after they've indicated they like the app */
 "Great!\n We love to hear from happy users \n😁" = "Страхотно!\nОбичаме отзиви от щастливи потребители\n😁";
@@ -851,6 +2680,9 @@
 /* H6 Aztec Style */
 "Heading 6" = "Заглавие 6";
 
+/* Health site intent topic */
+"Health" = "Здраве";
+
 /* Help button
    Open editor help options */
 "Help" = "Помощ";
@@ -859,6 +2691,12 @@
    Open editor help options
    Title of the 'Help & Support' screen within the 'Me' tab - used for spotlight indexing on iOS. */
 "Help & Support" = "Помощ";
+
+/* No comment provided by engineer. */
+"Help button" = "Бутон за помощ";
+
+/* No comment provided by engineer. */
+"Help icon" = "Иконка за помощ";
 
 /* Accessibility value if login page's password field is hiding the password (i.e. with asterisks). */
 "Hidden" = "Скрит";
@@ -869,9 +2707,62 @@
 /* No comment provided by engineer. */
 "Hide keyboard" = "Скриване на клавиатурата";
 
+/* No comment provided by engineer. */
+"Hide search heading" = "Скриване на заглавието на търсенето";
+
+/* Displays the History screen from the editor's alert sheet
+   Title of a navigation button that opens the scan history view */
+"History" = "История";
+
+/* Message title displayed when we fail to fetch the status of the backup in progress. */
+"Hmm, we couldn’t find your backup status" = "Не успяхме да заредим състоянието на бекъпа";
+
+/* Message title displayed when we fail to fetch the status of the restore in progress. */
+"Hmm, we couldn’t find your restore status" = "Не успяхме да заредим састоянието на възстановяването";
+
 /* Moderation Keys Title
    Settings: Comments Moderation */
 "Hold for Moderation" = "Задържане за модерация";
+
+/* Noun. Links to a blog's dashboard screen.
+   Title for dashboard view on the My Site screen
+   Title for the dashboard screen. */
+"Home" = "Начало";
+
+/* Title for setting which shows the current page assigned as a site's homepage
+   Title for the homepage section in site settings screen */
+"Homepage" = "Начална страница";
+
+/* Label for Homepage Settings site settings section
+   Title for the Homepage Settings screen */
+"Homepage Settings" = "Настройки на началната страница";
+
+/* Message informing the user that their static homepage page was set successfully */
+"Homepage successfully updated" = "Началната страница е обновена";
+
+/* User-facing string, presented to reflect that site assembly is underway. */
+"Hooray!\nAlmost done" = "Ура!\nПочти готово";
+
+/* Title for the fix section in Threat Details: Threat is fixed */
+"How did Jetpack fix it?" = "Как Jetpack я оправи?";
+
+/* No comment provided by engineer. */
+"How to edit your page" = "Как се редактира страница";
+
+/* No comment provided by engineer. */
+"How to edit your post" = "Как се редактира публикация";
+
+/* Title for the fix section in Threat Details */
+"How will we fix it?" = "Как ще я оправим?";
+
+/* Example post content used in the login prologue screens. */
+"I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next" = "Вдъхновен съм от работата фотографа Камерън Карстен. Ще пробвам тези техники вбъдеще";
+
+/* Text on the support form to refer to what area the user has problem with. */
+"I need help with" = "Имам нужда от помощ с";
+
+/* Describes the IP address section in the comment detail screen. */
+"IP address" = "IP адрес";
 
 /* Title of a button style */
 "Icon & Text" = "Икона и текст";
@@ -882,8 +2773,32 @@
 /* Message to show when site icon update failed */
 "Icon update failed" = "Промяната на иконата е неуспешна";
 
+/* The instructions text about not being able to find the magic link email. */
+"If you can’t find the email, please check your junk or spam email folder" = "Ако не може да откриете имейла, моля проверете junk или спам папките";
+
+/* Legal disclaimer for signing up. The underscores _..._ denote underline. */
+"If you continue with Apple or Google and don't already have a WordPress.com account, you are creating an account and you agree to our _Terms of Service_." = "Ако продължите с Apple или Google и все още нямате профил в WordPress.com, вие създавате профил и се съгласявате с нашите _Условия на ползване_.";
+
+/* First line of remove user warning in confirmation dialog. Note: '%@' is the placeholder for the user's name and it must exist twice in this string. */
+"If you remove %@, that user will no longer be able to access this site, but any content that was created by %@ will remain on the site." = "Ако премахнете %1$@, този потребител няма да може да достъпва сайта, но съдържанието, създадено от %2$@, ще остане на сайта.";
+
+/* First line of remove viewer warning in confirmation dialog. */
+"If you remove this viewer, he or she will not be able to visit this site." = "Ако премахнето този четец, той или тя няма да могат да посещават сайта.";
+
+/* Detailed instructions on Start Over settings page. This is the first paragraph. */
+"If you want a site but do not want any of the posts and pages you have now, our support team can delete your posts, pages, media, and comments for you." = "Ако искате да запазите сайта си, но не желаете никоя от настоящите публикации и страници, поддръжката ни може да изтрие вашите, страници, коментари и файлове вместо вас.";
+
+/* Paragraph 2 of 2 of main text body for the delete screen. */
+"If you're unsure about what will be deleted or need any help, not to worry, our support team is here to answer any questions you may have." = "Ако не сте сигурни какво ще бъде изтрито или имате нужда от помощ, свърежте се с екипа по поддръжката и задайте въпросите си.";
+
 /* Ignore action. Verb */
 "Ignore" = "Игнориране";
+
+/* Title for button that will ignore the threat */
+"Ignore threat" = "Пренебрегване на заплахата";
+
+/* Displays the ignored threats */
+"Ignored" = "Пренебрегнати";
 
 /* Hint for image alt on image settings. */
 "Image Alt" = "Описание на картинката";
@@ -891,17 +2806,32 @@
 /* Hint for image caption on image settings. */
 "Image Caption" = "Заглавие на изображението";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Описание на изображението";
+/* Hint for image link on image settings. */
+"Image Link" = "Връзка за изображението";
 
 /* Title of the screen for choosing an image's size. */
 "Image Size" = "Размер на изображението";
 
-/* Hint for image title on image settings. */
-"Image title" = "Заглавие на изображението";
+/* translators: accessibility text. %s: image caption. */
+"Image caption. %s" = "Описание на изображението. %s";
+
+/* No comment provided by engineer. */
+"Image file not found." = "Изображението не е налично.";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "С няколко думи, разкажете за какво е този сайт.";
+
+/* Title of button to enable publicize. */
+"In order to share your published posts to your social media you need to enable the Publicize module." = "За да споделите публикациите си в социалните мрежи, трябва да активирате модула за споделяне.";
+
+/* The app successfully disabled notifications for the subscription */
+"In-app notifications disabled" = "Известията в приложението са изключени";
+
+/* The app successfully enabled notifications for the subscription */
+"In-app notifications enabled" = "Известията в приложението са включени";
+
+/* Describes a status of a plugin */
+"Inactive" = "Неактивно";
 
 /* The plugin is not active on the site and has not enabled automatic updates */
 "Inactive, Autoupdates off" = "Деактивирано, автоматичните обновления са изключени";
@@ -909,14 +2839,29 @@
 /* The plugin is not active on the site and has enabled automatic updates */
 "Inactive, Autoupdates on" = "Деактивирано, автоматичните обновления са включени";
 
+/* Title of the switch to turn on or off the blogging prompts feature. */
+"Include a Blogging Prompt" = "Включване на блог предизвикателство";
+
 /* Describes a standard *.wordpress.com site domain */
 "Included with Site" = "Включен по подразбиране";
+
+/* Downloadable/Restorable items: general section footer text */
+"Includes wp-config.php and any non WordPress files" = "Съдържа wp-config.php и файлове извън WordPress";
 
 /* An error message shown when a user signed in with incorrect credentials. */
 "Incorrect username or password. Please try entering your login details again." = "Невалидно потребителско име или парола. Опитайте отново.";
 
+/* Title for a threat */
+"Infected core file" = "Инфектиран файл от ядрото";
+
+/* Title for a threat that includes the file name of the file */
+"Infected core file: %1$@" = "Инфектиран файл от ядрото: %1$@";
+
 /* WordPress.com Community Footer Text */
 "Information on WordPress.com courses and events (online & in-person)." = "Информация за WordPress.com курсове и събития (онлайн и лично).";
+
+/* Placeholder for the restore progress title. */
+"Initializing the restore process" = "Инициализиране на процеса на възстановяване";
 
 /* Default button title used in media picker to insert media (photos / videos) into a post.
    Label action for inserting a link on the editor */
@@ -926,8 +2871,17 @@
    Button title used in media picker to insert media (photos / videos) into a post. Placeholder will be the number of items that will be inserted. */
 "Insert %@" = "Вмъкване на %@";
 
+/* No comment provided by engineer. */
+"Insert Audio Block" = "Влагане на аудио блок";
+
+/* No comment provided by engineer. */
+"Insert Gallery Block" = "Влагане на галерия";
+
 /* Accessibility label for insert horizontal ruler button on formatting toolbar. */
 "Insert Horizontal Ruler" = "Вмъкване на хоризонтална линия";
+
+/* No comment provided by engineer. */
+"Insert Image Block" = "Влагане на блок за изображение";
 
 /* Accessibility label for insert link button on formatting toolbar.
    Discoverability title for insert link keyboard shortcut.
@@ -937,11 +2891,68 @@
 /* Discoverability title for insert media keyboard shortcut. */
 "Insert Media" = "Вмъкване на медиен файл";
 
+/* No comment provided by engineer. */
+"Insert Video Block" = "Влагане на видео блок";
+
+/* No comment provided by engineer. */
+"Insert crosspost" = "Вмъкване на кроспост";
+
 /* Accessibility label for insert media button on formatting toolbar. */
 "Insert media" = "Вмъкване на медия";
 
+/* No comment provided by engineer. */
+"Insert mention" = "Добавяне на споменаване";
+
+/* Default accessibility label for the media picker insert button. */
+"Insert selected" = "Вмъкване на избора";
+
+/* No comment provided by engineer. */
+"Inside" = "Вътре";
+
 /* Title of Insights stats filter. */
 "Insights" = "Избрани";
+
+/* Button label to install a plugin
+   Confirmation button displayd in alert displayed when user installs their first plugin. */
+"Install" = "Инсталиране";
+
+/* The default Jetpack view title
+   Title of a button for Jetpack Installation. */
+"Install Jetpack" = "Инсталиране на Jetpack";
+
+/* Install Plugin dialog title. */
+"Install Plugin" = "Инсталиране на разширение";
+
+/* Title of section that contains plugins' installation instruction */
+"Installation" = "Инсталация";
+
+/* Header of section in Plugin Directory showing installed plugins
+   Indicates the state of the plugin */
+"Installed" = "Инсталирани";
+
+/* Title of a progress view displayed while the first plugin for a site is being installed. */
+"Installing %@…" = "Инсталиране на %@...";
+
+/* The Jetpack view title used while the is installing */
+"Installing Jetpack" = "Инсталиране на Jetpack";
+
+/* The Jetpack view message used while the state is installing */
+"Installing Jetpack on your site. This can take up to a few minutes to complete." = "Инсталиране на Jetpack в сайта. Може да отнеме няколко минути.";
+
+/* Message displayed in an alert when user tries to install a first plugin on their site. */
+"Installing the first plugin on your site can take up to 1 minute. During this time you won’t be able to make changes to your site." = "Инсталирането на първото разширение на вашия сайт може да отнеме до 1 минута. През това време няма да може да извършвате други промени.";
+
+/* Title for a button that opens up the 'Getting More Views and Traffic' support page when tapped. */
+"Interested in building your audience? Check out our top tips" = "Имате ли интерес към изграждане на аудитория? Проверете съветите ни";
+
+/* Interior Design site intent topic */
+"Interior Design" = "Интериорен дизайн";
+
+/* Title displayed on the feature introduction view. */
+"Introducing Blogging Prompts" = "Представяме блог предизвикателства";
+
+/* Title of an alert letting the user know the email address that they've entered isn't valid */
+"Invalid Email Address" = "Невалиден имейл адрес";
 
 /* No comment provided by engineer. */
 "Invalid Site Address" = "Невалиден адрес на сайт";
@@ -956,6 +2967,21 @@
 "Invalid URL, please check if you wrote a valid site address." = "Невалиден адрес, моля проверете дали сте написали правилен адрес на сайта.";
 
 /* No comment provided by engineer. */
+"Invalid URL." = "Невалиден адрес.";
+
+/* No comment provided by engineer. */
+"Invalid URL. Audio file not found." = "Невалиден адрес. Аудио файлът не е открит.";
+
+/* Error message shown when the input URL is invalid. */
+"Invalid URL. Please double-check and try again." = "Невалиден адрес. Моля проверете и пробвайте пак.";
+
+/* No comment provided by engineer. */
+"Invalid URL. Please enter a valid URL." = "Невалиден адрес. Моля, въведете валиден адрес.";
+
+/* Error message generated when announcement service is unable to return a valid endpoint. */
+"Invalid endpoint" = "Невалидна точка";
+
+/* No comment provided by engineer. */
 "Invalid username" = "Невалидно потребителско име";
 
 /* The app successfully sent an invitation */
@@ -963,6 +2989,24 @@
 
 /* Send Person Invite */
 "Invite" = "Покана";
+
+/* Title for the Invite Link section of the Invite Person screen. */
+"Invite Link" = "Връзка с покана";
+
+/* Invite People Title */
+"Invite People" = "Покана на хора";
+
+/* An error message shown during log in when the username or password is incorrect. */
+"It looks like this username\/password isn't associated with this site." = "Изглежда потребителското име\/парола не е асоцирано с този сайт.";
+
+/* An error message shown when a wpcom user provides the wrong password. */
+"It seems like you've entered an incorrect password. Want to give it another try?" = "Изглежда сте въвели невалидна парола. Искате ли да опитате отново?";
+
+/* Title of a notification displayed prompting the user to create a new blog post. The %@ will be replaced with the blog's title. */
+"It's time to blog on %@!" = "Време е за блогване в %@!";
+
+/* Title of a notification displayed prompting the user to create a new blog post */
+"It's time to blog!" = "Време е за блогване!";
 
 /* Accessibility label for italic button on formatting toolbar.
    Discoverability title for italic formatting keyboard shortcut. */
@@ -973,9 +3017,92 @@
    Title for the Jetpack section in site settings screen */
 "Jetpack" = "Jetpack";
 
+/* Message stating the minimum required version for Jetpack and asks the user if they want to upgrade */
+"Jetpack %@ or later is required. Do you want to update Jetpack?" = "Изисква се Jetpack %@ или по-нов. Искате ли да го обновите?";
+
+/* Title of the button which opens the Jetpack FAQ page. */
+"Jetpack FAQ" = "Jetpack ЧЗВ";
+
+/* Description that explains that we are unable to auto fix the threat */
+"Jetpack Scan cannot automatically fix this threat. We suggest that you resolve the threat manually: ensure that WordPress, your theme, and all of your plugins are up to date, and remove the offending code, theme, or plugin from your site." = "Jetpack Scan не може да отстрани заплахата автоматично. Препоръчваме да я отстраните ръчно: обновете WordPress, темата си и всички разширения, премахнете всеки подозрителен код, тема или разширение.";
+
+/* Description for a label when the scan has failed
+   Error message shown when the scan start has failed. */
+"Jetpack Scan couldn't complete a scan of your site. Please check to see if your site is down – if it's not, try again. If it is, or if Jetpack Scan is still having problems, contact our support team." = "Jetpack Scan не завърши сканирането на вашия сайт. Проверете дали сайтът е достъпен – ако е, опитайте отново. Ако е недостъпен или ако Jetpack Scan продължава да има проблеми, свържете се с поддръжката.";
+
+/* Description for a label when there are threats on the site, displays the number of threats, and the site's title */
+"Jetpack Scan found %1$d potential threats with %2$@. Please review them below and take action or tap the fix all button. We are here to help if you need us." = "Jetpack Scan откри %1$d потенциални заплахи с %2$@. Моля, прегледайте ги и вземете мерки или изерете бутона за оправяне на всичко. Тук сме, за да окажем помощ.";
+
+/* Description for a label when there is a single threat on the site, displays the site's title */
+"Jetpack Scan found 1 potential threat with %1$@. Please review them below and take action or tap the fix all button. We are here to help if you need us." = "Jetpack Scan откри 1 потенциална заплаха с %1$@. Моля, прегледайте това и вземете мерки или изберете бутона за отстраняване на всички. Тук сме за помощ.";
+
+/* Description that explains how we will fix the threat */
+"Jetpack Scan will delete the affected file or directory." = "Jetpack Scan ще изтрие засегнатия файл или папка.";
+
+/* Description that explains how we will fix the threat */
+"Jetpack Scan will edit the affected file or directory." = "Jetpack Scan ще редактира засегнатия файл или папка.";
+
+/* Description that explains how we will fix the threat */
+"Jetpack Scan will replace the affected file or directory." = "Jetpack Scan ще замени засегнатия файл или папка.";
+
+/* Description that explains how we will fix the threat */
+"Jetpack Scan will resolve the threat." = "Jetpack Scan ще адресира заплахата.";
+
+/* Description that explains how we will fix the threat */
+"Jetpack Scan will rollback the affected file to an older (clean) version." = "Jetpack Scan ще възстанови засегнатия файл до по-стара и чиста версия.";
+
+/* Description that explains how we will fix the threat */
+"Jetpack Scan will rollback the affected file to the version from %1$@." = "Jetpack Scan ще възстанови засегнатия файл до версия от %1$@.";
+
+/* Description that explains how we will fix the threat */
+"Jetpack Scan will update to a newer version." = "Jetpack Scan ще се обнови до по-нова версия.";
+
+/* Noun. Title. Links to the blog's Settings screen. */
+"Jetpack Settings" = "Jetpack настройки";
+
+/* Insights 'Jetpack Social Connections' header
+   Section title for Publicize services in Sharing screen */
+"Jetpack Social Connections" = "Jetpack Social връзки";
+
+/* Message to show when Publicize connection synchronization failed */
+"Jetpack Social connection synchronization failed" = "Синхронизацията на услугата за споделяне е неуспешна";
+
+/* Message to show when Publicize service synchronization failed */
+"Jetpack Social service synchronization failed" = "Синхронизацията на услугата за споделяне е неуспешна";
+
+/* The default Jetpack view message used when an error occurred */
+"Jetpack could not be installed at this time." = "Jetpack не може да се инсталира в момента.";
+
+/* Subject of new Zendesk ticket. */
+"Jetpack for iOS Support" = "Jetpack за iOS поддръжка";
+
+/* The Jetpack view title for the success state */
+"Jetpack installed" = "Jetpack е инсталиран";
+
+/* No comment provided by engineer. */
+"Jetpack powered" = "Задвижвано от Jetpack";
+
+/* Confirmation message presented before fixing all the threats, displays the number of threats to be fixed */
+"Jetpack will be fixing all the detected active threats." = "Jetpack ще оправи установените заплаха.";
+
+/* Confirmation message presented before fixing a single threat */
+"Jetpack will be fixing the detected active threat." = "Jetpack ще оправи установената заплаха.";
+
+/* Footer for the Serve images from our servers setting */
+"Jetpack will optimize your images and serve them from the server location nearest to your visitors. Using our global content delivery network will boost the loading speed of your site." = "Jetpack ще оптимизира изображенията и ще ги доставя от сървър в близост до посетителите. Глобалната мрежа за доставяне на файлове ще подобри скоростта на зареждане на сайта ви.";
+
+/* Subtitle for button displaying the Automattic Work With Us web page, indicating that Automattic employees can work from anywhere in the world */
+"Join From Anywhere" = "Влезте отвсякъде";
+
+/* Displayed in the Notifications Tab as a message, when the Comments Filter shows no notifications */
+"Join a conversation: comment on posts from blogs you follow." = "Включете се в дискусията: коментирайте пост от блог който следвате.";
+
 /* Button shown if there are unsaved changes and the author cancelled editing a Comment.
    Goes back to editing the post. */
 "Keep Editing" = "Ще редактирам още";
+
+/* Button to cancel the replacement of a featured image. */
+"Keep current" = "Запазване на текущото";
 
 /* Autoapprove only from known users */
 "Known Users" = "Познати потребители";
@@ -998,13 +3125,41 @@
    User's Last Name */
 "Last Name" = "Фамилия";
 
+/* Content of a weekly roundup push notification containing stats about the user's site. The % markers are placeholders and will be replaced by the appropriate number of views and comments. The numbers indicate the order, so they can be rearranged if necessary – 1 is views, 2 is comments. */
+"Last week you had %1$@ views and %2$@ comments." = "Миналата седмица имате %1$@ прегледа и %2$@ коментара.";
+
+/* Content of a weekly roundup push notification containing stats about the user's site. The % markers are placeholders and will be replaced by the appropriate number of views and likes. The numbers indicate the order, so they can be rearranged if necessary – 1 is views, 2 is likes. */
+"Last week you had %1$@ views and %2$@ likes." = "Миналата седмица имате %1$@ прегледа и %2$@ харесвания.";
+
+/* Content of a weekly roundup push notification containing stats about the user's site. The % markers are placeholders and will be replaced by the appropriate number of views, comments, and likes. The numbers indicate the order, so they can be rearranged if necessary – 1 is views, 2 is comments, 3 is likes. */
+"Last week you had %1$@ views, %2$@ comments and %3$@ likes." = "Мисалата седмица имате %1$@ прегледа, %2$@ коментара и %3$@ харесвания.";
+
+/* Content of a weekly roundup push notification containing stats about the user's site. The % marker is a placeholder and will be replaced by the appropriate number of views */
+"Last week you had %@ views." = "Миналата седмица имате %@ прегледа.";
+
 /* Insights latest post summary header */
 "Latest Post Summary" = "Кратко описание на последната публикация";
+
+/* Title of a button. Tapping allows the user to learn more about the specific error. */
+"Learn More" = "Научете повече";
+
+/* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
+"Learn about new comments, likes, and follows in seconds." = "Научете за нови коментари, харесвания и абонаменти за секунди.";
 
 /* A button title.
    Link to cookie policy
    Menu title to show the prompts feature introduction modal. */
 "Learn more" = "Повече";
+
+/* Writing, Date and Time Settings: Learn more about date and time settings footer text */
+"Learn more about date and time formatting." = "Научете повече за форматирането на дата и час.";
+
+/* Accessibility label for the blogging prompts info button on the Blogging Reminders Settings screen.
+   Accessibility label for the blogging prompts info button on the prompts header view. */
+"Learn more about prompts" = "Научете повече за предизвикателствата";
+
+/* Footer text for Invite People role field. */
+"Learn more about roles" = "Още информация за ролите";
 
 /* Jetpack Settings: WordPress.com Login WordPress login footer text */
 "Learn more..." = "Научете повече...";
@@ -1012,8 +3167,32 @@
 /* Left alignment for an image. Should be the same as in core WP. */
 "Left" = "Подравняване вляво";
 
+/* Title displayed for selection of custom app icons that may be removed in a future release of the app. */
+"Legacy Icons" = "Стари икони";
+
+/* Title of button which shows a list of legal documentation such as privacy policy and acknowledgements */
+"Legal and More" = "Правна информация и още";
+
 /* Heading for instructions on Start Over settings page */
 "Let Us Help" = "Нека ви помогнем";
+
+/* Title for the button that will dismiss this view. */
+"Let me know when finished!" = "Информирайте ме като приключи!";
+
+/* Message info on the support screen. */
+"Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon." = "Кажете ни адреса на сайта ви и колкото можете повече за проблема. Ние ще се свържем с вас скоро.";
+
+/* Title to let the user know what do we want on the support screen. */
+"Let’s get this sorted" = "Нека подредим това";
+
+/* Lifestyle site intent topic */
+"Lifestyle" = "Начин на живот";
+
+/* Title for the app appearance setting for light mode */
+"Light" = "Светло";
+
+/* Title displayed for selection of custom app icons that have white backgrounds. */
+"Light backgrounds" = "Светли фонове";
 
 /* Button title to Like a comment.
    Like (verb)
@@ -1037,40 +3216,115 @@
 /* Setting: indicates if Replies to your comments will be notified */
 "Likes on my posts" = "Харесвания на моите публикации";
 
+/* VoiceOver accessibility hint, informing the user the button can be used to like a comment */
+"Likes the Comment." = "Харесва коментара.";
+
+/* This description is used to set the accessibility label for the Insights chart, with Views selected. */
+"Line Chart depicting Views for insights." = "Графика за прегледите за обобщение.";
+
+/* This description is used to set the accessibility label for the Insights chart, with Visitors selected. */
+"Line Chart depicting Visitors for insights." = "Графика на посетителите за обобщение.";
+
+/* No comment provided by engineer. */
+"Line Height" = "Височина на реда";
+
 /* Label for link title in Clicks stat. */
 "Link" = "Връзка";
 
 /* Menus title label when editing a menu item as a link. */
 "Link Address (URL)" = "Адрес на връзката (URL)";
 
+/* Link copied to clipboard notice title */
+"Link Copied to Clipboard" = "Връзката е копирана";
+
 /* Link name field placeholder */
 "Link Name" = "Име на връзката";
 
+/* No comment provided by engineer. */
+"Link Rel" = "Link Rel";
+
+/* Noun. Title for screen in editor that allows to configure link options */
+"Link Settings" = "Настройки на връзката";
+
+/* Noun. Label for the text of a link in the editor */
+"Link Text" = "Текст на връзката";
+
 /* Image link option title. */
 "Link To" = "Връзка към";
+
+/* No comment provided by engineer. */
+"Link inserted" = "Връзката е вмъкната";
+
+/* No comment provided by engineer. */
+"Link label" = "Текст на връзката";
+
+/* No comment provided by engineer. */
+"Link text" = "Текст на връзката";
+
+/* Action. Label for navigate and display links to other posts on the site */
+"Link to existing content" = "Връзка към съществуващо съдържание";
 
 /* A label title
    Comments Paging
    Settings: Comments Approval settings */
 "Links in comments" = "Връзки в коментарите";
 
+/* Title of the screen that load selected the revisions. */
+"Load" = "Зареждане";
+
 /* A short label.  A call to action to load more posts. */
 "Load more posts" = "Зареждане на още публикации";
+
+/* No comment provided by engineer. */
+"Loading" = "Зареждане";
 
 /* Menus label text displayed while menus are loading */
 "Loading Menus..." = "Зареждане на менютата...";
 
+/* Text displayed while loading site People. */
+"Loading People..." = "Зареждане на хора...";
+
+/* Text displayed while loading an specific plugin */
+"Loading Plugin..." = "Зареждане на разширението...";
+
 /* Text displayed while loading plugins for a site */
 "Loading Plugins..." = "Зареждане на разширенията...";
 
+/* Text displayed while loading the scan history for a site */
+"Loading Scan History..." = "Зареждане на историята на сканирания...";
+
+/* Text displayed while loading the scan section for a site */
+"Loading Scan..." = "Зареждане на сканирането...";
+
+/* Displayed while a comment is being loaded. */
+"Loading comment..." = "Зареждане на коментара...";
+
 /* Menus label text displayed when a menu is loading. */
 "Loading menu..." = "Зареждане на менюто...";
+
+/* Messaged displayed when fetching plugins. */
+"Loading plugins..." = "Зареждане на разширенията...";
+
+/* Displayed while blogging prompts are being loaded. */
+"Loading prompts..." = "Зареждане на предизвикателства...";
+
+/* Loading message shown while the Unsupported Block Editor is loading. */
+"Loading the block editor." = "Зареждане на блоковия редактор";
 
 /* Loading tags
    Loading. Verb
    Suggestions loading message
    Text displayed in HUD while a media item is being loaded. */
 "Loading..." = "Зареждане...";
+
+/* Local Services site intent topic */
+"Local Services" = "Местни услуги";
+
+/* A status label for a post that only exists on the user's iOS device, and has not yet been published to their blog. */
+"Local changes" = "Локални промени";
+
+/* No comment provided by engineer. */
+"Lock icon" = "Иконка за заключване";
 
 /* Button title.  Tapping takes the user to the login form.
    Label for logging in to WordPress.com account
@@ -1083,17 +3337,60 @@
    Label for logging out from WordPress.com account */
 "Log Out" = "Изход";
 
+/* Title of a button for signing in. */
+"Log in" = "Вход";
+
 /* A generic error message for a failed log in. */
 "Log in failed. Please try again." = "Неуспешно влизане - опитайте отново.";
+
+/* Button title. Takes the user to the login by email flow.
+   Button title. Tapping begins our normal log in process. */
+"Log in or sign up with WordPress.com" = "Влезте или се регистрирайте в WordPress.com";
+
+/* Instruction text on the login's email address screen. */
+"Log in to the WordPress.com account you used to connect Jetpack." = "Влезте в WordPress.com профила си, за да свържете Jetpack.";
+
+/* Instruction text on the login's email address screen. */
+"Log in to your WordPress.com account with your email address." = "Влезте във вашия WordPress.com профил с имейл адрес.";
+
+/* Instructions on the WordPress.com username / password log in form. */
+"Log in with your WordPress.com username and password." = "Вход с потребителско име и парола за WordPress.com.";
+
+/* LogOut confirmation text, whenever there are no local changes */
+"Log out of Jetpack?" = "Изход от Jetpack?";
+
+/* LogOut confirmation text, whenever there are no local changes */
+"Log out of Reader?" = "Изход от Читател?";
+
+/* LogOut confirmation text, whenever there are no local changes */
+"Log out of WordPress?" = "Излизане от WordPress?";
 
 /* Login Request Expired */
 "Login Request Expired" = "Заявката за влизане е изтекла";
 
+/* Button title. Takes the user to the Enter account password screen. */
+"Login with account password" = "Вход с потребител и парола";
+
+/* Title for the error view when the stats module is disabled. */
+"Looking for stats?" = "Търсите статистики?";
+
+/* Message asking the user to sign into Jetpack with WordPress.com credentials */
+"Looks like you have Jetpack set up on your site. Congrats! Log in with your WordPress.com credentials to enable Stats and Notifications." = "Изглежда използвате Jetpack. Чудесно! \nСтатистиката и известията ще се включат след като влезете с данните си за WordPress.com.";
+
 /* Title of a button. */
 "Lost your password?" = "Изгубена парола?";
 
+/* Option to select the Apple Mail app when logging in with magic links */
+"Mail (Default)" = "Mail (по подразбиране)";
+
 /* No comment provided by engineer. */
 "Main Navigation" = "Основна навигация";
+
+/* Explanation for the option to enable theme styles */
+"Make the block editor look like your theme." = "Преобразете редактора в стила на темата ви.";
+
+/* No comment provided by engineer. */
+"Make your content stand out by adding images, gifs, videos, and embedded media to your pages." = "Направете съдържанието впечатляващо с изображения, GIF-ове, видеа и вградено мултимедийно съдържание.";
 
 /* Button leading to a screen where users can manage their installed plugins
    Screen title, where users can see all their installed plugins.
@@ -1106,14 +3403,47 @@
    Title for the Jetpack Manage Connection Screen */
 "Manage Connection" = "Управление на връзката";
 
+/* Accessibility label for button that displays Manage Insight options. */
+"Manage Insight" = "Управление на обобщението";
+
 /* Return to blog screen action when theme activation succeeds */
 "Manage site" = "Управление на сайт";
+
+/* No comment provided by engineer. */
+"Manual" = "Ръчно";
+
+/* Section name for manual offsets in time zone selector */
+"Manual Offsets" = "Часова разлика";
 
 /* Describes a domain that was mapped to WordPress.com, but registered elsewhere */
 "Mapped Domain" = "Насочен домейн";
 
 /* Marks a notification as unread */
 "Mark Read" = "Маркиране като прочетено";
+
+/* Marks a notification as unread */
+"Mark Unread" = "Отбелязване като непрочетено";
+
+/* Confirmation title for marking all notifications under a filter as read. %1$@ is replaced by the filter name. */
+"Mark all %1$@ notifications as read?" = "Маркиране на %1$@ известия като прочетени?";
+
+/* Confirmation title for marking all notifications as read. */
+"Mark all notifications as read?" = "Маркиране на известията като прочетени?";
+
+/* Marks comment as spam */
+"Mark as Spam" = "Отбелязване като спам";
+
+/* Action title for unmarking referrer as spam */
+"Mark as not spam" = "Маркиране като не-спам";
+
+/* Action title for marking referrer as spam */
+"Mark as spam" = "Маркиране като спам";
+
+/* VoiceOver accessibility hint, informing the user the button can be used to Mark a comment as spam. */
+"Mark as spam." = "Отбелязване като спам.";
+
+/* Jetpack Settings: Match accounts using email */
+"Match accounts using email" = "Свързване на профили чрез имейл";
 
 /* Title for the image size settings option. */
 "Max Image Upload Size" = "Максимален размер за качване на файл";
@@ -1133,11 +3463,46 @@
    Title label for the media settings section in the app settings */
 "Media" = "Файлове";
 
+/* Label for the media cache navigation row in the app.
+   Media Cache title */
+"Media Cache" = "Файлов кеш";
+
+/* Label for size of media cache in the app. */
+"Media Cache Size" = "Размер на файловия кеш";
+
+/* Title for action sheet with media options. */
+"Media Options" = "Настройки за файла";
+
+/* Media Settings Title
+   User action to edit media settings. */
+"Media Settings" = "Настройки за файлове";
+
 /* Message to indicate progress of uploading media to server */
 "Media Uploading" = "Файловете се качват";
 
+/* Downloadable/Restorable items: Media Uploads */
+"Media Uploads" = "Качени файлове";
+
+/* Error message to show to users when trying to upload a media object with no local file associated */
+"Media doesn't have an associated file to upload." = "Медията няма файл за качване.";
+
+/* Error message to show to users when trying to upload a media object with file size is larger than the max file size allowed in the site */
+"Media filesize (%@) is too large to upload. Maximum allowed is %@" = "Размерът на файла (%1$@) е твърде голям за качване. Максимално позволено %2$@";
+
+/* translators: %s: block title e.g: \"Paragraph\". */
+"Media options" = "Настройки за файла";
+
+/* Alert displayed to the user when multiple media items have uploaded successfully. */
+"Media uploaded (%ld files)" = "Качени файлове (%ld файла)";
+
+/* Alert displayed to the user when a single media item has uploaded successfully. */
+"Media uploaded (1 file)" = "Качени файлове (1 файл)";
+
 /* Medium image size. Should be the same as in core WP. */
 "Medium" = "Средно";
+
+/* No comment provided by engineer. */
+"Mention" = "Споменаване";
 
 /* The default text used for filling the name of a menu when creating it.
    Title for the site menu view on the My Site screen */
@@ -1145,6 +3510,15 @@
 
 /* Menus placeholder text for the name field of a menu with no name. */
 "Menu Name" = "Име на меню";
+
+/* Screen reader string too choose a menu area to edit. %@ is the name of the menu area (Primary, Footer, etc...). %d is a number indicating the ammount of menu areas available. */
+"Menu area: %@, %d menu areas available" = "Меню област: %1$@, %2$d области са налични";
+
+/* Screen reader string too choose a menu to edit. First %@ is the name of the menu area (Primary, Footer, etc...). Second %@ is name of the menu currently selected. %d is a number indicating the ammount of menus available in the selected menu area. */
+"Menu in area %@: %@, %d menus available" = "Меню в област %1$@: %2$@, %3$d менюта са налични";
+
+/* Screen Reader: Description for text field that edits the menu name. */
+"Menu name" = "Име на менюто";
 
 /* Menus option in the blog details
    Noun. Name of the Menus feature
@@ -1154,6 +3528,18 @@
 /* Invite Message Editor's Title */
 "Message" = "Съобщение";
 
+/* Option to select the Microsft Outlook app when logging in with magic links */
+"Microsoft Outlook" = "Microsoft Outlook";
+
+/* Summary description for a threat */
+"Miscellaneous vulnerability" = "Злонамерена уязвимост";
+
+/* Title for the mobile web preview */
+"Mobile" = "Телефон";
+
+/* Jetpack Monitor Settings: Monitor site's uptime */
+"Monitor your site's uptime" = "Наблюдаване на времето, за което сайтът е работил";
+
 /* Post Stats months and years header. */
 "Months and Years" = "Месеци и години";
 
@@ -1162,9 +3548,73 @@
    Action button to display more available options */
 "More" = "Още";
 
+/* Action button to display more available options */
+"More Options" = "Повече настройки";
+
+/* Label for the posting activity legend. */
+"More Posts" = "Още публикации";
+
+/* No comment provided by engineer. */
+"More support options" = "Още опции за помощ";
+
+/* Screen reader text for button that will move the menu item. Argument is menu item's name. */
+"Move %@" = "Преместване на %@";
+
+/* No comment provided by engineer. */
+"Move block down" = "Преместване на блока надолу";
+
+/* translators: accessibility text. %1: current block position (number). %2: next block position (number) */
+"Move block down from row %1$s to row %2$s" = "Преместване на блока надолу от ред %1$s към ред %2$s";
+
+/* No comment provided by engineer. */
+"Move block left" = "Преместване на блока в ляво";
+
+/* translators: accessibility text. %1: current block position (number). %2: next block position (number) */
+"Move block left from position %1$s to position %2$s" = "Преместване на блока в ляво от позиция %1$s на позиция %2$s";
+
+/* No comment provided by engineer. */
+"Move block right" = "Преместване на блока в дясно";
+
+/* translators: accessibility text. %1: current block position (number). %2: next block position (number) */
+"Move block right from position %1$s to position %2$s" = "Преместване на блока в дясно от позиция %1$s на позиция %2$s";
+
+/* No comment provided by engineer. */
+"Move block up" = "Преместване на блока нагоре";
+
+/* translators: accessibility text. %1: current block position (number). %2: next block position (number) */
+"Move block up from row %1$s to row %2$s" = "Преместване на блока нагоре от ред %1$s към ред %2$s";
+
+/* No comment provided by engineer. */
+"Move blocks" = "Преместете на блокове";
+
+/* Option to move Insight down in the view. */
+"Move down" = "Преместване надолу";
+
+/* Screen reader text for button that will move the menu item */
+"Move menu item" = "Преместване на елемента";
+
 /* Title for button on the comment details page that moves the comment to trash when tapped.
    Trashes the comment */
 "Move to Trash" = "Преместване в кошчето";
+
+/* No comment provided by engineer. */
+"Move to bottom" = "Преместване най-отдолу";
+
+/* No comment provided by engineer. */
+"Move to top" = "Преместване най-отгоре";
+
+/* Option to move Insight up in the view. */
+"Move up" = "Преместване нагоре";
+
+/* VoiceOver accessibility hint, informing the user the button can be used to Move a comment to the Trash. */
+"Moves the comment to the Trash." = "Премества коментар в кошчето.";
+
+/* Example post title used in the login prologue screens. */
+"Museums to See In London" = "Хубави музеи в Лондон";
+
+/* An example tag used in the login prologue screens.
+   Music site intent topic */
+"Music" = "Музика";
 
 /* Link to My Profile section */
 "My Profile" = "Моят профил";
@@ -1174,11 +3624,69 @@
    Title of My Site tab */
 "My Site" = "Моят сайт";
 
+/* Example post title used in the login prologue screens. */
+"My Top Ten Cafes" = "Моите топ десет кафета";
+
+/* No comment provided by engineer. */
+"NEW" = "НОВО";
+
+/* Title for disclaimer in the dashboard's custom What's New page. */
+"NEW!" = "НОВО!";
+
+/* Accessibility label for the Email text field.
+   Header for a comment author's name, shown when editing a comment.
+   Name text field placeholder */
+"Name" = "Име";
+
+/* No comment provided by engineer. */
+"Navigate Up" = "Идете нагоре";
+
+/* No comment provided by engineer. */
+"Navigates to custom color picker" = "Към избор на цветове";
+
+/* No comment provided by engineer. */
+"Navigates to customize the gradient" = "Към настройване на преливането";
+
+/* No comment provided by engineer. */
+"Navigates to layout selection screen" = "Навигира към екран за избор на оформлението";
+
+/* translators: %s: Select control button label e.g. Small
+translators: %s: Select control button label e.g. \"Button width\" */
+"Navigates to select %s" = "Надигация за избор на %s";
+
+/* No comment provided by engineer. */
+"Navigates to the previous content sheet" = "Преминава към предишния екран със съдържание";
+
 /* 'Need help?' button label, links off to the WP for iOS FAQ. */
 "Need Help?" = "Помощ?";
 
+/* A button title. */
+"Need help finding your site address?" = "Имате ли нужда при намиране на адреса на Вашият сайт?";
+
+/* Takes the user to get help
+   The secondary button title in the migration welcome screen */
+"Need help?" = "Нужда от помощ?";
+
 /* Title of the more help button on alert helping users understand their site address */
 "Need more help?" = "Имате нужда от допълнителна помощ?";
+
+/* Describes a status of a plugin */
+"Needs Update" = "Необходимо е обновяване";
+
+/* No comment provided by engineer. */
+"Network connection lost, working offline" = "Интернет връзката прекъсна, офлайн сте";
+
+/* No comment provided by engineer. */
+"Network connection re-established" = "Интернет връзката е възстановена";
+
+/* Header of section in Plugin Directory showing newest plugins */
+"New" = "Ново";
+
+/* Blocklist Keyword Insertion Title */
+"New Blocklist Word" = "Нова дума в черния списък";
+
+/* Title of alert informing users about the Reader Save for Later feature. */
+"New Custom App Icons" = "Нови икони на приложението";
 
 /* IP Address or Range Insertion Title */
 "New IP or IP Range" = "Нов IP адрес или обхват от IP адреси";
@@ -1189,11 +3697,21 @@
 /* New Post 3D Touch Shortcut */
 "New Post" = "Нова публикация";
 
+/* Placeholder text for password field */
+"New password" = "Нова парола";
+
+/* Noun. The title of an item in a list. */
+"New posts" = "Нови публикации";
+
 /* Screen title, where users can see the newest plugins */
 "Newest" = "Най-нов";
 
 /* Sort Order */
 "Newest first" = "Първо най-новите";
+
+/* News site intent topic
+   Title of a button that displays the WordPress.org blog */
+"News" = "Новини";
 
 /* Next action on comment moderation snackbar.
    Next action on share extension editor screen.
@@ -1204,8 +3722,14 @@
 /* Accessibility label for the next notification button */
 "Next notification" = "Следващо уведомление";
 
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Без категория";
+/* Accessibility label */
+"Next period" = "Следващ период";
+
+/* Empty state message (People Management). %@ can be 'users' or 'followers' */
+"No %@ yet" = "Няма %@";
+
+/* Title of an error message. There were no third-party service accounts found to setup sharing. */
+"No Accounts Found" = "Не са открити профили";
 
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Няма връзка";
@@ -1219,6 +3743,24 @@
 /* Menus name field text when no menu is selected. */
 "No Menu Selected" = "Няма избрано меню";
 
+/* missing preview URL for blog post preview */
+"No Preview URL available" = "Няма адрес за преглед";
+
+/* No comment provided by engineer. */
+"No application can handle this request." = "Няма приложение за приемане на заявката.";
+
+/* No comment provided by engineer. */
+"No application can handle this request. Please install a Web browser." = "Няма приложение, което да може да обработи заявката. Инсталирайте браузър.";
+
+/* Advises the user that no Domain suggestions could be found for the search query. */
+"No available addresses matching your search" = "Няма налични адреси, съответстващи на търсенето";
+
+/* A short message that informs the user no sites could be loaded in the share extension. */
+"No available sites" = "Няма налични сайтове";
+
+/* No comment provided by engineer. */
+"No blocks found" = "Няма намерени блокове.";
+
 /* An option in a list. Automatically approve no comments. */
 "No comments" = "Няма коментари";
 
@@ -1231,11 +3773,70 @@
    Title for the error view when there's no connection */
 "No connection" = "Няма връзка";
 
+/* Message to show when Keyring connection synchronization succeeded but no matching connections were found. %@ is a service name like Facebook or Twitter */
+"No connections found for %@" = "Не бе открита връзка за %@";
+
+/* No comment provided by engineer. */
+"No custom placeholder set" = "Няма настроен заместващ текст";
+
+/* Text displayed when Period stat section has no data. */
+"No data for this period" = "Няма данни за периода";
+
+/* Text displayed when an Insights stat section has no data.
+   Text shown when there is no data to display in the stats list view. */
+"No data yet" = "Още няма данни";
+
+/* No comment provided by engineer. */
+"No description" = "Няма описание";
+
+/* Title for the view when there aren't any fixed threats to display */
+"No fixed threats" = "Няма отстранени заплахи";
+
+/* Title for the view when there aren't any history items to display */
+"No history yet" = "Още няма история";
+
+/* Title for the view when there aren't any ignored threats to display */
+"No ignored threats" = "Няма пренебрегнати заплахи";
+
+/* Title displayed when the user has removed all Insights from display. */
+"No insights added yet" = "Все още няма обобщения";
+
+/* This primary error message is displayed if a user encounters an issue with network reachability. */
+"No internet connection" = "Няма Интернет връзка";
+
+/* Error message shown when the user is browsing Notifications without an internet connection.
+   Error message shown when the user is browsing Reader without an internet connection. */
+"No internet connection. Some content may be unavailable while offline." = "Няма Интернет връзка. Част от съдържанието ще бъде недостъпно, докато сте офлайн.";
+
+/* Error message shown when the user is browsing Site Pages without an internet connection. */
+"No internet connection. Some pages may be unavailable while offline." = "Няма Интернет връзка. Някои страници ще бъдат недостъпни, докато сте офлайн.";
+
+/* Error message shown when the user is browsing Site Posts without an internet connection. */
+"No internet connection. Some posts may be unavailable while offline." = "Няма Интернет връзка. Някои публикации ще бъдат недостъпни, докато сте офлайн.";
+
 /* Displayed in the Notifications Tab as a title, when the Likes Filter shows no notifications */
 "No likes yet" = "Все още няма харесвания";
 
+/* Message displayed when no results are returned from a media library search. Should match Calypso. */
+"No media matching your search" = "Няма файлове, съответстващи на търсенето";
+
 /* Menus text shown when no menus were available for loading the Menus editor. */
 "No menus available" = "Няма налични менюта";
+
+/* A hint to users about creating a downloadable backup of their site. */
+"No need to wait around. We'll notify you when your backup is ready." = "Няма нужда да чакате. Ще ви известим, когато вашият бекъп е готов.";
+
+/* A hint to users about restoring their site. */
+"No need to wait around. We'll notify you when your site has been fully restored." = "Няма нужда да чакате. Ще ви известим, когато сайтът е напълно възстановен.";
+
+/* Displayed in the Notifications Tab as a title, when there are no notifications */
+"No notifications yet" = "Още няма известия";
+
+/* Text displayed when there's no matching with the text search */
+"No pages matching your search" = "Няма страници, съответстващи на търсенето";
+
+/* Text displayed when search for plugins returns no results */
+"No plugins found" = "Няма намерени разширения";
 
 /* A message title */
 "No posts" = "Няма публикации";
@@ -1252,11 +3853,35 @@
 /* Message shown whent the reader finds no posts for the chosen tag */
 "No posts have been made recently with this tag." = "Няма скорошни публикации с този етикет.";
 
+/* Accessibility value for a Stats' Posting Activity Month if there are no posts. */
+"No posts." = "Няма публикации.";
+
+/* No comment provided by engineer. */
+"No preview available" = "Няма налична визуализация.";
+
+/* Title displayed when there are no blogging prompts to display. */
+"No prompts yet" = "Няма предизвикателства";
+
 /* A message title */
 "No recent posts" = "Няма скорошни публикации";
 
 /* Shown when user is searching for specific Menu item options and no items are available, such as posts, pages, etc. */
 "No results. Please try a different search." = "Няма намерени резултати. Моля опитайте друго търсене.";
+
+/* Message displayed in Reader Saved Posts view if a user hasn't yet saved any posts. */
+"No saved posts" = "Няма запазени публикации";
+
+/* Button label for denying our request to re-allow push notifications */
+"No thanks" = "Не, благодаря";
+
+/* Text displayed when theme name search has no matches */
+"No themes matching your search" = "Няма теми, съответстващи на търсенето";
+
+/* Message for a notice informing the user their scan completed and no threats were found */
+"No threats found" = "Не са открити заплахи";
+
+/* No comment provided by engineer. */
+"No title" = "Без заглавие";
 
 /* Disabled
    No alignment for an image (default). Should be the same as in core WP.
@@ -1264,12 +3889,46 @@
    No size class defined for the image. Should be the same as in core WP. */
 "None" = "Без";
 
+/* Title shown on table row where no blogging reminders have been set up yet */
+"None set" = "Нищо не е избрано";
+
+/* Title of unanswered Blogging Prompts filter. */
+"Not Answered" = "Не е отговорено";
+
+/* Error title for alert, shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
+"Not Connected" = "Няма връзка";
+
 /* Nicer dialog answer for \"No\".
    Title of a button that cancels enabling notifications when tapped */
 "Not Now" = "Не сега";
 
+/* Error message to show to users when trying to upload a media object with file size is larger than the available site disk quota */
+"Not enough space to upload" = "Няма достатъчно място за качване";
+
+/* Button label for denying our request to allow push notifications
+   Not now button title shown in alert preparing users to grant permission for us to send them push notifications. */
+"Not now" = "Не сега";
+
+/* Instructions after a Magic Link was sent, but the email can't be found in their inbox. */
+"Not seeing the email? Check your Spam or Junk Mail folder." = "Не виждате имейла? Проверете спам или junk папките.";
+
+/* Label for the note displayed in the Feature Introduction view. */
+"Note:" = "Бележка:";
+
+/* No comment provided by engineer. */
+"Note: Column layout may vary between themes and screen sizes" = "Бележка: Колоните може да изглеждат различно на различните теми и екрани";
+
+/* No comment provided by engineer. */
+"Note: Layout may vary between themes and screen sizes" = "Бележка: Оформлението може да изглежда различно в различните теми и екрани.";
+
+/* No comment provided by engineer. */
+"Note: You must allow WordPress.com login to edit this block in the mobile editor." = "Бележка: Трябва да позволите WordPress.com профила да редактира този блок в мобилния редактор.";
+
 /* Shown when user is loading Menu item options and no items are available, such as posts, pages, etc. */
 "Nothing found." = "Нищо не бе открито.";
+
+/* A message title */
+"Nothing liked yet" = "Нищо харесано засега";
 
 /* Notifications Details Accessibility Identifier */
 "Notification Details Table" = "Таблица с детайли за известията";
@@ -1277,6 +3936,12 @@
 /* Title displayed in the Notification settings
    Title of the 'Notification Settings' screen within the 'Me' tab - used for spotlight indexing on iOS. */
 "Notification Settings" = "Настройки за известяване";
+
+/* Title for the time picker button in Blogging Reminders. */
+"Notification time" = "Време на известието";
+
+/* Description of the blogging prompts feature on the Blogging Reminders Settings screen. */
+"Notification will include a word or short phrase for inspiration" = "Известието ще включва нещо за вдъхновяване";
 
 /* Name of the Notifications feature.
    Notifications 3D Touch Shortcut
@@ -1292,6 +3957,21 @@
 /* Notifications tab bar item accessibility label, unread notifications state */
 "Notifications Unread" = "Непрочетени известия";
 
+/* Title for mark all as read success notice */
+"Notifications marked as read" = "Известията са маркирани като прочетени";
+
+/* Title of button to navigate to the next screen of the blogging reminders flow, setting up push notifications. */
+"Notify me" = "Уведомете ме";
+
+/* The default Jetpack view message for the success state */
+"Now that Jetpack is installed, we just need to get you set up. This will only take a minute." = "След като вече имате Jetpack, само трябва да ви настроим. Това ще отнеме минутка.";
+
+/* Register Domain - Address information field Number */
+"Number" = "Номер";
+
+/* No comment provided by engineer. */
+"Number of columns" = "Брой колони";
+
 /* Discoverability title for numbered list keyboard shortcut. */
 "Numbered List" = "Номериран списък";
 
@@ -1302,6 +3982,9 @@
    Ok button for dismissing alert helping users understand their site address
    OK Button title shown in alert informing users about the Reader Save for Later feature. */
 "OK" = "ОК";
+
+/* No comment provided by engineer. */
+"OPEN" = "ОТВАРЯНЕ";
 
 /* Disabled */
 "Off" = "Изключено";
@@ -1324,6 +4007,24 @@
 /* Sort Order */
 "Oldest first" = "Първо най-старите";
 
+/* Warning message about disabling group invite links. */
+"Once this invite link is disabled, nobody will be able to use it to join your team. Are you sure?" = "След като връзката е деактивирана, никой няма да може да я ползва, за да влезе в екипа ви. Сигурни ли сте?";
+
+/* No comment provided by engineer. */
+"Once you become familiar with the names of different blocks, you can add a block by typing a forward slash followed by the block name — for example, \/image or \/heading." = "След като свикнете с имената на различните блокове, можете да добавяте блок, като напишете наклонена черта, последвана от името на блока — например \/image или \/heading.";
+
+/* No comment provided by engineer. */
+"One" = "Едно";
+
+/* Warning label that informs the user to only scan login codes that they generated. */
+"Only scan QR codes taken directly from your web browser. Never scan a code sent to you by anyone else." = "Сканирайте QR кодове, взети директно от браузър. Никога не сканирайте кодове от непознати.";
+
+/* Subtitle displayed when the user has removed all Insights from display. */
+"Only see the most relevant stats. Add insights to fit your needs." = "Вижте само най-полезните статистики. Добавете обобщения според нуждите ви.";
+
+/* No comment provided by engineer. */
+"Only show excerpt" = "Показване само на откъс";
+
 /* An informal exclaimation that means `something went wrong`.
    Title for the view when there's an error loading a comment.
    Title for the view when there's an error loading Activity Log
@@ -1336,6 +4037,18 @@
 /* An informal exclaimation meaning `something went wrong`. */
 "Oops!" = "Упс!";
 
+/* No comment provided by engineer. */
+"Opacity" = "Плътност";
+
+/* No comment provided by engineer. */
+"Open Block Actions Menu" = "Отваряне на менюто с действия към блока";
+
+/* Opens iOS's Device Settings for WordPress App */
+"Open Device Settings" = "Отвори настройките на устройството";
+
+/* No comment provided by engineer. */
+"Open Jetpack Security settings" = "Отваряне на настройките за сигурност";
+
 /* The button title text for opening the user's preferred email app.
    Title of a button. The text should be capitalized.  Clicking opens the mail app in the user's iOS device. */
 "Open Mail" = "Към електронна поща";
@@ -1346,14 +4059,53 @@
 /* No comment provided by engineer. */
 "Open in Safari" = "Отваряне в Safari";
 
+/* Label for the description of openening a link using a new window */
+"Open in a new Window\/Tab" = "Отваряне в нов прозорец\/раздел";
+
+/* Button title to load a post in an in-app web view */
+"Open in browser" = "Отваряне в браузъра";
+
+/* No comment provided by engineer. */
+"Open link in a browser" = "Отваряне на връзката в браузър";
+
 /* Menus label for checkbox when editig item as a link. */
 "Open link in new window\/tab" = "Отваряне в нов прозорец\/раздел";
+
+/* Accessibility hint the Me button in My Site. */
+"Open the Me Section" = "Отваряне на моя профил";
+
+/* Accessibility hint to open web page in Safari */
+"Opens the web page in Safari" = "Отваря страницата в Safari";
 
 /* WordPress.com Research Footer Text */
 "Opportunities to participate in WordPress.com research & surveys." = "Възможности да участвате във WordPress.com изследвания и проучвания.";
 
+/* Invite: Message Hint. %1$d is the maximum number of characters allowed. */
+"Optional message up to %1$d characters to be included in the invitation." = "Опционално съобщение до %1$d символа, което да бъде пратено с поканата.";
+
+/* Footer text for Invite People message field. %1$d is the maximum number of characters allowed. */
+"Optional: Enter a custom message up to %1$d characters to be sent with your invitation." = "По желание: въведете свое съобщение до %1$d символа, което да бъде пратено с поканата.";
+
+/* Divider on initial auth view separating auth options. */
+"Or" = "Или";
+
+/* Instruction text for other forms of two-factor auth methods. */
+"Or choose another form of authentication." = "Или изберете друга форма на автентикация.";
+
+/* Label for button to log in using site address. Underscores _..._ denote underline. */
+"Or log in by _entering your site address_." = "Или влезте като _въведете вашия адрес на сайта_";
+
+/* The button title for a secondary call-to-action button on the password screen. When the user wants to try sending a magic link instead of entering a password. */
+"Or log in with magic link" = "Или вход с магическа връзка";
+
 /* Accessibility label for Ordered list button on formatting toolbar. */
 "Ordered List" = "Подреден списък";
+
+/* Register Domain - Domain contact information field Organization */
+"Organization" = "Организация";
+
+/* Register Domain - Domain contact information field placeholder for Organization */
+"Organization (Optional)" = "Организация (опционално)";
 
 /* Indicates a video will use its original size when uploaded.
    Indicates an image will use its original size when uploaded. */
@@ -1381,9 +4133,33 @@
    Other Sites Notification Settings Title */
 "Other Sites" = "Други сайтове";
 
+/* No comment provided by engineer. */
+"Outside" = "Отвън";
+
+/* Register Domain - Phone number section header title */
+"PHONE" = "ТЕЛЕФОН";
+
+/* Caption for the recommended sections in site designs. */
+"PICKED FOR YOU" = "ИЗБРАНИ ЗА ВАС";
+
+/* No comment provided by engineer. */
+"Padding" = "Отстояние";
+
 /* Noun. Type of content being selected is a blog page
    Title shown when selecting a post type of Page from the Share Extension. */
 "Page" = "Страница";
+
+/* Name of the button to open the page settings */
+"Page Settings" = "Настройки на страницата";
+
+/* translators: accessibility text. %s: Page break text. */
+"Page break block. %s" = "Блок за прекъсване на страница. %s";
+
+/* translators: accessibility text. %s: text content of the page title. */
+"Page title. %s" = "Заглавие на страница. %s";
+
+/* translators: accessibility text. empty page title. */
+"Page title. Empty" = "Заглавие на страница. Празно";
 
 /* Noun. Title. Links to the blog's Pages screen.
    This is the section title
@@ -1395,8 +4171,8 @@
    Settings: Comments Paging preferences */
 "Paging" = "Страници";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Категория родител";
+/* Parenting site intent topic */
+"Parenting" = "Родителство";
 
 /* Accessibility label for the password text field in the self-hosted login page.
    Label for entering password in password field
@@ -1405,6 +4181,18 @@
    Placeholder for the password textfield.
    Title for screen that shows self hosted password editor. */
 "Password" = "Парола";
+
+/* Password field placeholder text */
+"Password (optional)" = "Парола (опционално)";
+
+/* Loader title displayed by the loading view while the password is changed successfully */
+"Password changed successfully" = "Паролата е променена успешно.";
+
+/* No comment provided by engineer. */
+"Paste URL" = "Поставяне на адрес";
+
+/* No comment provided by engineer. */
+"Paste block after" = "Поставете на блока после";
 
 /* Button title for Pending comment state.
    Title of pending Comments filter. */
@@ -1417,14 +4205,59 @@
 /* Label for date periods. */
 "Period" = "Период";
 
+/* Close Account confirmation action title */
+"Permanently Close Account" = "Перманентно закриване на профила";
+
+/* Delete Site confirmation action title */
+"Permanently Delete Site" = "Перманентно изтриване на сайта";
+
+/* Personal site intent topic */
+"Personal" = "Персонален";
+
 /* Section title for the personalize table section in the blog details screen. */
 "Personalize" = "Персонализиране";
+
+/* Accessibility label for selecting an image or video from the device's photo library on formatting toolbar. */
+"Photo Library" = "Фото библиотека";
+
+/* Photography site intent topic */
+"Photography" = "Фотография";
+
+/* Title for selecting a new username in the site creation flow. */
+"Pick username" = "Избор на потребителско име";
+
+/* User action to play a video on the editor. */
+"Play video" = "Пускане на видео";
+
+/* No comment provided by engineer. */
+"Playback Bar Color" = "Цвят на плейбек навигацията";
+
+/* No comment provided by engineer. */
+"Playback Settings" = "Настройки за плейбек";
+
+/* Suggestion to add content before trying to publish post or page */
+"Please add some content before trying to publish." = "Моля, добавете съдържание, преди да публикувате.";
 
 /* Politely asks the user to check their internet connection before trying again. */
 "Please check your internet connection and try again." = "Проверете интернет връзката си и опитайте пак.";
 
+/* Confirmation title presented before fixing all the threats, displays the number of threats to be fixed */
+"Please confirm you want to fix all %1$d active threats" = "Потвърдете, че искате да отстраните всичките %1$d заплахи";
+
+/* Confirmation title presented before fixing a single threat */
+"Please confirm you want to fix this threat" = "Потвърдете, че искате да отстраните заплахата";
+
 /* Message displayed on an error alert to prompt the user to contact support */
 "Please contact support for assistance." = "Моля, свържете се с отдел поддръжка.";
+
+/* Subtitle message shown when the Unsupported Block Editor fails to load. It asks users to verify that the block editor is enabled on their site before trying again. */
+"Please ensure the block editor is enabled on your site and try again." = "Моля, проверете дали блоковия редактор е включен и пробвайте пак.";
+
+/* Message asking users to make sure that the block editor is enabled on their site in order for the Unsupported Block Editor to load properly. */
+"Please ensure the block editor is enabled on your site. If it is not enabled, it will not load." = "Моля, проверете дали блоковия редактор е включен. Ако не е, няма да се зареди.";
+
+/* Error message shown when a URL is invalid. */
+"Please enter a complete website address, like example.com." = "Моля, въведете пълен адрес на сайта, като primer.com.";
 
 /* No comment provided by engineer. */
 "Please enter a site address." = "Въведете адрес на сайт.";
@@ -1432,17 +4265,107 @@
 /* No comment provided by engineer. */
 "Please enter a username." = "Моля, въведете потребителско име.";
 
+/* Register Domain - Domain contact information validation error message for an input field */
+"Please enter a valid City" = "Моля, въведете валиден град";
+
+/* Register Domain - Domain contact information validation error message for an input field */
+"Please enter a valid Country" = "Моля, въведете валидна държава";
+
+/* Register Domain - Domain contact information validation error message for an input field */
+"Please enter a valid Email" = "Моля, въведете валиден имейл";
+
+/* Register Domain - Domain contact information validation error message for an input field */
+"Please enter a valid First Name" = "Моля, въведете валидно лично име";
+
+/* Register Domain - Domain contact information validation error message for an input field */
+"Please enter a valid Last Name" = "Моля, въведете валидно фамилно име";
+
+/* Register Domain - Domain contact information validation error message for an input field */
+"Please enter a valid Organization" = "Въведете валидна организация";
+
+/* Register Domain - Domain contact information validation error message for an input field */
+"Please enter a valid Postal Code" = "Моля, въведете валиден пощенски код";
+
+/* Register Domain - Domain contact information validation error message for an input field */
+"Please enter a valid State" = "Моля, въведете валиден щат";
+
+/* Register Domain - Domain contact information validation error message for an input field */
+"Please enter a valid address" = "Въведете валиден адрес";
+
+/* An error message. */
+"Please enter a valid email address for a WordPress.com account." = "Моля, въведете валиден имейл адрес за WordPress.com профил.";
+
 /* Error message displayed when the user attempts use an invalid email address. */
 "Please enter a valid email address." = "Моля, въвете валиден имейл адрес.";
+
+/* Register Domain - Domain contact information validation error message for an input field */
+"Please enter a valid phone number" = "Моля, въведете валиден телефонен номер";
+
+/* Instructional text shown when requesting the user's password for a login initiated via Sign In with Apple */
+"Please enter the password for your WordPress.com account to log in with your Apple ID." = "Моля, въведете паролата за вашия WordPress.cmo профил за вход с вашия Apple ID.";
 
 /* Popup message to ask for user credentials (fields shown below). */
 "Please enter your credentials" = "Въведете вашите потребителски данни";
 
+/* Instructions for alert asking for email. */
+"Please enter your email address." = "Моля, въведете вашия имейл.";
+
 /* A short prompt asking the user to properly fill out all login fields. */
 "Please fill out all the fields" = "Моля, попълнете всички полета";
 
+/* Share extension dialog text  - displayed when user is missing a login token. */
+"Please launch the WordPress app, log in to WordPress.com and make sure you have at least one site, then try again." = "Моля, поснете WordPress апликацията, влезте в WordPress.com и направете така, че да имате сайт, след което пробвайте пак.";
+
+/* Message for alert to prompt user to logout before connecting to a different wordpress.com site. */
+"Please log out before connecting to a different wordpress.com site" = "Моля, излезте, преди да свържете различен wordpress.com сайт";
+
+/* Used on an error alert to prompt the user to try again */
+"Please try again later" = "Опитайте по-късно";
+
+/* Description for the Jetpack Restore Failed message. */
+"Please try again later or contact support." = "Моля, опитайте пак или се свържете с поддръжката.";
+
+/* Prompt for the user to retry a failed action again later */
+"Please try again later." = "Опитайте по-късно.";
+
 /* No comment provided by engineer. */
 "Please try entering your login details again." = "Опитайте да въведете данните си за вход отново.";
+
+/* Asks the user to wait until the currently running fetch request completes. */
+"Please wait until the current fetch completes." = "Изчакайте докато заявката бъде завършена.";
+
+/* Link to a plugin's home page */
+"Plugin Homepage" = "Страница на разширението";
+
+/* Error displayed when trying to install a plugin on a site for the first time. */
+"Plugin cannot be installed due to disk space limitations." = "Разширението не може да се инсталира заради недостиг на място.";
+
+/* Error displayed when trying to install a plugin on a site for the first time. */
+"Plugin cannot be installed on VIP sites." = "Разширението не може да се инсталира на VIP сайтове.";
+
+/* Error displayed when trying to install a plugin on a site for the first time. */
+"Plugin feature is not available for this site." = "Функцията на разширението не е налична за сайта.";
+
+/* Error displayed when trying to install a plugin on a site for the first time. */
+"Plugin feature requires a business plan." = "Функция на разширението изисква Бизнес план.";
+
+/* Error displayed when trying to install a plugin on a site for the first time. */
+"Plugin feature requires a custom domain." = "Функция на разширението изисква да имате собствен домейн.";
+
+/* Error displayed when trying to install a plugin on a site for the first time. */
+"Plugin feature requires a verified email address." = "Функция на разширението изисква имейлът ви да е потвърден.";
+
+/* Error displayed when trying to install a plugin on a site for the first time. */
+"Plugin feature requires admin privileges." = "Функция на разширението изисква администраторски права.";
+
+/* Error displayed when trying to install a plugin on a site for the first time. */
+"Plugin feature requires primary domain subscription to be associated with this user." = "Функция на разширението изисква основният домейн да бъде към този потребител.";
+
+/* Error displayed when trying to install a plugin on a site for the first time. */
+"Plugin feature requires the site to be in good standing." = "Функция на разширението изисква сайтът да работи добре.";
+
+/* Error displayed when trying to install a plugin on a site for the first time. */
+"Plugin feature requires the site to be public." = "Функция на разширението изисква сайтът да е публичен.";
 
 /* Version of an installed plugin */
 "Plugin version" = "Версия на разширението";
@@ -1450,6 +4373,10 @@
 /* Noun. Title. Links to the plugin management feature.
    Title for the plugin directory */
 "Plugins" = "Разширения";
+
+/* An example tag used in the login prologue screens.
+   Politics site intent topic */
+"Politics" = "Политика";
 
 /* Header of section in Plugin Directory showing popular plugins
    Screen title, where users can see the most popular plugins */
@@ -1462,8 +4389,29 @@
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Публикация";
 
-/* Title for selecting categories for a post */
-"Post Categories" = "Категории";
+/* Name of the button to open the post settings */
+"Post Settings" = "Настройки на публикацията";
+
+/* Window title for Post Stats view. */
+"Post Stats" = "Статистики за публикацията";
+
+/* The footer text appears within the footer displaying when the post has been created. */
+"Post created on %@" = "Публикацията е създадена на %@";
+
+/* Title of the notification presented in Reader when a post is removed from save for later */
+"Post removed." = "Публикацията е премахната.";
+
+/* Title of the notification presented in Reader when a post is saved for later */
+"Post saved." = "Публикацията е записана.";
+
+/* translators: accessibility text. %s: text content of the post title. */
+"Post title. %s" = "Заглавие на публикация. %s";
+
+/* translators: accessibility text. empty post title. */
+"Post title. Empty" = "Заглавие на публикация. Празно";
+
+/* Register Domain - Address information field Postal Code */
+"Postal Code" = "Пощенски код";
 
 /* Insights 'Posting Activity' header
    Title for stats Posting Activity view. */
@@ -1475,6 +4423,22 @@
    Title of the screen showing the list of posts for a blog. */
 "Posts" = "Публикации";
 
+/* Title for setting which shows the current page assigned as a site's posts page */
+"Posts Page" = "Страница с публикации";
+
+/* Label for comments by posts and pages
+   Period Stats 'Posts and Pages' header */
+"Posts and Pages" = "Публикации и страници";
+
+/* Message informing the user that their static homepage for posts was set successfully */
+"Posts page successfully updated" = "Страницата с публикации беше обновена";
+
+/* Posts per Page Title */
+"Posts per Page" = "Публикации на страница";
+
+/* Label for selecting the number of posts per page */
+"Posts per page" = "Публикации на страница";
+
 /* A message explaining the Posts I Like feature in the reader */
 "Posts that you like will appear here." = "Тук се появяват харесваните от вас публикации.";
 
@@ -1484,14 +4448,32 @@
 /* Title of alert when attempting to delete site with purchases */
 "Premium Upgrades" = "Платени услуги";
 
+/* Title for label when the preparing to scan the users site */
+"Preparing to scan" = "Подготовка за сканиране";
+
 /* Displays the Post Preview Interface
    Title for button to preview a selected layout
    Title for screen to preview a selected homepage design.
    Title for screen to preview a static content. */
 "Preview" = "Преглед";
 
+/* Title for web preview device switching button */
+"Preview Device" = "Устройство за преглед";
+
+/* Title on display preview error */
+"Preview Unavailable" = "Преглед не е наличен";
+
+/* No comment provided by engineer. */
+"Preview page" = "Преглед на страницата";
+
 /* No comment provided by engineer. */
 "Preview post" = "Преглед";
+
+/* Accessibility label for the previous notification button */
+"Previous notification" = "Предишно известие";
+
+/* Accessibility label */
+"Previous period" = "Предишен период";
 
 /* Primary Site Picker's Title
    Primary Web Site */
@@ -1504,14 +4486,62 @@
 /* Title of button that displays the App's privacy policy */
 "Privacy Policy" = "Поверителност";
 
+/* Register Domain - Privacy Protection section header title */
+"Privacy Protection" = "Защита на поверителността";
+
+/* Link to privacy settings page
+   Privacy Settings Title */
+"Privacy Settings" = "Настройки за поверителност";
+
+/* No comment provided by engineer. */
+"Privacy and Rating" = "Поверителност и оценка";
+
+/* Link to the CCPA privacy notice for residents of California. */
+"Privacy notice for California users" = "Съобщение за поверителност за Калифорния";
+
+/* No comment provided by engineer. */
+"Problem displaying block. \nTap to attempt block recovery." = "Проблем при показването на блока. \nДокоснете да пробвате възстановяване.";
+
+/* Error message title informing the user that reader content could not be loaded. */
+"Problem loading content" = "Проблем при зареждането на съдържание";
+
+/* No comment provided by engineer. */
+"Problem opening the audio" = "Проблем с отварянето на аудио";
+
+/* No comment provided by engineer. */
+"Problem opening the video" = "Проблем с отварянето на видео";
+
+/* Register Domain - error displayed when there's a problem when purchasing the domain. */
+"Problem purchasing your domain. Please try again." = "Проблем при покупката на домейн. Опитайте отново.";
+
+/* Title of the notification presented when a prompt is skipped */
+"Prompt skipped" = "Предизвикателството е пропуснато";
+
+/* Title label for blogging prompts in the create new bottom action sheet.
+   Title label for the Prompts card in My Sites tab.
+   View title for Blogging Prompts list. */
+"Prompts" = "Предизвикателства";
+
 /* Label for the publish (verb) button. Tapping publishes a draft post.
    Publish post action on share extension site picker screen.
    Section title for the publish table section in the blog details screen */
 "Publish" = "Публикуване";
 
+/* Text displayed in the share extension's summary view. It describes the publish page action. */
+"Publish page on:" = "Публикуване на страницата на:";
+
+/* Text displayed in the share extension's summary view. It describes the publish post action. */
+"Publish post on:" = "Публикувай в:";
+
 /* Period Stats 'Published' header
    Title of the published filter. This filter shows a list of posts that the user has published. */
-"Published" = "Публикувано";
+"Published" = "Публикувани";
+
+/* A short message that informs the user a page is being published to the server from the share extension. */
+"Publishing page..." = "Публикуване на страницата...";
+
+/* A short message that informs the user a post is being published to the server from the share extension. */
+"Publishing post..." = "Публикуване...";
 
 /* Title of screen showing site purchases */
 "Purchases" = "Покупки";
@@ -1522,10 +4552,28 @@
 /* Suggests to enable Push Notification Settings in Settings.app */
 "Push Notifications have been turned off in iOS Settings App. Toggle \"Allow Notifications\" to turn them back on." = "Известията на устройството бяха изключени от настройките на iOS. Изберете \"Включване на известията\" за да ги включите.";
 
+/* This is the string we display when asking the user to approve push notifications in the settings app after previously having denied them. */
+"Push notifications have been turned off in iOS settings. Toggle “Allow Notifications” to turn them back on." = "Известията на устройството бяха изключени от настройките на iOS. Изберете \"Включване на известията\" за да ги включите.";
+
+/* Title for button allowing users to rate the app in the App Store */
+"Rate Us" = "Оценете ни";
+
+/* In the share extension, this is the text used right before attributing a quote to a website. Example: 'Read on www.site.com'. We are looking for the 'Read on' text in this situation. */
+"Read on" = "Повече в";
+
+/* Link to privacy policy */
+"Read privacy policy" = "Прочетете политиката ни за поверителност";
+
+/* Displayed at the footer of a Pingback Notification. */
+"Read the source post" = "Вижте източника на публикацията";
+
 /* Name of the Reader feature.
    Noun. Name of the Reader feature
    The accessibility value of the Reader tab. */
 "Reader" = "Четец";
+
+/* Real Estate site intent topic */
+"Real Estate" = "Недвижими имоти";
 
 /* Text for the 'Reblog' button. */
 "Reblog" = "Препубликуване";
@@ -1533,8 +4581,17 @@
 /* Title for a list of ssettings for editing a blog's Reblog and Like settings. */
 "Reblog & Like" = "Реблогване и харесване";
 
+/* Accessibility label for the reblog button. */
+"Reblog post" = "Реблогване";
+
+/* Accessibility hint for the reblog button. */
+"Reblog this post" = "Препубликуване на публикацията";
+
 /* Settings: Receiving Pingbacks */
 "Receive Pingbacks" = "Получаване на pingbacks";
+
+/* Descriptive text below a list of options. */
+"Receive notifications for new posts from this site" = "Получаване на известия за нови публикации от този сайт";
 
 /* Post Stats recent weeks header. */
 "Recent Weeks" = "Близки седмици";
@@ -1548,6 +4605,9 @@
 /* Message shwon to confirm a publicize connection has been successfully reconnected. */
 "Reconnected" = "Свързахте се отново";
 
+/* Action button to redo last change */
+"Redo" = "Повторение";
+
 /* Label for link title in Referrers stat. */
 "Referrer" = "Източник";
 
@@ -1558,15 +4618,42 @@
    The loading view button title displayed when an error occurred */
 "Refresh" = "Презареждане";
 
+/* Action to redeem domain credit. */
+"Register Domain" = "Регистрация на домейн";
+
+/* Register Domain - Register Privately with Privacy Protection option title */
+"Register Privately with Privacy Protection" = "Регистрирайте поверително със защита на поверителността";
+
+/* Install Plugin dialog register domain button text
+   Register domain - Title for the Register domain button
+   Title for the Register domain screen */
+"Register domain" = "Регистрация на домейн";
+
+/* Register Domain - Register publicly option title */
+"Register publicly" = "Публична регистрация";
+
 /* Describes a domain that was registered with WordPress.com */
 "Registered Domain" = "Регистриран домейн";
+
+/* Displayed in the Notifications Tab as a message, when the Unread Filter shows no notifications */
+"Reignite the conversation: write a new post." = "Възобновете разговора: напишете нова публикация";
 
 /* Label for selecting the related posts options */
 "Related Posts" = "Подобни публикации";
 
+/* Button title on the blogging prompt's feature introduction view to set a reminder. */
+"Remind me" = "Напомни ми";
+
+/* Title of the completion screen of the Blogging Reminders Settings screen when the reminders are removed. */
+"Reminders removed" = "Напомнянията са премахнати";
+
 /* Alert button to confirm a plugin to be removed
    Remove Action */
 "Remove" = "Премахване";
+
+/* Remove Person Alert Title
+   Remove User. Verb */
+"Remove %@" = "Премахване на %@";
 
 /* Label action for removing a link from the editor */
 "Remove Link" = "Премахване на връзка";
@@ -1577,8 +4664,65 @@
 /* Button to remove a plugin from a site */
 "Remove Plugin" = "Премахване на разширение";
 
+/* Title for the alert to confirm a plugin removal */
+"Remove Plugin?" = "Премахване на разширение?";
+
 /* Button to remove a site from the app */
 "Remove Site" = "Изтриване";
+
+/* Remove site icon button */
+"Remove Site Icon" = "Премахване на иконата на сайта";
+
+/* No comment provided by engineer. */
+"Remove as Featured Image" = "Да не е основно изображение";
+
+/* No comment provided by engineer. */
+"Remove block" = "Премахавне на блок";
+
+/* No comment provided by engineer. */
+"Remove blocks" = "Премахване на блокове";
+
+/* Option to remove Insight from view. */
+"Remove from insights" = "Премахване от обобщенията";
+
+/* User action to remove image. */
+"Remove image" = "Премахване на изображението";
+
+/* User action to remove video. */
+"Remove video" = "Изтриване на видеото";
+
+/* Notice confirming that an image has been removed as the post's featured image. */
+"Removed as featured image" = "Премахнато като основно изображение";
+
+/* Explanatory text for removing the location from uploaded media. */
+"Removes location metadata from photos before uploading them to your site." = "Премахва мета данните с местоположение от снимките, преди да ги качи в сайта ви.";
+
+/* No comment provided by engineer. */
+"Replace Current Block" = "Замяна на текущия блок";
+
+/* No comment provided by engineer. */
+"Replace audio" = "Замяна на аудио";
+
+/* Title message on dialog that prompts user to confirm or cancel the replacement of a featured image. */
+"Replace current featured image?" = "Замяна на основното изображение?";
+
+/* Button to confirm the replacement of a featured image. */
+"Replace featured image" = "Замяна на основното изображение";
+
+/* No comment provided by engineer. */
+"Replace file" = "Замяна на файл";
+
+/* No comment provided by engineer. */
+"Replace image" = "Замяна на изображение";
+
+/* No comment provided by engineer. */
+"Replace image or video" = "Замяна на изображение или видео";
+
+/* No comment provided by engineer. */
+"Replace video" = "Замяна на видео";
+
+/* VoiceOver accessibility hint, informing the user the button can be used to reply to a comment. */
+"Replies to a comment." = "Отговаря на коментар.";
 
 /* Setting: indicates if Replies to Comments will be notified */
 "Replies to your comments" = "Отговори на вашите коментари";
@@ -1587,6 +4731,9 @@
    Reply to a comment.
    Verb. Button title. Reply to a comment. */
 "Reply" = "Отговор";
+
+/* Provides hint that the screen displays a reply to a comment.%1$@ is a placeholder for the comment author that's been replied to.Example: Reply to Pamela Nguyen */
+"Reply to %1$@" = "Отговор на %1$@";
 
 /* An explaination of a setting. */
 "Require manual approval for comments that include more than this number of links." = "Ръчно одобряване на коментари които включват повече от зададения брой връзки.";
@@ -1597,11 +4744,20 @@
 /* Settings: Comments Approval settings */
 "Require name and email" = "Изискване на име и имейл";
 
+/* Jetpack Settings: Require two-step authentication */
+"Require two-step authentication" = "Изискване на двустъпкова автентикация";
+
 /* Settings: Comments Approval settings */
 "Require users to log in" = "Изискване потребителите да са влезли";
 
 /* Setting: WordPress.com Surveys */
 "Research" = "Изследване";
+
+/* Title of secondary button on alert prompting verify their accounts while attempting to publish */
+"Resend" = "Повторно пращане";
+
+/* The button title for a secondary call-to-action button. When the user can't remember their password. */
+"Reset your password" = "Нулиране на парола";
 
 /* Screen title. Resize and crop an image. */
 "Resize & Crop" = "Преоразмеряване и изрязване";
@@ -1609,11 +4765,26 @@
 /* The largest resolution allowed for uploading */
 "Resolution" = "Разделителна способност";
 
+/* Title for the fix section in Threat Details: Threat is not fixable */
+"Resolving the threat" = "Отстраняване на заплахата";
+
 /* Title for Jetpack Restore Complete screen
    Title for Jetpack Restore Status Failed screen
    Title for Jetpack Restore Status screen
    Title for the Jetpack Restore Site Screen */
 "Restore" = "Възстановяване";
+
+/* Title for Jetpack Restore Failed screen */
+"Restore Failed" = "Възстановяването не бе успешно";
+
+/* Title for error displayed when restoring a site fails. */
+"Restore failed" = "Възстановяването не бе успешно";
+
+/* Label that describes the restore site action */
+"Restore site" = "Възстановяване на сайт";
+
+/* Button title for restore site action */
+"Restore to this point" = "Възстановяване до тази точка";
 
 /* A prompt to attempt the failed network request again
    A prompt to attempt the failed network request again.
@@ -1628,14 +4799,35 @@
    User action to retry media upload. */
 "Retry" = "Отново";
 
+/* Button title that triggers a scan */
+"Retry Scan" = "Повторно сканиране";
+
+/* User action to retry all failed media uploads. */
+"Retry all" = "Повторен опит за всички";
+
+/* Share extension error dialog cancel button text */
+"Return to post" = "Връщане към публикацията";
+
 /* Cancels a pending Email Change */
 "Revert Pending Change" = "Отмяна на изчакващата промяна";
+
+/* Accessibility hint describing what happens if the undo button is tapped. */
+"Reverts the action performed on this notification." = "Отменя действието, извършено с това известие";
+
+/* Title of the screen that shows the revisions. */
+"Revision" = "Версия";
 
 /* Post Rich content */
 "Rich Content" = "Богато съдържание";
 
+/* No comment provided by engineer. */
+"Rich text editing" = "Редактиране с богато форматиране";
+
 /* Right alignment for an image. Should be the same as in core WP. */
 "Right" = "Подравняване вдясно";
+
+/* Example Reader feed title */
+"Rock 'n Roll Weekly" = "Седмичен рокендрол";
 
 /* Title. Indicates the user role an invite link is for.
    User Roles Title
@@ -1645,6 +4837,15 @@
 /* One Time Code has been sent via SMS */
 "SMS Sent" = "SMS изпратен";
 
+/* Section title for the moderation section of the comment details screen. */
+"STATUS" = "СЪСТОЯНИЕ";
+
+/* Button label to open web page in Safari */
+"Safari" = "Safari";
+
+/* Title of a row displayed on the debug screen used to configure the sandbox store use in the App. */
+"Sandbox Store" = "Тестов режим";
+
 /* Menus save button title
    Save Action
    Save draft post action on share extension site picker screen.
@@ -1653,26 +4854,181 @@
    Title of action button to save a Reader post to read later. */
 "Save" = "Запазване";
 
+/* Text displayed in the share extension's summary view that describes the action of saving multiple photos in a draft page. */
+"Save %ld photos as a draft page on:" = "Записване на %ld снимки като чернова в:";
+
+/* Text displayed in the share extension's summary view that describes the action of saving multiple photos in a draft post. */
+"Save %ld photos as a draft post on:" = "Записване на %ld снимки като чернова в:";
+
+/* Text displayed in the share extension's summary view that describes the action of saving a single photo in a draft page. */
+"Save 1 photo as a draft page on:" = "Записване на 1 снимка като чернова в:";
+
+/* Text displayed in the share extension's summary view that describes the action of saving a single photo in a draft post. */
+"Save 1 photo as a draft post on:" = "Записване на 1 снимка като чернова в:";
+
+/* Title of alert informing users about the Reader Save for Later feature. */
+"Save Posts for Later" = "Запазване на публикациите за по-късно";
+
+/* Text displayed in the share extension's summary view that describes the save draft page action. */
+"Save draft page on:" = "Записване на чернова в:";
+
+/* Text displayed in the share extension's summary view that describes the save draft post action. */
+"Save draft post on:" = "Записване на чернова в:";
+
+/* Body text of alert informing users about the Reader Save for Later feature. */
+"Save this post, and come back to read it whenever you'd like. It will only be available on this device — saved posts don't sync to other devices." = "Запомнете публикацията и се върнете да я прочетете, когато искате. Ще е налична само на това устройство. Запомнените публикации не се синхронизират с други устройства.";
+
+/* Title of action button for a Reader post that has been saved to read later. */
+"Saved" = "Записано";
+
+/* A short message that informs the user a draft page is being saved to the server from the share extension. */
+"Saving page…" = "Записване на страница...";
+
+/* A short message that informs the user a draft post is being saved to the server from the share extension. */
+"Saving post…" = "Записване на публикацията...";
+
 /* Menus save button title while it is saving a Menu. */
 "Saving..." = "Запазване...";
+
+/* Noun. Links to a blog's Jetpack Scan screen.
+   Noun. Name of the Scan feature
+   Title of the view */
+"Scan" = "Сканиране";
+
+/* Button label that prompts the user to scan the log in code again
+   Button title that triggers a scan */
+"Scan Again" = "Повторно сканиране";
+
+/* Title for a notice informing the user their scan has completed */
+"Scan Finished" = "Сканирането е приключено";
+
+/* Title of the view */
+"Scan History" = "История на сканиранията";
+
+/* Link to opening the QR login scanner */
+"Scan Login Code" = "Сканиране на код за влизане";
+
+/* Button title that triggers a scan */
+"Scan Now" = "Сканиране сега";
+
+/* Title for label when the actively scanning the users site */
+"Scanning files" = "Сканиране на файловете";
 
 /* Title of the scheduled filter. This filter shows a list of posts that are scheduled to be published at a future date. */
 "Scheduled" = "Насрочена";
 
+/* No comment provided by engineer. */
+"Scrollable block menu closed." = "Скролиращото блок меню е затворено.";
+
+/* No comment provided by engineer. */
+"Scrollable block menu opened. Select a block." = "Скролиращото блок меню е отворено. Изберете блок.";
+
 /* Title of Stats section that shows search engine referrer traffic. */
 "Search" = "Търсене";
+
+/* Label for list of search term */
+"Search Term" = "Ключова дума";
 
 /* Period Stats 'Search Terms' header */
 "Search Terms" = "Търсене на термини";
 
+/* No comment provided by engineer. */
+"Search block label. Current text is" = "Търсене на етикета на блога. Текущият текст е";
+
+/* No comment provided by engineer. */
+"Search blocks" = "Търсене на блокове";
+
+/* No comment provided by engineer. */
+"Search button. Current button text is" = "Бутон за търсене. Текущият текст на бутона е";
+
+/* title of the button that searches the first domain. */
+"Search for a domain" = "Търсене на домейн";
+
+/* Select domain name. Subtitle */
+"Search for a short and memorable keyword to help people find and visit your website." = "Потърсете кратка и запомняща се ключова дума, която да помогне на посетителите да открият сайта.";
+
+/* No comment provided by engineer. */
+"Search input field." = "Поле за търсене.";
+
+/* No comment provided by engineer. */
+"Search settings" = "Настройки за търсене";
+
 /* Menus search bar placeholder text. */
 "Search..." = "Търсене...";
+
+/* Accessibility hint for the domains search field in Site Creation. */
+"Searches for available domains to use for your site." = "Търси за налични домейни, които да ползвате за сайта.";
+
+/* Accessibility value presented in the signup epilogue for a password value. */
+"Secure text" = "Сигурен текст";
 
 /* Label for selecting the Blog Jetpack Security Settings section */
 "Security" = "Сигурност";
 
+/* Button in Plugin Directory letting users see more plugins */
+"See All" = "Всички";
+
+/* Caption displayed in promotional screens shown during the login flow. */
+"See comments and notifications in real time." = "Гледайте коментари и известия в реално време.";
+
+/* Select action on the app extension category picker screen. Saves the selected categories for the post.
+   Select action on the app extension post type picker screen. Saves the selected post type for the post. */
+"Select" = "Избор";
+
+/* Register Domain - Domain contact information field placeholder for Country */
+"Select Country" = "Изберете държава";
+
+/* Register Domain - Address information field placeholder for State */
+"Select State" = "Избор на област";
+
+/* No comment provided by engineer. */
+"Select a color" = "Избор на цвят";
+
+/* No comment provided by engineer. */
+"Select a color above" = "Избор на цвят";
+
+/* No comment provided by engineer. */
+"Select a layout" = "Избор на оформление";
+
+/* Accessibility label for selecting paragraph style button on formatting toolbar. */
+"Select paragraph style" = "Изберете стил на параграфа";
+
 /* Instructional text about the Sharing feature. */
 "Select the account you would like to authorize. Note that your posts will be automatically shared to the selected account." = "Изберете потребителя, който искате да оторизирате. Имайте предвид, че публикациите ви ще бъдат автоматично споделени с този потребител.";
+
+/* Prompt shown on the Blogging Reminders Settings screen. */
+"Select the days you want to blog on" = "Избор на дни, в които искате да блогвате";
+
+/* Accessibility hint for stat available to add to Insights. */
+"Select to add this stat to Insights." = "Избор за добавяне на статистиката към обобщения.";
+
+/* Voiceover hint for a button that allows the user to filter posts by author. */
+"Select to change the current author filter." = "Избор за промяна на филтъра по автор";
+
+/* Voiceover accessibility hint, informing the user they can select an item to filter a list of posts to show only their own posts. */
+"Select to just show my posts." = "Избор да се покажат само моите публикации";
+
+/* Accessibility hint for Manage Insight button. */
+"Select to manage this Insight." = "Избор за промяна на обобщението.";
+
+/* Voiceover accessibility hint, informing the user they can select an item to show posts written by all users on the site */
+"Select to show everyone's posts." = "Избор да се покажат публикации на всички";
+
+/* Screen reader text to represent the selected state of a button */
+"Selected" = "Избран";
+
+/* Error message when user tries to preview an image media like a video */
+"Selected media is not a video." = "Избраният файл не е видео.";
+
+/* Error message when user tries a no longer existent video media object. */
+"Selected media is unavailable." = "Избраният файл не е достъпен.";
+
+/* translators: %s: Select font size option value e.g: \"Selected: Large\".
+translators: %s: Select control option value e.g: \"Auto, 25%\". */
+"Selected: %s" = "Избран: %s";
+
+/* No comment provided by engineer. */
+"Selected: Default" = "Избрано: по подразбиране";
 
 /* Menus alert message for alerting the user to unsaved changes while trying to select a different menu location. */
 "Selecting a different menu location will discard changes you've made to the current menu. Are you sure you want to continue?" = "Избирането на друга позиция за това меню ще отхвърли промените, които сте направили към текущото меню. Сигурни ли сте, че искате да продължите?";
@@ -1680,14 +5036,62 @@
 /* Menus alert message for alerting the user to unsaved changes while trying to select a different menu. */
 "Selecting a different menu will discard changes you've made to the current menu. Are you sure you want to continue?" = "Избирането на друго меню ще отхвърли промените, които сте направили към текущото. Сигурни ли сте, че искате да продължите?";
 
+/* Title of an alert informing users that the video they are trying to select is not allowed. */
+"Selection not allowed" = "Изборът не е позволен";
+
+/* Accessibility hint for a domain in the Site Creation domains list. */
+"Selects this domain to use for your site." = "Избира този домейн за ползване във вашия сайт.";
+
+/* Screen reader hint (non-imperative) about what does the menu item selection button do */
+"Selects this item" = "Избира този елемент";
+
+/* Accessibility hint for a topic in the Site Creation intents view. */
+"Selects this topic as the intent for your site." = "Избира темата като намерението ви за този сайт.";
+
 /* Title of a button. The text should be uppercase.  Clicking requests a hyperlink be emailed ot the user. */
 "Send Link" = "Изпращане на връзка";
+
+/* The button title text for sending a magic link. */
+"Send Link by Email" = "Изпращане на връзка по имейл";
+
+/* Title of a row displayed on the debug screen used to send a pretend error message to the crash logging provider to ensure everything is working correctly */
+"Send Log Message" = "Изпращане на съобщение от дневника";
 
 /* Settings: Sending Pingbacks */
 "Send Pingbacks" = "Изпращане на pingbacks";
 
+/* Title of a row displayed on the debug screen used to crash the app and send a crash report to the crash logging provider to ensure everything is working correctly */
+"Send Test Crash" = "Изпращане на тестов краш";
+
+/* Button title. Sends a email verification link (Magin link) for signing in. */
+"Send email verification link" = "Изпращане на имейл с връзка за верификация";
+
+/* Jetpack Monitor Settings: Send notifications by email */
+"Send notifications by email" = "Изпращане на известия по имейл";
+
+/* Jetpack Monitor Settings: Send push notifications */
+"Send push notifications" = "Изпращане на пуш нотификации";
+
+/* Title for the Serve images from our servers setting */
+"Serve images from our servers" = "Доставяне на изображения от нашите сървъри";
+
 /* Label for connected service in Publicize stat. */
 "Service" = "Услуга";
+
+/* No comment provided by engineer. */
+"Set as Featured Image" = "Задайте като Препоръчано изображение";
+
+/* Notice confirming that an image has been set as the post's featured image. */
+"Set as featured image" = "Използване като основно изображение";
+
+/* The Jetpack view button title for the success state */
+"Set up" = "Настройка";
+
+/* Title for the Jetpack Installation & Connection */
+"Set up Jetpack" = "Настройка на Jetpack";
+
+/* User-facing string, presented to reflect that site assembly is underway. */
+"Setting up theme" = "Настройване на тема";
 
 /* Link to plugin's Settings
    Section title
@@ -1707,6 +5111,33 @@
 /* Message to show when setting save failed */
 "Settings update failed" = "Проблем при обновяване на настройките";
 
+/* Title for a button that recommends the app to others */
+"Share Jetpack with a friend" = "Споделяне на Jetpack с приятел";
+
+/* Title for a button that recommends the app to others */
+"Share Reader with a friend" = "Споделяне на Reader с приятел";
+
+/* Title for a button that recommends the app to others */
+"Share WordPress with a friend" = "Споделяне на WordPress с приятел";
+
+/* Accessibility label for button to share a comment from a notification */
+"Share comment" = "Споделяне на коментара";
+
+/* Informational text for Collect Information setting */
+"Share information with our analytics tool about your use of services while logged in to your WordPress.com account." = "Споделяне на информация с нашите инструменти за анализ за вашата употреба на услугата, докато сте във вашия WordPress.com профил";
+
+/* Title. A call to action to share an invite link. */
+"Share invite link" = "Споделяне на връзка с покана";
+
+/* Title for the button that will share the link for the downlodable backup file */
+"Share link" = "Споделяне на връзка";
+
+/* Title. `The `%@` is a placeholder for the service name. */
+"Share post to %@" = "Споделете публикацията в %@";
+
+/* Title for button allowing users to share information about the app with friends, such as via Messages */
+"Share with Friends" = "Споделяне с приятели";
+
 /* Aztec's Text Placeholder
    Share Extension Content Body Text Placeholder */
 "Share your story here..." = "Споделете вашата история тук...";
@@ -1720,6 +5151,12 @@
    Title of a list of buttons used for sharing content to other services. */
 "Sharing Buttons" = "Бутони за споделяне";
 
+/* Share extension error dialog title. */
+"Sharing Error" = "Грешка при споделяне";
+
+/* Share extension dialog title - displayed when user is missing a login token. */
+"Sharing error" = "Грешка при споделяне";
+
 /* Title for the `show like button` setting */
 "Show Like button" = "Показване на бутона за харесване";
 
@@ -1729,8 +5166,69 @@
 /* Title for the `show reblog button` setting */
 "Show Reblog button" = "Показване на бутон за реблогване";
 
+/* Accessibility label for the 'Show password' button in the login page's password field.
+   Accessibility label for the “Show password“ button in the login page's password field. */
+"Show password" = "Показване на паролата";
+
+/* No comment provided by engineer. */
+"Show post content" = "Показване на публикацията";
+
+/* Voiceover description for the post list filter which shows posts for all users on a site. */
+"Showing everyone's posts" = "Показване на публикации от всички";
+
+/* Voiceover description for the post list filter which shows posts for just the current user on a site. */
+"Showing just my posts" = "Показване само на моите публикации";
+
+/* Label on Post Stats view indicating which post the stats are for. */
+"Showing stats for:" = "Показване на статистика за:";
+
+/* Accessibility value if login page's password field is displaying the password. */
+"Shown" = "Показана";
+
 /* Help text when editing web address */
 "Shown publicly when you comment on blogs." = "Показва се публично когато коментирате на някой блог.";
+
+/* Accessibility hint for a follow notification. */
+"Shows all followers" = "Показва абонатите";
+
+/* Accessibility hint for a post or comment “like” notification. */
+"Shows all likes." = "Показва харесванията.";
+
+/* Accessibility hint for a comment notification. */
+"Shows details and moderation actions." = "Показва подробни действия за модерация.";
+
+/* Accessibility hint for a match/mention on a post notification. */
+"Shows the post" = "Показва публикацията";
+
+/* View title during the sign up process. */
+"Sign Up" = "Регистрация";
+
+/* Button title. Takes the user the Enter site credentials screen. */
+"Sign in with site credentials" = "Вход с идентификация за сайта";
+
+/* When social login fails, this button offers to let them signup for a new WordPress.com account */
+"Sign up" = "Регистрация";
+
+/* Button title. Tapping begins the process of creating a WordPress.com account. */
+"Sign up for WordPress.com" = "Вход в WordPress.com";
+
+/* Button title. Tapping begins our normal sign up process. */
+"Sign up with Email" = "Регистрация с имейл";
+
+/* Notice displayed to the user after clearing the Siri activity donations. */
+"Siri Reset Confirmation" = "Успешно са изчистени подсказките на Siri";
+
+/* Label for button that clears user activities donated to Siri. */
+"Siri Reset Prompt" = "Почистване на подсказките на Siri";
+
+/* Header for a single site, shown in Notification user profile. */
+"Site" = "Сайт";
+
+/* Title of the Domains Dashboard. */
+"Site Domains" = "Домейни към сайта";
+
+/* Accessibility label for site icon button */
+"Site Icon" = "Икона на сайта";
 
 /* Title for the Language Picker View */
 "Site Language" = "Език на сайта";
@@ -1738,19 +5236,40 @@
 /* Describes a site redirect domain */
 "Site Redirect" = "Пренасочване на сайт";
 
+/* Noun. Title. Links to the blog's Settings screen. */
+"Site Settings" = "Настройки на сайта";
+
 /* Default title for a site
    Label for site title blog setting
    Title for screen that show site title editor */
 "Site Title" = "Заглавие на сайта";
 
+/* Title of the navigation bar, shown when the large title is hidden. */
+"Site Topic" = "Тема на сайта";
+
 /* Setting: indicates if Achievements will be notified */
 "Site achievements" = "Постижения на сайта";
+
+/* Accessibility label of the site address field shown when adding a self-hosted site. */
+"Site address" = "Адрес на сайта";
 
 /* No comment provided by engineer. */
 "Site address must be at least 4 characters." = "Адресът на сайта трябва да съдържа поне 4 символа.";
 
+/* Downloadable/Restorable items: Site Database */
+"Site database" = "База данни на сайта";
+
 /* Overlay message displayed when site successfully deleted */
 "Site deleted" = "Сайтът бе изтрит";
+
+/* Error notice shown if the app can't find a specific site belonging to the user */
+"Site not found" = "Сайтът не е открит";
+
+/* Site timezone offset from UTC. The first %@ is plus or minus. %d is the number of hours. The last %@ is minutes, where applicable. Examples: `Site timezone (UTC+10:30)`, `Site timezone (UTC-8)`. */
+"Site timezone (UTC%@%d%@)" = "Настройка на часова зона (UTC%1$@%2$d%3$@)";
+
+/* Confirmation that the user successfully changed the site's title */
+"Site title changed successfully" = "Заглавието на сайта беше променено";
 
 /* Image size option title. */
 "Size" = "Размер";
@@ -1758,6 +5277,39 @@
 /* Continue without making a selection
    Continue without making a selection. */
 "Skip" = "Пропускане";
+
+/* Menu title to skip today's prompt. */
+"Skip for today" = "Пропускане за днес";
+
+/* translators: Slash inserter autocomplete results */
+"Slash inserter results" = "Резултати от слаш вграждане";
+
+/* Text display in the view when there aren't any Activities Types to display in the Activity Log Types picker */
+"So far, there are no fixed threats on your site." = "Засега няма отстранени заплахи на вашия сайт.";
+
+/* Text display in the view when there aren't any Activities Types to display in the Activity Log Types picker */
+"So far, there are no ignored threats on your site." = "Засега няма пренебрегнати заплахи на вашия сайт.";
+
+/* Label for social followers */
+"Social" = "Социални";
+
+/* No comment provided by engineer. */
+"Some blocks have additional settings. Tap the settings icon on the bottom right of the block to view more options." = "Някои блокове имат допълнителни настройки. Докоснете иконата за настройки от долния десен ъгъл на блока.";
+
+/* Title shown on the dashboard when it fails to load */
+"Some data wasn't loaded" = "Част от данните не са заредени";
+
+/* Title for a label that appears when the scan failed
+   Title for the error view when the scan start has failed */
+"Something went wrong" = "Нещо се обърка";
+
+/* This prompt is displayed when the user attempts to play a video in the editor but for some reason we are unable to retrieve from the server. */
+"Something went wrong. Please check your connectivity and try again." = "Възникна грешка! Проверете връзката си и пробвайте отново.";
+
+/* Error message shown when a media upload fails for a general network issue and the user should try again in a moment.
+   Error message shown when the app fails to save user selected interests
+   Error message shown when user tries to share the app with others, but failed due to unknown errors. */
+"Something went wrong. Please try again." = "Нещо се обърка. Моля опитайте отново.";
 
 /* Invite Validation Alert
    Update User Failed Title */
@@ -1784,6 +5336,9 @@
 /* No comment provided by engineer. */
 "Sorry, that email address is not allowed!" = "Този имейл адрес не е позволен!";
 
+/* This error message occurs when a user tries to create an account with a weak password. */
+"Sorry, that password does not meet our security guidelines. Please choose a password with a minimum length of six characters, mixing uppercase letters, lowercase letters, numbers and symbols." = "Съжаляваме, но паролата не отговаря на изискванията за сигурност. Иберете парола с минимална дължина от шест символа, смесвайки главни букви, малки букви, цифри и специални символи.";
+
 /* No comment provided by engineer. */
 "Sorry, that site already exists!" = "Този сайт вече съществува!";
 
@@ -1808,6 +5363,15 @@
 /* No comment provided by engineer. */
 "Sorry, you may not use that site address." = "Не можете да използвате този адрес.";
 
+/* A short error message letting the user know the requested reader content could not be loaded. */
+"Sorry. The content could not be loaded." = "Съдържанието не успя да се зареди.";
+
+/* An error message shown if a third-party social service does not specify any accounts that an be used with publicize sharing. */
+"Sorry. The social service did not tell us which account could be used for sharing." = "Социалната услуга не ни каза кой профил може да се ползва за споделяне.";
+
+/* A short error message leting the user know the requested search could not be performed. */
+"Sorry. Your search results could not be loaded." = "Резултатите от търсене не се заредиха.";
+
 /* Discussion Settings Title
    Settings: Comments Sort Order */
 "Sort By" = "Сортиране по";
@@ -1815,10 +5379,23 @@
 /* Title of button that displays the App's source code information */
 "Source Code" = "Изходен код";
 
+/* Label for showing the available disk space quota available for media */
+"Space used" = "Използвано място";
+
 /* Button title for Spam comment state.
    Marks comment as spam.
    Title of spam Comments filter. */
 "Spam" = "Спам";
+
+/* Option to select the Spark email app when logging in with magic links */
+"Spark" = "Spark";
+
+/* Label for selecting the Speed up your site Settings section
+   Title for the Speed up your site Settings Screen */
+"Speed up your site" = "Ускорете сайта";
+
+/* Sports site intent topic */
+"Sports" = "Спорт";
 
 /* Default post format
    Standard post format label */
@@ -1828,11 +5405,35 @@
    Title of Start Over settings page */
 "Start Over" = "Започване отначало";
 
+/* No comment provided by engineer. */
+"Start writing…" = "Започнете да пишете...";
+
+/* Accessibility hint for stat not available to add to Insights. */
+"Stat is already displayed in Insights." = "Статистиката е показана в Обобщения";
+
+/* Register Domain - Domain Address field State */
+"State" = "Област";
+
 /* Noun. Abbreviation of Statistics. Name of the Stats feature
    Noun. Abbv. of Statistics. Links to a blog's Stats screen.
    Stats 3D Touch Shortcut
    Stats window title */
 "Stats" = "Статистика";
+
+/* The loading view title displayed when an error occurred */
+"Stats not loaded" = "Статистиката не е заредена";
+
+/* Title of the first alert preparing users to grant permission for us to send them push notifications. */
+"Stay in the loop" = "Останете свързани";
+
+/* Subtitle giving the user more context about why to enable notifications. */
+"Stay in touch with like and comment notifications." = "Останете свързани чрез известия за харесвания и коментари.";
+
+/* Label text that defines a post marked as sticky */
+"Sticky" = "Залепена";
+
+/* User action to stop upload. */
+"Stop upload" = "Спиране на качването";
 
 /* Accessibility label for strikethrough button on formatting toolbar. */
 "Strike Through" = "Зачеркнат";
@@ -1843,9 +5444,24 @@
 /* Submit for review button label (saving content, ex: Post, Page, Comment). */
 "Submit for Review" = "Изпращане за преглед";
 
+/* Notice displayed to the user after clearing the spotlight index in app settings. */
+"Successfully cleared spotlight index" = "Успешно е изтрит индекса на Spotlight";
+
+/* The app successfully subscribed to the comments for the post */
+"Successfully followed conversation" = "Успешно последвана дискусия";
+
+/* Notice displayed after installing a plug-in. */
+"Successfully installed %@." = "Успешно инсталиране на %@.";
+
+/* The app successfully unsubscribed from the comments for the post */
+"Successfully unfollowed conversation" = "Прекратено е следването на дискусията";
+
 /* Setting: WordPress.com Suggestions
    Suggested domains */
 "Suggestions" = "Предложения";
+
+/* Announced by VoiceOver when new domains suggestions are shown in Site Creation. */
+"Suggestions updated" = "Препоръките са обновени";
 
 /* User role badge */
 "Super Admin" = "Супер админ";
@@ -1853,6 +5469,27 @@
 /* Support button that appears in the Theme Browser Header
    Theme Support action title */
 "Support" = "Помощ";
+
+/* Switches the Editor to HTML Mode */
+"Switch to HTML Mode" = "Превключване към HTML режим";
+
+/* Switches the Content to HTML Preview */
+"Switch to HTML Preview" = "Преминаване към HTML преглед";
+
+/* Switches the Editor to Rich Text Mode */
+"Switch to Visual Mode" = "Превключване към визуален режим";
+
+/* Switches the Content to Rich Text Preview */
+"Switch to Visual Preview" = "Преминаване към визуален преглед";
+
+/* Switches from the classic editor to block editor. */
+"Switch to block editor" = "Преминаване към блоков редактор";
+
+/* Message of the notice shown when toggling the HTML editor mode */
+"Switched to HTML mode" = "Превключено към HTML режим";
+
+/* Message of the notice shown when toggling the Visual editor mode */
+"Switched to Visual mode" = "Превключено към визуален режим";
 
 /* Accessibility Identifier for the H1 Aztec Style */
 "Switches to the Heading 1 font size" = "Превключва размера на шрифта на Заглавие 1";
@@ -1875,16 +5512,135 @@
 /* Accessibility Identifier for the Default Font Aztec Style. */
 "Switches to the default Font Size" = "Превключва размера на шрифта на този по подразбиране";
 
+/* No comment provided by engineer. */
+"Synced patterns" = "Синхронизирани макети";
+
+/* Title for the app appearance setting (light / dark mode) that uses the system default value */
+"System default" = "По подразбиране";
+
+/* Accessibility of stats table. Placeholder will be populated with name of data shown in table. */
+"Table showing %@" = "Таблица, показваща %@";
+
+/* Accessibility of stats table. Placeholders will be populated with names of data shown in table. */
+"Table showing %@ and %@" = "Таблица, показваща %1$@ и %2$@";
+
+/* Title for the tablet web preview */
+"Tablet" = "Таблет";
+
 /* Label for tagline blog setting
    Title for screen that show tagline editor */
 "Tagline" = "Кратко описание";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Етикети";
 
+/* Insights 'Tags and Categories' header */
+"Tags and Categories" = "Етикети и категории";
+
+/* No comment provided by engineer. */
+"Take a Photo" = "Направете снимка";
+
+/* No comment provided by engineer. */
+"Take a Video" = "Заснемане на видео";
+
+/* A hint shown to the user in stats telling them how to navigate to the Comments detail view. */
+"Tap \"View more\" to see your top commenters." = "Докоснете \"Още\", за да видите топ коментарите.";
+
+/* A hint displayed in the Saved Posts section of the Reader. The '[bookmark-outline]' placeholder will be replaced by an icon at runtime – please leave that string intact. */
+"Tap [bookmark-outline] to save a post to your list." = "Докоснете [bookmark-outline] за записване на публикацията във вашия списък.";
+
+/* Accessibility hint */
+"Tap for more detail." = "Докоснете за подробности.";
+
+/* No comment provided by engineer. */
+"Tap here to copy error details" = "Бутон за копиране на грешката";
+
+/* No comment provided by engineer. */
+"Tap here to copy post text" = "Бутон за копиране на публикацията";
+
+/* No comment provided by engineer. */
+"Tap here to show help" = "Докоснете тук за помощ";
+
+/* No comment provided by engineer. */
+"Tap here to show more details." = "Докоснете за повече информация.";
+
+/* Accessibility hint for a button that opens a view that allows to add new stats cards. */
+"Tap to add new stats cards." = "Докоснете за добавяне на статистически карти.";
+
 /* This is a status indicator on the editor */
 "Tap to cancel uploading." = "Натиснете, за да отмените качването.";
+
+/* Accessibility hint for button used to change site title */
+"Tap to change the site's title" = "Докоснете, за да смените заглавието на сайта";
+
+/* Accessibility hint to inform the user what action the hide button performs */
+"Tap to collapse the post tags" = "Докоснете за свиване на етикетите към публикацията";
+
+/* Accessibility hint
+   Accessibility hint to customize insights */
+"Tap to customize insights" = "Докоснете за промяна на обобщенията";
+
+/* Accessibility hint for referrer details row. */
+"Tap to display referrer web page." = "Маркирайте да покажете страницата на източника.";
+
+/* Accessibility hint prompting the user to tap a table row to edit its value. */
+"Tap to edit" = "Докосване за редакция";
+
+/* Message in a row indicating to tap to enter a custom value */
+"Tap to enter a custom value" = "Въведете собствена стойност";
+
+/* No comment provided by engineer. */
+"Tap to hide the keyboard" = "Докоснете за скриване на клавиатурата";
+
+/* Title for a push notification with fixed content that invites the user to load today's blogging prompt. */
+"Tap to load today's prompt..." = "Докоснете, за да заредите предизвикателството...";
+
+/* Accessibility hint for referrer action row. */
+"Tap to mark referrer as not spam." = "Маркирайте източника като не-спам.";
+
+/* Accessibility hint for referrer action row. */
+"Tap to mark referrer as spam." = "Маркирайте източника като спам.";
+
+/* Label for a button to retry loading posts */
+"Tap to retry" = "Докосване за повторен опит";
+
+/* VoiceOver Hint to inform the user what action the expand button performs */
+"Tap to see all the tags for this post" = "Докоснете, за да видите етикетите на тази публикация";
+
+/* Accessibility hint */
+"Tap to select the next period" = "Докоснете за следващ период";
+
+/* Accessibility hint */
+"Tap to select the previous period" = "Докоснете за предишен период";
+
+/* Accessibility hint for a button that opens a new view with more details. */
+"Tap to view more details." = "Докоснете за повече информация.";
+
+/* VoiceOver accessibility hint, informing the user the button can be used to access more stats about this week */
+"Tap to view more stats for this week" = "Докоснете, за да видите още статистики за седмицата";
+
+/* Accessibility hint to inform the user what action the post tag chip performs */
+"Tap to view posts for this tag" = "Докоснете, за да видите публикации с този етикет";
+
+/* Accessibility hint for button used to view the user's site */
+"Tap to view your site" = "Докоснете, за да видите сайта";
+
+/* Accessibility hint, informing user the button can be used to visit the Gravatar website. */
+"Tap to visit the Gravatar website in an external browser" = "Докоснете за да посетите Gravatar във външен браузър";
+
+/* Label for viewing the custom taxonomies */
+"Taxonomies" = "Категоризации";
+
+/* Technology site intent topic */
+"Technology" = "Технологии";
+
+/* Create site, step 1. Select type of site. Title */
+"Tell us what kind of site you'd like to make" = "Кажете ни какъв сайт искате да направите";
+
+/* The underlined title sentence */
+"Terms and Conditions" = "Условия за ползване";
 
 /* Title of button that displays the App's terms of service */
 "Terms of Service" = "Условия за ползване";
@@ -1892,11 +5648,23 @@
 /* Title of a button style */
 "Text Only" = "Само текст";
 
+/* No comment provided by engineer. */
+"Text color" = "Цвят на текста";
+
+/* No comment provided by engineer. */
+"Text formatting controls are located within the toolbar positioned above the keyboard while editing a text block" = "Контролите за форматиране на текст се намират в полето над клавиатурата, докато редактирате текстов блок.";
+
 /* Button title */
 "Text me a code instead" = "Изпращане на код чрез SMS";
 
+/* The button's title text to send a 2FA code via SMS text message. */
+"Text me a code via SMS" = "Изпращане на код чрез SMS";
+
 /* Message of alert when theme activation succeeds */
 "Thanks for choosing %@ by %@" = "Благодарим ви, че избрахте %1$@ от %2$@";
+
+/* Shown when a user pastes a code into the two factor field that contains letters or is the wrong length */
+"That doesn't appear to be a valid verification code." = "Това не изглежда да е валиден код за верификация.";
 
 /* Message to show to user when he tries to add a self-hosted site that isn't a WordPress site. */
 "That doesn't look like a WordPress site." = "Това не прилича на WordPress сайт.";
@@ -1916,20 +5684,80 @@
 /* No comment provided by engineer. */
 "That username is not allowed." = "Това потребителско име не е позволено.";
 
+/* Error message shown to a user who is trying to share to Facebook but does not have any available Facebook Pages. */
+"The Facebook connection cannot find any Pages. Publicize cannot connect to Facebook Profiles, only published Pages." = "Връзката с Facebook не може да открие страница. Не можем да публикуваме във Facebook профили, само във Facebook страници.";
+
+/* Description shown when a user logs in with Google but no matching WordPress.com account is found */
+"The Google account \"%@\" doesn't match any account on WordPress.com" = "Гугъл профила \"%@\" не съответства на никой WordPress.com профил";
+
 /* Error message shown when a media upload fails because the user isn't connected to the Internet. */
 "The Internet connection appears to be offline." = "Няма връзка с интернет.";
+
+/* Message informing the user that the site title can only be changed by an administrator user. */
+"The Site Title can only be changed by a user with the administrator role." = "Заглавието на сайта може да се смени само от администратор.";
+
+/* Description of the purpose of a site's title. */
+"The Site Title is displayed in the title bar of a web browser and is displayed in the header for most themes." = "Заглавието на сайта се показва в лентата за заглавие на браузъра и като заглавие в повечето теми";
 
 /* Error message describing a problem with a URL. */
 "The URL is missing a valid host." = "Този адрес няма валиден хост.";
 
+/* Example post title used in the login prologue screens. This is a post about football fans. */
+"The World's Best Fans" = "Най-добрите фенове на света";
+
+/* No comment provided by engineer. */
+"The basics" = "Основите";
+
+/* Subtitle displayed on the feature introduction view. */
+"The best way to become a better writer is to build a writing habit and share with others - that’s where Prompts come in!" = "Най-добрият начин да станете по-добър писател е да изградите писателки навици и да споделяте с другите - за това предизвикателствата ще помогнат.";
+
 /* Message for when the certificate for the server is invalid. The %@ placeholder will be replaced the a host name, received from the API. */
 "The certificate for this server is invalid. You might be connecting to a server that is pretending to be “%@” which could put your confidential information at risk.\n\nWould you like to trust the certificate anyway?" = "Сертификатът на този сървър е невалиден. Възможно е да се свързвате със сървър който се преструва че е \"%@\", което да изложи ваша конфиденциална информация на риск.\n\nСигурни ли сте, че искате да се доверите на този сертификат?";
+
+/* Message informing the user that posts page cannot be edited */
+"The content of your latest posts page is automatically generated and cannot be edited." = "Съдържанието на последната страница от публикации е автоматично генерирано и не може да се редактира.";
+
+/* No comment provided by engineer. */
+"The editor has encountered an unexpected error" = "Възникна неочаквана грешка в редактора";
+
+/* Title for a threat that includes the file name of the file */
+"The file %1$@ contains a malicious code pattern" = "Файлът %1$@ съдържа злонамерен код";
+
+/* Message shown when an image failed to load while trying to add it to the Media library. */
+"The image could not be added to the Media Library." = "Изображението не може да бъде добавено към Медийната Библиотека";
+
+/* Accessibility hint for list */
+"The kinds of sites that can be created" = "Видовете сайтове, които могат да се създадат";
 
 /* Footer Text displayed in Blog Language Settings View */
 "The language in which this site is primarily written." = "Основния език, който се използва за съдържанието на сайта.";
 
+/* Description for label when there are no threats on a users site and how long ago the scan ran. */
+"The last Jetpack scan ran %1$@ and did not find any risks.\n\nTo review your site again run a manual scan, or wait for Jetpack to scan your site later today." = "Последното сканиране на Jetpack беше изпълнено на %1$@ и не откри никакви заплахи.\n\nЗа да прегледате сайта си отново, стартирайте ръчно сканиране или изчакайте Jetpack да го сканира по-късно днес.";
+
+/* Description that informs for label when there are no threats on a users site */
+"The last jetpack scan did not find any risks.\n\nTo review your site again run a manual scan, or wait for Jetpack to scan your site later today." = "Последното сканиране на Jetpack не откри никакви рискове.\n\nЗа да прегледате сайта си отново, стартирайте ръчно сканиране или изчакайте Jetpack да го сканира по-късно днес.";
+
+/* Error message shown when trying to scan an invalid log in code. */
+"The log in code that was scanned could not be validated. Please tap the Scan Again button to rescan the code." = "Кодът за влизане не може да бъде потвърден. Моля, сканирайте отново.";
+
 /* WordPress.com Push Authentication Expired message */
 "The login request has expired. Log in to WordPress.com to try again." = "Заявката за влизане е изтекла. Влезте в WordPress.com, за да опитате отново.";
+
+/* Message shown when an image or video failed to load while trying to add it to the Media library. */
+"The media could not be added to the Media Library." = "Файлът не беше добавен към файловата библиотека.";
+
+/* Error shown when a module can not be enabled */
+"The module couldn't be activated." = "Модулът не можа да се включи.";
+
+/* Text above the selection of the number of posts to show per blog page */
+"The number of posts to show per page." = "Броят публикации на страница";
+
+/* A failure reason for when the request couldn't be serialized. */
+"The serialization of the request failed." = "Сериализацията на заявката е неуспешна.";
+
+/* A failure reason for when the response couldn't be serialized. */
+"The serialization of the response failed." = "Сериализацията на отговора е неуспешна.";
 
 /* No comment provided by engineer. */
 "The server returned an empty response. This usually means you need to increase the memory limit for your site." = "Сървърът върна празен отговор. Това обикновено значи, че трябва да вдигнете паметта на сайта си.";
@@ -1940,6 +5768,10 @@
 /* No comment provided by engineer. */
 "The site at %@ uses WordPress %@. We recommend to update to the latest version, or at least %@" = "Този сайт %1$@ използва WordPress %2$@. Препоръчително е да обновите до последната версия или поне до %3$@";
 
+/* Error message shown a URL does not point to an existing site.
+   Error message shown when a URL does not point to an existing site. */
+"The site at this address is not a WordPress site. For us to connect to it, the site must use WordPress." = "Сайтът на този адрес не е WordPress. За да се свържем с него, сайтът трябва да ползва WordPress.";
+
 /* Message shown when site deletion API failed */
 "The site could not be deleted." = "Сайтът не може да бъде изтрит.";
 
@@ -1949,8 +5781,20 @@
 /* People: Invitation Error */
 "The specified user cannot be found. Please, verify if it's correctly spelt." = "Този потребител не може да бъде открит. Моля, потвърдете че сте го изписали правилно.";
 
+/* Title for the technical details section in Threat Details */
+"The technical details" = "Технически подробности";
+
+/* Message displayed when a threat is fixed successfully. */
+"The threat was successfully fixed." = "Заплахата беше отстранена.";
+
 /* People: Invitation Error */
 "The user already has the specified role. Please, try assigning a different role." = "Потребителят вече има тази роля. Опитайте да назначите друга роля.";
+
+/* Error message shown when user attempts to remove the site owner. */
+"The user you are trying to remove is the owner of this site. Please contact support for assistance." = "Потребителят, който се опитвате да премахнете, е собственик на сайта. Моля свържете се с поддръжката.";
+
+/* Message shown when a video failed to load while trying to add it to the Media library. */
+"The video could not be added to the Media Library." = "Избраното Видео не може да бъде добавено към Медийната Библиотека.";
 
 /* Title of alert when theme activation succeeds */
 "Theme Activated" = "Темата е активирана";
@@ -1966,17 +5810,37 @@
 /* Error displayed if a comment fails to get updated */
 "There has been an unexpected error while editing your comment" = "Възникна неизвестна грешка при редактиране на коментара";
 
+/* Register domain - Error message displayed whenever registering domain fails unexpectedly */
+"There has been an unexpected error while registering your domain" = "Имаше грешка при регистрацията на домейн";
+
 /* Invite Failed Message */
 "There has been an unexpected error while sending your Invitation" = "Възникна грешка при изпращане на вашата покана";
 
 /* Displayed after a failed Notification Settings call */
 "There has been an unexpected error while updating your Notification Settings" = "Възникна неочаквана грешка докато се обновяваха вашите настройки за известявания";
 
+/* Generic error alert message */
+"There has been an unexpected error." = "Имаше неочаквана грешка.";
+
+/* Displayed when there's a pending Email Change. The variable is the new email address. */
+"There is a pending change of your email to %@. Please check your inbox for a confirmation link." = "Има изчакваща промяна на вашия имейл адрес към %@. Проверете пощата си за връзката за потвърждение.";
+
 /* Informs the user about an issue connecting to the third-party sharing service. The `%@` is a placeholder for the service name. */
 "There is an issue connecting to %@. Reconnect to continue publicizing." = "Възникна грешка при свързването с %@. Свържете се отново, за да продължите да споделяте.";
 
+/* Displayed during Site Creation, when searching for Verticals and the server returns an error.
+   The Jetpack view title used when an error occurred
+   This primary message message is displayed if a user encounters a general error. */
+"There was a problem" = "Имаше проблем";
+
 /* Error message informing the user that there was a problem blocking posts from a site from their reader. */
 "There was a problem blocking posts from the specified site." = "Възникна проблем при блокирането на публикациите от сайта.";
+
+/* A general error message shown to the user when there was an API communication failure. */
+"There was a problem communicating with the site." = "Неуспешна комуникация със сайта.";
+
+/* The loading view subtitle displayed when an error occurred */
+"There was a problem loading your data, refresh your page to try again." = "Имаше проблем със зареждането на данните, презаредете страницата и пробвайте пак.";
 
 /* Error message informing the user that there was a problem clearing the block on site preventing its posts from displaying in the reader. */
 "There was a problem removing the block for specified site." = "Възникна проблем при премахването на блока от този сайт.";
@@ -1984,37 +5848,188 @@
 /* A short error message shown in a prompt. */
 "There was a problem saving changes to sharing management." = "Възникна проблем при запазването на промените в управлението на споделянето.";
 
+/* Text displayed when there is a failure changing the password.
+   Text displayed when there is a failure loading the history. */
+"There was an error changing the password" = "Имаше грешка при промяната на парола";
+
 /* Text displayed when there is a failure loading plugins */
 "There was an error loading plugins" = "Възникна проблем със зареждането на разширенията";
 
+/* Text displayed when there is a failure loading blogging prompts. */
+"There was an error loading prompts." = "Грешка при зареждане на предизвикателствата.";
+
+/* Text displayed when there is a failure loading a comment. */
+"There was an error loading the comment." = "Възникна проблем при зареждане на коментара.";
+
+/* Text displayed when there is a failure loading the history. */
+"There was an error loading the history" = "Имаше грешка при зареждане на историята";
+
+/* Text displayed when there is a failure loading the history feed */
+"There was an error loading the scan history" = "Имаше грешка при зареждане на историята на сканиране";
+
+/* Text displayed when there is a failure loading the status */
+"There was an error loading the scan status" = "Имаше грешка при зареждане на резултата от сканиране";
+
+/* Text displayed when there is a failure loading the plugin */
+"There was an error loading this plugin" = "Възникна проблем със зареждането на разширението.";
+
+/* Text displayed when there is a failure saving the username. */
+"There was an error saving the username" = "Грешка при записване на потребителя";
+
+/* Updating Role failed error message */
+"There was an error updating @%@" = "Възникна грешка при обновяване на @%@";
+
+/* Text displayed when user tries to create a downloadable backup when there is already one being prepared */
+"There's a backup currently being prepared, please wait before starting the next one" = "В момента се приготвя бекъп, моля изчакайте, преди да стартирате нов";
+
+/* Text displayed when user tries to start a restore when there is already one running */
+"There's a restore currently in progress, please wait before starting the next one" = "В момента има активно възстановяване, моля изчакайте, преди да стартирате ново";
+
+/* Insights 'This Year' header */
+"This Year" = "Тази година";
+
+/* Paragraph 1 of 2 of main text body for the delete screen. NOTE: it is important the localized 'can not' text be surrounded with the HTML '<b>' tags. */
+"This action <b>can not<\/b> be undone. Deleting the site will remove all content, contributors, domains, and upgrades from the site." = "Това действие <b>не може<\/b> да бъде отменено. Изтриването на сайта ще премахне цялото съдържание, сътрудници, домейни и ъпгрейди на сайта.";
+
 /* An error message display if the users device does not have a camera input available */
 "This app needs permission to access the Camera to capture new media, please change the privacy settings if you wish to allow this." = "Това приложение се нуждае от разрешение да използва камерата, за да може да заснема. Моля, променете вашите настройки за поверителност ако искате да разрешите това.";
+
+/* A description informing the user in order to proceed with this feature we will need camera permissions, and how to enable it. */
+"This app needs permission to access the Camera to scan login codes, tap on the Open Settings button to enable it." = "Приложението има нужда от права за достъп до камерата, за да сканира кодове за вход. Отворете вашия бутон за настройки, за да активирате камерата.";
+
+/* No comment provided by engineer. */
+"This color combination may be hard for people to read. Try using a brighter background color and\/or a darker text color." = "Тази цветова комбинация може да е трудна за четене. Опитайте с по-ярък фон и\/или по-тъмен цвят на текста.";
+
+/* No comment provided by engineer. */
+"This color combination may be hard for people to read. Try using a darker background color and\/or a brighter text color." = "Тази цветова комбинация може да а е трудна за четене. Опитайте с по-тъмен фон и\/или по ярък цвят на текста.";
+
+/* An error message informing the user the email address they entered did not match a WordPress.com account. */
+"This email address is not registered on WordPress.com." = "Email адресът не е регистриран в WordPress.com.";
+
+/* Message to show to user when media upload failed because server doesn't support media type */
+"This file is too large to upload to your site or it does not support this media format." = "Файлът е твърде голям за да се качи или е от неподдържан файлов формат.";
+
+/* Create site, step 1. Select type of site. Subtitle */
+"This helps us make recommendations. But you're never locked in -- all sites evolve!" = "Това ще ни помогне да правим препоръки. Не сте вързан - всички сайтове се променят!";
+
+/* Informational text for the privacy policy link */
+"This information helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, and more as detailed in our privacy policy." = "Информацията ни помага да подобрим нашите продукти, да направим маркетинга по-адекватен, да персонализираме WordPress.com преживяването ви и още, както е обяснено в политиката за поверителност.";
+
+/* The body of a notification displayed to the user prompting them to create a new blog post. The emoji should ideally remain, as part of the text. */
+"This is your reminder to blog today ✍️" = "Напомняме ви да блогнете ✍️";
+
+/* Error message shown when the user scanned an expired log in code. */
+"This log in code has expired. Please tap the Scan Again button to rescan the code." = "Този код за влизане е изтекъл. Моля, докоснете бутона за повторно сканиране и сканирайте кода пак.";
+
+/* Error message displayed when unable to close user account due to unresolved chargebacks. */
+"This user account cannot be closed if there are unresolved chargebacks." = "Профилът не може да се затвори, докато има текущи оспорвания на плащания.";
+
+/* Error message displayed when unable to close user account due to having active purchases. */
+"This user account cannot be closed while it has active purchases." = "Профилът не може да се затвори, докато има активни покупки.";
+
+/* Error message displayed when unable to close user account due to having active subscriptions. */
+"This user account cannot be closed while it has active subscriptions." = "Профилът не може да се затвори, докато има активни покупки.";
 
 /* A description of the twitter sharing setting.
    Information about the twitter sharing feature. */
 "This will be included in tweets when people share using the Twitter button." = "Това ще бъде включено в туитовете при споделяне чрез бутона на Twitter.";
 
+/* Warning when confirming to remove a plugin that's active */
+"This will deactivate the plugin and delete all associated files and data." = "Това ще изключи разширението и ще изтрие свързаните файлове и данни.";
+
+/* Warning when confirming to remove a plugin that's inactive */
+"This will delete all associated files and data." = "Това ще изтрие всички свързани файлове и данни.";
+
+/* Detailed instructions on Start Over settings page. This is the second paragraph. */
+"This will keep your site and URL active, but give you a fresh start on your content creation. Just contact us to have your current content cleared out." = "Това ще запази сайта и адреса ви активни, но ще ви даде чисто начало за ново съдържание. Свържете с нас, за да изчистим текущото ви съдържание.";
+
 /* Discussion Settings Title
    Settings: Comments Threading preferences */
 "Threading" = "Позволяване на отговори";
 
+/* Title for a threat */
+"Threat Found" = "Открита е заплаха";
+
+/* Title for the Jetpack Scan Threat Details screen */
+"Threat details" = "Подробности за заплахата";
+
+/* Summary description for a threat that includes the threat signature */
+"Threat found %1$@" = "Открита е заплахата %1$@";
+
+/* Description for threat file */
+"Threat found in file:" = "Открита е заплаха във файла:";
+
+/* Message displayed when a threat is ignored successfully. */
+"Threat ignored." = "Заплахата е пренебрегната.";
+
+/* No comment provided by engineer. */
+"Three" = "Три";
+
 /* Thumbnail image size. Should be the same as in core WP. */
 "Thumbnail" = "Умалена картинка";
+
+/* Message shown if a thumbnail preview of a media item unavailable. */
+"Thumbnail unavailable." = "Умалена картинка не е налична.";
+
+/* No comment provided by engineer. */
+"Tiled gallery settings" = "Настройки на мозайката";
+
+/* Blog Writing Settings: Time Format
+   Writing Time Format Settings Title */
+"Time Format" = "Формат на часа";
+
+/* Label for the timezone setting */
+"Time Zone" = "Часова зона";
+
+/* Error when the uses takes more than 1 minute to submit a security key. */
+"Time's up, but don't worry, your security is our priority. Please try again!" = "Времето изтече, но не се тревожете, сигурността е наш приоритет. Опитайте пак!";
 
 /* WordPress.com Marketing Footer Text */
 "Tips for getting the most out of WordPress.com." = "Съвети, с които да извлечете максималното от WordPress.com";
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Заглавие";
+
+/* Instructions for alert asking for email and name. */
+"To continue please enter your email address and name." = "За да продължите, моля въведете вашия имейл адрес и име.";
+
+/* Text instructing the user to enter their email address. */
+"To create your new WordPress.com account, please enter your email address." = "За създаване на нов WordPress.com профил, въведете вашия имейл адрес.";
+
+/* Message asking the user if they want to set up Jetpack from notifications */
+"To get helpful notifications on your phone from your WordPress site, you'll need to install the Jetpack plugin." = "За да получавате полезни известия на телефона от вашия WordPress сайт, ще трябва да инсталирате разширението Jetpack.";
+
+/* Informational text for Report Crashes setting */
+"To help us improve the app’s performance and fix the occasional bug, enable automatic crash reports." = "За да ни помогнете с производителността на приложението и отделни грешки, моля включете автоматичните краш доклади.";
+
+/* Install Plugin dialog text. */
+"To install plugins, you need to have a custom domain associated with your site." = "За да инсталирате разширения, трябва да имате собствен домейн към вашия сайт.";
+
+/* Instructional text shown when requesting the user's password for Apple login. */
+"To proceed with this Apple ID, please first log in with your WordPress.com password. This will only be asked once." = "За да продължите с Apple ID, моля първо влезте с вашата WordPress.com парола. Това се прави само веднъж.";
+
+/* Instructional text shown when requesting the user's password for Google login. */
+"To proceed with this Google account, please first log in with your WordPress.com password. This will only be asked once." = "За да продължите с Вашият Google акаунт, моля логнете се първо с Вашият WordPress.com акаунт. Това ще бъде изискано само веднъж.";
+
+/* No comment provided by engineer. */
+"To remove a block, select the block and click the three dots in the bottom right of the block to view the settings. From there, choose the option to remove the block." = "За да изтриете блок, изберете блока и кликнете трите точки в долния десен ъгъл на блока, за да видите настройки. От там, изберете да премахнете блока.";
+
+/* Prompt telling users that they need to enable push notifications on their device to use the blogging reminders feature. */
+"To use blogging reminders, you'll need to turn on push notifications." = "За да ползвате напомняния за блогване, ще трябва да включите пуш нотификациите.";
+
+/* Message asking the user if they want to set up Jetpack from stats */
+"To use stats on your site, you'll need to install the Jetpack plugin." = "За да ползвате статистика, трябва да инсталирате разширението Jetpack.";
 
 /* Comments Today Section Header
    Insights 'Today' header
    Notifications Today Section Header */
 "Today" = "Днес";
+
+/* Title for a push notification showing today's blogging prompt. */
+"Today's Prompt 💡" = "Днешното предизвикателство 💡";
 
 /* Insights Management 'Today's Stats' title */
 "Today's Stats" = "Днешна статистика";
@@ -2022,17 +6037,61 @@
 /* Discoverability title for HTML keyboard shortcut. */
 "Toggle HTML Source " = "Включване на HTML";
 
+/* Accessibility Identifier for the Aztec Ordered List Style. */
+"Toggles the ordered list style" = "Включете стила на подреден лист";
+
+/* Accessibility Identifier for the Aztec Unordered List Style */
+"Toggles the unordered list style" = "Включете стила на неподреден лист";
+
+/* Insights 'Top Commenters' header */
+"Top Commenters" = "Топ коментари";
+
+/* Cell title for the Top Level option case
+   Screen reader text expressing the menu item is at the top level and has no parent. */
+"Top level" = "Най-високо ниво";
+
 /* Shortened version of the main title to be used in back navigation */
 "Topic" = "Тема";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Used when a Reader Topic is not found for a specific id */
+"Topic not found for id:" = "Темата не е открита за id:";
+
+/* 'This Year' label for total number of comments.
+   Insights 'Total Comments' header */
+"Total Comments" = "Общо коментари";
+
+/* 'This Year' label for total number of likes.
+   Insights 'Total Likes' header */
+"Total Likes" = "Общо харесвания";
+
+/* 'This Year' label for the total number of posts. */
+"Total Posts" = "Общо публикации";
+
+/* 'This Year' label for total number of words. */
+"Total Words" = "Общо думи";
+
+/* Title for the traffic section in site settings screen */
+"Traffic" = "Трафик";
+
+/* Describes a domain that was transferred from elsewhere to wordpress.com */
+"Transferred Domain" = "Трансфериран домейн";
+
+/* translators: %s: block title e.g: \"Paragraph\". */
+"Transform %s to" = "Превръщане на %s в";
+
+/* No comment provided by engineer. */
+"Transform block…" = "Превръщане на блока...";
+
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Кошче";
 
 /* Title of the trashed filter. This filter shows posts that have been moved to the trash bin.
    Title of trashed Comments filter. */
 "Trashed" = "Изхвърлени";
+
+/* Travel site intent topic */
+"Travel" = "Пътуване";
 
 /* Connect when the SSL certificate is invalid */
 "Trust" = "Да, ок";
@@ -2045,14 +6104,62 @@
    Try to load the list of interests again. */
 "Try Again" = "Опитайте отново";
 
+/* Button label for trying to retrieve the history again
+   Button label for trying to retrieve the scan status again
+   Button that lets users try to reload the plugin directory after loading failure
+   Re-load the history again. It appears if the loading call fails. */
+"Try again" = "Повторен опит";
+
+/* No comment provided by engineer. */
+"Try another search term" = "Опитайте друго търсене";
+
+/* Button title on the blogging prompt's feature introduction view to answer a prompt. */
+"Try it now" = "Опитайте сега";
+
+/* The title of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
+"Try the new Block Editor" = "Опитайте блоковия редактор";
+
+/* When social login fails, this button offers to let the user try again with a differen email address */
+"Try with another email" = "Опитайте с друг email";
+
+/* When social login fails, this button offers to let them try tp login using a URL */
+"Try with the site address" = "Опитайте с адреса на сайта";
+
+/* Destructive menu title to remove the prompt card from the dashboard. */
+"Turn off prompts" = "Изключване на предизвикателствата";
+
+/* Title for a button which takes the user to the WordPress app's settings in the system Settings app. */
+"Turn on notifications" = "Включване на известията";
+
+/* Title of the screen in the Blogging Reminders flow which prompts users to enable push notifications. */
+"Turn on push notifications" = "Включване на пуш нотификациите";
+
+/* Notification Settings switch for the app. */
+"Turning the switch off will disable all notifications from this app, regardless of type." = "Изключването  ще деактивира абсолютно всички известия от това приложение.";
+
 /* Title of button that displays the app's Twitter profile */
 "Twitter" = "Twitter";
 
 /* Title for the setting to edit the twitter username used when sharing to twitter. */
 "Twitter Username" = "Потребителско име в Twitter";
 
+/* No comment provided by engineer. */
+"Two" = "Две";
+
+/* Type menu item in share extension. */
+"Type" = "Вид";
+
+/* No comment provided by engineer. */
+"Type a URL" = "Въведете адрес";
+
+/* Placeholder text for domain search during site creation. */
+"Type a keyword for more ideas" = "Въведете ключова дума за идеи";
+
 /* A placeholder for the sharing label. */
 "Type a label" = "Въведете етикет";
+
+/* Site creation. Seelect a domain, search field placeholder */
+"Type a name for your site" = "Въведете име на вашия сайт";
 
 /* URL text field placeholder */
 "URL" = "Връзка";
@@ -2060,11 +6167,83 @@
 /* Menus label for describing which menu the location uses in the header. */
 "USES" = "ИЗПОЛЗВА";
 
+/* Shown when a user logs in with Google but it subsequently fails to work as login to WordPress.com */
+"Unable To Connect" = "Неуспешна връзка";
+
 /* Title of a prompt saying the app needs an internet connection before it can load posts */
 "Unable to Load Posts" = "Неуспешно зареждане на публикации";
 
 /* Title of error prompt shown when a sync the user initiated fails. */
 "Unable to Sync" = "Неуспешна синхронизация";
+
+/* An error message shown when there is an issue creating new invite links. */
+"Unable to create new invite links." = "Неуспешно създаване на връзките за покана.";
+
+/* An error message shown when there is an issue creating new invite links. */
+"Unable to disable invite links." = "Сеуспешно деактивиране на връзките за покана.";
+
+/* Message displayed when opening the link to the downloadable backup fails. */
+"Unable to download file" = "Неуспешно изтегляне на файла";
+
+/* No comment provided by engineer. */
+"Unable to embed media" = "Неуспешно влагане на файл";
+
+/* The app failed to subscribe to the comments for the post */
+"Unable to follow conversation" = "Неуспешно последване на дискусия";
+
+/* Title for No results full page screen displayedfrom pages list when there is no connection */
+"Unable to load pages right now." = "Неуспешно зареждане на страниците";
+
+/* Message for when posts fail to load on the dashboard
+   Title for No results full page screen displayedfrom post list when there is no connection */
+"Unable to load posts right now." = "Неуспешно зареждане на публикациите.";
+
+/* Title message shown when the Unsupported Block Editor fails to load. */
+"Unable to load the block editor right now." = "Неуспешно зареждане на блоковия редактор в момента.";
+
+/* Text displayed in HUD if there was an error attempting to load a media image. */
+"Unable to load the image. Please choose a different one or try again later." = "Неуспешно зареждане на изображението. Моля изберете друго и повторете.";
+
+/* Default title shown for no-results when the device is offline.
+   Informing the user that a network request failed because the device wasn't able to establish a network connection.
+   Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
+"Unable to load this content right now." = "Неуспешно зареждане на съдържанието.";
+
+/* Dialog box title for when the user is canceling an upload. */
+"Unable to play video" = "Видеото не може да се пусне";
+
+/* No comment provided by engineer. */
+"Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Неуспешно прочитане на WordPress сайт на този адрес. Докоснете \"Имате нужда от помощ?\", за да видите често задаваните въпроси.";
+
+/* Title for the Jetpack Restore Failed message. */
+"Unable to restore your site" = "Неуспешно възстановяване на сайта";
+
+/* Message displayed when sharing a link to the downloadable backup fails. */
+"Unable to share link" = "Неуспешно споделяне на връзка";
+
+/* Error informing the user that their homepage settings could not be updated */
+"Unable to update homepage settings" = "Неуспешно обновяване на настройките на началната страница";
+
+/* This is an error message that could be shown when updating Plans in the app. */
+"Unable to update plan prices. There is a problem with the supplied blog." = "Неуспешно обновяване на цените на плановете. Има проблем с блога.";
+
+/* Alert displayed to the user when a single post has failed to upload. */
+"Unable to upload 1 post" = "Неуспешно качване на 1 публикация";
+
+/* Alert displayed to the user when a single post and multiple files have failed to upload. */
+"Unable to upload 1 post, %ld files" = "Неуспешно качване на 1 публикация, %ld файла";
+
+/* Alert displayed to the user when a single post and 1 file has failed to upload. */
+"Unable to upload 1 post, 1 file" = "Неуспешно качване на 1 публикация, 1 файл";
+
+/* Error message displayed when an error occurred checking for email availability. */
+"Unable to verify the email address. Please try again later." = "Неуспешно потвърждаване на имейл. Моля, опитайте пак.";
+
+/* Message displayed when visiting the Jetpack settings page fails. */
+"Unable to visit Jetpack settings for site" = "Неуспешно зареждане на настройките на Jetpack";
+
+/* Message displayed when visiting a site fails. */
+"Unable to visit site" = "Неуспешно посещаване на сайта";
 
 /* Error reason to display when the writing of a image to a file fails */
 "Unable to write image to file" = "Неуспешно записване на изображението във файл";
@@ -2072,6 +6251,15 @@
 /* Unapproves a Comment
    Unapproves a comment */
 "Unapprove" = "Неодобрение";
+
+/* Unapproves a Comment */
+"Unapprove Comment" = "Неодобрение на коментар";
+
+/* VoiceOver accessibility hint, informing the user the button can be used to unapprove a comment */
+"Unapproves the Comment." = "Неодобряване на коментара.";
+
+/* When the App can't figure out what language a blog is configured to use. */
+"Undefined" = "Неопределено";
 
 /* Accessibility label for underline button on formatting toolbar.
    Discoverability title for underline formatting keyboard shortcut. */
@@ -2083,16 +6271,34 @@
    Button title. Reverts the previous notification operation
    Revert an operation
    Revert enabling notification after successfully subcribing to the comments for the post. */
-"Undo" = "Връщане";
+"Undo" = "Отмяна";
+
+/* Title for a button that unsubscribes the user from the post. */
+"Unfollow Conversation" = "Отмяна следването на дискусията";
+
+/* No comment provided by engineer. */
+"Ungroup block" = "Разгрупиране на блок";
 
 /* Label for size of media when it's not possible to calculate it. */
 "Unknown" = "Непознат";
+
+/* Title for Unknown HTML Editor */
+"Unknown HTML" = "Неизвестен HTML";
 
 /* Unknown error */
 "Unknown error" = "Непозната грешка";
 
 /* People: Invitation Error */
 "Unknown error has occurred" = "Възникна неизвестна грешка";
+
+/* Search Terms label for 'unknown search terms'. */
+"Unknown search terms" = "Непознати термини за търсене";
+
+/* translators: %s: the hex color value */
+"Unlabeled color. %s" = "Цвят без етикет. %s";
+
+/* VoiceOver accessibility hint, informing the user the button can be used to stop liking a comment */
+"Unlike the Comment." = "Нехаресване на коментара.";
 
 /* Displayed when a site has no name */
 "Unnamed Site" = "Сайт без име";
@@ -2103,11 +6309,20 @@
 /* Filters Unread Notifications */
 "Unread" = "Непрочетени";
 
+/* Title of unreplied Comments filter. */
+"Unreplied" = "Без отговор";
+
 /* Menus alert title for alerting the user to unsaved changes. */
 "Unsaved Changes" = "Незапазени промени";
 
 /* No comment provided by engineer. */
 "Unsupported" = "Не се поддържа";
+
+/* Label for an untitled post in the revision browser */
+"Untitled" = "Неозаглавен";
+
+/* Title for the card displaying upcoming scheduled posts. */
+"Upcoming scheduled posts" = "Предстоящи планирани публикации";
 
 /* (Verb) Title of button confirming updating settings for blogging reminders.
    Button label to update a plugin
@@ -2118,11 +6333,57 @@
 /* Label action for updating a link on the editor */
 "Update Link" = "Обновяване на връзката";
 
+/* Title for sheet displayed allowing user to update their site icon */
+"Update Site Icon" = "Промяна иконата на сайта";
+
+/* A notice message that's shown after the user updates their profile information. */
+"Updates might take some time to sync with your Gravatar profile." = "Обновяването ще отнеме време, докато се синхронизира с Gravatar.";
+
+/* Accessibility hint for the Comments button in Stats Overview. */
+"Updates the bar chart to show comments." = "Обновява графиката със стълбове да показва коментари.";
+
+/* Accessibility hint for the Likes button in Stats Overview. */
+"Updates the bar chart to show likes." = "Обновява графиката със стълбове да показва харесвания.";
+
+/* Accessibility hint for the Views button in Stats Overview. */
+"Updates the bar chart to show views." = "Обновява графиката със стълбове да показва прегледи.";
+
+/* Accessibility hint for the Visitors button in Stats Overview. */
+"Updates the bar chart to show visitors." = "Обновява графиката със стълбове да показва посетители.";
+
+/* No comment provided by engineer. */
+"Updates the title." = "Обновява заглавието.";
+
+/* Describes a status of a plugin
+   Updating label title */
+"Updating" = "Обновяване";
+
+/* Text in the profile editing page. Lets the user know about the consequences of their profile editing actions and how this relates to Gravatar. */
+"Updating your avatar, name and about info here will also update it across all sites that use Gravatar profiles." = "Обновяването на аватара, името и личната информация ще ги обнови във всички сайтове, ползващи Gravatar.";
+
+/* No comment provided by engineer. */
+"Upgrade your plan to upload audio" = "Ъпгрейднете плана си за да качвате аудио";
+
+/* No comment provided by engineer. */
+"Upgrade your plan to use video covers" = "Ъпгрейднете плана си за да ползвате видео заглавки";
+
+/* Title for button displayed when the user has an empty media library */
+"Upload Media" = "Качване на файл";
+
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Неуспешно качване";
 
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Качено";
+/* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
+"Uploaded 1 draft post, %ld files" = "Качена е 1 чернова, %ld файла";
+
+/* Local notification displayed to the user when a single draft post and 1 file has been uploaded successfully. */
+"Uploaded 1 draft post, 1 file" = "Качени 1 чернова, 1 файл";
+
+/* System notification displayed to the user when a single post and multiple files have uploaded successfully. */
+"Uploaded 1 post, %ld files" = "Качена е 1 публикация, %ld файла";
+
+/* System notification displayed to the user when a single post and 1 file has uploaded successfully. */
+"Uploaded 1 post, 1 file" = "Качена е 1 публикация, 1 файл";
 
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Качени теми";
@@ -2133,8 +6394,29 @@
 /* Title for alert when trying to save/exit a post before media upload process is complete. */
 "Uploading media" = "Качване на файл";
 
+/* Message of an alert informing users that the video they are trying to select is not allowed. */
+"Uploading videos longer than 5 minutes requires a paid plan." = "Качването на видеа по-дълги от 5 минути изисква платен план.";
+
+/* No comment provided by engineer. */
+"Uploading…" = "Качва се...";
+
 /* Use the current image */
 "Use" = "Използване";
+
+/* The button's title text to use a security key. */
+"Use a security key" = "Ползване на ключ за сигурност";
+
+/* Option to enable the block editor for new posts */
+"Use block editor" = "Използвайте блоковия редактор";
+
+/* No comment provided by engineer. */
+"Use icon button" = "Използване на бутон с икона";
+
+/* The button title text for logging in with WP.com password instead of magic link. */
+"Use password to sign in" = "Използване на парола за вход";
+
+/* Option to enable theme styles in the block editor */
+"Use theme styles" = "Използване на стиловете на темата";
 
 /* A placeholder for the twitter username
    Accessibility label for the username text field in the self-hosted login page.
@@ -2146,6 +6428,9 @@
    Username label text.
    Username placeholder */
 "Username" = "Потребителско име";
+
+/* Message displayed in a Notice when the username has changed successfully. The placeholder is the new username. */
+"Username changed to %@" = "Потребителят е променен на %@";
 
 /* Setting: indicates if Mentions will be notified */
 "Username mentions" = "Споменавания на потребителското име";
@@ -2160,8 +6445,39 @@
 /* two factor code placeholder */
 "Verification code" = "Код за потвърждение";
 
+/* Message shown when a verification email was re-sent succesfully */
+"Verification email sent, check your inbox." = "Изпратен е email за верификация, моля проверете Вашата входяща поща.";
+
 /* Push Authentication Alert Title */
 "Verify Log In" = "Потвърждение на влизането";
+
+/* Description for the version label in the What's new page. */
+"Version " = "Версия ";
+
+/* Version of a plugin to install
+   Version of an installed plugin */
+"Version %@" = "Версия %@";
+
+/* Message to show what version is currently installed when a new plugin version is available */
+"Version %@ installed" = "Версия %@ е инсталирана";
+
+/* Message to show when a new plugin version is available */
+"Version %@ is available" = "Версия %@ е налична";
+
+/* Message shown if a video preview image is unavailable while the video is being uploaded. */
+"Video Preview Unavailable" = "Преглед на видеото не е наличен";
+
+/* translators: accessibility text. %s: video caption. */
+"Video caption. %s" = "Кратко описание на видеото. %s";
+
+/* translators: accessibility text. Empty video caption. */
+"Video caption. Empty" = "Кратко описание на видеото. Празно";
+
+/* Message shown if a video export is canceled by the user. */
+"Video export canceled." = "Експортът на видео е отменен.";
+
+/* Title of an alert informing users that the video they are trying to select is not allowed. */
+"Video not uploaded" = "Видеото не е качено";
 
 /* Period Stats 'Videos' header */
 "Videos" = "Видео клипове";
@@ -2174,11 +6490,23 @@
 /* Action title. Opens the user's site in an in-app browser */
 "View Site" = "Към сайта";
 
+/* Title for button on the post details page to show all comments when tapped. */
+"View all comments" = "Всички коментари";
+
 /* Displays More Rows */
 "View all…" = "Всички...";
 
 /* Displays Less Rows */
 "View less…" = "По-малко...";
+
+/* Accessibility label for View more button in Stats.
+   Accessibility label for viewing more posting activity.
+   Label for viewing more posting activity.
+   Label for viewing more stats. */
+"View more" = "Още";
+
+/* Menu title to show more prompts. */
+"View more prompts" = "Още предизвикателства";
 
 /* User role badge */
 "Viewer" = "Читател";
@@ -2195,11 +6523,20 @@
    Today's Stats 'Views' label */
 "Views" = "Преглеждания";
 
+/* Insights views and visitors header */
+"Views & Visitors" = "Прегледи и посетители";
+
 /* A call to action to visit the specified blog.  The '%@' characters are a placholder for the blog name. */
 "Visit %@" = "Преглед %@";
 
 /* A call to action to visit the specified blog.  The '%@' characters are a placholder for the blog name. */
 "Visit %@ for more" = "Преглед на %@ за повече";
+
+/* Text of a button that links to the VaultPress dashboard. */
+"Visit Dashboard" = "Към таблото";
+
+/* Title for the button that will open a link to this site. */
+"Visit site" = "Към сайта";
 
 /* Accessibility label used for distinguishing Views and Visitors in the Stats → Views bar chart.
    All Time Stats 'Visitors' label
@@ -2209,14 +6546,140 @@
    Today's Stats 'Visitors' label */
 "Visitors" = "Посетители";
 
+/* Summary description for a threat */
+"Vulnerability found in WordPress" = "Открита е уязвимост в WordPress";
+
+/* Summary description for a threat */
+"Vulnerability found in plugin" = "Открита е уязвимост в разширението";
+
+/* Summary description for a threat */
+"Vulnerability found in theme" = "Открита е уязвимост в темата";
+
+/* Title for a threat */
+"Vulnerable Plugin" = "Уязвимо разширение";
+
+/* Title for a threat that includes the file name of the plugin and the affected version */
+"Vulnerable Plugin: %1$@ (version %2$@)" = "Уязвимо разширение: %1$@ (версия %2$@)";
+
+/* Title for a threat */
+"Vulnerable Theme" = "Уязвима тема";
+
+/* Title for a threat that includes the file name of the theme and the affected version */
+"Vulnerable Theme %1$@ (version %2$@)" = "Уязвима тема %1$@ (версия %2$@)";
+
 /* Action title. Noun. Opens the user's WordPress Admin in an external browser. */
 "WP Admin" = "WP Admin";
+
+/* Downloadable/Restorable items: WP-content directory */
+"WP-content directory" = "Папката wp-content";
+
+/* Message shown on screen while waiting for Google to finish its signup process. */
+"Waiting for Google to complete…" = "Изчакваме Google да приключи...";
+
+/* No comment provided by engineer. */
+"Waiting for connection" = "Изчаква се връзка";
+
+/* Text while the webauthn signature is being verified
+   Text while waiting for a security key challenge */
+"Waiting for security key" = "Изчакване на ключ за сигурност";
+
+/* View title during the Google auth process. */
+"Waiting..." = "Изчакване...";
+
+/* Editing GIF alert title.
+   Noun. Title for Jetpack Restore warning.
+   Title for Jetpack Restore Warning screen */
+"Warning" = "Внимание";
+
+/* No comment provided by engineer. */
+"Warning message" = "Предупреждение";
+
+/* Caption displayed in promotional screens shown during the login flow. */
+"Watch your audience grow with in-depth analytics." = "Гледайте как аудиторията ви нараства с задълбочени анализи.";
 
 /* Error message displayed when a refresh is taking longer than usual. The refresh hasn't failed and it might still succeed */
 "We are having trouble loading data" = "Възникна проблем при зареждането на данните";
 
+/* No comment provided by engineer. */
+"We are working hard to add more blocks with each release." = "Работим по добавянето на още блокове с всяка версия.";
+
+/* Message for error displayed when preparing a backup fails. */
+"We couldn't create your backup. Please try again later." = "Не успяхме да създадем бекъп. Опитайте отново.";
+
+/* Message for error displayed when restoring a site fails. */
+"We couldn't restore your site. Please try again later." = "Не успяхме да възстановим сайта ви. Опитайте отново след малко.";
+
+/* Description that appears when a media fails to load in the Media Editor. */
+"We couldn't retrieve this media.\nPlease tap to retry." = "Не можахме да получим файла.\nМоля, докоснете за повторен опит.";
+
+/* Hint displayed when we fail to fetch the status of the backup in progress. */
+"We couldn’t find the status to say how long your backup will take." = "Не успяхме да открием състоянието, за да ви покажем колко време ще отнеме създаването на бекъп.";
+
+/* Hint displayed when we fail to fetch the status of the restore in progress. */
+"We couldn’t find the status to say how long your restore will take." = "Не успяхме да открием състоянието, за да ви покажем колко време ще отнеме възстановяването.";
+
+/* Message to show when Keyring connection synchronization failed. %@ is a service name like Facebook or Twitter */
+"We had trouble loading connections for %@" = "Възникна проблем при зареждането на връзката за %@";
+
 /* Error message displayed when a refresh failed */
 "We had trouble loading data" = "Има проблем със зареждането на данните";
+
+/* message to ask a user to check their email for a WordPress.com email */
+"We just emailed a link to %@. Please check your mail app and tap the link to log in." = "Току-що пратихме връзка по имейл на %@. Моля, проверете имейл приложението и посетете връзката за вход.";
+
+/* The subtitle text on the magic link requested screen followed by the email address. */
+"We just sent a magic link to" = "Току-що пратихме магическа връзка на";
+
+/* Description for the Jetpack Backup Complete message. %1$@ is a placeholder for the selected date. */
+"We successfully created a backup of your site from %1$@." = "Успешно създадохме бекъп на вашия сайт от %1$@.";
+
+/* Informational text about link to other tracking tools */
+"We use other tracking tools, including some from third parties. Read about these and how to control them." = "Използваме други средства за наблюдение, включително на трети страни. Прочетете за тях и как да ги контролирате.";
+
+/* Error message displayed when an error occurred sending the magic link email. */
+"We were unable to send you an email at this time. Please try again later." = "Неуспешно пращане на имейл. Моля, опитайте по-късно.";
+
+/* Description for label when the actively scanning the users site */
+"We will send you an email if security threats are found. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Ще ви пратим имейл, ако открием заплахи. Междувременно, може да ползвате сайта си нормално. Може да проверите прогреса по всяко време.";
+
+/* Instructional text for the magic link login flow. */
+"We'll email you a magic link that'll log you in instantly, no password needed. Hunt and peck no more!" = "Ще ви изпратим на email магически линк, който ще ви позволи да влезете мигновенно. Парола не е необходима.";
+
+/* Instruction text on the Sign Up screen. */
+"We'll email you a signup link to create your new WordPress.com account." = "Ще ви пратим по имейл връзка, с която да създадете нов WordPress.com профил.";
+
+/* This is the string we display when asking the user to approve push notifications */
+"We'll notify you when you get followers, comments, and likes." = "Ще ви известим, когато имате нови абонати, коментари и харесвания.";
+
+/* Body text of the first alert preparing users to grant permission for us to send them push notifications. */
+"We'll notify you when you get new followers, comments, and likes. Would you like to allow push notifications?" = "Ще ви известим, като получите нови абонати, коментари и харесвания. Искате ли да позволите пуш нотификациите?";
+
+/* Text confirming email address to be used for new account. */
+"We'll use this email address to create your new WordPress.com account." = "Ще ползваме този имейл за да създадем вашия нов WordPress.com профил.";
+
+/* Description for the Jetpack Backup Status message. %1$@ is a placeholder for the selected date. */
+"We're creating a downloadable backup of your site from %1$@." = "Създаваме бекъп, готов за изтегляне, от вашия сайт от %1$@.";
+
+/* Title of progress label displayed when a first plugin on a site is almost done installing. */
+"We're doing the final setup—almost done…" = "Правим финалните настройки. Почти готови...";
+
+/* Detail text display informing the user that we're fixing threats */
+"We're hard at work fixing these threats in the background. In the meantime feel free to continue to use your site as normal, you can check back on progress at any time." = "Работим сериозно за оправяне на тези заплахи. Междувременно, продължете да ползвате сайта нормално. Можете да проверите прогреса по всяко време.";
+
+/* Error message shown when having trouble connecting to a Jetpack site. */
+"We're not able to connect to the Jetpack site at that URL.  Contact us for assistance." = "Ние не можем да се свържем с Jetpack сайта на този адрес.  Свържете се с нас за помощ.";
+
+/* Description for the Jetpack Restore Status message. %1$@ is a placeholder for the selected date. */
+"We're restoring your site back to %1$@." = "Възстановяваме вашия сайт към %1$@.";
+
+/* Description for label when the user's site is a multisite. */
+"We're sorry, Jetpack Scan is not compatible with multisite WordPress installations at this time." = "За съжаление, Jetpack Scan не е съвместим с Multisite WordPress инсталации към момента.";
+
+/* A hint to users indicating a link to the downloadable backup file has also been sent to their email. */
+"We've also emailed you a link to your file." = "Пратихме ви имейл с връзка към вашия файл.";
+
+/* Instruction text after a signup Magic Link was requested. */
+"We've emailed you a signup link to create your new WordPress.com account. Check your email on this device, and tap the link in the email you receive from WordPress.com." = "Изпратихме ви имейл с връзка за регистрация, за да създадете новия си профил в WordPress.com. Проверете пощата си с това устройство и заредете връзката от писмото.";
 
 /* Account Settings Web Address label
    Header for a comment author's web address, shown when editing a comment. */
@@ -2225,14 +6688,97 @@
 /* The title of the option group for editing an image's size, alignment, etc. on the image details screen. */
 "Web Display Settings" = "Визуални настройки";
 
+/* Example Reader feed title */
+"Web News" = "Уеб новини";
+
+/* Describes the web address section in the comment detail screen. */
+"Web address" = "Адрес";
+
+/* Title of a button. A call to action to view more stats for this week */
+"Week" = "Седмица";
+
+/* Blog Writing Settings: Weeks starts on */
+"Week starts on" = "Седмицата започва от";
+
+/* Setting: indicates if the site reports its Weekly Roundup
+   Title of Weekly Roundup push notification */
+"Weekly Roundup" = "Седмичен обзор";
+
+/* Title of Weekly Roundup push notification. %@ is a placeholder and will be replaced with the title of one of the user's websites. */
+"Weekly Roundup: %@" = "Седмично обобщение: %@";
+
 /* A message title */
 "Welcome to the Reader" = "Добре дошли в Reader";
+
+/* No comment provided by engineer. */
+"Welcome to the world of blocks" = "Добре дошли в света на блоковете";
+
+/* Caption displayed in promotional screens shown during the login flow. */
+"Welcome to the world's most popular website builder." = "Добре дошли в света на най-популярното средство за създаване на сайтове.";
 
 /* Title displayed in the Notification Settings for WordPress.com */
 "We’ll always send important emails regarding your account, but you can get some helpful extras, too." = "Ще ви изпращаме важни имейли относно профила ви, също можете да получите и някои полезни екстри.";
 
+/* The message of a notice telling users that the classic editor is deprecated and will be removed in a future version of the app. */
+"We’ll be removing the classic editor for new posts soon, but this won’t affect editing any of your existing posts or pages. Get a head start by enabling the Block Editor now in site settings." = "Скоро ще премахнем класическия редактор за нови публикации, но това няма да засегне редактирането на съществуващите ви публикации или страници. Включете Блоковия редактор сега в настройките на сайта.";
+
+/* Hint displayed when we fail to fetch the status of the backup in progress.
+   Hint displayed when we fail to fetch the status of the restore in progress. */
+"We’ll notify you when its done." = "Ще ви информираме, като е готово.";
+
+/* Description of Blogging Prompts displayed in the Feature Introduction view. */
+"We’ll show you a new prompt each day on your dashboard to help get those creative juices flowing!" = "Ще ви показваме ново предизвикателство всеки ден на вашето табло, за да вдъхновим вашата креативност.";
+
+/* Hint displayed when we fail to fetch the status of the backup in progress. */
+"We’ll still attempt to backup your site." = "Ще се опитаме да създадем бекъп на сайта.";
+
+/* Hint displayed when we fail to fetch the status of the restore in progress. */
+"We’ll still attempt to restore your site." = "Ще се опитаме да възстановим сайта.";
+
+/* translators: %s: embed block variant's label e.g: \"Twitter\". */
+"We’re working hard on adding support for %s previews. In the meantime, you can preview the embedded content on the page." = "Работим по добавянето на поддръжка за %s прегледи. Междувременно, можете да прегледате вграденото съдържание в страницата.";
+
+/* translators: %s: embed block variant's label e.g: \"Twitter\". */
+"We’re working hard on adding support for %s previews. In the meantime, you can preview the embedded content on the post." = "Работим по добавянето на поддръжка за %s прегледи. Междувременно, можете да прегледате вграденото съдържание в публикацията.";
+
+/* Body text of alert informing users about the Reader Save for Later feature. */
+"We’ve updated our custom app icons with a fresh new look. There are 10 new styles to choose from, or you can simply keep your existing icon if you prefer." = "Обновихме иконите на приложението. Има 10 нови стила, от които да избирате или може да запазите текущата.";
+
+/* Title displayed via UIAlertController when a user inserts a document into a post. */
+"What do you want to do with this file: upload it and add a link to the file into your post, or add the contents of the file directly to the post?" = "Какво искате да направите с този файл: да го качите и да добавите връзка в публикацията или да добавите съдържанието му директно в публикацията?";
+
+/* This is a link that takes the user to the external Gravatar website */
+"What is Gravatar?" = "Какво е Gravatar?";
+
+/* Navigates to page with details about What is WordPress.com. */
+"What is WordPress.com?" = "Какво е WordPress.com?";
+
+/* No comment provided by engineer. */
+"What is a block?" = "Какво е блок?";
+
+/* No comment provided by engineer. */
+"What is alt text?" = "Какво е алт текст?";
+
+/* Title for the problem section in the Threat Details */
+"What was the problem?" = "Какъв беше проблема?";
+
+/* Title of section that contains plugins' change log */
+"What's New" = "Какво ново";
+
+/* Opens the What's New / Feature Announcement modal */
+"What's New in Jetpack" = "Какво ново в Jetpack";
+
+/* Opens the What's New / Feature Announcement modal */
+"What's New in Reader" = "Какво ново в Читателя";
+
+/* Opens the What's New / Feature Announcement modal */
+"What's New in WordPress" = "Какво ново в WordPress";
+
 /* Title of alert helping users understand their site address */
 "What's my site address?" = "Какъв е адресът на моя сайт?";
+
+/* Select the site's intent. Title */
+"What's your website about?" = "За какво е вашия сайт?";
 
 /* Text rendered at the bottom of the Discussion Moderation Keys editor */
 "When a comment contains any of these words in its content, name, URL, e-mail or IP, it will be held in the moderation queue. You can enter partial words, so \"press\" will match \"WordPress\"." = "Когато коментар съдържа някоя от тези думи в съдържанието, името, адреса, имейла или IP адреса, този коментар ще бъде задържан за модерация. Можете да добавяте частични думи - например \"press\" ще хване и \"WordPress\".";
@@ -2240,17 +6786,53 @@
 /* Text rendered at the bottom of the Discussion Blocklist Keys editor */
 "When a comment contains any of these words in its content, name, URL, e-mail, or IP, it will be marked as spam. You can enter partial words, so \"press\" will match \"WordPress\"." = "Когато коментар съдържа някоя от тези думи в съдържанието, името, адреса, имейла или IP адреса, този коментар ще бъде маркиран като спам. Можете да добавяте частични думи - например \"press\" ще хване и \"WordPress\".";
 
+/* An error message shown when a wpcom user provides the wrong password. */
+"Whoops, something went wrong and we couldn't log you in. Please try again!" = "Упс, нещо се обърка и входът беше неуспешен. Моля опитайте отново!";
+
+/* Generic error on the 2FA screen */
+"Whoops, something went wrong. Please try again!" = "Нещо се обърка. Опитайте отново!";
+
+/* Error when the uses chooses an invalid security key on the 2FA screen. */
+"Whoops, that security key does not seem valid. Please try again with another one" = "Ключът за сигурност изглежда невалиден. Моля опитайте отново с друг";
+
+/* Error message shown when an incorrect two factor code is provided. */
+"Whoops, that's not a valid two-factor verification code. Double-check your code and try again!" = "Упс, това не е валиден код за двуфакторно удостоверяване. Моля проверете кода още веднъж и опитайте отново!";
+
+/* No comment provided by engineer. */
+"Width Settings" = "Настройки за ширина";
+
 /* Help text when editing email address */
 "Will not be publicly displayed." = "Няма да бъде показван публично.";
 
+/* Caption displayed in promotional screens shown during the login flow. */
+"With this powerful editor you can post on the go." = "С този отличен редактор, може да публикувате по всяко време.";
+
 /* Title of Stats section that shows WordPress.com followers. */
 "WordPress" = "WordPress";
+
+/* Subject line for when sharing the app with others through mail or any other activity types that support contains a subject field. */
+"WordPress Apps - Apps for any screen" = "WordPress приложенията са за всеки екран";
 
 /* Settings for a Wordpress Blog */
 "WordPress Blog" = "WordPress Blog";
 
 /* Accessibility label for selecting an image or video from the user's WordPress media library on formatting toolbar. */
 "WordPress Media Library" = "Медийна библиотека на WordPress";
+
+/* Downloadable/Restorable items: WordPress Plugins */
+"WordPress Plugins" = "Разширения за WordPress";
+
+/* Downloadable/Restorable items: WordPress Themes */
+"WordPress Themes" = "WordPress теми";
+
+/* Subject of new Zendesk ticket. */
+"WordPress for iOS Support" = "Поддръжка на WordPress за iOS";
+
+/* Title for label when the user's site is a multisite. */
+"WordPress multisites are not supported" = "WordPress Multisite не се поддържа";
+
+/* Downloadable/Restorable items: WordPress root */
+"WordPress root" = "WordPress root";
 
 /* No comment provided by engineer. */
 "WordPress version too old" = "Версията на WordPress е прекалено стара";
@@ -2264,8 +6846,33 @@
 /* WordPress.com sign-in/sign-out section header title */
 "WordPress.com Account" = "Профил в WordPress.com";
 
+/* Title for the WordPress.com themes section, should be the same as in Calypso */
+"WordPress.com Themes" = "WordPress.com Теми";
+
 /* WordPress.com Notification Settings Title */
 "WordPress.com Updates" = "Известия от WordPress.com";
+
+/* Jetpack Settings: WordPress.com Login settings */
+"WordPress.com login" = "WordPress.com потребителско име";
+
+/* Link to a WordPress.org page for the plugin */
+"WordPress.org Plugin Page" = "Страница на разширението в WordPress.org";
+
+/* Title of button that displays the Automattic Work With Us web page */
+"Work With Us" = "Работете с нас";
+
+/* No comment provided by engineer. */
+"Working Offline" = "Работа офлайн";
+
+/* Accessibility label for the Stats' world map. */
+"World map showing views by country." = "Картата на света показва прегледи по държава.";
+
+/* Second line of Remove user/viewer warning in confirmation dialog. */
+"Would you still like to remove this person?" = "Сигурни ли сте че искате да премахнете този човек?";
+
+/* Button title. Opens the editor to write a new post.
+   Opens the editor to write a new post. */
+"Write Post" = "Напишете публикация";
 
 /* Placeholder text for inline compose view */
 "Write a reply…" = "Отговор...";
@@ -2273,12 +6880,39 @@
 /* Title for the writing section in site settings screen */
 "Writing" = "Писане";
 
+/* Writing & Poetry site intent topic */
+"Writing & Poetry" = "Писане и поезия";
+
+/* No comment provided by engineer. */
+"X-Axis Position" = "Х-позиция";
+
+/* No comment provided by engineer. */
+"Y-Axis Position" = "Y-позиция";
+
+/* Option to select the Yahoo Mail app when logging in with magic links */
+"Yahoo Mail" = "Yahoo Mail";
+
+/* 'This Year' label for the the year. */
+"Year" = "Година";
+
 /* Yes */
 "Yes" = "Да";
+
+/* Button label that confirms the user wants to log in and will authenticate them via the browser */
+"Yes, log me in" = "Да, нека вляза";
 
 /* Comments Yesterday Section Header
    Notifications Yesterday Section Header */
 "Yesterday" = "Вчера";
+
+/* Main message on dialog that prompts user to confirm or cancel the replacement of a featured image. */
+"You already have a featured image set. Do you want to replace it with the new image?" = "Вече имате основно изображение. Искате ли да го замените с ново изображение?";
+
+/* Paragraph displayed in the tableview header. The placholders are for the current username, highlight text and the current display name. */
+"You are about to change your username, which is currently %@. %@" = "Ще смените потребителското име, което е %1$@. %2$@";
+
+/* Alert message. */
+"You are changing your username to %@. Changing your username will also affect your Gravatar profile and IntenseDebate profile addresses. \nConfirm your new username to continue." = "Променяте потребителското име на %@. Промяната на потребителското име ще засегне Gravatar и IntenseDebate профилите. \nПотвърдете смяната на потреибителско име за продължаване.";
 
 /* This is a notification the user receives if they are trying to save a post (or exit) before the media upload process is complete. */
 "You are currently uploading media. Please wait until this completes." = "В момента качвате файлове. Изчакайте докато качването приключи.";
@@ -2286,32 +6920,200 @@
 /* This prompt is displayed when the user attempts to stop media uploads in the post editor. */
 "You are currently uploading media. This action will cancel uploads in progress.\n\nAre you sure?" = "В момента качвате файлове. Това действие ще отмени всички текущи качвания.\n\nСигурни ли сте?";
 
+/* No comment provided by engineer. */
+"You can also rearrange blocks by tapping a block and then tapping the up and down arrows that appear on the bottom left side of the block to move it up or down." = "Може да пренареждате блокове като докоснете блок и после докоснете стрелките нагоре и надолу от долната лява страна на блока, за да го преместите.";
+
+/* Information shown below the optional password field after new account creation. */
+"You can always log in with a link like the one you just used, but you can also set up a password if you prefer." = "Винаги можете да влезете с връзка като тази, която току-що ползвахте, но може и да зададете парола, ако предпочитате.";
+
+/* Note displayed in the Feature Introduction view. */
+"You can control Blogging Prompts and Reminders at any time in My Site > Settings > Blogging" = "Може да управлявате предизвикателствата и напомнянията от Моят сайт > Настройки > Блогване";
+
+/* Accessibility hint for Note displayed in the Feature Introduction view. */
+"You can control Blogging Prompts and Reminders at any time in My Site, Settings, Blogging" = "Може да управлявате предизвикателствата и напомнянията от Моят сайт, Настройки, Блогване";
+
+/* No comment provided by engineer. */
+"You can copy your post text in case your content is impacted. Copy error details to debug and share with support." = "Може да копирате текста на публикацията, в случай че съдържанието е засегнато. Копирайте грешката, за да я споделите с поддръжката.";
+
+/* No comment provided by engineer. */
+"You can edit this block using the web version of the editor." = "Може да редактирате блока чрез уеб версията на редактора.";
+
 /* Discussion Settings: Footer Text */
 "You can override these settings for individual posts." = "Можете да презаписвате тези настройки за отделните публикации.";
+
+/* Prompt shown on the Blogging Reminders Settings screen. */
+"You can update this any time" = "Може да обновите по всяко време";
+
+/* Prompt shown on the completion screen of the Blogging Reminders Settings screen. */
+"You can update this any time via My Site > Site Settings" = "Може да обновите това по всяко време от Моят сайт > Настройки на сайта";
 
 /* No comment provided by engineer. */
 "You cannot use that email address to signup. We are having problems with them blocking some of our email. Please use another email provider." = "Не можете да използвате този адрес за регистрация. Имаме проблеми с тях, блокират писмата от нас. Опитайте с друг имейл адрес от различен доставчик.";
 
+/* Displayed when the user views drafts in the pages list and there are no pages */
+"You don't have any draft pages" = "Нямате никакви чернови";
+
+/* Displayed when the user views drafts in the posts list and there are no posts */
+"You don't have any draft posts" = "Нямате никакви чернови";
+
+/* Title displayed when the user doesn't have any media in their media library. Should match Calypso. */
+"You don't have any media." = "Нямате файлове.";
+
+/* Displayed when the user views scheduled pages in the pages list and there are no pages */
+"You don't have any scheduled pages" = "Нямате планирани страници";
+
+/* Displayed when the user views scheduled posts in the posts list and there are no posts */
+"You don't have any scheduled posts" = "Нямате планирани публикации";
+
+/* Displayed when the user views trashed in the pages list and there are no pages */
+"You don't have any trashed pages" = "Нямате публикации в кошчето";
+
+/* Displayed when the user views trashed in the posts list and there are no posts */
+"You don't have any trashed posts" = "Нямате публикации в кошчето";
+
+/* Description for the first domain purchased with a paid plan. */
+"You have a free one-year domain registration with your plan." = "Имате безплатна едногодишна регистрация на домейн с вашия план.";
+
 /* Message alert when attempting to delete site with purchases */
 "You have active premium upgrades on your site. Please cancel your upgrades prior to deleting your site." = "Имате активни платени услуги на сайта. Моля, отменете ги преди да изтриете сайта си.";
+
+/* Warning displayed before logging out. The %d placeholder will contain the number of local posts (SINGULAR!) */
+"You have changes to %d post that hasn't been uploaded to your site. Logging out now will delete those changes. Log out anyway?" = "Имате промени към %d публикация, която не е качена на сайта. Излизането сега ще изтрие тази промяна. Искате ли да излезете?";
+
+/* Warning displayed before logging out. The %d placeholder will contain the number of local posts (PLURAL!) */
+"You have changes to %d posts that haven’t been uploaded to your site. Logging out now will delete those changes. Log out anyway?" = "Имате промени към %d публикации, които не са качени на сайта. Излизането сега ще изтрие тези промени. Искате ли да излезете?";
+
+/* Text shown to the user when setting up blogging reminders, if they complete the flow and have chosen not to add any reminders. */
+"You have no reminders set." = "Още нямате напомняния.";
 
 /* Title of message with options that shown when there are unsaved changes and the author cancelled editing a Comment. */
 "You have unsaved changes." = "Имате незапазени промени.";
 
+/* Displayed when the user views published pages in the pages list and there are no pages */
+"You haven't published any pages yet" = "Все още нямате публикувани страници";
+
+/* Displayed when the user views published posts in the posts list and there are no posts */
+"You haven't published any posts yet" = "Не сте публикували публикации";
+
+/* Title for a view milestone push notification */
+"You hit a milestone 🚀" = "Достигнахте важен етап 🚀";
+
+/* Text rendered at the bottom of the Allowlisted IP Addresses editor, should match Calypso. */
+"You may allowlist an IP address or series of addresses preventing them from ever being blocked by Jetpack. IPv4 and IPv6 are acceptable. To specify a range, enter the low value and high value separated by a dash. Example: 12.12.12.1-12.12.12.100." = "Вие трябва да разрешите на IP адрес или серия от адреси да не бъдат блокирани от Jetpack. IPv4 и IPv6 адреси са допустими. За да укажете област, въведете долният адрес следван от тире и горният адрес. Например: 12.12.12.1-12.12.12.100.";
+
 /* Error message informing the user that being logged into a WordPress.com account is required. */
 "You must be signed in to a WordPress.com account to perform this action." = "За да извършите това действие, влезте в профила си в WordPress.com.";
+
+/* Body of alert prompting users to verify their accounts while attempting to publish */
+"You need to verify your account before you can publish a post.\nDon’t worry, your post is safe and will be saved as a draft." = "Вие трябва да верифицирате Вашият акаунт преди да можете да публикувате пост.\nНе се безпокойте, Вашият пост ще бъде записан като чернова.";
+
+/* Example Likes notification displayed in the prologue carousel of the app. Number of likes should marked with * characters and will be displayed as bold text. */
+"You received *50 likes* on your site today" = "Получихте *50 харесвания* на вашия сайт днес";
+
+/* Informs that the user has replied to this comment.
+   Notification text - below a comment notification detail
+   Text to look for */
+"You replied to this comment." = "Отговорили сте на коментара.";
 
 /* Error messaged show when a mobile plugin is redirecting traffict to their site, DudaMobile in particular */
 "You seem to have installed a mobile plugin from DudaMobile which is preventing the app to connect to your blog" = "Изглежда, че сте инсталирали мобилно разширение от DudaMobile, което пречи на приложението да се свърже с вашия блог.";
 
+/* Message displayed in ignore threat alert. %1$@ is a placeholder for the blog name. */
+"You shouldn’t ignore a security issue unless you are absolutely sure it’s harmless. If you choose to ignore this threat, it will remain on your site \"%1$@\"." = "Не трябва да пренебрегвате проблемите със сигурността, дори да вярвате, че са безобидни. Ако изберете да игнорирате тази заплаха, тя ще остане на сайта ви \"%1$@\".";
+
+/* Paragraph text that needs to be highlighted */
+"You will not be able to change your username back." = "Няма да може да върнете потребителското име обратно.";
+
+/* Blogging Reminders description confirming a user's choices. The placeholder will be replaced at runtime with a day of the week. The HTML markup is used to bold the word 'once'. */
+"You'll get a reminder to blog <strong>once<\/strong> a week on %@ at %@." = "Ще получите напомняне да блогнете <strong>веднъж<\/strong> седмично, %1$@ в %2$@.";
+
+/* Message for the action with opt-out revert action.
+   The app successfully subscribed to the comments for the post */
+"You'll get notifications in the app" = "Ще получавате известия в приложението";
+
+/* Blogging Reminders description confirming a user's choices. The first placeholder will be populated with a count of the number of times a week they'll be reminded. The second will be a formatted list of days. For example: 'You'll get reminders to blog 2 times a week on Monday and Tuesday. */
+"You'll get reminders to blog %@ times a week on %@." = "Ще получите напомняне да блогвате %1$@ пъти седмично в %2$@.";
+
+/* Displayed in the Notifications Tab as a title, when the Unread Filter shows no unread notifications as a title */
+"You're all up to date!" = "Всичко е актуално!";
+
+/* Error message displayed when unable to close user account due to being unauthorized. */
+"You're not authorized to close the account." = "Нямате права да затворите профила.";
+
 /* Displayed in the Notification Settings View */
 "Your Sites" = "Вашите сайтове";
+
+/* Text in the profile editing page. Let the user know that their profile is managed by Gravatar. */
+"Your WordPress.com profile is powered by Gravatar." = "Профилът в WordPress.com използва Gravatar.";
+
+/* Footer for AMP Traffic Site Setting, should match Calypso. */
+"Your WordPress.com site supports the use of Accelerated Mobile Pages, a Google-led initiative that dramatically speeds up loading times on mobile devices." = "Вашият WordPress.com сайт поддържа AMP, инициатива на Google за ускоряване на зареждането на сайтове от мобилни устройства.";
+
+/* Share extension error dialog text. */
+"Your account does not have permission to upload media to this site. The Site Administrator can change these permissions." = "Профилът ви няма права за качване на файлове в този сайт. Администраторът на сайта може да промени правата.";
+
+/* Title for the Jetpack Backup Complete message. */
+"Your backup is now available for download" = "Вашият бекъп е наличен за изтегляне";
+
+/* Instructional text that displays the current username and display name. */
+"Your current username is %@. With few exceptions, others will only ever see your display name, %@." = "Вашето потребителско име е %1$@. С някои изключения, други хора могат да виждат само публичното ви име, %2$@.";
+
+/* Details about recently acquired domain on domain credit redemption success screen */
+"Your new domain %@ is being set up. It may take up to 30 minutes for your domain to start working." = "Новият ви домейн %@ се настройва. Може да отнеме до 30 минути, преди да проработи.";
+
+/* Help text that describes how the password should be. It appears while editing the password */
+"Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ & )." = "Паролата ви трябва да е поне шест знака. За да я направите по-сложна, използвайте главни и малки букви, цифри и символи като ! \"? $% ^ &).";
+
+/* Message of Export Content confirmation alert */
+"Your posts, pages, and settings will be mailed to the account's email address." = "Вашите публикации, страници и настройки ще бъдат изпратени на имейл адреса от профила.";
 
 /* Message of Export Content confirmation alert; substitution is user's email address */
 "Your posts, pages, and settings will be mailed to you at %@." = "Вашите публикации, страници и настройки ще ви бъдат изпратени на %@.";
 
+/* This is shown to the user when their domain search query contains invalid characters. */
+"Your search includes characters not supported in WordPress.com domains. The following characters are allowed: A–Z, a–z, 0–9." = "Търсенето включва символи, които не се поддържат от домейните в WordPress.com. Позволени са A–Z, a–z, 0–9.";
+
+/* Body text of alert helping users understand their site address */
+"Your site address appears in the bar at the top of the screen when you visit your site in Safari." = "Вашият адрес на сайта излиза най-отгоре полето за адрес, когато отворите сайта със Safari.";
+
+/* Description for label when the user has a site with VaultPress. */
+"Your site already is protected by VaultPress. You can find a link to your VaultPress dashboard below." = "Сайтът ви вече е защитен от VaultPress. Може да намерите връзка към VaultPress на таблото по-долу.";
+
+/* Title for label when the user has VaultPress enabled. */
+"Your site has VaultPress" = "Сайтът ви има VaultPress";
+
+/* User-facing string, presented to reflect that site assembly completed successfully. */
+"Your site has been created!" = "Вече имате сайт!";
+
+/* Title for the Jetpack Restore Complete message. */
+"Your site has been restored" = "Сайтът ви е възстановен";
+
+/* Subtitle for the Site Icon Picker */
+"Your site icon is used across the web: in browser tabs, site previews on social media, and the WordPress.com Reader." = "Иконата на сайта се ползва в браузър прозорци, прегледи в социалните мрежи и в WordPress.com Reader.";
+
 /* Message to show to user when media upload failed because user doesn't have enough space on quota/disk */
 "Your site is out of storage space for media uploads." = "Сайтът ви няма повече пространство за качване на файлове.";
+
+/* Title for label when there are threats on the users site */
+"Your site may be at risk" = "Сайтът ви може би е заплашен";
+
+/* User-facing string, presented to reflect that site assembly is underway. */
+"Your site will be ready shortly" = "Сайтът ви ще е готов скоро";
+
+/* Explanatory text bellow the Disconnect from WordPress.com button */
+"Your site will no longer send data to WordPress.com and Jetpack features will stop working. You will lose access to the site on the app and you will have to re-add it with the site credentials." = "Вашият сайт няма да изпраща повече данни на WordPress.com и Jetpack допълненията ще спрат да функционират. Вие ще загубите достъп до сайта от приложението и ще трябва да го добавите отново чрез данните за достъп до сайта.";
+
+/* The default Jetpack view message */
+"Your website credentials will not be stored and are used only for the purpose of installing Jetpack." = "Данните за достъп към сайта няма да бъдат съхранени и ще се ползват само за инсталиране на Jetpack.";
+
+/* Prompt displayed as part of the stats Weekly Roundup push notification. */
+"Your weekly roundup is ready, tap here to see the details!" = "Седмичното обобщение е готово, вижте подробностите!";
+
+/* Describes the expected behavior when the user disables in-app notifications in Reader Comments. */
+"You’re following this conversation. You will receive an email and a notification whenever a new comment is made." = "Следвате дискусията. Ще получите имейл и известие, когато има нов коментар.";
+
+/* Describes the expected behavior when the user enables in-app notifications in Reader Comments. */
+"You’re following this conversation. You will receive an email whenever a new comment is made." = "Следвате дискусията. Ще получите имейл, когато има нов коментар.";
 
 /* Age between dates equaling one day. */
 "a day" = "1 ден";
@@ -2322,20 +7124,5802 @@
 /* Age between dates equaling one year. */
 "a year" = "1 година";
 
+/* Error message displayed when unable to close user account due to having active atomic site. */
+"accountSettings.closeAccount.error.atomicSite" = "Този профил не може да бъде закрит веднага, защото има активни покупки. Моля, свържете се с нашия екип за поддръжка, за да завършите изтриването на профила.";
+
+/* The file with the acknowledgements is missing */
+"acknowledgements.manifest_not_found" = "Неуспешно зареждане на благодарности";
+
+/* The title for the list of third-party software we use */
+"acknowledgements.title" = "Благодарности";
+
+/* Placeholder text shown when the activity actor's display name is empty */
+"activity.unknownUser" = "Неизвестен потребител";
+
+/* Label for the backup checkpoint date */
+"activityDetail.checkpointDate" = "Контролна дата";
+
+/* Button title for downloading a backup */
+"activityDetail.download.button" = "Изтегляне";
+
+/* Button title for restoring a backup */
+"activityDetail.restore.button" = "Възстановяване";
+
+/* Section title for restore site actions */
+"activityDetail.section.restoreSite" = "Възстановяване на сайта";
+
+/* Section title for user information */
+"activityDetail.section.user" = "Потребител";
+
+/* Title for the activity detail view */
+"activityDetail.title" = "Събитие";
+
+/* Deselect all button */
+"activityLogs.activityTypes.deselectAll" = "От-маркиране на всички";
+
+/* Empty state message when no activity types are available */
+"activityLogs.activityTypes.empty" = "Няма видове активност";
+
+/* Select all button */
+"activityLogs.activityTypes.selectAll" = "Избор на всички";
+
+/* Activity type selection screen title */
+"activityLogs.activityTypes.title" = "Видове активност";
+
+/* Empty state message for activity logs */
+"activityLogs.empty" = "Няма активност";
+
+/* Activity types filter label */
+"activityLogs.filter.activityTypes" = "Видове активност";
+
+/* End date filter label */
+"activityLogs.filter.endDate" = "Крайна дата";
+
+/* Reset filters button label */
+"activityLogs.filter.reset" = "Изчистване на филтрите";
+
+/* Start date filter label */
+"activityLogs.filter.startDate" = "Начална дата";
+
+/* Notice shown to free plan users about limited activity log events */
+"activityLogs.freePlan.notice" = "Тъй като сте с безплатен план, ще виждате ограничен дневник на активността.";
+
+/* Title for activity logs screen
+   Title for the activity logs screen */
+"activityLogs.title" = "Активност";
+
+/* Screen title */
+"addCategory.navigationTitle" = "Добавяне на категория";
+
+/* Cell title */
+"addCategory.parentCategory" = "Родителска категория";
+
+/* Cell placeholder */
+"addCategory.titlePlaceholder" = "Заглавие";
+
+/* Accessibility identifier for an 'Add Comment' button */
+"addCommentButton.accessibilityIdentifity" = "Добавяне на коментар";
+
+/* Error message when user cancels login */
+"addSite.selfHosted.cancelled" = "Входът беше прекратен";
+
+/* A message to inform users to type the site address in the text field. */
+"addSite.selfHosted.enterSiteAddress" = "Въведете адреса на WordPress сайта, който искате да свържете.";
+
+/* Error message shown when failing to load details from a self-hosted WordPress site */
+"addSite.selfHosted.loadingSiteInfoFailure" = "Неуспешно зареждане на подробности за WordPress сайта";
+
+/* Error message when user signs in with an unexpected usern. The first argument is the expected username */
+"addSite.selfHosted.mismatchUser" = "Моля, влезте с потребителя %@";
+
+/* Error message shown when failing to save a self-hosted site to user's device */
+"addSite.selfHosted.savingSiteFailure" = "Неуспешно записване на WordPress сайта, опитайте по-късно.";
+
+/* Title of the page to add a self-hosted site */
+"addSite.selfHosted.title" = "Добавяне на сайт от хостинг";
+
+/* Error message when XML-RPC is disabled on the WordPress site. The first argument is detailed error message */
+"addSite.selfHosted.xmlrpcDisabled" = "Неуспешна връзка. Изискваните XML-RPC методи не са налични. Моля, свържете се с хостинг доставчика си.";
+
 /* Age between dates equaling one hour. */
 "an hour" = "1 час";
+
+/* This is the string we display when prompting the user to review the Jetpack app */
+"appRatings.jetpack.prompt" = "Какво мислите за Jetpack?";
+
+/* This is the string we display when prompting the user to review the Reader app */
+"appRatings.reader.prompt" = "Какво мислите за Reader?";
+
+/* This is the string we display when prompting the user to review the WordPress app */
+"appRatings.wordpress.prompt" = "Какво мислите за WordPress?";
+
+/* Option to enable the optimization of images when uploading. */
+"appSettings.media.imageOptimizationRow" = "Оптимизиране на изображенията";
+
+/* Indicates an image will use high quality when uploaded. */
+"appSettings.media.imageQuality.high" = "Високо";
+
+/* Indicates an image will use low quality when uploaded. */
+"appSettings.media.imageQuality.low" = "Ниско";
+
+/* Indicates an image will use maximum quality when uploaded. */
+"appSettings.media.imageQuality.maximum" = "Максимално";
+
+/* Indicates an image will use medium quality when uploaded. */
+"appSettings.media.imageQuality.medium" = "Средно";
+
+/* The quality of image used when uploading */
+"appSettings.media.imageQuality.title" = "Качество";
+
+/* Title for the image quality settings option. */
+"appSettings.media.imageQualityRow" = "Качество на изображението";
+
+/* Cancel button title */
+"appUpdate.action.cancel" = "Отказ";
+
+/* Get the latest version button title */
+"appUpdate.action.latestVersion" = "Изтеглете последната версия";
+
+/* Update button title */
+"appUpdate.action.update" = "Обновяване";
+
+/* Message for view displayed when there's a newer version of the app available */
+"appUpdate.message" = "Изтеглете последната версия на приложението, за да го ползвате.";
+
+/* Title for view displayed when there's a newer version of the app available */
+"appUpdate.title" = "Има налично обновяване";
+
+/* Format for latest version available */
+"appUpdate.versionFormat" = "Версия %@";
+
+/* Section title for what's new in the latest update available */
+"appUpdate.whatsNew" = "Какво ново";
+
+/* The list item of experimental features that users can choose to enable */
+"application-settings.experimental-features" = "Експериментални функции";
+
+/* Complete information about application passwords with security benefits, creation process, management instructions, and revocation warning */
+"applicationPassword.info.content" = "Паролите за приложения са по-сигурен начин това приложение да получава достъп до съдържанието на вашия сайт, без да използва истинската ви парола.\n\nКогато добавяте сайтове в приложението, паролите за приложения ще се създават автоматично при необходимост.\n\nМожете да преглеждате и управлявате тези пароли в потребителския си профил в административния панел на вашия WordPress сайт.\n\nМоля, обърнете внимание, че отнемането на пароли за приложения ще прекрати достъпа на приложението до вашия сайт. Бъдете внимателни, когато отнемате пароли за приложения, създадени от приложението.";
+
+/* Button to dismiss the application password information view */
+"applicationPassword.info.gotIt.button" = "Ясно";
+
+/* Title for the application passwords information view */
+"applicationPassword.info.title" = "Относно пароли на приложението";
+
+/* Title of row for displaying an application password's creation date */
+"applicationPassword.item.creationDate" = "Дата на създаване";
+
+/* Footer message indicating that this application password is currently active and being used by the app */
+"applicationPassword.item.currentlyInUse" = "Паролата на приложението се ползва в момента.";
+
+/* Title of row for displaying an application password's last used date */
+"applicationPassword.item.lastUsed" = "Последно използванe";
+
+/* Title of row for displaying an application password's last used IP address */
+"applicationPassword.item.lastUsedIp" = "Спирък с IP адреси";
+
+/* Title of row for displaying an application password name */
+"applicationPassword.item.name" = "Име";
+
+/* Title of section for displaying application password details */
+"applicationPassword.item.section.security" = "Сигурност";
+
+/* String format of creation date of an application password. There is one argument: the creation date relative to now (i.e. 5 days ago). */
+"applicationPassword.list.item.created-date-format" = "Създаден %@";
+
+/* String format of last used time of an application password. There is one argument: the last used time relative to now (i.e. 5 days ago). */
+"applicationPassword.list.item.last-used-format" = "Последно използване на %@";
+
+/* Last used time of an application password if it's never been used */
+"applicationPassword.list.item.unused" = "Не се ползва още.";
+
+/* Title of application passwords list */
+"applicationPassword.list.title" = "Пароли на приложения";
+
+/* Error message when the current site's url cannot be found */
+"applicationPasswordMigration.error.siteUrlNotFound" = "Не откриваме адреса на текущия сайт";
+
+/* Error message shown when the site doesn't support Application Passwords feature */
+"applicationPasswordMigration.error.unsupported" = "Сайтът не поддържа пароли на приложението";
+
+/* Error message when the username does not match the signed-in user. The first argument is the currently signed in user's user login name */
+"applicationPasswordMigration.error.usernameMismatch" = "Трябва да влезете с потребителя \"%@\"";
+
+/* Error message when the site's REST API is not accessible for application password creation */
+"applicationPasswordRepository.error.restApiInaccessible" = "Не може да се достъпи REST API на сайта";
+
+/* Error message when application password creation fails for unknown reasons */
+"applicationPasswordRepository.error.unknown" = "Създаването на парола за приложения беше неуспешно";
+
+/* Error message when the username cannot be found for application password creation */
+"applicationPasswordRepository.error.usernameNotFound" = "Не може да бъде открито потребителското име за сайта";
+
+/* Description for the prompt to upgrade to Application Passwords. The first argument is the name of the feature that requires Application Passwords. */
+"applicationPasswordRequired.description" = "Паролите за приложения са по-сигурен начин за свързване към вашия самостоятелно хостван сайт и позволяват поддръжка на функции като %@.";
+
+/* Feature name for managing application passwords in the app */
+"applicationPasswordRequired.feature.applicationPasswords" = "Управление на паролите на приложенията";
+
+/* Feature name for the block editor in application password required prompt */
+"applicationPasswordRequired.feature.blockEditor" = "Блоков редактор";
+
+/* Feature name for managing terms and taxonomies in the app */
+"applicationPasswordRequired.feature.customTaxonomies" = "Управление на категоризацията";
+
+/* Feature name for managing plugins in the app */
+"applicationPasswordRequired.feature.plugins" = "Управление на разширенията";
+
+/* Feature name for managing users in the app */
+"applicationPasswordRequired.feature.users" = "Управление на потребителите";
+
+/* Title for the button to authenticate with Application Passwords */
+"applicationPasswordRequired.getStartedButton" = "Първи стъпки";
+
+/* Title for the prompt to upgrade to Application Passwords */
+"applicationPasswordRequired.title" = "Изисква се парола на приложението";
+
+/* translators: displays audio file extension. e.g. MP3 audio file */
+"audio file" = "аудио файл";
+
+/* An alert suggesting to load autosaved revision for a published post */
+"autosaveAlert.cancel" = "Отказ";
+
+/* An alert suggesting to load autosaved revision for a published post */
+"autosaveAlert.message" = "Направили сте промени към публикацията от друго устройство, които не са записани. Редактирано: %@";
+
+/* An alert suggesting to load autosaved revision for a published post */
+"autosaveAlert.title" = "Автоматично записване е налично";
+
+/* An alert suggesting to load autosaved revision for a published post */
+"autosaveAlert.viewChanges" = "Преглед на промените";
+
+/* Alert message when something goes wrong with the selected image. */
+"avatarMenu.failedToSetAvatarAlertMessage" = "Неуспешно зареждане на изображението. Моля изберете друго и повторете.";
+
+/* Title for menu that is shown when you tap your gravatar */
+"avatarMenu.title" = "Обновяване на Gravatar";
+
+/* The title of a button to close the classic editor deprecation notice alert dialog. */
+"aztecPost.deprecationNotice.dismiss" = "Затваряне";
+
+/* User action to dismiss media options. */
+"aztecPost.mediaAttachmentActionSheet.dismiss" = "Отмяна";
+
+/* Download button title */
+"backup.download.header.download" = "Изтегляне";
+
+/* Shows when the download link will expire. %@ is the relative time (e.g., 'in 2 hours') */
+"backup.download.header.expiresIn" = "Изтича на %@";
+
+/* Message displayed when a backup has finished. %@ is the date and time. */
+"backup.download.header.message" = "Вашият бекъп за %@ е готов";
+
+/* Title shown when a backup is ready to download */
+"backup.download.header.title" = "Бекъпът е готов за изтегляне";
+
+/* Message shown when a downloadable backup is in progress */
+"backup.inProgress.message" = "Подготвяне на бекъп за изтегляне";
+
+/* Title shown when a downloadable backup is being created */
+"backup.inProgress.title" = "Създаване на бекъп за изтегляне";
+
+/* Text displayed in the view when there aren't any Backups to display */
+"backups.empty.subtitle" = "Първият ви бекъп ще се появи тук в рамките на 24 часа и ще получите известие, когато е готов";
+
+/* Title for the view when there aren't any Backups to display */
+"backups.empty.title" = "Вашият бекъп ще е готов скоро";
+
+/* Title for backups screen
+   Title for the backups screen */
+"backups.title" = "Бекъпи";
+
+/* Button title for the button that shows the Blaze flow when tapped. */
+"blaze.campaigns.create.button.title" = "Създаване";
+
+/* Text displayed when there are no Blaze campaigns to display. */
+"blaze.campaigns.empty.subtitle" = "Още не сте създали кампании. Цъкнете Създаване, за да започнете.";
+
+/* Title displayed when there are no Blaze campaigns to display. */
+"blaze.campaigns.empty.title" = "Нямате кампании";
+
+/* Text displayed when there is a failure loading Blaze campaigns. */
+"blaze.campaigns.errorMessage" = "Възникна грешка със зареждането на кампаниите.";
+
+/* Title for the view when there's an error loading Blaze campiagns. */
+"blaze.campaigns.errorTitle" = "Опа";
+
+/* Displayed while Blaze campaigns are being loaded. */
+"blaze.campaigns.loading.title" = "Зареждане на кампании...";
+
+/* Title for the screen that allows users to manage their Blaze campaigns. */
+"blaze.campaigns.title" = "Blaze кампании";
+
+/* Description for the Blaze dashboard card. */
+"blaze.dashboard.card.description" = "Споделяне на работата ви чрез милиони сайтове.";
+
+/* Title for a menu action in the context menu on the Blaze card. */
+"blaze.dashboard.card.menu.hide" = "Скриване";
+
+/* Title for a menu action in the context menu on the Blaze card. */
+"blaze.dashboard.card.menu.learnMore" = "Повече информация";
+
+/* Title for the Blaze dashboard card. */
+"blaze.dashboard.card.title" = "Рекламиране на съдържание с Blaze";
+
+/* Button title for a Blaze overlay prompting users to select a post to blaze. */
+"blaze.overlay.buttonTitle" = "Рекламиране с Blaze";
+
+/* Description for the Blaze overlay. */
+"blaze.overlay.descriptionOne" = "Рекламирайте публикация или страница само за няколко долара на ден.";
+
+/* Description for the Blaze overlay. */
+"blaze.overlay.descriptionThree" = "Следете ефективността на рекламата и я прекратете по всяко време.";
+
+/* Description for the Blaze overlay. */
+"blaze.overlay.descriptionTwo" = "Вашето съдържание ще се появи на милиони WordPress и Tumblr сайтове.";
+
+/* Title for the Blaze overlay. */
+"blaze.overlay.title" = "Намиране на трафик за сайта с Blaze";
+
+/* Button title for the Blaze overlay prompting users to blaze the selected page. */
+"blaze.overlay.withPage.buttonTitle" = "Реклама на страницата";
+
+/* Button title for the Blaze overlay prompting users to blaze the selected post. */
+"blaze.overlay.withPost.buttonTitle" = "Реклама на публикацията";
+
+/* Short status description */
+"blazeCampaign.status.active" = "Активна";
+
+/* Short status description */
+"blazeCampaign.status.approved" = "Одобрена";
+
+/* Short status description */
+"blazeCampaign.status.canceled" = "Прекратена";
+
+/* Short status description */
+"blazeCampaign.status.completed" = "Приключена";
+
+/* Short status description */
+"blazeCampaign.status.inmoderation" = "В модерация";
+
+/* Short status description */
+"blazeCampaign.status.processing" = "Обработване";
+
+/* Short status description */
+"blazeCampaign.status.rejected" = "Отказана";
+
+/* Short status description */
+"blazeCampaign.status.scheduled" = "Планирана";
+
+/* Title for budget stats view */
+"blazeCampaigns.budget" = "Бюджет";
+
+/* Title for impressions stats view */
+"blazeCampaigns.clicks" = "Кликове";
+
+/* Title for impressions stats view */
+"blazeCampaigns.impressions" = "Показвания";
+
+/* Title for the context menu action that hides the dashboard card. */
+"blogDashboard.contextMenu.hideThis" = "Скриване";
+
+/* Action shown in a bottom notice to dismiss it. */
+"blogDashboard.dismiss" = "Отхвърляне";
+
+/* Context menu button title */
+"blogHeader.actionVisitSite" = "Към сайта";
+
+/* Badge title in site list */
+"blogList.siteBadge.staging" = "Стейджинг";
+
+/* Title for a button that, when tapped, shows more info about participating in Bloganuary. */
+"bloganuary.dashboard.card.button.learnMore" = "Повече информация";
+
+/* Short description for the Bloganuary event, shown right below the title. */
+"bloganuary.dashboard.card.description" = "През януари, блог предизвикателствата ще идват от Блогянуари - нашето предизвикателство за изграждане на блогове през новата година.";
+
+/* Title for the Bloganuary dashboard card while Bloganuary is running. */
+"bloganuary.dashboard.card.runningTitle" = "Блогянуари е тук!";
+
+/* Title for the Bloganuary dashboard card. */
+"bloganuary.dashboard.card.title" = "Блогянуари идва!";
+
+/* Title of a button that calls the user to enable the Blogging Prompts feature. */
+"bloganuary.learnMore.modal.button.promptsDisabled" = "Включване на блог предизвикателствата";
+
+/* Title of a button that will dismiss the Bloganuary modal when tapped.
+Note that the word 'go' here should have a closer meaning to 'start' rather than 'move forward'. */
+"bloganuary.learnMore.modal.button.promptsEnabled" = "Хайде!";
+
+/* The second line of the description shown in the Bloganuary modal sheet. */
+"bloganuary.learnMore.modal.description.second" = "Публикуване на отговор.";
+
+/* The third line of the description shown in the Bloganuary modal sheet. */
+"bloganuary.learnMore.modal.description.third" = "Вижте какво публикуват другите блогъри за вдъхновение и за да изградите контакти.";
+
+/* The first line of the description shown in the Bloganuary modal sheet. */
+"bloganuary.learnMore.modal.descriptions.first" = "Получаване на ново предизвикателство всеки ден.";
+
+/* An additional piece of information shown in case the user has the Blogging Prompts feature disabled. */
+"bloganuary.learnMore.modal.footer.addition" = "За да се включите в Блогянуари, трябва да активирате предизвикателствата.";
+
+/* An informative excerpt shown in a subtler tone. */
+"bloganuary.learnMore.modal.footer.text" = "Блогянуари ще ползва дневни предизвикателства за писане през месец Януари.";
+
+/* The headline text of the Bloganuary modal sheet. */
+"bloganuary.learnMore.modal.headline" = "Присъединете се към едномесечното ни предизвикателство";
+
+/* Verb. Dismisses the blogging prompt notification. */
+"bloggingPrompt.pushNotification.customActionDescription.dismiss" = "Отхвърляне";
+
+/* Title of the set goals button in the Blogging Reminders Settings flow. */
+"bloggingRemindersPrompt.intro.continueButton" = "Настройка на напомняния";
+
+/* Description on the first screen of the Blogging Reminders Settings flow called aftet post publishing. */
+"bloggingRemindersPrompt.intro.details" = "Настройте вашите напомняния за блогване за дните, в които искате да публикувате.";
+
+/* Title of the Blogging Reminders Settings screen. */
+"bloggingRemindersPrompt.intro.title" = "Напомняния за блогване";
+
+/* Add self-hosted site button */
+"button.addSelfHostedSite" = "Добавете сайт със самостоятелен хостинг";
+
+/* Create WordPress.com site button */
+"button.createDotCoSite" = "Създаване на сайт в WordPress.com";
+
+/* Used when displaying author of a plugin. */
+"by %@" = "от %@";
+
+/* Option for users to rate a chat bot answer as helpful. */
+"chat.rateHelpful" = "Отбележете като полезно";
+
+/* Title for the checkout view */
+"checkout.title" = "Поръчка";
+
+/* Post Editor / Button in the 'More' menu */
+"classicEditor.moreMenu.saveDraft" = "Запазване на чернова";
+
+/* Button to add more screenshots */
+"com.jetpack.support.addMoreScreenshots" = "Добавяне на още скрийншоти";
+
+/* Button to add screenshots */
+"com.jetpack.support.addScreenshots" = "Добавяне на скрийншоти";
+
+/* Header for application logs section */
+"com.jetpack.support.applicationLogs" = "Дневник на приложението";
+
+/* Description explaining why including logs is helpful */
+"com.jetpack.support.applicationLogsDescription" = "Включването на дневници ще помогне на екипа ни да разреши проблема. Дневниците могат да съдържат скорошна дейност.";
+
+/* Navigation title for application logs screen */
+"com.jetpack.support.applicationLogsTitle" = "Дневник на приложението";
+
+/* Format string for attachment identifier */
+"com.jetpack.support.attachment" = "Прикачен файл %@";
+
+/* Format string for attachment size limit. %1$@ is current size, %2$@ is maximum size */
+"com.jetpack.support.attachmentLimit" = "Ограничение за прикачени файлове: %1$@ \/ %2$@";
+
+/* Bot greeting message. %1$@ is the user's name */
+"com.jetpack.support.botGreeting" = "Здрасти, %1$@!";
+
+/* Bot introduction message explaining its purpose */
+"com.jetpack.support.botIntroduction" = "Аз съм вашият личен ИИ асистент. Мога да помогна по въпроси за вашия сайт или профил.";
+
+/* Format string for cache file count and size. %1$d is the number of files, %2$@ is the formatted size. The system will pluralize 'files' based on the number – please specify it as the largest plural value */
+"com.jetpack.support.cacheFiles" = "%1$d кеширани файлове (%2$@)";
+
+/* Message shown when cache has no files */
+"com.jetpack.support.cacheIsEmpty" = "Кешът е празен";
+
+/* Button to cancel current action */
+"com.jetpack.support.cancel" = "Отказ";
+
+/* Warning message that deleted logs cannot be recovered */
+"com.jetpack.support.cannotRecoverLogs" = "Няма да можете да ги върнете.";
+
+/* Button to clear all activity logs */
+"com.jetpack.support.clearAllActivityLogs" = "Изтриване на дневниците на активността";
+
+/* Button to clear disk cache */
+"com.jetpack.support.clearDiskCache" = "Изтриване на дисковия кеш.";
+
+/* Description explaining the purpose of clearing disk cache */
+"com.jetpack.support.clearDiskCacheDescription" = "Изтриване на временни файлове за освобождаване на място или оправяне на проблеми.";
+
+/* Progress text while clearing cache */
+"com.jetpack.support.clearing" = "Изчистване...";
+
+/* Message shown when cache clearing is complete */
+"com.jetpack.support.complete" = "Готово";
+
+/* Confirmation message when canceling a draft */
+"com.jetpack.support.confirmCancelMessage" = "Наистина ли искате да отмените съобщението? Ще изгубите данните, които сте въвели";
+
+/* Title for alert confirming cancellation */
+"com.jetpack.support.confirmCancellation" = "Потвърдете отмяната";
+
+/* Confirmation dialog title when deleting all logs */
+"com.jetpack.support.confirmDeleteAllLogs" = "Наистина ли искате да изтриете всички дневници?";
+
+/* Section title for contact information */
+"com.jetpack.support.contactInformation" = "Информация за контакт";
+
+/* Button to continue editing a message */
+"com.jetpack.support.continueWriting" = "Продължете да пишете";
+
+/* Message shown at end of closed support conversation */
+"com.jetpack.support.conversationEnded" = "Край на разговора. Не са възможни нови отговори.";
+
+/* Navigation title for bot conversations list */
+"com.jetpack.support.conversations" = "Разговори";
+
+/* Button to delete all log files */
+"com.jetpack.support.deleteAllLogs" = "Изтриване на всички дневници";
+
+/* Description text for diagnostics screen */
+"com.jetpack.support.diagnosticsDescription" = "Изпълняване на обичайни задачи по поддръжка и оглед на проблеми.";
+
+/* Navigation title for diagnostics screen */
+"com.jetpack.support.diagnosticsTitle" = "Диагностика";
+
+/* Button to discard changes in a draft message */
+"com.jetpack.support.discardChanges" = "Отмяна на промените";
+
+/* Notice explaining where support will send email responses */
+"com.jetpack.support.emailNotice" = "Ще ви пратим имейл на този адрес.";
+
+/* Error title when logs fail to load */
+"com.jetpack.support.errorLoadingLogs" = "Грешка при зареждане на дневниците";
+
+/* Error message when support conversations fail to load */
+"com.jetpack.support.errorLoadingSupportConversations" = "Грешка при зареждане на разговорите с поддръжката";
+
+/* Title for error alerts */
+"com.jetpack.support.errorTitle" = "Грешка";
+
+/* Option to export log as a file */
+"com.jetpack.support.exportAsFile" = "Експорт като файл";
+
+/* Button to dismiss alerts. */
+"com.jetpack.support.gotIt" = "Ясно";
+
+/* Text on the support form to refer to what area the user has problem with. */
+"com.jetpack.support.iNeedHelp" = "Имам нужда от помощ с";
+
+/* Toggle label to include application logs in the support request */
+"com.jetpack.support.includeApplicationLogs" = "Включване на дневници от програмата";
+
+/* Section title for issue details */
+"com.jetpack.support.issueDetails" = "Подробности за проблема";
+
+/* Format string for when conversation was last updated */
+"com.jetpack.support.lastUpdated" = "Последно обновено %@";
+
+/* Progress message while loading conversation messages */
+"com.jetpack.support.loadingBotConversationMessages" = "Зареждане на съобщенията";
+
+/* Progress message while loading bot conversations */
+"com.jetpack.support.loadingBotConversations" = "Зареждане на разговорите с бота";
+
+/* Progress text while loading support conversations */
+"com.jetpack.support.loadingConversations" = "Зареждане на разговорите";
+
+/* Progress message while loading disk usage information */
+"com.jetpack.support.loadingDiskUsage" = "Зареждане на ползваното място";
+
+/* Progress message while loading an image attachment */
+"com.jetpack.support.loadingImage" = "Зареждане на изображение";
+
+/* Progress message shown in overlay while refreshing content */
+"com.jetpack.support.loadingLatestContent" = "Зареждане на най-новото съдържание";
+
+/* Progress message while loading application log content */
+"com.jetpack.support.loadingLogContent" = "Зареждане на съдържанието на дневниците...";
+
+/* Progress message while loading log files */
+"com.jetpack.support.loadingLogs" = "Зареждане на дневниците...";
+
+/* Progress text while loading conversation messages */
+"com.jetpack.support.loadingMessages" = "Зареждане на съобщенията";
+
+/* Progress message while loading a video attachment */
+"com.jetpack.support.loadingVideo" = "Зареждане на видео";
+
+/* Section header for log files sorted by date */
+"com.jetpack.support.logFilesByDate" = "Дневници, подредени по дата на създаване";
+
+/* Text indicating which log files will be included in the support request */
+"com.jetpack.support.logFilesToUpload" = "Следните дневници ще бъдат качени:";
+
+/* Footer text explaining log retention policy */
+"com.jetpack.support.logRetentionNotice" = "Запомнени са до седем дни с дневници.";
+
+/* Section header for message text input */
+"com.jetpack.support.message" = "Съобщение";
+
+/* Success message when reply is sent successfully */
+"com.jetpack.support.messageSent" = "Съобщението е изпратено";
+
+/* Format string for number of messages in conversation */
+"com.jetpack.support.messagesCount" = "%d Съобщения";
+
+/* The title of a new bot chat in the support area of the app */
+"com.jetpack.support.new-bot-chat" = "Нов разговор с бот";
+
+/* Option to create a new support ticket */
+"com.jetpack.support.newSupportTicket" = "Нов билет за поддръжка";
+
+/* Label shown when there are no bot conversations */
+"com.jetpack.support.noConversations" = "Няма разговори";
+
+/* Description shown when no log files are available */
+"com.jetpack.support.noLogsAvailable" = "Няма налични дневници на дейността";
+
+/* Label shown when no log files are available */
+"com.jetpack.support.noLogsFound" = "Не са открити дневници";
+
+/* Button to open a support ticket */
+"com.jetpack.support.openSupportTicket" = "Отваряне на билет за поддръжка";
+
+/* Text indicating a field is optional */
+"com.jetpack.support.optional" = "(По избор)";
+
+/* Navigation title for replying to a support conversation */
+"com.jetpack.support.reply" = "Отговор";
+
+/* Description for saving log as a file */
+"com.jetpack.support.saveAsFile" = "Запазване като файл за споделяне или запазване";
+
+/* Label for screenshots section */
+"com.jetpack.support.screenshots" = "Скрийншоти";
+
+/* Description for screenshots section */
+"com.jetpack.support.screenshotsDescription" = "Добавянето на скрийншоти може да ни помогне да разберем и оправим проблема по-бързо.";
+
+/* Button to send a message or reply */
+"com.jetpack.support.send" = "Изпращане";
+
+/* Description for sending logs to support */
+"com.jetpack.support.sendLogsToSupport" = "Изпращане на дневниците директно към поддръжката";
+
+/* Progress text while sending a message */
+"com.jetpack.support.sending" = "Изпращане";
+
+/* Progress message shown while sending a message */
+"com.jetpack.support.sendingMessage" = "Изпращане на съобщение";
+
+/* Button to share content */
+"com.jetpack.support.share" = "Споделяне";
+
+/* Navigation title for sharing activity log */
+"com.jetpack.support.shareActivityLog" = "Споделяне на дневника на дейностите";
+
+/* Message shown when sharing log with support */
+"com.jetpack.support.sharingWithSupport" = "Споделяне с техническата поддръжка!";
+
+/* Site Address title on the support form */
+"com.jetpack.support.siteAddress" = "Адрес на сайта";
+
+/* Placeholder for site address field */
+"com.jetpack.support.siteAddressPlaceholder" = "https:\/\/yoursite.com";
+
+/* Description encouraging user to start a new conversation */
+"com.jetpack.support.startNewConversation" = "Започнете нов разговор с бутона по-горе";
+
+/* Subject title on the support form */
+"com.jetpack.support.subject" = "Тема";
+
+/* Placeholder for subject field */
+"com.jetpack.support.subjectPlaceholder" = "Кратко описание на проблема";
+
+/* Button title to submit a support request. */
+"com.jetpack.support.submitRequest" = "Изпращане на заявка за помощ";
+
+/* Navigation title for the support conversations list */
+"com.jetpack.support.supportConversations" = "Разговори с поддръжката";
+
+/* Title for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSent" = "Заявката е пратена!";
+
+/* Message for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSentMessage" = "Вашата заявка за поддръжка е изпратена. Ще ви отговорим по имейл колкото можем по-скоро.";
+
+/* Progress message shown while bot is thinking */
+"com.jetpack.support.thinking" = "Мислене...";
+
+/* Title of the view for contacting support. */
+"com.jetpack.support.title" = "Връзка с техническа поддръжка";
+
+/* Button to retry a failed operation */
+"com.jetpack.support.tryAgain" = "Повторен опит";
+
+/* Error title when log deletion fails */
+"com.jetpack.support.unableToDeleteLogs" = "Неуспешно изтриване на дневниците";
+
+/* Error message when conversation cannot be displayed */
+"com.jetpack.support.unableToDisplayConversation" = "Неуспешно показване на дискусията";
+
+/* Error title when video cannot be loaded or played */
+"com.jetpack.support.unableToDisplayVideo" = "Неуспешно показване на видео";
+
+/* Error message when application logs cannot be loaded */
+"com.jetpack.support.unableToLoadApplicationLogs" = "Неуспешно зареждане на дневниците";
+
+/* Error title when bot conversations fail to load */
+"com.jetpack.support.unableToLoadConversations" = "Неуспешно зареждане на дискусиите";
+
+/* Error title when messages fail to load */
+"com.jetpack.support.unableToLoadMessages" = "Неуспешно зареждане на съобщенията";
+
+/* Error title when message sending fails */
+"com.jetpack.support.unableToSendMessage" = "Неуспешно изпращане на съобщение";
+
+/* Button to view an attachment */
+"com.jetpack.support.view" = "Преглед";
+
+/* Progress message shown during cache clearing operation */
+"com.jetpack.support.working" = "Работи";
+
+/* Displayed in the confirmation alert when marking comment notifications as read. */
+"comment" = "коментар";
+
+/* Sentence fragment.
+The full phrase is 'Comments on' followed by the title of the post on a separate line. */
+"comment.header.subText.commentThread" = "Коментари на";
+
+/* Provides a hint that the current screen displays a comment on a post.
+The title of the post will be displayed below this text.
+Example: Comment on 
+ My First Post */
+"comment.header.subText.post" = "Коментар на";
+
+/* Provides a hint that the current screen displays a reply to a comment.
+%1$@ is a placeholder for the comment author's name that's been replied to.
+Example: Reply to Pamela Nguyen */
+"comment.header.subText.reply" = "Отговор на %1$@";
+
+/* Button in an alert confirming discaring a new draft */
+"commentCreate.closeConfirmationAlert.deleteDraft" = "Изтриване на чернова";
+
+/* Button to keep the changes in an alert confirming discaring changes */
+"commentCreate.closeConfirmationAlert.keepEditing" = "Продължаване на редакцията";
+
+/* Button in an alert confirming saving a new draft */
+"commentCreate.closeConfirmationAlert.saveDraft" = "Запазване на чернова";
+
+/* Error title */
+"commentCreate.failedToSentComment" = "Неуспешно изпращане на коментар";
+
+/* Navigation bar title when leaving a reply to a comment */
+"commentCreate.navigationTitleComment" = "Коментар";
+
+/* Navigation bar title when leaving a reply to a comment */
+"commentCreate.navigationTitleReply" = "Отговор";
+
+/* Navigation bar title when leaving a reply to a comment */
+"commentCreate.placeholderLeaveComment" = "Оставяне на отговор...";
+
+/* Navigation bar title when leaving a reply to a comment */
+"commentCreate.placeholderLeaveReply" = "Отговор...";
+
+/* Navigation bar button title */
+"commentCreate.send" = "Изпращане";
+
+/* Button in an alert confirming discaring a new draft */
+"commentEdit.closeConfirmationAlert.deleteDraft" = "Отмяна на промените";
+
+/* Button to keep the changes in an alert confirming discaring changes */
+"commentEdit.closeConfirmationAlert.keepEditing" = "Продължаване на редакцията";
+
+/* Error title */
+"commentEdit.failedToSaveComment" = "Неуспешно записване на коментара";
+
+/* Navigation bar title when leaving a editing an existing comment */
+"commentEdit.navigationTitle" = "Редактиране на коментар";
+
+/* Error title */
+"comments.failedToLike" = "Неуспешно харесване на коментара";
+
+/* Error message informing a user about an invalid password. */
+"common.reEnterPasswordMessage" = "Потребителят и паролата, запомнени в приложението, може да са остарели. Моля, въведете паролата в настройки и опитайте пак.";
+
+/* An error message. */
+"common.unableToConnect" = "Неуспешно свързване";
+
+/* Footnote for the privacy compliance popover. */
+"compliance.analytics.popover.footnote" = "Тези бисквитки ни позволяват да оптимизираме производителността, като събираме информация как потребителите ползват сайта.";
+
+/* Save Button Title for the privacy compliance popover. */
+"compliance.analytics.popover.save.button" = "Запис";
+
+/* Settings Button Title for the privacy compliance popover. */
+"compliance.analytics.popover.settings.button" = "Към настройките";
+
+/* Subtitle for the privacy compliance popover. */
+"compliance.analytics.popover.subtitle" = "Обработваме лична информация, за да оптимизираме нашия сайт и маркетинг, базирано на вашето съгласие и нашия легитимен интерес.";
+
+/* Title for the privacy compliance popover. */
+"compliance.analytics.popover.title" = "Управление на поверителността";
+
+/* Toggle Title for the privacy compliance popover. */
+"compliance.analytics.popover.toggle" = "Анализи";
+
+/* Accessibility hint for create floating action button */
+"createPostSheet.createPostHint" = "Създаване на публикация или страница";
+
+/* Create Sheet button title */
+"createSheet.page" = "Страница";
+
+/* Create Sheet button title */
+"createSheet.post" = "Публикация";
+
+/* Create Sheet button title */
+"createSheet.postFromAudio" = "Публикация от аудио";
+
+/* Customize Insights description */
+"customizeInsightsCell.content" = "Създайте свое персонализирано табло и изберете какво да виждате. Фокусирайте се върху нужните данни.";
+
+/* Accessibility hint */
+"customizeInsightsCell.dismissButton.accessibilityHint" = "Докоснете за отхвърляне на картата";
+
+/* Customize Insights button title */
+"customizeInsightsCell.dismissButton.title" = "Отмяна";
+
+/* Customize Insights title */
+"customizeInsightsCell.title" = "Настройте своите обобщения";
+
+/* Accessibility hint */
+"customizeInsightsCell.tryItButton.accessibilityHint" = "Докоснете за промяна на обобщенията";
+
+/* Customize Insights button title */
+"customizeInsightsCell.tryItButton.title" = "Опитайте сега";
+
+/* Title for an empty state view when no cards are displayed */
+"dasboard.emptyView.subtitle" = "Добавете карти, подходящи за нуждите ви от информация.";
+
+/* Title for an empty state view when no cards are displayed */
+"dasboard.emptyView.title" = "Няма карти за показване";
+
+/* Personialize home screen button title */
+"dasboard.personalizeHomeButton" = "Персонализация на началния екран";
+
+/* Title for a menu action in the context menu on the Jetpack Social dashboard card. */
+"dashboard.card.social.menu.hide" = "Скриване";
+
+/* Title for the Jetpack Social dashboard card when the user has no social connections. */
+"dashboard.card.social.noconnections.title" = "Споделяне в социалните ви мрежи";
+
+/* Title for the Jetpack Social dashboard card when the user has no social shares left. */
+"dashboard.card.social.noshares.title" = "Нямате повече споделяния!";
+
+/* Title for comments button on dashboard. */
+"dashboard.menu.comments" = "Коментари";
+
+/* Title for media button on dashboard. */
+"dashboard.menu.media" = "Файлове";
+
+/* Title for more button on dashboard. */
+"dashboard.menu.more" = "Още";
+
+/* Title for pages button on dashboard. */
+"dashboard.menu.pages" = "Страници";
+
+/* Title for posts button on dashboard. */
+"dashboard.menu.posts" = "Публикации";
+
+/* Title for stats button on dashboard. */
+"dashboard.menu.stats" = "Статистика";
+
+/* Title for the Activity Log dashboard card context menu item that navigates the user to the full Activity Logs screen. */
+"dashboardCard.ActivityLog.contextMenu.allActivity" = "Цялата дейност";
+
+/* Title for the Activity Log dashboard card. */
+"dashboardCard.ActivityLog.title" = "Скорошна дейност";
+
+/* Title for an action that opens the full pages list. */
+"dashboardCard.Pages.contextMenu.allPages" = "Всички страници";
+
+/* Title for the Pages dashboard card. */
+"dashboardCard.Pages.title" = "Страници";
+
+/* Title for impressions stats view */
+"dashboardCard.blazeCampaigns.clicks" = "Кликове";
+
+/* Title of a button that starts the campaign creation flow. */
+"dashboardCard.blazeCampaigns.createCampaignButton" = "Създаване на кампания";
+
+/* Title for impressions stats view */
+"dashboardCard.blazeCampaigns.impressions" = "Показвания";
+
+/* Title for the Learn more button in the More menu. */
+"dashboardCard.blazeCampaigns.learnMore" = "Повече информация";
+
+/* Title for the card displaying blaze campaigns. */
+"dashboardCard.blazeCampaigns.title" = "Blaze кампания";
+
+/* Title for the View All Campaigns button in the More menu */
+"dashboardCard.blazeCampaigns.viewAllCampaigns" = "Преглед на кампаниите";
+
+/* Title of a button that starts the page creation flow. */
+"dashboardCard.pages.add.button.title" = "Добавяне на страници към сайта ви";
+
+/* Title of label marking a draft page */
+"dashboardCard.pages.cell.status.draft" = "Чернова";
+
+/* Title of label marking a published page */
+"dashboardCard.pages.cell.status.publish" = "Публикувана";
+
+/* Title of label marking a scheduled page */
+"dashboardCard.pages.cell.status.schedule" = "Планирана";
+
+/* Title of a button that starts the page creation flow. */
+"dashboardCard.pages.create.button.title" = "Създаване на нова страница";
+
+/* Title of a label that encourages the user to create a new page. */
+"dashboardCard.pages.create.description" = "Започнете със специални, мобилни оформления";
+
+/* Title for the View stats button in the More menu */
+"dashboardCard.stats.viewStats" = "Статистика за прегледите";
+
+/* Debug menu item title */
+"debugMenu.analytics" = "Анализи";
+
+/* Boolean User Defaults debug menu item */
+"debugMenu.booleanUserDefaults" = "Булеви стойности по подразбиране";
+
+/* Boolean User Defaults Debug Menu screen title */
+"debugMenu.booleanUserDefaults.title" = "Булеви стойности по подразбиране";
+
+/* Feature flags menu item */
+"debugMenu.featureFlags" = "Фийчър флагове";
+
+/* Debug Menu action for TipKit */
+"debugMenu.hideAllTips" = "Скриване на всички съвети";
+
+/* Title of the screen that allows the user to change the Reader CSS URL for debug builds */
+"debugMenu.readerCellTitle" = "Reader CSS адрес";
+
+/* Placeholder for the reader CSS URL */
+"debugMenu.readerDefaultURL" = "Адрес по подразбиране";
+
+/* Hint for the reader CSS URL field */
+"debugMenu.readerHit" = "Добавяне на собствен CSS адрес, който да се зареди в Reader. Ако ползвате Calypso локално, това е нещо като http:\/\/192.168.15.23:3000\/calypso\/reader-mobile.css";
+
+/* Remote Config Debug Menu section title */
+"debugMenu.remoteConfig.currentValue" = "Текуща стойност";
+
+/* Remote Config Debug Menu section title */
+"debugMenu.remoteConfig.defaultValue" = "Стойност по подразбиране";
+
+/* Remote Config Debug Menu section title */
+"debugMenu.remoteConfig.overridenValue" = "Дистанционна конфигурация";
+
+/* Remote Config Debug Menu section title */
+"debugMenu.remoteConfig.remoteConfigValue" = "Стойност в дистанционна конфигурация";
+
+/* Remote Config Debug Menu reset button title */
+"debugMenu.remoteConfig.reset" = "Изчистване";
+
+/* Remote Config Debug Menu screen title
+   Remote Config debug menu title */
+"debugMenu.remoteConfig.title" = "Дистанционна конфигурация";
+
+/* Debug Menu action for TipKit */
+"debugMenu.resetTipKitData" = "Нулиране на данните";
+
+/* Debug Menu section title */
+"debugMenu.section.logging" = "Журнал";
+
+/* Debug Menu section title */
+"debugMenu.section.settings" = "Настройки";
+
+/* Debug Menu section title */
+"debugMenu.section.tipKit" = "TipKit";
+
+/* Debug Menu action for TipKit */
+"debugMenu.showAllTips" = "Показване на всички съвети";
+
+/* Title for debug menu screen */
+"debugMenu.title" = "Разработчик";
+
+/* Weekly Roundup debug menu item */
+"debugMenu.weeklyRoundup" = "Седмичен обзор";
+
+/* Title for selecting a default category for a post */
+"defaultCategory.title" = "Категория по подразбиране";
+
+/* Error tilte */
+"discussionSettings.saveErrorTitle" = "Неуспешно записване на настройките";
+
+/* Title for a menu action in the context menu on the Jetpack install card. */
+"domain.dashboard.card.menu.hide" = "Скриване";
+
+/* Domain management buy domain card button title */
+"domain.management.buy.card.button.title" = "Вземи домейн";
+
+/* Domain management buy domain card subtitle */
+"domain.management.buy.card.subtitle" = "Добавяне на сайт по-късно.";
+
+/* Domain management buy domain card title */
+"domain.management.buy.card.title" = "Покупка на домейн";
+
+/* The expired label of the domain card in All Domains screen. */
+"domain.management.card.expired.label" = "Изтекъл";
+
+/* Label indicating that a domain name registration has no expiry date. */
+"domain.management.card.neverExpires.label" = "Никога не изтича";
+
+/* The renews label of the domain card in All Domains screen. */
+"domain.management.card.renews.label" = "Подновява се";
+
+/* The empty state button title in All Domains screen when the user doesn't have any domains */
+"domain.management.default.empty.state.button.title" = "Търсене на домейн";
+
+/* The empty state description in All Domains screen when the user doesn't have any domains */
+"domain.management.default.empty.state.description" = "Докоснете по-долу за да откриете вашия домейн.";
+
+/* The empty state title in All Domains screen when the user doesn't have any domains */
+"domain.management.default.empty.state.title" = "Нямате никакви домейни.";
+
+/* The empty state description in All Domains screen when an error occurs */
+"domain.management.error.empty.state.description" = "Грешка при зареждане. Моля, свържете се с техническата поддръжка, ако проблемът се задържи.";
+
+/* The empty state title in All Domains screen when an error occurs */
+"domain.management.error.empty.state.title" = "Нещо се обърка";
+
+/* The empty state button title in All Domains screen when an error occurs */
+"domain.management.error.state.button.title" = "Повторен опит";
+
+/* The empty state description in All Domains screen when the user is offline */
+"domain.management.offline.empty.state.description" = "Проверете Интернет връзката си и опитайте пак.";
+
+/* The empty state title in All Domains screen when the user is offline */
+"domain.management.offline.empty.state.title" = "Няма Интернет връзка";
+
+/* Domain management choose site card button title */
+"domain.management.purchase.footer" = "*Безплатен домейн за една година се включва във всички платени годишни планове";
+
+/* Domain management purchase domain screen title */
+"domain.management.purchase.subtitle" = "Можете да добавите сайт по-късно съвсем лесно";
+
+/* Domain management purchase domain screen title. */
+"domain.management.purchase.title" = "Изберете как да ползвате домейна";
+
+/* The empty state description in All Domains screen when the are no domains matching the search criteria */
+"domain.management.search.empty.state.description" = "Не се откриват домейни, съвпадащи с търсенето на '%@'";
+
+/* The empty state title in All Domains screen when the are no domains matching the search criteria */
+"domain.management.search.empty.state.title" = "Не са намерени съответстващи домейни";
+
+/* Domain management choose site card button title */
+"domain.management.site.card.button.title" = "Избор на сайт";
+
+/* Domain management choose site card subtitle */
+"domain.management.site.card.footer" = "Безплатен домейн за първата година*";
+
+/* Domain management choose site card subtitle */
+"domain.management.site.card.subtitle" = "Ползвайте със сайт, който съществува.";
+
+/* Domain management choose site card title */
+"domain.management.site.card.title" = "Съществуващ WordPress.com сайт";
+
+/* Domain Management Screen Title */
+"domain.management.title" = "Всички домейни";
+
+/* Domain Purchase Completion footer */
+"domain.purchase.preview.footer" = "Може да отнеме до 30 минути за домейна да започне да работи.";
+
+/* Domain Purchase Completion description (only for FREE domains). */
+"domain.purchase.preview.free.description" = "Сега ще ви помогнем да го приготвите за браузване.";
+
+/* Domain Purchase Completion description (only for PAID domains). */
+"domain.purchase.preview.paid.description" = "Пратихме ви касовата бележка по имейл. Следващата стъпка е да ви помогнем да го приготвите за всички.";
+
+/* Reflects that site is live when domain purchase feature flag is ON. */
+"domain.purchase.preview.title" = "Супер, сайтът ви работи!";
+
+/* The 'Best Alternative' label under the domain name in 'Choose a domain' screen */
+"domain.suggestions.row.best-alternative" = "Алтернатива";
+
+/* The text to display for paid domains on sale in 'Site Creation > Choose a domain' screen */
+"domain.suggestions.row.first-year" = "за първата година";
+
+/* The text to display for free domains in 'Site Creation > Choose a domain' screen */
+"domain.suggestions.row.free" = "Безплатен";
+
+/* The text to display for paid domains that are free for the first year with the paid plan in 'Site Creation > Choose a domain' screen */
+"domain.suggestions.row.free-with-plan" = "Безплатен за първата година с годишен платен план";
+
+/* The 'Recommended' label under the domain name in 'Choose a domain' screen */
+"domain.suggestions.row.recommended" = "Препоръчан";
+
+/* The 'Sale' label under the domain name in 'Choose a domain' screen */
+"domain.suggestions.row.sale" = "Промоция";
+
+/* The text to display for paid domains in 'Site Creation > Choose a domain' screen */
+"domain.suggestions.row.yearly" = "на година";
+
+/* Help button */
+"domainSelection.helpButton.title" = "Помощ";
+
+/* Description for the first domain purchased with a free plan. */
+"domainSelection.redirectPrompt.title" = "Домейните, купени в този сайт, ще пренасочват към %1$@";
+
+/* Search domain - Title for the Suggested domains screen */
+"domainSelection.search.title" = "Търсене на домейни";
+
+/* Title for the checkout screen. */
+"domains.checkout.title" = "Поръчка";
+
+/* Action shown in a bottom notice to dismiss it. */
+"domains.failure.dismiss" = "Отмяна";
+
+/* Content show when the domain selection action fails. */
+"domains.failure.title" = "Домейнът, който се опитвате да добавите, не може да бъде купен с Jetpack в момента.";
+
+/* Title for the screen where the user can choose how to use the domain they're end up purchasing. */
+"domains.purchase.choice.title" = "Покупка на домейн";
+
+/* Title of screen where user chooses a site to connect to their selected domain */
+"domains.sitePicker.title" = "Избор на сайт";
+
+/* No comment provided by engineer. */
+"double-tap to change unit" = "двойно докосване за промяна на мярката";
+
+/* Message for delete tag confirmation dialog */
+"edit.tag.delete.confirmation.message" = "Сигурни ли сте, че искате да изтриете това?";
+
+/* Title for delete a term confirmation dialog */
+"edit.tag.delete.confirmation.title" = "Изтриване";
+
+/* Placeholder text for tag description field */
+"edit.tag.description.placeholder" = "Добавяне на описание...";
+
+/* Placeholder text for tag name field */
+"edit.tag.name.placeholder" = "Име на етикет";
+
+/* Navigation title for new tag creation */
+"edit.tag.new.title" = "Нов етикет";
+
+/* Section header for tag description in edit tag view */
+"edit.tag.section.description" = "Описание";
+
+/* Section header for tag name in edit tag view */
+"edit.tag.section.tag" = "Име";
+
+/* Context menu action to insert a block */
+"editor.blockInserter.insertBlock" = "Вмъкване на блок";
+
+/* Placeholder text for block search field */
+"editor.blockInserter.search" = "Търсене";
+
+/* Button title to collapse and show fewer blocks */
+"editor.blockInserter.showLess" = "По-малко";
+
+/* Button title to expand and show more blocks */
+"editor.blockInserter.showMore" = "Още";
+
+/* Error message when media insertion fails */
+"editor.media.failedToInsert" = "Неуспешно вмъкване на файл";
+
+/* Category name for section showing all patterns */
+"editor.patterns.all" = "Всички";
+
+/* Context menu action to insert a pattern */
+"editor.patterns.insertPattern" = "Вмъкване на макет";
+
+/* Title shown when no patterns match the search */
+"editor.patterns.noPatternsFound" = "Няма намерени макети";
+
+/* Navigation title for patterns view */
+"editor.patterns.title" = "Макети";
+
+/* Category name for patterns without a category */
+"editor.patterns.uncategorized" = "Без категория";
+
+/* Register Domain - Address information field Number placeholder */
+"eg. 1122334455" = "напр. 1122334455";
+
+/* Register Domain - Address information field Country Code placeholder */
+"eg. 44" = "напр. 44";
+
+/* Accessibility label for more button in dashboard quick start card. */
+"ellipsisButton.AccessibilityLabel" = "Повече";
+
+/* Shared empty state view */
+"emptyStateView.noSearchResult.description" = "Опит за ново търсене";
+
+/* Shared empty state view */
+"emptyStateView.noSearchResult.title" = "Няма резултати";
+
+/* A name of the ID field (it's a technical field, has to be short, displayed below everything else) */
+"entityMetadataFooterView.id" = "ID";
+
+/* Placeholder for the site url textfield.
+   Site Address placeholder */
+"example.com" = "primer.com";
+
+/* Accept button title for the alert asking for feedback */
+"experimentalFeatures.editorFeedbackAccept" = "Обратна връзка";
+
+/* Dismiss button title for the alert asking for feedback */
+"experimentalFeatures.editorFeedbackDecline" = "Не сега";
+
+/* Message for the alert asking for feedback on the experimental editor */
+"experimentalFeatures.editorFeedbackMessage" = "Бихте ли споделили мнението си за експерименталния редактор?";
+
+/* Title for the alert asking for feedback */
+"experimentalFeatures.editorFeedbackTitle" = "Споделяне на обратна връзка";
+
+/* Communicates the future removal of the option to disable the experimental editor, displayed beneath the experimental features list */
+"experimentalFeatures.editorNote" = "Експерименталният блоков редактор ще стане редактор по подразбиране в бъдеще. Няма да може да се изключва.";
+
+/* The title for the experimental features list */
+"experimentalFeaturesList.heading" = "Експериментални функции";
+
+/* Title for confirmation navigation bar button item */
+"externalMediaPicker.add" = "Добавяне";
+
+/* Bottom toolbar title in the selection mode */
+"externalMediaPicker.toolbarSelectItemsPrompt" = "Изберете изображения";
+
+/* Bottom toolbar title in the selection mode */
+"externalMediaPicker.toolbarViewSelected" = "Преглед на избраните (%@)";
+
+/* Title of screen the displays the details of an advertisement campaign. */
+"feature.blaze.campaignDetails.title" = "Подробности за кампанията";
+
+/* Name of a feature that allows the user to promote their posts. */
+"feature.blaze.title" = "Blaze";
+
+/* Description for the Free to Paid plans dashboard card. */
+"freeToPaidPlans.dashboard.card.description" = "Вземете безплатен домейн за първата година, премахнете рекламите на сайта ви и увеличете наличното пространство.";
+
+/* Title for a menu action in the context menu on the Free to Paid plans dashboard card. */
+"freeToPaidPlans.dashboard.card.menu.hide" = "Скриване";
+
+/* Title for the Free to Paid plans dashboard card. */
+"freeToPaidPlans.dashboard.card.shortTitle" = "Безплатен домейн с годишен план";
+
+/* Done button title on the domain purchase result screen. Closes the screen. */
+"freeToPaidPlans.resultView.done" = "Готово";
+
+/* Notice on the domain purchase result screen. Tells user how long it might take for their domain to be ready. */
+"freeToPaidPlans.resultView.notice" = "Може да отнеме до 30 минути за домейна да започне да работи.";
+
+/* Sub-title for the domain purchase result screen. Tells user their domain is being set up. */
+"freeToPaidPlans.resultView.subtitle" = "Вашият домейн %@ се настройва.";
+
+/* Title for the domain purchase result screen. Tells user their domain was obtained. */
+"freeToPaidPlans.resultView.title" = "Всичко е готово!";
+
+/* A generic error message for a footer view in a list with pagination */
+"general.pagingFooterView.errorMessage" = "Възникна грешка";
+
+/* A footer retry button */
+"general.pagingFooterView.retry" = "Повторен опит";
+
+/* Generated content length (needs to be short) */
+"generation.length.long" = "Дълъг";
+
+/* Generated content length (needs to be short) */
+"generation.length.medium" = "Среден";
+
+/* Generated content length (needs to be short) */
+"generation.length.short" = "Къс";
+
+/* AI generation style */
+"generation.style.conversational" = "Противоречив";
+
+/* AI generation style */
+"generation.style.engaging" = "Вълнуващ";
+
+/* AI generation style */
+"generation.style.formal" = "Формален";
+
+/* AI generation style */
+"generation.style.professional" = "Професионален";
+
+/* AI generation style */
+"generation.style.witty" = "Остроумен";
+
+/* A generic title for an error */
+"generic.error.title" = "Грешка";
+
+/* Title for button that will open up the blogging reminders screen. */
+"growAudienceCell.bloggingReminders.actionButton" = "Създайте напомняния за блогване";
+
+/* Title for button that will open up the blogging reminders screen. */
+"growAudienceCell.bloggingReminders.completed.actionButton" = "Редакция на напомнянията";
+
+/* A detailed message to users indicating that they've set up blogging reminders. */
+"growAudienceCell.bloggingReminders.completed.details" = "Продължавайте да блогвате и дръжте под око посетителите, идващи в сайта ви.";
+
+/* A hint to users that they've set up blogging reminders. */
+"growAudienceCell.bloggingReminders.completed.tip" = "Имате напомняния за блогване";
+
+/* A detailed message to users about growing the audience for their site through blogging reminders. */
+"growAudienceCell.bloggingReminders.details" = "„Редовното публикуване помага да изградите аудитория. Напомнянията ви помагат да останете на прав път.";
+
+/* Title for button that will dismiss the Grow Your Audience card. */
+"growAudienceCell.dismiss" = "Отмяна";
+
+/* Title for button that will open up the subscribe topics screen. */
+"growAudienceCell.readerDiscover.actionButton" = "Открийте блогове за абониране";
+
+/* Title for button that will open up the follow topics screen. */
+"growAudienceCell.readerDiscover.completed.action" = "Повторете";
+
+/* A detailed message to users indicating that they've set up reader discover. */
+"growAudienceCell.readerDiscover.completed.details" = "Продължавайте! Харесването и коментирането е добър начин да изградите последователи. Отидете в Reader, за да откриете още публикации.";
+
+/* A hint to users that they've set up reader discover. */
+"growAudienceCell.readerDiscover.completed.tip" = "Свързахте се с други блогове";
+
+/* A detailed message to users about growing the audience for their site through reader discover. */
+"growAudienceCell.readerDiscover.details" = "Свържете се с други блогъри чрез абониране, харесване и коментиране на техните публикации.";
+
+/* Title for button that will open up the social media Sharing screen. */
+"growAudienceCell.social.actionButton" = "Включване на споделянето";
+
+/* Title for button that will open up the social media Sharing screen. */
+"growAudienceCell.social.completed.button" = "Свързване на още мрежи";
+
+/* A detailed message to users indicating that they've set up post sharing. */
+"growAudienceCell.social.completed.details" = "Когато публикувате, публикацията ще се сподели автоматично в свързаните социални мрежи.";
+
+/* A hint to users that they've set up post sharing. */
+"growAudienceCell.social.completed.title" = "Споделянето е настроено!";
+
+/* A detailed message to users about growing the audience for their site through enabling post sharing. */
+"growAudienceCell.social.title" = "Споделяйте автоматично новите публикации в социалните мрежи, за да доведете посетители.";
+
+/* A hint to users about growing the audience for their site, when their site doesn't have many views yet. */
+"growAudienceCell.tip" = "Съвет за разрастване на аудиторията";
+
+/* Description for view count. Singular. */
+"growAudienceCell.viewsCount.plural" = "Прегледа на сайта до момента";
+
+/* Description for view count. Singular. */
+"growAudienceCell.viewsCount.singular" = "Преглед на сайта до момента";
+
+/* User action to dismiss media options. */
+"gutenberg.mediaAttachmentActionSheet.dismiss" = "Отхвърляне";
 
 /* (placeholder) Help the user enter a URL into the field */
 "http:\/\/my-site-address (URL)" = "http:\/\/my-site-address (Адрес)";
 
+/* The message for the first feedback alert */
+"in-app.feedback.alert.message" = "Харесвате ли Jetpack приложението?";
+
+/* The 'no' button title for the first feedback alert */
+"in-app.feedback.alert.no" = "Не точно";
+
+/* The 'Not Now' button title for the first feedback alert */
+"in-app.feedback.alert.notNow" = "Не сега";
+
+/* The title for the first feedback alert */
+"in-app.feedback.alert.title" = "Вашето мнение е ценно за нас";
+
+/* The 'yes' button title for the first feedback alert */
+"in-app.feedback.alert.yes" = "Отлично";
+
+/* The message for the negative feedback alert */
+"in-app.feedback.negative.alert.message" = "Бихте ли споделили повече подробности?";
+
+/* The 'no' button for the negative feedback alert */
+"in-app.feedback.negative.alert.no" = "Не сега";
+
+/* The title for the negative feedback alert */
+"in-app.feedback.negative.alert.title" = "Помогнете ни да се подобрим";
+
+/* The 'yes' button for the negative feedback alert */
+"in-app.feedback.negative.alert.yes" = "Да";
+
+/* Sentence to justify why the app is asking permission from the user to use their camera. */
+"infoplist.NSCameraUsageDescription" = "За да заснемате снимки или видео клипове за вашите публикации.";
+
+/* This sentence is shown when the app asks permission from the user to use their location. */
+"infoplist.NSLocationUsageDescription" = "WordPress иска да добавя данни за местоположение към публикациите на сайтове, в които сте включили геотагинг.";
+
+/* This sentence is shown when the app asks permission from the user to use their location. */
+"infoplist.NSLocationWhenInUseUsageDescription" = "WordPress иска да добавя данни за местоположение към публикациите на сайтове, в които сте включили геотагинг.";
+
+/* Sentence to justify why the app asks permission from the user to access the device microphone. */
+"infoplist.NSMicrophoneUsageDescription" = "Позволете достъп до микрофона, за да записвате звук във вашите видеа.";
+
+/* Sentence to justify why the app asks permission from the user to access their Media Library. */
+"infoplist.NSPhotoLibraryUsageDescription" = "Да добавяте снимки или видео към публикациите си.";
+
+/* Text for the Insights Overview stat difference label. Shows the change from the previous period, including the percentage value. E.g.: +12.3K (5%). %1$@ is the placeholder for the change sign ('-', '+', or none). %2$@ is the placeholder for the change numerical value. %3$@ is the placeholder for the change percentage value. */
+"insights.visitorsLineChartCell.differenceLabelWithNumber" = "%1$@%2$@ (%3$@)";
+
+/* Text for the Insights Overview stat difference label. Shows the change from the previous period. E.g.: +12.3K. %1$@ is the placeholder for the change sign ('-', '+', or none). %2$@ is the placeholder for the change numerical value. */
+"insights.visitorsLineChartCell.differenceLabelWithoutPercentage" = "%1$@%2$@";
+
+/* Message shown when Apple Intelligence is disabled */
+"intelligence.unavailableView.appleIntelligenceDisabled.message" = "За да създадете откъси с ИИ, моля включете Apple Intelligence от Настройки. Тази функция използва обработка на вашето устройство, за да защити личната ви информация.";
+
+/* Button to open Apple Intelligence settings */
+"intelligence.unavailableView.appleIntelligenceDisabled.openSettings" = "Отваряне на настройките";
+
+/* Title shown when Apple Intelligence is disabled */
+"intelligence.unavailableView.appleIntelligenceDisabled.title" = "Изисква се Apple Intelligence";
+
+/* Message shown when Apple Intelligence is unavailable */
+"intelligence.unavailableView.appleIntelligenceUnvailable.message" = "Apple Intelligence не е наличен на това устройство";
+
+/* Title shown when Apple Intelligence is unavailable */
+"intelligence.unavailableView.appleIntelligenceUnvailable.title" = "Apple Intelligence е наличен";
+
+/* Description shown when the AI model is not ready */
+"intelligence.unavailableView.preparingModel.description" = "ИИ моделът се изтегла или се приготвя. Моля, опитайте след малко.";
+
+/* Title shown when the AI model is not ready */
+"intelligence.unavailableView.preparingModel.title" = "Приготвя се модел...";
+
+/* Cancel dialog confirmation title */
+"inviteSubscribers.cancelConfirmationTitle" = "Сигурни ли сте, че искате да премахнете новите абонати?";
+
+/* Cancel dialog confirmation button */
+"inviteSubscribers.discardChanges" = "Отмяна на промените";
+
+/* A footer view (small text). The button title is inserted by the app via a parameter. */
+"inviteSubscribers.disclosure" = "Като изберете \"%@\", вие обявявате, че имате съгласието на всеки човек да им пращате имейли. Оплаквания за спам или висок процент отхвърляния от абонатите може да доведе до действия срещу вашия профил.";
+
+/* Field title (not shown, accessibility) */
+"inviteSubscribers.fieldTitleEmail" = "Имейл";
+
+/* Import success snackbar title */
+"inviteSubscribers.importSuccessMessage" = "Ще отнеме няколко минути за импорта да приключи";
+
+/* Import success snackbar title */
+"inviteSubscribers.importSuccessTitle" = "Импортът започна";
+
+/* Screen title */
+"inviteSubscribers.title" = "Добавяне на абонати";
+
+/* Footer text for Invite Links section of the Invite People screen. */
+"invite_people_invite_link_footer" = "Използвайте тази връзка, за да добавите членовете на екипа си, без да се налага да ги каните един по един. Всеки, който посети този адрес, ще може да се регистрира във вашата организация. Уверете, че го споделяте само с доверени лица.";
+
+/* Name of the "Save as Draft" action as it should appear in the iOS Share Sheet when sharing content from other apps to Jetpack */
+"ios-jetpack-sharesheet.CFBundleDisplayName" = "Запазване като чернова";
+
+/* Name of the "Save as Draft" action as it should appear in the iOS Share Sheet when sharing content from other apps to Jetpack. Must be less than 16 characters long. Typically the same text as CFBundleDisplayName, but could be shorter if needed. */
+"ios-jetpack-sharesheet.CFBundleName" = "Запазване като чернова";
+
+/* Name of the "Save as Draft" action as it should appear in the iOS Share Sheet when sharing content from other apps to WordPress */
+"ios-sharesheet.CFBundleDisplayName" = "Запазване като чернова";
+
+/* Name of the "Save as Draft" action as it should appear in the iOS Share Sheet when sharing content from other apps to WordPress. Must be less than 16 characters long. Typically the same text as CFBundleDisplayName, but could be shorter if needed. */
+"ios-sharesheet.CFBundleName" = "Запазване като чернова";
+
+/* This text is used when the user is configuring the iOS widget and selecting which WordPress site they want the widget to be for */
+"ios-widget.BOl9KQ" = "Има  ${count}, съвпадащи с ‘${site}’.";
+
+/* This text is used when the user is configuring the iOS widget, as a label for the dropdown to select the site to configure it for */
+"ios-widget.ILcGmf" = "Сайт";
+
+/* This text is used when the user is configuring the iOS widget, as the title for the modal when selecting the site to configure it for */
+"ios-widget.cyajMn" = "Сайт";
+
 /* This text is used when the user is configuring the iOS widget to suggest them to select the site to configure the widget for */
 "ios-widget.gpCwrM" = "Select Site";
+
+/* This text is used when configuring the iOS widget and confirming the WordPress site the user wants the widget to be for */
+"ios-widget.s4dJhx" = "Само да потвърдим, искате ‘${site}’?";
 
 /* This text is required by Apple to be part of the translations but is not shown to the users. You can use the English version verbatim without translation for this entry. */
 "ios-widget.tVvJ9c" = "Select Site Intent";
 
+/* Title of a badge indicating when a feature in plural form will be removed. First argument is the feature name. Second argument is the number of days/weeks it will be removed in. Ex: Notifications are moving in 2 weeks */
+"jetpack.branding.badge_banner.moving_in.plural" = "%1$@ се местят в %2$@";
+
+/* Title of a badge indicating when a feature in singular form will be removed. First argument is the feature name. Second argument is the number of days/weeks it will be removed in. Ex: Reader is moving in 2 weeks */
+"jetpack.branding.badge_banner.moving_in.singular" = "%1$@ се мести в %2$@";
+
+/* Title of a badge indicating that a feature in plural form will be removed soon. First argument is the feature name. Ex: Notifications are moving soon */
+"jetpack.branding.badge_banner.moving_soon.plural" = "%@ се местят скоро";
+
+/* Title of a badge indicating that a feature in singular form will be removed soon. First argument is the feature name. Ex: Reader is moving soon */
+"jetpack.branding.badge_banner.moving_soon.singular" = "%@ се мести скоро";
+
+/* Title of the Jetpack powered badge. */
+"jetpack.branding.badge_banner.title" = "Задвижвано от Jetapack";
+
+/* Title of the Jetpack powered badge. */
+"jetpack.branding.badge_banner.title.phase2" = "Изтеглете Jetpack приложение";
+
+/* Button title of the Jetpack powered overlay. */
+"jetpack.branding.overlay.button.title" = "Опитайте приложението Jetpack";
+
+/* Description of the Jetpack powered overlay. */
+"jetpack.branding.overlay.description" = "Новото Jetpack приложение има статистика, известия, Reader и прави WordPress по-добър.";
+
+/* Title of the Jetpack powered overlay. */
+"jetpack.branding.overlay.title" = "WordPress е по-добър с Jetpack";
+
+/* Title for the button that starts the Jetpack connection process */
+"jetpack.connection.connect.button" = "Свързване на вашия сайт";
+
+/* Error message shown when WordPress.com authentication fails */
+"jetpack.connection.error.authentication" = "Невалиден WordPress.com профил";
+
+/* Error message shown when a connection step is attempted in an invalid order */
+"jetpack.connection.error.context" = "Стъпката не е готова още";
+
+/* Title for the retry button shown when a connection step fails */
+"jetpack.connection.retry.button" = "Повторен опит";
+
+/* Status message when a connection step is pending */
+"jetpack.connection.stage.pending" = "Изчаква се започване";
+
+/* Status message when a connection step is in progress */
+"jetpack.connection.stage.processing" = "В ход...";
+
+/* Status message when a connection step is completed successfully */
+"jetpack.connection.stage.success" = "Готово";
+
+/* Title for the finalization step in Jetpack connection flow */
+"jetpack.connection.step.finalize.title" = "Финализиране на връзката";
+
+/* Title for the install step in Jetpack connection flow */
+"jetpack.connection.step.install.title" = "Инсталиране на Jetpack";
+
+/* Title for the login step in Jetpack connection flow */
+"jetpack.connection.step.login.title" = "Вход в WordPress.com";
+
+/* Title for the site connection step in Jetpack connection flow */
+"jetpack.connection.step.site.title" = "Свързване с вашия сайт";
+
+/* Title for the user connection step in Jetpack connection flow */
+"jetpack.connection.step.user.title" = "Създаване на WordPress.com профил";
+
+/* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
+"jetpack.fullscreen.overlay.early.switch.title" = "Преминете към Jetpack";
+
+/* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
+"jetpack.fullscreen.overlay.late.switch.title" = "Преминете към Jetpack";
+
+/* Title of a button that displays a blog post in a web view. */
+"jetpack.fullscreen.overlay.learnMore" = "Научете повече на jetpack.com";
+
+/* Description of the Notifications feature. */
+"jetpack.fullscreen.overlay.newUsers.notifications.subtitle" = "Получаване на известия за коментари, харесвания, прегледи и други.";
+
+/* Description of the Reader feature. */
+"jetpack.fullscreen.overlay.newUsers.reader.subtitle" = "Намерете и следвайте любимите сайтове и общества. Споделете своето съдържание.";
+
+/* Description of the Statistics feature. */
+"jetpack.fullscreen.overlay.newUsers.stats.subtitle" = "Наблюдавайте как трафика ви нараства с полезни съвети и статистики.";
+
+/* Name of the Statistics feature. */
+"jetpack.fullscreen.overlay.newUsers.stats.title" = "Статистика и обобщения";
+
+/* Title of a screen that prompts the user to switch the Jetpack app. */
+"jetpack.fullscreen.overlay.newUsers.subtitle" = "Jetpack ви позволява вършите повече с вашия WordPress сайт. Смяната е безплатна и отнема минута.";
+
+/* Title of a screen that prompts the user to switch the Jetpack app. */
+"jetpack.fullscreen.overlay.newUsers.title" = "Дайте на WordPress подкрепа с Jetpack";
+
+/* Title of a button that dismisses an overlay and displays the Notifications screen. */
+"jetpack.fullscreen.overlay.notifications.continue.title" = "Към известията";
+
+/* Title of a button that dismisses an overlay that prompts the user to switch the Jetpack app. */
+"jetpack.fullscreen.overlay.phaseFour.general.continue.title" = "По-късно";
+
+/* Title of a screen that prompts the user to switch the Jetpack app. */
+"jetpack.fullscreen.overlay.phaseFour.subtitle" = "Статистиките, известията, Reader и другите функции от Jetpack са премахнати от WordPress приложението.";
+
+/* Title of a screen that prompts the user to switch the Jetpack app. */
+"jetpack.fullscreen.overlay.phaseFour.title" = "Jetpack функциите се преместиха.";
+
+/* Subtitle of a screen displayed when the user accesses the Notifications screen from the WordPress app. The screen showcases the Jetpack app. */
+"jetpack.fullscreen.overlay.phaseOne.notifications.subtitle" = "Преминете към Jetpack, за да продължите да получавате известия в реално време.";
+
+/* Title of a screen displayed when the user accesses the Notifications screen from the WordPress app. The screen showcases the Jetpack app. */
+"jetpack.fullscreen.overlay.phaseOne.notifications.title" = "Вземете известия с Jetpack приложението";
+
+/* Subtitle of a screen displayed when the user accesses the Reader screen from the WordPress app. The screen showcases the Jetpack app. */
+"jetpack.fullscreen.overlay.phaseOne.reader.subtitle" = "Преминете към Jetpack, за да търсите, следвате и харесвате любимите си сайтове и публикации.";
+
+/* Title of a screen displayed when the user accesses the Reader screen from the WordPress app. The screen showcases the Jetpack app. */
+"jetpack.fullscreen.overlay.phaseOne.reader.title" = "Абонирайте се за всеки сайт с Jetpack";
+
+/* Subtitle of a screen displayed when the user trys creating a new site from the WordPress app. The screen showcases the Jetpack app. */
+"jetpack.fullscreen.overlay.phaseOne.siteCreation.subtitle" = "Jetpack осигурява статистики, известия и още, за да ви помогне да изградите WordPress сайта на мечтите си.";
+
+/* Subtitle of a screen displayed when the user accesses the Stats screen from the WordPress app. The screen showcases the Jetpack app. */
+"jetpack.fullscreen.overlay.phaseOne.stats.subtitle" = "Преминете към Jetpack, за да наблюдавате как трафикът ви расте със статистики и обобщения.";
+
+/* Title of a screen displayed when the user accesses the Stats screen from the WordPress app. The screen showcases the Jetpack app. */
+"jetpack.fullscreen.overlay.phaseOne.stats.title" = "Вземете статистики с новото приложение Jetpack";
+
+/* A footnote in a screen displayed when the user accesses a Jetpack powered feature from the WordPress app. The screen showcases the Jetpack app. */
+"jetpack.fullscreen.overlay.phaseThree.footnote" = "Смяната е безплатна и ще отнеме минутка.";
+
+/* Title of a button that dismisses an overlay that showcases the Jetpack app. */
+"jetpack.fullscreen.overlay.phaseThree.general.continue.title" = "Продължаване без Jetpack";
+
+/* Title of a screen that showcases the Jetpack app. */
+"jetpack.fullscreen.overlay.phaseThree.general.title" = "Функциите от Jetpack се местят скоро.";
+
+/* Subtitle of a screen displayed when the user trys creating a new site from the WordPress app. The screen showcases the Jetpack app. */
+"jetpack.fullscreen.overlay.phaseTwo.siteCreation.subtitle" = "Jetpack предоставя статистики, известия и още, за да ви помогне да развиете WordPress сайта си.\n\nПриложението WordPress вече не поддържа създаването на нов сайт.";
+
+/* Subtitle of a screen displayed when the user accesses a Jetpack-powered feature from the WordPress app. */
+"jetpack.fullscreen.overlay.phaseTwoAndThree.fallbackSubtitle" = "Статистиките, известията, Reader и другите функции от Jetpack ще бъдат премахнати от WordPress приложението.";
+
+/* Title of a screen displayed when the user accesses the Notifications screen from the WordPress app. The screen showcases the Jetpack app. */
+"jetpack.fullscreen.overlay.phaseTwoAndThree.notifications.title" = "Известията се местят в Jetpack";
+
+/* Title of a screen displayed when the user accesses the Reader screen from the WordPress app. The screen showcases the Jetpack app. */
+"jetpack.fullscreen.overlay.phaseTwoAndThree.reader.title" = "Reader се мести в приложението Jetpack";
+
+/* Title of a screen displayed when the user accesses the Stats screen from the WordPress app. The screen showcases the Jetpack app. */
+"jetpack.fullscreen.overlay.phaseTwoAndThree.stats.title" = "Статистиките се местят в приложението Jetpack";
+
+/* Subtitle of a screen displayed when the user accesses a Jetpack-powered feature from the WordPress app. The '%@' characters are a placeholder for the date the features will be removed. */
+"jetpack.fullscreen.overlay.phaseTwoAndThree.subtitle" = "Статистиките, известията, Reader и другите функции от Jetpack ще бъдат премахнати от WordPress приложението на %@.";
+
+/* Title of a button that dismisses an overlay and displays the Reader screen. */
+"jetpack.fullscreen.overlay.reader.continue.title" = "Продължаване към Reader";
+
+/* Title of a screen that prompts the user to switch the Jetpack app. */
+"jetpack.fullscreen.overlay.selfHosted.subtitle" = "Мобилното приложение Jetpack е създадено да работи заедно с разширението Jetpack. Сменете приложението сега, за да получите достъп до статистики, известия и Reader.";
+
+/* Title of a screen that prompts the user to switch the Jetpack app. */
+"jetpack.fullscreen.overlay.selfHosted.title" = "Сайтът ви има Jetpack";
+
+/* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
+"jetpack.fullscreen.overlay.siteCreation.continue.title" = "Продължаване без Jetpack";
+
+/* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
+"jetpack.fullscreen.overlay.siteCreation.switch.title" = "Опитайте приложението Jetpack";
+
+/* Title of a screen displayed when the user trys creating a new site from the WordPress app. The screen showcases the Jetpack app. */
+"jetpack.fullscreen.overlay.siteCreation.title" = "Създаване на нов WordPress сайт с Jetpack";
+
+/* Title of a button that dismisses an overlay and displays the Stats screen. */
+"jetpack.fullscreen.overlay.stats.continue.title" = "Продължаване към статистиката";
+
+/* The description text shown after the user has successfully installed the Jetpack plugin. */
+"jetpack.install-flow.success.description" = "Можете да ползвате този сайт с приложението.";
+
+/* Title of the primary button shown after the Jetpack plugin has been installed. Tapping on the button dismisses the installation screen. */
+"jetpack.install-flow.success.primaryButtonText" = "Готово";
+
+/* Title of a button for connecting user account to Jetpack. */
+"jetpack.install.connectUser.button.title" = "Свързване на профил";
+
+/* Message asking the user if they want to set up Jetpack from notifications */
+"jetpack.install.connectUser.notifications.description" = "За да получавате полезни известия на телефона си от вашия WordPress сайт, ще трябва да се свържете с вашия профил.";
+
+/* Message asking the user if they want to set up Jetpack from stats by connecting their user account */
+"jetpack.install.connectUser.stats.description" = "За да ползвате статистики е нужно да свържете разширението Jetpack с вашия профил.";
+
+/* Description inside a menu card communicating that features are moving to the Jetpack app. */
+"jetpack.menuCard.description" = "Статистиките, известията, Reader и други функции ще се преместят в Jetpack приложението.";
+
+/* Menu item title to hide the card. */
+"jetpack.menuCard.hide" = "Скриване";
+
+/* Title of a button that displays a blog post in a web view. */
+"jetpack.menuCard.learnMore" = "Повече информация";
+
+/* Description inside a menu card prompting users to switch to the Jetpack app. */
+"jetpack.menuCard.newUsers.title" = "Отключете пълния потенциал на сайта. В Jetpack има статистики, известия и Reader.";
+
+/* Title of a button prompting users to switch to the Jetpack app. */
+"jetpack.menuCard.phaseFour.title" = "Преминете към Jetpack";
+
+/* Menu item title to hide the card for now and show it later. */
+"jetpack.menuCard.remindLater" = "Напомняне по-късно";
+
+/* Jetpack Plugin Modal footnote */
+"jetpack.plugin.modal.footnote" = "Чрез настройването на Jetpack се съгласявате с нашите %@";
+
+/* Jetpack Plugin Modal primary button title */
+"jetpack.plugin.modal.primary.button.title" = "Инсталирайте пълното разширение";
+
+/* Jetpack Plugin Modal secondary button title */
+"jetpack.plugin.modal.secondary.button.title" = "Връзка с отдела по поддръжка";
+
+/* The 'full Jetpack plugin' string in the subtitle */
+"jetpack.plugin.modal.subtitle.jetpack.plugin" = "пълен Jetpack";
+
+/* Jetpack Plugin Modal footnote terms and conditions */
+"jetpack.plugin.modal.terms" = "Условия за ползване";
+
+/* Jetpack Plugin Modal title */
+"jetpack.plugin.modal.title" = "Моля, инсталирайте разширението Jetpack";
+
+/* Add an author prompt for the jetpack prologue */
+"jetpack.prologue.prompt.addAuthor" = "Добавяне на автор";
+
+/* Build a site prompt for the jetpack prologue */
+"jetpack.prologue.prompt.buildSite" = "Изграждане на сайт";
+
+/* Check notifications prompt for the jetpack prologue */
+"jetpack.prologue.prompt.checkNotifications" = "Проверете известията";
+
+/* Share on Facebook prompt for the jetpack prologue */
+"jetpack.prologue.prompt.fbShare" = "Споделете във Facebook";
+
+/* Fix a security issue prompt for the jetpack prologue */
+"jetpack.prologue.prompt.fixSecurity" = "Оправете проблем със сигурността";
+
+/* Post a photo prompt for the jetpack prologue */
+"jetpack.prologue.prompt.postPhoto" = "Публикувайте снимка";
+
+/* Respond to comments prompt for the jetpack prologue */
+"jetpack.prologue.prompt.respondComments" = "Отговорете на коментари";
+
+/* Restore a backup prompt for the jetpack prologue */
+"jetpack.prologue.prompt.restoreBackup" = "Възстановяване от бекъп";
+
+/* Search for plugins prompt for the jetpack prologue */
+"jetpack.prologue.prompt.searchPlugins" = "Търсене на разширения";
+
+/* Update a plugin prompt for the jetpack prologue */
+"jetpack.prologue.prompt.updatePlugin" = "Обновяване на разширение";
+
+/* Watch your stats prompt for the jetpack prologue */
+"jetpack.prologue.prompt.watchStats" = "Вижте статистиките";
+
+/* Write a blog prompt for the jetpack prologue */
+"jetpack.prologue.prompt.writeBlog" = "Напишете блог";
+
+/* Description for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.description" = "Всеки може да види публикацията";
+
+/* Title for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.title" = "Всички";
+
+/* Description for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.description" = "Само платени абонати могат да видят публикацията";
+
+/* Title for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.title" = "Платени абонати";
+
+/* Description for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.description" = "Публикацията е видима за всички абонати, включително безплатните.";
+
+/* Title for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.title" = "Всички абонати";
+
+/* Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account */
+"jetpackSite.connectToDefaultAccount" = "Трябва да влезете с %@ за да ползвате статистики и известия.";
+
+/* Accessibility label for add card button */
+"jetpackStats.accessibility.addCardButton" = "Нов елемент за статистика";
+
+/* Accessibility label for back navigation */
+"jetpackStats.accessibility.backToStats" = "Обратно към статистиките";
+
+/* Card title accessibility label. %1$@ is the card title. */
+"jetpackStats.accessibility.cardTitle" = "%1$@ елемент";
+
+/* Accessibility label for chart container */
+"jetpackStats.accessibility.chartContainer" = "Графика";
+
+/* Chart trend accessibility label. %1$@ is metric name, %2$@ is trend description. */
+"jetpackStats.accessibility.chartTrend" = "%1$@ %2$@";
+
+/* Chart data point accessibility label. %1$@ is metric name, %2$@ is value, %3$@ is date. */
+"jetpackStats.accessibility.chartValue" = "%1$@: %2$@ на %3$@";
+
+/* Selected date range accessibility label. %1$@ is the range. */
+"jetpackStats.accessibility.dateRangeSelected" = "Период: %1$@";
+
+/* Accessibility label for error state */
+"jetpackStats.accessibility.errorLoadingStats" = "Грешка при зареждане на статистиките";
+
+/* Accessibility label for loading state */
+"jetpackStats.accessibility.loadingStats" = "Зареждане на статистиките";
+
+/* Accessibility label for more options menu */
+"jetpackStats.accessibility.moreOptions" = "Още опции";
+
+/* Accessibility hint for next period navigation */
+"jetpackStats.accessibility.navigateToNextDateRange" = "Зареждане на следващия период";
+
+/* Accessibility hint for previous period navigation */
+"jetpackStats.accessibility.navigateToPreviousDateRange" = "Зареждане на предишния период";
+
+/* Accessibility label for next period navigation button */
+"jetpackStats.accessibility.nextPeriod" = "Следващ период";
+
+/* Accessibility label for empty data state */
+"jetpackStats.accessibility.noDataAvailable" = "Няма налични данни за периода";
+
+/* Accessibility label for opening link in browser */
+"jetpackStats.accessibility.openInBrowser" = "Отваряне в браузъра";
+
+/* Accessibility label for previous period navigation button */
+"jetpackStats.accessibility.previousPeriod" = "Предишен период";
+
+/* Accessibility label for realtime visitor count */
+"jetpackStats.accessibility.realtimeVisitorCount" = "Посетители онлайн в момента";
+
+/* Accessibility hint for retry action */
+"jetpackStats.accessibility.retryLoadingStats" = "Докоснете два пъти за повторен опит за зареждане";
+
+/* Accessibility hint for date range selection */
+"jetpackStats.accessibility.selectDateRange" = "Избор на период";
+
+/* Accessibility hint for tab selection. %1$@ is the tab name. */
+"jetpackStats.accessibility.selectTab" = "Избор на %1$@ подпрозорец";
+
+/* Accessibility announcement when stats finish loading */
+"jetpackStats.accessibility.statsLoaded" = "Статистиката е заредена";
+
+/* Accessibility label for stats tab bar */
+"jetpackStats.accessibility.statsTabBar" = "Подпрозорци за статистики";
+
+/* Accessibility announcement when a tab is selected. %1$@ is the tab name. */
+"jetpackStats.accessibility.tabSelected" = "Избран е %1$@ подпрозорец";
+
+/* Top list item accessibility label. %1$d is rank, %2$@ is title, %3$@ is value. */
+"jetpackStats.accessibility.topListItem" = "Подреждане %1$d: %2$@, %3$@";
+
+/* Accessibility hint for viewing chart data */
+"jetpackStats.accessibility.viewChartData" = "Вижте подробни данни";
+
+/* Accessibility hint for items that can show more details */
+"jetpackStats.accessibility.viewMoreDetails" = "Двойно тапване за повече информация";
+
+/* Singular visitor count. %1$d is the number. */
+"jetpackStats.accessibility.visitorNow" = "%1$d посетител онлайн сега";
+
+/* Plural visitors count. %1$d is the number. */
+"jetpackStats.accessibility.visitorsNow" = "%1$d посетители онлайн сега";
+
+/* Chart option description */
+"jetpackStats.addChart.chartDescription" = "Показване на трендове";
+
+/* Chart option title */
+"jetpackStats.addChart.chartOption" = "Графика";
+
+/* Title for data type selection */
+"jetpackStats.addChart.selectDataType" = "Избор на вид данни";
+
+/* Title for metric selection */
+"jetpackStats.addChart.selectMetric" = "Избор на метрики";
+
+/* Today chart title */
+"jetpackStats.addChart.today" = "Днес";
+
+/* Today option description
+   Top list option description */
+"jetpackStats.addChart.topListDescription" = "Вижте най-популярното съдържание";
+
+/* Top list option title */
+"jetpackStats.addChart.topListOption" = "Топ списък";
+
+/* Plural item count for archive sections. %1$d is the number. */
+"jetpackStats.archiveSections.itemCount.plural" = "%1$d елемента";
+
+/* Singular item count for archive sections. %1$d is the number. */
+"jetpackStats.archiveSections.itemCount.singular" = "%1$d елемент";
+
+/* Title for the author details screen */
+"jetpackStats.authorDetails.title" = "Автор";
+
+/* Button to add a new chart */
+"jetpackStats.button.addCard" = "Добавяне на елемент";
+
+/* Apply button */
+"jetpackStats.button.apply" = "Прилагане";
+
+/* Cancel button */
+"jetpackStats.button.cancel" = "Отказ";
+
+/* Button to customize a chart or widget */
+"jetpackStats.button.customize" = "Редакция на елемент";
+
+/* Button to delete a chart or widget */
+"jetpackStats.button.deleteWidget" = "Изтриване на елемент";
+
+/* Done button */
+"jetpackStats.button.done" = "Готово";
+
+/* Button to download data as CSV file */
+"jetpackStats.button.downloadCSV" = "Изтегляне на CSV";
+
+/* Learn more about stats button */
+"jetpackStats.button.learnMore" = "Научете повече";
+
+/* Button to move a card */
+"jetpackStats.button.moveCard" = "Преместване на елемент";
+
+/* Button to move card down */
+"jetpackStats.button.moveDown" = "Преместване надолу";
+
+/* Button to move card to the bottom */
+"jetpackStats.button.moveToBottom" = "Преместване най-отдолу";
+
+/* Button to move card to the top */
+"jetpackStats.button.moveToTop" = "Преместване най-отгоре";
+
+/* Button to move card up */
+"jetpackStats.button.moveUp" = "Преместване нагоре";
+
+/* OK button */
+"jetpackStats.button.ok" = "ОК";
+
+/* Button to reset chart settings to default */
+"jetpackStats.button.resetSettings" = "Нулиране на настройките";
+
+/* Share chart menu item */
+"jetpackStats.button.share" = "Споделяне";
+
+/* Button title */
+"jetpackStats.button.showAll" = "Показване на всичко";
+
+/* Button to collapse and show fewer items */
+"jetpackStats.button.showLess" = "По-малко";
+
+/* Button to expand and show more items */
+"jetpackStats.button.showMore" = "Още";
+
+/* Last 10 years date range */
+"jetpackStats.calendar.last10Years" = "Последните 10 години";
+
+/* Last 12 months date range */
+"jetpackStats.calendar.last12Months" = "Последните 12 месеца";
+
+/* Last 12 weeks (84 days) date range */
+"jetpackStats.calendar.last12Weeks" = "Последните 12 седмици";
+
+/* Last 28 days date range */
+"jetpackStats.calendar.last28Days" = "Последните 38 дни";
+
+/* Last 30 days date range */
+"jetpackStats.calendar.last30Days" = "Последните 30 дни";
+
+/* Last 3 years date range */
+"jetpackStats.calendar.last3Years" = "Последните 3 години";
+
+/* Last 6 months date range */
+"jetpackStats.calendar.last6Months" = "Последните 6 месеца";
+
+/* Last 7 days date range */
+"jetpackStats.calendar.last7Days" = "Последните 7 дни";
+
+/* Month time period */
+"jetpackStats.calendar.month" = "Месец";
+
+/* Quarter time period */
+"jetpackStats.calendar.quarter" = "Тримесечие";
+
+/* This month date range */
+"jetpackStats.calendar.thisMonth" = "Този месец";
+
+/* This quarter date range */
+"jetpackStats.calendar.thisQuarter" = "Това тримесечие";
+
+/* This week date range */
+"jetpackStats.calendar.thisWeek" = "Тази седмица";
+
+/* This year date range */
+"jetpackStats.calendar.thisYear" = "Тази година";
+
+/* Today date range */
+"jetpackStats.calendar.today" = "Днес";
+
+/* Week time period */
+"jetpackStats.calendar.week" = "Седмица";
+
+/* Year time period */
+"jetpackStats.calendar.year" = "Година";
+
+/* Bar chart type */
+"jetpackStats.chart.barChart" = "Стълбове";
+
+/* Shown for empty states */
+"jetpackStats.chart.dataEmpty" = "Няма данни за периода";
+
+/* Genertic error message */
+"jetpackStats.chart.generitcError" = "Нещо не проработи";
+
+/* Shown for metrics that don't support hourly data */
+"jetpackStats.chart.hourlyDataNotAvailable" = "Данни по час не са налични";
+
+/* Shown when current period data might be incomplete */
+"jetpackStats.chart.incompleteData" = "Може да покаже непълни данни";
+
+/* Line chart type */
+"jetpackStats.chart.lineChart" = "Линии";
+
+/* Show chart data menu item */
+"jetpackStats.chart.showData" = "Показване на данните";
+
+/* Label for change value */
+"jetpackStats.chartData.change" = "Промяна";
+
+/* Column header for date */
+"jetpackStats.chartData.date" = "ДАТА";
+
+/* Section title for detailed data */
+"jetpackStats.chartData.detailedData" = "Подробни данни";
+
+/* Label for previous value */
+"jetpackStats.chartData.previous" = "Предишен";
+
+/* Title for chart data screen */
+"jetpackStats.chartData.title" = "Данни за графиката";
+
+/* Label for total value */
+"jetpackStats.chartData.total" = "Общо";
+
+/* Column header for value */
+"jetpackStats.chartData.value" = "СТОЙНОСТ";
+
+/* Context menu action to copy country name */
+"jetpackStats.contextMenu.copyCountryName" = "Копиране на държавата";
+
+/* Context menu action to copy domain */
+"jetpackStats.contextMenu.copyDomain" = "Копиране на домейна";
+
+/* Context menu action to copy file name */
+"jetpackStats.contextMenu.copyFileName" = "Копиране на името на файла";
+
+/* Context menu action to copy file path */
+"jetpackStats.contextMenu.copyFilePath" = "Копиране на файловата пътека";
+
+/* Context menu action to copy name */
+"jetpackStats.contextMenu.copyName" = "Копиране на името";
+
+/* Context menu action to copy search term */
+"jetpackStats.contextMenu.copySearchTerm" = "Копиране на ключовата дума";
+
+/* Context menu action to copy title */
+"jetpackStats.contextMenu.copyTitle" = "Копиране на заглавието";
+
+/* Context menu action to copy URL */
+"jetpackStats.contextMenu.copyURL" = "Копиране на адреса";
+
+/* Context menu action to copy video URL */
+"jetpackStats.contextMenu.copyVideoURL" = "Копиране на адреса на видеото";
+
+/* Context menu action to open link in browser */
+"jetpackStats.contextMenu.openInBrowser" = "Отваряне в браузъра";
+
+/* Context menu action to search term in Google */
+"jetpackStats.contextMenu.searchInGoogle" = "Търсене в Google";
+
+/* Message shown when a country has no views */
+"jetpackStats.countries.noViews" = "Няма посещения";
+
+/* CSV header for country column */
+"jetpackStats.csv.country" = "Държава";
+
+/* CSV header for country code column */
+"jetpackStats.csv.countryCode" = "Код на държавата";
+
+/* CSV header for date column */
+"jetpackStats.csv.date" = "Дата";
+
+/* CSV header for domain column */
+"jetpackStats.csv.domain" = "Домейн";
+
+/* CSV header for file name column */
+"jetpackStats.csv.fileName" = "Име на файл";
+
+/* CSV header for file path column */
+"jetpackStats.csv.filePath" = "Пътека на файла";
+
+/* CSV header for name column */
+"jetpackStats.csv.name" = "Име";
+
+/* CSV header for role column */
+"jetpackStats.csv.role" = "Роля";
+
+/* CSV header for search term column */
+"jetpackStats.csv.searchTerm" = "Ключова дума";
+
+/* CSV header for section column */
+"jetpackStats.csv.section" = "Секция";
+
+/* CSV header for title column */
+"jetpackStats.csv.title" = "Заглавие";
+
+/* CSV header for type column */
+"jetpackStats.csv.type" = "Вид";
+
+/* CSV header for URL column */
+"jetpackStats.csv.url" = "Адрес";
+
+/* CSV header for video URL column */
+"jetpackStats.csv.videoURL" = "Видео адрес";
+
+/* Title for comparison menu */
+"jetpackStats.datePicker.compareWith" = "Сравнение с...";
+
+/* Title for custom date range picker */
+"jetpackStats.datePicker.customRange" = "Избор на период";
+
+/* Menu item for custom date range picker */
+"jetpackStats.datePicker.customRangeMenu" = "Избор на период...";
+
+/* From date label */
+"jetpackStats.datePicker.from" = "От";
+
+/* Compare with same period last year option */
+"jetpackStats.datePicker.lastYear" = "Миналата година";
+
+/* Menu item for more date period options */
+"jetpackStats.datePicker.more" = "Още...";
+
+/* Compare with preceding period option */
+"jetpackStats.datePicker.precedingPeriod" = "Предишен период";
+
+/* Label for quick period selection */
+"jetpackStats.datePicker.quickPeriodsForStartDate" = "Периоди за стартова дата";
+
+/* Site time zone header */
+"jetpackStats.datePicker.siteTimeZone" = "Часова зона на сайта";
+
+/* Explanation of how stats are reported in site time zone */
+"jetpackStats.datePicker.siteTimeZoneDescription" = "Статистиките се показват съобразно часовата  зона на сайта. Ако има посещение от Вторник в посетителската зона, но понеделник във вашата, записът е за понеделник.";
+
+/* To date label */
+"jetpackStats.datePicker.to" = "До";
+
+/* Message explaining how to use the date range control */
+"jetpackStats.dateRangeTip.message" = "Преглед на последните дни, седмици, месеци, години или потребителски периоди.";
+
+/* Title for stats date range control tip */
+"jetpackStats.dateRangeTip.title" = "Навигация във времето";
+
+/* Section title for the list of child links */
+"jetpackStats.externalLinkDetails.childLinks" = "Под-връзки";
+
+/* Button to open the external link in browser */
+"jetpackStats.externalLinkDetails.openLink" = "Отваряне на връзката";
+
+/* Title for the external link details screen */
+"jetpackStats.externalLinkDetails.title" = "Външна връзка";
+
+/* Label for daily average in tooltip */
+"jetpackStats.postDetails.dailyAverage" = "Средно дневно";
+
+/* Title for email metrics card */
+"jetpackStats.postDetails.emailMetrics" = "Имейли";
+
+/* Must be short!Label for emails sent metric */
+"jetpackStats.postDetails.emailsSent" = "Изпратени имейли";
+
+/* Legend label for lower activity */
+"jetpackStats.postDetails.less" = "По-малко";
+
+/* Singular like count. %1$d is the number. */
+"jetpackStats.postDetails.like" = "%1$d харесване";
+
+/* Plural likes count. %1$d is the number. */
+"jetpackStats.postDetails.likes" = "%1$d харесвания";
+
+/* Title for monthly activity heatmap */
+"jetpackStats.postDetails.monthsAndYears" = "Последните месеци";
+
+/* Legend label for higher activity */
+"jetpackStats.postDetails.more" = "Още";
+
+/* Label */
+"jetpackStats.postDetails.noLikesYet" = "Все още няма харесвания";
+
+/* Must be short! Label for email open rate metric */
+"jetpackStats.postDetails.openRate" = "Процент отваряния";
+
+/* Shows when the post was published. %1$@ is the formatted date. */
+"jetpackStats.postDetails.published" = "Публикувано на %1$@";
+
+/* Title for recent weeks activity heatmap */
+"jetpackStats.postDetails.recentWeeks" = "Последните седмици";
+
+/* Navigation title */
+"jetpackStats.postDetails.title" = "Статистика за публикации";
+
+/* Section title */
+"jetpackStats.postDetails.top10" = "Топ 10";
+
+/* Section title */
+"jetpackStats.postDetails.top50" = "Топ 50";
+
+/* Must be short!Label for total email opens metric */
+"jetpackStats.postDetails.totalOpens" = "Общо отваряния";
+
+/* Must be short!Label for unique email opens metric */
+"jetpackStats.postDetails.uniqueOpens" = "Уникални отваряния";
+
+/* Label for week-over-week comparison in tooltip */
+"jetpackStats.postDetails.weekOverWeek" = "Седмица спрямо седмица";
+
+/* Label for weekly total in tooltip */
+"jetpackStats.postDetails.weekTotal" = "Общо за седмицата";
+
+/* Title for weekly activity heatmap */
+"jetpackStats.postDetails.weeklyActivity" = "Седмична дейност";
+
+/* Title for error alert when marking referrer as spam fails */
+"jetpackStats.referrerDetails.errorAlertTitle" = "Грешка";
+
+/* Button to mark a referrer as spam */
+"jetpackStats.referrerDetails.markAsSpam" = "Отбелязване като спам";
+
+/* Error message when marking a referrer as spam fails */
+"jetpackStats.referrerDetails.markAsSpamError" = "Неуспешно отбелязване като спам";
+
+/* Label shown when a referrer is already marked as spam */
+"jetpackStats.referrerDetails.markedAsSpam" = "Отбелязано като спам";
+
+/* Section title for the list of referral sources */
+"jetpackStats.referrerDetails.referralSources" = "Източници на трафик";
+
+/* Title for the referrer details screen */
+"jetpackStats.referrerDetails.title" = "Източник на трафик";
+
+/* Archive data type */
+"jetpackStats.siteDataTypes.archive" = "Архив";
+
+/* Authors data type */
+"jetpackStats.siteDataTypes.authors" = "Автори";
+
+/* External links data type */
+"jetpackStats.siteDataTypes.externalLinks" = "Външни връзки";
+
+/* File downloads data type */
+"jetpackStats.siteDataTypes.fileDownloads" = "Изтегляния на файлове";
+
+/* Locations data type */
+"jetpackStats.siteDataTypes.locations" = "Местоположения";
+
+/* Posts and pages data type */
+"jetpackStats.siteDataTypes.postsAndPages" = "Публикации и страници";
+
+/* Referrers data type */
+"jetpackStats.siteDataTypes.referrers" = "Източници на трафик";
+
+/* Search terms data type */
+"jetpackStats.siteDataTypes.searchTerms" = "Ключови думи";
+
+/* Videos data type */
+"jetpackStats.siteDataTypes.videos" = "Видеа";
+
+/* Bounce rate metric */
+"jetpackStats.siteMetrics.bounceRate" = "Процент на отпадане";
+
+/* Site comments metric */
+"jetpackStats.siteMetrics.comments" = "Коментари";
+
+/* Download count */
+"jetpackStats.siteMetrics.downloads" = "Изтегляния";
+
+/* Site likes metric */
+"jetpackStats.siteMetrics.likes" = "Харесвания";
+
+/* Site posts metric */
+"jetpackStats.siteMetrics.posts" = "Публикации";
+
+/* Time on site metric */
+"jetpackStats.siteMetrics.timeOnSite" = "Време в сайта";
+
+/* Site views metric */
+"jetpackStats.siteMetrics.views" = "Прегледи";
+
+/* Site visitors metric */
+"jetpackStats.siteMetrics.visitors" = "Посетители";
+
+/* Current active visitors metric */
+"jetpackStats.siteMetrics.visitorsNow" = "Посетители сега";
+
+/* Insights tab */
+"jetpackStats.tabs.insights" = "Анализи";
+
+/* Realtime tab */
+"jetpackStats.tabs.realtime" = "Реално време";
+
+/* Subscribers tab */
+"jetpackStats.tabs.subscribers" = "Абонати";
+
+/* Traffic tab */
+"jetpackStats.tabs.traffic" = "Трафик";
+
+/* Stats screen title */
+"jetpackStats.title" = "Статистика";
+
+/* Today card title */
+"jetpackStats.todayCard.title" = "Днес";
+
+/* Title for items with highest bounce rate */
+"jetpackStats.topList.highestBounceRate" = "Най-висок процент на отпадане";
+
+/* Title for items with longest time on site */
+"jetpackStats.topList.longestTimeOnSite" = "Най-дълго време в сайта";
+
+/* Title for most commented items */
+"jetpackStats.topList.mostCommented" = "Най-коментирано";
+
+/* Title for chart */
+"jetpackStats.topList.mostDownloads" = "Най-изтегляно";
+
+/* Title for most liked items */
+"jetpackStats.topList.mostLiked" = "Най-харесвано";
+
+/* Title for most posts (per author) */
+"jetpackStats.topList.mostPosts" = "Най-много публикации";
+
+/* Title for most viewed items */
+"jetpackStats.topList.mostViewed" = "Най-преглеждано";
+
+/* Title for items with most visitors */
+"jetpackStats.topList.mostVisitors" = "Най-много посетители";
+
+/* Title for a call-to-action button on the Jetpack install card. */
+"jetpackinstallcard.button.learn" = "Повече информация";
+
+/* Title for a menu action in the context menu on the Jetpack install card. */
+"jetpackinstallcard.menu.hide" = "Скриване";
+
+/* Text displayed in the Jetpack install card on the Home screen and Menu screen when a user has an individual Jetpack plugin installed but not the full plugin. %1$@ is a placeholder for the plugin the user has installed. %1$@ is bold. */
+"jetpackinstallcard.notice.individual" = "Този сайт ползва разширението %1$@, който не поддържа всички функции на приложението. Моля, инсталирайте пълния Jetpack.";
+
+/* Text displayed in the Jetpack install card on the Home screen and Menu screen when a user has multiple installed individual Jetpack plugins but not the full plugin. */
+"jetpackinstallcard.notice.multiple" = "Този сайт ползва индивидуални Jetpack разширения, които не поддържат всички функции на приложението. Моля, инсталирайте пълния Jetpack.";
+
 /* Later today */
 "later today" = "по-късно днес";
+
+/* Displayed in the confirmation alert when marking like notifications as read. */
+"like" = "харесване";
+
+/* Error message that informs likes from a private blog cannot be fetched. */
+"likesListViewController.likesList.privateBlogErrorMessage" = "Нямате права за преглед на този затворен блог.";
+
+/* Default empty state message format when there are no terms. %1$@ is the taxonomy name. */
+"localizedLabels.defaultNoTerms.format" = "Няма %1$@";
+
+/* Default search placeholder format. %1$@ is the taxonomy name. */
+"localizedLabels.defaultSearch.format" = "Търсене на %1$@";
+
+/* Button to dismiss the re-authentication view */
+"login.appPasswordReAuth.cancelButton" = "Отказ";
+
+/* Description explaining why the user needs to re-authenticate */
+"login.appPasswordReAuth.description" = "Паролата за приложението, закачена към апликацията вече не съществува в профила ви.\nМоля, влезте отново, за да създадете нова парола за приложението.";
+
+/* Button to start the re-authentication process */
+"login.appPasswordReAuth.signInButton" = "Вход";
+
+/* Title shown when the application password is invalid */
+"login.appPasswordReAuth.title" = "Невалидна парола на приложението";
+
+/* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
+"login.twoFactorInstructions.details" = "Моля, въведете код за верификация от вашето приложение за аутентикация към WordPress.com профила ви.";
+
+/* Indicating that referrer was marked as spam */
+"marked as spam" = "обелязано като спам";
+
+/* Button title when verification link sending failed */
+"me.verifyEmail.button.retry" = "Опитайте отново";
+
+/* Button title to send verification link */
+"me.verifyEmail.button.send" = "Повторно изпращане на имейл";
+
+/* Button title while verification link is being sent */
+"me.verifyEmail.button.sending" = "Изпращане...";
+
+/* Button title after verification link is sent */
+"me.verifyEmail.button.sent" = "Имейлът е изпратен";
+
+/* Message for email verification card */
+"me.verifyEmail.message.noEmail" = "Потвърдете имейла, за да потвърдите своя профил и да достъпите повече функции.\nПроверете своята поща за имейл за потвърждение или цъкнете '%@', за да получите нов.";
+
+/* Message for email verification card with email address */
+"me.verifyEmail.message.withEmail" = "Потвърдете имейла, за да потвърдите своя профил и да достъпите повече функции.\nПроверете своята поща %1$@ за имейл за потвърждение или цъкнете '%2$@', за да получите нов.";
+
+/* Title for email verification card */
+"me.verifyEmail.title" = "Потвърдете имейла си";
+
+/* Me tab menu items */
+"meMenu.submitFeedback" = "Обратна връзка";
+
+/* Title of error prompt shown when a sync fails. */
+"media.syncFailed" = "Неуспешно синхронизиране на файлове";
+
+/* An error message the app shows if media import fails */
+"mediaExporter.error.unknown" = "Елементът не може да бъде добавен във файловата библиотека";
+
+/* An error message the app shows if media import fails */
+"mediaExporter.error.unsupportedContentType" = "Видът файл не се поддържа";
+
+/* Message of an alert informing users that the video they are trying to select is not allowed. */
+"mediaExporter.videoLimitExceededError" = "Качването на видеа по-дълги от 5 минути изисква платен план.";
+
+/* Accessibility hint for add button to add items to the user's media library */
+"mediaLibrary.addButtonAccessibilityHint" = "Добавяне на файл";
+
+/* Accessibility label for add button to add items to the user's media library */
+"mediaLibrary.addButtonAccessibilityLabel" = "Добавяне";
+
+/* Button name in the more menu */
+"mediaLibrary.aspectRatioGrid" = "Съотношение на страните";
+
+/* Navigation bar button item */
+"mediaLibrary.buttonAddMedia" = "Добавяне на файл";
+
+/* Context menu button */
+"mediaLibrary.buttonDelete" = "Изтриване";
+
+/* Navigation bar button item */
+"mediaLibrary.buttonFilter" = "Филтър";
+
+/* Media screen navigation bar button Select title */
+"mediaLibrary.buttonSelect" = "Избор";
+
+/* Verb. Button title. Tapping cancels an action. */
+"mediaLibrary.deleteConfirmationCancel" = "Отказ";
+
+/* Title for button that permanently deletes one or more media items (photos / videos) */
+"mediaLibrary.deleteConfirmationConfirm" = "Изтриване";
+
+/* Message prompting the user to confirm that they want to permanently delete a group of media items. */
+"mediaLibrary.deleteConfirmationMessageMany" = "Сигурни ли сте, че искате да изтриете тези елементи безвъзвратно?";
+
+/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
+"mediaLibrary.deleteConfirmationMessageOne" = "Сигурни ли сте, че искате да изтриете този елемент безвъзвратно?";
+
+/* Text displayed in HUD if there was an error attempting to delete a group of media items. */
+"mediaLibrary.deletionFailureMessage" = "Неуспешно изтриване на всички файлове.";
+
+/* Text displayed in HUD while a media item is being deleted. */
+"mediaLibrary.deletionProgressViewTitle" = "Изтриване...";
+
+/* Text displayed in HUD after successfully deleting a media item */
+"mediaLibrary.deletionSuccessMessage" = "Изтрито!";
+
+/* The name of the media filter */
+"mediaLibrary.filterAudio" = "Аудио";
+
+/* The name of the media filter */
+"mediaLibrary.filterDefault" = "Подразбиране (Всички)";
+
+/* The name of the media filter */
+"mediaLibrary.filterDocuments" = "Документи";
+
+/* The name of the media filter */
+"mediaLibrary.filterImages" = "Изображения";
+
+/* The name of the media filter */
+"mediaLibrary.filterVideos" = "Видеа";
+
+/* User action to delete un-uploaded media. */
+"mediaLibrary.retryOptionsAlert.delete" = "Изтриване";
+
+/* Verb. Button title. Tapping dismisses a prompt. */
+"mediaLibrary.retryOptionsAlert.dismissButton" = "Затваряне";
+
+/* User action to retry media upload. */
+"mediaLibrary.retryOptionsAlert.retry" = "Нов опит за качване";
+
+/* Message displayed when no results are returned from a media library search. Should match Calypso. */
+"mediaLibrary.searchResultsEmptyTitle" = "Няма файлове, съответстващи на търсенето";
+
+/* Text displayed in HUD if there was an error attempting to share a group of media items. */
+"mediaLibrary.sharingFailureMessage" = "Неуспешно споделяне на избраните елементи.";
+
+/* Button name in the more menu */
+"mediaLibrary.squareGrid" = "Квадратна решетка";
+
+/* Detail message for buying storage add-on */
+"mediaLibrary.storageDetails.buyStorage.detail" = "Отваряне на повече място за качествени снимки, видеа и други файлове.";
+
+/* Message about buying storage add-on */
+"mediaLibrary.storageDetails.buyStorage.message" = "Покупка на допълнително пространство";
+
+/* Label for audio media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.audio" = "Аудио";
+
+/* Label for document media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.document" = "Документи";
+
+/* Label for image media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.image" = "Изображения";
+
+/* Label for other/unknown media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.other" = "Друго";
+
+/* Label for PowerPoint/presentation media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.powerpoint" = "Презентации";
+
+/* Label for video media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.video" = "Видеа";
+
+/* Success message shown after upgrading plan */
+"mediaLibrary.storageDetails.purchase.plan.success" = "Планът ви беше ъпгрейднат!";
+
+/* Success message shown after purchasing storage add-on */
+"mediaLibrary.storageDetails.purchase.storage.success" = "Пространството във файловата библиотека беше увеличено!";
+
+/* Title for the storage details screen */
+"mediaLibrary.storageDetails.title" = "Библиотека за съхранение на файлове";
+
+/* Detail message for upgrading plan */
+"mediaLibrary.storageDetails.upgradePlan.detail" = "Ъпгрейднете плана си за повече пространство";
+
+/* Message about upgrading plan */
+"mediaLibrary.storageDetails.upgradePlan.message" = "Ъпгрейднете плана";
+
+/* Storage usage message showing used space and total space. %1$@ is used space, %2$@ is total space. */
+"mediaLibrary.storageDetails.usage" = "%1$@ от %2$@ са използвани";
+
+/* Message shown while calculating storage usage */
+"mediaLibrary.storageDetails.usage.calculating" = "Пресмятане...";
+
+/* Media screen navigation title */
+"mediaLibrary.title" = "Файлове";
+
+/* Bottom toolbar title in the selection mode */
+"mediaLibrary.toolbarSelectImagesMany" = "%d изображения са избрани";
+
+/* Bottom toolbar title in the selection mode */
+"mediaLibrary.toolbarSelectImagesOne" = "1 изображение е избрано";
+
+/* Bottom toolbar title in the selection mode */
+"mediaLibrary.toolbarSelectItemsMany" = "%d елемента са избрани";
+
+/* Bottom toolbar title in the selection mode */
+"mediaLibrary.toolbarSelectItemsOne" = "1 елемент е избран";
+
+/* Bottom toolbar title in the selection mode */
+"mediaLibrary.toolbarSelectItemsPrompt" = "Избор на елементи";
+
+/* A name of the action in the context menu */
+"mediaPicker.imagePlayground" = "Пясъчник за картинки";
+
+/* Message for alert when access to camera is not granted */
+"mediaPicker.noCameraAccessMessage" = "Това приложение се нуждае от разрешение да използва камерата, за да може да заснема. Моля, променете вашите настройки за поверителност ако искате да разрешите това.";
+
+/* Title for alert when access to camera is not granted */
+"mediaPicker.noCameraAccessTitle" = "Заснемане";
+
+/* Button that opens the Settings app */
+"mediaPicker.openSettings" = "Отваряне на настройки";
+
+/* The name of the action in the context menu for selecting photos from Tenor (free GIF library) */
+"mediaPicker.pickFromFreeGIFLibrary" = "Безплатна библиотека с GIF-ове";
+
+/* The name of the action in the context menu (user's WordPress Media Library */
+"mediaPicker.pickFromMediaLibrary" = "Избор от Файлове";
+
+/* The name of the action in the context menu for selecting photos from other apps (Files app) */
+"mediaPicker.pickFromOtherApps" = "Други файлове";
+
+/* The name of the action in the context menu */
+"mediaPicker.pickFromPhotosLibrary" = "Избор от устройството";
+
+/* The name of the action in the context menu for selecting photos from free stock photos */
+"mediaPicker.pickFromStockPhotos" = "Безплатна фото библиотека";
+
+/* The name of the action in the context menu */
+"mediaPicker.takePhoto" = "Заснемане на снимка";
+
+/* The name of the action in the context menu */
+"mediaPicker.takePhotoOrVideo" = "Заснемане на снимка или видео";
+
+/* The name of the action in the context menu */
+"mediaPicker.takeVideo" = "Заснемане на видео";
+
+/* The menu item of viewing media library usage */
+"mediaPicker.viewUsage" = "Преглед на потреблението";
+
+/* Navigation title for media preview. Example: 1 of 3 */
+"mediaPreview.NofM" = "%1$@ от %2$@";
+
+/* Max image size in pixels (e.g. 300x300px) */
+"mediaSizeSlider.valueFormat" = "%1$d × %2$d px";
+
+/* The description in the Delete WordPress screen */
+"migration.deleteWordpress.description" = "Изглежда сякаш още имате WordPress приложението инсталирано.";
+
+/* The primary button title in the Delete WordPress screen */
+"migration.deleteWordpress.primaryButton" = "Ясно";
+
+/* The secondary button title in the Delete WordPress screen */
+"migration.deleteWordpress.secondaryButton" = "Нужда от помощ?";
+
+/* The title in the Delete WordPress screen */
+"migration.deleteWordpress.title" = "Вече нямате нужда от WordPress приложението на вашето устройство";
+
+/* Footer for the migration done screen. */
+"migration.done.footer" = "Препоръчваме ви да изтриете WordPress приложението, за да избегнете конфликти.";
+
+/* Highlighted text in the footer of the migration done screen. */
+"migration.done.footer.highlighted" = "деинсталиране на WordPress приложението";
+
+/* Primary description in the migration done screen. */
+"migration.done.primaryDescription" = "Прехвърлихме вашите данни и настройки. Всичко е точно.";
+
+/* Secondary description (second paragraph) in the migration done screen. */
+"migration.done.secondaryDescription" = "Време е да продължите пътешествието си с WordPress в Jetpack приложението.";
+
+/* Title of the migration done screen. */
+"migration.done.title" = "Благодаря, че избрахте Jetpack!";
+
+/* The description in the Load WordPress screen */
+"migration.loadWordpress.description" = "Изглежда още имате WordPress приложението инсталирано.";
+
+/* The primary button title in the Load WordPress screen */
+"migration.loadWordpress.primaryButton" = "Отваряне на WordPress";
+
+/* The secondary button title in the Load WordPress screen */
+"migration.loadWordpress.secondaryButton" = "Не, благодаря";
+
+/* The secondary description in the Load WordPress screen */
+"migration.loadWordpress.secondaryDescription" = "Бихте ли искали да прехвърлите данните от WordPress и да влезете автоматично?";
+
+/* The title in the Load WordPress screen */
+"migration.loadWordpress.title" = "Добре дошли в Jetpack!";
+
+/* Secondary button title in the migration notifications screen. */
+"migration.notifications.actions.secondary.title" = "По-късно";
+
+/* Footer for the migration notifications screen. */
+"migration.notifications.footer" = "Когато се появи предупреждението, разрешете да получавате всички известия от WordPress.";
+
+/* Highlighted text in the footer of the migration notifications screen. */
+"migration.notifications.footer.highlighted" = "Позволяване";
+
+/* Primary description in the migration notifications screen. */
+"migration.notifications.primaryDescription" = "Ще имате същите известия, но ще идват в Jetpack приложението.";
+
+/* Secondary description in the migration notifications screen */
+"migration.notifications.secondaryDescription" = "Ще изключим известията от WordPress приложението";
+
+/* Title of the migration notifications screen. */
+"migration.notifications.title" = "Позволете известията, за да следите какво става със сайта";
+
+/* The primary description in the migration welcome screen */
+"migration.welcome.primaryDescription" = "Изглежда сякаш мигрирате от WordPress приложението.";
+
+/* The plural form of the secondary description in the migration welcome screen */
+"migration.welcome.secondaryDescription.plural" = "Открихме сайта. Продължете, за да трансферирате всичките данни и да влезете в Jetpack автоматично.";
+
+/* The singular form of the secondary description in the migration welcome screen */
+"migration.welcome.secondaryDescription.singular" = "Открихме сайта. Продължете, за да трансферирате всичките данни и да влезете в Jetpack автоматично.";
+
+/* The title in the migration welcome screen */
+"migration.welcome.title" = "Добре дошли в Jetpack!";
+
+/* Primary button title in the migration done screen. */
+"migrationDone.actions.primaryTitle" = "Да започваме";
+
+/* Description for the static screen displayed prompting users to switch the Jetpack app. */
+"movedToJetpack.description" = "Jetpack има цялата функционалност на приложението WordPress плюс достъп до статистики, известия и Reader.";
+
+/* Hint for the static screen displayed prompting users to switch the Jetpack app. */
+"movedToJetpack.hint" = "Смяната е безплатна и ще отнеме минутка.";
+
+/* Title for a button that prompts users to switch to the Jetpack app. */
+"movedToJetpack.jetpackButtonTitle" = "Преминете към Jetpack";
+
+/* Title for a button that displays a blog post in a web view. */
+"movedToJetpack.learnMoreButtonTitle" = "Научете повече на jetpack.com";
+
+/* Title for the static screen displayed in the Stats screen prompting users to switch to the Jetpack app. */
+"movedToJetpack.notifications.title" = "Ползвайте WordPress с известия в Jetpack приложението.";
+
+/* Title for the static screen displayed in the Reader screen prompting users to switch to the Jetpack app. */
+"movedToJetpack.reader.title" = "Ползвайте WordPress с Reader в Jetpack приложението.";
+
+/* Title for the static screen displayed in the Stats screen prompting users to switch to the Jetpack app. */
+"movedToJetpack.stats.title" = "Ползвайте WordPress със статистики в Jetpack приложението.";
+
+/* Section title for the content table section in the blog details screen */
+"my-site.menu.content.section.title" = "Съдържание";
+
+/* Section title for the maintenance table section in the blog details screen */
+"my-site.menu.maintenance.section.title" = "Поддръжка";
+
+/* Title for the site monitoring row in the blog details screen */
+"my-site.menu.site-monitoring.row.title" = "Мониторинг на сайта";
+
+/* Title for the social row in the blog details screen */
+"my-site.menu.social.row.title" = "Социални";
+
+/* Section title for the traffic table section in the blog details screen */
+"my-site.menu.traffic.section.title" = "Трафик";
+
+/* Title for the card displaying draft posts. */
+"my-sites.drafts.card.title" = "Работете по чернова";
+
+/* Title for the View all drafts button in the More menu */
+"my-sites.drafts.card.viewAllDrafts" = "Преглед на всички чернови";
+
+/* Title for the View all scheduled drafts button in the More menu */
+"my-sites.scheduled.card.viewAllScheduledPosts" = "Преглед на планираните публикации";
+
+/* Title for the card displaying today's stats. */
+"my-sites.stats.card.title" = "Статистика от днес";
+
+/* Title for the domain focus card on My Site */
+"mySite.domain.focus.cardCell.title" = "Новини";
+
+/* Button title of the domain focus card on My Site */
+"mySite.domain.focus.cardView.button.title" = "Трансфер на вашите домейни";
+
+/* Description of the domain focus card on My Site */
+"mySite.domain.focus.cardView.description" = "Както знаете, Google Domains беше продаден на Squarespace. Трансферирайте вашите домейни към WordPress.com сега и ще покрием разходите по прехвърляне плюс регистрация за една година.";
+
+/* Title of the domain focus card on My Site */
+"mySite.domain.focus.cardView.title" = "Изискайте своя Google Domains";
+
+/* Title for the menu item */
+"mySite.menu.subscribers" = "Абонати";
+
+/* Title for the menu item */
+"mySite.menu.users" = "Потребители";
+
+/* Button title. Displays the account and setting screen. */
+"mySite.noSites.button.accountAndSettings" = "Профил и настройки";
+
+/* Message description for when a user has no sites. */
+"mySite.noSites.description" = "Създаване на нов сайт за вашия бизнес, списание или личен блог, или свързване на съществуващ WordPress.";
+
+/* Title description for when a user has no sites. */
+"mySite.noSites.stateViewTitle" = "Създайте първия си сайт";
+
+/* Button that reveals more site actions */
+"mySite.siteActions.button" = "Действия";
+
+/* Accessibility hint for button used to show more site actions */
+"mySite.siteActions.hint" = "Докоснете за повече действия";
+
+/* Menu title for the personalize home option */
+"mySite.siteActions.personalizeHome" = "Персонализиране на началото";
+
+/* Menu title for the change site icon option */
+"mySite.siteActions.siteIcon" = "Промяна иконата на сайта";
+
+/* Menu title for the change site title option */
+"mySite.siteActions.siteTitle" = "Промяна на заглавието на сайта";
+
+/* Menu title for the visit site option */
+"mySite.siteActions.visitSite" = "Към сайта";
+
+/* A no results message displayed on the atomic logs screen. */
+"noLogs.empty" = "Няма записи в дневника за този период";
+
+/* A generic error message displayed on the atomic logs screen. */
+"noLogs.error" = "Възникна грешка";
+
+/* Button title for the retry button on the atomic logs screen. */
+"noLogs.retry" = "Повторен опит";
+
+/* Dismiss button title. */
+"noResultsViewController.dismissButton" = "Отмяна";
+
+/* Setting: indicates if New Subscriptions will be notified */
+"notification.settings.description.subscriber" = "Абонаменти";
+
+/* Notification Settings for your subscribed sites */
+"notification.settings.footer.subscribedSites" = "Настройте опциите за абонамент към нови публикации и коментари";
+
+/* Displayed in the Notification Settings View */
+"notification.settings.header.subscribedSites" = "Абонирани сайтове";
+
+/* Error message that informs comment details from a private blog cannot be fetched. */
+"notificationCommentDetailViewController.commentDetails.privateBlogErrorMessage" = "Нямате права за преглед на този затворен блог.";
+
+/* The user has previously tapped 'Like' on this comment */
+"notifications.accessibility-comment-like-button-on" = "Харесали сте този коментар";
+
+/* The user has not previously tapped 'Like' on this post or comment */
+"notifications.accessibility-like-button-off" = "Не харесано";
+
+/* The user has previously tapped 'Like' on this post */
+"notifications.accessibility-post-like-button-on" = "Харесали сте тази публикация";
+
+/* A label for screenreader users */
+"notifications.accessibility-tap-to-like-this-comment" = "Двойно докосване, за да харесате коментара";
+
+/* A label for screenreader users */
+"notifications.accessibility-tap-to-like-this-post" = "Двойно докосване, за да харесате публикацията";
+
+/* A label for screenreader users */
+"notifications.accessibility-tap-to-share-this-post" = "Двойно докосване, за да споделите публикацията";
+
+/* A label for screenreader users */
+"notifications.accessibility-tap-to-unlike-this-comment" = "Двойсо докосване, за да от-харесате коментара";
+
+/* A label for screenreader users */
+"notifications.accessibility-tap-to-unlike-this-post" = "Двойно кликване за да от-харесате публикацията";
+
+/* VoiceOver accessibility hint, informing the user the button can be used to subscribe to a blog. */
+"notifications.action.subscribe.hint" = "Абониране за блога.";
+
+/* VoiceOver accessibility hint, informing the user the button can be used to unsubscribe from a blog. */
+"notifications.action.subscribe.selectedHint" = "Премахване на абонамент.";
+
+/* User is subscribed to the blog. */
+"notifications.action.subscribe.selectedTitle" = "Абонирано";
+
+/* Prompt to subscribe to a blog. */
+"notifications.action.subscribe.title" = "Абониране";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"notifications.appRatings.prompt.no.buttonTitle" = "Може да е по-добре";
+
+/* This is one of the buttons we display inside of the prompt to review the app */
+"notifications.appRatings.prompt.yes.buttonTitle" = "Харесва ми";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"notifications.appRatings.sendFeedback.no.buttonTitle" = "Не, благодаря";
+
+/* This is one of the buttons we display when prompting the user for a review */
+"notifications.appRatings.sendFeedback.yes.buttonTitle" = "Изпращане на обратна връзка";
+
+/* Prompt to subscribe to a blog. */
+"notifications.button.subscribe" = "Абониране";
+
+/* User is subscribed to the blog. */
+"notifications.button.subscribed" = "Абонирано";
+
+/* VoiceOver accessibility hint, informing the user the button can be used to subscribe to a blog. */
+"notifications.button.subscribedHint" = "Абонира за блога.";
+
+/* Filters Subscribers Notifications */
+"notifications.filter.subscribers.title" = "Абонати";
+
+/* Displayed in the confirmation alert when marking follow notifications as read. */
+"notifications.filter.subscriptions.confirmationMessageTitle" = "абониране";
+
+/* Displayed in the Notifications Tab as a title, when the Subscriber Filter shows no notifications */
+"notifications.noresults.subscribers" = "Все още няма абонати";
+
+/* Message to use along with the post URL when sharing a post */
+"notifications.share.messageWithPost" = "Погледнете моята публикация \"%@\":";
+
+/* Message to use along with the post URL when sharing a post */
+"notifications.share.messageWithoutPost" = "Погледнете моята публикация:";
+
+/* Marks all notifications under the filter as read */
+"notificationsViewController.navigationBar.action.markAllAsRead" = "Маркиране като прочетени";
+
+/* Link to Notification Settings section */
+"notificationsViewController.navigationBar.action.settings" = "Настройки на известията";
+
+/* Accessibility label for the navigation bar menu button */
+"notificationsViewController.navigationBar.menu.accessibilityLabel" = "Бутон от менюто в навигацията";
+
+/* Badge for page cells */
+"pageList.badgeHomepage" = "Начална страница";
+
+/* Badge for page cells */
+"pageList.badgePendingReview" = "Очаква преглед";
+
+/* Badge for page cells */
+"pageList.badgePosts" = "Страница с публикации";
+
+/* Badge for page cells */
+"pageList.badgePrivate" = "Лична";
+
+/* Subtitle of the theme template homepage cell */
+"pages.template.subtitle" = "Вашата начална страница ползва тема и ще се отвори в уеб редактора.";
+
+/* Title of the theme template homepage cell */
+"pages.template.title" = "Начална страница";
+
+/* Message informing the user that their static homepage page was set successfully */
+"pages.updatePage.successTitle" = "Страницата е обновена";
+
+/* Menu option for filtering posts by everyone */
+"pagesList.pagesByEveryone" = "Публикации от всички";
+
+/* Menu option for filtering posts by me */
+"pagesList.pagesByMe" = "Мои публикации";
+
+/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
+"parentCategory.noCategory" = "Без категория";
+
+/* Title for selecting parent category of a category */
+"parentCategory.title" = "Родителска категория";
+
+/* Title for the parent page picker screen */
+"parentPagePicker.title" = "Родителска страница";
+
+/* Navigation title displayed on the navigation bar */
+"parentPageSettings.title" = "Родителска страница";
+
+/* No comment provided by engineer. */
+"password" = "парола";
+
+/* Section footer displayed below the list of toggles */
+"personalizeHome.cardsSectionFooter" = "Картите могат да показват различно съдържание, в зависимост от това какво се случва със сайта. Разработваме и нови карти и контроли.";
+
+/* Section header */
+"personalizeHome.cardsSectionHeader" = "Показване или скриване на карти";
+
+/* Card title for the pesonalization menu */
+"personalizeHome.dashboardCard.activityLog" = "Скорошна дейност";
+
+/* Card title for the pesonalization menu */
+"personalizeHome.dashboardCard.blaze" = "Blaze";
+
+/* Card title for the pesonalization menu */
+"personalizeHome.dashboardCard.draftPosts" = "Чернови";
+
+/* Card title for the pesonalization menu */
+"personalizeHome.dashboardCard.pages" = "Страници";
+
+/* Card title for the pesonalization menu */
+"personalizeHome.dashboardCard.prompts" = "Блог предизвикателства";
+
+/* Card title for the pesonalization menu */
+"personalizeHome.dashboardCard.scheduledPosts" = "Планирани публикации";
+
+/* Card title for the pesonalization menu */
+"personalizeHome.dashboardCard.todaysStats" = "Статистики от днес";
+
+/* Page title */
+"personalizeHome.navigationTitle" = "Персонализация на началния екран";
+
+/* Section header for shortcuts */
+"personalizeHome.shortcutsSectionHeader" = "Показване или скриване на преки пътища";
+
+/* Register Domain - Domain contact information field Phone */
+"phone number" = "телефонен номер";
+
+/* A title for the filter on the PHP logs screen */
+"phpLogs.filterEndDate" = "Крайна дата";
+
+/* A title for the filter on the PHP logs screen */
+"phpLogs.filterSeverity" = "Тежест";
+
+/* A title for the filter on the PHP logs screen */
+"phpLogs.filterStartDate" = "Начална дата";
+
+/* A title for the log severity level */
+"phpLogs.severityDeprecated" = "Не се използва";
+
+/* A title for the log severity level */
+"phpLogs.severityFatalError" = "Фатална грешка";
+
+/* A title for the log severity level */
+"phpLogs.severityUser" = "Потребител";
+
+/* A title for the log severity level */
+"phpLogs.severityWarning" = "Warning";
+
+/* Title for the plan selection view */
+"planSelection.title" = "Планове";
+
+/* Button label to activate a plugin */
+"pluginDetails.activate.button" = "Активиране";
+
+/* Button label showing plugin is activated */
+"pluginDetails.activated.button" = "Активно";
+
+/* Message shown while a plugin is being activated */
+"pluginDetails.activating.message" = "Изчакайте, докато разрширението се включва...";
+
+/* Title shown while a plugin is being activated */
+"pluginDetails.activating.title" = "Включване на разширението";
+
+/* Plugin author information. The placeholder is the author name */
+"pluginDetails.author" = "От %@";
+
+/* Button label to deactivate a plugin */
+"pluginDetails.deactivate.button" = "Изключване";
+
+/* Message shown while a plugin is being deactivated */
+"pluginDetails.deactivating.message" = "Изчакайте, докато разрширението се изключва...";
+
+/* Title shown while a plugin is being deactivated */
+"pluginDetails.deactivating.title" = "Изключване на разширение";
+
+/* Button label to delete a plugin */
+"pluginDetails.delete.button" = "Изтриване";
+
+/* Message of the confirmation alert when deleting a plugin. The placeholder is the plugin name */
+"pluginDetails.delete.confirmationMessage" = "Наистина ли искате да изтриете %@?";
+
+/* Title of the confirmation alert when deleting a plugin */
+"pluginDetails.delete.confirmationTitle" = "Изтриване на разширението?";
+
+/* Button label to install a plugin */
+"pluginDetails.install.button" = "Инсталиране";
+
+/* Message shown while a plugin is being installed */
+"pluginDetails.install.message" = "Изчакайте, докато разрширението се инсталира...";
+
+/* Title shown while a plugin is being installed */
+"pluginDetails.install.title" = "Инсталиране на разширение";
+
+/* Message shown while loading plugin details */
+"pluginDetails.loading" = "Зареждане на информацията за разширения...";
+
+/* Placeholder message shown when a plugin has no description */
+"pluginDetails.noDescription" = "Разширението няма описание";
+
+/* Title of the changelog section in plugin details */
+"pluginDetails.section.changelog" = "Дневник на промените";
+
+/* Title of the description section in plugin details */
+"pluginDetails.section.description" = "Описание";
+
+/* Title of the details section in plugin details */
+"pluginDetails.section.details" = "Подробности";
+
+/* Title of the FAQ section in plugin details */
+"pluginDetails.section.faq" = "ЧЗВ";
+
+/* Title of the installation section in plugin details */
+"pluginDetails.section.installation" = "Инсталация";
+
+/* Title of the reviews section in plugin details */
+"pluginDetails.section.reviews" = "Отзиви";
+
+/* Title of the screenshots section in plugin details */
+"pluginDetails.section.screenshots" = "Скрийншоти";
+
+/* Message shown while a plugin is being uninstalled */
+"pluginDetails.uninstalling.message" = "Изчакайте, докато разрширението се премахва...";
+
+/* Title shown while a plugin is being uninstalled */
+"pluginDetails.uninstalling.title" = "Деинсталация на разширение";
+
+/* Button title to update a plugin */
+"pluginDetails.update.action" = "Обновяване сега";
+
+/* Title shown when a plugin update is available */
+"pluginDetails.update.title" = "Има налично обновяване";
+
+/* Message shown when a plugin update is available. The placeholder is the new version number */
+"pluginDetails.update.versionAvailable" = "Версия %@ е налична. Моля, обновете я от вашето WordPress табло.";
+
+/* Button label to view plugin on WordPress.org */
+"pluginDetails.viewOnWordPressOrg.button" = "Вижте в WordPress.org";
+
+/* Title for the post author selection screen */
+"postAuthorPicker.title" = "Автор";
+
+/* Title for selecting categories for a post or a page */
+"postCategories.title" = "Категории";
+
+/* Toggle label for allowing comments on post */
+"postDiscussion.allowComments.label" = "Разрешаване на коментарите";
+
+/* Toggle label for allowing pings/trackbacks on post */
+"postDiscussion.allowPings.label" = "Позволяване на pingback";
+
+/* Footer text when comments are disabled */
+"postDiscussion.comments.disabled.footer" = "Посетителите не могат да добавят нови коментари или отговори. Съществуващите коментари остават видими.";
+
+/* Footer text when comments are enabled */
+"postDiscussion.comments.enabled.footer" = "Посетителите могат да добавят нови коментари и отговори.";
+
+/* Link text for learning more about pingbacks and trackbacks */
+"postDiscussion.pingbacks.learnMore.text" = "Повече информация за pingbacks и trackbacks";
+
+/* Navigation title for post discussion settings */
+"postDiscussion.title" = "Дискусия";
+
+/* Button in an alert confirming discaring changes */
+"postEditor.closeConfirmationAlert.discardChanges" = "Отмяна на промените";
+
+/* Button in an alert confirming discaring a new draft */
+"postEditor.closeConfirmationAlert.discardDraft" = "Изтриване на черновата";
+
+/* Button to keep the changes in an alert confirming discaring changes */
+"postEditor.closeConfirmationAlert.keepEditing" = "Продължаване на редакцията";
+
+/* Button in an alert confirming saving a new draft */
+"postEditor.closeConfirmationAlert.saveDraft" = "Запазване на чернова";
+
+/* Creating autosave to generate a preview (status message */
+"postEditor.creatingAutosaveForPreview" = "Автоматично записване...";
+
+/* Post Editor / Button in the 'More' menu */
+"postEditor.moreMenu.codeEditor" = "Редактор на код";
+
+/* Post Editor / 'More' menu details labels with 'Blocks', 'Words' and 'Characters' counts as parameters (in that order) */
+"postEditor.moreMenu.contentStructure" = "Блокове: %1$li, думи: %2$li, символи: %3$li";
+
+/* Post Editor / Button in the 'More' menu */
+"postEditor.moreMenu.help" = "Помощ";
+
+/* Post Editor / Button in the 'More' menu */
+"postEditor.moreMenu.helpAndSupport" = "Помощ и поддръжка";
+
+/* Post Editor / Button in the 'More' menu */
+"postEditor.moreMenu.pageSettings" = "Настройки на страницата";
+
+/* Post Editor / Button in the 'More' menu */
+"postEditor.moreMenu.postSettings" = "Настройки на публикацията";
+
+/* Post Editor / Button in the 'More' menu */
+"postEditor.moreMenu.preview" = "Преглед";
+
+/* Post Editor / Button in the 'More' menu */
+"postEditor.moreMenu.revisions" = "Версии";
+
+/* Post Editor / Button in the 'More' menu */
+"postEditor.moreMenu.saveDraft" = "Запазване на чернова";
+
+/* Post Editor / Button in the 'More' menu */
+"postEditor.moreMenu.sendFeedback" = "Обратна връзка";
+
+/* Post Editor / Button in the 'More' menu */
+"postEditor.moreMenu.visualEditor" = "Визуален редактор";
+
+/* A 'View' action for a snackbar informing the user that some media files requires their attention */
+"postEditor.postHasFailingMediaUploadsSnackbar.actionView" = "Преглед";
+
+/* A message for a snackbar informing the user that some media files requires their attention */
+"postEditor.postHasFailingMediaUploadsSnackbar.message" = "Някои файлове не се качиха";
+
+/* Editor, notice for successful recovery a trashed post */
+"postEditor.recoverTrashedPost.postRecoveredNoticeTitle" = "Публикацията бе възстановена като чернова";
+
+/* Editor, alert for recovering a trashed post */
+"postEditor.recoverTrashedPostAlert.cancel" = "Отказ";
+
+/* Editor, alert for recovering a trashed post */
+"postEditor.recoverTrashedPostAlert.message" = "Изтрита %1$@ не може да се редактира. За да редактирате %1$@, трябва да я възстановите като я направите чернова.";
+
+/* Editor, alert for recovering a trashed post */
+"postEditor.recoverTrashedPostAlert.restore" = "Възстановяване";
+
+/* Editor, alert for recovering a trashed post */
+"postEditor.recoverTrashedPostAlert.title" = "%@ е изтрит";
+
+/* Title for a snackbar */
+"postEditor.revisionLoaded" = "Версията е заредена";
+
+/* Saving draft to generate a preview (status message */
+"postEditor.savingDraftForPreview" = "Запазване на чернова...";
+
+/* Empty state description when no post formats are available */
+"postFormatPicker.emptyState.description" = "Форматите за публикация не са конфигурирани";
+
+/* Empty state title when no post formats are available */
+"postFormatPicker.emptyState.title" = "Няма налични формати за публикация";
+
+/* Navigation bar title for the Post Format picker */
+"postFormatPicker.navigationTitle" = "Формат на публикацията";
+
+/* Error message when post formats refresh fails */
+"postFormatPicker.refreshErrorMessage" = "Неуспешно презареждане на форматите на публикацията";
+
+/* Button title */
+"postFromAudio.beginRecording" = "Начало на записа";
+
+/* Button title */
+"postFromAudio.buttonUpgrade" = "Ъпгрейднете за още заявки";
+
+/* Button close title (only used as an accessibility identifier) */
+"postFromAudio.close" = "Затваряне";
+
+/* Button title */
+"postFromAudio.done" = "Готово";
+
+/* The AI failed to understand the request for any reasons */
+"postFromAudio.errorMessage.cantUnderstandRequest" = "Нещо се обърка при обработката на заявката. Опитайте отново.";
+
+/* The screen subtitle in the error state */
+"postFromAudio.errorMessage.generic" = "Нещо се обърка";
+
+/* Message for 'not eligible' state view */
+"postFromAudio.notEnoughRequestsMessage" = "Нямате останали заявки, за да създадете публикация от аудио.";
+
+/* Button title */
+"postFromAudio.retry" = "Повторен опит";
+
+/* The screen subtitle */
+"postFromAudio.subtitleRequestsAvailable" = "Налични заявки:";
+
+/* The screen title */
+"postFromAudio.title" = "Публикация от аудио";
+
+/* The screen title when recording */
+"postFromAudio.titleProcessing" = "Обработва се...";
+
+/* The screen title when recording */
+"postFromAudio.titleRecoding" = "Записване...";
+
+/* The value for the `requests available:` field for an unlimited plan */
+"postFromAudio.unlimited" = "Неограничено";
+
+/* Accessibility label for the post author in the post list. The parameter is the author name. For example, \"By Elsa.\" */
+"postList.a11y.authorChunkFormat" = "От %@.";
+
+/* Accessibility label for a post's excerpt in the post list. The parameter is the post excerpt. For example, \"Excerpt. This is the first paragraph.\" */
+"postList.a11y.exerptChunkFormat" = "Откъс. %@.";
+
+/* Accessibility label for a sticky post in the post list. */
+"postList.a11y.sticky" = "Залепено.";
+
+/* Accessibility label for a post in the post list. The first placeholder is the post title. The second placeholder is the date. */
+"postList.a11y.titleAndDateChunkFormat" = "%1$@, %2$@.";
+
+/* Badge for post cells */
+"postList.badgePendingReview" = "Очаква се преглед";
+
+/* Cancels an Action */
+"postList.cancel" = "Отказ";
+
+/* Delete option in the confirmation alert when deleting a page from the trash. */
+"postList.deletePermanently.actionTitle" = "Изтриване завинаги";
+
+/* Message of the confirmation alert when deleting a page from the trash. */
+"postList.deletePermanently.alertMessage" = "Сигурни ли сте, че искате безвъзвратно да изтриете \"%@\"?";
+
+/* An error message */
+"postList.errorUnsyncedChangesMessage" = "Приложението качва предни промени към сървъра. Опитайте отново.";
+
+/* A generic error message title */
+"postList.genericErrorMessage" = "Нещо се обърка";
+
+/* Label for a post in the post list. Indicates that the post has offline changes. */
+"postList.offlineChanges" = "Офлайн промени";
+
+/* Title for the 'Trash' post list row swipe action */
+"postList.swipeActionDelete" = "Изтриване";
+
+/* Title for the 'Delete' post list row swipe action */
+"postList.swipeActionDeletePermanently" = "Изтриване";
+
+/* Title for the 'View' post list row swipe action */
+"postList.swipeActionView" = "Преглед";
+
+/* Trash option in the trash post or page confirmation alert. */
+"postList.trash.actionTitle" = "Преместване в кошчето";
+
+/* Message of the trash post or page confirmation alert. */
+"postList.trash.alertMessage" = "Сигурни ли сте, че искате да изтриете \"%@\"? Всички промени, които не са записани, ще бъдат изгубени.";
+
+/* Cancel (single) upload button in postMediaUploadStatusView */
+"postMediaUploadStatusView.cancelUpload" = "Спиране на качването";
+
+/* Placeholder text in postMediaUploadStatusView when no uploads remain */
+"postMediaUploadStatusView.noPendingUploads" = "Няма изчакващи качвания";
+
+/* Shows the upload progress with two preformatted parameters: %1$@ is the placeholder for completed bytes, and %2$@ is the placeholder for total bytes */
+"postMediaUploadStatusView.progress" = "%1$@ от %2$@";
+
+/* Retry (single) upload button in postMediaUploadStatusView */
+"postMediaUploadStatusView.retryUpload" = "Нов опит за качване";
+
+/* Retry upload button in postMediaUploadStatusView */
+"postMediaUploadStatusView.retryUploads" = "Нов опит за качване";
+
+/* Title for post media upload status view */
+"postMediaUploadStatusView.title" = "Медийни файлове";
+
+/* Title of notification displayed when either a new or an existing draft is saved */
+"postNotice.draftSaved" = "Черновата е запазена";
+
+/* Title of notification displayed when a page has been successfully saved as a draft. */
+"postNotice.pagePending" = "Страницата изчаква преглед";
+
+/* Title of notification displayed when a page has been successfully published. */
+"postNotice.pagePublished" = "Страницата е публикувана";
+
+/* Title of notification displayed when a page has been successfully scheduled. */
+"postNotice.pageScheduled" = "Страницата е планирана";
+
+/* Title of notification displayed when a page has been successfully updated. */
+"postNotice.pageUpdated" = "Страницата е обновена";
+
+/* Title of notification displayed when a post has been successfully saved as a draft. */
+"postNotice.postPendingReview" = "Публикацията изчаква преглед";
+
+/* Title of notification displayed when a post has been successfully published. */
+"postNotice.postPublished" = "Публикацията е публикувана";
+
+/* Title of notification displayed when a post has been successfully scheduled. */
+"postNotice.postScheduled" = "Публикацията е планирана";
+
+/* Title of notification displayed when a post has been successfully updated. */
+"postNotice.postUpdated" = "Публикацията е обновена";
+
+/* Button title. Displays a summary / sharing screen for a specific post. */
+"postNotice.view" = "Преглед";
+
+/* Error message: content was modified on another device */
+"postSaveErrorMessage.conflict" = "Съдържанието е променено от друго устройство";
+
+/* Error message: item permanently deleted */
+"postSaveErrorMessage.deleted" = "\"%@\" беше окончателно изтрит и не може да се обнови";
+
+/* A default value for an post without a title */
+"postSaveErrorMessage.postUntitled" = "Без заглавие";
+
+/* Section header for Access settings in Post Settings */
+"postSettings.access.header" = "Достъп";
+
+/* Label for the author field in Post Settings */
+"postSettings.author.label" = "Автор";
+
+/* Label for the add category button field. Should be the same as WP core. */
+"postSettings.categories.addCategoryButton" = "Добавяне на категория";
+
+/* Label for the categories field. Should be the same as WP core.
+   Label for the category field. Should be the same as WP core. */
+"postSettings.categories.label" = "Категории";
+
+/* Button to confirm discarding changes */
+"postSettings.discardChanges.button" = "Отмяна на промените";
+
+/* Message for the discard changes confirmation dialog */
+"postSettings.discardChanges.message" = "Има незапазени промени. Сигурни ли сте, че искате да ги премахнете?";
+
+/* Title for the discard changes confirmation dialog */
+"postSettings.discardChanges.title" = "Отмяна на промените?";
+
+/* Status text when discussion (comments) is disabled */
+"postSettings.discussion.closed" = "Затворена";
+
+/* Label for the discussion settings field in Post Settings */
+"postSettings.discussion.label" = "Дискусия";
+
+/* Status text when discussion (comments) is enabled */
+"postSettings.discussion.open" = "Отваряне";
+
+/* Label for the checkbox that lets you send a post to newsletter subscribers */
+"postSettings.emailToSubscribers.label" = "Имейл към абонатите";
+
+/* Character count for excerpt. %1$d is the number of characters. */
+"postSettings.excerpt.characterCount" = "%1$d символа";
+
+/* Button to generate an excerpt using AI */
+"postSettings.excerpt.generateButton" = "Генериране";
+
+/* Character count display. %d is replaced with the number of characters. */
+"postSettings.excerpt.generator.characterCount" = "%d символа";
+
+/* Button to suggest (generate) more options */
+"postSettings.excerpt.generator.generateMore" = "Препоръчване на още опции";
+
+/* Label for the length picker section */
+"postSettings.excerpt.generator.length" = "Дължина";
+
+/* Accessibility label for the length adjustment slider */
+"postSettings.excerpt.generator.lengthSlider" = "Плъзгач за дължина";
+
+/* Button to make excerpts longer */
+"postSettings.excerpt.generator.longer" = "По-дълъг";
+
+/* Label for excerpt option number. %d is replaced with the option number. */
+"postSettings.excerpt.generator.option" = "Настройка %d";
+
+/* Title shown when ready to generate excerpts */
+"postSettings.excerpt.generator.ready" = "Готов за генериране";
+
+/* Description shown when ready to generate excerpts */
+"postSettings.excerpt.generator.readyDescription" = "Опции за създаване на откъс с ИИ.";
+
+/* Button to make excerpts shorter */
+"postSettings.excerpt.generator.shorter" = "По-кратък";
+
+/* Title for the style picker section */
+"postSettings.excerpt.generator.style" = "Стил на текста";
+
+/* Label for the style picker section */
+"postSettings.excerpt.generator.styleLabel" = "Стил";
+
+/* Accessibility label for the style picker */
+"postSettings.excerpt.generator.stylePicker" = "Стил";
+
+/* Title for the excerpt generator popover */
+"postSettings.excerpt.generator.title" = "Създаване на откъс";
+
+/* Section header for Excerpt in Post Settings */
+"postSettings.excerpt.header" = "Откъс";
+
+/* Placeholder text for the excerpt field in Post Settings */
+"postSettings.excerpt.placeholder" = "Напишете кратко обобщение на публикацията за показване в индекси, архиви и резултати от търсене.";
+
+/* Word count for excerpt. %1$d is the number of words. */
+"postSettings.excerpt.wordCount" = "%1$d думи";
+
+/* Cancel upload button in Post Settings / Featured Image cell */
+"postSettings.featuredImage.cancelUpload" = "Спиране на качването";
+
+/* Section header for Featured Image in Post Settings */
+"postSettings.featuredImage.header" = "Основно изображение";
+
+/* Replace image upload button in Post Settings / Featured Image cell */
+"postSettings.featuredImage.replaceImage" = "Замяна";
+
+/* Button in Post Settings */
+"postSettings.featuredImage.setFeaturedImageButton" = "Задаване на основно изображение";
+
+/* Snackbar title */
+"postSettings.featuredImage.uploadFailed" = "Неуспешно качване на основно изображение";
+
+/* Post Settings */
+"postSettings.featuredImage.uploading" = "Качва се...";
+
+/* Label for the last edited field in Post Settings */
+"postSettings.lastEdited.label" = "Последна редакция";
+
+/* Section header for Info in Post Settings */
+"postSettings.metadata.header" = "Информация";
+
+/* Section header for More Options in Post Settings. Should use the same translation as core WP. */
+"postSettings.moreOptions.header" = "Повече настройки";
+
+/* The title of the Page Settings screen. */
+"postSettings.navigationTitle.page" = "Настройки на страницата";
+
+/* The title of the Post Settings screen. */
+"postSettings.navigationTitle.post" = "Настройки на публикацията";
+
+/* Label for the Organization area (categories, keywords, ...) in post settings. */
+"postSettings.organization.header" = "Организация";
+
+/* Message when trying to save a deleted page */
+"postSettings.pageDeleted.message" = "Страницата е изтрита и не може да се запише.";
+
+/* Title of alert when trying to save a deleted page */
+"postSettings.pageDeleted.title" = "Страницата е изтрита";
+
+/* Label for the parent page field */
+"postSettings.parentPage.label" = "Родителска страница";
+
+/* Cell title for the Top Level option case */
+"postSettings.parentPage.topLevel" = "Най-високо ниво";
+
+/* Accessibility label for hide password button */
+"postSettings.passwordEntry.hidePassword" = "Скриване на паролата";
+
+/* Instructions for password entry */
+"postSettings.passwordEntry.instructions" = "Въведете парола за защита на публикацията. Само гости с парола ще могат да я видят.";
+
+/* Navigation title for password entry screen */
+"postSettings.passwordEntry.navigationTitle" = "Въведете парола";
+
+/* Placeholder for password field */
+"postSettings.passwordEntry.placeholder" = "Въвеждане на парола";
+
+/* Accessibility label for show password button */
+"postSettings.passwordEntry.showPassword" = "Показване на паролата";
+
+/* Label for the pending review toggle in Post Settings */
+"postSettings.pendingReview.label" = "Очакваща преглед";
+
+/* Label for the permalink field in Post Settings */
+"postSettings.permalink.label" = "Постоянна връзка";
+
+/* Message when trying to save a deleted post */
+"postSettings.postDeleted.message" = "Публикацията е изтрита и не може да се запише.";
+
+/* Title of alert when trying to save a deleted post */
+"postSettings.postDeleted.title" = "Публикацията е изтрита";
+
+/* Label for the post format field. Should be the same as WP core. */
+"postSettings.postFormat.label" = "Формат на публикацията";
+
+/* Label for the post ID field in Post Settings */
+"postSettings.postID.label" = "ID";
+
+/* Label for the publish date field in Post Settings */
+"postSettings.publishDate.label" = "Дата";
+
+/* Placeholder value for a publishing date in the prepublishing sheet when the date is not selected */
+"postSettings.publishDateImmediately" = "Веднага";
+
+/* Section header for General settings in Post Settings */
+"postSettings.section.general" = "Основни";
+
+/* Description text explaining what the slug editor does */
+"postSettings.slug.customizeDescription" = "Настройте последната част от постоянната връзка";
+
+/* Hint text for the slug field. Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso. */
+"postSettings.slug.hint" = "Краткото име е версия на заглавието, подходяща за уеб адрес.";
+
+/* Label for the slug field. Should be the same as WP core. */
+"postSettings.slug.label" = "Кратко име";
+
+/* Button text to learn more about permalinks */
+"postSettings.slug.learnMore" = "Научете повече";
+
+/* Label for the slug field. Should be the same as WP core. */
+"postSettings.slug.navigationTitle" = "Кратко име";
+
+/* Notice shown when the post doesn't have a remote and permalink template is missing */
+"postSettings.slug.permalinkDraftNotice" = "Предложената постоянна връзка ще се появи, когато черновата се запише";
+
+/* Label for the permalink preview */
+"postSettings.slug.permalinkLabel" = "Постоянна връзка";
+
+/* Section title for the permalink preview */
+"postSettings.slug.permalinkSection" = "Постоянна връзка";
+
+/* Placeholder for the slug field */
+"postSettings.slug.placeholder" = "Въвеждане на кратко име";
+
+/* Label for the preview button in Post Settings */
+"postSettings.socialSharing.header" = "Споделяне в социалните мрежи";
+
+/* Label for the status field in Post Settings */
+"postSettings.status.label" = "Състояние";
+
+/* Navigation title for status picker */
+"postSettings.statusPicker.navigationTitle" = "Състояние и видимост";
+
+/* Label showing the current password */
+"postSettings.statusPicker.passwordLabel" = "Парола";
+
+/* Toggle label for password protection */
+"postSettings.statusPicker.passwordProtected" = "Защитена с парола";
+
+/* Subtitle for password protected toggle */
+"postSettings.statusPicker.passwordProtectedSubtitle" = "Видима с парола";
+
+/* Label for schedule date row */
+"postSettings.statusPicker.scheduleDate" = "Дата";
+
+/* Toggle label for sticky posts */
+"postSettings.statusPicker.sticky" = "Залепена";
+
+/* Subtitle for sticky toggle */
+"postSettings.statusPicker.stickySubtitle" = "Залепете тази публикация в горната част на блога";
+
+/* Label for the sticky post toggle. Sticky posts are displayed at the top of the blog. */
+"postSettings.stickyPost.label" = "Залепена";
+
+/* Label for the add tags button field. Should be the same as WP core. */
+"postSettings.tags.addTagsButton" = "Добавяне на етикети";
+
+/* Label for the tags field. Should be the same as WP core. */
+"postSettings.tags.label" = "Етикети";
+
+/* Label for the tag suggestions section. */
+"postSettings.tags.suggestions" = "Препоръчани етикети";
+
+/* Label for the visibility field in Post Settings */
+"postSettings.visibility.label" = "Видимост";
+
+/* Navigation bar title of the Post Stats screen */
+"postStats.title" = "Статистика за публикации";
+
+/* Post status title */
+"postStatus.deleted.details" = "Изтрита завинаги";
+
+/* Post status title */
+"postStatus.deleted.title" = "Изтрита";
+
+/* Post status details */
+"postStatus.draft.details" = "Не е готово за публикуване";
+
+/* Post status title */
+"postStatus.draft.title" = "Чернова";
+
+/* Post status details */
+"postStatus.pending.details" = "Изчаква одобрение преди публикуване";
+
+/* Post status title */
+"postStatus.pending.title" = "Изчаква одобрение";
+
+/* Post status details */
+"postStatus.private.details" = "Видимо само за администратори и редактори";
+
+/* Post status title */
+"postStatus.private.title" = "Лична";
+
+/* Post status details */
+"postStatus.published.details" = "Видима за всички";
+
+/* Post status title */
+"postStatus.published.title" = "Публикувана";
+
+/* Post status details */
+"postStatus.scheduled.details" = "Автоматично публикуване на избрана дата";
+
+/* Post status title */
+"postStatus.scheduled.title" = "Планирана";
+
+/* Post status title */
+"postStatus.trash.details" = "В кошчето, но не изтрита";
+
+/* Post status title */
+"postStatus.trash.title" = "Изтрита";
+
+/* Button to add a new taxonomy term. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.addTag" = "Добавяне на %1$@";
+
+/* Placeholder text for the taxonomy search field. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.searchOrAdd.placeholder" = "Търсене или добавяне на %1$@";
+
+/* Message shown when no taxonomy terms are selected. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.selectionEmpty" = "Няма избрани %1$@";
+
+/* Button cancel */
+"postVisibilityPicker.cancel" = "Отказ";
+
+/* Navigation bar title for the Post Visibility picker */
+"postVisibilityPicker.navigationTitle" = "Видимост";
+
+/* Password placeholder text */
+"postVisibilityPicker.password" = "Парола";
+
+/* Button save */
+"postVisibilityPicker.save" = "Запис";
+
+/* Promote the post with Blaze. */
+"posts.blaze.actionTitle" = "Реклама с Blaze";
+
+/* Label for post comments option. Tapping displays comments for a post. */
+"posts.comments.actionTitle" = "Коментари";
+
+/* Label for the delete post option. Tapping permanently deletes a post. */
+"posts.delete.actionTitle" = "Изтриване завинаги";
+
+/* Label for an option that moves a post to the draft folder */
+"posts.draft.actionTitle" = "Промяна като чернова";
+
+/* Label for post duplicate option. Tapping creates a copy of the post. */
+"posts.duplicate.actionTitle" = "Дублиране";
+
+/* Opens a submenu for page attributes. */
+"posts.pageAttributes.actionTitle" = "Атрибути на страницата";
+
+/* Label for the preview post button. Tapping displays the post as it appears on the web. */
+"posts.preview.actionTitle" = "Преглед";
+
+/* Label for the publish post button. */
+"posts.publish.actionTitle" = "Публикуване";
+
+/* Set the selected page as the homepage. */
+"posts.setHomepage.actionTitle" = "Да е заглавна страница";
+
+/* Set the selected page as a posts page. */
+"posts.setPostsPage.actionTitle" = "Да е страница с публикации";
+
+/* Set the selected page as a regular page. */
+"posts.setRegularPage.actionTitle" = "Да е нормална страница";
+
+/* Label for post settings option. Tapping displays settings for a post. */
+"posts.settings.actionTitle" = "Настройки";
+
+/* Label for post stats option. Tapping displays statistics for a post. */
+"posts.stats.actionTitle" = "Статистика";
+
+/* Label for a option that moves a post to the trash folder */
+"posts.trash.actionTitle" = "Преместване в кошчето";
+
+/* Label for the view post button. Tapping displays the post as it appears on the web. */
+"posts.view.actionTitle" = "Преглед";
+
+/* Menu option for filtering posts by everyone */
+"postsList.postsByEveryone" = "Публикации от всички";
+
+/* Menu option for filtering posts by me */
+"postsList.postsByMe" = "Мои публикации";
+
+/* Title for the button to subscribe to Jetpack Social on the remaining shares view */
+"postsettings.social.remainingshares.subscribe" = "Абонирайте се, за да споделите още";
+
+/* The second half of the remaining social shares a user has. This is only displayed when there is no social limit warning. */
+"postsettings.social.remainingshares.text.part" = " в следващите 30 дни";
+
+/* Beginning text of the remaining social shares a user has left. %1$d is their current remaining shares. This text is combined with ' in the next 30 days' if there is no warning displayed. */
+"postsettings.social.shares.text.format" = "%1$d споделяния остават";
+
+/* Label for a cell in the pre-publishing sheet */
+"prepublishing.categories" = "Категории";
+
+/* Button to confirm discarding changes */
+"prepublishing.discardChanges.button" = "Отмяна на промените";
+
+/* Message for the discard changes confirmation dialog */
+"prepublishing.discardChanges.message" = "Има незапазени промени в настройките на публикацията. Сигурни ли сте, че искате да ги премахнете?";
+
+/* Title for the discard changes confirmation dialog */
+"prepublishing.discardChanges.title" = "Отмяна на промените?";
+
+/* Label for a cell in the pre-publishing sheet */
+"prepublishing.jetpackSocial" = "Jetpack Social";
+
+/* Details for a publish button state in the pre-publishing sheet; count as a parameter */
+"prepublishing.mediaUploadFailedDetails" = "%@ елемента не се качиха";
+
+/* Title for a publish button state in the pre-publishing sheet */
+"prepublishing.mediaUploadFailedTitle" = "Неуспешно качване на файл";
+
+/* Primary button label in the pre-publishing sheet */
+"prepublishing.publish" = "Публикуване";
+
+/* Label for a cell in the pre-publishing sheet */
+"prepublishing.publishDate" = "Дата на публикуване";
+
+/* Placeholder value for a publishing date in the prepublishing sheet when the date is not selected */
+"prepublishing.publishDateImmediately" = "Веднага";
+
+/* The title of the top section that shows the site your are publishing to. Default is 'Ready to Publish?' */
+"prepublishing.publishingSectionTitle" = "Готово за публикуване?";
+
+/* Label in the header in the pre-publishing sheet */
+"prepublishing.publishingTo" = "Публикуване в";
+
+/* Button to confirm discarding changes */
+"prepublishing.saveChanges.button" = "Запазване на промените";
+
+/* Primary button label in the pre-publishing shee */
+"prepublishing.schedule" = "Планиране";
+
+/* The primary label for the auto-sharing row on the pre-publishing sheet.
+Indicates the number of social accounts that will be sharing the blog post.
+%1$d is a placeholder for the number of social network accounts that will be auto-shared.
+Example: Sharing to 3 accounts */
+"prepublishing.social.label.multipleConnections" = "Споделяне в %1$d профила";
+
+/* The primary label for the auto-sharing row on the pre-publishing sheet.
+Indicates the blog post will not be shared to any social accounts. */
+"prepublishing.social.label.notSharing" = "Да не се споделя";
+
+/* The primary label for the auto-sharing row on the pre-publishing sheet.
+Indicates the number of social accounts that will be sharing the blog post.
+This string is displayed when some of the social accounts are turned off for auto-sharing.
+%1$d is a placeholder for the number of social media accounts that will be sharing the blog post.
+%2$d is a placeholder for the total number of social media accounts connected to the user's blog.
+Example: Sharing to 2 of 3 accounts */
+"prepublishing.social.label.partialConnections" = "Споделяне в %1$d от %2$d профила";
+
+/* The primary label for the auto-sharing row on the pre-publishing sheet.
+Indicates the blog post will be shared to a social media account.
+%1$@ is a placeholder for the account name.
+Example: Sharing to @wordpress */
+"prepublishing.social.label.singleConnection" = "Споделяне в %1$@";
+
+/* A subtext that's shown below the primary label in the auto-sharing row on the pre-publishing sheet.
+Informs the remaining limit for post auto-sharing.
+%1$d is a placeholder for the remaining shares.
+Example: 27 social shares remaining */
+"prepublishing.social.remainingShares.format" = "%1$d споделяния остават";
+
+/* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
+"prepublishing.social.warningIcon.accessibilityHint" = "Предупреждение";
+
+/* The navigation title for a screen that edits the sharing message for the post. */
+"prepublishing.socialAccounts.editMessage.navigationTitle" = "Настройте съобщението";
+
+/* The label for a call-to-action button in the social accounts' footer section. */
+"prepublishing.socialAccounts.footer.button.text" = "Абонирайте се, за да споделяте повече";
+
+/* Text shown below the list of social accounts to indicate how many social shares available for the site.
+Note that the '30 days' part is intended to be a static value.
+%1$d is a placeholder for the amount of remaining shares.
+Example: 27 social shares remaining in the next 30 days */
+"prepublishing.socialAccounts.footer.remainingShares.text" = "%1$d оставащи споделяния за следващите 30 дни";
+
+/* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
+"prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "Предупреждение";
+
+/* Table section title */
+"prepublishing.socialAccounts.message.label" = "Съобщение";
+
+/* Placeholder text for the message field in Social Sharing */
+"prepublishing.socialAccounts.messagePlaceholder" = "Добавете кратко съобщение за споделяне в социалните медии към публикацията";
+
+/* The navigation title for the pre-publishing social accounts screen. */
+"prepublishing.socialAccounts.navigationTitle" = "Социални";
+
+/* Table section title */
+"prepublishing.socialAccounts.servicesSectionTitle" = "Услуги";
+
+/* Label for a cell in the pre-publishing sheet */
+"prepublishing.tags" = "Етикети";
+
+/* Navigation title */
+"prepublishing.title" = "Публикуване";
+
+/* Details label for a publish button state in the pre-publishing sheet */
+"prepublishing.uploadMediaManyItemsRemaining" = "%@ елемента остават";
+
+/* Details label for a publish button state in the pre-publishing sheet */
+"prepublishing.uploadMediaOneItemRemaining" = "остава %@ елемент";
+
+/* Title for a publish button state in the pre-publishing sheet */
+"prepublishing.uploadingMedia" = "Качване на файл";
+
+/* Label for a cell in the pre-publishing sheet */
+"prepublishing.visibility" = "Видимост";
+
+/* An error message displayed when attempting to update their profile while the user's email address is not verified. */
+"profile.update.email.verification.required" = "За да обновите профила си, трябва да потвърдите имейла си първо.";
+
+/* Caption displayed in promotional screens shown during the login flow. */
+"prologue.title.reader" = "Абонирайте се за любимите сайтове и открийте нови блогове.";
+
+/* Title for a tappable string that opens the reader with a prompts tag */
+"prompts.card.viewprompts.title" = "Всички отговори";
+
+/* Post publish date picker title for date cell */
+"publishDatePicker.date" = "Дата на публикуване";
+
+/* Post publish date picker footer view when the selected date time zone is different from your current time zone; followed by the time in the current time zone. */
+"publishDatePicker.footerCurrentTimezone" = "Дата във вашата часова зона:";
+
+/* Post publish date picker: selected value placeholder when no date is selected and the post will be published immediately */
+"publishDatePicker.immediately" = "Веднага";
+
+/* Post publish time zone cell title */
+"publishDatePicker.timeZone" = "Часова зона";
+
+/* Post publish date picker */
+"publishDatePicker.title" = "Дата на публикуване";
+
+/* Post publish success view: button 'Done' */
+"publishSuccessView.done" = "Готово";
+
+/* Post publish success view: button 'Promote with Blaze' */
+"publishSuccessView.promoteWithBlaze" = "Реклама с Blaze";
+
+/* Post publish success view: button 'Share post' */
+"publishSuccessView.share" = "Споделяне на публикация";
+
+/* Post publish success view: title */
+"publishSuccessView.title" = "Публикацията е публикувана!";
+
+/* Post publish success view: button 'View post' */
+"publishSuccessView.view" = "Преглед на публикацията";
+
+/* Informational notice title. Showed when you scan a code using a camera app outside of the app, which is not allowed. */
+"qrLogin.codeHasToBeScannedFromTheAppNotice.title" = "Сканирайте кода с приложението";
+
+/* Button label that dismisses the qr log in flow and returns the user back to the previous screen */
+"qrLoginVerifyAuthorization.completedInstructions.dismiss" = "Отмяна";
+
+/* Subtitle instructing the user to tap the dismiss button to leave the log in flow. %@ is a placeholder for the dismiss button name. */
+"qrLoginVerifyAuthorization.completedInstructions.subtitle" = "Докоснете '%@' и се върнете в браузъра за да продължите.";
+
+/* Title for the success view when the user has successfully logged in */
+"qrLoginVerifyAuthorization.completedInstructions.title" = "Влезли сте!";
+
+/* No comment provided by engineer. */
+"reachability-utils.alert.cancel" = "ОК";
+
+/* No comment provided by engineer. */
+"reachability-utils.alert.retry" = "Отново?";
+
+/* No comment provided by engineer. */
+"reachability-utils.alert.title" = "Няма връзка";
+
+/* Message of error prompt shown when no internet connection is available */
+"reachability-utils.alert.utils" = "Няма връзка с Интернет";
+
+/* Navigation title */
+"reader.article.summary" = "Обобщение";
+
+/* Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog. */
+"reader.blocked.blog.message" = "Блогът %@ вече няма да се показва при четене. Докоснете за отмяна.";
+
+/* The formatted number of posts and followers for a site. '%1$@' is a placeholder for the blog post count. '%2$@' is a placeholder for the blog subscriber count. Example: `5,000 posts • 10M subscribers` */
+"reader.blog.header.values" = "%1$@ публикации • %2$@ абоната";
+
+/* Error message title informing the user that a search for sites in the Reader could not be loaded. */
+"reader.blog.search.loading.error" = "Проблем при зареждането на блогове";
+
+/* A brief prompt when the user is searching for blogs in the Reader. */
+"reader.blog.search.loading.title" = "Зареждане на блогове...";
+
+/* Message shown when the reader finds no blogs for the specified search phrase. The %@ is a placeholder for the search phrase. */
+"reader.blog.search.no.results.message.format" = "Не са открити блогове за %@ на вашия език.";
+
+/* A message title */
+"reader.blog.search.no.results.title" = "Няма намерени блогове";
+
+/* A shared button title for Reader */
+"reader.button.addToFavorites" = "Добавяне към любими";
+
+/* A shared button title for Reader */
+"reader.button.notificationSettings" = "Настройки на известията";
+
+/* A shared button title for Reader */
+"reader.button.removeFromFavorites" = "Премахване от любими";
+
+/* A shared button title for Reader */
+"reader.button.subscribe" = "Абониране";
+
+/* Reader sidebar button title */
+"reader.button.unfollow" = "Спиране на следването";
+
+/* A shared button title for Reader */
+"reader.button.unsubscribe" = "Спиране на абонамент";
+
+/* Button title. Follow the comments on a post. */
+"reader.comments.buttonFollow" = "Следване";
+
+/* Informational message, should be short. */
+"reader.comments.commentsClosed" = "Коментарите са забранени";
+
+/* Empty state view title */
+"reader.comments.emptyStateTitle" = "Коментирайте първи.";
+
+/* Empty state view title */
+"reader.comments.errorLoadingComments" = "Неочаквана грешка при зареждане на коментарите.";
+
+/* VoiceOver hint */
+"reader.comments.followingSettingAccessibilityIdentifier" = "Отваряне на настройките за известия на публикацията";
+
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"reader.comments.noPermissionToViewPrivateBlog" = "Нямате права за преглед на този затворен блог";
+
+/* Navigation title */
+"reader.comments.title" = "Коментари";
+
+/* Accessibility hint to inform that the author section can be tapped to see posts from the site. */
+"reader.detail.header.authorInfo.a11y.hint" = "Вижте публикациите от сайта";
+
+/* Plural format string for displaying the number of post likes. %1$d is the number of likes. The underscores denote underline and is not displayed. */
+"reader.detail.likes.plural" = "_%1$d харесвания_";
+
+/* Describes that only one user likes a post. The underscores denote underline and is not displayed. */
+"reader.detail.likes.single" = "_1 харесване_";
+
+/* Title for the Comment button on the Reader Detail toolbar.
+Note: Since the display space is limited, a short or concise translation is preferred. */
+"reader.detail.toolbar.comment.button" = "Коментар";
+
+/* Title for the Like button in the Reader Detail toolbar.
+This is shown when the user has not liked the post yet.
+Note: Since the display space is limited, a short or concise translation is preferred. */
+"reader.detail.toolbar.like.button" = "Харесване";
+
+/* Accessibility hint for the Like button state. The button shows that the user has not liked the post,
+but tapping on this button will add a Like to the post. */
+"reader.detail.toolbar.like.button.a11y.hint" = "Харесва публикацията.";
+
+/* Title for the Like button in the Reader Detail toolbar.
+This is shown when the user has already liked the post.
+Note: Since the display space is limited, a short or concise translation is preferred. */
+"reader.detail.toolbar.liked.button" = "Харесано";
+
+/* Accessibility hint for the Liked button state. The button shows that the user has liked the post,
+but tapping on this button will remove their like from the post. */
+"reader.detail.toolbar.liked.button.a11y.hint" = "От-харесва публикацията";
+
+/* Accessibility hint for the 'Save Post' button. */
+"reader.detail.toolbar.save.button.a11y.hint" = "Запомня публикацията за по-късно.";
+
+/* Accessibility label for the 'Save Post' button. */
+"reader.detail.toolbar.save.button.a11y.label" = "Запомни публикацията";
+
+/* Accessibility hint for the 'Save Post' button when a post is already saved. */
+"reader.detail.toolbar.saved.button.a11y.hint" = "Отменя запазването";
+
+/* Accessibility label for the 'Save Post' button when a post has been saved. */
+"reader.detail.toolbar.saved.button.a11y.label" = "Запазена публикация";
+
+/* Header view channel (filter) */
+"reader.discover.channel.dailyPrompts" = "Предизвикателства";
+
+/* Header view channel (filter) */
+"reader.discover.channel.firstPost" = "Първи публикации";
+
+/* Header view channel (filter) */
+"reader.discover.channel.latest" = "Последни";
+
+/* Header view channel (filter) */
+"reader.discover.channel.recommended" = "Препоръчани";
+
+/* Reader Discover header view details label. The text has a Markdown URL: [interests](/interests). Only the text in the square brackets needs to be translated: [<translate_this>](/interests). */
+"reader.discover.header.title" = "Разгледайте популярни блогове, които вдъхновяват, забавляват и обучават, базирано на вашите [интереси](\/interests).";
+
+/* Used in multiple contexts, usually as a screen title */
+"reader.discover.title" = "Откривател";
+
+/* Screen title */
+"reader.editInterests.title" = "Редактиране на интереси";
+
+/* Error message informing the user that they are already following a blog in their reader. */
+"reader.error.already.subscribed.message" = "Вече сте абониран за този блог.";
+
+/* VoiceOver accessibility hint, informing the user the button can be used to follow a tag. */
+"reader.follow.button.accessibility.hint" = "Следване на етикет";
+
+/* Reader screen title for follow conversation settings */
+"reader.followConversationSettings.title" = "Настройки за разговорите";
+
+/* Screen header details */
+"reader.following.header.details" = "Следвайте блоговете, за които сте абониран.";
+
+/* Empty state view */
+"reader.following.lists.emptyTitle" = "Списъците са празни";
+
+/* Screen header details */
+"reader.home.header.details" = "Следвайте блоговете, за които сте абониран.";
+
+/* Used in multiple contexts, usually as a screen title */
+"reader.home.title" = "Начало";
+
+/* Used in multiple contexts, usually as a screen title */
+"reader.library.title" = "Библиотека";
+
+/* Used in multiple contexts, usually as a screen title */
+"reader.likes.title" = "Харесвания";
+
+/* Used in multiple contexts, usually as a screen title */
+"reader.lists.title" = "Списъци";
+
+/* Reader logged-out screen details */
+"reader.loggedOut.details" = "Влезте с WordPress.com профил, за да следвате любимите си блогове";
+
+/* Reader logged-out screen sign in button */
+"reader.loggedOut.signIn" = "Вход";
+
+/* Reader logged-out screen title */
+"reader.loggedOut.title" = "Включете се в разговора";
+
+/* Title for button on the no followed blogs result screen */
+"reader.no.blogs.button" = "Откриване на блогове";
+
+/* Subtitle for the no followed blogs result screen */
+"reader.no.blogs.subtitle" = "Абонирайте се за блогове и ще видите последните им публикации тук. Потърсете и блогове, които вече харесвате.";
+
+/* Title for the no followed blogs result screen */
+"reader.no.blogs.title" = "Няма абонаменти за блогове";
+
+/* Message shown when the reader finds no posts for the chosen blog */
+"reader.no.results.blog.response.message" = "Този сайт няма публикации. Опитайте по-късно.";
+
+/* Message shown when the reader finds no posts for the chosen list */
+"reader.no.results.list.response.message" = "Сайтовете в този списък нямат скорошни публикации.";
+
+/* A message explaining the Following topic in the reader */
+"reader.no.results.response.message" = "Най-новите публикации от блоговете и сайтовете, за които сте абонирани, ще се показват тук.";
+
+/* Notice title when blocking a blog fails. */
+"reader.notice.blog.blocked.failure" = "Неуспешно блокиране";
+
+/* Notice title when blocking a site succeeds. */
+"reader.notice.blog.blocked.success" = "Блокиран блог";
+
+/* Title of a prompt. */
+"reader.notice.blog.unsubscribed.error" = "Неуспешно премахване на абонамент";
+
+/* Notice title when turning blog notifications off fails. */
+"reader.notice.disable.notification.failure" = "Неуспешно изключване на известията на блога";
+
+/* Notice title when turning blog notifications off succeeds. */
+"reader.notice.disable.notification.success" = "Известията за блога са изключени";
+
+/* Notice title when turning blog notifications on fails. */
+"reader.notice.enable.notification.failure" = "Неуспешно включване на известията за блога";
+
+/* Message prompting user to enable blog notifications. */
+"reader.notice.enable.notification.prompt" = "Включване на известията?";
+
+/* Notice title when turning blog notifications on succeeds. */
+"reader.notice.enable.notification.success" = "Известията са включени";
+
+/* A default value used to fill in the site name when the followed site somehow has missing site name or URL.
+Example: given a notice format "Following %@" and empty site name, this will be "Following this blog". */
+"reader.notice.subscribe.blog.unknown" = "този блог";
+
+/* Notice title when subscribing to a blog fails. */
+"reader.notice.subscribe.failure" = "Неуспешен абонамент към блога";
+
+/* Notice title when following a blog succeeds. %1$@ is a placeholder for the site name. */
+"reader.notice.subscribe.success" = "Абонирани за %1$@";
+
+/* Notice title when unsubscribing to a blog fails. */
+"reader.notice.unsubscribe.failure" = "Неуспешно абониране за блога";
+
+/* Notice title when unfollowing a blog succeeds. */
+"reader.notice.unsubscribe.success" = "Абонаментът е прекратен";
+
+/* Notice title when blocking a user fails. */
+"reader.notice.user.blocked" = "reader.notice.user.block.failed";
+
+/* Button accessibility label */
+"reader.post.buttonBookmark.accessibilityLabel" = "Отметка";
+
+/* Button accessibility label */
+"reader.post.buttonComment.accessibilityLabel" = "Показване на коментарите";
+
+/* Button accessibility label */
+"reader.post.buttonLike.accessibilityLabel" = "Харесване";
+
+/* Button accessibility label */
+"reader.post.buttonReblog.accessibilityLabel" = "Реблог";
+
+/* Button accessibility label */
+"reader.post.buttonRemoveBookmark.accessibilityLint" = "Премахване на отметката";
+
+/* Button accessibility label */
+"reader.post.buttonRemoveLike.accessibilityLabel" = "Премахване на харесване";
+
+/* Accessibility hint for the site header */
+"reader.post.buttonSite.accessibilityHint" = "Отваря подробностите за сайта";
+
+/* Button accessibility label */
+"reader.post.moreMenu.accessibilityLabel" = "Още действия";
+
+/* Accessibility label showing total number of comments */
+"reader.post.numberOfComments.accessibilityLabel" = "%@ коментара";
+
+/* Accessibility label showing total number of likes */
+"reader.post.numberOfLikes.accessibilityLabel" = "%@ харесвания";
+
+/* Context menu action */
+"reader.postContextMenu.blockOrReportMenu" = "Блокиране или докладване";
+
+/* Context menu action */
+"reader.postContextMenu.blockSite" = "Блокиране на сайта";
+
+/* Context menu action */
+"reader.postContextMenu.blockUser" = "Блокиране на потребителя";
+
+/* Context menu action (placeholder value when blog name not available – should never happen) */
+"reader.postContextMenu.blogDetails" = "Подробности за блога";
+
+/* Context menu action */
+"reader.postContextMenu.manageNotifications" = "Управление на известията";
+
+/* Context menu action */
+"reader.postContextMenu.markRead" = "Прочетено";
+
+/* Context menu action */
+"reader.postContextMenu.markUnread" = "Маркирай непрочетено";
+
+/* Context menu action */
+"reader.postContextMenu.reportPost" = "Докладване на публикация";
+
+/* Context menu action */
+"reader.postContextMenu.reportUser" = "Докладване на потребител";
+
+/* Context menu action */
+"reader.postContextMenu.showBlog" = "Към блога";
+
+/* Context menu action */
+"reader.postContextMenu.summarize" = "Обобщение";
+
+/* Context menu action */
+"reader.postContextMenu.viewInBrowser" = "Преглед в браузъра";
+
+/* Reader post details view placeholder when blog name not avail */
+"reader.postDetails.blog" = "блог";
+
+/* Button title */
+"reader.postDetails.viewFullPost" = "Преглед на цялата публикация";
+
+/* Reader post details view */
+"reader.postDetails.viewModeDescription" = "Собственикът на блога показва единствено откъс от тяхното съдържание. Трябва да посетите сайта им за пълната публикация.";
+
+/* Name for the Candy color theme, used in the Reader's reading preferences. */
+"reader.preferences.color.candy" = "Бонбон";
+
+/* Name for the Default color theme, used in the Reader's reading preferences. */
+"reader.preferences.color.default" = "По подразбиране";
+
+/* Name for the Evening color theme, used in the Reader's reading preferences. */
+"reader.preferences.color.evening" = "Вечер";
+
+/* Name for the h4x0r color theme, used in the Reader's reading preferences. */
+"reader.preferences.color.h4x0r" = "h4x0r";
+
+/* Name for the OLED color theme, used in the Reader's reading preferences. */
+"reader.preferences.color.oled" = "OLED";
+
+/* Name for the Sepia color theme, used in the Reader's reading preferences. */
+"reader.preferences.color.sepia" = "Сепия";
+
+/* Name for the Soft color theme, used in the Reader's reading preferences. */
+"reader.preferences.color.soft" = "Мек";
+
+/* Accessibility label describing the list of colors to be selected from. */
+"reader.preferences.control.colors.a11y" = "Цветове";
+
+/* Title for a button to save and apply the customized Reader Preferences settings when tapped. */
+"reader.preferences.control.doneButton" = "Готово";
+
+/* Accessibility label describing the list of fonts to be selected from. */
+"reader.preferences.control.fonts.a11y" = "Шрифтове";
+
+/* Describes that the slider is used to customize the text size in the Reader. */
+"reader.preferences.control.sizeSlider.description" = "Размер";
+
+/* Text for a small label in the navigation bar that hints that this is an experimental feature.
+
+The enclosing angled brackets ('<' and '>') are decorative and only intended as a flavor.
+Feel free to replace it with other bracket types that you think looks better for the locale. */
+"reader.preferences.navBar.experimental.label" = "<Experimental>";
+
+/* Description text for the preview section of Reader Preferences */
+"reader.preferences.preview.body.text" = "Избор на цветове, шрифтове и размери. Прегледайте избора и прочетете на публикациите с вашите стилове, след като сте готови.";
+
+/* Title text for a preview */
+"reader.preferences.preview.header" = "Предпочитания за четене";
+
+/* Example tag for preview */
+"reader.preferences.preview.tags.colors" = "цветове";
+
+/* Example tag for preview */
+"reader.preferences.preview.tags.fonts" = "шрифтове";
+
+/* Example tag for preview */
+"reader.preferences.preview.tags.reading" = "четене";
+
+/* Accessibility label for a list of tags in the preview section. */
+"reader.preferences.preview.tagsList.a11y" = "Примерни етикети";
+
+/* Accessibility label for the Extra Large size option, used in the Reader's reading preferences. */
+"reader.preferences.size.extraLarge" = "Много голям";
+
+/* Accessibility label for the Extra Small size option, used in the Reader's reading preferences. */
+"reader.preferences.size.extraSmall" = "Много малък";
+
+/* Accessibility label for the Large size option, used in the Reader's reading preferences. */
+"reader.preferences.size.large" = "Голям";
+
+/* Accessibility label for the Normal size option, used in the Reader's reading preferences. */
+"reader.preferences.size.normal" = "Нормален";
+
+/* Accessibility label for the Small size option, used in the Reader's reading preferences. */
+"reader.preferences.size.small" = "Малък";
+
+/* Button title. Tapping lets the user manage the blogs they follow. */
+"reader.reblog.manage.blogs" = "Управление на блоговете";
+
+/* A subtitle with more detailed info for the user when no WordPress.com blogs could be found. */
+"reader.reblog.no.blogs.subtitle" = "След като създадете WordPress.com blog, можете да реблогвате съдържанието, което харесвате в него.";
+
+/* A short message that informs the user no WordPress.com blogs could be found. */
+"reader.reblog.no.blogs.title" = "Няма налични WordPress.com блогове";
+
+/* Used in multiple contexts, usually as a screen title */
+"reader.recent.title" = "Скорошни";
+
+/* Used in multiple contexts, usually as a screen title */
+"reader.saved.title" = "Записано";
+
+/* Notification title for when saved post is removed */
+"reader.savedPostRemovedNotificationTitle" = "Запомнената публикация е отписана";
+
+/* Reader Search */
+"reader.search.clearHistory" = "Изчистване на историята";
+
+/* Title of a Reader tab showing Sites matching a user's search query */
+"reader.search.tab.blogs" = "Блогове";
+
+/* Title of a Reader tab showing Posts matching a user's search query */
+"reader.search.tab.posts" = "Публикации";
+
+/* Title of the Reader's search feature
+   Used in multiple contexts, usually as a screen title */
+"reader.search.title" = "Търсене";
+
+/* Screen title. Reader select interests title label text. */
+"reader.select.interests.follow.title" = "Следване на етикети";
+
+/* Label displayed to the user while loading their selected interests */
+"reader.select.interests.following" = "Следване на нови етикети...";
+
+/* Reader select interests next button disabled title text */
+"reader.select.tags.continue" = "Изберете няколко за да продължите";
+
+/* Reader select interests next button enabled title text */
+"reader.select.tags.done" = "Готово";
+
+/* Label displayed to the user while loading their selected interests */
+"reader.select.tags.loading" = "Търсене на блогове и истории, които да ви харесат...";
+
+/* Message shown when there are no new topics to follow. */
+"reader.select.tags.no.results.follow.title" = "Няма нови последвани етикети";
+
+/* Reader select interests subtitle label text */
+"reader.select.tags.subtitle" = "Избор на етикети";
+
+/* Reader select interests title label text */
+"reader.select.tags.title" = "Открийте и следвайте нови любими блогове";
+
+/* Reader sidebar section title */
+"reader.sidebar.section.favorites.title" = "Любими";
+
+/* Reader sidebar section title */
+"reader.sidebar.section.library.title" = "Библиотека";
+
+/* Reader sidebar section title */
+"reader.sidebar.section.lists.title" = "Списъци";
+
+/* Reader sidebar section title */
+"reader.sidebar.section.organization.title" = "Организация";
+
+/* Reader sidebar section title */
+"reader.sidebar.section.subscriptions.title" = "Абонаменти";
+
+/* Reader sidebar button */
+"reader.sidebar.section.tags.addTag" = "Добавяне на етикет";
+
+/* Reader sidebar button */
+"reader.sidebar.section.tags.discoverTags" = "Откриване на още етикети";
+
+/* Reader sidebar section title */
+"reader.sidebar.section.tags.title" = "Етикети";
+
+/* Verb. Button title. Subscribes to a new blog. */
+"reader.subscribe.button.title" = "Абониране";
+
+/* Verb. Button title. The user is subscribed to a blog. */
+"reader.subscribed.button.title" = "Абонирано";
+
+/* Short error message */
+"reader.subscription.invalidURLError" = "Моля, въведете валиден адрес";
+
+/* Button subtitle */
+"reader.subscriptions.addSubscriptionButtonSubtitle" = "Абониране за сайтове, бюлетини и RSS фийдове";
+
+/* Button title */
+"reader.subscriptions.addSubscriptionButtonTitle" = "Добавяне на абонамент";
+
+/* Empty state details */
+"reader.subscriptions.emptyStateDetails" = "Сайтовете, които откривате и абонирате, ще се покажат тук";
+
+/* Button title for managing subscription settings */
+"reader.subscriptions.settings" = "Настройки";
+
+/* Number of subscriptions on a site (plural) */
+"reader.subscriptions.subscriptionsPlural" = "%@ абоната";
+
+/* Number of subscriptions on a site (singular) */
+"reader.subscriptions.subscriptionsSingular" = "%@ абонат";
+
+/* Used in multiple contexts, usually as a screen title */
+"reader.subscriptions.title" = "Абонаменти";
+
+/* A suggestion of topics the user might want to subscribe to */
+"reader.suggested.blogs.title" = "Блогове за абониране";
+
+/* A suggestion of topics (tags) the user might like */
+"reader.suggested.tags.title" = "Може да харесате";
+
+/* Title of a feature to add a new tag to the tags subscribed by the user. */
+"reader.tags.add.tag" = "Добавяне на етикет";
+
+/* Button Title. Tapping subscribes the user to a new tag. */
+"reader.tags.add.tag.action" = "Добавяне на етикет";
+
+/* Placeholder text. A call to action for the user to type any tag to which they would like to subscribe. */
+"reader.tags.add.tag.placeholder" = "Добавяне на етикет";
+
+/* Title of a feature to add a new tag to the tags subscribed by the user. */
+"reader.tags.add.tag.title" = "Добавяне на етикет";
+
+/* Button title. Tapping shows the Subscribe to Tags screen. */
+"reader.tags.discover.more.tags" = "Откриване на етикети";
+
+/* Title for an error snackbar */
+"reader.tags.failedToUnfollowErrorTitle" = "Темата не можа да се премахне";
+
+/* Verb. Button title. Follows a new tag. */
+"reader.tags.follow.button.title" = "Следване";
+
+/* Verb. Button title. The user is following a tag. */
+"reader.tags.following.button.title" = "Последвано";
+
+/* Used in multiple contexts, usually as a screen title */
+"reader.tags.title" = "Етикети";
+
+/* Accessibility label for unsubscribing from a tag */
+"reader.tags.unfollow.accessibility.label" = "Спиране следването на %@";
+
+/* Field title */
+"reader.userProfile.site" = "Сайт";
+
+/* Reader Welcome screen login button */
+"reader.welcome.continueText" = "Продължаване с WordPress.com";
+
+/* Reader Welcome screen */
+"reader.welcome.subtitle" = "Влезте в най-голямото общество за блогване";
+
+/* Reader app primary navigation tab bar */
+"readerApp.tabBar.discover" = "Откривател";
+
+/* Reader app primary navigation tab bar */
+"readerApp.tabBar.me" = "Аз";
+
+/* Reader app primary navigation tab bar */
+"readerApp.tabBar.notifications" = "Известия";
+
+/* Spoken accessibility label */
+"readerDetail.backButton.accessibilityLabel" = "Назад";
+
+/* Spoken accessibility label */
+"readerDetail.dismissButton.accessibilityLabel" = "Отмяна";
+
+/* Spoken accessibility label for the Reading Preferences menu. */
+"readerDetail.displaySettingButton.displaySettingsLabel" = "Настройки за четене";
+
+/* Section title for global related posts. */
+"readerDetail.globalPostsSection.accessibilityLabel" = "Още на WordPress.com";
+
+/* Section title for local related posts. %1$@ is a placeholder for the blog display name. */
+"readerDetail.localPostsSection.accessibilityLabel" = "Повече от %1$@";
+
+/* Spoken accessibility label */
+"readerDetail.moreButton.accessibilityLabel" = "Повече";
+
+/* Spoken accessibility label */
+"readerDetail.safariButton.accessibilityLabel" = "Отваряне в сафари";
+
+/* Error message that informs reader detail from a private blog cannot be fetched. */
+"readerDetailCoordinator.readerDetail.privateBlogErrorMessage" = "Нямате права за преглед на този затворен блог.";
+
+/* The button title for the transfer footer view in Register Domain screen */
+"register.domain.transfer.button.title" = "Трансфер на домейн";
+
+/* The title for the transfer footer view in Register Domain screen */
+"register.domain.transfer.title" = "Искате да трансферирате домейн, който вече притежавате?";
+
+/* Information of what related post are and how they are presented */
+"relatedPostsSettings.optionsFooter" = "Свързани публикации показва подобно съдържание от вашия сайт под публикациите.";
+
+/* Text for related post cell preview */
+"relatedPostsSettings.preview1.details" = "в \"Мобилно\"";
+
+/* Text for related post cell preview */
+"relatedPostsSettings.preview1.title" = "Има голямо обновяване за iPhone\/iPad";
+
+/* Text for related post cell preview */
+"relatedPostsSettings.preview2.details" = "в \"Приложения\"";
+
+/* Text for related post cell preview */
+"relatedPostsSettings.preview2.title" = "Подобрения в приложението на WordPress за Андроид";
+
+/* Text for related post cell preview */
+"relatedPostsSettings.preview3.details" = "в \"Обновяване\"";
+
+/* Text for related post cell preview */
+"relatedPostsSettings.preview3.title" = "Фокус на обновяването: VideoPress за сватби";
+
+/* Section title for related posts section preview */
+"relatedPostsSettings.previewsHeaders" = "Преглед";
+
+/* Label for Related Post header preview */
+"relatedPostsSettings.relatedPostsHeader" = "Свързани публикации";
+
+/* Message to show when setting save failed */
+"relatedPostsSettings.settingsUpdateFailed" = "Проблем при обновяване на настройките";
+
+/* Label for configuration switch to show/hide the header for the related posts section */
+"relatedPostsSettings.showHeader" = "Показване на заглавката";
+
+/* Label for configuration switch to enable/disable related posts */
+"relatedPostsSettings.showRelatedPosts" = "Показване на подобни публикации";
+
+/* Label for configuration switch to show/hide images thumbnail for the related posts */
+"relatedPostsSettings.showThumbnail" = "Показване на изображенията";
+
+/* Title for screen that allows configuration of your blog/site related posts settings. */
+"relatedPostsSettings.title" = "Свързани публикации";
+
+/* A version of the post on another device. */
+"resolveConflict.anotherDevice" = "Друго устройство";
+
+/* A version of the post on the current device. */
+"resolveConflict.currentDevice" = "Текущо устройство";
+
+/* Description for the Resolve Conflict screen. */
+"resolveConflict.description" = "Публикацията е променена от друго устройство. Изберете версията, която искате да запазите.";
+
+/* Title for the cancel button on the Resolve Conflict screen. */
+"resolveConflict.navigation.cancel" = "Отказ";
+
+/* Title for the save button on the Resolve Conflict screen. */
+"resolveConflict.navigation.save" = "Запис";
+
+/* Title for the Resolve Conflict screen. */
+"resolveConflict.navigation.title" = "Разрешаване на конфликт";
+
+/* Displayed when a call is made to load the history but there's no result or an error. */
+"revisions.emptyStateSubtitle" = "Когато направите промени в едитора, ще можете да видите история на версиите тук";
+
+/* Displayed when a call is made to load the revisions but there's no result or an error. */
+"revisions.emptyStateTitle" = "Няма ревизии засега";
+
+/* Post revisions list screen / loading view title */
+"revisions.loadingTitle" = "Зареждане...";
+
+/* Post revisions list screen title */
+"revisions.title" = "Версии";
+
+/* User action to dismiss media options. */
+"shareExtension.editor.attachmentActions.dismiss" = "Отмяна";
+
+/* User action to remove media. */
+"shareExtension.editor.attachmentActions.remove" = "Премахване";
+
+/* Title for action sheet with media options. */
+"shareExtension.editor.attachmentActions.title" = "Настройки за файла";
+
+/* Share extension error dialog retry button label. */
+"shareModularViewController.retryAlert.accept" = "Повторен опит";
+
+/* Share extension error dialog cancel button label. */
+"shareModularViewController.retryAlert.dismiss" = "Отмяна";
+
+/* Share extension error dialog text. */
+"shareModularViewController.retryAlert.message" = "Нещо се обърка при споделяне. Опитайте отново.";
+
+/* Share extension error dialog title. */
+"shareModularViewController.retryAlert.title" = "Грешка при споделяне";
+
+/* A shared button title used in different contexts */
+"shared.button.add" = "Добавяне";
+
+/* A shared button title used in different contexts */
+"shared.button.cancel" = "Отказ";
+
+/* A shared button title used in different contexts */
+"shared.button.clear" = "Изчистване";
+
+/* A shared button title used in different contexts */
+"shared.button.close" = "Затваряне";
+
+/* A shared button title used in different contexts */
+"shared.button.continue" = "Напред";
+
+/* A shared button title used in different contexts */
+"shared.button.copy" = "Копиране";
+
+/* A shared button title used in different contexts */
+"shared.button.copyLink" = "Копиране на връзка";
+
+/* A shared button title used in different contexts */
+"shared.button.delete" = "Изтриване";
+
+/* A shared button title used in different contexts */
+"shared.button.done" = "Готово";
+
+/* A shared button title used in different contexts */
+"shared.button.edit" = "Редакция";
+
+/* A shared button title used in different contexts */
+"shared.button.ok" = "ОК";
+
+/* A shared button title used in different contexts */
+"shared.button.remove" = "Изтриване";
+
+/* A shared button title used in different contexts */
+"shared.button.retry" = "Повторен опит";
+
+/* A shared button title used in different contexts */
+"shared.button.save" = "Запис";
+
+/* A shared button title used in different contexts (send email, send message, sent invites) */
+"shared.button.send" = "Изпращане";
+
+/* A shared button title used in different contexts */
+"shared.button.share" = "Споделяне";
+
+/* A shared button title used in different contexts */
+"shared.button.undo" = "Отмяна";
+
+/* A shared button title used in different contexts */
+"shared.button.view" = "Преглед";
+
+/* A generic error title indicating that a screen failed to fetch the latest data */
+"shared.error.failiedToReloadData" = "Неуспешно обновяване на данните";
+
+/* A generic error message */
+"shared.error.geneirc" = "Нещо не проработи";
+
+/* A generic error message */
+"shared.error.generic" = "Нещо се обърка";
+
+/* As in default value */
+"shared.misc.default" = "По подразбиране";
+
+/* Default value with a value. Example usage when ordering items: Default (Date Edited). */
+"shared.misc.defaultWithValue" = "По подразбиране (%@)";
+
+/* A default filter value */
+"shared.misc.showAll" = "Показване на всички";
+
+/* Sort ordering */
+"shared.misc.sortAascending" = "Възходящ ред";
+
+/* A button title used in different contexts */
+"shared.misc.sortBy" = "Подреждане по";
+
+/* Sort ordering */
+"shared.misc.sortDescending" = "Низходящ ред";
+
+/* Sidebar button title on iPad */
+"sidebar.addSite" = "Добавяне на сайт";
+
+/* Sidebar button title on iPad */
+"sidebar.allSites" = "Всички сайтове";
+
+/* Sidebar button title on iPad */
+"sidebar.createSite" = "Създаване на сайт";
+
+/* Sidebar item on iPad */
+"sidebar.domains" = "Домейни";
+
+/* Sidebar item on iPad */
+"sidebar.help" = "Помощ и поддръжка";
+
+/* Sidebar item on iPad */
+"sidebar.me" = "Аз";
+
+/* Sidebar section title on iPad */
+"sidebar.moreSectionTitle" = "Още";
+
+/* Sidebar section title on iPad */
+"sidebar.mySitesSectionTitle" = "Сайтове";
+
+/* Sidebar item on iPad */
+"sidebar.notifications" = "Известия";
+
+/* Template site address for the search bar. */
+"site.cration.domain.site.address" = "https:\/\/yoursitename.com";
+
+/* The error message to show in the 'Site Creation > Assembly Step' when the domain checkout fails for unknown reasons. */
+"site.creation.assembly.step.domain.checkout.error.subtitle" = "Вашият уебсайт беше създаден успешно, но се появи проблем с подготовката на плащане на домейна. Моля, опитайте отново или се свържете с екипа за поддръжка.";
+
+/* Site name description that sits in the template website view. */
+"site.creation.domain.tooltip.description" = "Както в примера по-горе, домейнът позволява на хората да намерят и посетят сайта с браузър.";
+
+/* Site name that is placed in the tooltip view. */
+"site.creation.domain.tooltip.site.name" = "TvoiaSait.com";
+
+/* Header of the secondary domains list section in the Domains Dashboard. %1$@ is the name of the site. */
+"site.domains.domainSection.title" = "Други домейни за %1$@";
+
+/* A section title which displays a row with a free WP.com domain */
+"site.domains.freeDomainSection.title" = "Вашият безплатен WordPress.com домейн";
+
+/* Description for the first domain purchased with a paid plan. */
+"site.domains.freeDomainWithPaidPlan.description" = "Вземете една година безплатна регистрация или трансфер с всеки годишен платен план.";
+
+/* Title of the card that starts the purchase of the first domain with a paid plan. */
+"site.domains.freeDomainWithPaidPlan.title" = "Добавяне на домейн";
+
+/* Footer of the primary site section in the Domains Dashboard. */
+"site.domains.primaryDomain" = "Вашият основен адрес е това, което посетителите ще виждат в адрес бара, когато зареждат сайта.";
+
+/* Primary domain label, used in the site address section of the Domains Dashboard. */
+"site.domains.primaryDomain.title" = "Основен домейн";
+
+/* Title for a button that opens domain purchasing flow. */
+"site.domains.purchaseDirectly.buttons.title" = "Търсене на домейн";
+
+/* Title for a button that opens plan and domain purchasing flow. */
+"site.domains.purchaseWithPlan.buttons.title" = "Ъпгрейднете плана си";
+
+/* Title for the featured plugins section */
+"site.plugins.add.category.featured" = "На фокус";
+
+/* Title for the popular plugins section */
+"site.plugins.add.category.popular" = "Популярни";
+
+/* Title for the recommended plugins section */
+"site.plugins.add.category.recommended" = "Препоръчани";
+
+/* Title for the search results section */
+"site.plugins.add.category.searchResults" = "Резултати от търсенето";
+
+/* Message shown when no plugins are found in the list */
+"site.plugins.add.empty" = "Няма намерени разширения";
+
+/* Tag shown next to plugins that are already installed */
+"site.plugins.add.installed.tag" = "Инсталирани";
+
+/* Error message shown when plugins failed to load, with retry option */
+"site.plugins.add.loadError" = "Неуспешно зареждане на разширения. Докоснете тук за повторен опит";
+
+/* Message shown while loading plugins in the list */
+"site.plugins.add.loading" = "Зареждане на разширенията...";
+
+/* Navigation title for the add new plugin screen */
+"site.plugins.add.title" = "Добавяне на разширение";
+
+/* Message shown when there are no active plugins on the site */
+"site.plugins.empty.active" = "Няма активни разширения";
+
+/* Button label to add a new plugin when no plugins are installed */
+"site.plugins.empty.addButton" = "Добавяне на разширение";
+
+/* Message shown when there are no inactive plugins on the site */
+"site.plugins.empty.inactive" = "Няма неактивни разширения";
+
+/* The plugin fillter option for displaying active plugins */
+"site.plugins.filter.option.active" = "Активни";
+
+/* The plugin fillter option for displaying all plugins */
+"site.plugins.filter.option.all" = "Всички";
+
+/* The plugin fillter option for displaying inactive plugins */
+"site.plugins.filter.option.inactive" = "Неактивни";
+
+/* Title of the plugin filter picker */
+"site.plugins.filter.title" = "Филтриране";
+
+/* Message displayed when fetching installed plugins from the site */
+"site.plugins.loading" = "Зареждане на инсталираните разширения...";
+
+/* No installed plugins message */
+"site.plugins.noInstalledPlugins" = "Нямате инсталирани разширения засега";
+
+/* Installed plugins list title */
+"site.plugins.title" = "Разширения";
+
+/* Back button title shown in Site Creation flow to come back from Plan selection to Domain selection */
+"siteCreation.domain.backButton.title" = "Домейни";
+
+/* Button to progress to the next step after selecting domain in Site Creation */
+"siteCreation.domains.buttons.selectDomain" = "Избор на домейн";
+
+/* Default text for adding a new item when no label is provided */
+"siteCustomTaxonomies.defaultAddNew" = "Добавяне";
+
+/* Description for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.description" = "Категоризациите ви помагат да организирате съдържанието отвъд стандартните категории и етикети.";
+
+/* Title for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.title" = "Няма ваши категоризации";
+
+/* Navigation title for the custom taxonomies screen */
+"siteCustomTaxonomies.navigationTitle" = "Категоризации";
+
+/* Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio. */
+"siteMedia.accessibilityLabelAudio" = "Аудио, %@";
+
+/* Accessibility label for other media items in the media collection view. The parameter is the filename file. */
+"siteMedia.accessibilityLabelDocument" = "Документ, %@";
+
+/* Accessibility label for image thumbnails in the media collection view. The parameter is the creation date of the image. */
+"siteMedia.accessibilityLabelImage" = "Изображение, %@";
+
+/* Accessibility label for video thumbnails in the media collection view. The parameter is the creation date of the video. */
+"siteMedia.accessibilityLabelVideo" = "Видео, %@";
+
+/* Accessibility label to use when creation date from media asset is not know. */
+"siteMedia.accessibilityUnknownCreationDate" = "Неизвестна дата на създаване";
+
+/* Accessibility hint for actions when displaying media items. */
+"siteMedia.cellAccessibilityHint" = "Избор на файл.";
+
+/* Label for the alt for a media asset (image) */
+"siteMedia.details.altText" = "Alt текст";
+
+/* Verb. Button title. Tapping cancels an action. */
+"siteMedia.details.cancel" = "Отказ";
+
+/* Noun. Label for the caption for a media asset (image / video) */
+"siteMedia.details.caption" = "Кратко описание";
+
+/* Title for button that permanently deletes a media item (photo / video) */
+"siteMedia.details.delete" = "Изтриване";
+
+/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
+"siteMedia.details.deleteConfirmation" = "Сигурни ли сте, че искате да изтриете този елемент безвъзвратно?";
+
+/* Text displayed in HUD after successfully deleting a media item */
+"siteMedia.details.deleted" = "Изтрито!";
+
+/* Text displayed in HUD while a media item is being deleted. */
+"siteMedia.details.deleting" = "Изтриване...";
+
+/* Label for the description for a media asset (image / video) */
+"siteMedia.details.description" = "Описание";
+
+/* Label for the dimensions in pixels for a media asset (image / video) */
+"siteMedia.details.dimensions" = "Размери";
+
+/* Label for the file name for a media asset (image / video) */
+"siteMedia.details.fileName" = "Име на файла";
+
+/* Label for the file size for a media asset (image / video) */
+"siteMedia.details.fileSize" = "Размер на файла";
+
+/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
+"siteMedia.details.fileType" = "Вид файл";
+
+/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
+"siteMedia.details.mediaDeleted" = "Този файл беше изтрит.";
+
+/* Noun. Label for the title of a media asset (image / video) */
+"siteMedia.details.title" = "Заглавие";
+
+/* Accessibility label for trash buttons in nav bars */
+"siteMedia.details.trash" = "Изтриване";
+
+/* Text displayed in HUD if there was an error attempting to delete a media item. */
+"siteMedia.details.unableToDeleteMedia" = "Неуспешно изтриване на файл.";
+
+/* Error shown when the app fails to load a video from the user's media library. */
+"siteMedia.details.unableToLoadVideo" = "Неуспешно зареждане на видео.";
+
+/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
+"siteMedia.details.unableToSaveMedia" = "Неуспешен запис на файл";
+
+/* Label for the date a media asset (image / video) was uploaded */
+"siteMedia.details.uploaded" = "Качено";
+
+/* Title for the URL field */
+"siteMedia.details.url" = "Адрес";
+
+/* Hint for image alt on image settings. */
+"siteMedia.hints.imageAlt" = "Алт атрибут на изображението";
+
+/* Hint for image caption on image settings. */
+"siteMedia.hints.imageCaption" = "Заглавие на изображението";
+
+/* Hint for image description on image settings. */
+"siteMedia.hints.imageDescription" = "Описание на изображението";
+
+/* Hint for image title on image settings. */
+"siteMedia.hints.imageTitle" = "Заглавие на изображението";
+
+/* Accessibility hint for media item preview for user's viewing an item in their media library */
+"siteMediaItem.contentViewAccessibilityHint" = "Докоснете, за да видите файла в цял екран";
+
+/* Accessibility label for media item preview for user's viewing an item in their media library */
+"siteMediaItem.contentViewAccessibilityLabel" = "Преглед на файла";
+
+/* Title for confirmation navigation bar button item */
+"siteMediaPicker.add" = "Добавяне";
+
+/* Button selection media in media picker */
+"siteMediaPicker.deselect" = "Отмаркиране";
+
+/* Button selection media in media picker */
+"siteMediaPicker.select" = "Избор";
+
+/* Media screen navigation title */
+"siteMediaPicker.title" = "Файлове";
+
+/* Site Monitoring log entry details navigation title */
+"siteMonitoring.entryDetailsTitle" = "Запис в дневника";
+
+/* Site Monitoring details screen metadata key */
+"siteMonitoring.metadataKeyCached" = "Кеширано";
+
+/* Site Monitoring details screen metadata key */
+"siteMonitoring.metadataKeyFile" = "Файл";
+
+/* Site Monitoring details screen metadata key */
+"siteMonitoring.metadataKeyHTTPHost" = "HTTP хост";
+
+/* Site Monitoring details screen metadata key */
+"siteMonitoring.metadataKeyKind" = "Вид";
+
+/* Site Monitoring details screen metadata key */
+"siteMonitoring.metadataKeyLine" = "Линия";
+
+/* Site Monitoring details screen metadata key */
+"siteMonitoring.metadataKeyName" = "Име";
+
+/* Site Monitoring details screen metadata key */
+"siteMonitoring.metadataKeyReferrer" = "Източник";
+
+/* Site Monitoring details screen metadata key */
+"siteMonitoring.metadataKeyRequestTime" = "Време на заявката";
+
+/* Site Monitoring details screen metadata key */
+"siteMonitoring.metadataKeyRequestURL" = "Адрес на заявката";
+
+/* Site Monitoring details screen metadata key */
+"siteMonitoring.metadataKeyResponseBodySize" = "Размер на отговора";
+
+/* Site Monitoring details screen metadata key */
+"siteMonitoring.metadataKeyStatus" = "Състояние";
+
+/* Site Monitoring details screen metadata key */
+"siteMonitoring.metadataKeyTimestamp" = "Времена";
+
+/* Title for metrics screen. */
+"siteMonitoring.metrics" = "Метрики";
+
+/* Title for PHP logs screen. */
+"siteMonitoring.phpLogs" = "PHP дневник";
+
+/* Title for web server log screen. */
+"siteMonitoring.webServerLogs" = "Дневник на уеб сървъра";
+
+/* All sites section title for site switcher. */
+"sitePicker.allSitesSectionTitle" = "Всички сайтове";
+
+/* Recents section title for site switcher. */
+"sitePicker.recentSitesSectionTitle" = "Последни сайтове";
+
+/* Title for site switcher screen */
+"sitePicker.title" = "Моите сайтове";
+
+/* The plugin author displayed in the plugins list. The first argument is plugin author name
+   The plugin version displayed in the plugins list. The first argument is plugin version */
+"sitePluginsList.item.author" = "От %@";
+
+/* The message displayed when a plugin has no description */
+"sitePluginsList.item.noDescriptionAvailable" = "Авторът на разширението не е въвел описание.";
+
+/* Button to activate a plugin */
+"sitePluginsList.itemAction.activate" = "Включване";
+
+/* Button to deactivate a plugin */
+"sitePluginsList.itemAction.deactivate" = "Изключване";
+
+/* Button to delete a plugin */
+"sitePluginsList.itemAction.delete" = "Изтриване";
+
+/* Button to view the plugin on WordPress.org website */
+"sitePluginsList.itemAction.viewOnWordPressOrg" = "Преглед в WordPress.org";
+
+/* Title for screen to select the privacy options for a blog */
+"siteSettings.privacy.title" = "Поверителност";
+
+/* Format string for adding a new taxonomy term. %1$@ is the taxonomy name. */
+"siteTaxonomy.addNew.format" = "Добавяне на %1$@";
+
+/* Hint for users when hidden privacy setting is set */
+"siteVisibility.hidden.hint" = "Сайтът ви е скрит от посетителите зад начална страница \"Очаквайте скоро\", докато не е готов за показване.";
+
+/* Text for privacy settings: Hidden */
+"siteVisibility.hidden.title" = "Скрит";
+
+/* Hint for users when private privacy setting is set */
+"siteVisibility.private.hint" = "Сайтът ви е видим само за вас и потребителите, които одобрите.";
+
+/* Text for privacy settings: Private */
+"siteVisibility.private.title" = "Личен";
+
+/* Hint for users when public privacy setting is set */
+"siteVisibility.public.hint" = "Вашият сайт е видим за всички и може да се индексира от търсачки.";
+
+/* Text for privacy settings: Public */
+"siteVisibility.public.title" = "Публичен";
+
+/* Text for unknown privacy setting */
+"siteVisibility.unknown.hint" = "Неизвестен";
+
+/* Text for unknown privacy setting */
+"siteVisibility.unknown.title" = "Неизвестен";
+
+/* Label for the blogging reminders setting */
+"sitesettings.reminders.title" = "Напомняния";
+
+/* Body text for the Jetpack Social no connection view */
+"social.noconnection.body" = "Увеличете трафика си чрез автоматично споделяне на публикациите в социалните мрежи.";
+
+/* Title for the connect button to add social sharing for the Jetpack Social no connection view */
+"social.noconnection.connectAccounts" = "Свързване на профили";
+
+/* Accessibility label for the social media icons in the Jetpack Social no connection view */
+"social.noconnection.icons.accessibility.label" = "Иконки за социалните мрежи";
+
+/* Title for the not now button to hide the Jetpack Social no connection view */
+"social.noconnection.notnow" = "Не сега";
+
+/* Plural body text for the Jetpack Social no shares dashboard card. %1$d is the number of social accounts the user has. */
+"social.noshares.body.plural" = "Публикациите ви няма да бъдат споделени във вашите %1$d профила.";
+
+/* Singular body text for the Jetpack Social no shares dashboard card. */
+"social.noshares.body.singular" = "Вашите публикации няма да бъдат споделени в социалните медии";
+
+/* Accessibility label for the social media icons in the Jetpack Social no shares dashboard card */
+"social.noshares.icons.accessibility.label" = "Иконки за социалните мрежи";
+
+/* Title for the button to subscribe to Jetpack Social on the no shares dashboard card */
+"social.noshares.subscribe" = "Абонирайте се, за да споделите още";
+
+/* Section title for the disabled Twitter service in the Social screen */
+"social.section.disabledTwitter.header" = "Автоматично споделяне в Туитър не е налично";
+
+/* Text for a hyperlink that allows the user to learn more about the Twitter deprecation. */
+"social.twitterDeprecation.link" = "Още информация";
+
+/* A smallprint that hints the reason behind why Twitter is deprecated. */
+"social.twitterDeprecation.text" = "Twitter не се поддържа заради промените в условията за ползване и цените.";
+
+/* The number of connected accounts on a third party sharing service connected to the user's blog. The '%d' is a placeholder for the number of accounts. */
+"socialSharing.connectionDetails.nAccount" = "%d профила";
+
+/* Title of Subscribers stats tab. */
+"stats.dashboard.tab.subscribers" = "Абонати";
+
+/* Title of Traffic stats tab. */
+"stats.dashboard.tab.traffic" = "Трафик";
+
+/* Accessibility label used for distinguishing Views and Visitors in the Stats → Insights Views Visitors Line chart. */
+"stats.insights.accessibility.label.viewsVisitorsLastDays" = "Последните 7 дни";
+
+/* Accessibility label used for distinguishing Views and Visitors in the Stats → Insights Views Visitors Line chart. */
+"stats.insights.accessibility.label.viewsVisitorsPreviousDays" = "Предните 7 дни";
+
+/* Label shown on some metrics in the Stats Insights section, such as Comments count. The placeholders will be populated with a change and a percentage – e.g. '+17 (40%) higher than the previous 7-days'. The *s mark the numerical values, which will be highlighted differently from the rest of the text. */
+"stats.insights.label.totalLikes.higherNumber" = "*%1$@%2$@ (%3$@)* повече от предните 7 дни";
+
+/* Label shown on some metrics in the Stats Insights section, such as Comments count. The placeholders will be populated with a change and a percentage – e.g. '-17 (40%) lower than the previous 7-days'. The *s mark the numerical values, which will be highlighted differently from the rest of the text. */
+"stats.insights.label.totalLikes.lowerNumber" = "*%1$@%2$@ (%3$@)* по-малко от предните 7 дни";
+
+/* Label shown in Stats Insights when a metric is showing the same level as the previous 7 days */
+"stats.insights.label.totalLikes.same" = "Същите като за предните 7 дни";
+
+/* Stats insights views higher than previous 7 days */
+"stats.insights.label.views.sevenDays.higher" = "Вашите прегледи през последните 7 дни са %@ повече от предните 7 дни.\n";
+
+/* Stats insights views lower than previous 7 days */
+"stats.insights.label.views.sevenDays.lower" = "Вашите прегледи през последните 7 дни са %@ по-малко от предните 7 дни.\n";
+
+/* Stats insights label shown when the user's view count is the same as the previous 7 days. */
+"stats.insights.label.views.sevenDays.same" = "Вашите прегледи през последните 7 дни са същите като предните 7 дни.\n";
+
+/* Last 7-days legend label */
+"stats.insights.label.viewsVisitorsLastDays" = "Последните 7 дни";
+
+/* Previous 7-days legend label */
+"stats.insights.label.viewsVisitorsPreviousDays" = "Предишни 7 дни";
+
+/* Stats insights visitors higher than previous 7 days */
+"stats.insights.label.visitors.sevenDays.higher" = "Вашите посетители през последните 7 дни са %@ повече от предните 7 дни.\n";
+
+/* Stats insights visitors lower than previous 7 days */
+"stats.insights.label.visitors.sevenDays.lower" = "Вашите посетители през последните 7 дни са %@ по-малко от предните 7 дни.\n";
+
+/* Stats insights label shown when the user's visitor count is the same as the previous 7 days. */
+"stats.insights.label.visitors.sevenDays.same" = "Вашите посетители през последните 7 дни са същите като предните 7 дни.\n";
+
+/* Title for Comments count in Latest Post Summary stats card. */
+"stats.insights.latestPostSummary.comments" = "Коментари";
+
+/* Title of button shown in Stats prompting the user to create a post on their site. */
+"stats.insights.latestPostSummary.createPost" = "Създаване на публикация";
+
+/* Title for Likes count in Latest Post Summary stats card. */
+"stats.insights.latestPostSummary.likes" = "Харесвания";
+
+/* Prompt shown in the 'Latest Post Summary' stats card if a user hasn't yet published anything. */
+"stats.insights.latestPostSummary.noData" = "Върнете се като публикувате първата си публикация!";
+
+/* Publish date of a post displayed in Stats. Placeholder will be replaced with a localized relative time, e.g. 2 days ago */
+"stats.insights.latestPostSummary.publishDate" = "Публикувано на %@";
+
+/* Title for Views count in Latest Post Summary stats card. */
+"stats.insights.latestPostSummary.views" = "Прегледи";
+
+/* Header title indicating which Stats Insights cards the user currently has set to active. */
+"stats.insights.management.activeCards" = "Активни карти";
+
+/* Header title indicating which Stats Insights cards the user currently has disabled. */
+"stats.insights.management.inactiveCards" = "Неактивни карти";
+
+/* Prompt displayed on the Stats Insights management screen telling the user that all Stats cards are enabled. */
+"stats.insights.management.noCardsPrompt" = "Няма неактивни карти";
+
+/* Title of button to cancel an alert and take no action. */
+"stats.insights.management.savePrompt.cancelButton" = "Отказ";
+
+/* Title of button in Stats Insights management, prompting the user to discard changes to their list of active Stats cards. */
+"stats.insights.management.savePrompt.discardButton" = "Отмяна на промените";
+
+/* Title of alert in Stats Insights management, prompting the user to save changes to their list of active Stats cards. */
+"stats.insights.management.savePrompt.message" = "Променихте активните карти с обобщения.";
+
+/* Title of button in Stats Insights management, prompting the user to save changes to their list of active Stats cards. */
+"stats.insights.management.savePrompt.saveButton" = "Запомняне на промените";
+
+/* Prompt displayed on the Stats Insights management screen telling the user to tap a row to add it to their list of active cards. */
+"stats.insights.management.selectCardsPrompt" = "Изберете карти от списъка по-долу";
+
+/* Title of the Stats Insights Management screen */
+"stats.insights.management.title" = "Управление на статистически карти";
+
+/* Insights 'Most Popular Time' header. Fire emoji should remain part of the string. */
+"stats.insights.mostPopularCard.title" = "🔥 Най-популярно време";
+
+/* Label showing the percentage of views to a user's site which fall on a particular day. */
+"stats.insights.mostPopularCard.viewsNumber" = "%1$@ прегледи";
+
+/* Hint displayed on the 'Most Popular Time' stats card when a user's site hasn't yet received enough traffic. */
+"stats.insights.mostPopularTime.noData" = "Няма достатъчно дейност. Върнете се, когато сайтът ви има повече посетители!";
+
+/* Insights 'Subscribers' header */
+"stats.insights.subscribers.title" = "Абонати";
+
+/* A hint shown to the user in stats informing the user how many likes one of their posts has received. The %1$@ placeholder will be replaced with the title of a post, the %2$@ with the number of likes. */
+"stats.insights.totalLikes.guideText.plural" = "Последната ви публикация %1$@ има %2$@ харесвания.";
+
+/* A hint shown to the user in stats informing the user that one of their posts has received a like. The %1$@ placeholder will be replaced with the title of a post, and the %2$@ will be replaced by the numeral one. */
+"stats.insights.totalLikes.guideText.singular" = "Последната ви публикация %1$@ има %2$@ харесване.";
+
+/* Label displaying total number of WordPress.com subscribers. %@ is the total. */
+"stats.insights.totalSubscribers.dotcomCount" = "Общо абонати в WordPress.com: %@";
+
+/* Label displaying total number of email subscribers. %@ is the total. */
+"stats.insights.totalSubscribers.emailCount" = "Общо имейл абонати: %@";
+
+/* Insights 'Total Subscribers' header */
+"stats.insights.totalSubscribers.title" = "Общо абонати";
+
+/* Menu item to disable the new stats */
+"stats.menu.disableNewStats" = "Изключи новите статистики";
+
+/* Menu item to send feedback about new stats experience */
+"stats.menu.sendFeedback" = "Обратна връзка";
+
+/* Menu item to enable new stats experience */
+"stats.menu.tryNewStats" = "Нови статистики";
+
+/* Text for the Stats Traffic Overview stat difference label. Shows the change from the previous period, including the percentage value. E.g.: +12.3K (5%). %1$@ is the placeholder for the change sign ('-', '+', or none). %2$@ is the placeholder for the change numerical value. %3$@ is the placeholder for the change percentage value. */
+"stats.overview.differenceLabelWithNumber" = "%1$@%2$@ (%3$@)";
+
+/* Stats 'Today' header */
+"stats.period.todayCard.title" = "Днес";
+
+/* Table column title that shows the date since the user became a subscriber. */
+"stats.section.dataSubtitles.subscriberSince" = "Абонат от";
+
+/* Table column title that shows the names of subscribers. */
+"stats.section.itemSubtitles.subscriber" = "Име";
+
+/* Title for the legend of the Stats Subscribers line chart. */
+"stats.subscribers.chart.legend" = "Абонати";
+
+/* A title for table's column that shows a number of times a post was opened from an email */
+"stats.subscribers.emailsSummary.column.clicks" = "Кликове";
+
+/* A title for table's column that shows a number of email openings */
+"stats.subscribers.emailsSummary.column.opens" = "Отваряния";
+
+/* A title for table's column that shows a name of an email */
+"stats.subscribers.emailsSummary.column.title" = "Последни имейли";
+
+/* Stats 'Emails' card header */
+"stats.subscribers.emailsSummaryCard.title" = "Имейли";
+
+/* Stats 'Subscriber Growth' card header, contains a chart showing the progression in the number of subscribers */
+"stats.subscribers.growthChart.title" = "Ръст на абонатите";
+
+/* Stats 'Subscribers' card header */
+"stats.subscribers.subscribersListCard.title" = "Абонати";
+
+/* Accessibility of stats table. Placeholders will be populated with names of data shown in table. */
+"stats.topTotalsCell.voiceOverDescription" = "Таблицата показва %1$@, %2$@ и %3$@";
+
+/* The label for the option to show Stats Traffic chart for Days. */
+"stats.traffic.days" = "Дни";
+
+/* The label for the option to show Stats Traffic chart for Days. */
+"stats.traffic.hours" = "Часове";
+
+/* The label for the option to show Stats Traffic chart for Months. */
+"stats.traffic.months" = "Месеци";
+
+/* The label for the option to show Stats Traffic chart for Weeks. */
+"stats.traffic.weeks" = "Седмици";
+
+/* The label for the option to show Stats Traffic chart for Years. */
+"stats.traffic.years" = "Години";
+
+/* Dismiss the AlertView */
+"stockPhotos.strings.dismiss" = "Отмяна";
+
+/* Subtitle for placeholder in Free Photos. The company name 'Pexels' should always be written as it is. */
+"stockPhotos.subtitle" = "Снимки, осигурени от Pexels";
+
+/* Title for placeholder in Free Photos */
+"stockPhotos.title" = "Търсене на безплатни снимки за добавяне в библиотеката от файлове!";
+
+/* The section title and or placeholder */
+"submit.feedback.detailsPlaceholder" = "Подробности";
+
+/* The footer in the Submit Feedback screen to clarify that it's not support */
+"submit.feedback.footer" = "Ако имате нужда от помощ, моля свържете се чрез екрана \"Помощ и поддръжка\"";
+
+/* The button title for the Submit button in the In-App Feedback screen */
+"submit.feedback.submit.button" = "Изпращане";
+
+/* The title for the the In-App Feedback screen */
+"submit.feedback.title" = "Обратна връзка";
+
+/* Submit feedback screen failure alert title */
+"submitFeedback.attachmentsStillUploadingAlertTitle" = "Някои прикачени файлове не се качиха";
+
+/* Submit feedback screen cancellation confirmation alert action */
+"submitFeedback.cancellationAlertContinueEditing" = "Продължаване на редакцията";
+
+/* Submit feedback screen cancellation confirmation alert action */
+"submitFeedback.cancellationAlertDiscardFeedbackButton" = "Отмяна на обратната връзка";
+
+/* Submit feedback screen cancellation confirmation alert title */
+"submitFeedback.cancellationAlertTitle" = "Сигурни ли сте, че искате да отмените обратната връзка";
+
+/* Submit feedback screen failure alert title */
+"submitFeedback.failureAlertTitle" = "Неуспешно изпращане на обратна връзка";
+
+/* Submit feedback screen submit success notice messages */
+"submitFeedback.successNoticeMessage" = "Благодаря, че помагате да подобрим приложението";
+
+/* Submit feedback screen submit fsuccess notice title */
+"submitFeedback.successNoticeTitle" = "Обратната връзка е пратена";
+
+/* Button title */
+"subscriberDetails.buttonDeleteSubscriber" = "Изтриване на абоната";
+
+/* Remove subscriber confirmation dialog message; subscriber name as input. */
+"subscriberDetails.deleteSubscriberConfirmationDialog.message" = "Сигурен ли сте, че искате да премахнете %@? Няма да могат да получават известия от вас повече.";
+
+/* Remove subscriber confirmation dialog title */
+"subscriberDetails.deleteSubscriberConfirmationDialog.title" = "Изтриване на абоната";
+
+/* Form field name */
+"subscriberDetails.fieldName.country" = "Държава";
+
+/* Form field name */
+"subscriberDetails.fieldName.email" = "Имейл";
+
+/* Form field name */
+"subscriberDetails.fieldName.paidUpgrade" = "Платен ъпгрейд";
+
+/* Form field name */
+"subscriberDetails.fieldName.plan" = "План";
+
+/* Form field name */
+"subscriberDetails.fieldName.planEndDate" = "Крайна дата";
+
+/* Form field name */
+"subscriberDetails.fieldName.planStartDate" = "Начална дата";
+
+/* Form field name */
+"subscriberDetails.fieldName.planStatus" = "Състояние на плана";
+
+/* Form field name */
+"subscriberDetails.fieldName.renewalInterval" = "Период за подновяване";
+
+/* Form field name */
+"subscriberDetails.fieldName.renewalPrice" = "Цена за подновяване";
+
+/* Form field name */
+"subscriberDetails.fieldName.site" = "Сайт";
+
+/* Form field name (has to be short!) */
+"subscriberDetails.fieldName.statsClickedEmails" = "Кликнати";
+
+/* Form field name (has to be short!) */
+"subscriberDetails.fieldName.statsEmailCount" = "Имейли";
+
+/* Form field name (has to be short!) */
+"subscriberDetails.fieldName.statsOpenedEmails" = "Отворени";
+
+/* Form field name */
+"subscriberDetails.fieldName.subscriptionDate" = "Дата на абонамент";
+
+/* Name of a free plan */
+"subscriberDetails.plan.free" = "Безплатен";
+
+/* Newsletter subscription plan type */
+"subscriberDetails.plan.gift" = "Подарък";
+
+/* Card section title */
+"subscriberDetails.section.newletterSubscription" = "Абонамент за бюлетин";
+
+/* Card section title */
+"subscriberDetails.section.subscriberDetails" = "Подробности за абоната";
+
+/* Button title */
+"subscribers.buttonDeleteSubscriber" = "Изтриване на абоната";
+
+/* Remove subscriber confirmation dialog message; subscriber name as input. */
+"subscribers.deleteSubscriberConfirmationDialog.message" = "Сигурен ли сте, че искате да премахнете %@? Няма да могат да получават известия от вас повече.";
+
+/* Remove subscriber confirmation dialog title */
+"subscribers.deleteSubscriberConfirmationDialog.title" = "Изтриване на абоната";
+
+/* Empty state view title */
+"subscribers.empty" = "Няма абонати";
+
+/* Empty state view title */
+"subscribers.filter.emailSubscription" = "Имейл абонамент";
+
+/* Empty state view title */
+"subscribers.filter.paymentType" = "Плащане";
+
+/* Email subscription type filter */
+"subscribers.filterByEmailSubscriptionType.blocked" = "Блокирани";
+
+/* Email subscription type filter */
+"subscribers.filterByEmailSubscriptionType.email" = "Абонирани";
+
+/* Email subscription type filter */
+"subscribers.filterByEmailSubscriptionType.reader" = "Не е абонирано";
+
+/* Email subscription type filter */
+"subscribers.filterByEmailSubscriptionType.unconfirmed" = "Непотвърдени";
+
+/* Subscription type filter */
+"subscribers.filterBySubscriptionType.free" = "Безплатен";
+
+/* Subscription type filter */
+"subscribers.filterBySubscriptionType.paid" = "Платен";
+
+/* Part of the label in the menu showing how many subscribers are displayed (has to have two arguments!) */
+"subscribers.menu.nOutOf" = "%1$@ от %2$@";
+
+/* Part of the label in the menu showing how many subscribers are displayed */
+"subscribers.menu.subscribers" = "Абонати:";
+
+/* Subscribers sort by field */
+"subscribers.sortField.dateSubscribed" = "Дата на абонамент";
+
+/* Subscribers sort by field */
+"subscribers.sortField.email" = "Имейл";
+
+/* Subscribers sort by field */
+"subscribers.sortField.name" = "Име";
+
+/* Subscribers sort by field */
+"subscribers.sortField.plan" = "План";
+
+/* Subscribers sort by field */
+"subscribers.sortField.subscriptionStatus" = "Имейл абонамент";
+
+/* Screen title */
+"subscribers.title" = "Абонати";
+
+/* Section title for prominent suggestions */
+"suggestions.section.prominent" = "В този разговор";
+
+/* Section title for regular suggestions */
+"suggestions.section.regular" = "Членове на сайта";
+
+/* Label for the current activity log file in the list. */
+"support.activityLogs.currentLogTilte" = "Текущ";
+
+/* Message shown in the alert when attempting to clear old activity logs. */
+"support.activityLogs.deleteLogsAlert.message" = "Сигурни ли сте, че искате да изтриете всички записи в дневника?";
+
+/* Title shown in the alert when attempting to clear old activity logs. */
+"support.activityLogs.deleteLogsAlert.title" = "Изтриване на дневника";
+
+/* Title shown in the navigation bar of the Activity Logs screen. */
+"support.activityLogs.navigationTitle" = "История на активността";
+
+/* Footer text explaining the log retention policy in the Activity Logs screen. */
+"support.activityLogs.sectionFooter" = "Съхраняват се журнали за последните 7 дни.";
+
+/* Dismiss the current view */
+"support.button.close.title" = "Готово";
+
+/* Accessibility hint, informing user the button can be used to visit the Jetpack migration FAQ website. */
+"support.button.jetpackMigation.accessibilityHint" = "Посетете често задаваните въпроси в браузъра";
+
+/* Option in Support view to visit the Jetpack migration FAQ website. */
+"support.button.jetpackMigration.title" = "Посетете често задаваните въпроси";
+
+/* Button for confirming logging out from WordPress.com account */
+"support.button.logOut.title" = "Изход";
+
+/* Accessibility hint, informing user the button can be used to visit the support forums website. */
+"support.button.visitForum.accessibilityHint" = "Докоснете, за да посетите форума във външен браузър";
+
+/* Option in Support view to visit the WordPress.org support forums. */
+"support.button.visitForum.title" = "Посетете WordPress.org";
+
+/* Indicator that the chat bot is processing user's input. */
+"support.chatBot.botThinkingIndicator" = "Мислене...";
+
+/* Dismiss the current view */
+"support.chatBot.close.title" = "Затваряне";
+
+/* Button for users to contact the support team directly. */
+"support.chatBot.contactSupport" = "Връзка с отдела по поддръжка";
+
+/* Initial message shown to the user when the chat starts. */
+"support.chatBot.firstMessage" = "Здрасти, аз съм Jetpack AI Assistant.\\n\\nС какво мога да помогна?\\n\\nАко не мога да отговоря на въпроса, ще помогна със създаването на билет за техническа поддръжка.";
+
+/* Placeholder text for the chat input field. */
+"support.chatBot.inputPlaceholder" = "Изпращане на съобщение...";
+
+/* An example question shown to a user seeking support */
+"support.chatBot.questionFive" = "Забравих информацията за вход";
+
+/* An example question shown to a user seeking support */
+"support.chatBot.questionFour" = "Защо не мога да вляза?";
+
+/* An example question shown to a user seeking support */
+"support.chatBot.questionOne" = "Какъв е адресът на моя сайт?";
+
+/* An example question shown to a user seeking support */
+"support.chatBot.questionSix" = "Как да ползвам моя домейн в приложението?";
+
+/* An example question shown to a user seeking support */
+"support.chatBot.questionThree" = "Не мога да кача снимки или видео";
+
+/* An example question shown to a user seeking support */
+"support.chatBot.questionTwo" = "Помощ, сайтът ми не работи!";
+
+/* Option for users to report a chat bot answer as inaccurate. */
+"support.chatBot.reportInaccuracy" = "Докладване като неточен";
+
+/* Button title referring to the sources of information. */
+"support.chatBot.sources" = "Източници";
+
+/* Prompt for users suggesting to select a default question from the list to start a support chat. */
+"support.chatBot.suggestionsPrompt" = "Не знаете какво да попитате?";
+
+/* Notice informing user that there was an error submitting their support ticket. */
+"support.chatBot.ticketCreationFailure" = "Грешка при създаването на билет за поддръжка";
+
+/* Notice informing user that their support ticket is being created. */
+"support.chatBot.ticketCreationLoading" = "Създаване на билет за поддръжка...";
+
+/* Notice informing user that their support ticket has been created. */
+"support.chatBot.ticketCreationSuccess" = "Създаден е билет";
+
+/* Title of the view that shows support chat bot. */
+"support.chatBot.title" = "Техническа поддръжка";
+
+/* A title for a text that displays a transcript of an answer in a support chat */
+"support.chatBot.zendesk.answer" = "Отговор";
+
+/* A title for a text that displays a transcript of user's question in a support chat */
+"support.chatBot.zendesk.question" = "Въпрос";
+
+/* A title for a text that displays a transcript from a conversation between Jetpack Mobile Bot (chat bot) and a user */
+"support.chatBot.zendesk.transcript" = "Jetpack Mobile Bot транскрипт";
+
+/* Suggestion in Support view to visit the Forums. */
+"support.row.communityForum.title" = "Задайте въпрос към форума на общността и получете помощ от доброволци.";
+
+/* Accessibility hint describing what happens if the Contact Email button is tapped. */
+"support.row.contactEmail.accessibilityHint" = "Позазва прозорец за смяна на имейла за връзка.";
+
+/* Display value for Support email field if there is no user email address. */
+"support.row.contactEmail.emailNoteSet.detail" = "Не е зададено";
+
+/* Support email label. */
+"support.row.contactEmail.title" = "Имейл";
+
+/* Option in Support view to contact the support team. */
+"support.row.contactUs.title" = "Връзка с поддръжката";
+
+/* Option in Support view to enable/disable adding debug information to support ticket. */
+"support.row.debug.title" = "Дебъг";
+
+/* Support email label. */
+"support.row.email.title" = "Имейл";
+
+/* Option in Support view to launch the Help Center. */
+"support.row.helpCenter.title" = "Помощен център за WordPress";
+
+/* An informational card description in Support view explaining what tapping the link on card does */
+"support.row.jetpackMigration.description" = "Нашите често задавани въпроси дават отговори не много въпроси, които може да имате.";
+
+/* An informational card title in Support view */
+"support.row.jetpackMigration.title" = "Благодарим ви, че преминахте на Jetpack!";
+
+/* Option in Support view to see activity logs. */
+"support.row.logs.title" = "Дневници";
+
+/* Option in Support view to access previous help tickets. */
+"support.row.tickets.title" = "Билети";
+
+/* Label in Support view displaying the app version. */
+"support.row.version.title" = "Версия";
+
+/* Support screen footer text explaining the benefits of enabling the Debug feature. */
+"support.sectionFooter.advanced.title" = "Включете дебъгване, за да включите допълнителна информация във вашия дневник, която може да помогне за разрешаване на проблеми с приложението.";
+
+/* WordPress.com sign-out section header title */
+"support.sectionHeader.account.title" = "Профил в WordPress.com";
+
+/* Section header in Support view for advanced information. */
+"support.sectionHeader.advanced.title" = "Напреднали";
+
+/* Section header in Support view for the Forums. */
+"support.sectionHeader.forum.title" = "Форуми";
+
+/* Section header in Support view for priority support. */
+"support.sectionHeader.prioritySupport.title" = "Приоритетна поддръжка";
+
+/* View title for Help & Support page. */
+"support.title" = "Помощ";
+
+/* Subject of new Zendesk ticket. */
+"support.zendesk.readerAppTicketSubject" = "Reader за iOS поддръжка";
+
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
+"tags.empty.description" = "Етикетите помагат за организацията и помагат на посетителите да открият свързани публикации.";
+
+/* Title for empty state when there are no tags */
+"tags.empty.title" = "Няма етикети";
+
+/* Error message when tag data is invalid */
+"tags.error.invalid_tag" = "Информацията за етикета не е валидна. Опитайте отново.";
+
+/* Error message when the tags service cannot connect to the remote site */
+"tags.error.no_remote_service" = "Свързването на сайта не беше успешно. Моля, проверете връзката и опитайте отново.";
+
+/* Button to remove a selected tag. %1$@ is the tag name. */
+"tags.remove.button" = "Премахване на %1$@";
+
+/* Placeholder text for the tag search field */
+"tags.search.placeholder" = "Търсене в етикети";
+
+/* Title for the tags screen */
+"tags.title" = "Етикети";
+
+/* Title for placeholder in Tenor picker */
+"tenor.welcomeMessage" = "Търсене на GIF-ове за вашата файлова библиотека!";
+
+/* Header of delete screen section listing things that will be deleted. */
+"these items will be deleted:" = "следните елементи ще бъдат изтрити:";
+
+/* Section title for suggested timezones */
+"timeZoneSelector.suggested" = "Предложения";
+
+/* Title for the time zone selector */
+"timeZoneSelector.title" = "Часова зона";
+
+/* Action button title to enable new stats from tip */
+"tips.newStats.action" = "Включване";
+
+/* Tip for new stats feature */
+"tips.newStats.message" = "Ползвайте удобни и мощни статистики. Върнете се обратно, когато поискате.";
+
+/* Tip for new stats feature */
+"tips.newStats.title" = "Нови статистики";
+
+/* Tip for sidebar */
+"tips.sidebar.message" = "Плъзнете надясно, за да получите достъп до вашите сайтове, Reader, известията и профила";
+
+/* Tip for sidebar */
+"tips.sidebar.title" = "Странична лента";
+
+/* Tip for site picker */
+"tips.sitePickerTip.message" = "Докоснете, за да изберете различен размер или да създадете нов";
+
+/* Tip for site picker */
+"tips.sitePickerTip.title" = "Вашите сайтове";
+
+/* Message explaining how to use the date range control */
+"tips.statsDateRange.message" = "Ползвайте календара за да изберете дни, седмици, месеци, години или да изберете периоди за преглед на статистиката.";
+
+/* Title for stats date range control tip */
+"tips.statsDateRange.title" = "Навигация във времето";
+
+/* The part of the nudge title that should be emphasized, this content needs to match a string in 'If you want to try get more...' */
+"top tips" = "водещи съвети";
+
+/* Message for error notice shown if the app can't find a specific site belonging to the user */
+"universalLink.qrCodeMedia.error.message" = "Проверете дали сте влезли с правилния профил";
+
+/* Title for error notice shown if the app can't find a specific site belonging to the user */
+"universalLink.qrCodeMedia.error.title" = "Сайтът не е открит";
+
+/* Used when the response doesn't have a valid url to display */
+"unknown url" = "непознат адрес";
+
+/* Indicating that referrer was unmarked as spam */
+"unmarked as spam" = "отмаркирано от спам";
+
+/* Displayed in the confirmation alert when marking unread notifications as read. */
+"unread" = "непрочетени";
+
+/* Sites's User Profile. Displayed when the name is empty! */
+"user.details.title.user" = "Потребител на сайта";
+
+/* Site's Viewers Profile. Displayed when the name is empty! */
+"user.details.title.viewer" = "Посетител на сайта";
+
+/* The 'Account Management' section of the user profile – matches what's in /wp-admin/profile.php */
+"userDetails.accountManagementSectionTitle" = "Управление на профила";
+
+/* The help message for reassigning content to a user after deletion. */
+"userDetails.alert.attributeContentToUserHelpMessage" = "Страници и публикации, принадлежащи на изтрит потребител, ще бъдат прехвърлени към друг потребител по ваш избор.";
+
+/* The label that appears in the alert that appears when deleting a user */
+"userDetails.alert.attributeContentToUserLabel" = "Избран потребител";
+
+/* The message that appears when deleting a user. */
+"userDetails.alert.deleteUserAttributionMessage" = "Избор на потребител, към който да се свърже това съдържание.";
+
+/* The title of the confirmation button in the alert that appears when deleting a user */
+"userDetails.alert.deleteUserConfirmButtonTitle" = "Да, изтриване на потребителя";
+
+/* The title of the cancel button in the confirmation alert that appears when deleting a user */
+"userDetails.alert.deleteUserConfirmationCancelButton" = "Отказ";
+
+/* The title of the delete button in the confirmation alert that appears when deleting a user */
+"userDetails.alert.deleteUserConfirmationDeleteButton" = "Изтриване";
+
+/* The message in the alert that appears when deleting a user. The first argument is the display name of the user to which content will be attributed */
+"userDetails.alert.deleteUserConfirmationMessage" = "Сигурни ли сте, че искате да изтриете потребителя и да прехвърлите съдържанието към %@?";
+
+/* The title of the alert that appears when deleting a user
+   The title of the confirmation alert that appears when deleting a user */
+"userDetails.alert.deleteUserConfirmationTitle" = "Потвърждение за изтриване";
+
+/* The message in the alert that appears when deleting a user */
+"userDetails.alert.deleteUserErrorAlertMessage" = "Грешка при изтриване на потребителя.";
+
+/* The title of the alert that appears when deleting a user */
+"userDetails.alert.deleteUserErrorAlertTitle" = "Грешка";
+
+/* The 'Biographical Info' field of the user profile – matches what's in /wp-admin/profile.php */
+"userDetails.bioFieldTitle" = "Биографична информация";
+
+/* The 'Update' button to set a new password on the user profile */
+"userDetails.button.updatePassword" = "Обновяване";
+
+/* The 'Delete User' button on the user profile – matches what's in /wp-admin/profile.php */
+"userDetails.deleteUserActionTitle" = "Изтриване на потребител";
+
+/* The 'Deleting User…' button on the user profile */
+"userDetails.deletingUserActionTitle" = "Изтриване на потребител...";
+
+/* The 'Email' field of the user profile – matches what's in /wp-admin/profile.php */
+"userDetails.emailAddressFieldTitle" = "Имейл адрес";
+
+/* The message in the alert that appears when setting a new password on the user profile */
+"userDetails.newPasswordAlertMessage" = "Въвеждане на нова парола за този потребител";
+
+/* The 'Role' field of the user profile – matches what's in /wp-admin/profile.php */
+"userDetails.roleFieldTitle" = "Роля";
+
+/* The 'Set New Password' button on the user profile – matches what's in /wp-admin/profile.php */
+"userDetails.setNewPasswordActionTitle" = "Нова парола";
+
+/* The placeholder text for the 'New Password' field on the user profile */
+"userDetails.textField.placeholder.newPassword" = "Нова парола";
+
+/* The placeholder text for the 'Confirm New Password' field on the user profile */
+"userDetails.textField.placeholder.newPasswordConfirmation" = "Потвърждение на новата парола";
+
+/* The 'Website' field of the user profile – matches what's in /wp-admin/profile.php */
+"userDetails.websiteFieldTitle" = "Уебсайт";
+
+/* Header text fo the search results section in the users list */
+"userList.searchResults.header" = "Резултати от търсенето";
+
+/* Shown when the user list is empty */
+"userlist.nousersfound" = "Няма намерени потребители.";
+
+/* An instruction for the user to tap to start searching */
+"userlist.searchprompt" = "Търсене";
+
+/* The heading at the top of the user list */
+"userlist.title" = "Потребители";
+
+/* Screen title */
+"users.title" = "Потребители";
+
+/* Verb. Dismiss the web view screen. */
+"webKit.button.dismiss" = "Отмяна";
+
+/* Button label to share a web page */
+"webKit.button.share" = "Споделяне";
+
+/* A title for the filter on the PHP logs screen */
+"webServerLogs.filterEndDate" = "Крайна дата";
+
+/* A title for the filter on the PHP logs screen */
+"webServerLogs.filterRequestType" = "Вид заявка";
+
+/* A title for the filter on the PHP logs screen */
+"webServerLogs.filterStartDate" = "Начална дата";
+
+/* A title for the filter on the PHP logs screen */
+"webServerLogs.filterStatus" = "Състояние";
+
+/* Second part of delete screen title stating [the site] will be unavailable in the future. */
+"will be unavailable in the future." = "няма да бъде достъпно в бъдеще.";
+
+/* Title for the link for site creation guide. */
+"wordPressAuthenticatorDisplayStrings.default.siteCreationGuideButtonTitle" = "Стартирате нов сайт?";
+
+/* This is a comma separated list of keywords used for spotlight indexing of the 'Help & Support' screen within the 'Me' tab */
+"wordpress, help, support, faq, questions, debug, logs, help center, contact" = "wordpress, help, support, faq, questions, debug, logs, help center, contact, поддръжка, помощ, въпрос, дневник, съпорт, поддръжка, връзка";
+
+/* This is a comma separated list of keywords used for spotlight indexing of the 'Me' tab. */
+"wordpress, me, app settings, settings, cache, media, about, upload, usage, statistics" = "wordpress, me, app settings, settings, cache, media, about, upload, usage, statistics, кеш, медия, файл, относно, употреба, статистика";
+
+/* This is a comma separated list of keywords used for spotlight indexing of the 'Notification Settings' screen within the 'Me' tab. */
+"wordpress, me, notification, notification settings, settings, comments, email, ping, follow, customize, customise" = "wordpress, me, notification, notification settings, settings, comments, email, ping, follow, customize, customise, известие, нотификация, настройки на нотификациите, настройки на известията, настройки, коментари, имейл, следване, настройка";
+
+/* This is a comma separated list of keywords used for spotlight indexing of the 'Me' tab. */
+"wordpress, me, settings, account, notification log out, logout, log in, login, help, support" = "wordpress, me, settings, account, notification log out, logout, log in, login, help, support, настройки, сетингс, акаунт, изход, излизане, логаут, помощ";
+
+/* This is a comma separated list of keywords used for spotlight indexing of the 'Notifications' tab. */
+"wordpress, notifications, alerts, updates" = "wordpress, notifications, alerts, updates, нотификации, известия, обновявания";
+
+/* This is a comma-separated list of keywords used for spotlight indexing of the 'Reader' tab. */
+"wordpress, reader, articles, posts, blog post, followed, discover, likes, my likes, tags, topics" = "wordpress, reader, articles, posts, blog post, followed, discover, likes, my likes, tags, topics, четене, читател, статии, постове, пост, публикация, публикации, харесвания, харесване, тагове, таг, теми";
+
+/* This is a comma separated list of keywords used for spotlight indexing of the 'My Sites' tab. */
+"wordpress, sites, site, blogs, blog" = "wordpress, sites, site, blogs, blog, сайт, сайтове, блог, блогове";
+
+/* Error message that describes an unknown error had occured */
+"wordpress-api.error.unknown" = "Нещо се обърка. Изчакайте малко и опитайте отново.";
+
+/* Jetpack Plugin Modal on WordPress primary button title */
+"wordpress.jetpack.plugin.modal.primary.button.title" = "Преминете към Jetpack";
+
+/* Jetpack Plugin Modal on WordPress secondary button title */
+"wordpress.jetpack.plugin.modal.secondary.button.title" = "Продължаване без Jetpack";
+
+/* Jetpack Plugin Modal (multiple plugins) on WordPress subtitle with formatted texts. %1$@ is for the site name. */
+"wordpress.jetpack.plugin.modal.subtitle.plural" = "%1$@ ползва индивидуални Jetpack разжирения, които не се поддържат от приложението WordPress.";
+
+/* Jetpack Plugin Modal on WordPress (single plugin) subtitle with formatted texts. %1$@ is for the site name and %2$@ is for the specific plugin name. */
+"wordpress.jetpack.plugin.modal.subtitle.singular" = "%1$@ ползва разширението %2$@, което не се поддържа от WordPress приложението.";
+
+/* Second paragraph of the Jetpack Plugin Modal on WordPress asking the user to switch to Jetpack. */
+"wordpress.jetpack.plugin.modal.subtitle.switch" = "Моля, преминете към приложението Jetpack, където ще ви помогнем да свържете Jetpack разширението, за да ползвате всички функции за този сайт.";
+
+/* Jetpack Plugin Modal title in WordPress */
+"wordpress.jetpack.plugin.modal.title" = "Сайтът не се поддържа от WordPress приложението";
+
+/* Message to show when a request for a WP.com API endpoint is throttled */
+"wordpresskit.api.message.endpoint_throttled" = "Лимитът е достигнат. Опитайте отново след минута. Ако опитате преди това само ще увеличите времето, което ще трябва да изчакате преди да изтече забраната. Ако смятате, че това е грешка, свържете се с поддръжката.";
+
+/* Message to show to user when the app can't find WordPress.org REST API URL. */
+"wordpresskit.org-rest-api.not-found" = "Не успяхме да открием REST API адреса на вашия сайт. Приложението се нуждае от него, за да комуникира със сайта ви. Свържете се с вашия хостинг, за да решите този проблем.";
+
+/* Description of the jetpack migration success card, used in My site. */
+"wp.migration.successCard.description" = "Добре дошли в Jetpack. Може да премахнете WordPress приложението.";
+
+/* Title of a button that displays a blog post in a web view. */
+"wp.migration.successCard.learnMore" = "Повече информация";
+
+/* Error message when user denies access to WordPress.com */
+"wpComLogin.error.accessDenied" = "Достъпът е отказан. Трябва да одобрите вход в WordPress.com";
+
+/* Error message when user signs in with an different account than the account that's alredy signed in. The first argument is the current signed-in account email address */
+"wpComLogin.error.alreadySignedIn" = "Вече сте влезли с имейл %@. Моля излезте и пробвайте пак.";
+
+/* Error message when failing to load user details during WordPress.com login */
+"wpComLogin.error.fetchUser" = "Неуспешно зареждане на потребителска информация";
+
+/* Error message when failing to load account's site after signing in */
+"wpComLogin.error.loadingSites" = "Сайтовете към профила ви не могат да се заредят. Опитайте пак.";
+
+/* Error message when user signs in with an unexpected email address. The first argument is the expected email address */
+"wpComLogin.error.mismatchedEmail" = "Моля, влезте с имейла %@";
+
+/* Message shown when user denies WordPress.com login, offering option to try with different account */
+"wpComLogin.loginDenied.message" = "Можете да влезете с друг профил, ако е нужно. Докоснете \"%@\" за начало.";
+
+/* Title of alert shown when user cancels WordPress.com login */
+"wpComLogin.loginDenied.title" = "Входът е отменен";
+
+/* Button title for signing in with a different WordPress.com account */
+"wpComLogin.loginDenied.useDifferentAccount" = "Ползване на друг профил";
+
+/* Button title to log out the current WordPress.com account */
+"wpcom.token.alert.button.logout" = "Изход";
+
+/* Button title to Sign In to WordPress.com */
+"wpcom.token.alert.button.signin" = "Вход";
+
+/* Message title to be displayed when the user needs to re-authenticate their WordPress.com account. */
+"wpcom.token.fix.signin" = "Вход в WordPress.com";
+
+/* Detailed message to be displayed when the user needs to re-authenticate their WordPress.com account. */
+"wpcom.token.fix.signin.message" = "Трябва да влезете в WordPress.com, за да достъпите профила си.";
+
+/* Managing Zendesk attachments */
+"zendeskAttachmentsSection.addAttachment" = "Прикачване на файл";
+
+/* Managing Zendesk attachments */
+"zendeskAttachmentsSection.removeAttachment" = "Премахване на прикачен файл";
+
+/* Managing Zendesk attachments */
+"zendeskAttachmentsSection.unsupportedAttachmentErrorMessage" = "Неподдържан прикачен файл";
+
+/* Label for button to log in using Google. The {G} will be replaced with the Google logo. */
+"{G} Log in with Google." = "{G} Вход с Google.";
 
 /* Item 4 of delete screen section listing things that will be deleted. */
 "• Domains" = "• Домейни";
@@ -2349,6 +12933,13 @@
 /* Item 1 of delete screen section listing things that will be deleted. */
 "• Posts" = "• Публикации";
 
+/* Item 6 of delete screen section listing things that will be deleted. */
+"• Purchased Upgrades" = "• Закупени ъпгрейди";
+
 /* Item 2 of delete screen section listing things that will be deleted. */
 "• Users & Authors" = "• Потребители и автори";
+
+/* Label that indicates a blogging prompt has been answered.
+   Title label that indicates the prompt has been answered. */
+"✓ Answered" = "✓ Отговорено";
 

--- a/WordPress/Resources/cs.lproj/Localizable.strings
+++ b/WordPress/Resources/cs.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 /* Translation-Revision-Date: 2024-02-29 12:54:40+0000 */
 /* Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n >= 2 && n <= 4) ? 1 : 2); */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: cs_CZ */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -557,8 +557,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "Téměř hotovo! Zadejte ověřovací kód z aplikace Authenticator.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Alternativní text";
 
 /* Instruction text to explain to help users type their password instead of using magic link login option. */
@@ -689,9 +688,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "Opravdu chcete odpojit Jetpack od webové stránky?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "Opravdu chcete tuto položku trvale smazat?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "Opravdu chcete odebrat %1$@ z %2$@?";
@@ -1016,7 +1012,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Zrušit";
@@ -1044,8 +1039,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Nemůžete se rozhodnout? Šablonu můžete kdykoli změnit.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Titulek";
 
 /* Alert title. */
@@ -1693,8 +1687,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "Základní";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Výchozí rubrika";
 
 /* Label for selecting the default post format
@@ -1703,9 +1696,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Výchozí pro nové příspěvky";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Smazat";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Smazat menu";
@@ -1724,20 +1714,13 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "Smazat menu";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Smazáno!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Mazání webu...";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Mazání...";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "Odmítnout";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Popis";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1752,9 +1735,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "Nechtěli jste vytvořit nový účet? Vraťte se zpět a znovu zadejte svou emailovou adresu.";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Rozměry";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "Deaktivovat";
@@ -2022,7 +2002,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "Úpravou tohoto GIF odstraníte jeho animaci.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Šéfredaktor";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2358,11 +2338,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "Nastavení blok souboru";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "Název souboru";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Typ souboru";
 
 /* Film & Television site intent topic */
 "Film & Television" = "Film a televize";
@@ -2709,9 +2686,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "Titulek obrázku";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Popis obrázku";
-
 /* Hint for image link on image settings. */
 "Image Link" = "Odkaz na obrázek";
 
@@ -2723,9 +2697,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "Soubor obrázku nebyl nalezen.";
-
-/* Hint for image title on image settings. */
-"Image title" = "Nadpis obrázku";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "Několika slovy popište, čím se budete na webu zabývat.";
@@ -3601,9 +3572,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "Nenalezeny žádné účty.";
 
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Žádná rubrika";
-
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Bez připojení";
 
@@ -4035,9 +4003,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "Stránkování";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Nadřazená rubrika";
-
 /* Parenting site intent topic */
 "Parenting" = "Rodičovství";
 
@@ -4246,9 +4211,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Příspěvek";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Rubriky příspěvku";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "Nastavení příspěvku";
@@ -4548,9 +4510,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "Odebere metadata polohy z fotografií před jejich nahráním na web.";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "Odebráním sledujících přestanou dostávat aktualizace z vašeho webu. Pokud se rozhodnou, mohou stále navštívit váš web a znovu jej sledovat.";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "Vyměňte aktuální blok";
@@ -5375,6 +5334,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "Popis webu";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Štítky";
 
@@ -5742,9 +5702,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "Platnost tohoto přihlašovacího kódu vypršela. Klepnutím na tlačítko Skenovat znovu kód se znovu naskenujte.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "Tato mediální položka byla smazána.";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "Tento uživatelský účet nelze uzavřít, pokud existují nevyřešená zpětná zúčtování.";
 
@@ -5810,7 +5767,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Název";
@@ -5901,8 +5857,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "Změnit blok...";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Odstranit";
 
@@ -5996,9 +5951,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "Nelze vytvořit nové odkazy na pozvánky.";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "Nelze smazat mediální položku.";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "Nelze deaktivovat odkazy na pozvánky.";
 
@@ -6029,9 +5981,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "Momentálně tento obsah nelze načíst.";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "Nelze načíst video.";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Nelze přehrát video";
 
@@ -6040,9 +5989,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Web nelze obnovit";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "Nelze uložit mediální položku.";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "Odkaz nelze sdílet";
@@ -6186,9 +6132,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Nahrávání selhalo";
-
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Nahráno";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "Nahráno 1 koncept příspěvku, %ld souborů";
@@ -6656,7 +6599,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "Mapa světa zobrazující zobrazení podle země.";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "Chcete opravdu odstranit uživatele?";
 
 /* Button title. Opens the editor to write a new post.

--- a/WordPress/Resources/cy.lproj/Localizable.strings
+++ b/WordPress/Resources/cy.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 /* Translation-Revision-Date: 2022-05-03 21:53:03+0000 */
 /* Plural-Forms: nplurals=4; plural=(n==1) ? 0 : (n==2) ? 1 : (n != 8 && n != 11) ? 2 : 3; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: cy_GB */
 
 /* Title of a list of buttons used for sharing content to other services. These buttons appear when the user taps a `More` button. */
@@ -134,8 +134,7 @@
 /* No comment provided by engineer. */
 "Allow this connection to be used by all admins and users of your site." = "Caniatáu i'r cysylltiad hwn gael ei ddefnyddio gan holl weinyddwyr a defnyddwyr eich gwefan.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Testun Amgen";
 
 /* An error description explaining that a Menu could not be created. */
@@ -294,7 +293,6 @@
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Diddymu";
@@ -307,8 +305,7 @@
 /* Dialog box title for when the user is canceling an upload. */
 "Cancel media uploads" = "Diddymu llwytho cyfryngau";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Egluryn";
 
 /* Alert title. */
@@ -505,8 +502,7 @@
 /* Action title. Noun. Opens the user's WordPress.com dashboard in an external browser. */
 "Dashboard" = "Bwrdd Rheoli";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Categori Rhagosodedig";
 
 /* Label for selecting the default post format
@@ -515,9 +511,6 @@
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Rhagosodiadau Gwefannau Newydd";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Dileu";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Dileu Dewislen";
@@ -622,7 +615,7 @@
 /* Title for the edit sharing buttons section */
 "Edit sharing buttons" = "Golygu'r botymau rhannu";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Golygydd";
 
 /* Accessibility label for the Email text field.
@@ -763,9 +756,6 @@
 
 /* Title of the screen for choosing an image's size. */
 "Image Size" = "Maint Delwedd";
-
-/* Hint for image title on image settings. */
-"Image title" = "Teitl delwedd";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "Esboniwch, mewn ychydig eiriau, bwrpas y wefan.";
@@ -1015,9 +1005,6 @@
    Title of a button. The text should be capitalized. */
 "Next" = "Nesaf";
 
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Dim Categori";
-
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Dim Cysylltiad";
 
@@ -1202,9 +1189,6 @@
    Settings: Comments Paging preferences */
 "Paging" = "Tudalennu";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Categori Rhiant";
-
 /* Accessibility label for the password text field in the self-hosted login page.
    Label for entering password in password field
    Login dialog password placeholder
@@ -1258,9 +1242,6 @@
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Cofnod";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Categoriau Cofnodion";
 
 /* Insights 'Posting Activity' header
    Title for stats Posting Activity view. */
@@ -1644,6 +1625,7 @@
 "Tagline" = "Llinell Tag";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Tagiau";
 
@@ -1748,9 +1730,6 @@
 /* An error message display if the users device does not have a camera input available */
 "This app needs permission to access the Camera to capture new media, please change the privacy settings if you wish to allow this." = "Mae'r ap angen caniatâd i gael mynediad at y Camera i gipio cyfryngau newydd, newidiwch y gosodiadau preifatrwydd os ydych yn dymuno caniatáu hyn.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "Mae'r eitem cyfrwng hwn wedi ei ddileu.";
-
 /* A description of the twitter sharing setting.
    Information about the twitter sharing feature. */
 "This will be included in tweets when people share using the Twitter button." = "Bydd hyn cael ei gynnwys mewn trydar pan fydd pobl yn rhannu gan ddefnyddio'r botwm Twitter.";
@@ -1767,7 +1746,6 @@
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Teitl";
@@ -1786,8 +1764,7 @@
 /* Shortened version of the main title to be used in back navigation */
 "Topic" = "Pwnc";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Dileu";
 
@@ -1826,9 +1803,6 @@
 
 /* Title of error prompt shown when a sync the user initiated fails. */
 "Unable to Sync" = "Methu Cydweddu";
-
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "Methu llwytho fideo";
 
 /* Error reason to display when the writing of a image to a file fails */
 "Unable to write image to file" = "Methu ysgrifennu'r ddelwedd i ffeil";
@@ -1881,9 +1855,6 @@
 
 /* Label action for updating a link on the editor */
 "Update Link" = "Diweddaru Dolen";
-
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Wedi ei lwytho";
 
 /* \"Uploading\" Status text */
 "Uploading" = "Llwytho i fyny";

--- a/WordPress/Resources/da.lproj/Localizable.strings
+++ b/WordPress/Resources/da.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 /* Translation-Revision-Date: 2025-08-13 08:09:18+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: da_DK */
 
 /* Age between dates over one day.
@@ -39,8 +39,7 @@
    Title of the screen for choosing an image's alignment. */
 "Alignment" = "Justering";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Alternativ tekst";
 
 /* Approve action. Verb
@@ -114,7 +113,6 @@
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Annuller";
@@ -122,8 +120,7 @@
 /* Dialog box title for when the user is canceling an upload. */
 "Cancel media uploads" = "Annuller overførsel af medier";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Billedtekst";
 
 /* Center alignment for an image. Should be the same as in core WP. */
@@ -212,36 +209,22 @@
 /* Action title. Noun. Opens the user's WordPress.com dashboard in an external browser. */
 "Dashboard" = "Kontrolpanel";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Standardkategori";
 
 /* Label for selecting the default post format
    Title for screen to select a default post format for a blog */
 "Default Post Format" = "Standard indlægsformat";
 
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Slet";
-
 /* Title for button on the comment details page that deletes the comment when tapped. */
 "Delete Permanently" = "Slet permanent";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Slettet!";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Sletter...";
-
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Beskrivelse";
 
 /* Details button that appears in the Theme Browser Header
    Theme Details action title */
 "Details" = "Detaljer";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Dimensioner";
 
 /* Adjective. Comment threading is disabled. */
 "Disabled" = "Slået fra";
@@ -296,7 +279,7 @@
 /* No comment provided by engineer. */
 "Edit media" = "Rediger medie";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Editor";
 
 /* Accessibility label for the Email text field.
@@ -341,11 +324,8 @@
 /* A brief prompt shown when the comment list is empty, letting the user know the app is currently fetching new comments. */
 "Fetching comments..." = "Henter kommentarer...";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "Filnavn";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Filtype";
 
 /* User role badge */
 "Follower" = "Følger";
@@ -388,9 +368,6 @@
 
 /* Displays the ignored threats */
 "Ignored" = "Ignoreret";
-
-/* Hint for image description on image settings. */
-"Image Description" = "Beskrivelse af billede";
 
 /* Title of the screen for choosing an image's size. */
 "Image Size" = "Billedstørrelse";
@@ -571,9 +548,6 @@
 /* Empty state message (People Management). %@ can be 'users' or 'followers' */
 "No %@ yet" = "Ingen %@ endnu";
 
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Ingen kategori";
-
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Ingen forbindelse";
 
@@ -676,9 +650,6 @@
    Title of the screen showing the list of pages for a blog. */
 "Pages" = "Sider";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Forælderkategori";
-
 /* Accessibility label for the password text field in the self-hosted login page.
    Label for entering password in password field
    Login dialog password placeholder
@@ -722,9 +693,6 @@
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Indlæg";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Indlægskategorier";
 
 /* All Time Stats 'Posts' label
    Insights 'Posts' header
@@ -949,6 +917,7 @@
 "Support" = "Support";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Tags";
 
@@ -1001,7 +970,6 @@
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Titel";
@@ -1014,8 +982,7 @@
 /* Shortened version of the main title to be used in back navigation */
 "Topic" = "Emne";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Slet";
 
@@ -1062,9 +1029,6 @@
 
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Upload fejlede";
-
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Uploadet";
 
 /* \"Uploading\" Status text */
 "Uploading" = "Uploader";

--- a/WordPress/Resources/de.lproj/Localizable.strings
+++ b/WordPress/Resources/de.lproj/Localizable.strings
@@ -1,6 +1,6 @@
-/* Translation-Revision-Date: 2025-10-10 09:54:08+0000 */
+/* Translation-Revision-Date: 2025-11-26 09:54:09+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: de */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -581,8 +581,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "Fast geschafft! Gib bitte den Verifizierungscode aus deiner Authenticator-App ein.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Alt-Text";
 
 /* No comment provided by engineer. */
@@ -725,9 +724,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "Bist du sicher, dass du Jetpack von der Website trennen möchtest?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "Bist du sicher, dass du dieses Element endgültig löschen möchtest?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "Möchtest du wirklich %1$@ aus %2$@ entfernen?";
@@ -1082,7 +1078,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Abbrechen";
@@ -1110,8 +1105,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Unentschlossen? Du kannst das Theme jederzeit ändern.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Untertitel";
 
 /* Alert title. */
@@ -1269,7 +1263,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Choose video" = "Video auswählen";
 
 /* Register Domain - Address information field City */
-"City" = "Ort";
+"City" = "Stadt";
 
 /* Title of the card that starts the registration of a free domain with a paid plan, in the Domains Dashboard. */
 "Claim your free domain" = "Kostenlose Domain in Anspruch nehmen";
@@ -1765,7 +1759,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Date and Time Format" = "Datums- und Zeitformat";
 
 /* Navigates to debug menu only available in development builds */
-"Debug" = "Debug";
+"Debug" = "Fehlerdiagnose";
 
 /* Only December needs to be translated */
 "December 17, 2017" = "17. Dezember 2017";
@@ -1777,8 +1771,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "Standard";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Standardkategorie";
 
 /* Label for selecting the default post format
@@ -1787,9 +1780,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Standardeinstellungen für neue Beiträge";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Löschen";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Menü löschen";
@@ -1808,14 +1798,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "Menü löschen";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Gelöscht!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Lösche Website …";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Wird gelöscht …";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "Ablehnen";
@@ -1823,8 +1807,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "Beschreibe den Zweck des Bildes. Lass dieses Feld frei, falls es dekorativ ist.";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Beschreibung";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1842,9 +1825,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "Du wolltest kein neues Konto erstellen? Gehe zurück und gib deine E-Mail-Adresse noch einmal ein.";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Abmessungen";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "Deaktivieren";
@@ -2121,7 +2101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "Wenn dieses GIF bearbeitet wird, wird die Animation entfernt.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Editor";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2437,7 +2417,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Fastmail" = "Fastmail";
 
 /* Header of section in Plugin Directory showing featured plugins */
-"Featured" = "Vorgestellt";
+"Featured" = "Hervorgehoben";
 
 /* Text displayed while fetching themes */
 "Fetching Themes..." = "Rufe Themes ab ...";
@@ -2463,11 +2443,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "Blockeinstellungen der Datei";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "Dateiname";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Dateityp";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "Der Dateityp wird nicht als Mediendatei unterstützt.";
@@ -2781,6 +2758,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post content used in the login prologue screens. */
 "I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next" = "Ich finde die Arbeit von Fotograf Cameron Karsten sehr inspirierend. Das nächste Mal probiere ich diese Techniken auch aus";
 
+/* Text on the support form to refer to what area the user has problem with. */
+"I need help with" = "Ich brauche Hilfe bei";
+
 /* Describes the IP address section in the comment detail screen. */
 "IP address" = "IP-Adresse";
 
@@ -2826,9 +2806,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "Bildunterschrift";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Bildbeschreibung";
-
 /* Hint for image link on image settings. */
 "Image Link" = "Bild-Link";
 
@@ -2840,9 +2817,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "Bilddatei nicht gefunden.";
-
-/* Hint for image title on image settings. */
-"Image title" = "Bildtitel";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "Erkläre in ein paar Worten, worum es auf der Website geht. ";
@@ -3205,6 +3179,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the button that will dismiss this view. */
 "Let me know when finished!" = "Lass mich wissen, wenn du fertig bist!";
 
+/* Message info on the support screen. */
+"Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon." = "Teile uns deine Website-Adresse (URL) mit und gib uns möglichst viele Informationen zu dem Problem. Wir melden uns bei dir.";
+
+/* Title to let the user know what do we want on the support screen. */
+"Let’s get this sorted" = "Lass uns das Problem lösen";
+
 /* Lifestyle site intent topic */
 "Lifestyle" = "Lifestyle";
 
@@ -3405,6 +3385,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Hauptnavigation";
+
+/* Explanation for the option to enable theme styles */
+"Make the block editor look like your theme." = "Lass den Block-Editor wie dein Theme aussehen.";
 
 /* No comment provided by engineer. */
 "Make your content stand out by adding images, gifs, videos, and embedded media to your pages." = "Sorge dafür, dass dein Inhalt hervorsticht, indem du Bilder, GIFs, Videos und andere eingebettete Medien zu deinen Seiten hinzufügst.";
@@ -3612,7 +3595,7 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Title for button on the comment details page that moves the comment to trash when tapped.
    Trashes the comment */
-"Move to Trash" = "In Papierkorb verschieben";
+"Move to Trash" = "In den Papierkorb verschieben";
 
 /* No comment provided by engineer. */
 "Move to bottom" = "Nach unten verschieben";
@@ -3747,9 +3730,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "Keine Konten gefunden";
-
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Keine Kategorie";
 
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Keine Verbindung";
@@ -3987,7 +3967,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Now that Jetpack is installed, we just need to get you set up. This will only take a minute." = "Jetpack ist installiert. Jetzt müssen wir nur noch die Einrichtung abschließen. Dies dauert nur eine Minute.";
 
 /* Register Domain - Address information field Number */
-"Number" = "Anzahl";
+"Number" = "Nummer";
 
 /* No comment provided by engineer. */
 "Number of columns" = "Anzahl der Spalten";
@@ -4119,7 +4099,7 @@ translators: %s: Select control button label e.g. \"Button width\" */
 "Or log in with magic link" = "Oder mit magischem Link anmelden";
 
 /* Accessibility label for Ordered list button on formatting toolbar. */
-"Ordered List" = "Geordnete Liste";
+"Ordered List" = "Nummerierte Liste";
 
 /* Register Domain - Domain contact information field Organization */
 "Organization" = "Organisation";
@@ -4190,9 +4170,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Discussion Settings
    Settings: Comments Paging preferences */
 "Paging" = "Seitennummerierung";
-
-/* Title for selecting parent category of a category */
-"Parent Category" = "Übergeordnete Kategorie";
 
 /* Parenting site intent topic */
 "Parenting" = "Kindererziehung";
@@ -4411,9 +4388,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Veröffentlichen";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Beitragskategorien";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "Beitragseinstellungen";
@@ -4722,9 +4696,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "Entfernt vor dem Hochladen von Fotos zu deiner Website die jeweiligen Standort-Metadaten.";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "Wenn du Follower entfernst, erhalten sie keine Updates mehr von deiner Website. Wenn sie möchten, können sie deine Website aber weiterhin besuchen und dir auch wieder folgen.";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "Aktuellen Block ersetzen";
@@ -5561,6 +5532,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "Untertitel";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Schlagwörter";
 
@@ -5657,6 +5629,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint, informing user the button can be used to visit the Gravatar website. */
 "Tap to visit the Gravatar website in an external browser" = "Tippe, um die Gravatar-Website in einem externen Browser zu öffnen";
+
+/* Label for viewing the custom taxonomies */
+"Taxonomies" = "Taxonomien";
 
 /* Technology site intent topic */
 "Technology" = "Technologie";
@@ -5946,9 +5921,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "Dieser Anmeldecode ist abgelaufen. Bitte tippe auf den Button „Erneut scannen“, um den Code erneut zu scannen.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "Dieses Medienelement wurde gelöscht.";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "Dieses Benutzerkonto kann nicht geschlossen werden, solange noch ungelöste Rückbuchungen bestehen.";
 
@@ -6017,7 +5989,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Titel";
@@ -6111,8 +6082,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "Block umwandeln …";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Papierkorb";
 
@@ -6209,9 +6179,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "Neue Einladungslinks können nicht erstellt werden.";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "Medienelement kann nicht gelöscht werden.";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "Einladungslinks können nicht deaktiviert werden";
 
@@ -6242,9 +6209,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "Dieser Inhalt kann gerade nicht geladen werden.";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "Video konnte nicht geladen werden.";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Video konnte nicht abgespielt werden";
 
@@ -6253,9 +6217,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Deine Website kann nicht wiederhergestellt werden";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "Medienelement kann nicht gespeichert werden.";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "Link kann nicht geteilt werden";
@@ -6343,7 +6304,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Unnamed Site" = "Unbenannte Website";
 
 /* Accessibility label for unordered list button on formatting toolbar. */
-"Unordered List" = "Ungeordnete Liste";
+"Unordered List" = "Unsortierte Liste";
 
 /* Filters Unread Notifications */
 "Unread" = "Ungelesen";
@@ -6412,9 +6373,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Hochladen fehlgeschlagen";
 
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Hochgeladen";
-
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "1 Beitragsentwurf, %ld Dateien hochgeladen";
 
@@ -6456,6 +6414,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The button title text for logging in with WP.com password instead of magic link. */
 "Use password to sign in" = "Mit Passwort anmelden";
+
+/* Option to enable theme styles in the block editor */
+"Use theme styles" = "Theme-Stile verwenden";
 
 /* A placeholder for the twitter username
    Accessibility label for the username text field in the self-hosted login page.
@@ -6572,10 +6533,10 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Visit %@ for more" = "Besuche %@ für mehr";
 
 /* Text of a button that links to the VaultPress dashboard. */
-"Visit Dashboard" = "Dashboard besuchen";
+"Visit Dashboard" = "Dashboard aufrufen";
 
 /* Title for the button that will open a link to this site. */
-"Visit site" = "Website besuchen";
+"Visit site" = "Website aufrufen";
 
 /* Accessibility label used for distinguishing Views and Visitors in the Stats → Views bar chart.
    All Time Stats 'Visitors' label
@@ -6737,7 +6698,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Week" = "Woche";
 
 /* Blog Writing Settings: Weeks starts on */
-"Week starts on" = "Woche beginnt am";
+"Week starts on" = "Erster Wochentag";
 
 /* Setting: indicates if the site reports its Weekly Roundup
    Title of Weekly Roundup push notification */
@@ -6802,7 +6763,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "What was the problem?" = "Was war das Problem?";
 
 /* Title of section that contains plugins' change log */
-"What's New" = "Was ist neu?";
+"What's New" = "Neues";
 
 /* Opens the What's New / Feature Announcement modal */
 "What's New in Jetpack" = "Neu in Jetpack";
@@ -6906,7 +6867,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "Weltkarte mit Aufrufen pro Land.";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "Möchtest du diese Person trotzdem entfernen?";
 
 /* Button title. Opens the editor to write a new post.
@@ -7194,7 +7155,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "activityDetail.title" = "Ereignis";
 
 /* Deselect all button */
-"activityLogs.activityTypes.deselectAll" = "Auswahl aufheben";
+"activityLogs.activityTypes.deselectAll" = "Alle abwählen";
 
 /* Empty state message when no activity types are available */
 "activityLogs.activityTypes.empty" = "Es sind keine Aktivitätstypen verfügbar";
@@ -7282,7 +7243,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "appSettings.media.imageQuality.low" = "Niedrig";
 
 /* Indicates an image will use maximum quality when uploaded. */
-"appSettings.media.imageQuality.maximum" = "Maximal";
+"appSettings.media.imageQuality.maximum" = "Maximum";
 
 /* Indicates an image will use medium quality when uploaded. */
 "appSettings.media.imageQuality.medium" = "Mittel";
@@ -7312,7 +7273,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "appUpdate.versionFormat" = "Version %@";
 
 /* Section title for what's new in the latest update available */
-"appUpdate.whatsNew" = "Neuigkeiten";
+"appUpdate.whatsNew" = "Neues";
 
 /* The list item of experimental features that users can choose to enable */
 "application-settings.experimental-features" = "Experimentelle Funktionen";
@@ -7377,14 +7338,19 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Description for the prompt to upgrade to Application Passwords. The first argument is the name of the feature that requires Application Passwords. */
 "applicationPasswordRequired.description" = "Anwendungspasswörter sind eine noch sicherere Methode, auf deine selbst gehostete Website zuzugreifen und Funktionen wie %@ zu nutzen.";
 
+/* Feature name for managing application passwords in the app */
+"applicationPasswordRequired.feature.applicationPasswords" = "Verwaltung der Anwendungspasswörter";
+
 /* Feature name for the block editor in application password required prompt */
 "applicationPasswordRequired.feature.blockEditor" = "Block-Editor";
+
+/* Feature name for managing terms and taxonomies in the app */
+"applicationPasswordRequired.feature.customTaxonomies" = "Taxonomieverwaltung";
 
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "Plugin-Verwaltung";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "Benutzerverwaltung";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -7542,7 +7508,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "blogDashboard.dismiss" = "Verwerfen";
 
 /* Context menu button title */
-"blogHeader.actionVisitSite" = "Zur Website";
+"blogHeader.actionVisitSite" = "Website aufrufen";
 
 /* Badge title in site list */
 "blogList.siteBadge.staging" = "Staging";
@@ -7613,6 +7579,288 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 
 /* Post Editor / Button in the 'More' menu */
 "classicEditor.moreMenu.saveDraft" = "Entwurf speichern";
+
+/* Button to add more screenshots */
+"com.jetpack.support.addMoreScreenshots" = "Weitere Screenshots hinzufügen";
+
+/* Button to add screenshots */
+"com.jetpack.support.addScreenshots" = "Screenshots hinzufügen";
+
+/* Header for application logs section */
+"com.jetpack.support.applicationLogs" = "Anwendungsprotokolle";
+
+/* Description explaining why including logs is helpful */
+"com.jetpack.support.applicationLogsDescription" = "Das Hinzufügen von Protokollen kann unserem Team helfen, Probleme zu untersuchen. Protokolle können aktuelle App-Aktivitäten enthalten.";
+
+/* Navigation title for application logs screen */
+"com.jetpack.support.applicationLogsTitle" = "Anwendungsprotokolle";
+
+/* Format string for attachment identifier */
+"com.jetpack.support.attachment" = "Anhang: %@";
+
+/* Format string for attachment size limit. %1$@ is current size, %2$@ is maximum size */
+"com.jetpack.support.attachmentLimit" = "Anhangslimit: %1$@\/%2$@";
+
+/* Bot greeting message. %1$@ is the user's name */
+"com.jetpack.support.botGreeting" = "Hallo %1$@!";
+
+/* Bot introduction message explaining its purpose */
+"com.jetpack.support.botIntroduction" = "Ich bin dein persönlicher KI-Assistent. Ich kann dich bei allen Fragen zu deiner Website oder deinem Konto unterstützen.";
+
+/* Format string for cache file count and size. %1$d is the number of files, %2$@ is the formatted size. The system will pluralize 'files' based on the number – please specify it as the largest plural value */
+"com.jetpack.support.cacheFiles" = "%1$d zwischengespeicherte Dateien (%2$@)";
+
+/* Message shown when cache has no files */
+"com.jetpack.support.cacheIsEmpty" = "Cache ist leer";
+
+/* Button to cancel current action */
+"com.jetpack.support.cancel" = "Abbrechen";
+
+/* Warning message that deleted logs cannot be recovered */
+"com.jetpack.support.cannotRecoverLogs" = "Dieser Vorgang kann nicht rückgängig gemacht werden.";
+
+/* Button to clear all activity logs */
+"com.jetpack.support.clearAllActivityLogs" = "Alle Aktivitätsprotokolle löschen";
+
+/* Button to clear disk cache */
+"com.jetpack.support.clearDiskCache" = "Festplatten-Cache leeren";
+
+/* Description explaining the purpose of clearing disk cache */
+"com.jetpack.support.clearDiskCacheDescription" = "Entferne temporäre Dateien, um Speicherplatz freizugeben oder Probleme zu lösen.";
+
+/* Progress text while clearing cache */
+"com.jetpack.support.clearing" = "Wird gelöscht ...";
+
+/* Message shown when cache clearing is complete */
+"com.jetpack.support.complete" = "Abschließen";
+
+/* Confirmation message when canceling a draft */
+"com.jetpack.support.confirmCancelMessage" = "Bist du sicher, dass du diesen Entwurf löschen möchtest? Alle eingegebenen Daten gehen verloren";
+
+/* Title for alert confirming cancellation */
+"com.jetpack.support.confirmCancellation" = "Löschen bestätigen";
+
+/* Confirmation dialog title when deleting all logs */
+"com.jetpack.support.confirmDeleteAllLogs" = "Bist du sicher, dass du alle Protokolle löschen möchtest?";
+
+/* Section title for contact information */
+"com.jetpack.support.contactInformation" = "Kontaktinformation";
+
+/* Button to continue editing a message */
+"com.jetpack.support.continueWriting" = "Weiterschreiben";
+
+/* Message shown at end of closed support conversation */
+"com.jetpack.support.conversationEnded" = "Ende der Unterhaltung. Weitere Antworten sind nicht möglich.";
+
+/* Navigation title for bot conversations list */
+"com.jetpack.support.conversations" = "Unterhaltungen";
+
+/* Button to delete all log files */
+"com.jetpack.support.deleteAllLogs" = "Alle Protokolle löschen";
+
+/* Description text for diagnostics screen */
+"com.jetpack.support.diagnosticsDescription" = "Führe häufige Wartungs- und Problembehandlungsaufgaben aus.";
+
+/* Navigation title for diagnostics screen */
+"com.jetpack.support.diagnosticsTitle" = "Diagnose";
+
+/* Button to discard changes in a draft message */
+"com.jetpack.support.discardChanges" = "Änderungen verwerfen";
+
+/* Notice explaining where support will send email responses */
+"com.jetpack.support.emailNotice" = "Wir senden dir eine E-Mail an diese Adresse.";
+
+/* Error title when logs fail to load */
+"com.jetpack.support.errorLoadingLogs" = "Fehler beim Laden der Protokolle";
+
+/* Error message when support conversations fail to load */
+"com.jetpack.support.errorLoadingSupportConversations" = "Fehler beim Laden der Supportunterhaltungen";
+
+/* Title for error alerts */
+"com.jetpack.support.errorTitle" = "Fehler";
+
+/* Option to export log as a file */
+"com.jetpack.support.exportAsFile" = "Als Datei exportieren";
+
+/* Button to dismiss alerts. */
+"com.jetpack.support.gotIt" = "Schließen";
+
+/* Text on the support form to refer to what area the user has problem with. */
+"com.jetpack.support.iNeedHelp" = "Ich brauche Hilfe bei";
+
+/* Toggle label to include application logs in the support request */
+"com.jetpack.support.includeApplicationLogs" = "Anwendungsprotokolle einbeziehen";
+
+/* Section title for issue details */
+"com.jetpack.support.issueDetails" = "Problemdetails";
+
+/* Format string for when conversation was last updated */
+"com.jetpack.support.lastUpdated" = "Letzte Aktualisierung: %@";
+
+/* Progress message while loading conversation messages */
+"com.jetpack.support.loadingBotConversationMessages" = "Nachrichten werden geladen";
+
+/* Progress message while loading bot conversations */
+"com.jetpack.support.loadingBotConversations" = "Bot-Unterhaltungen werden geladen";
+
+/* Progress text while loading support conversations */
+"com.jetpack.support.loadingConversations" = "Unterhaltungen werden geladen";
+
+/* Progress message while loading disk usage information */
+"com.jetpack.support.loadingDiskUsage" = "Festplattennutzung wird geladen";
+
+/* Progress message while loading an image attachment */
+"com.jetpack.support.loadingImage" = "Bild wird geladen";
+
+/* Progress message shown in overlay while refreshing content */
+"com.jetpack.support.loadingLatestContent" = "Aktueller Inhalt wird geladen";
+
+/* Progress message while loading application log content */
+"com.jetpack.support.loadingLogContent" = "Protokollinhalt wird geladen …";
+
+/* Progress message while loading log files */
+"com.jetpack.support.loadingLogs" = "Protokolle werden geladen …";
+
+/* Progress text while loading conversation messages */
+"com.jetpack.support.loadingMessages" = "Nachrichten werden geladen";
+
+/* Progress message while loading a video attachment */
+"com.jetpack.support.loadingVideo" = "Video wird geladen";
+
+/* Section header for log files sorted by date */
+"com.jetpack.support.logFilesByDate" = "Protokolldateien nach Erstellungsdatum";
+
+/* Text indicating which log files will be included in the support request */
+"com.jetpack.support.logFilesToUpload" = "Die folgenden Protokolldateien werden hochgeladen:";
+
+/* Footer text explaining log retention policy */
+"com.jetpack.support.logRetentionNotice" = "Es werden Protokolle für einen Zeitraum von bis zu sieben Tagen gespeichert.";
+
+/* Section header for message text input */
+"com.jetpack.support.message" = "Nachricht";
+
+/* Success message when reply is sent successfully */
+"com.jetpack.support.messageSent" = "Nachricht gesendet";
+
+/* Format string for number of messages in conversation */
+"com.jetpack.support.messagesCount" = "%d Nachrichten";
+
+/* The title of a new bot chat in the support area of the app */
+"com.jetpack.support.new-bot-chat" = "Neuer Bot-Chat";
+
+/* Option to create a new support ticket */
+"com.jetpack.support.newSupportTicket" = "Neues Support-Ticket";
+
+/* Label shown when there are no bot conversations */
+"com.jetpack.support.noConversations" = "Keine Unterhaltungen";
+
+/* Description shown when no log files are available */
+"com.jetpack.support.noLogsAvailable" = "Es sind keine Aktivitätsprotokolle verfügbar";
+
+/* Label shown when no log files are available */
+"com.jetpack.support.noLogsFound" = "Keine Protokolle gefunden";
+
+/* Button to open a support ticket */
+"com.jetpack.support.openSupportTicket" = "Ein Support-Ticket öffnen";
+
+/* Text indicating a field is optional */
+"com.jetpack.support.optional" = "(optional)";
+
+/* Navigation title for replying to a support conversation */
+"com.jetpack.support.reply" = "Antworten";
+
+/* Description for saving log as a file */
+"com.jetpack.support.saveAsFile" = "Als Datei zum Teilen oder Aufbewahren speichern";
+
+/* Label for screenshots section */
+"com.jetpack.support.screenshots" = "Screenshots";
+
+/* Description for screenshots section */
+"com.jetpack.support.screenshotsDescription" = "Das Hinzufügen von Screenshots kann uns helfen, dein Problem schneller zu verstehen und zu lösen.";
+
+/* Button to send a message or reply */
+"com.jetpack.support.send" = "Senden";
+
+/* Description for sending logs to support */
+"com.jetpack.support.sendLogsToSupport" = "Protokolle direkt an das Support-Team senden";
+
+/* Progress text while sending a message */
+"com.jetpack.support.sending" = "Wird gesendet";
+
+/* Progress message shown while sending a message */
+"com.jetpack.support.sendingMessage" = "Nachricht wird gesendet";
+
+/* Button to share content */
+"com.jetpack.support.share" = "Teilen";
+
+/* Navigation title for sharing activity log */
+"com.jetpack.support.shareActivityLog" = "Aktivitätsprotokoll teilen";
+
+/* Message shown when sharing log with support */
+"com.jetpack.support.sharingWithSupport" = "Wird mit dem Support geteilt!";
+
+/* Site Address title on the support form */
+"com.jetpack.support.siteAddress" = "Website-Adresse";
+
+/* Placeholder for site address field */
+"com.jetpack.support.siteAddressPlaceholder" = "https:\/\/yoursite.com";
+
+/* Description encouraging user to start a new conversation */
+"com.jetpack.support.startNewConversation" = "Starte eine neue Unterhaltung über den oben angezeigten Button";
+
+/* Subject title on the support form */
+"com.jetpack.support.subject" = "Betreff";
+
+/* Placeholder for subject field */
+"com.jetpack.support.subjectPlaceholder" = "Kurze Zusammenfassung deines Problems";
+
+/* Button title to submit a support request. */
+"com.jetpack.support.submitRequest" = "Supportanfrage senden";
+
+/* Navigation title for the support conversations list */
+"com.jetpack.support.supportConversations" = "Support-Unterhaltungen";
+
+/* Title for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSent" = "Anfrage gesendet!";
+
+/* Message for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSentMessage" = "Deine Supportanfrage wurde erfolgreich übermittelt. Wir antworten dir so schnell wie möglich per E-Mail.";
+
+/* Progress message shown while bot is thinking */
+"com.jetpack.support.thinking" = "Lass mich nachdenken …";
+
+/* Title of the view for contacting support. */
+"com.jetpack.support.title" = "Support kontaktieren";
+
+/* Button to retry a failed operation */
+"com.jetpack.support.tryAgain" = "Erneut versuchen";
+
+/* Error title when log deletion fails */
+"com.jetpack.support.unableToDeleteLogs" = "Die Protokolle können nicht gelöscht werden";
+
+/* Error message when conversation cannot be displayed */
+"com.jetpack.support.unableToDisplayConversation" = "Die Unterhaltung kann nicht angezeigt werden";
+
+/* Error title when video cannot be loaded or played */
+"com.jetpack.support.unableToDisplayVideo" = "Video kann nicht angezeigt werden";
+
+/* Error message when application logs cannot be loaded */
+"com.jetpack.support.unableToLoadApplicationLogs" = "Anwendungsprotokolle konnten nicht geladen werden";
+
+/* Error title when bot conversations fail to load */
+"com.jetpack.support.unableToLoadConversations" = "Konversationen konnten nicht geladen werden";
+
+/* Error title when messages fail to load */
+"com.jetpack.support.unableToLoadMessages" = "Nachrichten konnten nicht geladen werden";
+
+/* Error title when message sending fails */
+"com.jetpack.support.unableToSendMessage" = "Nachricht kann nicht gesendet werden";
+
+/* Button to view an attachment */
+"com.jetpack.support.view" = "Anzeigen";
+
+/* Progress message shown during cache clearing operation */
+"com.jetpack.support.working" = "In Arbeit";
 
 /* Displayed in the confirmation alert when marking comment notifications as read. */
 "comment" = "Kommentar";
@@ -7879,6 +8127,9 @@ Example: Reply to Pamela Nguyen */
 /* Weekly Roundup debug menu item */
 "debugMenu.weeklyRoundup" = "Wöchentliche Zusammenfassung";
 
+/* Title for selecting a default category for a post */
+"defaultCategory.title" = "Standardkategorie";
+
 /* Error tilte */
 "discussionSettings.saveErrorTitle" = "Einstellungen konnten nicht gespeichert werden";
 
@@ -8018,16 +8269,16 @@ Example: Reply to Pamela Nguyen */
 "double-tap to change unit" = "Zum Wechseln der Einheit zweimal tippen";
 
 /* Message for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.message" = "Bist du sicher, dass du dieses Schlagwort löschen möchtest?";
+"edit.tag.delete.confirmation.message" = "Bist du sicher, dass du dies löschen möchtest?";
 
-/* Title for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.title" = "Schlagwort löschen";
+/* Title for delete a term confirmation dialog */
+"edit.tag.delete.confirmation.title" = "Löschen";
 
 /* Placeholder text for tag description field */
 "edit.tag.description.placeholder" = "Beschreibung hinzufügen …";
 
 /* Placeholder text for tag name field */
-"edit.tag.name.placeholder" = "Schlagwortname";
+"edit.tag.name.placeholder" = "Schlagwort-Name";
 
 /* Navigation title for new tag creation */
 "edit.tag.new.title" = "Neues Schlagwort";
@@ -8036,7 +8287,37 @@ Example: Reply to Pamela Nguyen */
 "edit.tag.section.description" = "Beschreibung";
 
 /* Section header for tag name in edit tag view */
-"edit.tag.section.tag" = "Schlagwort";
+"edit.tag.section.tag" = "Name";
+
+/* Context menu action to insert a block */
+"editor.blockInserter.insertBlock" = "Block einfügen";
+
+/* Placeholder text for block search field */
+"editor.blockInserter.search" = "Suchen";
+
+/* Button title to collapse and show fewer blocks */
+"editor.blockInserter.showLess" = "Weniger anzeigen";
+
+/* Button title to expand and show more blocks */
+"editor.blockInserter.showMore" = "Mehr anzeigen";
+
+/* Error message when media insertion fails */
+"editor.media.failedToInsert" = "Medien konnten nicht eingefügt werden";
+
+/* Category name for section showing all patterns */
+"editor.patterns.all" = "Alle";
+
+/* Context menu action to insert a pattern */
+"editor.patterns.insertPattern" = "Vorlage einfügen";
+
+/* Title shown when no patterns match the search */
+"editor.patterns.noPatternsFound" = "Keine Vorlagen gefunden";
+
+/* Navigation title for patterns view */
+"editor.patterns.title" = "Vorlagen";
+
+/* Category name for patterns without a category */
+"editor.patterns.uncategorized" = "Unkategorisiert";
 
 /* Register Domain - Address information field Number placeholder */
 "eg. 1122334455" = "z. B. 1122334455";
@@ -8591,6 +8872,24 @@ Example: Reply to Pamela Nguyen */
 /* Write a blog prompt for the jetpack prologue */
 "jetpack.prologue.prompt.writeBlog" = "Ein Blog schreiben";
 
+/* Description for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.description" = "Jeder kann diesen Beitrag anzeigen";
+
+/* Title for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.title" = "Jeder";
+
+/* Description for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.description" = "Nur zahlende Abonnenten können diesen Beitrag anzeigen";
+
+/* Title for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.title" = "Zahlende Abonnenten";
+
+/* Description for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.description" = "Der Beitrag ist für alle Abonnenten sichtbar, auch für kostenlose";
+
+/* Title for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.title" = "Alle Abonnenten";
+
 /* Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account */
 "jetpackSite.connectToDefaultAccount" = "Du musst dich mit %@ anmelden, um Statistiken und Benachrichtigungen zu verwenden.";
 
@@ -9142,7 +9441,7 @@ Example: Reply to Pamela Nguyen */
 "jetpackStats.topList.longestTimeOnSite" = "Längste Zeit auf der Website";
 
 /* Title for most commented items */
-"jetpackStats.topList.mostCommented" = "Am meisten kommentiert";
+"jetpackStats.topList.mostCommented" = "Meistkommentiert";
 
 /* Title for chart */
 "jetpackStats.topList.mostDownloads" = "Am meisten heruntergeladen";
@@ -9179,6 +9478,12 @@ Example: Reply to Pamela Nguyen */
 
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "Du hast keine Berechtigung, diesen privaten Blog anzuzeigen.";
+
+/* Default empty state message format when there are no terms. %1$@ is the taxonomy name. */
+"localizedLabels.defaultNoTerms.format" = "Keine %1$@";
+
+/* Default search placeholder format. %1$@ is the taxonomy name. */
+"localizedLabels.defaultSearch.format" = "%1$@ suchen";
 
 /* Button to dismiss the re-authentication view */
 "login.appPasswordReAuth.cancelButton" = "Abbrechen";
@@ -9315,17 +9620,23 @@ Example: Reply to Pamela Nguyen */
 /* Message about buying storage add-on */
 "mediaLibrary.storageDetails.buyStorage.message" = "Speicherplatz-Add-on kaufen";
 
-/* Message shown when all media items are attached */
-"mediaLibrary.storageDetails.cleanup.allAttached" = "Alle Elemente in der Mediathek sind verknüpft.";
+/* Label for audio media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.audio" = "Audio";
 
-/* Message shown while loading unattached media count */
-"mediaLibrary.storageDetails.cleanup.loading" = "Es wird ermittelt, ob nicht verknüpfte Medienelemente vorhanden sind …";
+/* Label for document media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.document" = "Dokumente";
 
-/* Message about unattached media that can be cleaned up. %1$d is the count of unattached media. */
-"mediaLibrary.storageDetails.cleanup.message" = "%1$d Elemente nicht verknüpft. Entferne sie, um Speicherplatz freizugeben.";
+/* Label for image media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.image" = "Bilder";
 
-/* Title for cleanup section */
-"mediaLibrary.storageDetails.cleanup.title" = "Nicht verwendete Elemente entfernen";
+/* Label for other/unknown media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.other" = "Sonstige";
+
+/* Label for PowerPoint/presentation media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.powerpoint" = "Präsentationen";
+
+/* Label for video media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.video" = "Videos";
 
 /* Success message shown after upgrading plan */
 "mediaLibrary.storageDetails.purchase.plan.success" = "Dein Website-Tarif wurde aktualisiert!";
@@ -9577,7 +9888,7 @@ Example: Reply to Pamela Nguyen */
 "mySite.siteActions.siteTitle" = "Website-Titel ändern";
 
 /* Menu title for the visit site option */
-"mySite.siteActions.visitSite" = "Zur Website";
+"mySite.siteActions.visitSite" = "Website aufrufen";
 
 /* A no results message displayed on the atomic logs screen. */
 "noLogs.empty" = "Es gibt keine Protokolleinträge innerhalb dieses Zeitraums";
@@ -9679,7 +9990,7 @@ Example: Reply to Pamela Nguyen */
 "notificationsViewController.navigationBar.action.markAllAsRead" = "Alle als gelesen markieren";
 
 /* Link to Notification Settings section */
-"notificationsViewController.navigationBar.action.settings" = "Benachrichtigungs-Einstellungen";
+"notificationsViewController.navigationBar.action.settings" = "Benachrichtigungseinstellungen";
 
 /* Accessibility label for the navigation bar menu button */
 "notificationsViewController.navigationBar.menu.accessibilityLabel" = "Menü-Button der Navigationsleiste";
@@ -9710,6 +10021,12 @@ Example: Reply to Pamela Nguyen */
 
 /* Menu option for filtering posts by me */
 "pagesList.pagesByMe" = "Seiten von mir";
+
+/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
+"parentCategory.noCategory" = "Keine Kategorie";
+
+/* Title for selecting parent category of a category */
+"parentCategory.title" = "Übergeordnete Kategorie";
 
 /* Title for the parent page picker screen */
 "parentPagePicker.title" = "Übergeordnete Seite";
@@ -9869,6 +10186,27 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the post author selection screen */
 "postAuthorPicker.title" = "Autor";
+
+/* Title for selecting categories for a post or a page */
+"postCategories.title" = "Kategorien";
+
+/* Toggle label for allowing comments on post */
+"postDiscussion.allowComments.label" = "Kommentare erlauben";
+
+/* Toggle label for allowing pings/trackbacks on post */
+"postDiscussion.allowPings.label" = "Pingbacks erlauben";
+
+/* Footer text when comments are disabled */
+"postDiscussion.comments.disabled.footer" = "Besucher können keine neuen Kommentare oder Antworten hinzufügen. Bestehende Kommentare bleiben sichtbar.";
+
+/* Footer text when comments are enabled */
+"postDiscussion.comments.enabled.footer" = "Besucher können neue Kommentare und Antworten hinzufügen.";
+
+/* Link text for learning more about pingbacks and trackbacks */
+"postDiscussion.pingbacks.learnMore.text" = "Weitere Informationen zu Pingbacks und Trackbacks";
+
+/* Navigation title for post discussion settings */
+"postDiscussion.title" = "Diskussion";
 
 /* Button in an alert confirming discaring changes */
 "postEditor.closeConfirmationAlert.discardChanges" = "Änderungen verwerfen";
@@ -10101,6 +10439,9 @@ Example: Reply to Pamela Nguyen */
 /* A default value for an post without a title */
 "postSaveErrorMessage.postUntitled" = "Ohne Titel";
 
+/* Section header for Access settings in Post Settings */
+"postSettings.access.header" = "Zugriff";
+
 /* Label for the author field in Post Settings */
 "postSettings.author.label" = "Autor";
 
@@ -10119,6 +10460,18 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the discard changes confirmation dialog */
 "postSettings.discardChanges.title" = "Änderungen verwerfen?";
+
+/* Status text when discussion (comments) is disabled */
+"postSettings.discussion.closed" = "Geschlossen";
+
+/* Label for the discussion settings field in Post Settings */
+"postSettings.discussion.label" = "Diskussion";
+
+/* Status text when discussion (comments) is enabled */
+"postSettings.discussion.open" = "Offen";
+
+/* Label for the checkbox that lets you send a post to newsletter subscribers */
+"postSettings.emailToSubscribers.label" = "E-Mail an Abonnenten";
 
 /* Character count for excerpt. %1$d is the number of characters. */
 "postSettings.excerpt.characterCount" = "%1$d Zeichen";
@@ -10222,6 +10575,21 @@ Example: Reply to Pamela Nguyen */
 /* Cell title for the Top Level option case */
 "postSettings.parentPage.topLevel" = "Oberste Ebene";
 
+/* Accessibility label for hide password button */
+"postSettings.passwordEntry.hidePassword" = "Passwort verbergen";
+
+/* Instructions for password entry */
+"postSettings.passwordEntry.instructions" = "Gib ein Passwort ein, um diesen Beitrag zu schützen. Nur Benutzer mit dem Passwort können ihn anzeigen.";
+
+/* Navigation title for password entry screen */
+"postSettings.passwordEntry.navigationTitle" = "Passwort eingeben";
+
+/* Placeholder for password field */
+"postSettings.passwordEntry.placeholder" = "Passwort eingeben";
+
+/* Accessibility label for show password button */
+"postSettings.passwordEntry.showPassword" = "Passwort anzeigen";
+
 /* Label for the pending review toggle in Post Settings */
 "postSettings.pendingReview.label" = "Ausstehende Überprüfung";
 
@@ -10249,17 +10617,59 @@ Example: Reply to Pamela Nguyen */
 /* Section header for General settings in Post Settings */
 "postSettings.section.general" = "Allgemein";
 
+/* Description text explaining what the slug editor does */
+"postSettings.slug.customizeDescription" = "Passe den letzten Teil des Permalink an.";
+
 /* Hint text for the slug field. Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso. */
 "postSettings.slug.hint" = "Die Titelform ist die URL-freundliche Version des Beitragstitels.";
 
 /* Label for the slug field. Should be the same as WP core. */
 "postSettings.slug.label" = "Titelform";
 
+/* Button text to learn more about permalinks */
+"postSettings.slug.learnMore" = "Weitere Informationen";
+
+/* Label for the slug field. Should be the same as WP core. */
+"postSettings.slug.navigationTitle" = "Titelform";
+
+/* Notice shown when the post doesn't have a remote and permalink template is missing */
+"postSettings.slug.permalinkDraftNotice" = "Der vorgeschlagene Permalink wird angezeigt, wenn der Entwurf auf dem Server gespeichert wird";
+
+/* Label for the permalink preview */
+"postSettings.slug.permalinkLabel" = "Permalink";
+
+/* Section title for the permalink preview */
+"postSettings.slug.permalinkSection" = "Permalink";
+
 /* Placeholder for the slug field */
 "postSettings.slug.placeholder" = "Titelform eingeben";
 
 /* Label for the preview button in Post Settings */
 "postSettings.socialSharing.header" = "Social Sharing";
+
+/* Label for the status field in Post Settings */
+"postSettings.status.label" = "Status";
+
+/* Navigation title for status picker */
+"postSettings.statusPicker.navigationTitle" = "Status und Sichtbarkeit";
+
+/* Label showing the current password */
+"postSettings.statusPicker.passwordLabel" = "Passwort";
+
+/* Toggle label for password protection */
+"postSettings.statusPicker.passwordProtected" = "Passwortgeschützt";
+
+/* Subtitle for password protected toggle */
+"postSettings.statusPicker.passwordProtectedSubtitle" = "Nur sichtbar für diejenigen, die das Passwort kennen";
+
+/* Label for schedule date row */
+"postSettings.statusPicker.scheduleDate" = "Datum";
+
+/* Toggle label for sticky posts */
+"postSettings.statusPicker.sticky" = "Oben gehalten";
+
+/* Subtitle for sticky toggle */
+"postSettings.statusPicker.stickySubtitle" = "Diesen Beitrag oben im Blog anheften";
 
 /* Label for the sticky post toggle. Sticky posts are displayed at the top of the blog. */
 "postSettings.stickyPost.label" = "Oben gehalten";
@@ -10279,17 +10689,56 @@ Example: Reply to Pamela Nguyen */
 /* Navigation bar title of the Post Stats screen */
 "postStats.title" = "Beitrags-Statistiken";
 
-/* Button to add a new tag. %1$@ is the tag name. */
-"postTags.addTag" = "Schlagwort hinzufügen";
+/* Post status title */
+"postStatus.deleted.details" = "Dauerhaft gelöscht";
 
-/* Placeholder text for the tag search field */
-"postTags.searchOrAdd.placeholder" = "Schlagwörter suchen oder hinzufügen";
+/* Post status title */
+"postStatus.deleted.title" = "Gelöscht";
 
-/* Message shown when no tags are selected */
-"postTags.selectionEmpty" = "Es wurden keine Schlagwörter ausgewählt";
+/* Post status details */
+"postStatus.draft.details" = "Nicht bereit zum Veröffentlichen";
 
-/* Title for the tags screen */
-"postTags.title" = "Schlagwörter";
+/* Post status title */
+"postStatus.draft.title" = "Entwurf";
+
+/* Post status details */
+"postStatus.pending.details" = "Vor dem Veröffentlichen auf Überprüfung warten";
+
+/* Post status title */
+"postStatus.pending.title" = "Ausstehend";
+
+/* Post status details */
+"postStatus.private.details" = "Nur für Website-Administratoren und Redakteure sichtbar";
+
+/* Post status title */
+"postStatus.private.title" = "Privat";
+
+/* Post status details */
+"postStatus.published.details" = "Sichtbar für jeden";
+
+/* Post status title */
+"postStatus.published.title" = "Veröffentlicht";
+
+/* Post status details */
+"postStatus.scheduled.details" = "Automatisch an einem ausgewählten Datum veröffentlichen";
+
+/* Post status title */
+"postStatus.scheduled.title" = "Geplant";
+
+/* Post status title */
+"postStatus.trash.details" = "In den Papierkorb verschoben, aber noch nicht gelöscht";
+
+/* Post status title */
+"postStatus.trash.title" = "In den Papierkorb verschoben";
+
+/* Button to add a new taxonomy term. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.addTag" = "%1$@ hinzufügen";
+
+/* Placeholder text for the taxonomy search field. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.searchOrAdd.placeholder" = "%1$@ suchen oder hinzufügen";
+
+/* Message shown when no taxonomy terms are selected. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.selectionEmpty" = "Keine %1$@ ausgewählt";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Abbrechen";
@@ -10365,9 +10814,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "Kategorien";
-
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "Schließen";
 
 /* Button to confirm discarding changes */
 "prepublishing.discardChanges.button" = "Änderungen verwerfen";
@@ -10456,12 +10902,17 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "Warnung";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "Nachricht";
+
+/* Placeholder text for the message field in Social Sharing */
+"prepublishing.socialAccounts.messagePlaceholder" = "Schreibe eine kurze Nachricht, die du in den sozialen Medien neben dem Beitrag teilen kannst";
 
 /* The navigation title for the pre-publishing social accounts screen. */
 "prepublishing.socialAccounts.navigationTitle" = "Social";
+
+/* Table section title */
+"prepublishing.socialAccounts.servicesSectionTitle" = "Dienstleistungen";
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.tags" = "Schlagwörter";
@@ -11346,7 +11797,7 @@ Feel free to replace it with other bracket types that you think looks better for
 "site.domains.purchaseWithPlan.buttons.title" = "Tarif-Upgrade durchführen";
 
 /* Title for the featured plugins section */
-"site.plugins.add.category.featured" = "Vorgestellt";
+"site.plugins.add.category.featured" = "Hervorgehoben";
 
 /* Title for the popular plugins section */
 "site.plugins.add.category.popular" = "Beliebt";
@@ -11408,6 +11859,18 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Button to progress to the next step after selecting domain in Site Creation */
 "siteCreation.domains.buttons.selectDomain" = "Domain auswählen";
 
+/* Default text for adding a new item when no label is provided */
+"siteCustomTaxonomies.defaultAddNew" = "Hinzufügen";
+
+/* Description for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.description" = "Mithilfe von Taxonomien kannst du Inhalte über Standardkategorien und -schlagwörter hinaus organisieren.";
+
+/* Title for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.title" = "Keine individuellen Taxonomien";
+
+/* Navigation title for the custom taxonomies screen */
+"siteCustomTaxonomies.navigationTitle" = "Taxonomien";
+
 /* Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio. */
 "siteMedia.accessibilityLabelAudio" = "Audio, %@";
 
@@ -11426,8 +11889,77 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Accessibility hint for actions when displaying media items. */
 "siteMedia.cellAccessibilityHint" = "Wähle Medien aus.";
 
+/* Label for the alt for a media asset (image) */
+"siteMedia.details.altText" = "Alt-Text";
+
+/* Verb. Button title. Tapping cancels an action. */
+"siteMedia.details.cancel" = "Abbrechen";
+
+/* Noun. Label for the caption for a media asset (image / video) */
+"siteMedia.details.caption" = "Untertitel\/Bildunterschrift";
+
+/* Title for button that permanently deletes a media item (photo / video) */
+"siteMedia.details.delete" = "Löschen";
+
+/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
+"siteMedia.details.deleteConfirmation" = "Bist du sicher, dass du dieses Element endgültig löschen möchtest?";
+
+/* Text displayed in HUD after successfully deleting a media item */
+"siteMedia.details.deleted" = "Gelöscht!";
+
+/* Text displayed in HUD while a media item is being deleted. */
+"siteMedia.details.deleting" = "Wird gelöscht …";
+
+/* Label for the description for a media asset (image / video) */
+"siteMedia.details.description" = "Beschreibung";
+
+/* Label for the dimensions in pixels for a media asset (image / video) */
+"siteMedia.details.dimensions" = "Abmessungen";
+
+/* Label for the file name for a media asset (image / video) */
+"siteMedia.details.fileName" = "Dateiname";
+
+/* Label for the file size for a media asset (image / video) */
+"siteMedia.details.fileSize" = "Dateigröße";
+
+/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
+"siteMedia.details.fileType" = "Dateityp";
+
+/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
+"siteMedia.details.mediaDeleted" = "Dieses Medienelement wurde gelöscht.";
+
+/* Noun. Label for the title of a media asset (image / video) */
+"siteMedia.details.title" = "Titel";
+
+/* Accessibility label for trash buttons in nav bars */
+"siteMedia.details.trash" = "Papierkorb";
+
+/* Text displayed in HUD if there was an error attempting to delete a media item. */
+"siteMedia.details.unableToDeleteMedia" = "Medienelement kann nicht gelöscht werden.";
+
+/* Error shown when the app fails to load a video from the user's media library. */
+"siteMedia.details.unableToLoadVideo" = "Video kann nicht geladen werden.";
+
+/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
+"siteMedia.details.unableToSaveMedia" = "Medienelement kann nicht gespeichert werden.";
+
+/* Label for the date a media asset (image / video) was uploaded */
+"siteMedia.details.uploaded" = "Hochgeladen";
+
 /* Title for the URL field */
 "siteMedia.details.url" = "URL";
+
+/* Hint for image alt on image settings. */
+"siteMedia.hints.imageAlt" = "Alt-Text für Bild";
+
+/* Hint for image caption on image settings. */
+"siteMedia.hints.imageCaption" = "Bildunterschrift";
+
+/* Hint for image description on image settings. */
+"siteMedia.hints.imageDescription" = "Bildbeschreibung";
+
+/* Hint for image title on image settings. */
+"siteMedia.hints.imageTitle" = "Bildtitel";
 
 /* Accessibility hint for media item preview for user's viewing an item in their media library */
 "siteMediaItem.contentViewAccessibilityHint" = "Tippen, um Medien im Vollbildmodus anzuzeigen";
@@ -11526,11 +12058,14 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Datenschutz";
 
+/* Format string for adding a new taxonomy term. %1$@ is the taxonomy name. */
+"siteTaxonomy.addNew.format" = "%1$@ hinzufügen";
+
 /* Hint for users when hidden privacy setting is set */
 "siteVisibility.hidden.hint" = "Bis deine Website einsatzbereit ist, bleibt sie mit dem Hinweis „Demnächst verfügbar“ für Besucher verborgen.";
 
 /* Text for privacy settings: Hidden */
-"siteVisibility.hidden.title" = "Verborgen";
+"siteVisibility.hidden.title" = "Ausgeblendet";
 
 /* Hint for users when private privacy setting is set */
 "siteVisibility.private.hint" = "Deine Website ist nur für dich und von dir freigegebene Benutzer sichtbar.";
@@ -12049,7 +12584,7 @@ Feel free to replace it with other bracket types that you think looks better for
 "support.row.contactUs.title" = "Support kontaktieren";
 
 /* Option in Support view to enable/disable adding debug information to support ticket. */
-"support.row.debug.title" = "Fehlersuche";
+"support.row.debug.title" = "Fehlerdiagnose";
 
 /* Support email label. */
 "support.row.email.title" = "E-Mail";
@@ -12093,7 +12628,8 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Subject of new Zendesk ticket. */
 "support.zendesk.readerAppTicketSubject" = "Reader für iOS-Support";
 
-/* Description for empty state when there are no tags */
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
 "tags.empty.description" = "Schlagwörter helfen dabei, deine Inhalte zu organisieren, und erleichtern es Lesern, ähnliche Beiträge zu finden.";
 
 /* Title for empty state when there are no tags */
@@ -12170,9 +12706,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "ungelesen";
-
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "Abonnenten der Website";
 
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "Benutzer der Website";
@@ -12258,9 +12791,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* The heading at the top of the user list */
 "userlist.title" = "Benutzer";
-
-/* Site Subscribers */
-"users.list.title.subscribers" = "Abonnenten";
 
 /* Screen title */
 "users.title" = "Benutzer";

--- a/WordPress/Resources/en-AU.lproj/Localizable.strings
+++ b/WordPress/Resources/en-AU.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 /* Translation-Revision-Date: 2024-06-13 21:04:23+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: en_AU */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -578,8 +578,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "Almost there! Please enter the verification code from your authenticator app.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Alt Text";
 
 /* No comment provided by engineer. */
@@ -719,9 +718,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "Are you sure you want to disconnect Jetpack from the site?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "Are you sure you want to permanently delete this item?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "Are you sure you want to remove %1$@ from %2$@?";
@@ -1067,7 +1063,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Cancel";
@@ -1095,8 +1090,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Can’t decide? You can change the theme at any time.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Caption";
 
 /* Alert title. */
@@ -1750,8 +1744,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "Default";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Default Category";
 
 /* Label for selecting the default post format
@@ -1760,9 +1753,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Defaults for New Posts";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Delete";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Delete Menu";
@@ -1781,14 +1771,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "Delete menu";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Deleted!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Deleting site…";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Deleting...";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "Deny";
@@ -1796,8 +1780,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "Describe the purpose of the image. Leave empty if decorative.";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Description";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1815,9 +1798,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "Didn't mean to create a new account? Go back to re-enter your email address.";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Dimensions";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "Disable";
@@ -2094,7 +2074,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "Editing this GIF will remove its animation.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Editor";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2430,11 +2410,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "File block settings";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "File name";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "File type";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "File type not supported as a media file.";
@@ -2793,9 +2770,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "Image Caption";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Image Description";
-
 /* Hint for image link on image settings. */
 "Image Link" = "Image Link";
 
@@ -2807,9 +2781,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "Image file not found.";
-
-/* Hint for image title on image settings. */
-"Image title" = "Image title";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "In a few words, explain what this site is about.";
@@ -3709,9 +3680,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "No Accounts Found";
 
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "No Category";
-
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "No Connection";
 
@@ -4152,9 +4120,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "Paging";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Parent Category";
-
 /* Parenting site intent topic */
 "Parenting" = "Parenting";
 
@@ -4369,9 +4334,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Post";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Post Categories";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "Post Settings";
@@ -4680,9 +4642,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "Removes location metadata from photos before uploading them to your site.";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again.";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "Replace Current Block";
@@ -5513,6 +5472,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "Tagline";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Tags";
 
@@ -5886,9 +5846,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "This log in code has expired. Please tap the Scan Again button to rescan the code.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "This media item has been deleted.";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "This user account cannot be closed if there are unresolved chargebacks.";
 
@@ -5957,7 +5914,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Title";
@@ -6051,8 +6007,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "Transform block…";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Trash";
 
@@ -6149,9 +6104,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "Unable to create new invite links.";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "Unable to delete media item.";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "Unable to disable invite links.";
 
@@ -6182,9 +6134,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "Unable to load this page right now.";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "Unable to load video.";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Unable to play video";
 
@@ -6193,9 +6142,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Unable to restore your site";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "Unable to save media item.";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "Unable to share link";
@@ -6345,9 +6291,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Upload failed";
-
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Uploaded";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "Uploaded 1 draft post, %ld files";
@@ -6834,7 +6777,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "World map showing views by country.";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "Would you still like to remove this person?";
 
 /* Button title. Opens the editor to write a new post.
@@ -8537,8 +8480,7 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "Warning";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "Message";
 
 /* The navigation title for the pre-publishing social accounts screen. */

--- a/WordPress/Resources/en-CA.lproj/Localizable.strings
+++ b/WordPress/Resources/en-CA.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 /* Translation-Revision-Date: 2025-09-04 22:04:21+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: en_CA */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -581,8 +581,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "Almost there! Please enter the verification code from your authenticator app.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Alt Text";
 
 /* No comment provided by engineer. */
@@ -725,9 +724,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "Are you sure you want to disconnect Jetpack from the site?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "Are you sure you want to permanently delete this item?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "Are you sure you want to remove %1$@ from %2$@?";
@@ -1082,7 +1078,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Cancel";
@@ -1110,8 +1105,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Can’t decide? You can change the theme at any time.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Caption";
 
 /* Alert title. */
@@ -1777,8 +1771,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "Default";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Default Category";
 
 /* Label for selecting the default post format
@@ -1787,9 +1780,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Defaults for New Posts";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Delete";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Delete Menu";
@@ -1808,14 +1798,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "Delete menu";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Deleted!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Deleting site…";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Deleting…";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "Deny";
@@ -1823,8 +1807,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "Describe the purpose of the image. Leave empty if decorative.";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Description";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1842,9 +1825,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "Didn't mean to create a new account? Go back to re-enter your email address.";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Dimensions";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "Disable";
@@ -2121,7 +2101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "Editing this GIF will remove its animation.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Editor";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2463,11 +2443,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "File block settings";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "File name";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "File type";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "File type not supported as a media file.";
@@ -2826,9 +2803,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "Image Caption";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Image Description";
-
 /* Hint for image link on image settings. */
 "Image Link" = "Image Link";
 
@@ -2840,9 +2814,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "Image file not found.";
-
-/* Hint for image title on image settings. */
-"Image title" = "Image title";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "In a few words, explain what this site is about.";
@@ -3748,9 +3719,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "No Accounts Found";
 
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "No Category";
-
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "No Connection";
 
@@ -4191,9 +4159,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "Paging";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Parent Category";
-
 /* Parenting site intent topic */
 "Parenting" = "Parenting";
 
@@ -4411,9 +4376,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Post";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Post Categories";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "Post Settings";
@@ -4722,9 +4684,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "Removes location metadata from photos before uploading them to your site.";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again.";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "Replace Current Block";
@@ -5561,6 +5520,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "Tagline";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Tags";
 
@@ -5946,9 +5906,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "This log in code has expired. Please tap the Scan Again button to rescan the code.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "This media item has been deleted.";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "This user account cannot be closed if there are unresolved chargebacks.";
 
@@ -6017,7 +5974,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Title";
@@ -6111,8 +6067,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "Transform block…";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Trash";
 
@@ -6209,9 +6164,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "Unable to create new invite links.";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "Unable to delete media item.";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "Unable to disable invite links.";
 
@@ -6242,9 +6194,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "Unable to load this content right now.";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "Unable to load video.";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Unable to play video";
 
@@ -6253,9 +6202,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Unable to restore your site";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "Unable to save media item.";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "Unable to share link";
@@ -6411,9 +6357,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Upload failed";
-
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Uploaded";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "Uploaded 1 draft post, %ld files";
@@ -6906,7 +6849,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "World map showing views by country.";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "Would you still like to remove this person?";
 
 /* Button title. Opens the editor to write a new post.
@@ -7380,8 +7323,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "Plugin Management";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "User Management";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -8005,12 +7947,6 @@ Example: Reply to Pamela Nguyen */
 /* No comment provided by engineer. */
 "double-tap to change unit" = "double tap to change unit";
 
-/* Message for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.message" = "Are you sure you want to delete this tag?";
-
-/* Title for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.title" = "Delete Tag";
-
 /* Placeholder text for tag description field */
 "edit.tag.description.placeholder" = "Add a description...";
 
@@ -8022,9 +7958,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Section header for tag description in edit tag view */
 "edit.tag.section.description" = "Description";
-
-/* Section header for tag name in edit tag view */
-"edit.tag.section.tag" = "Tag";
 
 /* Register Domain - Address information field Number placeholder */
 "eg. 1122334455" = "eg. 1122334455";
@@ -10180,9 +10113,6 @@ Example: Reply to Pamela Nguyen */
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "Categories";
 
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "Close";
-
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.jetpackSocial" = "Jetpack Social";
 
@@ -10255,8 +10185,7 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "Warning";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "Message";
 
 /* The navigation title for the pre-publishing social accounts screen. */
@@ -11880,7 +11809,8 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Subject of new Zendesk ticket. */
 "support.zendesk.readerAppTicketSubject" = "Reader for iOS Support";
 
-/* Description for empty state when there are no tags */
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
 "tags.empty.description" = "Tags help organize your content and make it easier for readers to find related posts.";
 
 /* Title for empty state when there are no tags */
@@ -11957,9 +11887,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "unread";
-
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "Site's Subscriber";
 
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "Site's User";
@@ -12045,9 +11972,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* The heading at the top of the user list */
 "userlist.title" = "Users";
-
-/* Site Subscribers */
-"users.list.title.subscribers" = "Subscribers";
 
 /* Screen title */
 "users.title" = "Users";

--- a/WordPress/Resources/en-GB.lproj/Localizable.strings
+++ b/WordPress/Resources/en-GB.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 /* Translation-Revision-Date: 2025-10-08 13:05:48+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: en_GB */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -581,8 +581,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "Almost there! Please enter the verification code from your authenticator app.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Alt Text";
 
 /* No comment provided by engineer. */
@@ -725,9 +724,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "Are you sure you want to disconnect Jetpack from the site?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "Are you sure you want to permanently delete this item?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "Are you sure you want to remove %1$@ from %2$@?";
@@ -1082,7 +1078,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Cancel";
@@ -1110,8 +1105,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Can’t decide? You can change the theme at any time.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Caption";
 
 /* Alert title. */
@@ -1777,8 +1771,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "Default";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Default Category";
 
 /* Label for selecting the default post format
@@ -1787,9 +1780,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Defaults for New Posts";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Delete";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Delete Menu";
@@ -1808,14 +1798,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "Delete menu";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Deleted!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Deleting site…";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Deleting...";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "Deny";
@@ -1823,8 +1807,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "Describe the purpose of the image. Leave empty if decorative.";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Description";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1842,9 +1825,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "Didn't mean to create a new account? Go back to re-enter your email address.";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Dimensions";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "Disable";
@@ -2121,7 +2101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "Editing this GIF will remove its animation.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Editor";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2463,11 +2443,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "File block settings";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "File name";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "File type";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "File type not supported as a media file.";
@@ -2826,9 +2803,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "Image Caption";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Image Description";
-
 /* Hint for image link on image settings. */
 "Image Link" = "Image Link";
 
@@ -2840,9 +2814,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "Image file not found.";
-
-/* Hint for image title on image settings. */
-"Image title" = "Image title";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "In a few words, explain what this site is about.";
@@ -3748,9 +3719,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "No Accounts Found";
 
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "No Category";
-
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "No Connection";
 
@@ -4191,9 +4159,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "Paging";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Parent Category";
-
 /* Parenting site intent topic */
 "Parenting" = "Parenting";
 
@@ -4411,9 +4376,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Post";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Post Categories";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "Post Settings";
@@ -4722,9 +4684,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "Removes location metadata from photos before uploading them to your site.";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again.";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "Replace Current Block";
@@ -5561,6 +5520,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "Tagline";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Tags";
 
@@ -5946,9 +5906,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "This log-in code has expired. Please tap the Scan Again button to rescan the code.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "This media item has been deleted.";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "This user account cannot be closed if there are unresolved chargebacks.";
 
@@ -6017,7 +5974,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Title";
@@ -6111,8 +6067,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "Transform block…";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Bin";
 
@@ -6209,9 +6164,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "Unable to create new invite links.";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "Unable to delete media item.";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "Unable to disable invite links.";
 
@@ -6242,9 +6194,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "Unable to load this content right now.";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "Unable to load video.";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Unable to play video";
 
@@ -6253,9 +6202,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Unable to restore your site";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "Unable to save media item.";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "Unable to share link";
@@ -6411,9 +6357,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Upload failed";
-
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Uploaded";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "Uploaded one draft post, %ld files";
@@ -6906,7 +6849,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "World map showing views by country.";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "Would you still like to remove this person?";
 
 /* Button title. Opens the editor to write a new post.
@@ -7383,8 +7326,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "Plugin Management";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "User Management";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -8017,12 +7959,6 @@ Example: Reply to Pamela Nguyen */
 /* No comment provided by engineer. */
 "double-tap to change unit" = "double tap to change unit";
 
-/* Message for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.message" = "Are you sure you want to delete this tag?";
-
-/* Title for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.title" = "Delete Tag";
-
 /* Placeholder text for tag description field */
 "edit.tag.description.placeholder" = "Add a description...";
 
@@ -8034,9 +7970,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Section header for tag description in edit tag view */
 "edit.tag.section.description" = "Description";
-
-/* Section header for tag name in edit tag view */
-"edit.tag.section.tag" = "Tag";
 
 /* Register Domain - Address information field Number placeholder */
 "eg. 1122334455" = "eg. 1122334455";
@@ -9315,18 +9248,6 @@ Example: Reply to Pamela Nguyen */
 /* Message about buying storage add-on */
 "mediaLibrary.storageDetails.buyStorage.message" = "Buy storage add-on";
 
-/* Message shown when all media items are attached */
-"mediaLibrary.storageDetails.cleanup.allAttached" = "All items in the Media Library are attached.";
-
-/* Message shown while loading unattached media count */
-"mediaLibrary.storageDetails.cleanup.loading" = "Finding out if there are any unattached media items...";
-
-/* Message about unattached media that can be cleaned up. %1$d is the count of unattached media. */
-"mediaLibrary.storageDetails.cleanup.message" = "%1$d item unattached. Remove them to free up some space.";
-
-/* Title for cleanup section */
-"mediaLibrary.storageDetails.cleanup.title" = "Remove unused items";
-
 /* Success message shown after upgrading plan */
 "mediaLibrary.storageDetails.purchase.plan.success" = "Your site plan has been upgraded!";
 
@@ -10279,18 +10200,6 @@ Example: Reply to Pamela Nguyen */
 /* Navigation bar title of the Post Stats screen */
 "postStats.title" = "Post Stats";
 
-/* Button to add a new tag. %1$@ is the tag name. */
-"postTags.addTag" = "Add tag";
-
-/* Placeholder text for the tag search field */
-"postTags.searchOrAdd.placeholder" = "Search or add tags";
-
-/* Message shown when no tags are selected */
-"postTags.selectionEmpty" = "No tags are selected";
-
-/* Title for the tags screen */
-"postTags.title" = "Tags";
-
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Cancel";
 
@@ -10365,9 +10274,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "Categories";
-
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "Close";
 
 /* Button to confirm discarding changes */
 "prepublishing.discardChanges.button" = "Discard Changes";
@@ -10456,8 +10362,7 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "Warning";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "Message";
 
 /* The navigation title for the pre-publishing social accounts screen. */
@@ -12093,7 +11998,8 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Subject of new Zendesk ticket. */
 "support.zendesk.readerAppTicketSubject" = "Reader for iOS Support";
 
-/* Description for empty state when there are no tags */
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
 "tags.empty.description" = "Tags help organise your content and make it easier for readers to find related posts.";
 
 /* Title for empty state when there are no tags */
@@ -12170,9 +12076,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "unread";
-
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "Site's Subscriber";
 
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "Site's User";
@@ -12258,9 +12161,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* The heading at the top of the user list */
 "userlist.title" = "Users";
-
-/* Site Subscribers */
-"users.list.title.subscribers" = "Subscribers";
 
 /* Screen title */
 "users.title" = "Users";

--- a/WordPress/Resources/es.lproj/Localizable.strings
+++ b/WordPress/Resources/es.lproj/Localizable.strings
@@ -1,6 +1,6 @@
-/* Translation-Revision-Date: 2025-10-06 19:00:22+0000 */
+/* Translation-Revision-Date: 2025-11-27 04:51:42+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: es */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -581,8 +581,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "¡Ya falta poco! Por favor, introduce el código de verificación de tu aplicación authenticator.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Texto Alt";
 
 /* No comment provided by engineer. */
@@ -725,9 +724,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "¿Estás seguro de querer desconectar Jetpack del sitio?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "¿Estás seguro de que quieres eliminar permanentemente este elemento?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "¿Estás seguro de querer borrar %1$@ de %2$@?";
@@ -1082,7 +1078,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Cancelar";
@@ -1110,8 +1105,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "¿No puedes decidirte? Puedes cambiar el tema en cualquier momento.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Pie de ilustración";
 
 /* Alert title. */
@@ -1777,8 +1771,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "Por defecto";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Categoría por defecto";
 
 /* Label for selecting the default post format
@@ -1787,9 +1780,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Opciones predeterminadas para entradas nuevas";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Borrar";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Eliminar menú";
@@ -1808,14 +1798,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "Borrar menú";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "¡Eliminado!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Eliminando sitio...";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Borrando...";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "Denegar";
@@ -1823,8 +1807,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "Describe el propósito de la imagen. Déjalo vacío si la imagen es decorativa.";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Descripción";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1842,9 +1825,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "¿No querías crear una nueva cuenta? Vuelve atrás y vuelve a introducir tu dirección de correo electrónico.";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Dimensiones";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "Desactivar";
@@ -2121,7 +2101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "Editar este GIF eliminará su animación.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Editor";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2463,11 +2443,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "Ajustes del bloque de archivo";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "Nombre del archivo";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Tipo de archivo";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "Tipo de archivo no admitido como archivo de medios.";
@@ -2781,6 +2758,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post content used in the login prologue screens. */
 "I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next" = "El trabajo de Cameron Karsten me sirve de inspiración. Probaré estas técnicas en mi siguiente trabajo";
 
+/* Text on the support form to refer to what area the user has problem with. */
+"I need help with" = "Necesito ayuda con";
+
 /* Describes the IP address section in the comment detail screen. */
 "IP address" = "Dirección IP";
 
@@ -2826,9 +2806,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "Leyenda de la imagen";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Descripción de la imagen";
-
 /* Hint for image link on image settings. */
 "Image Link" = "Enlace de la imagen";
 
@@ -2840,9 +2817,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "Archivo de imagen no encontrado.";
-
-/* Hint for image title on image settings. */
-"Image title" = "Título de la imagen";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "En pocas palabras, explica de qué trata este sitio.";
@@ -3205,6 +3179,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the button that will dismiss this view. */
 "Let me know when finished!" = "¡Avísame cuando haya terminado!";
 
+/* Message info on the support screen. */
+"Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon." = "Indícanos la dirección de tu sitio (URL) y facilítanos tanta información como puedas sobre el problema. Nos pondremos en contacto contigo en breve.";
+
+/* Title to let the user know what do we want on the support screen. */
+"Let’s get this sorted" = "Vamos a solucionarlo";
+
 /* Lifestyle site intent topic */
 "Lifestyle" = "Estilo de vida";
 
@@ -3405,6 +3385,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Navegación principal";
+
+/* Explanation for the option to enable theme styles */
+"Make the block editor look like your theme." = "Haz que el editor de bloques se vea como tu tema.";
 
 /* No comment provided by engineer. */
 "Make your content stand out by adding images, gifs, videos, and embedded media to your pages." = "Haz que tu contenido destaque añadiendo imágenes, gifs, vídeos y medios incrustados a tus páginas.";
@@ -3747,9 +3730,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "No se han encontrado cuentas";
-
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Sin categoría";
 
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Sin conexión";
@@ -4191,9 +4171,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "Paginación";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Categoría superior";
-
 /* Parenting site intent topic */
 "Parenting" = "Paternidad";
 
@@ -4411,9 +4388,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Publicar";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Categorías de entrada";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "Ajustes de entrada";
@@ -4722,9 +4696,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "Elimina los metadatos de ubicación de las fotos antes de subirlas a tu sitio.";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "Eliminar seguidores hace que dejen de recibir novedades de tu sitio. Si eligen hacerlo pueden aún visitar tu sitio, y seguirlo de nuevo.";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "Reemplazar el bloque actual";
@@ -5561,6 +5532,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "Descripción corta";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Etiquetas";
 
@@ -5657,6 +5629,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint, informing user the button can be used to visit the Gravatar website. */
 "Tap to visit the Gravatar website in an external browser" = "Toca para visitar el sitio web de Gravatar en un navegador externo";
+
+/* Label for viewing the custom taxonomies */
+"Taxonomies" = "Taxonomías";
 
 /* Technology site intent topic */
 "Technology" = "Tecnología";
@@ -5946,9 +5921,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "Este código de acceso ha caducado. Toca el botón Analizar de nuevo para volver a escanear el código.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "Este elemento multimedia ha sido borrado.";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "No es posible cerrar la cuenta de este usuario si tiene devoluciones sin resolver.";
 
@@ -6017,7 +5989,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Título";
@@ -6111,8 +6082,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "Transformar bloque…";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Papelera";
 
@@ -6209,9 +6179,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "No se han podido crear nuevos enlaces de invitación.";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "No ha sido posible eliminar el elemento multimedia.";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "No se han podido desactivar los enlaces de invitación.";
 
@@ -6242,9 +6209,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "En este momento no se ha podido cargar esta página.";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "No ha sido posible cargar el vídeo.";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "No ha sido posible reproducir el vídeo";
 
@@ -6253,9 +6217,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "No es posible restaurar tu sitio";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "No ha sido posible guardar el elemento multimedia.";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "No es posible compartir el enlace";
@@ -6412,9 +6373,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Carga fallida";
 
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Subido";
-
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "Subida 1 entrada en borrador, %ld archivos";
 
@@ -6456,6 +6414,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The button title text for logging in with WP.com password instead of magic link. */
 "Use password to sign in" = "Usar una contraseña para acceder";
+
+/* Option to enable theme styles in the block editor */
+"Use theme styles" = "Usar estilos de tema";
 
 /* A placeholder for the twitter username
    Accessibility label for the username text field in the self-hosted login page.
@@ -6906,7 +6867,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "Mapa del mundo que muestra las visualizaciones por país.";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "¿Aún quieres eliminar a esta persona?";
 
 /* Button title. Opens the editor to write a new post.
@@ -7377,14 +7338,19 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Description for the prompt to upgrade to Application Passwords. The first argument is the name of the feature that requires Application Passwords. */
 "applicationPasswordRequired.description" = "Las contraseñas de aplicaciones son una forma más segura de conectar con tu sitio autoalojado y permitir el uso de funciones como %@.";
 
+/* Feature name for managing application passwords in the app */
+"applicationPasswordRequired.feature.applicationPasswords" = "Gestión de contraseñas de aplicación";
+
 /* Feature name for the block editor in application password required prompt */
 "applicationPasswordRequired.feature.blockEditor" = "Editor de bloques";
+
+/* Feature name for managing terms and taxonomies in the app */
+"applicationPasswordRequired.feature.customTaxonomies" = "Gestión de taxonomías";
 
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "Gestión de plugins";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "Gestión de usuarios";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -7613,6 +7579,288 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 
 /* Post Editor / Button in the 'More' menu */
 "classicEditor.moreMenu.saveDraft" = "Guardar borrador";
+
+/* Button to add more screenshots */
+"com.jetpack.support.addMoreScreenshots" = "Añadir más capturas de pantalla";
+
+/* Button to add screenshots */
+"com.jetpack.support.addScreenshots" = "Añadir capturas de pantalla";
+
+/* Header for application logs section */
+"com.jetpack.support.applicationLogs" = "Registros de la aplicación";
+
+/* Description explaining why including logs is helpful */
+"com.jetpack.support.applicationLogsDescription" = "Incluir registros puede ayudar a nuestro equipo a investigar los problemas. Los registros pueden contener actividad reciente de la aplicación.";
+
+/* Navigation title for application logs screen */
+"com.jetpack.support.applicationLogsTitle" = "Registros de la aplicación";
+
+/* Format string for attachment identifier */
+"com.jetpack.support.attachment" = "Adjunto %@";
+
+/* Format string for attachment size limit. %1$@ is current size, %2$@ is maximum size */
+"com.jetpack.support.attachmentLimit" = "Límite de adjuntos: %1$@\/%2$@";
+
+/* Bot greeting message. %1$@ is the user's name */
+"com.jetpack.support.botGreeting" = "¡Hola, %1$@!";
+
+/* Bot introduction message explaining its purpose */
+"com.jetpack.support.botIntroduction" = "Soy tu asistente personal de IA. Puedo ayudarte con preguntas sobre tu sitio o tu cuenta.";
+
+/* Format string for cache file count and size. %1$d is the number of files, %2$@ is the formatted size. The system will pluralize 'files' based on the number – please specify it as the largest plural value */
+"com.jetpack.support.cacheFiles" = "%1$d archivos en caché (%2$@)";
+
+/* Message shown when cache has no files */
+"com.jetpack.support.cacheIsEmpty" = "La caché está vacía";
+
+/* Button to cancel current action */
+"com.jetpack.support.cancel" = "Cancelar";
+
+/* Warning message that deleted logs cannot be recovered */
+"com.jetpack.support.cannotRecoverLogs" = "No podrás recuperarlos.";
+
+/* Button to clear all activity logs */
+"com.jetpack.support.clearAllActivityLogs" = "Borrar todos los registros de actividad";
+
+/* Button to clear disk cache */
+"com.jetpack.support.clearDiskCache" = "Borrar caché del disco";
+
+/* Description explaining the purpose of clearing disk cache */
+"com.jetpack.support.clearDiskCacheDescription" = "Elimina los archivos temporales para liberar espacio o resolver problemas.";
+
+/* Progress text while clearing cache */
+"com.jetpack.support.clearing" = "Borrando…";
+
+/* Message shown when cache clearing is complete */
+"com.jetpack.support.complete" = "Completado";
+
+/* Confirmation message when canceling a draft */
+"com.jetpack.support.confirmCancelMessage" = "¿Seguro que quieres cancelar este mensaje? Perderás los datos que hayas introducido";
+
+/* Title for alert confirming cancellation */
+"com.jetpack.support.confirmCancellation" = "Confirmar cancelación";
+
+/* Confirmation dialog title when deleting all logs */
+"com.jetpack.support.confirmDeleteAllLogs" = "¿Seguro que quieres eliminar todos los registros?";
+
+/* Section title for contact information */
+"com.jetpack.support.contactInformation" = "Información de contacto";
+
+/* Button to continue editing a message */
+"com.jetpack.support.continueWriting" = "Seguir escribiendo";
+
+/* Message shown at end of closed support conversation */
+"com.jetpack.support.conversationEnded" = "Fin de la conversación. No hay más respuestas posibles.";
+
+/* Navigation title for bot conversations list */
+"com.jetpack.support.conversations" = "Conversaciones";
+
+/* Button to delete all log files */
+"com.jetpack.support.deleteAllLogs" = "Eliminar todos los registros";
+
+/* Description text for diagnostics screen */
+"com.jetpack.support.diagnosticsDescription" = "Ejecuta tareas habituales de mantenimiento y solución de problemas.";
+
+/* Navigation title for diagnostics screen */
+"com.jetpack.support.diagnosticsTitle" = "Diagnósticos";
+
+/* Button to discard changes in a draft message */
+"com.jetpack.support.discardChanges" = "Descartar cambios";
+
+/* Notice explaining where support will send email responses */
+"com.jetpack.support.emailNotice" = "Te escribiremos a esta dirección.";
+
+/* Error title when logs fail to load */
+"com.jetpack.support.errorLoadingLogs" = "Error al cargar los registros";
+
+/* Error message when support conversations fail to load */
+"com.jetpack.support.errorLoadingSupportConversations" = "Error al cargar las conversaciones de asistencia";
+
+/* Title for error alerts */
+"com.jetpack.support.errorTitle" = "Error";
+
+/* Option to export log as a file */
+"com.jetpack.support.exportAsFile" = "Exportar como archivo";
+
+/* Button to dismiss alerts. */
+"com.jetpack.support.gotIt" = "Entendido";
+
+/* Text on the support form to refer to what area the user has problem with. */
+"com.jetpack.support.iNeedHelp" = "Necesito ayuda con";
+
+/* Toggle label to include application logs in the support request */
+"com.jetpack.support.includeApplicationLogs" = "Incluir registros de la aplicación";
+
+/* Section title for issue details */
+"com.jetpack.support.issueDetails" = "Detalles del problema";
+
+/* Format string for when conversation was last updated */
+"com.jetpack.support.lastUpdated" = "Última actualización: %@";
+
+/* Progress message while loading conversation messages */
+"com.jetpack.support.loadingBotConversationMessages" = "Cargando mensajes";
+
+/* Progress message while loading bot conversations */
+"com.jetpack.support.loadingBotConversations" = "Cargando conversaciones del bot";
+
+/* Progress text while loading support conversations */
+"com.jetpack.support.loadingConversations" = "Cargando conversaciones";
+
+/* Progress message while loading disk usage information */
+"com.jetpack.support.loadingDiskUsage" = "Cargando uso de disco";
+
+/* Progress message while loading an image attachment */
+"com.jetpack.support.loadingImage" = "Cargando imagen";
+
+/* Progress message shown in overlay while refreshing content */
+"com.jetpack.support.loadingLatestContent" = "Cargando el contenido más reciente";
+
+/* Progress message while loading application log content */
+"com.jetpack.support.loadingLogContent" = "Cargando contenido del registro…";
+
+/* Progress message while loading log files */
+"com.jetpack.support.loadingLogs" = "Cargando registros…";
+
+/* Progress text while loading conversation messages */
+"com.jetpack.support.loadingMessages" = "Cargando mensajes";
+
+/* Progress message while loading a video attachment */
+"com.jetpack.support.loadingVideo" = "Cargando vídeo";
+
+/* Section header for log files sorted by date */
+"com.jetpack.support.logFilesByDate" = "Archivos de registro por fecha de creación";
+
+/* Text indicating which log files will be included in the support request */
+"com.jetpack.support.logFilesToUpload" = "Se subirán los siguientes archivos de registro:";
+
+/* Footer text explaining log retention policy */
+"com.jetpack.support.logRetentionNotice" = "Se guardan registros de hasta siete días de antigüedad.";
+
+/* Section header for message text input */
+"com.jetpack.support.message" = "Mensaje";
+
+/* Success message when reply is sent successfully */
+"com.jetpack.support.messageSent" = "Mensaje enviado";
+
+/* Format string for number of messages in conversation */
+"com.jetpack.support.messagesCount" = "%d mensajes";
+
+/* The title of a new bot chat in the support area of the app */
+"com.jetpack.support.new-bot-chat" = "Nuevo chat de bots";
+
+/* Option to create a new support ticket */
+"com.jetpack.support.newSupportTicket" = "Nueva petición de asistencia";
+
+/* Label shown when there are no bot conversations */
+"com.jetpack.support.noConversations" = "No hay conversaciones";
+
+/* Description shown when no log files are available */
+"com.jetpack.support.noLogsAvailable" = "No hay registros de actividad disponibles";
+
+/* Label shown when no log files are available */
+"com.jetpack.support.noLogsFound" = "No se han encontrado registros";
+
+/* Button to open a support ticket */
+"com.jetpack.support.openSupportTicket" = "Abre una petición de asistencia";
+
+/* Text indicating a field is optional */
+"com.jetpack.support.optional" = "(Opcional)";
+
+/* Navigation title for replying to a support conversation */
+"com.jetpack.support.reply" = "Responder";
+
+/* Description for saving log as a file */
+"com.jetpack.support.saveAsFile" = "Guardar como archivo para compartir o guardar";
+
+/* Label for screenshots section */
+"com.jetpack.support.screenshots" = "Capturas de pantalla";
+
+/* Description for screenshots section */
+"com.jetpack.support.screenshotsDescription" = "Añadir capturas de pantalla puede ayudarnos a entender y resolver tu problema más rápido.";
+
+/* Button to send a message or reply */
+"com.jetpack.support.send" = "Enviar";
+
+/* Description for sending logs to support */
+"com.jetpack.support.sendLogsToSupport" = "Enviar registros directamente al equipo de soporte";
+
+/* Progress text while sending a message */
+"com.jetpack.support.sending" = "Enviando";
+
+/* Progress message shown while sending a message */
+"com.jetpack.support.sendingMessage" = "Enviando mensaje";
+
+/* Button to share content */
+"com.jetpack.support.share" = "Compartir";
+
+/* Navigation title for sharing activity log */
+"com.jetpack.support.shareActivityLog" = "Compartir registro de actividad";
+
+/* Message shown when sharing log with support */
+"com.jetpack.support.sharingWithSupport" = "Compartiendo con el equipo de soporte";
+
+/* Site Address title on the support form */
+"com.jetpack.support.siteAddress" = "Dirección del sitio";
+
+/* Placeholder for site address field */
+"com.jetpack.support.siteAddressPlaceholder" = "https:\/\/tusitio.com";
+
+/* Description encouraging user to start a new conversation */
+"com.jetpack.support.startNewConversation" = "Inicia una nueva conversación con el botón de arriba";
+
+/* Subject title on the support form */
+"com.jetpack.support.subject" = "Asunto";
+
+/* Placeholder for subject field */
+"com.jetpack.support.subjectPlaceholder" = "Breve resumen de tu problema";
+
+/* Button title to submit a support request. */
+"com.jetpack.support.submitRequest" = "Enviar solicitud de asistencia";
+
+/* Navigation title for the support conversations list */
+"com.jetpack.support.supportConversations" = "Conversaciones de asistencia";
+
+/* Title for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSent" = "¡Solicitud enviada!";
+
+/* Message for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSentMessage" = "Tu solicitud de asistencia se ha enviado correctamente. Te responderemos por correo electrónico lo antes posible.";
+
+/* Progress message shown while bot is thinking */
+"com.jetpack.support.thinking" = "Pensando…";
+
+/* Title of the view for contacting support. */
+"com.jetpack.support.title" = "Contactar con soporte técnico";
+
+/* Button to retry a failed operation */
+"com.jetpack.support.tryAgain" = "Intentar de nuevo";
+
+/* Error title when log deletion fails */
+"com.jetpack.support.unableToDeleteLogs" = "No se pueden eliminar los registros";
+
+/* Error message when conversation cannot be displayed */
+"com.jetpack.support.unableToDisplayConversation" = "No se puede mostrar la conversación";
+
+/* Error title when video cannot be loaded or played */
+"com.jetpack.support.unableToDisplayVideo" = "No se puede reproducir el vídeo";
+
+/* Error message when application logs cannot be loaded */
+"com.jetpack.support.unableToLoadApplicationLogs" = "No se pueden cargar los registros de la aplicación";
+
+/* Error title when bot conversations fail to load */
+"com.jetpack.support.unableToLoadConversations" = "No se pueden cargar las conversaciones";
+
+/* Error title when messages fail to load */
+"com.jetpack.support.unableToLoadMessages" = "No se pueden cargar los mensajes";
+
+/* Error title when message sending fails */
+"com.jetpack.support.unableToSendMessage" = "No se puede enviar el mensaje";
+
+/* Button to view an attachment */
+"com.jetpack.support.view" = "Ver";
+
+/* Progress message shown during cache clearing operation */
+"com.jetpack.support.working" = "En proceso";
 
 /* Displayed in the confirmation alert when marking comment notifications as read. */
 "comment" = "comentario";
@@ -7879,6 +8127,9 @@ Example: Reply to Pamela Nguyen */
 /* Weekly Roundup debug menu item */
 "debugMenu.weeklyRoundup" = "Resumen semanal";
 
+/* Title for selecting a default category for a post */
+"defaultCategory.title" = "Categoría por defecto";
+
 /* Error tilte */
 "discussionSettings.saveErrorTitle" = "No se han podido guardar los ajustes";
 
@@ -8018,10 +8269,10 @@ Example: Reply to Pamela Nguyen */
 "double-tap to change unit" = "doble toque para cambiar de unidad";
 
 /* Message for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.message" = "¿Seguro que quieres eliminar esta etiqueta?";
+"edit.tag.delete.confirmation.message" = "¿Seguro que quieres eliminar esto?";
 
-/* Title for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.title" = "Borrar etiqueta";
+/* Title for delete a term confirmation dialog */
+"edit.tag.delete.confirmation.title" = "Eliminar";
 
 /* Placeholder text for tag description field */
 "edit.tag.description.placeholder" = "Añadir una descripción...";
@@ -8036,7 +8287,37 @@ Example: Reply to Pamela Nguyen */
 "edit.tag.section.description" = "Descripción";
 
 /* Section header for tag name in edit tag view */
-"edit.tag.section.tag" = "Etiqueta";
+"edit.tag.section.tag" = "Nombre";
+
+/* Context menu action to insert a block */
+"editor.blockInserter.insertBlock" = "Insertar bloque";
+
+/* Placeholder text for block search field */
+"editor.blockInserter.search" = "Buscar";
+
+/* Button title to collapse and show fewer blocks */
+"editor.blockInserter.showLess" = "Mostrar menos";
+
+/* Button title to expand and show more blocks */
+"editor.blockInserter.showMore" = "Mostrar más";
+
+/* Error message when media insertion fails */
+"editor.media.failedToInsert" = "No se han podido insertar los medios";
+
+/* Category name for section showing all patterns */
+"editor.patterns.all" = "Todos";
+
+/* Context menu action to insert a pattern */
+"editor.patterns.insertPattern" = "Insertar patrón";
+
+/* Title shown when no patterns match the search */
+"editor.patterns.noPatternsFound" = "No se han encontrado patrones";
+
+/* Navigation title for patterns view */
+"editor.patterns.title" = "Patrones";
+
+/* Category name for patterns without a category */
+"editor.patterns.uncategorized" = "Sin categorizar";
 
 /* Register Domain - Address information field Number placeholder */
 "eg. 1122334455" = "p.ej. 1122334455";
@@ -8590,6 +8871,24 @@ Example: Reply to Pamela Nguyen */
 
 /* Write a blog prompt for the jetpack prologue */
 "jetpack.prologue.prompt.writeBlog" = "Escribe un blog";
+
+/* Description for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.description" = "Cualquiera puede ver esta entrada";
+
+/* Title for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.title" = "Todos";
+
+/* Description for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.description" = "Solo los suscriptores de pago pueden ver esta entrada";
+
+/* Title for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.title" = "Suscriptores de pago";
+
+/* Description for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.description" = "La entrada es visible para todos los suscriptores, incluidos los gratuitos";
+
+/* Title for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.title" = "Todos los suscriptores";
 
 /* Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account */
 "jetpackSite.connectToDefaultAccount" = "Debes acceder con %@ para usar Estadísticas y Notificaciones.";
@@ -9180,6 +9479,12 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "No tienes permiso para ver este blog privado.";
 
+/* Default empty state message format when there are no terms. %1$@ is the taxonomy name. */
+"localizedLabels.defaultNoTerms.format" = "No hay %1$@";
+
+/* Default search placeholder format. %1$@ is the taxonomy name. */
+"localizedLabels.defaultSearch.format" = "Buscar %1$@";
+
 /* Button to dismiss the re-authentication view */
 "login.appPasswordReAuth.cancelButton" = "Cancelar";
 
@@ -9315,17 +9620,23 @@ Example: Reply to Pamela Nguyen */
 /* Message about buying storage add-on */
 "mediaLibrary.storageDetails.buyStorage.message" = "Compra la extensión de almacenamiento";
 
-/* Message shown when all media items are attached */
-"mediaLibrary.storageDetails.cleanup.allAttached" = "Todos los elementos de la biblioteca de medios están adjuntos.";
+/* Label for audio media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.audio" = "Audio";
 
-/* Message shown while loading unattached media count */
-"mediaLibrary.storageDetails.cleanup.loading" = "Buscando si hay algún elemento de medios sin adjuntar...";
+/* Label for document media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.document" = "Documentos";
 
-/* Message about unattached media that can be cleaned up. %1$d is the count of unattached media. */
-"mediaLibrary.storageDetails.cleanup.message" = "%1$d elemento sin adjuntar. Elimínalos para liberar algo de espacio.";
+/* Label for image media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.image" = "Imágenes";
 
-/* Title for cleanup section */
-"mediaLibrary.storageDetails.cleanup.title" = "Eliminar elementos sin uso";
+/* Label for other/unknown media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.other" = "Otros";
+
+/* Label for PowerPoint/presentation media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.powerpoint" = "Presentaciones";
+
+/* Label for video media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.video" = "Vídeos";
 
 /* Success message shown after upgrading plan */
 "mediaLibrary.storageDetails.purchase.plan.success" = "¡El plan de tu sitio se ha actualizado!";
@@ -9711,6 +10022,12 @@ Example: Reply to Pamela Nguyen */
 /* Menu option for filtering posts by me */
 "pagesList.pagesByMe" = "Mis páginas";
 
+/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
+"parentCategory.noCategory" = "Sin categoría";
+
+/* Title for selecting parent category of a category */
+"parentCategory.title" = "Categoría superior";
+
 /* Title for the parent page picker screen */
 "parentPagePicker.title" = "Página superior";
 
@@ -9869,6 +10186,27 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the post author selection screen */
 "postAuthorPicker.title" = "Autor";
+
+/* Title for selecting categories for a post or a page */
+"postCategories.title" = "Categorías";
+
+/* Toggle label for allowing comments on post */
+"postDiscussion.allowComments.label" = "Permitir comentarios";
+
+/* Toggle label for allowing pings/trackbacks on post */
+"postDiscussion.allowPings.label" = "Permitir pingbacks";
+
+/* Footer text when comments are disabled */
+"postDiscussion.comments.disabled.footer" = "Los visitantes no pueden añadir comentarios ni respuestas nuevos. Los comentarios existentes permanecen visibles.";
+
+/* Footer text when comments are enabled */
+"postDiscussion.comments.enabled.footer" = "Los visitantes pueden añadir comentarios y respuestas nuevos.";
+
+/* Link text for learning more about pingbacks and trackbacks */
+"postDiscussion.pingbacks.learnMore.text" = "Más información sobre los pingbacks y trackbacks";
+
+/* Navigation title for post discussion settings */
+"postDiscussion.title" = "Debate";
 
 /* Button in an alert confirming discaring changes */
 "postEditor.closeConfirmationAlert.discardChanges" = "Descartar cambios";
@@ -10101,6 +10439,9 @@ Example: Reply to Pamela Nguyen */
 /* A default value for an post without a title */
 "postSaveErrorMessage.postUntitled" = "Sin título";
 
+/* Section header for Access settings in Post Settings */
+"postSettings.access.header" = "Acceso";
+
 /* Label for the author field in Post Settings */
 "postSettings.author.label" = "Autor";
 
@@ -10119,6 +10460,18 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the discard changes confirmation dialog */
 "postSettings.discardChanges.title" = "¿Descartar cambios?";
+
+/* Status text when discussion (comments) is disabled */
+"postSettings.discussion.closed" = "Cerrado";
+
+/* Label for the discussion settings field in Post Settings */
+"postSettings.discussion.label" = "Debate";
+
+/* Status text when discussion (comments) is enabled */
+"postSettings.discussion.open" = "Abierto";
+
+/* Label for the checkbox that lets you send a post to newsletter subscribers */
+"postSettings.emailToSubscribers.label" = "Enviar por correo electrónico a los suscriptores";
 
 /* Character count for excerpt. %1$d is the number of characters. */
 "postSettings.excerpt.characterCount" = "%1$d caracteres";
@@ -10222,6 +10575,21 @@ Example: Reply to Pamela Nguyen */
 /* Cell title for the Top Level option case */
 "postSettings.parentPage.topLevel" = "Nivel superior";
 
+/* Accessibility label for hide password button */
+"postSettings.passwordEntry.hidePassword" = "Ocultar contraseña";
+
+/* Instructions for password entry */
+"postSettings.passwordEntry.instructions" = "Introduce una contraseña para proteger esta entrada. Solo los usuarios que tengan la contraseña podrán verla.";
+
+/* Navigation title for password entry screen */
+"postSettings.passwordEntry.navigationTitle" = "Introducir contraseña";
+
+/* Placeholder for password field */
+"postSettings.passwordEntry.placeholder" = "Introducir contraseña";
+
+/* Accessibility label for show password button */
+"postSettings.passwordEntry.showPassword" = "Mostrar contraseña";
+
 /* Label for the pending review toggle in Post Settings */
 "postSettings.pendingReview.label" = "Pendiente de revisión";
 
@@ -10249,17 +10617,59 @@ Example: Reply to Pamela Nguyen */
 /* Section header for General settings in Post Settings */
 "postSettings.section.general" = "General";
 
+/* Description text explaining what the slug editor does */
+"postSettings.slug.customizeDescription" = "Personaliza la última parte del enlace permanente.";
+
 /* Hint text for the slug field. Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso. */
 "postSettings.slug.hint" = "El slug es la versión apta para URLs del título de la entrada.";
 
 /* Label for the slug field. Should be the same as WP core. */
 "postSettings.slug.label" = "Slug";
 
+/* Button text to learn more about permalinks */
+"postSettings.slug.learnMore" = "Más información";
+
+/* Label for the slug field. Should be the same as WP core. */
+"postSettings.slug.navigationTitle" = "Slug";
+
+/* Notice shown when the post doesn't have a remote and permalink template is missing */
+"postSettings.slug.permalinkDraftNotice" = "El enlace permanente sugerido aparecerá cuando se guarde el borrador en el servidor";
+
+/* Label for the permalink preview */
+"postSettings.slug.permalinkLabel" = "Enlace permanente";
+
+/* Section title for the permalink preview */
+"postSettings.slug.permalinkSection" = "Enlace permanente";
+
 /* Placeholder for the slug field */
 "postSettings.slug.placeholder" = "Introducir slug";
 
 /* Label for the preview button in Post Settings */
 "postSettings.socialSharing.header" = "Compartir en redes sociales";
+
+/* Label for the status field in Post Settings */
+"postSettings.status.label" = "Estado";
+
+/* Navigation title for status picker */
+"postSettings.statusPicker.navigationTitle" = "Estado y visibilidad";
+
+/* Label showing the current password */
+"postSettings.statusPicker.passwordLabel" = "Contraseña";
+
+/* Toggle label for password protection */
+"postSettings.statusPicker.passwordProtected" = "Protegida con contraseña";
+
+/* Subtitle for password protected toggle */
+"postSettings.statusPicker.passwordProtectedSubtitle" = "Solo visible para quienes conozcan la contraseña";
+
+/* Label for schedule date row */
+"postSettings.statusPicker.scheduleDate" = "Fecha";
+
+/* Toggle label for sticky posts */
+"postSettings.statusPicker.sticky" = "Fija";
+
+/* Subtitle for sticky toggle */
+"postSettings.statusPicker.stickySubtitle" = "Fija esta entrada en la parte superior del blog";
 
 /* Label for the sticky post toggle. Sticky posts are displayed at the top of the blog. */
 "postSettings.stickyPost.label" = "Fija";
@@ -10279,17 +10689,56 @@ Example: Reply to Pamela Nguyen */
 /* Navigation bar title of the Post Stats screen */
 "postStats.title" = "Estadísticas de la entrada";
 
-/* Button to add a new tag. %1$@ is the tag name. */
-"postTags.addTag" = "Añadir etiqueta";
+/* Post status title */
+"postStatus.deleted.details" = "Eliminada permanentemente";
 
-/* Placeholder text for the tag search field */
-"postTags.searchOrAdd.placeholder" = "Buscar o añadir etiquetas";
+/* Post status title */
+"postStatus.deleted.title" = "Eliminada";
 
-/* Message shown when no tags are selected */
-"postTags.selectionEmpty" = "No hay etiquetas seleccionadas";
+/* Post status details */
+"postStatus.draft.details" = "No está lista para publicarse";
 
-/* Title for the tags screen */
-"postTags.title" = "Etiquetas";
+/* Post status title */
+"postStatus.draft.title" = "Borrador";
+
+/* Post status details */
+"postStatus.pending.details" = "Esperando revisión antes de publicar";
+
+/* Post status title */
+"postStatus.pending.title" = "Pendiente";
+
+/* Post status details */
+"postStatus.private.details" = "Solo visible para administradores y editores del sitio";
+
+/* Post status title */
+"postStatus.private.title" = "Privada";
+
+/* Post status details */
+"postStatus.published.details" = "Visible por todos";
+
+/* Post status title */
+"postStatus.published.title" = "Publicada";
+
+/* Post status details */
+"postStatus.scheduled.details" = "Publicar automáticamente en una fecha elegida";
+
+/* Post status title */
+"postStatus.scheduled.title" = "Programada";
+
+/* Post status title */
+"postStatus.trash.details" = "Enviada a la papelera pero no eliminada aún";
+
+/* Post status title */
+"postStatus.trash.title" = "Enviada a la papelera";
+
+/* Button to add a new taxonomy term. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.addTag" = "Añadir %1$@";
+
+/* Placeholder text for the taxonomy search field. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.searchOrAdd.placeholder" = "Buscar o añadir %1$@";
+
+/* Message shown when no taxonomy terms are selected. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.selectionEmpty" = "No se han seleccionado %1$@";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Cancelar";
@@ -10365,9 +10814,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "Categorías";
-
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "Cerrar";
 
 /* Button to confirm discarding changes */
 "prepublishing.discardChanges.button" = "Descartar cambios";
@@ -10456,12 +10902,17 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "Advertencia";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "Mensaje";
+
+/* Placeholder text for the message field in Social Sharing */
+"prepublishing.socialAccounts.messagePlaceholder" = "Escribe un mensaje breve para compartirlo en las redes sociales junto a la entrada";
 
 /* The navigation title for the pre-publishing social accounts screen. */
 "prepublishing.socialAccounts.navigationTitle" = "Social";
+
+/* Table section title */
+"prepublishing.socialAccounts.servicesSectionTitle" = "Servicios";
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.tags" = "Etiquetas";
@@ -11408,6 +11859,18 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Button to progress to the next step after selecting domain in Site Creation */
 "siteCreation.domains.buttons.selectDomain" = "Elegir dominio";
 
+/* Default text for adding a new item when no label is provided */
+"siteCustomTaxonomies.defaultAddNew" = "Añadir";
+
+/* Description for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.description" = "Las taxonomías te ayudan a organizar el contenido más allá de las categorías y etiquetas estándar.";
+
+/* Title for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.title" = "No hay taxonomías personalizadas";
+
+/* Navigation title for the custom taxonomies screen */
+"siteCustomTaxonomies.navigationTitle" = "Taxonomías";
+
 /* Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio. */
 "siteMedia.accessibilityLabelAudio" = "Audio, %@";
 
@@ -11426,8 +11889,77 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Accessibility hint for actions when displaying media items. */
 "siteMedia.cellAccessibilityHint" = "Elige medios.";
 
+/* Label for the alt for a media asset (image) */
+"siteMedia.details.altText" = "Texto alternativo";
+
+/* Verb. Button title. Tapping cancels an action. */
+"siteMedia.details.cancel" = "Cancelar";
+
+/* Noun. Label for the caption for a media asset (image / video) */
+"siteMedia.details.caption" = "Leyenda";
+
+/* Title for button that permanently deletes a media item (photo / video) */
+"siteMedia.details.delete" = "Eliminar";
+
+/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
+"siteMedia.details.deleteConfirmation" = "¿Seguro que quieres eliminar este elemento de forma permanente?";
+
+/* Text displayed in HUD after successfully deleting a media item */
+"siteMedia.details.deleted" = "Eliminado.";
+
+/* Text displayed in HUD while a media item is being deleted. */
+"siteMedia.details.deleting" = "Eliminando…";
+
+/* Label for the description for a media asset (image / video) */
+"siteMedia.details.description" = "Descripción";
+
+/* Label for the dimensions in pixels for a media asset (image / video) */
+"siteMedia.details.dimensions" = "Dimensiones";
+
+/* Label for the file name for a media asset (image / video) */
+"siteMedia.details.fileName" = "Nombre del archivo";
+
+/* Label for the file size for a media asset (image / video) */
+"siteMedia.details.fileSize" = "Tamaño de archivo";
+
+/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
+"siteMedia.details.fileType" = "Tipo de archivo";
+
+/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
+"siteMedia.details.mediaDeleted" = "Este elemento de medios se ha eliminado.";
+
+/* Noun. Label for the title of a media asset (image / video) */
+"siteMedia.details.title" = "Título";
+
+/* Accessibility label for trash buttons in nav bars */
+"siteMedia.details.trash" = "Papelera";
+
+/* Text displayed in HUD if there was an error attempting to delete a media item. */
+"siteMedia.details.unableToDeleteMedia" = "No se puede eliminar el elemento de medios.";
+
+/* Error shown when the app fails to load a video from the user's media library. */
+"siteMedia.details.unableToLoadVideo" = "No se puede cargar el vídeo.";
+
+/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
+"siteMedia.details.unableToSaveMedia" = "No se puede guardar el elemento de medios.";
+
+/* Label for the date a media asset (image / video) was uploaded */
+"siteMedia.details.uploaded" = "Subido el";
+
 /* Title for the URL field */
 "siteMedia.details.url" = "URL";
+
+/* Hint for image alt on image settings. */
+"siteMedia.hints.imageAlt" = "Texto alternativo de la imagen";
+
+/* Hint for image caption on image settings. */
+"siteMedia.hints.imageCaption" = "Leyenda de la imagen";
+
+/* Hint for image description on image settings. */
+"siteMedia.hints.imageDescription" = "Descripción de la imagen";
+
+/* Hint for image title on image settings. */
+"siteMedia.hints.imageTitle" = "Título de la imagen";
 
 /* Accessibility hint for media item preview for user's viewing an item in their media library */
 "siteMediaItem.contentViewAccessibilityHint" = "Toca para ver los medios a pantalla completa";
@@ -11525,6 +12057,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Privacidad";
+
+/* Format string for adding a new taxonomy term. %1$@ is the taxonomy name. */
+"siteTaxonomy.addNew.format" = "Añadir %1$@";
 
 /* Hint for users when hidden privacy setting is set */
 "siteVisibility.hidden.hint" = "El sitio web se ocultará a los visitantes y mostrará el aviso \"Próximamente\" hasta que se pueda visualizar.";
@@ -12093,7 +12628,8 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Subject of new Zendesk ticket. */
 "support.zendesk.readerAppTicketSubject" = "Compatibilidad con el Lector para iOS";
 
-/* Description for empty state when there are no tags */
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
 "tags.empty.description" = "Las etiquetas ayudan a organizar tu contenido y facilitan a los lectores la búsqueda de entradas relacionadas.";
 
 /* Title for empty state when there are no tags */
@@ -12170,9 +12706,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "no leído";
-
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "Suscriptor del sitio";
 
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "Usuario del sitio";
@@ -12258,9 +12791,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* The heading at the top of the user list */
 "userlist.title" = "Usuarios";
-
-/* Site Subscribers */
-"users.list.title.subscribers" = "Suscriptores";
 
 /* Screen title */
 "users.title" = "Usuarios";

--- a/WordPress/Resources/fr.lproj/Localizable.strings
+++ b/WordPress/Resources/fr.lproj/Localizable.strings
@@ -1,6 +1,6 @@
-/* Translation-Revision-Date: 2025-10-07 11:54:09+0000 */
+/* Translation-Revision-Date: 2025-11-25 11:54:11+0000 */
 /* Plural-Forms: nplurals=2; plural=n > 1; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: fr */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -581,8 +581,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "On y est presque ! Veuillez saisir le code de vérification de votre app d’authentification.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Texte alternatif";
 
 /* No comment provided by engineer. */
@@ -722,9 +721,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "Confirmez-vous vouloir déconnecter Jetpack de votre site ?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "Confirmez-vous vouloir supprimer définitivement cet élément ?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "Confirmez-vous vouloir supprimer %1$@ de %2$@ ?";
@@ -1076,7 +1072,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Annuler";
@@ -1104,8 +1099,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Vous n’arrivez pas à choisir ? Vous pouvez modifier le thème à tout moment.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Légende";
 
 /* Alert title. */
@@ -1771,8 +1765,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "Par défaut";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Catégorie par défaut";
 
 /* Label for selecting the default post format
@@ -1781,9 +1774,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Paramètres par défaut pour les nouveaux articles";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Effacer";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Supprimer le menu";
@@ -1802,14 +1792,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "Supprimer le menu";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Supprimer !";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Suppression du site...";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Effacement... ";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "Refuser";
@@ -1817,8 +1801,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "Décrivez le rôle de cette image. N’indiquez rien si l’image est purement décorative.";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Description";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1836,9 +1819,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "Vous ne voulez pas créer de nouveau compte ? Revenez en arrière et ressaisissez votre adresse e-mail.";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Dimensions";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "Désactiver";
@@ -2115,7 +2095,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "La modification de ce GIF supprimera son animation.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Éditeur";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2457,11 +2437,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "Réglages du bloc fichier";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "Nom de fichier";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Type de fichier";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "Type de fichier non pris en charge comme fichier média.";
@@ -2772,6 +2749,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post content used in the login prologue screens. */
 "I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next" = "Le travail du photographe Cameron Karsten m’inspire tellement. Je vais essayer ces techniques lors de mon prochain";
 
+/* Text on the support form to refer to what area the user has problem with. */
+"I need help with" = "J’ai besoin d’aide concernant";
+
 /* Describes the IP address section in the comment detail screen. */
 "IP address" = "Adresse IP";
 
@@ -2817,9 +2797,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "Légende de l’image";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Description de l’image";
-
 /* Hint for image link on image settings. */
 "Image Link" = "Lien de l’image";
 
@@ -2831,9 +2808,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "Fichier image introuvable.";
-
-/* Hint for image title on image settings. */
-"Image title" = "Titre de l’image";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "Décrivez votre site en quelques mots.";
@@ -3196,6 +3170,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the button that will dismiss this view. */
 "Let me know when finished!" = "Indiquez-moi lorsque l’opération est terminée !";
 
+/* Message info on the support screen. */
+"Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon." = "Indiquez-nous l’adresse de votre site (URL) et dites-nous tout ce que vous pouvez sur ce problème. Nous vous recontacterons au plus vite.";
+
+/* Title to let the user know what do we want on the support screen. */
+"Let’s get this sorted" = "Voyons comment nous pouvons régler votre problème";
+
 /* Lifestyle site intent topic */
 "Lifestyle" = "Style de vie";
 
@@ -3396,6 +3376,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Navigation principale";
+
+/* Explanation for the option to enable theme styles */
+"Make the block editor look like your theme." = "Faire ressembler l’éditeur de blocs à votre thème.";
 
 /* No comment provided by engineer. */
 "Make your content stand out by adding images, gifs, videos, and embedded media to your pages." = "Faites ressortir votre contenu en ajoutant des images, des gifs, des vidéos ou des médias embarqués à vos pages.";
@@ -3738,9 +3721,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "Aucun compte trouvé";
-
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Pas de catégorie";
 
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Pas de connexion";
@@ -4182,9 +4162,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "Pagination";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Catégorie mère";
-
 /* Parenting site intent topic */
 "Parenting" = "Parentalité";
 
@@ -4402,9 +4379,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Article ";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Catégories d'articles";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "Réglages d’article";
@@ -4713,9 +4687,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "Retirer les métadonnées de localisation des photos avant des les téléverser sur votre site.";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "Les abonnés que vous supprimez ne recevront plus les mises à jour de votre site. Mais ils pourront toujours consulter le site et s’y réabonner s’ils le souhaitent.";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "Remplacer le bloc actuel";
@@ -5552,6 +5523,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "Description";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Étiquettes";
 
@@ -5937,9 +5909,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "Ce code de connexion a expiré. Appuyez sur Scanner à nouveau pour rescanner le code.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "Ce média a été supprimé.";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "Ce compte utilisateur ne peut pas être clôturé s’il y a des contestations de paiement non résolues.";
 
@@ -6008,7 +5977,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Titre";
@@ -6102,8 +6070,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "Transformer le bloc…";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Déplacer vers la corbeille";
 
@@ -6200,9 +6167,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "Impossible de créer de nouveaux liens d’invitation.";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "Impossible de supprimer le média.";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "Impossible de désactiver les liens d’invitation.";
 
@@ -6233,9 +6197,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "Impossible de charger cette page pour le moment. ";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "Impossible de charger la vidéo.";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Impossible de lancer la vidéo";
 
@@ -6244,9 +6205,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Impossible de restaurer votre site";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "Impossible d’enregistrer le média.";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "Impossible de partager le lien";
@@ -6403,9 +6361,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Le téléversement a échoué";
 
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Téléversé";
-
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "Un article brouillon et %ld fichiers téléversés";
 
@@ -6447,6 +6402,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The button title text for logging in with WP.com password instead of magic link. */
 "Use password to sign in" = "Utilisez le mot de passe pour la connexion";
+
+/* Option to enable theme styles in the block editor */
+"Use theme styles" = "Utiliser les styles de thème";
 
 /* A placeholder for the twitter username
    Accessibility label for the username text field in the self-hosted login page.
@@ -6894,7 +6852,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "La carte du monde affiche les vues par pays.";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "Voulez-vous toujours supprimer cette personne ?";
 
 /* Button title. Opens the editor to write a new post.
@@ -7353,14 +7311,19 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Description for the prompt to upgrade to Application Passwords. The first argument is the name of the feature that requires Application Passwords. */
 "applicationPasswordRequired.description" = "Les mots de passe d’application sont un moyen plus sûr de vous connecter à votre site auto-hébergé et activer des fonctionnalités telles que %@.";
 
+/* Feature name for managing application passwords in the app */
+"applicationPasswordRequired.feature.applicationPasswords" = "Gestion des mots de passe d’applications";
+
 /* Feature name for the block editor in application password required prompt */
 "applicationPasswordRequired.feature.blockEditor" = "Éditeur de blocs";
+
+/* Feature name for managing terms and taxonomies in the app */
+"applicationPasswordRequired.feature.customTaxonomies" = "Gestion des taxonomies";
 
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "Gestion des extensions";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "Gestion des utilisateurs";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -7583,6 +7546,276 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 
 /* Post Editor / Button in the 'More' menu */
 "classicEditor.moreMenu.saveDraft" = "Enregistrer le brouillon";
+
+/* Button to add more screenshots */
+"com.jetpack.support.addMoreScreenshots" = "Ajouter d’autres captures d’écran";
+
+/* Button to add screenshots */
+"com.jetpack.support.addScreenshots" = "Ajouter des captures d’écran";
+
+/* Header for application logs section */
+"com.jetpack.support.applicationLogs" = "Journaux d’application";
+
+/* Description explaining why including logs is helpful */
+"com.jetpack.support.applicationLogsDescription" = "Inclure des journaux peut aider notre équipe à examiner les problèmes. Les journaux peuvent contenir une activité récente de l’application.";
+
+/* Navigation title for application logs screen */
+"com.jetpack.support.applicationLogsTitle" = "Journaux d’application";
+
+/* Format string for attachment identifier */
+"com.jetpack.support.attachment" = "Pièce jointe %@";
+
+/* Format string for attachment size limit. %1$@ is current size, %2$@ is maximum size */
+"com.jetpack.support.attachmentLimit" = "Limite de pièces jointes : %1$@ \/ %2$@";
+
+/* Bot greeting message. %1$@ is the user's name */
+"com.jetpack.support.botGreeting" = "Salutations %1$@ !";
+
+/* Bot introduction message explaining its purpose */
+"com.jetpack.support.botIntroduction" = "Je suis votre assistant IA personnel. Je peux vous aider à répondre à toute question concernant votre site ou votre compte.";
+
+/* Format string for cache file count and size. %1$d is the number of files, %2$@ is the formatted size. The system will pluralize 'files' based on the number – please specify it as the largest plural value */
+"com.jetpack.support.cacheFiles" = "%1$d fichiers mis en cache (%2$@)";
+
+/* Message shown when cache has no files */
+"com.jetpack.support.cacheIsEmpty" = "Le cache est vide";
+
+/* Button to cancel current action */
+"com.jetpack.support.cancel" = "Annuler";
+
+/* Warning message that deleted logs cannot be recovered */
+"com.jetpack.support.cannotRecoverLogs" = "Vous ne pourrez pas les récupérer.";
+
+/* Button to clear all activity logs */
+"com.jetpack.support.clearAllActivityLogs" = "Effacer tous les journaux d’activités";
+
+/* Button to clear disk cache */
+"com.jetpack.support.clearDiskCache" = "Vider le cache du disque";
+
+/* Description explaining the purpose of clearing disk cache */
+"com.jetpack.support.clearDiskCacheDescription" = "Supprimez les fichiers temporaires pour libérer de l’espace ou résoudre les problèmes.";
+
+/* Progress text while clearing cache */
+"com.jetpack.support.clearing" = "Nettoyage…";
+
+/* Message shown when cache clearing is complete */
+"com.jetpack.support.complete" = "Terminé";
+
+/* Confirmation message when canceling a draft */
+"com.jetpack.support.confirmCancelMessage" = "Voulez-vous vraiment annuler ce message ? Vous perdrez toutes les données que vous avez saisies";
+
+/* Title for alert confirming cancellation */
+"com.jetpack.support.confirmCancellation" = "Confirmer l’annulation";
+
+/* Confirmation dialog title when deleting all logs */
+"com.jetpack.support.confirmDeleteAllLogs" = "Voulez-vous vraiment supprimer tous les journaux ?";
+
+/* Section title for contact information */
+"com.jetpack.support.contactInformation" = "Coordonnées";
+
+/* Button to continue editing a message */
+"com.jetpack.support.continueWriting" = "Continuer d’écrire";
+
+/* Message shown at end of closed support conversation */
+"com.jetpack.support.conversationEnded" = "Fin de la conversation. Aucune autre réponse n’est possible.";
+
+/* Button to delete all log files */
+"com.jetpack.support.deleteAllLogs" = "Effacer tous les journaux";
+
+/* Description text for diagnostics screen */
+"com.jetpack.support.diagnosticsDescription" = "Exécutez des tâches de maintenance et de résolution de problème courantes.";
+
+/* Button to discard changes in a draft message */
+"com.jetpack.support.discardChanges" = "Abandonner les modifications";
+
+/* Notice explaining where support will send email responses */
+"com.jetpack.support.emailNotice" = "Nous vous enverrons un e-mail à cette adresse.";
+
+/* Error title when logs fail to load */
+"com.jetpack.support.errorLoadingLogs" = "Erreur lors du chargement des journaux";
+
+/* Error message when support conversations fail to load */
+"com.jetpack.support.errorLoadingSupportConversations" = "Erreur lors du chargement des conversations d’assistance";
+
+/* Title for error alerts */
+"com.jetpack.support.errorTitle" = "Erreur";
+
+/* Option to export log as a file */
+"com.jetpack.support.exportAsFile" = "Exporter en tant que fichier";
+
+/* Button to dismiss alerts. */
+"com.jetpack.support.gotIt" = "J’ai compris";
+
+/* Text on the support form to refer to what area the user has problem with. */
+"com.jetpack.support.iNeedHelp" = "J’ai besoin d’aide concernant";
+
+/* Toggle label to include application logs in the support request */
+"com.jetpack.support.includeApplicationLogs" = "Inclure les journaux d’application";
+
+/* Section title for issue details */
+"com.jetpack.support.issueDetails" = "Détails du problème";
+
+/* Format string for when conversation was last updated */
+"com.jetpack.support.lastUpdated" = "Dernière mise à jour %@";
+
+/* Progress message while loading conversation messages */
+"com.jetpack.support.loadingBotConversationMessages" = "Chargement des messages";
+
+/* Progress message while loading bot conversations */
+"com.jetpack.support.loadingBotConversations" = "Chargement des conversations de bots";
+
+/* Progress text while loading support conversations */
+"com.jetpack.support.loadingConversations" = "Chargement des conversations";
+
+/* Progress message while loading disk usage information */
+"com.jetpack.support.loadingDiskUsage" = "Chargement de l’utilisation du disque";
+
+/* Progress message while loading an image attachment */
+"com.jetpack.support.loadingImage" = "Chargement de l’image";
+
+/* Progress message shown in overlay while refreshing content */
+"com.jetpack.support.loadingLatestContent" = "Chargement du dernier contenu";
+
+/* Progress message while loading application log content */
+"com.jetpack.support.loadingLogContent" = "Chargement du contenu du journal…";
+
+/* Progress message while loading log files */
+"com.jetpack.support.loadingLogs" = "Chargement des journaux…";
+
+/* Progress text while loading conversation messages */
+"com.jetpack.support.loadingMessages" = "Chargement des messages";
+
+/* Progress message while loading a video attachment */
+"com.jetpack.support.loadingVideo" = "Chargement de la vidéo";
+
+/* Section header for log files sorted by date */
+"com.jetpack.support.logFilesByDate" = "Fichiers journaux par date de création";
+
+/* Text indicating which log files will be included in the support request */
+"com.jetpack.support.logFilesToUpload" = "Les fichiers journaux suivants seront chargés :";
+
+/* Footer text explaining log retention policy */
+"com.jetpack.support.logRetentionNotice" = "Conserve jusqu’à sept jours de rapports de bugs.";
+
+/* Success message when reply is sent successfully */
+"com.jetpack.support.messageSent" = "Message envoyé";
+
+/* Format string for number of messages in conversation */
+"com.jetpack.support.messagesCount" = "%d messages";
+
+/* The title of a new bot chat in the support area of the app */
+"com.jetpack.support.new-bot-chat" = "Nouveau chat bot";
+
+/* Option to create a new support ticket */
+"com.jetpack.support.newSupportTicket" = "Nouveau ticket d’assistance";
+
+/* Label shown when there are no bot conversations */
+"com.jetpack.support.noConversations" = "Aucune conversation";
+
+/* Description shown when no log files are available */
+"com.jetpack.support.noLogsAvailable" = "Il n’y a aucun journal d’activités disponible";
+
+/* Label shown when no log files are available */
+"com.jetpack.support.noLogsFound" = "Aucun journal trouvé";
+
+/* Button to open a support ticket */
+"com.jetpack.support.openSupportTicket" = "Ouvrir un ticket d’assistance";
+
+/* Text indicating a field is optional */
+"com.jetpack.support.optional" = "(Facultatif)";
+
+/* Navigation title for replying to a support conversation */
+"com.jetpack.support.reply" = "Répondre";
+
+/* Description for saving log as a file */
+"com.jetpack.support.saveAsFile" = "Enregistrer en tant que fichier à partager ou à stocker";
+
+/* Label for screenshots section */
+"com.jetpack.support.screenshots" = "Captures d’écran";
+
+/* Description for screenshots section */
+"com.jetpack.support.screenshotsDescription" = "L’ajout de captures d’écran peut nous aider à comprendre et résoudre votre problème plus rapidement.";
+
+/* Button to send a message or reply */
+"com.jetpack.support.send" = "Envoyer";
+
+/* Description for sending logs to support */
+"com.jetpack.support.sendLogsToSupport" = "Envoyer les journaux directement à l’équipe d’assistance";
+
+/* Progress text while sending a message */
+"com.jetpack.support.sending" = "Envoi en cours";
+
+/* Progress message shown while sending a message */
+"com.jetpack.support.sendingMessage" = "Envoyer un message";
+
+/* Button to share content */
+"com.jetpack.support.share" = "Partager";
+
+/* Navigation title for sharing activity log */
+"com.jetpack.support.shareActivityLog" = "Partager le journal d’activités";
+
+/* Message shown when sharing log with support */
+"com.jetpack.support.sharingWithSupport" = "Partage avec l’assistance !";
+
+/* Site Address title on the support form */
+"com.jetpack.support.siteAddress" = "Adresse du site";
+
+/* Description encouraging user to start a new conversation */
+"com.jetpack.support.startNewConversation" = "Commencer une nouvelle conversation en utilisant le bouton ci-dessus";
+
+/* Subject title on the support form */
+"com.jetpack.support.subject" = "Objet";
+
+/* Placeholder for subject field */
+"com.jetpack.support.subjectPlaceholder" = "Bref résumé de votre problème";
+
+/* Button title to submit a support request. */
+"com.jetpack.support.submitRequest" = "Envoyer la demande d’aide";
+
+/* Navigation title for the support conversations list */
+"com.jetpack.support.supportConversations" = "Conversations d’assistance";
+
+/* Title for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSent" = "Demande envoyée !";
+
+/* Message for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSentMessage" = "Votre demande d’assistance a bien été envoyée. Nous vous enverrons une réponse par e-mail dès que possible.";
+
+/* Progress message shown while bot is thinking */
+"com.jetpack.support.thinking" = "En cours de réflexion…";
+
+/* Title of the view for contacting support. */
+"com.jetpack.support.title" = "Contacter l’assistance";
+
+/* Button to retry a failed operation */
+"com.jetpack.support.tryAgain" = "Réessayer";
+
+/* Error title when log deletion fails */
+"com.jetpack.support.unableToDeleteLogs" = "Impossible de supprimer les journaux";
+
+/* Error message when conversation cannot be displayed */
+"com.jetpack.support.unableToDisplayConversation" = "Impossible d’afficher la conversation";
+
+/* Error title when video cannot be loaded or played */
+"com.jetpack.support.unableToDisplayVideo" = "Impossible d’afficher la vidéo";
+
+/* Error message when application logs cannot be loaded */
+"com.jetpack.support.unableToLoadApplicationLogs" = "Impossible de charger les journaux d’application";
+
+/* Error title when bot conversations fail to load */
+"com.jetpack.support.unableToLoadConversations" = "Impossible de charger les conversations";
+
+/* Error title when messages fail to load */
+"com.jetpack.support.unableToLoadMessages" = "Impossible de charger les messages";
+
+/* Error title when message sending fails */
+"com.jetpack.support.unableToSendMessage" = "Impossible d’envoyer le message";
+
+/* Button to view an attachment */
+"com.jetpack.support.view" = "Voir";
+
+/* Progress message shown during cache clearing operation */
+"com.jetpack.support.working" = "En cours";
 
 /* Displayed in the confirmation alert when marking comment notifications as read. */
 "comment" = "commentaire";
@@ -7840,6 +8073,9 @@ Example: Reply to Pamela Nguyen */
 /* Weekly Roundup debug menu item */
 "debugMenu.weeklyRoundup" = "Résumé hebdomadaire";
 
+/* Title for selecting a default category for a post */
+"defaultCategory.title" = "Catégorie par défaut";
+
 /* Error tilte */
 "discussionSettings.saveErrorTitle" = "Échec de l’enregistrement des réglages";
 
@@ -7979,10 +8215,10 @@ Example: Reply to Pamela Nguyen */
 "double-tap to change unit" = "appuyer deux fois pour modifier l’unité";
 
 /* Message for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.message" = "Voulez-vous vraiment supprimer cette étiquette ?";
+"edit.tag.delete.confirmation.message" = "Voulez-vous vraiment le supprimer ?";
 
-/* Title for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.title" = "Supprimer l’étiquette";
+/* Title for delete a term confirmation dialog */
+"edit.tag.delete.confirmation.title" = "Supprimer";
 
 /* Placeholder text for tag description field */
 "edit.tag.description.placeholder" = "Ajoutez une description…";
@@ -7994,7 +8230,37 @@ Example: Reply to Pamela Nguyen */
 "edit.tag.new.title" = "Nouvelle étiquette";
 
 /* Section header for tag name in edit tag view */
-"edit.tag.section.tag" = "Étiquette";
+"edit.tag.section.tag" = "Nom";
+
+/* Context menu action to insert a block */
+"editor.blockInserter.insertBlock" = "Insérer le bloc";
+
+/* Placeholder text for block search field */
+"editor.blockInserter.search" = "Rechercher";
+
+/* Button title to collapse and show fewer blocks */
+"editor.blockInserter.showLess" = "Afficher moins";
+
+/* Button title to expand and show more blocks */
+"editor.blockInserter.showMore" = "Voir plus";
+
+/* Error message when media insertion fails */
+"editor.media.failedToInsert" = "Échec d’insertion du média";
+
+/* Category name for section showing all patterns */
+"editor.patterns.all" = "Tout";
+
+/* Context menu action to insert a pattern */
+"editor.patterns.insertPattern" = "Insérer la composition";
+
+/* Title shown when no patterns match the search */
+"editor.patterns.noPatternsFound" = "Aucune composition trouvée";
+
+/* Navigation title for patterns view */
+"editor.patterns.title" = "Compositions";
+
+/* Category name for patterns without a category */
+"editor.patterns.uncategorized" = "Sans catégorie";
 
 /* Register Domain - Address information field Number placeholder */
 "eg. 1122334455" = "ex. 1122334455";
@@ -8546,6 +8812,24 @@ Example: Reply to Pamela Nguyen */
 /* Write a blog prompt for the jetpack prologue */
 "jetpack.prologue.prompt.writeBlog" = "Tenir un blog";
 
+/* Description for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.description" = "Tout le monde peut voir cet article";
+
+/* Title for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.title" = "Tout le monde";
+
+/* Description for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.description" = "Seuls les abonnés payants peuvent voir cet article";
+
+/* Title for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.title" = "Abonnés payants";
+
+/* Description for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.description" = "L’article est visible par tous les abonnés, y compris les abonnés gratuits";
+
+/* Title for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.title" = "Tous les abonnés";
+
 /* Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account */
 "jetpackSite.connectToDefaultAccount" = "Vous devez vous connecter avec %@ pour utiliser Stats et Notifications.";
 
@@ -8721,6 +9005,9 @@ Example: Reply to Pamela Nguyen */
 /* Last 12 months date range */
 "jetpackStats.calendar.last12Months" = "12 derniers mois";
 
+/* Last 12 weeks (84 days) date range */
+"jetpackStats.calendar.last12Weeks" = "Douze dernières semaines";
+
 /* Last 28 days date range */
 "jetpackStats.calendar.last28Days" = "28 derniers jours";
 
@@ -8880,6 +9167,9 @@ Example: Reply to Pamela Nguyen */
 /* Compare with same period last year option */
 "jetpackStats.datePicker.lastYear" = "Année dernière";
 
+/* Menu item for more date period options */
+"jetpackStats.datePicker.more" = "Plus…";
+
 /* Compare with preceding period option */
 "jetpackStats.datePicker.precedingPeriod" = "Période précédente";
 
@@ -8894,6 +9184,12 @@ Example: Reply to Pamela Nguyen */
 
 /* To date label */
 "jetpackStats.datePicker.to" = "À";
+
+/* Message explaining how to use the date range control */
+"jetpackStats.dateRangeTip.message" = "Affichez les derniers jours, semaines, mois ou années, ou sélectionnez des plages de dates personnalisées.";
+
+/* Title for stats date range control tip */
+"jetpackStats.dateRangeTip.title" = "Naviguez dans le temps";
 
 /* Section title for the list of child links */
 "jetpackStats.externalLinkDetails.childLinks" = "Sous-liens";
@@ -9096,6 +9392,12 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "Vous n’avez pas le droit de voir ce blog privé.";
 
+/* Default empty state message format when there are no terms. %1$@ is the taxonomy name. */
+"localizedLabels.defaultNoTerms.format" = "Pas de %1$@";
+
+/* Default search placeholder format. %1$@ is the taxonomy name. */
+"localizedLabels.defaultSearch.format" = "Rechercher %1$@";
+
 /* Button to dismiss the re-authentication view */
 "login.appPasswordReAuth.cancelButton" = "Annuler";
 
@@ -9228,17 +9530,14 @@ Example: Reply to Pamela Nguyen */
 /* Message about buying storage add-on */
 "mediaLibrary.storageDetails.buyStorage.message" = "Acheter un module de stockage";
 
-/* Message shown when all media items are attached */
-"mediaLibrary.storageDetails.cleanup.allAttached" = "Tous les éléments de la médiathèque sont attachés.";
+/* Label for other/unknown media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.other" = "Autre";
 
-/* Message shown while loading unattached media count */
-"mediaLibrary.storageDetails.cleanup.loading" = "Découvrir s’il y a des éléments multimédias non attachés…";
+/* Label for PowerPoint/presentation media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.powerpoint" = "Présentations";
 
-/* Message about unattached media that can be cleaned up. %1$d is the count of unattached media. */
-"mediaLibrary.storageDetails.cleanup.message" = "%1$d élément non attaché. Supprimez-les pour libérer de l’espace.";
-
-/* Title for cleanup section */
-"mediaLibrary.storageDetails.cleanup.title" = "Supprimer les éléments inutilisés";
+/* Label for video media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.video" = "Vidéos";
 
 /* Success message shown after upgrading plan */
 "mediaLibrary.storageDetails.purchase.plan.success" = "Le plan de votre site a été mis à niveau !";
@@ -9621,6 +9920,12 @@ Example: Reply to Pamela Nguyen */
 /* Menu option for filtering posts by me */
 "pagesList.pagesByMe" = "Mes pages";
 
+/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
+"parentCategory.noCategory" = "Pas de catégorie";
+
+/* Title for selecting parent category of a category */
+"parentCategory.title" = "Catégorie parente";
+
 /* Title for the parent page picker screen */
 "parentPagePicker.title" = "Page parente";
 
@@ -9779,6 +10084,27 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the post author selection screen */
 "postAuthorPicker.title" = "Auteur";
+
+/* Title for selecting categories for a post or a page */
+"postCategories.title" = "Catégories";
+
+/* Toggle label for allowing comments on post */
+"postDiscussion.allowComments.label" = "Autoriser les commentaires";
+
+/* Toggle label for allowing pings/trackbacks on post */
+"postDiscussion.allowPings.label" = "Autoriser les pings";
+
+/* Footer text when comments are disabled */
+"postDiscussion.comments.disabled.footer" = "Les visiteurs ne peuvent pas ajouter de commentaires ou de réponses. Les commentaires existants restent visibles.";
+
+/* Footer text when comments are enabled */
+"postDiscussion.comments.enabled.footer" = "Les visiteurs peuvent ajouter des commentaires ou des réponses.";
+
+/* Link text for learning more about pingbacks and trackbacks */
+"postDiscussion.pingbacks.learnMore.text" = "En savoir plus sur les pings et les rétroliens";
+
+/* Navigation title for post discussion settings */
+"postDiscussion.title" = "Commentaires";
 
 /* Button in an alert confirming discaring changes */
 "postEditor.closeConfirmationAlert.discardChanges" = "Abandonner les modifications";
@@ -10011,6 +10337,9 @@ Example: Reply to Pamela Nguyen */
 /* A default value for an post without a title */
 "postSaveErrorMessage.postUntitled" = "Sans titre";
 
+/* Section header for Access settings in Post Settings */
+"postSettings.access.header" = "Accès";
+
 /* Label for the author field in Post Settings */
 "postSettings.author.label" = "Auteur";
 
@@ -10029,6 +10358,18 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the discard changes confirmation dialog */
 "postSettings.discardChanges.title" = "Abandonner les modifications ?";
+
+/* Status text when discussion (comments) is disabled */
+"postSettings.discussion.closed" = "Fermé";
+
+/* Label for the discussion settings field in Post Settings */
+"postSettings.discussion.label" = "Commentaires";
+
+/* Status text when discussion (comments) is enabled */
+"postSettings.discussion.open" = "Ouvert";
+
+/* Label for the checkbox that lets you send a post to newsletter subscribers */
+"postSettings.emailToSubscribers.label" = "E-mail aux abonnés";
 
 /* Character count for excerpt. %1$d is the number of characters. */
 "postSettings.excerpt.characterCount" = "%1$d caractères";
@@ -10120,6 +10461,21 @@ Example: Reply to Pamela Nguyen */
 /* Cell title for the Top Level option case */
 "postSettings.parentPage.topLevel" = "Niveau supérieur";
 
+/* Accessibility label for hide password button */
+"postSettings.passwordEntry.hidePassword" = "Masquer le mot de passe";
+
+/* Instructions for password entry */
+"postSettings.passwordEntry.instructions" = "Saisissez un mot de passe pour protéger cette publication. Seuls les utilisateurs avec le mot de passe pourront l’afficher.";
+
+/* Navigation title for password entry screen */
+"postSettings.passwordEntry.navigationTitle" = "Saisir le mot de passe";
+
+/* Placeholder for password field */
+"postSettings.passwordEntry.placeholder" = "Saisir le mot de passe";
+
+/* Accessibility label for show password button */
+"postSettings.passwordEntry.showPassword" = "Afficher le mot de passe";
+
 /* Label for the permalink field in Post Settings */
 "postSettings.permalink.label" = "Permalien";
 
@@ -10138,14 +10494,50 @@ Example: Reply to Pamela Nguyen */
 /* Section header for General settings in Post Settings */
 "postSettings.section.general" = "Tous publics";
 
+/* Description text explaining what the slug editor does */
+"postSettings.slug.customizeDescription" = "Personnalisez la dernière partie du permalien.";
+
 /* Hint text for the slug field. Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso. */
 "postSettings.slug.hint" = "Le slug est la version du titre de l’article compatible avec les URL.";
+
+/* Button text to learn more about permalinks */
+"postSettings.slug.learnMore" = "Lire la suite";
+
+/* Notice shown when the post doesn't have a remote and permalink template is missing */
+"postSettings.slug.permalinkDraftNotice" = "Le permalien suggéré apparaîtra lorsque le brouillon sera enregistré sur le serveur";
+
+/* Label for the permalink preview */
+"postSettings.slug.permalinkLabel" = "Permalien";
+
+/* Section title for the permalink preview */
+"postSettings.slug.permalinkSection" = "Permalien";
 
 /* Placeholder for the slug field */
 "postSettings.slug.placeholder" = "Saisir un slug";
 
 /* Label for the preview button in Post Settings */
 "postSettings.socialSharing.header" = "Partage sur les réseaux sociaux";
+
+/* Label for the status field in Post Settings */
+"postSettings.status.label" = "État";
+
+/* Navigation title for status picker */
+"postSettings.statusPicker.navigationTitle" = "État et visibilité";
+
+/* Label showing the current password */
+"postSettings.statusPicker.passwordLabel" = "Mot de passe";
+
+/* Toggle label for password protection */
+"postSettings.statusPicker.passwordProtected" = "Protégé par un mot de passe";
+
+/* Subtitle for password protected toggle */
+"postSettings.statusPicker.passwordProtectedSubtitle" = "Uniquement visible par ceux qui connaissent le mot de passe";
+
+/* Toggle label for sticky posts */
+"postSettings.statusPicker.sticky" = "Épinglé";
+
+/* Subtitle for sticky toggle */
+"postSettings.statusPicker.stickySubtitle" = "Épingler cet article en haut du blog";
 
 /* Label for the sticky post toggle. Sticky posts are displayed at the top of the blog. */
 "postSettings.stickyPost.label" = "Épinglé";
@@ -10165,14 +10557,53 @@ Example: Reply to Pamela Nguyen */
 /* Navigation bar title of the Post Stats screen */
 "postStats.title" = "Statistiques de l’article";
 
-/* Button to add a new tag. %1$@ is the tag name. */
-"postTags.addTag" = "Ajouter une étiquette";
+/* Post status title */
+"postStatus.deleted.details" = "Supprimé définitivement";
 
-/* Placeholder text for the tag search field */
-"postTags.searchOrAdd.placeholder" = "Rechercher ou ajouter des étiquettes";
+/* Post status title */
+"postStatus.deleted.title" = "Supprimé";
 
-/* Title for the tags screen */
-"postTags.title" = "Étiquettes";
+/* Post status details */
+"postStatus.draft.details" = "Pas encore prêt à publier du contenu";
+
+/* Post status title */
+"postStatus.draft.title" = "Brouillon";
+
+/* Post status details */
+"postStatus.pending.details" = "En attente de relecture avant publication";
+
+/* Post status title */
+"postStatus.pending.title" = "En attente";
+
+/* Post status title */
+"postStatus.private.title" = "Privé";
+
+/* Post status details */
+"postStatus.published.details" = "Visible pour tout le monde";
+
+/* Post status title */
+"postStatus.published.title" = "Publié";
+
+/* Post status details */
+"postStatus.scheduled.details" = "Publier automatiquement à une date choisie";
+
+/* Post status title */
+"postStatus.scheduled.title" = "Planifié";
+
+/* Post status title */
+"postStatus.trash.details" = "Déplacé vers la corbeille, mais pas encore supprimé";
+
+/* Post status title */
+"postStatus.trash.title" = "Déplacé vers la corbeille";
+
+/* Button to add a new taxonomy term. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.addTag" = "Ajouter %1$@";
+
+/* Placeholder text for the taxonomy search field. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.searchOrAdd.placeholder" = "Rechercher ou ajouter %1$@";
+
+/* Message shown when no taxonomy terms are selected. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.selectionEmpty" = "Aucun(e) %1$@ sélectionné(e)";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Annuler";
@@ -10248,9 +10679,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "Catégories";
-
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "Fermer";
 
 /* Button to confirm discarding changes */
 "prepublishing.discardChanges.button" = "Abandonner les modifications";
@@ -10336,9 +10764,11 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "Attention";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "Message";
+
+/* Placeholder text for the message field in Social Sharing */
+"prepublishing.socialAccounts.messagePlaceholder" = "Rédiger un bref message à partager sur les réseaux sociaux en même temps que l’article";
 
 /* The navigation title for the pre-publishing social accounts screen. */
 "prepublishing.socialAccounts.navigationTitle" = "Réseaux sociaux";
@@ -11276,6 +11706,15 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Button to progress to the next step after selecting domain in Site Creation */
 "siteCreation.domains.buttons.selectDomain" = "Sélectionner un domaine";
 
+/* Default text for adding a new item when no label is provided */
+"siteCustomTaxonomies.defaultAddNew" = "Ajouter";
+
+/* Description for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.description" = "Les taxonomies vous aident à organiser votre contenu au-delà des catégories et étiquettes standard.";
+
+/* Title for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.title" = "Aucune taxonomie personnalisée";
+
 /* Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio. */
 "siteMedia.accessibilityLabelAudio" = "Audio, %@";
 
@@ -11294,8 +11733,71 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Accessibility hint for actions when displaying media items. */
 "siteMedia.cellAccessibilityHint" = "Sélectionnez un média.";
 
+/* Label for the alt for a media asset (image) */
+"siteMedia.details.altText" = "Texte alternatif";
+
+/* Verb. Button title. Tapping cancels an action. */
+"siteMedia.details.cancel" = "Annuler";
+
+/* Noun. Label for the caption for a media asset (image / video) */
+"siteMedia.details.caption" = "Légende";
+
+/* Title for button that permanently deletes a media item (photo / video) */
+"siteMedia.details.delete" = "Supprimer";
+
+/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
+"siteMedia.details.deleteConfirmation" = "Voulez-vous vraiment supprimer définitivement cet élément ?";
+
+/* Text displayed in HUD after successfully deleting a media item */
+"siteMedia.details.deleted" = "Supprimé !";
+
+/* Text displayed in HUD while a media item is being deleted. */
+"siteMedia.details.deleting" = "Suppression…";
+
+/* Label for the file name for a media asset (image / video) */
+"siteMedia.details.fileName" = "Nom du fichier";
+
+/* Label for the file size for a media asset (image / video) */
+"siteMedia.details.fileSize" = "Taille du fichier";
+
+/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
+"siteMedia.details.fileType" = "Type de fichier";
+
+/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
+"siteMedia.details.mediaDeleted" = "Cet élément multimédia a été supprimé.";
+
+/* Noun. Label for the title of a media asset (image / video) */
+"siteMedia.details.title" = "Titre";
+
+/* Accessibility label for trash buttons in nav bars */
+"siteMedia.details.trash" = "Corbeille";
+
+/* Text displayed in HUD if there was an error attempting to delete a media item. */
+"siteMedia.details.unableToDeleteMedia" = "Impossible de supprimer l’élément multimédia.";
+
+/* Error shown when the app fails to load a video from the user's media library. */
+"siteMedia.details.unableToLoadVideo" = "Impossible de charger la vidéo.";
+
+/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
+"siteMedia.details.unableToSaveMedia" = "Impossible d’enregistrer l’élément multimédia.";
+
+/* Label for the date a media asset (image / video) was uploaded */
+"siteMedia.details.uploaded" = "Chargé";
+
 /* Title for the URL field */
 "siteMedia.details.url" = "URL";
+
+/* Hint for image alt on image settings. */
+"siteMedia.hints.imageAlt" = "Image alternative";
+
+/* Hint for image caption on image settings. */
+"siteMedia.hints.imageCaption" = "Légende de l’image";
+
+/* Hint for image description on image settings. */
+"siteMedia.hints.imageDescription" = "Description de l’image";
+
+/* Hint for image title on image settings. */
+"siteMedia.hints.imageTitle" = "Titre de l’image";
 
 /* Accessibility hint for media item preview for user's viewing an item in their media library */
 "siteMediaItem.contentViewAccessibilityHint" = "Appuyer pour voir le média en plein écran";
@@ -11384,6 +11886,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Confidentialité";
+
+/* Format string for adding a new taxonomy term. %1$@ is the taxonomy name. */
+"siteTaxonomy.addNew.format" = "Ajouter %1$@";
 
 /* Hint for users when hidden privacy setting is set */
 "siteVisibility.hidden.hint" = "Votre site est masqué derrière une mention « Bientôt disponible » jusqu’à ce qu’il soit prêt.";
@@ -11952,7 +12457,8 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Subject of new Zendesk ticket. */
 "support.zendesk.readerAppTicketSubject" = "Assistance Lecteur pour iOS";
 
-/* Description for empty state when there are no tags */
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
 "tags.empty.description" = "Les étiquettes aident à organiser votre contenu et permettent aux lecteurs de trouver plus facilement des articles similaires.";
 
 /* Title for empty state when there are no tags */
@@ -12006,6 +12512,12 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Tip for site picker */
 "tips.sitePickerTip.title" = "Vos sites";
 
+/* Message explaining how to use the date range control */
+"tips.statsDateRange.message" = "Utilisez le calendrier pour sélectionner des jours, des semaines, des mois ou des années, ou choisissez des plages de dates personnalisées pour afficher vos statistiques.";
+
+/* Title for stats date range control tip */
+"tips.statsDateRange.title" = "Naviguez dans le temps";
+
 /* The part of the nudge title that should be emphasized, this content needs to match a string in 'If you want to try get more...' */
 "top tips" = "meilleurs conseils";
 
@@ -12023,9 +12535,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "non lues";
-
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "Abonné du site";
 
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "Utilisateur du site";
@@ -12111,9 +12620,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* The heading at the top of the user list */
 "userlist.title" = "Utilisateurs";
-
-/* Site Subscribers */
-"users.list.title.subscribers" = "Abonnés";
 
 /* Screen title */
 "users.title" = "Utilisateurs";

--- a/WordPress/Resources/he.lproj/Localizable.strings
+++ b/WordPress/Resources/he.lproj/Localizable.strings
@@ -1,6 +1,6 @@
-/* Translation-Revision-Date: 2025-10-08 13:54:09+0000 */
+/* Translation-Revision-Date: 2025-11-25 14:54:11+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: he_IL */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -581,8 +581,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "כמעט סיימת! יש להזין את קוד האימות מאפליקציית האימות.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "טקסט חלופי";
 
 /* No comment provided by engineer. */
@@ -725,9 +724,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "האם ברצונך לנתק את Jetpack מהאתר?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "האם אכן ברצונך למחוק פריט זה לצמיתות?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "האם ברצונך להסיר את %1$@ מ-%2$@?";
@@ -1082,7 +1078,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "בטל";
@@ -1110,8 +1105,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "לא הצלחת להחליט? תהיה לך אפשרות לשנות את ערכת העיצוב בכל עת.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "כיתוב";
 
 /* Alert title. */
@@ -1777,8 +1771,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "ברירת מחדל";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "קטגוריית ברירת מחדל";
 
 /* Label for selecting the default post format
@@ -1787,9 +1780,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "ברירות מחדל עבור פוסטים חדשים";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "מחק";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "מחיקת תפריט";
@@ -1808,14 +1798,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "מחיקת תפריט";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "הפריט נמחק!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "מוחק אתר…";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "מוחק...";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "דחייה";
@@ -1823,8 +1807,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "לתאר את מטרת התמונה. אם התמונה נועדה לקישוט בלבד, יש להשאיר את השדה ריק.";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "תיאור";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1842,9 +1825,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "לא התכוונת ליצור חשבון חדש? יש לחזור אחורה כדי להזין מחדש את כתובת האימייל שלך.";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "מידות";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "להשבית";
@@ -2121,7 +2101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "עריכה קובץ ה-GIF תסיר את ההנפשה שלו.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "עורך";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2463,11 +2443,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "הגדרות של בלוק הקובץ";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "שם קובץ";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "סוג קובץ";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "סוג הקובץ לא נתמך כקובץ מדיה.";
@@ -2781,6 +2758,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post content used in the login prologue screens. */
 "I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next" = "העבודות של הצלם קמרון קרסטן הן השראה עצומה עבורי. את הטכניקות האלה אביא לידי ביטוי בפעם הבאה שאצור";
 
+/* Text on the support form to refer to what area the user has problem with. */
+"I need help with" = "דרושה לי עזרה לגבי";
+
 /* Describes the IP address section in the comment detail screen. */
 "IP address" = "כתובת IP";
 
@@ -2826,9 +2806,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "כיתוב התמונה";
 
-/* Hint for image description on image settings. */
-"Image Description" = "תיאור תמונה";
-
 /* Hint for image link on image settings. */
 "Image Link" = "קישור תמונה";
 
@@ -2840,9 +2817,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "לא נמצא קובץ תמונה.";
-
-/* Hint for image title on image settings. */
-"Image title" = "כותרת התמונה";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "במספר מילים, הסבר במה עוסק האתר.";
@@ -3205,6 +3179,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the button that will dismiss this view. */
 "Let me know when finished!" = "הודיעו לי כאשר הפעולה מסתיימת!";
 
+/* Message info on the support screen. */
+"Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon." = "אנחנו מבקשים לדעת את כתובת האתר שלך (כתובת ה-URL) וכמה שיותר פרטים לגבי הבעיה. לאחר שליחת הבקשה, ניצור קשר בהקדם.";
+
+/* Title to let the user know what do we want on the support screen. */
+"Let’s get this sorted" = "ננסה לתקן את הבעיה עכשיו";
+
 /* Lifestyle site intent topic */
 "Lifestyle" = "לייף סטייל";
 
@@ -3405,6 +3385,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Main Navigation" = "ניווט ראשי";
+
+/* Explanation for the option to enable theme styles */
+"Make the block editor look like your theme." = "להציג את עורך הבלוקים בסגנון שדומה לתבנית שלך.";
 
 /* No comment provided by engineer. */
 "Make your content stand out by adding images, gifs, videos, and embedded media to your pages." = "כדאי להבליט את התוכן על ידי הוספה של תמונות, הנפשות GIF, סרטונים ומדיה מוטמעת בעמודים שלך.";
@@ -3747,9 +3730,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "לא נמצאו חשבונות";
-
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "אין קטגוריה";
 
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "אין חיבור";
@@ -4191,9 +4171,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "עימוד";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "קטגוריית אב";
-
 /* Parenting site intent topic */
 "Parenting" = "הורות";
 
@@ -4408,9 +4385,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "פוסט";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "קטגוריות";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "הגדרות פוסט";
@@ -4719,9 +4693,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "הפעולה מסירה מטא-נתונים של מיקום מהתמונות שלך לפני ההעלאה לאתר.";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "הסרת עוקבים תפסיק את שליחת העדכונים אליהם מהאתר שלך. אם העוקבים יבחרו לעשות זאת, הם עדיין יוכלו לבקר באתר שלך ולעקוב אחריו שוב.";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "יש להחליף את הבלוק הנוכחי";
@@ -5558,6 +5529,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "תיאור האתר";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "תגיות";
 
@@ -5654,6 +5626,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint, informing user the button can be used to visit the Gravatar website. */
 "Tap to visit the Gravatar website in an external browser" = "יש להקיש כדי לעבור לאתר של Gravatar בדפדפן חיצוני";
+
+/* Label for viewing the custom taxonomies */
+"Taxonomies" = "טקסונומיות";
 
 /* Technology site intent topic */
 "Technology" = "טכנולוגיה";
@@ -5943,9 +5918,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "פג תוקפו של קוד ההתחברות. יש ללחוץ על הכפתור 'לסרוק שוב' כדי לסרוק שוב את הקוד.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "פריט המדיה נמחק.";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "לא ניתן לסגור את חשבון המשתמש כל עוד יש לו חיובים שלא שולמו.";
 
@@ -6014,7 +5986,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "כותרת";
@@ -6108,8 +6079,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "לשנות בלוק...";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "לאשפה";
 
@@ -6206,9 +6176,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "לא ניתן ליצור קישורי הזמנה חדשים.";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "לא ניתן למחוק פריט מדיה.";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "לא ניתן להשבית את קישורי ההזמנה.";
 
@@ -6239,9 +6206,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "אין אפשרות לטעון את התוכן כרגע.";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "לא ניתן לטעון את הווידאו.";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "אין אפשרות לנגן את הווידאו";
 
@@ -6250,9 +6214,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "לא ניתן לשחזר את האתר שלך";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "לא ניתן לשמור פריט מדיה.";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "לא ניתן לשתף את הקישור";
@@ -6409,9 +6370,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "העלאה נכשלה";
 
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "הועלה";
-
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "הועלה פוסט טיוטה אחד, %ld קבצים";
 
@@ -6453,6 +6411,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The button title text for logging in with WP.com password instead of magic link. */
 "Use password to sign in" = "להשתמש בסיסמה כדי להתחבר";
+
+/* Option to enable theme styles in the block editor */
+"Use theme styles" = "להשתמש בסגנונות של התבנית";
 
 /* A placeholder for the twitter username
    Accessibility label for the username text field in the self-hosted login page.
@@ -6900,7 +6861,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "מפת העולם שמציגה צפיות לפי מדינה.";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "האם עדיין תרצה להסיר את המשתמש הזה?";
 
 /* Button title. Opens the editor to write a new post.
@@ -7371,11 +7332,19 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Description for the prompt to upgrade to Application Passwords. The first argument is the name of the feature that requires Application Passwords. */
 "applicationPasswordRequired.description" = "סיסמאות אפליקציה הן דרך מאובטחת יותר להתחבר לאתר באחסון עצמי, והן מאפשרות תמיכה באפשרויות כמו %@.";
 
+/* Feature name for managing application passwords in the app */
+"applicationPasswordRequired.feature.applicationPasswords" = "ניהול סיסמות אפליקציה";
+
+/* Feature name for the block editor in application password required prompt */
+"applicationPasswordRequired.feature.blockEditor" = "עורך הבלוקים";
+
+/* Feature name for managing terms and taxonomies in the app */
+"applicationPasswordRequired.feature.customTaxonomies" = "ניהול טקסונומיות";
+
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "ניהול תוספים";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "ניהול משתמשים";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -7598,6 +7567,285 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 
 /* Post Editor / Button in the 'More' menu */
 "classicEditor.moreMenu.saveDraft" = "לשמור טיוטה";
+
+/* Button to add more screenshots */
+"com.jetpack.support.addMoreScreenshots" = "להוסיף עוד צילומי מסך";
+
+/* Button to add screenshots */
+"com.jetpack.support.addScreenshots" = "להוסיף צילומי מסך";
+
+/* Header for application logs section */
+"com.jetpack.support.applicationLogs" = "יומני אפליקציה";
+
+/* Description explaining why including logs is helpful */
+"com.jetpack.support.applicationLogsDescription" = "הוספה של יומני פעילות יכולה לעזור לצוות שלנו לחקור בעיות. יומני הפעילות עשויים להכיל פעולות שבוצעו באפליקציה לאחרונה.";
+
+/* Navigation title for application logs screen */
+"com.jetpack.support.applicationLogsTitle" = "יומני אפליקציה";
+
+/* Format string for attachment identifier */
+"com.jetpack.support.attachment" = "קובץ מצורף %@";
+
+/* Format string for attachment size limit. %1$@ is current size, %2$@ is maximum size */
+"com.jetpack.support.attachmentLimit" = "מגבלה לקובץ המצורף: %1$@ \/ %2$@";
+
+/* Bot greeting message. %1$@ is the user's name */
+"com.jetpack.support.botGreeting" = "אהלן, %1$@!";
+
+/* Bot introduction message explaining its purpose */
+"com.jetpack.support.botIntroduction" = "אני עוזר הבינה המלאכותית האישי שלך. אני יכול לענות על שאלות לגבי האתר והחשבון שלך.";
+
+/* Format string for cache file count and size. %1$d is the number of files, %2$@ is the formatted size. The system will pluralize 'files' based on the number – please specify it as the largest plural value */
+"com.jetpack.support.cacheFiles" = "⁦%1$d⁩ קבצים מאוחסנים במטמון (%2$@)";
+
+/* Message shown when cache has no files */
+"com.jetpack.support.cacheIsEmpty" = "המטמון ריק";
+
+/* Button to cancel current action */
+"com.jetpack.support.cancel" = "לבטל";
+
+/* Warning message that deleted logs cannot be recovered */
+"com.jetpack.support.cannotRecoverLogs" = "לא תהיה לך אפשרות לשחזר אותם.";
+
+/* Button to clear all activity logs */
+"com.jetpack.support.clearAllActivityLogs" = "למחוק את כל יומני הפעילות";
+
+/* Button to clear disk cache */
+"com.jetpack.support.clearDiskCache" = "למחקו את המטמון של הדיסק";
+
+/* Description explaining the purpose of clearing disk cache */
+"com.jetpack.support.clearDiskCacheDescription" = "ניתן להסיר קבצים זמניים כדי לפנות שטח אחסון או לפתור את הבעיות.";
+
+/* Progress text while clearing cache */
+"com.jetpack.support.clearing" = "מוחק...";
+
+/* Message shown when cache clearing is complete */
+"com.jetpack.support.complete" = "הושלם";
+
+/* Confirmation message when canceling a draft */
+"com.jetpack.support.confirmCancelMessage" = "האם ברצונך לבטל את ההודעה הזאת? כל הנתונים שהזנת יאבדו";
+
+/* Title for alert confirming cancellation */
+"com.jetpack.support.confirmCancellation" = "אשר ביטול";
+
+/* Confirmation dialog title when deleting all logs */
+"com.jetpack.support.confirmDeleteAllLogs" = "האם ברצונך למחוק את כל יומני הפעילות?";
+
+/* Section title for contact information */
+"com.jetpack.support.contactInformation" = "פרטים ליצירת קשר";
+
+/* Button to continue editing a message */
+"com.jetpack.support.continueWriting" = "להמשיך לכתוב";
+
+/* Message shown at end of closed support conversation */
+"com.jetpack.support.conversationEnded" = "השיחה הסתיימה. אין אפשרות לתשובות נוספות.";
+
+/* Navigation title for bot conversations list */
+"com.jetpack.support.conversations" = "שיחות";
+
+/* Button to delete all log files */
+"com.jetpack.support.deleteAllLogs" = "למחוק את כל יומני הפעילות";
+
+/* Description text for diagnostics screen */
+"com.jetpack.support.diagnosticsDescription" = "להפעיל משימות נפוצות של תחזוקה ופתרון בעיות.";
+
+/* Navigation title for diagnostics screen */
+"com.jetpack.support.diagnosticsTitle" = "אבחונים";
+
+/* Button to discard changes in a draft message */
+"com.jetpack.support.discardChanges" = "לבטל את השינויים";
+
+/* Notice explaining where support will send email responses */
+"com.jetpack.support.emailNotice" = "אנו נשלח לך תכתובות לכתובת האימייל הזאת.";
+
+/* Error title when logs fail to load */
+"com.jetpack.support.errorLoadingLogs" = "שגיאה בטעינה של יומני הפעילות";
+
+/* Error message when support conversations fail to load */
+"com.jetpack.support.errorLoadingSupportConversations" = "שגיאה בטעינה של השיחות עם התמיכה";
+
+/* Title for error alerts */
+"com.jetpack.support.errorTitle" = "שגיאה";
+
+/* Option to export log as a file */
+"com.jetpack.support.exportAsFile" = "לייצא כקובץ";
+
+/* Button to dismiss alerts. */
+"com.jetpack.support.gotIt" = "הבנתי";
+
+/* Text on the support form to refer to what area the user has problem with. */
+"com.jetpack.support.iNeedHelp" = "דרושה לי עזרה לגבי";
+
+/* Toggle label to include application logs in the support request */
+"com.jetpack.support.includeApplicationLogs" = "לכלול את יומני האפליקציה";
+
+/* Section title for issue details */
+"com.jetpack.support.issueDetails" = "פרטי הבעיה";
+
+/* Format string for when conversation was last updated */
+"com.jetpack.support.lastUpdated" = "עדכון אחרון: %@";
+
+/* Progress message while loading conversation messages */
+"com.jetpack.support.loadingBotConversationMessages" = "טוען הודעות";
+
+/* Progress message while loading bot conversations */
+"com.jetpack.support.loadingBotConversations" = "טוען שיחות עם הבוט";
+
+/* Progress text while loading support conversations */
+"com.jetpack.support.loadingConversations" = "טוען שיחות";
+
+/* Progress message while loading disk usage information */
+"com.jetpack.support.loadingDiskUsage" = "טוען שימוש בדיסק";
+
+/* Progress message while loading an image attachment */
+"com.jetpack.support.loadingImage" = "טוען את התמונה";
+
+/* Progress message shown in overlay while refreshing content */
+"com.jetpack.support.loadingLatestContent" = "טוען את התכנים האחרונים";
+
+/* Progress message while loading application log content */
+"com.jetpack.support.loadingLogContent" = "טוען את התכנים של יומן הפעילות...";
+
+/* Progress message while loading log files */
+"com.jetpack.support.loadingLogs" = "טוען את יומני הרישום...";
+
+/* Progress text while loading conversation messages */
+"com.jetpack.support.loadingMessages" = "טוען הודעות";
+
+/* Progress message while loading a video attachment */
+"com.jetpack.support.loadingVideo" = "טוען את הווידאו";
+
+/* Section header for log files sorted by date */
+"com.jetpack.support.logFilesByDate" = "קובצי יומן לפי תאריך יצירה";
+
+/* Text indicating which log files will be included in the support request */
+"com.jetpack.support.logFilesToUpload" = "קובצי היומן הבאים יועלו:";
+
+/* Footer text explaining log retention policy */
+"com.jetpack.support.logRetentionNotice" = "אנחנו שומרים קובצי יומן עד שבעה ימים אחורה.";
+
+/* Section header for message text input */
+"com.jetpack.support.message" = "הודעה";
+
+/* Success message when reply is sent successfully */
+"com.jetpack.support.messageSent" = "הודעה נשלחה";
+
+/* Format string for number of messages in conversation */
+"com.jetpack.support.messagesCount" = "%d הודעות";
+
+/* The title of a new bot chat in the support area of the app */
+"com.jetpack.support.new-bot-chat" = "צ'אט חדש עם הבוט";
+
+/* Option to create a new support ticket */
+"com.jetpack.support.newSupportTicket" = "פנייה חדשה לתמיכה";
+
+/* Label shown when there are no bot conversations */
+"com.jetpack.support.noConversations" = "אין שיחות";
+
+/* Description shown when no log files are available */
+"com.jetpack.support.noLogsAvailable" = "אין יומני פעילות זמינים";
+
+/* Label shown when no log files are available */
+"com.jetpack.support.noLogsFound" = "לא נמצאו יומני פעילות";
+
+/* Button to open a support ticket */
+"com.jetpack.support.openSupportTicket" = "לפתוח פנייה לתמיכה";
+
+/* Text indicating a field is optional */
+"com.jetpack.support.optional" = "(אופציונלי)";
+
+/* Navigation title for replying to a support conversation */
+"com.jetpack.support.reply" = "להגיב";
+
+/* Description for saving log as a file */
+"com.jetpack.support.saveAsFile" = "לשמור כקובץ לשיתוף או לאחסון";
+
+/* Label for screenshots section */
+"com.jetpack.support.screenshots" = "צילומי מסך";
+
+/* Description for screenshots section */
+"com.jetpack.support.screenshotsDescription" = "הוספה של צילומי מסך תעזר לצוות שלנו לפתור את הבעיה מהר יותר.";
+
+/* Button to send a message or reply */
+"com.jetpack.support.send" = "לשלוח";
+
+/* Description for sending logs to support */
+"com.jetpack.support.sendLogsToSupport" = "לשלוח יומנים ישירות לצוות התמיכה";
+
+/* Progress text while sending a message */
+"com.jetpack.support.sending" = "שולח";
+
+/* Progress message shown while sending a message */
+"com.jetpack.support.sendingMessage" = "שולח את ההודעה";
+
+/* Button to share content */
+"com.jetpack.support.share" = "לשתף";
+
+/* Navigation title for sharing activity log */
+"com.jetpack.support.shareActivityLog" = "לשתף את יומן הפעילות";
+
+/* Message shown when sharing log with support */
+"com.jetpack.support.sharingWithSupport" = "משתף עם התמיכה!";
+
+/* Site Address title on the support form */
+"com.jetpack.support.siteAddress" = "כתובת האתר";
+
+/* Description encouraging user to start a new conversation */
+"com.jetpack.support.startNewConversation" = "אפשר להתחיל שיחה חדשה באמצעות הכפתור שלמעלה";
+
+/* Subject title on the support form */
+"com.jetpack.support.subject" = "נושא";
+
+/* Placeholder for subject field */
+"com.jetpack.support.subjectPlaceholder" = "סיכום קצר של הבעיה";
+
+/* Button title to submit a support request. */
+"com.jetpack.support.submitRequest" = "לשלוח בקשת תמיכה";
+
+/* Navigation title for the support conversations list */
+"com.jetpack.support.supportConversations" = "שיחות עם התמיכה";
+
+/* Title for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSent" = "הבקשה נשלחה!";
+
+/* Message for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSentMessage" = "בקשת התמיכה שלך נשלחה בהצלחה. אנחנו נשלח מענה באימייל בהקדם האפשרי.";
+
+/* Progress message shown while bot is thinking */
+"com.jetpack.support.thinking" = "מנסה למצוא תשובה...";
+
+/* Title of the view for contacting support. */
+"com.jetpack.support.title" = "לפנות לתמיכה";
+
+/* Button to retry a failed operation */
+"com.jetpack.support.tryAgain" = "יש לנסות שוב";
+
+/* Error title when log deletion fails */
+"com.jetpack.support.unableToDeleteLogs" = "לא ניתן למחוק את יומני הפעילות";
+
+/* Error message when conversation cannot be displayed */
+"com.jetpack.support.unableToDisplayConversation" = "אין אפשרות להציג את השיחה";
+
+/* Error title when video cannot be loaded or played */
+"com.jetpack.support.unableToDisplayVideo" = "אין אפשרות להציג את הווידאו";
+
+/* Error message when application logs cannot be loaded */
+"com.jetpack.support.unableToLoadApplicationLogs" = "אין אפשרות לטעון את יומני האפליקציה";
+
+/* Error title when bot conversations fail to load */
+"com.jetpack.support.unableToLoadConversations" = "אין אפשרות לטעון את השיחה";
+
+/* Error title when messages fail to load */
+"com.jetpack.support.unableToLoadMessages" = "אין אפשרות לטעון את ההודעה";
+
+/* Error title when message sending fails */
+"com.jetpack.support.unableToSendMessage" = "לא ניתן לשלוח את ההודעה";
+
+/* Button to view an attachment */
+"com.jetpack.support.view" = "להציג";
+
+/* Progress message shown during cache clearing operation */
+"com.jetpack.support.working" = "בעבודה";
 
 /* Displayed in the confirmation alert when marking comment notifications as read. */
 "comment" = "תגובה";
@@ -7861,6 +8109,9 @@ Example: Reply to Pamela Nguyen */
 /* Weekly Roundup debug menu item */
 "debugMenu.weeklyRoundup" = "סיכום שבועי";
 
+/* Title for selecting a default category for a post */
+"defaultCategory.title" = "קטגוריית ברירת מחדל";
+
 /* Error tilte */
 "discussionSettings.saveErrorTitle" = "שמירת ההגדרות נכשלה";
 
@@ -8000,10 +8251,10 @@ Example: Reply to Pamela Nguyen */
 "double-tap to change unit" = "יש להקיש פעמיים כדי לשנות את היחידה";
 
 /* Message for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.message" = "האם ברצונך למחוק את התגית הזאת?";
+"edit.tag.delete.confirmation.message" = "האם ברצונך למחוק את הפרטים האלה?";
 
-/* Title for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.title" = "למחוק תגית";
+/* Title for delete a term confirmation dialog */
+"edit.tag.delete.confirmation.title" = "למחוק";
 
 /* Placeholder text for tag description field */
 "edit.tag.description.placeholder" = "להוסיף תיאור...";
@@ -8018,7 +8269,37 @@ Example: Reply to Pamela Nguyen */
 "edit.tag.section.description" = "תיאור";
 
 /* Section header for tag name in edit tag view */
-"edit.tag.section.tag" = "תגית";
+"edit.tag.section.tag" = "שם";
+
+/* Context menu action to insert a block */
+"editor.blockInserter.insertBlock" = "להוסיף בלוק";
+
+/* Placeholder text for block search field */
+"editor.blockInserter.search" = "לחפש";
+
+/* Button title to collapse and show fewer blocks */
+"editor.blockInserter.showLess" = "להציג פחות";
+
+/* Button title to expand and show more blocks */
+"editor.blockInserter.showMore" = "להציג עוד";
+
+/* Error message when media insertion fails */
+"editor.media.failedToInsert" = "ההוספה של המדיה נכשלה";
+
+/* Category name for section showing all patterns */
+"editor.patterns.all" = "הכול";
+
+/* Context menu action to insert a pattern */
+"editor.patterns.insertPattern" = "להוסיף מקבץ בלוקים";
+
+/* Title shown when no patterns match the search */
+"editor.patterns.noPatternsFound" = "לא נמצאו מקבצי בלוקים";
+
+/* Navigation title for patterns view */
+"editor.patterns.title" = "מקבצי בלוקים";
+
+/* Category name for patterns without a category */
+"editor.patterns.uncategorized" = "לא מסווג";
 
 /* Register Domain - Address information field Number placeholder */
 "eg. 1122334455" = "לדוגמה 1122334455";
@@ -8572,6 +8853,24 @@ Example: Reply to Pamela Nguyen */
 
 /* Write a blog prompt for the jetpack prologue */
 "jetpack.prologue.prompt.writeBlog" = "לכתוב בלוג";
+
+/* Description for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.description" = "כל אחד יכול להציג את הפוסט הנוכחי";
+
+/* Title for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.title" = "כולם";
+
+/* Description for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.description" = "רק מנויים בתשלום יכולים להציג את הפוסט הנוכחי";
+
+/* Title for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.title" = "מנויים משלמים";
+
+/* Description for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.description" = "הבלוק זמין לכל המנויים, כולל מנויים בחינם";
+
+/* Title for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.title" = "כל המנויים";
 
 /* Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account */
 "jetpackSite.connectToDefaultAccount" = "עליך להתחבר באמצעות %@ כדי להשתמש ב'נתונים סטטיסטיים' וב'הודעות'.";
@@ -9162,6 +9461,12 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "אין לך הרשאה להציג את הבלוג הפרטי הזה.";
 
+/* Default empty state message format when there are no terms. %1$@ is the taxonomy name. */
+"localizedLabels.defaultNoTerms.format" = "ללא %1$@";
+
+/* Default search placeholder format. %1$@ is the taxonomy name. */
+"localizedLabels.defaultSearch.format" = "לחפש את %1$@";
+
 /* Button to dismiss the re-authentication view */
 "login.appPasswordReAuth.cancelButton" = "ביטול";
 
@@ -9262,6 +9567,9 @@ Example: Reply to Pamela Nguyen */
 "mediaLibrary.filterAudio" = "אודיו";
 
 /* The name of the media filter */
+"mediaLibrary.filterDefault" = "ברירת מחדל (הכול)";
+
+/* The name of the media filter */
 "mediaLibrary.filterDocuments" = "מסמכים";
 
 /* The name of the media filter */
@@ -9294,17 +9602,23 @@ Example: Reply to Pamela Nguyen */
 /* Message about buying storage add-on */
 "mediaLibrary.storageDetails.buyStorage.message" = "לרכוש הרחבת אחסון";
 
-/* Message shown when all media items are attached */
-"mediaLibrary.storageDetails.cleanup.allAttached" = "כל הפריטים בספריית המדיה מצורפים.";
+/* Label for audio media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.audio" = "אודיו";
 
-/* Message shown while loading unattached media count */
-"mediaLibrary.storageDetails.cleanup.loading" = "בודק אם יש פריטי מדיה לא מצורפים...";
+/* Label for document media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.document" = "מסמכים";
 
-/* Message about unattached media that can be cleaned up. %1$d is the count of unattached media. */
-"mediaLibrary.storageDetails.cleanup.message" = "פריט ⁦%1$d⁩ הוסר. יש להסיר אותם כדי לפנות מקום.";
+/* Label for image media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.image" = "תמונות";
 
-/* Title for cleanup section */
-"mediaLibrary.storageDetails.cleanup.title" = "להסיר פריטים שאינם בשימוש";
+/* Label for other/unknown media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.other" = "אחר";
+
+/* Label for PowerPoint/presentation media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.powerpoint" = "מצגות";
+
+/* Label for video media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.video" = "סרטוני וידאו";
 
 /* Success message shown after upgrading plan */
 "mediaLibrary.storageDetails.purchase.plan.success" = "תוכנית האתר שלך שודרגה!";
@@ -9690,6 +10004,12 @@ Example: Reply to Pamela Nguyen */
 /* Menu option for filtering posts by me */
 "pagesList.pagesByMe" = "Pages by me";
 
+/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
+"parentCategory.noCategory" = "אין קטגוריה";
+
+/* Title for selecting parent category of a category */
+"parentCategory.title" = "קטגוריית אם";
+
 /* Title for the parent page picker screen */
 "parentPagePicker.title" = "עמוד הורה";
 
@@ -9848,6 +10168,27 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the post author selection screen */
 "postAuthorPicker.title" = "מחבר";
+
+/* Title for selecting categories for a post or a page */
+"postCategories.title" = "קטגוריות";
+
+/* Toggle label for allowing comments on post */
+"postDiscussion.allowComments.label" = "פתוח לתגובות";
+
+/* Toggle label for allowing pings/trackbacks on post */
+"postDiscussion.allowPings.label" = "לאפשר תגובות פינגבק";
+
+/* Footer text when comments are disabled */
+"postDiscussion.comments.disabled.footer" = "מבקרים לא יוכלו להוסיף תגובות או תשובות חדשות. תגובות קיימות יישארו גלויות.";
+
+/* Footer text when comments are enabled */
+"postDiscussion.comments.enabled.footer" = "מבקרים יוכלו להוסיף תגובות ותשובות חדשות.";
+
+/* Link text for learning more about pingbacks and trackbacks */
+"postDiscussion.pingbacks.learnMore.text" = "מידע נוסף בנושא תגובות פינגבאק (Pingback) וטראקבק (Trackback)";
+
+/* Navigation title for post discussion settings */
+"postDiscussion.title" = "דיון";
 
 /* Button in an alert confirming discaring changes */
 "postEditor.closeConfirmationAlert.discardChanges" = "לבטל את השינויים";
@@ -10080,6 +10421,9 @@ Example: Reply to Pamela Nguyen */
 /* A default value for an post without a title */
 "postSaveErrorMessage.postUntitled" = "ללא כותרת";
 
+/* Section header for Access settings in Post Settings */
+"postSettings.access.header" = "גישה";
+
 /* Label for the author field in Post Settings */
 "postSettings.author.label" = "מחבר";
 
@@ -10098,6 +10442,18 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the discard changes confirmation dialog */
 "postSettings.discardChanges.title" = "האם לבטל את השינויים?";
+
+/* Status text when discussion (comments) is disabled */
+"postSettings.discussion.closed" = "סגור";
+
+/* Label for the discussion settings field in Post Settings */
+"postSettings.discussion.label" = "דיון";
+
+/* Status text when discussion (comments) is enabled */
+"postSettings.discussion.open" = "פתוח";
+
+/* Label for the checkbox that lets you send a post to newsletter subscribers */
+"postSettings.emailToSubscribers.label" = "לשלוח אימייל למינויים";
 
 /* Character count for excerpt. %1$d is the number of characters. */
 "postSettings.excerpt.characterCount" = "⁦%1$d⁩ תווים";
@@ -10198,6 +10554,21 @@ Example: Reply to Pamela Nguyen */
 /* Cell title for the Top Level option case */
 "postSettings.parentPage.topLevel" = "עליון";
 
+/* Accessibility label for hide password button */
+"postSettings.passwordEntry.hidePassword" = "להסתיר סיסמה";
+
+/* Instructions for password entry */
+"postSettings.passwordEntry.instructions" = "להזין סיסמה כדי להגן על פוסט זה. רק למשתמשים שיודעים את הסיסמה תהיה אפשרות להציג את הפוסט.";
+
+/* Navigation title for password entry screen */
+"postSettings.passwordEntry.navigationTitle" = "להזין סיסמה";
+
+/* Placeholder for password field */
+"postSettings.passwordEntry.placeholder" = "להזין סיסמה";
+
+/* Accessibility label for show password button */
+"postSettings.passwordEntry.showPassword" = "להציג סיסמה";
+
 /* Label for the pending review toggle in Post Settings */
 "postSettings.pendingReview.label" = "ביקורת ממתינה לאישור";
 
@@ -10225,17 +10596,59 @@ Example: Reply to Pamela Nguyen */
 /* Section header for General settings in Post Settings */
 "postSettings.section.general" = "כללי";
 
+/* Description text explaining what the slug editor does */
+"postSettings.slug.customizeDescription" = "להתאים אישית את החלק האחרון של הקישור הקבוע.";
+
 /* Hint text for the slug field. Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso. */
 "postSettings.slug.hint" = "המזהה לכתובת היא גרסה ידידותית לכתובת URL של כותרת הפוסט.";
 
 /* Label for the slug field. Should be the same as WP core. */
 "postSettings.slug.label" = "מזהה לכתובת";
 
+/* Button text to learn more about permalinks */
+"postSettings.slug.learnMore" = "למידע נוסף";
+
+/* Label for the slug field. Should be the same as WP core. */
+"postSettings.slug.navigationTitle" = "מזהה לכתובת";
+
+/* Notice shown when the post doesn't have a remote and permalink template is missing */
+"postSettings.slug.permalinkDraftNotice" = "הקישור הקבוע המוצע יופיע כאשר הטיוטה נשמרת בשרת";
+
+/* Label for the permalink preview */
+"postSettings.slug.permalinkLabel" = "קישור קבוע";
+
+/* Section title for the permalink preview */
+"postSettings.slug.permalinkSection" = "קישור קבוע";
+
 /* Placeholder for the slug field */
 "postSettings.slug.placeholder" = "הזנת מזהה לכתובת";
 
 /* Label for the preview button in Post Settings */
 "postSettings.socialSharing.header" = "שיתוף ברשתות חברתיות";
+
+/* Label for the status field in Post Settings */
+"postSettings.status.label" = "מצב";
+
+/* Navigation title for status picker */
+"postSettings.statusPicker.navigationTitle" = "מצב ונראות";
+
+/* Label showing the current password */
+"postSettings.statusPicker.passwordLabel" = "סיסמה";
+
+/* Toggle label for password protection */
+"postSettings.statusPicker.passwordProtected" = "מוגן בסיסמה";
+
+/* Subtitle for password protected toggle */
+"postSettings.statusPicker.passwordProtectedSubtitle" = "להציג רק לאנשים שיודעים את הסיסמה";
+
+/* Label for schedule date row */
+"postSettings.statusPicker.scheduleDate" = "תאריך";
+
+/* Toggle label for sticky posts */
+"postSettings.statusPicker.sticky" = "דביק";
+
+/* Subtitle for sticky toggle */
+"postSettings.statusPicker.stickySubtitle" = "להצמיד פוסט זה בחלק העליון של הבלוג";
 
 /* Label for the sticky post toggle. Sticky posts are displayed at the top of the blog. */
 "postSettings.stickyPost.label" = "דביק";
@@ -10252,14 +10665,56 @@ Example: Reply to Pamela Nguyen */
 /* Label for the visibility field in Post Settings */
 "postSettings.visibility.label" = "נראות";
 
-/* Button to add a new tag. %1$@ is the tag name. */
-"postTags.addTag" = "להוסיף תגית";
+/* Navigation bar title of the Post Stats screen */
+"postStats.title" = "נתונים סטטיסטיים של הפוסט";
 
-/* Placeholder text for the tag search field */
-"postTags.searchOrAdd.placeholder" = "לחפש או להוסיף תגית";
+/* Post status title */
+"postStatus.deleted.details" = "נמחק לצמיתות";
 
-/* Title for the tags screen */
-"postTags.title" = "תגיות";
+/* Post status title */
+"postStatus.deleted.title" = "נמחק";
+
+/* Post status details */
+"postStatus.draft.details" = "לא מוכן לפרסום";
+
+/* Post status title */
+"postStatus.draft.title" = "טיוטה";
+
+/* Post status details */
+"postStatus.pending.details" = "בהמתנה לביקורת לפני הפרסום";
+
+/* Post status title */
+"postStatus.pending.title" = "בהמתנה";
+
+/* Post status title */
+"postStatus.private.title" = "פרטי";
+
+/* Post status details */
+"postStatus.published.details" = "זמין לכולם";
+
+/* Post status title */
+"postStatus.published.title" = "פורסם";
+
+/* Post status details */
+"postStatus.scheduled.details" = "פרסום אוטומטי בתאריך שנבחר";
+
+/* Post status title */
+"postStatus.scheduled.title" = "מתוזמן לפרסום";
+
+/* Post status title */
+"postStatus.trash.details" = "הפריט הועבר לפח אבל עדיין לא נמחק";
+
+/* Post status title */
+"postStatus.trash.title" = "הועבר לפח";
+
+/* Button to add a new taxonomy term. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.addTag" = "להוסיף %1$@";
+
+/* Placeholder text for the taxonomy search field. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.searchOrAdd.placeholder" = "לחפש או להוסיף את %1$@";
+
+/* Message shown when no taxonomy terms are selected. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.selectionEmpty" = "לא נבחרו פריטים של %1$@";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "ביטול";
@@ -10335,9 +10790,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "קטגוריות";
-
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "לסגור";
 
 /* Button to confirm discarding changes */
 "prepublishing.discardChanges.button" = "לבטל את השינויים";
@@ -10423,12 +10875,17 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "אזהרה";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "הודעה";
+
+/* Placeholder text for the message field in Social Sharing */
+"prepublishing.socialAccounts.messagePlaceholder" = "לכתוב הודעה קצרה שתשותף ברשתות החברתיות לצד הפוסט";
 
 /* The navigation title for the pre-publishing social accounts screen. */
 "prepublishing.socialAccounts.navigationTitle" = "רשתות חברתיות";
+
+/* Table section title */
+"prepublishing.socialAccounts.servicesSectionTitle" = "שירותים";
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.tags" = "תגיות";
@@ -11360,6 +11817,18 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Button to progress to the next step after selecting domain in Site Creation */
 "siteCreation.domains.buttons.selectDomain" = "לבחור דומיין";
 
+/* Default text for adding a new item when no label is provided */
+"siteCustomTaxonomies.defaultAddNew" = "להוסיף";
+
+/* Description for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.description" = "טקסונומיות מסייעות לך לארגן תוכן מעבר לקטגוריות ולתגיות הסטנדרטיות.";
+
+/* Title for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.title" = "לא קיימות טקסונומיות מותאמות אישית";
+
+/* Navigation title for the custom taxonomies screen */
+"siteCustomTaxonomies.navigationTitle" = "טקסונומיות";
+
 /* Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio. */
 "siteMedia.accessibilityLabelAudio" = "אודיו, %@";
 
@@ -11378,8 +11847,77 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Accessibility hint for actions when displaying media items. */
 "siteMedia.cellAccessibilityHint" = "יש לבחור מדיה.";
 
+/* Label for the alt for a media asset (image) */
+"siteMedia.details.altText" = "טקסט חלופי";
+
+/* Verb. Button title. Tapping cancels an action. */
+"siteMedia.details.cancel" = "לבטל";
+
+/* Noun. Label for the caption for a media asset (image / video) */
+"siteMedia.details.caption" = "כיתוב";
+
+/* Title for button that permanently deletes a media item (photo / video) */
+"siteMedia.details.delete" = "למחוק";
+
+/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
+"siteMedia.details.deleteConfirmation" = "בחרת למחוק פריט זה לצמיתות – האם ההחלטה סופית?";
+
+/* Text displayed in HUD after successfully deleting a media item */
+"siteMedia.details.deleted" = "הפריט נמחק!";
+
+/* Text displayed in HUD while a media item is being deleted. */
+"siteMedia.details.deleting" = "מוחק...";
+
+/* Label for the description for a media asset (image / video) */
+"siteMedia.details.description" = "תיאור";
+
+/* Label for the dimensions in pixels for a media asset (image / video) */
+"siteMedia.details.dimensions" = "ממדים";
+
+/* Label for the file name for a media asset (image / video) */
+"siteMedia.details.fileName" = "שם הקובץ";
+
+/* Label for the file size for a media asset (image / video) */
+"siteMedia.details.fileSize" = "גודל הקובץ";
+
+/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
+"siteMedia.details.fileType" = "סוג קובץ";
+
+/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
+"siteMedia.details.mediaDeleted" = "פריט המדיה נמחק.";
+
+/* Noun. Label for the title of a media asset (image / video) */
+"siteMedia.details.title" = "כותרת";
+
+/* Accessibility label for trash buttons in nav bars */
+"siteMedia.details.trash" = "פח";
+
+/* Text displayed in HUD if there was an error attempting to delete a media item. */
+"siteMedia.details.unableToDeleteMedia" = "לא ניתן למחוק פריט מדיה.";
+
+/* Error shown when the app fails to load a video from the user's media library. */
+"siteMedia.details.unableToLoadVideo" = "לא ניתן לטעון את הווידאו.";
+
+/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
+"siteMedia.details.unableToSaveMedia" = "לא ניתן לשמור פריט מדיה.";
+
+/* Label for the date a media asset (image / video) was uploaded */
+"siteMedia.details.uploaded" = "הועלה";
+
 /* Title for the URL field */
 "siteMedia.details.url" = "כתובת URL";
+
+/* Hint for image alt on image settings. */
+"siteMedia.hints.imageAlt" = "טקסט חלופי לתמונה";
+
+/* Hint for image caption on image settings. */
+"siteMedia.hints.imageCaption" = "כיתוב התמונה";
+
+/* Hint for image description on image settings. */
+"siteMedia.hints.imageDescription" = "תיאור תמונה";
+
+/* Hint for image title on image settings. */
+"siteMedia.hints.imageTitle" = "כותרת התמונה";
 
 /* Accessibility hint for media item preview for user's viewing an item in their media library */
 "siteMediaItem.contentViewAccessibilityHint" = "יש להקיש כדי להציג מדיה במסך מלא";
@@ -11477,6 +12015,9 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "פרטיות";
+
+/* Format string for adding a new taxonomy term. %1$@ is the taxonomy name. */
+"siteTaxonomy.addNew.format" = "להוסיף %1$@";
 
 /* Hint for users when hidden privacy setting is set */
 "siteVisibility.hidden.hint" = "האתר מוסתר ממבקרים, אשר רואים רק הודעת 'בקרוב' עד שהאתר יהיה מוכן לצפייה.";
@@ -12042,7 +12583,8 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Subject of new Zendesk ticket. */
 "support.zendesk.readerAppTicketSubject" = "Reader לתמיכה ב-iOS";
 
-/* Description for empty state when there are no tags */
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
 "tags.empty.description" = "תגיות עוזרות לארגן את התוכן שלך ולעזור לקוראים למצוא פוסטים קשורים בקלות.";
 
 /* Title for empty state when there are no tags */
@@ -12119,9 +12661,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "לא נקרא";
-
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "מנוי של האתר";
 
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "משתמש של האתר";
@@ -12207,9 +12746,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* The heading at the top of the user list */
 "userlist.title" = "משתמשים";
-
-/* Site Subscribers */
-"users.list.title.subscribers" = "מנויים";
 
 /* Screen title */
 "users.title" = "משתמשים";

--- a/WordPress/Resources/hr.lproj/Localizable.strings
+++ b/WordPress/Resources/hr.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 /* Translation-Revision-Date: 2022-05-03 22:00:55+0000 */
 /* Plural-Forms: nplurals=3; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2); */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: hr */
 
 /* Singular button title to Like a comment. %1$d is a placeholder for the number of Likes.
@@ -102,7 +102,6 @@
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Otkaži";
@@ -159,14 +158,7 @@
 /* Action title. Noun. Opens the user's WordPress.com dashboard in an external browser. */
 "Dashboard" = "Nadzorna ploča";
 
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Obriši";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Brišem...";
-
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Opis";
 
 /* Details button that appears in the Theme Browser Header
@@ -218,7 +210,7 @@
 /* No comment provided by engineer. */
 "Edit focal point" = "ažuriraj žarišno mjesto";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Uređivač";
 
 /* Accessibility label for the email address text field.
@@ -415,9 +407,6 @@
    Title of the screen showing the list of pages for a blog. */
 "Pages" = "Stranice";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Matična Kategorija";
-
 /* Accessibility label for the password text field in the self-hosted login page.
    Label for entering password in password field
    Login dialog password placeholder
@@ -565,6 +554,7 @@
 "Support" = "Podrška";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Tagovi";
 
@@ -590,7 +580,6 @@
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Naslov";
@@ -648,9 +637,6 @@
 /* Describes a status of a plugin
    Updating label title */
 "Updating" = "Ažuriranje ";
-
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Preneseno";
 
 /* \"Uploading\" Status text */
 "Uploading" = "Prenosim";

--- a/WordPress/Resources/hu.lproj/Localizable.strings
+++ b/WordPress/Resources/hu.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 /* Translation-Revision-Date: 2022-05-03 21:53:29+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: hu */
 
 /* Empty Post Title */
@@ -64,7 +64,6 @@
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Mégse";
@@ -110,12 +109,6 @@
 
 /* Action title. Noun. Opens the user's WordPress.com dashboard in an external browser. */
 "Dashboard" = "Vezérlőpult";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Törlés";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Törlés...";
 
 /* Adjective. Comment threading is disabled. */
 "Disabled" = "Kikapcsolva";
@@ -361,9 +354,6 @@
    Title of the screen showing the list of pages for a blog. */
 "Pages" = "Oldalak";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Szülő kategória";
-
 /* Accessibility label for the password text field in the self-hosted login page.
    Label for entering password in password field
    Login dialog password placeholder
@@ -590,7 +580,6 @@
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Cím";
@@ -629,9 +618,6 @@
 
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Sikertelen feltöltés";
-
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Feltöltve";
 
 /* \"Uploading\" Status text */
 "Uploading" = "Feltöltés";

--- a/WordPress/Resources/id.lproj/Localizable.strings
+++ b/WordPress/Resources/id.lproj/Localizable.strings
@@ -1,6 +1,6 @@
-/* Translation-Revision-Date: 2025-10-10 09:54:08+0000 */
+/* Translation-Revision-Date: 2025-11-25 10:54:12+0000 */
 /* Plural-Forms: nplurals=2; plural=n > 1; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: id */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -581,8 +581,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "Hampir selesai! Masukkan kode verifikasi dari aplikasi pengautentikasi.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Teks Alt";
 
 /* No comment provided by engineer. */
@@ -725,9 +724,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "Apakah Anda yakin ingin memutuskan sambungan Jetpack dari situs?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "Anda yakin ingin menghapus item ini secara permanen?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "Anda yakin ingin menghapus %1$@ dari %2$@?";
@@ -1082,7 +1078,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Batal";
@@ -1110,8 +1105,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Bingung memilih? Anda dapat mengganti tema kapan saja.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Keterangan";
 
 /* Alert title. */
@@ -1777,8 +1771,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "Default";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Kategori Default";
 
 /* Label for selecting the default post format
@@ -1787,9 +1780,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Default untuk Pos Baru";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Hapus";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Hapus Menu";
@@ -1808,14 +1798,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "Hapus menu";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Dihapus!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Menghapus situs…";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Menghapus...";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "Tolak";
@@ -1823,8 +1807,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "Jelaskan maksud gambar tersebut. Biarkan kosong jika gambar hanya hiasan.";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Deskripsi";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1842,9 +1825,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "Tidak ingin membuat akun baru? Silakan kembali dan masukkan lagi alamat email Anda.";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Dimensi";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "Nonaktifkan";
@@ -2121,7 +2101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "Mengedit GIF ini akan menghapus animasinya.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Penyunting";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2463,11 +2443,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "Pengaturan blok Berkas";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "Nama file";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Jenis file";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "Jenis berkas tidak didukung sebagai berkas media.";
@@ -2781,6 +2758,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post content used in the login prologue screens. */
 "I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next" = "Saya sangat terinspirasi oleh karya fotografer Cameron Karsten. Saya akan mencoba teknik ini selanjutnya";
 
+/* Text on the support form to refer to what area the user has problem with. */
+"I need help with" = "Saya butuh bantuan untuk";
+
 /* Describes the IP address section in the comment detail screen. */
 "IP address" = "Alamat IP";
 
@@ -2826,9 +2806,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "Keterangan Gambar";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Deskripsi Gambar";
-
 /* Hint for image link on image settings. */
 "Image Link" = "Tautan Gambar";
 
@@ -2840,9 +2817,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "Berkas gambar tidak ditemukan.";
-
-/* Hint for image title on image settings. */
-"Image title" = "Judul gambar";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "Dalam beberapa kata, jelaskan tentang apa situs ini.";
@@ -3205,6 +3179,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the button that will dismiss this view. */
 "Let me know when finished!" = "Beri tahu saya jika sudah selesai!";
 
+/* Message info on the support screen. */
+"Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon." = "Uraikan masalah sedetail mungkin dan sertakan alamat situs (URL) Anda. Kami akan segera menindaklanjutinya.";
+
+/* Title to let the user know what do we want on the support screen. */
+"Let’s get this sorted" = "Mari atasi masalahnya";
+
 /* Lifestyle site intent topic */
 "Lifestyle" = "Gaya hidup";
 
@@ -3405,6 +3385,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Navigasi Utama";
+
+/* Explanation for the option to enable theme styles */
+"Make the block editor look like your theme." = "Jadikan editor blok terlihat seperti tema Anda.";
 
 /* No comment provided by engineer. */
 "Make your content stand out by adding images, gifs, videos, and embedded media to your pages." = "Buat konten Anda menonjol dengan menambahkan gambar, gif, video, dan media tersemat ke halaman Anda.";
@@ -3747,9 +3730,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "Tidak Ada Akun yang Ditemukan";
-
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Tanpa Kategori";
 
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Tidak ada Koneksi";
@@ -4191,9 +4171,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "Penentuan halaman";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Kategori Induk";
-
 /* Parenting site intent topic */
 "Parenting" = "Pengasuhan";
 
@@ -4411,9 +4388,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Postingan";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Kategori Pos";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "Pengaturan Pos";
@@ -4722,9 +4696,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "Menghapus metadata lokasi dari foto sebelum diunggah ke situs.";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "Jika pengikut dibuang, mereka akan berhenti menerima pembaruan dari situs Anda. Mereka tetap bebas mengunjungi dan mengikuti kembali situs Anda.";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "Ganti Blok Saat Ini";
@@ -5561,6 +5532,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "Tagline";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Tag";
 
@@ -5657,6 +5629,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint, informing user the button can be used to visit the Gravatar website. */
 "Tap to visit the Gravatar website in an external browser" = "Ketuk di sini untuk membuka situs Gravatar di browser di luar aplikasi";
+
+/* Label for viewing the custom taxonomies */
+"Taxonomies" = "Taksonomi";
 
 /* Technology site intent topic */
 "Technology" = "Teknologi";
@@ -5946,9 +5921,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "Kode login telah kedaluwarsa. Silakan ketuk tombol Pindai Lagi untuk memindai ulang kode.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "Item media ini sudah dihapus.";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "Akun pengguna ini tidak dapat ditutup jika ada proses penagihan balik yang belum terselesaikan.";
 
@@ -6017,7 +5989,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Judul";
@@ -6111,8 +6082,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "Mengubah blok...";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Buang";
 
@@ -6209,9 +6179,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "Tidak dapat membuat tautan undangan baru.";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "Tidak dapat menghapus item media.";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "Tidak dapat menonaktifkan tautan undangan.";
 
@@ -6242,9 +6209,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "Tidak dapat memuat konten ini sekarang.";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "Tidak dapat memuat video.";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Tidak dapat memutar video";
 
@@ -6253,9 +6217,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Tidak dapat memulihkan situs Anda";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "Tidak dapat menyimpan item media.";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "Tidak dapat berbagi tautan";
@@ -6412,9 +6373,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Unggah gagal";
 
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Terunggah";
-
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "Berhasil mengunggah 1 pos konsep, %ld file";
 
@@ -6456,6 +6414,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The button title text for logging in with WP.com password instead of magic link. */
 "Use password to sign in" = "Gunakan kata sandi untuk login";
+
+/* Option to enable theme styles in the block editor */
+"Use theme styles" = "Gunakan gaya tema";
 
 /* A placeholder for the twitter username
    Accessibility label for the username text field in the self-hosted login page.
@@ -6906,7 +6867,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "Peta dunia menampilkan kunjungan berdasarkan negara.";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "Apakah Anda masih ingin menghapus orang ini?";
 
 /* Button title. Opens the editor to write a new post.
@@ -7377,14 +7338,19 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Description for the prompt to upgrade to Application Passwords. The first argument is the name of the feature that requires Application Passwords. */
 "applicationPasswordRequired.description" = "Agar lebih aman, gunakan kata sandi aplikasi untuk terhubung dengan situs Anda yang dihosting sendiri sehingga Anda mendapatkan dukungan bagi fitur seperti %@.";
 
+/* Feature name for managing application passwords in the app */
+"applicationPasswordRequired.feature.applicationPasswords" = "Pengelolaan Kata Sandi Aplikasi";
+
 /* Feature name for the block editor in application password required prompt */
 "applicationPasswordRequired.feature.blockEditor" = "Editor Blok";
+
+/* Feature name for managing terms and taxonomies in the app */
+"applicationPasswordRequired.feature.customTaxonomies" = "Pengelolaan Taksonomi";
 
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "Pengelolaan Plugin";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "Pengelolaan Pengguna";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -7613,6 +7579,282 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 
 /* Post Editor / Button in the 'More' menu */
 "classicEditor.moreMenu.saveDraft" = "Simpan Konsep";
+
+/* Button to add more screenshots */
+"com.jetpack.support.addMoreScreenshots" = "Tambah Tangkapan Layar Lain";
+
+/* Button to add screenshots */
+"com.jetpack.support.addScreenshots" = "Tambah Tangkapan Layar";
+
+/* Header for application logs section */
+"com.jetpack.support.applicationLogs" = "Log Aplikasi";
+
+/* Description explaining why including logs is helpful */
+"com.jetpack.support.applicationLogsDescription" = "Menyertakan log dapat membantu tim kami menyelidiki kendala. Log mungkin berisi aktivitas aplikasi terbaru.";
+
+/* Navigation title for application logs screen */
+"com.jetpack.support.applicationLogsTitle" = "Log Aplikasi";
+
+/* Format string for attachment identifier */
+"com.jetpack.support.attachment" = "Lampiran %@";
+
+/* Format string for attachment size limit. %1$@ is current size, %2$@ is maximum size */
+"com.jetpack.support.attachmentLimit" = "Batas Lampiran: %1$@ \/ %2$@";
+
+/* Bot greeting message. %1$@ is the user's name */
+"com.jetpack.support.botGreeting" = "Halo %1$@!";
+
+/* Bot introduction message explaining its purpose */
+"com.jetpack.support.botIntroduction" = "Saya asisten AI pribadi Anda. Saya bisa menjawab segala pertanyaan tentang situs atau akun Anda.";
+
+/* Format string for cache file count and size. %1$d is the number of files, %2$@ is the formatted size. The system will pluralize 'files' based on the number – please specify it as the largest plural value */
+"com.jetpack.support.cacheFiles" = "%1$d file cache (%2$@)";
+
+/* Message shown when cache has no files */
+"com.jetpack.support.cacheIsEmpty" = "Cache kosong";
+
+/* Button to cancel current action */
+"com.jetpack.support.cancel" = "Batalkan";
+
+/* Warning message that deleted logs cannot be recovered */
+"com.jetpack.support.cannotRecoverLogs" = "Anda tidak akan bisa mengembalikannya.";
+
+/* Button to clear all activity logs */
+"com.jetpack.support.clearAllActivityLogs" = "Hapus Semua Log Aktivitas";
+
+/* Button to clear disk cache */
+"com.jetpack.support.clearDiskCache" = "Hapus Cache Disk";
+
+/* Description explaining the purpose of clearing disk cache */
+"com.jetpack.support.clearDiskCacheDescription" = "Hapus file sementara untuk mengosongkan ruang atau mengatasi masalah.";
+
+/* Progress text while clearing cache */
+"com.jetpack.support.clearing" = "Menghapus ...";
+
+/* Message shown when cache clearing is complete */
+"com.jetpack.support.complete" = "Selesai";
+
+/* Confirmation message when canceling a draft */
+"com.jetpack.support.confirmCancelMessage" = "Anda yakin ingin membatalkan pesan ini? Anda akan kehilangan data yang telah dimasukkan";
+
+/* Title for alert confirming cancellation */
+"com.jetpack.support.confirmCancellation" = "Konfirmasi Pembatalan";
+
+/* Confirmation dialog title when deleting all logs */
+"com.jetpack.support.confirmDeleteAllLogs" = "Anda yakin ingin menghapus semua log?";
+
+/* Section title for contact information */
+"com.jetpack.support.contactInformation" = "Informasi Kontak";
+
+/* Button to continue editing a message */
+"com.jetpack.support.continueWriting" = "Lanjutkan Menulis";
+
+/* Message shown at end of closed support conversation */
+"com.jetpack.support.conversationEnded" = "Akhir dari percakapan. Tidak ada balasan lebih lanjut yang dapat diberikan.";
+
+/* Navigation title for bot conversations list */
+"com.jetpack.support.conversations" = "Percakapan";
+
+/* Button to delete all log files */
+"com.jetpack.support.deleteAllLogs" = "Hapus semua Log";
+
+/* Description text for diagnostics screen */
+"com.jetpack.support.diagnosticsDescription" = "Jalankan tugas pemeliharaan dan pemecahan masalah umum.";
+
+/* Navigation title for diagnostics screen */
+"com.jetpack.support.diagnosticsTitle" = "Diagnostik";
+
+/* Button to discard changes in a draft message */
+"com.jetpack.support.discardChanges" = "Buang Perubahan";
+
+/* Notice explaining where support will send email responses */
+"com.jetpack.support.emailNotice" = "Kami akan mengirimkan e-mail kepada Anda di alamat ini.";
+
+/* Error title when logs fail to load */
+"com.jetpack.support.errorLoadingLogs" = "Error saat memuat log";
+
+/* Error message when support conversations fail to load */
+"com.jetpack.support.errorLoadingSupportConversations" = "Error saat memuat percakapan dukungan";
+
+/* Option to export log as a file */
+"com.jetpack.support.exportAsFile" = "Ekspor sebagai file";
+
+/* Button to dismiss alerts. */
+"com.jetpack.support.gotIt" = "Mengerti";
+
+/* Text on the support form to refer to what area the user has problem with. */
+"com.jetpack.support.iNeedHelp" = "Saya butuh bantuan untuk";
+
+/* Toggle label to include application logs in the support request */
+"com.jetpack.support.includeApplicationLogs" = "Sertakan log aplikasi";
+
+/* Section title for issue details */
+"com.jetpack.support.issueDetails" = "Detail Isu";
+
+/* Format string for when conversation was last updated */
+"com.jetpack.support.lastUpdated" = "Pembaruan terakhir %@";
+
+/* Progress message while loading conversation messages */
+"com.jetpack.support.loadingBotConversationMessages" = "Memuat Pesan";
+
+/* Progress message while loading bot conversations */
+"com.jetpack.support.loadingBotConversations" = "Memuat Percakapan Bot";
+
+/* Progress text while loading support conversations */
+"com.jetpack.support.loadingConversations" = "Memuat Percakapan";
+
+/* Progress message while loading disk usage information */
+"com.jetpack.support.loadingDiskUsage" = "Memuat Penggunaan Disk";
+
+/* Progress message while loading an image attachment */
+"com.jetpack.support.loadingImage" = "Memuat Gambar";
+
+/* Progress message shown in overlay while refreshing content */
+"com.jetpack.support.loadingLatestContent" = "Memuat konten terakhir";
+
+/* Progress message while loading application log content */
+"com.jetpack.support.loadingLogContent" = "Memuat konten ...";
+
+/* Progress message while loading log files */
+"com.jetpack.support.loadingLogs" = "Memuat log ...";
+
+/* Progress text while loading conversation messages */
+"com.jetpack.support.loadingMessages" = "Memuat Pesan";
+
+/* Progress message while loading a video attachment */
+"com.jetpack.support.loadingVideo" = "Memuat Video";
+
+/* Section header for log files sorted by date */
+"com.jetpack.support.logFilesByDate" = "Catat file berdasarkan tanggal pembuatan";
+
+/* Text indicating which log files will be included in the support request */
+"com.jetpack.support.logFilesToUpload" = "File log berikut ini akan diunggah:";
+
+/* Footer text explaining log retention policy */
+"com.jetpack.support.logRetentionNotice" = "Log hingga tujuh hari disimpan.";
+
+/* Section header for message text input */
+"com.jetpack.support.message" = "Pesan";
+
+/* Success message when reply is sent successfully */
+"com.jetpack.support.messageSent" = "Pesan Terkirim";
+
+/* Format string for number of messages in conversation */
+"com.jetpack.support.messagesCount" = "%d Pesan";
+
+/* The title of a new bot chat in the support area of the app */
+"com.jetpack.support.new-bot-chat" = "Obrolan Bot Baru";
+
+/* Option to create a new support ticket */
+"com.jetpack.support.newSupportTicket" = "Tiket Dukungan Baru";
+
+/* Label shown when there are no bot conversations */
+"com.jetpack.support.noConversations" = "Tidak Ada Percakapan";
+
+/* Description shown when no log files are available */
+"com.jetpack.support.noLogsAvailable" = "Tidak ada log aktivitas";
+
+/* Label shown when no log files are available */
+"com.jetpack.support.noLogsFound" = "Log Tidak Ditemukan";
+
+/* Button to open a support ticket */
+"com.jetpack.support.openSupportTicket" = "Buka Tiket Dukungan";
+
+/* Text indicating a field is optional */
+"com.jetpack.support.optional" = "(Opsional)";
+
+/* Navigation title for replying to a support conversation */
+"com.jetpack.support.reply" = "Balas";
+
+/* Description for saving log as a file */
+"com.jetpack.support.saveAsFile" = "Simpan sebagai file untuk dibagikan atau disimpan";
+
+/* Label for screenshots section */
+"com.jetpack.support.screenshots" = "Tangkapan layar";
+
+/* Description for screenshots section */
+"com.jetpack.support.screenshotsDescription" = "Menambahkan tangkapan layar dapat membantu kami memahami dan menyelesaikan masalah Anda lebih cepat.";
+
+/* Button to send a message or reply */
+"com.jetpack.support.send" = "Kirim";
+
+/* Description for sending logs to support */
+"com.jetpack.support.sendLogsToSupport" = "Kirim log langsung ke tim dukungan";
+
+/* Progress text while sending a message */
+"com.jetpack.support.sending" = "Mengirim";
+
+/* Progress message shown while sending a message */
+"com.jetpack.support.sendingMessage" = "Mengirim Pesan";
+
+/* Button to share content */
+"com.jetpack.support.share" = "Bagikan";
+
+/* Navigation title for sharing activity log */
+"com.jetpack.support.shareActivityLog" = "Bagikan Log Aktivitas";
+
+/* Message shown when sharing log with support */
+"com.jetpack.support.sharingWithSupport" = "Berbagi dengan dukungan!";
+
+/* Site Address title on the support form */
+"com.jetpack.support.siteAddress" = "Alamat Situs";
+
+/* Description encouraging user to start a new conversation */
+"com.jetpack.support.startNewConversation" = "Mulai percakapan baru dengan tombol di atas";
+
+/* Subject title on the support form */
+"com.jetpack.support.subject" = "Subjek";
+
+/* Placeholder for subject field */
+"com.jetpack.support.subjectPlaceholder" = "Ringkasan singkat permasalahan Anda";
+
+/* Button title to submit a support request. */
+"com.jetpack.support.submitRequest" = "Daftarkan Permohonan Dukungan";
+
+/* Navigation title for the support conversations list */
+"com.jetpack.support.supportConversations" = "Percakapan Dukungan";
+
+/* Title for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSent" = "Permintaan Terkirim!";
+
+/* Message for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSentMessage" = "Permintaan dukungan Anda berhasil dikirim. Kami akan mengirimkan email balasan secepatnya.";
+
+/* Progress message shown while bot is thinking */
+"com.jetpack.support.thinking" = "Berpikir ...";
+
+/* Title of the view for contacting support. */
+"com.jetpack.support.title" = "Hubungi Dukungan";
+
+/* Button to retry a failed operation */
+"com.jetpack.support.tryAgain" = "Coba Lagi";
+
+/* Error title when log deletion fails */
+"com.jetpack.support.unableToDeleteLogs" = "Tidak dapat menghapus log";
+
+/* Error message when conversation cannot be displayed */
+"com.jetpack.support.unableToDisplayConversation" = "Tidak dapat menampilkan percakapan";
+
+/* Error title when video cannot be loaded or played */
+"com.jetpack.support.unableToDisplayVideo" = "Tidak dapat menampilkan video";
+
+/* Error message when application logs cannot be loaded */
+"com.jetpack.support.unableToLoadApplicationLogs" = "Tidak dapat memuat log aplikasi";
+
+/* Error title when bot conversations fail to load */
+"com.jetpack.support.unableToLoadConversations" = "Tidak dapat memuat percakapan";
+
+/* Error title when messages fail to load */
+"com.jetpack.support.unableToLoadMessages" = "Tidak Dapat Memuat Pesan";
+
+/* Error title when message sending fails */
+"com.jetpack.support.unableToSendMessage" = "Tidak dapat mengirim Pesan";
+
+/* Button to view an attachment */
+"com.jetpack.support.view" = "Lihat";
+
+/* Progress message shown during cache clearing operation */
+"com.jetpack.support.working" = "Bekerja";
 
 /* Displayed in the confirmation alert when marking comment notifications as read. */
 "comment" = "komentar";
@@ -7876,6 +8118,9 @@ Example: Reply to Pamela Nguyen */
 /* Weekly Roundup debug menu item */
 "debugMenu.weeklyRoundup" = "Ringkasan Mingguan";
 
+/* Title for selecting a default category for a post */
+"defaultCategory.title" = "Kategori Standar";
+
 /* Error tilte */
 "discussionSettings.saveErrorTitle" = "Gagal menyimpan pengaturan";
 
@@ -8015,10 +8260,10 @@ Example: Reply to Pamela Nguyen */
 "double-tap to change unit" = "ketuk dua kali untuk mengubah unit";
 
 /* Message for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.message" = "Anda yakin ingin menghapus tag ini?";
+"edit.tag.delete.confirmation.message" = "Anda yakin ingin menghapus ini?";
 
-/* Title for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.title" = "Hapus Tag";
+/* Title for delete a term confirmation dialog */
+"edit.tag.delete.confirmation.title" = "Hapus";
 
 /* Placeholder text for tag description field */
 "edit.tag.description.placeholder" = "Tambahkan deskripsi...";
@@ -8031,6 +8276,39 @@ Example: Reply to Pamela Nguyen */
 
 /* Section header for tag description in edit tag view */
 "edit.tag.section.description" = "Deskripsi";
+
+/* Section header for tag name in edit tag view */
+"edit.tag.section.tag" = "Nama";
+
+/* Context menu action to insert a block */
+"editor.blockInserter.insertBlock" = "Masukkan Blok";
+
+/* Placeholder text for block search field */
+"editor.blockInserter.search" = "Cari";
+
+/* Button title to collapse and show fewer blocks */
+"editor.blockInserter.showLess" = "Tampilkan Sedikit";
+
+/* Button title to expand and show more blocks */
+"editor.blockInserter.showMore" = "Tampilkan Lebih Banyak";
+
+/* Error message when media insertion fails */
+"editor.media.failedToInsert" = "Gagal memasukkan media";
+
+/* Category name for section showing all patterns */
+"editor.patterns.all" = "Semua";
+
+/* Context menu action to insert a pattern */
+"editor.patterns.insertPattern" = "Sisipkan Pola";
+
+/* Title shown when no patterns match the search */
+"editor.patterns.noPatternsFound" = "Pola Tidak Ditemukan";
+
+/* Navigation title for patterns view */
+"editor.patterns.title" = "Pola";
+
+/* Category name for patterns without a category */
+"editor.patterns.uncategorized" = "Tanpa Kategori";
 
 /* Register Domain - Address information field Number placeholder */
 "eg. 1122334455" = "misalnya 1122334455";
@@ -8581,6 +8859,24 @@ Example: Reply to Pamela Nguyen */
 
 /* Write a blog prompt for the jetpack prologue */
 "jetpack.prologue.prompt.writeBlog" = "Tulis blog";
+
+/* Description for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.description" = "Siapa pun dapat melihat pos ini";
+
+/* Title for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.title" = "Semua orang";
+
+/* Description for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.description" = "Hanya pelanggan berbayar yang dapat melihat pos ini";
+
+/* Title for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.title" = "Pelanggan Berbayar";
+
+/* Description for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.description" = "Pos dapat dilihat oleh semua pelanggan, termasuk pelanggan gratis";
+
+/* Title for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.title" = "Semua Pelanggan";
 
 /* Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account */
 "jetpackSite.connectToDefaultAccount" = "Anda perlu login dengan %@ untuk menggunakan Statistik dan Pemberitahuan.";
@@ -9156,6 +9452,12 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "Anda tidak memiliki izin untuk melihat blog pribadi ini.";
 
+/* Default empty state message format when there are no terms. %1$@ is the taxonomy name. */
+"localizedLabels.defaultNoTerms.format" = "Tidak ada %1$@";
+
+/* Default search placeholder format. %1$@ is the taxonomy name. */
+"localizedLabels.defaultSearch.format" = "Cari %1$@";
+
 /* Button to dismiss the re-authentication view */
 "login.appPasswordReAuth.cancelButton" = "Batalkan";
 
@@ -9291,17 +9593,20 @@ Example: Reply to Pamela Nguyen */
 /* Message about buying storage add-on */
 "mediaLibrary.storageDetails.buyStorage.message" = "Beli add-on ruang penyimpanan";
 
-/* Message shown when all media items are attached */
-"mediaLibrary.storageDetails.cleanup.allAttached" = "Semua item di Pustaka Media terlampir.";
+/* Label for document media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.document" = "Dokumen";
 
-/* Message shown while loading unattached media count */
-"mediaLibrary.storageDetails.cleanup.loading" = "Mencari apakah ada item media yang tidak terlampir...";
+/* Label for image media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.image" = "Gambar";
 
-/* Message about unattached media that can be cleaned up. %1$d is the count of unattached media. */
-"mediaLibrary.storageDetails.cleanup.message" = "%1$d item tidak terlampir. Hapus item untuk mengosongkan sebagian ruang.";
+/* Label for other/unknown media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.other" = "Lainnya";
 
-/* Title for cleanup section */
-"mediaLibrary.storageDetails.cleanup.title" = "Hapus item yang tidak digunakan";
+/* Label for PowerPoint/presentation media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.powerpoint" = "Presentasi";
+
+/* Label for video media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.video" = "Video";
 
 /* Success message shown after upgrading plan */
 "mediaLibrary.storageDetails.purchase.plan.success" = "Paket situs Anda telah diupgrade!";
@@ -9687,6 +9992,12 @@ Example: Reply to Pamela Nguyen */
 /* Menu option for filtering posts by me */
 "pagesList.pagesByMe" = "Halaman oleh saya";
 
+/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
+"parentCategory.noCategory" = "Tanpa Kategori";
+
+/* Title for selecting parent category of a category */
+"parentCategory.title" = "Kategori Induk";
+
 /* Title for the parent page picker screen */
 "parentPagePicker.title" = "Halaman Induk";
 
@@ -9842,6 +10153,27 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the post author selection screen */
 "postAuthorPicker.title" = "Penulis";
+
+/* Title for selecting categories for a post or a page */
+"postCategories.title" = "Kategori";
+
+/* Toggle label for allowing comments on post */
+"postDiscussion.allowComments.label" = "Izinkan Komentar";
+
+/* Toggle label for allowing pings/trackbacks on post */
+"postDiscussion.allowPings.label" = "Izinkan Pingback & Trackback";
+
+/* Footer text when comments are disabled */
+"postDiscussion.comments.disabled.footer" = "Pengunjung tidak dapat menambahkan komentar atau balasan baru. Komentar yang sudah ada tetap dapat dilihat.";
+
+/* Footer text when comments are enabled */
+"postDiscussion.comments.enabled.footer" = "Pengunjung dapat menambahkan komentar dan balasan baru.";
+
+/* Link text for learning more about pingbacks and trackbacks */
+"postDiscussion.pingbacks.learnMore.text" = "Pelajari selengkapnya tentang pingback & trackback";
+
+/* Navigation title for post discussion settings */
+"postDiscussion.title" = "Diskusi";
 
 /* Button in an alert confirming discaring changes */
 "postEditor.closeConfirmationAlert.discardChanges" = "Buang Perubahan";
@@ -10074,6 +10406,9 @@ Example: Reply to Pamela Nguyen */
 /* A default value for an post without a title */
 "postSaveErrorMessage.postUntitled" = "Tanpa Judul";
 
+/* Section header for Access settings in Post Settings */
+"postSettings.access.header" = "Akses";
+
 /* Label for the author field in Post Settings */
 "postSettings.author.label" = "Penulis";
 
@@ -10092,6 +10427,18 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the discard changes confirmation dialog */
 "postSettings.discardChanges.title" = "Buang Perubahan?";
+
+/* Status text when discussion (comments) is disabled */
+"postSettings.discussion.closed" = "Ditutup";
+
+/* Label for the discussion settings field in Post Settings */
+"postSettings.discussion.label" = "Diskusi";
+
+/* Status text when discussion (comments) is enabled */
+"postSettings.discussion.open" = "Buka";
+
+/* Label for the checkbox that lets you send a post to newsletter subscribers */
+"postSettings.emailToSubscribers.label" = "Pelanggan Email";
 
 /* Character count for excerpt. %1$d is the number of characters. */
 "postSettings.excerpt.characterCount" = "%1$d karakter";
@@ -10192,6 +10539,21 @@ Example: Reply to Pamela Nguyen */
 /* Cell title for the Top Level option case */
 "postSettings.parentPage.topLevel" = "Tingkat teratas";
 
+/* Accessibility label for hide password button */
+"postSettings.passwordEntry.hidePassword" = "Sembunyikan kata sandi";
+
+/* Instructions for password entry */
+"postSettings.passwordEntry.instructions" = "Masukkan kata sandi untuk melindungi pos ini Hanya pengguna dengan kata sandi yang dapat melihatnya.";
+
+/* Navigation title for password entry screen */
+"postSettings.passwordEntry.navigationTitle" = "Masukkan Kata Sandi";
+
+/* Placeholder for password field */
+"postSettings.passwordEntry.placeholder" = "Masukkan kata sandi";
+
+/* Accessibility label for show password button */
+"postSettings.passwordEntry.showPassword" = "Tampilkan kata sandi";
+
 /* Label for the pending review toggle in Post Settings */
 "postSettings.pendingReview.label" = "Menunggu Peninjauan";
 
@@ -10213,14 +10575,44 @@ Example: Reply to Pamela Nguyen */
 /* Section header for General settings in Post Settings */
 "postSettings.section.general" = "Umum";
 
+/* Description text explaining what the slug editor does */
+"postSettings.slug.customizeDescription" = "Sesuaikan bagian terakhir Permalink.";
+
 /* Hint text for the slug field. Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso. */
 "postSettings.slug.hint" = "Slug adalah judul pos versi ramah URL.";
+
+/* Button text to learn more about permalinks */
+"postSettings.slug.learnMore" = "Baca selengkapnya";
+
+/* Notice shown when the post doesn't have a remote and permalink template is missing */
+"postSettings.slug.permalinkDraftNotice" = "Permalink yang disarankan akan muncul ketika konsep disimpan di server";
 
 /* Placeholder for the slug field */
 "postSettings.slug.placeholder" = "Masukkan slug";
 
 /* Label for the preview button in Post Settings */
 "postSettings.socialSharing.header" = "Berbagi di Media Sosial";
+
+/* Navigation title for status picker */
+"postSettings.statusPicker.navigationTitle" = "Status & Visibilitas";
+
+/* Label showing the current password */
+"postSettings.statusPicker.passwordLabel" = "Kata Sandi";
+
+/* Toggle label for password protection */
+"postSettings.statusPicker.passwordProtected" = "Dilindungi Kata Sandi";
+
+/* Subtitle for password protected toggle */
+"postSettings.statusPicker.passwordProtectedSubtitle" = "Hanya dapat dilihat orang yang mengetahui kata sandi";
+
+/* Label for schedule date row */
+"postSettings.statusPicker.scheduleDate" = "Tanggal";
+
+/* Toggle label for sticky posts */
+"postSettings.statusPicker.sticky" = "Melekat";
+
+/* Subtitle for sticky toggle */
+"postSettings.statusPicker.stickySubtitle" = "Sematkan pos ini di bagian atas blog";
 
 /* Label for the sticky post toggle. Sticky posts are displayed at the top of the blog. */
 "postSettings.stickyPost.label" = "Melekat";
@@ -10240,14 +10632,56 @@ Example: Reply to Pamela Nguyen */
 /* Navigation bar title of the Post Stats screen */
 "postStats.title" = "Statistik Pos";
 
-/* Button to add a new tag. %1$@ is the tag name. */
-"postTags.addTag" = "Tambahkan tag";
+/* Post status title */
+"postStatus.deleted.details" = "Dihapus secara permanen";
 
-/* Placeholder text for the tag search field */
-"postTags.searchOrAdd.placeholder" = "Cari atau tambah tag";
+/* Post status title */
+"postStatus.deleted.title" = "Dihapus";
 
-/* Title for the tags screen */
-"postTags.title" = "Tag";
+/* Post status details */
+"postStatus.draft.details" = "Belum siap dipublikasikan";
+
+/* Post status title */
+"postStatus.draft.title" = "Konsep";
+
+/* Post status details */
+"postStatus.pending.details" = "Menunggu peninjauan sebelum dipublikasikan";
+
+/* Post status title */
+"postStatus.pending.title" = "Ditangguhkan";
+
+/* Post status details */
+"postStatus.private.details" = "Hanya dapat dilihat oleh admin dan editor situs";
+
+/* Post status title */
+"postStatus.private.title" = "Privat";
+
+/* Post status details */
+"postStatus.published.details" = "Dapat dilihat oleh semua orang";
+
+/* Post status title */
+"postStatus.published.title" = "Dipublikasikan";
+
+/* Post status details */
+"postStatus.scheduled.details" = "Publikasikan secara otomatis pada tanggal yang dipilih";
+
+/* Post status title */
+"postStatus.scheduled.title" = "Terjadwal";
+
+/* Post status title */
+"postStatus.trash.details" = "Dibuang tetapi belum dihapus";
+
+/* Post status title */
+"postStatus.trash.title" = "Dibuang";
+
+/* Button to add a new taxonomy term. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.addTag" = "Tambahkan %1$@";
+
+/* Placeholder text for the taxonomy search field. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.searchOrAdd.placeholder" = "Cari atau tambah %1$@";
+
+/* Message shown when no taxonomy terms are selected. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.selectionEmpty" = "Tidak ada %1$@ yang dipilih";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Batal";
@@ -10323,9 +10757,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "Kategori";
-
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "Tutup";
 
 /* Button to confirm discarding changes */
 "prepublishing.discardChanges.button" = "Buang Perubahan";
@@ -10414,12 +10845,17 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "Peringatan";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "Pesan";
+
+/* Placeholder text for the message field in Social Sharing */
+"prepublishing.socialAccounts.messagePlaceholder" = "Tulis pesan singkat untuk dibagikan di media sosial bersama pos";
 
 /* The navigation title for the pre-publishing social accounts screen. */
 "prepublishing.socialAccounts.navigationTitle" = "Media Sosial";
+
+/* Table section title */
+"prepublishing.socialAccounts.servicesSectionTitle" = "Layanan";
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.tags" = "Tag";
@@ -11357,6 +11793,18 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Button to progress to the next step after selecting domain in Site Creation */
 "siteCreation.domains.buttons.selectDomain" = "Pilih domain";
 
+/* Default text for adding a new item when no label is provided */
+"siteCustomTaxonomies.defaultAddNew" = "Tambah";
+
+/* Description for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.description" = "Taksonomi membantu Anda menata konten lebih lanjut di samping penataan dengan kategori dan tag standar.";
+
+/* Title for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.title" = "Tidak ada taksonomi khusus";
+
+/* Navigation title for the custom taxonomies screen */
+"siteCustomTaxonomies.navigationTitle" = "Taksonomi";
+
 /* Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio. */
 "siteMedia.accessibilityLabelAudio" = "Audio, %@";
 
@@ -11375,8 +11823,77 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Accessibility hint for actions when displaying media items. */
 "siteMedia.cellAccessibilityHint" = "Pilih media.";
 
+/* Label for the alt for a media asset (image) */
+"siteMedia.details.altText" = "Teks Alt";
+
+/* Verb. Button title. Tapping cancels an action. */
+"siteMedia.details.cancel" = "Batalkan";
+
+/* Noun. Label for the caption for a media asset (image / video) */
+"siteMedia.details.caption" = "Keterangan";
+
+/* Title for button that permanently deletes a media item (photo / video) */
+"siteMedia.details.delete" = "Hapus";
+
+/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
+"siteMedia.details.deleteConfirmation" = "Anda yakin ingin menghapus item ini secara permanen?";
+
+/* Text displayed in HUD after successfully deleting a media item */
+"siteMedia.details.deleted" = "Dihapus!";
+
+/* Text displayed in HUD while a media item is being deleted. */
+"siteMedia.details.deleting" = "Menghapus ...";
+
+/* Label for the description for a media asset (image / video) */
+"siteMedia.details.description" = "Deskripsi";
+
+/* Label for the dimensions in pixels for a media asset (image / video) */
+"siteMedia.details.dimensions" = "Dimensi";
+
+/* Label for the file name for a media asset (image / video) */
+"siteMedia.details.fileName" = "Nama File";
+
+/* Label for the file size for a media asset (image / video) */
+"siteMedia.details.fileSize" = "Ukuran File";
+
+/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
+"siteMedia.details.fileType" = "Tipe File";
+
+/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
+"siteMedia.details.mediaDeleted" = "Item media ini sudah dihapus.";
+
+/* Noun. Label for the title of a media asset (image / video) */
+"siteMedia.details.title" = "Judul";
+
+/* Accessibility label for trash buttons in nav bars */
+"siteMedia.details.trash" = "Buang";
+
+/* Text displayed in HUD if there was an error attempting to delete a media item. */
+"siteMedia.details.unableToDeleteMedia" = "Tidak dapat menghapus item media.";
+
+/* Error shown when the app fails to load a video from the user's media library. */
+"siteMedia.details.unableToLoadVideo" = "Tidak dapat memuat video.";
+
+/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
+"siteMedia.details.unableToSaveMedia" = "Tidak dapat menyimpan item media.";
+
+/* Label for the date a media asset (image / video) was uploaded */
+"siteMedia.details.uploaded" = "Sudah diunggah";
+
 /* Title for the URL field */
 "siteMedia.details.url" = "URL";
+
+/* Hint for image alt on image settings. */
+"siteMedia.hints.imageAlt" = "Gambar Alternatif";
+
+/* Hint for image caption on image settings. */
+"siteMedia.hints.imageCaption" = "Keterangan Gambar";
+
+/* Hint for image description on image settings. */
+"siteMedia.hints.imageDescription" = "Deskripsi Gambar";
+
+/* Hint for image title on image settings. */
+"siteMedia.hints.imageTitle" = "Judul gambar";
 
 /* Accessibility hint for media item preview for user's viewing an item in their media library */
 "siteMediaItem.contentViewAccessibilityHint" = "Ketuk untuk melihat media dalam layar penuh";
@@ -11474,6 +11991,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Privasi";
+
+/* Format string for adding a new taxonomy term. %1$@ is the taxonomy name. */
+"siteTaxonomy.addNew.format" = "Tambahkan %1$@";
 
 /* Hint for users when hidden privacy setting is set */
 "siteVisibility.hidden.hint" = "Situs Anda belum dapat dilihat pengunjung dan masih bertuliskan “Akan Segera Hadir”.";
@@ -12036,7 +12556,8 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Subject of new Zendesk ticket. */
 "support.zendesk.readerAppTicketSubject" = "Pembaca untuk Dukungan iOS";
 
-/* Description for empty state when there are no tags */
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
 "tags.empty.description" = "Tag membantu mengatur konten Anda dan memudahkan pembaca menemukan pos terkait.";
 
 /* Title for empty state when there are no tags */
@@ -12113,9 +12634,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "belum dibaca";
-
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "Pengikut Situs";
 
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "Pengguna Situs";
@@ -12201,9 +12719,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* The heading at the top of the user list */
 "userlist.title" = "Pengguna";
-
-/* Site Subscribers */
-"users.list.title.subscribers" = "Pengikut";
 
 /* Screen title */
 "users.title" = "Pengguna";

--- a/WordPress/Resources/is.lproj/Localizable.strings
+++ b/WordPress/Resources/is.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 /* Translation-Revision-Date: 2022-05-03 21:53:34+0000 */
 /* Plural-Forms: nplurals=2; plural=n % 10 != 1 || n % 100 == 11; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: is */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -137,8 +137,7 @@
 /* No comment provided by engineer. */
 "Allow this connection to be used by all admins and users of your site." = "Leyfa öllum stjórnendum og notendum þessa vefs að nota þessa tengingu.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Skýringartexti";
 
 /* An error description explaining that a Menu could not be created. */
@@ -191,9 +190,6 @@
 
 /* Menus confirmation text for confirming if a user wants to delete a menu. */
 "Are you sure you want to delete the menu?" = "Ertu viss um að þú viljir eyða valmyndinni?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "Ertu viss um að þú viljir eyða þessum hlut varanlega?";
 
 /* No comment provided by engineer. */
 "Authenticating" = "Athuga auðkenni";
@@ -300,7 +296,6 @@
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Hætta við";
@@ -313,8 +308,7 @@
 /* Dialog box title for when the user is canceling an upload. */
 "Cancel media uploads" = "Hætta við skráarupphal";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Myndatexti";
 
 /* Alert title. */
@@ -517,8 +511,7 @@
 /* Action title. Noun. Opens the user's WordPress.com dashboard in an external browser. */
 "Dashboard" = "Stjórnborð";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Sjálfgefinn flokkur";
 
 /* Label for selecting the default post format
@@ -527,9 +520,6 @@
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Sjálfgildi fyrir nýjar færslur";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Eyða";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Eyða valmynd";
@@ -545,25 +535,15 @@
 /* Title of alert when site deletion fails */
 "Delete Site Error" = "Villa við að eyða vef";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Eytt!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Eyði vef...";
 
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Eyði...";
-
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Lýsing";
 
 /* Details button that appears in the Theme Browser Header
    Theme Details action title */
 "Details" = "Upplýsingar";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Mál";
 
 /* Adjective. Comment threading is disabled. */
 "Disabled" = "Óvirk";
@@ -647,7 +627,7 @@
 /* Title for the edit sharing buttons section */
 "Edit sharing buttons" = "Breyta deilihnöppum";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Ritstjóri";
 
 /* Accessibility label for the Email text field.
@@ -733,11 +713,8 @@
 /* A short message to inform the user data for their sites are being fetched. */
 "Fetching sites..." = "Sæki vefi...";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "Skráarnafn";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Skráartegund";
 
 /* Register Domain - Domain contact information field First name
    User's First Name */
@@ -835,14 +812,8 @@
 /* Hint for image caption on image settings. */
 "Image Caption" = "Myndatexti";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Lýsing myndar";
-
 /* Title of the screen for choosing an image's size. */
 "Image Size" = "Stærð myndar";
-
-/* Hint for image title on image settings. */
-"Image title" = "Titill myndar";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "Í fáeinum orðum, segðu hvað þessi vefur gerir eða fjallar um.";
@@ -1124,9 +1095,6 @@
 /* Accessibility label for the next notification button */
 "Next notification" = "Næsta tilknning";
 
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Enginn flokkur";
-
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Engin tenging";
 
@@ -1317,9 +1285,6 @@
    Settings: Comments Paging preferences */
 "Paging" = "Síðuskipting";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Yfirflokkur";
-
 /* Accessibility label for the password text field in the self-hosted login page.
    Label for entering password in password field
    Login dialog password placeholder
@@ -1373,9 +1338,6 @@
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Færsla";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Færsluflokkar";
 
 /* Insights 'Posting Activity' header
    Title for stats Posting Activity view. */
@@ -1779,6 +1741,7 @@
 "Tagline" = "Kjörorð";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Efnisorð";
 
@@ -1892,9 +1855,6 @@
 /* An error message display if the users device does not have a camera input available */
 "This app needs permission to access the Camera to capture new media, please change the privacy settings if you wish to allow this." = "Þetta forrit þarf heimild til þess að komast í myndavélina og taka nýjar myndir\/myndbönd, vinsamlegast breyttu persónuverndarstillingum ef þú vilt leyfa þetta.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "Þessari skrá hefur verið eytt.";
-
 /* A description of the twitter sharing setting.
    Information about the twitter sharing feature. */
 "This will be included in tweets when people share using the Twitter button." = "Þetta fylgir með í tístunum þegar fólk deilir með því að nota Twitter hnappinn.";
@@ -1911,7 +1871,6 @@
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Titill";
@@ -1930,8 +1889,7 @@
 /* Shortened version of the main title to be used in back navigation */
 "Topic" = "Umfjöllunarefni";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Rusl";
 
@@ -1970,15 +1928,6 @@
 
 /* Title of error prompt shown when a sync the user initiated fails. */
 "Unable to Sync" = "Gat ekki samstillt";
-
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "Gat ekki eytt skrá.";
-
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "Gat ekki hlaðið myndbandi.";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "Gat ekki vistað skrá.";
 
 /* Error reason to display when the writing of a image to a file fails */
 "Unable to write image to file" = "Gat ekki vistað mynd í skrá";
@@ -2034,9 +1983,6 @@
 
 /* Title for button displayed when the user has an empty media library */
 "Upload Media" = "Halaðu upp skrá";
-
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Efni upphlaðið";
 
 /* \"Uploading\" Status text */
 "Uploading" = "Hlaða upp";

--- a/WordPress/Resources/it.lproj/Localizable.strings
+++ b/WordPress/Resources/it.lproj/Localizable.strings
@@ -1,6 +1,6 @@
-/* Translation-Revision-Date: 2025-10-07 11:54:09+0000 */
+/* Translation-Revision-Date: 2025-11-26 10:54:09+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: it */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -581,8 +581,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "Ci siamo quasi! Inserisci il codice di verifica dalla tua app di autenticazione.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Testo Alt (alternativo)";
 
 /* No comment provided by engineer. */
@@ -725,9 +724,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "Vuoi davvero disconnettere Jetpack dal sito?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "Vuoi davvero eliminare in modo permanente questo elemento?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "Vuoi davvero rimuovere %1$@ da %2$@?";
@@ -1082,7 +1078,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Annulla";
@@ -1110,8 +1105,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Non riesci a decidere? Puoi cambiare tema in qualsiasi momento.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Didascalia";
 
 /* Alert title. */
@@ -1777,8 +1771,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "Predefinito";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Categoria predefinita";
 
 /* Label for selecting the default post format
@@ -1787,9 +1780,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Valori predefiniti per i nuovi articoli";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Elimina";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Elimina menu";
@@ -1808,14 +1798,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "Cancella menu";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Eliminato! ";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Eliminazione del sito in corso ...";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Eliminazione...";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "Nega";
@@ -1823,8 +1807,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "Descrivi lo scopo dell'immagine. Lascia vuoto se decorativa.";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Descrizione";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1842,9 +1825,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "Non volevi creare un nuovo account? Torna indietro per inserire nuovamente l'indirizzo email.";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Dimensioni";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "Disattiva";
@@ -2121,7 +2101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "La modifica di questa GIF rimuoverà la sua animazione.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Editor";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2463,11 +2443,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "Impostazioni blocco file";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "Nome file";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Tipo di file";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "Tipo di file non supportato come file multimediale.";
@@ -2781,6 +2758,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post content used in the login prologue screens. */
 "I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next" = "Sono ispirato dal lavoro del fotografo Cameron Karsten. Proverò queste tecniche durante il mio prossimo";
 
+/* Text on the support form to refer to what area the user has problem with. */
+"I need help with" = "Ho bisogno di aiuto con";
+
 /* Describes the IP address section in the comment detail screen. */
 "IP address" = "Indirizzo IP";
 
@@ -2826,9 +2806,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "Didascalia immagine";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Descrizione immagine";
-
 /* Hint for image link on image settings. */
 "Image Link" = "Collegamento all'immagine";
 
@@ -2840,9 +2817,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "File immagine non trovato.";
-
-/* Hint for image title on image settings. */
-"Image title" = "Titolo immagine";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "Spiega in poche parole di cosa tratta il sito.";
@@ -3205,6 +3179,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the button that will dismiss this view. */
 "Let me know when finished!" = "Informami una volta terminata l'operazione.";
 
+/* Message info on the support screen. */
+"Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon." = "Inserisci l'indirizzo del tuo sito (URL) e parlaci in dettaglio del problema: ti contatteremo al più presto.";
+
+/* Title to let the user know what do we want on the support screen. */
+"Let’s get this sorted" = "Mettiamo ordine";
+
 /* Lifestyle site intent topic */
 "Lifestyle" = "Stile di vita";
 
@@ -3405,6 +3385,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Navigazione principale";
+
+/* Explanation for the option to enable theme styles */
+"Make the block editor look like your theme." = "Rendi l'editor a blocchi simile al tuo tema.";
 
 /* No comment provided by engineer. */
 "Make your content stand out by adding images, gifs, videos, and embedded media to your pages." = "Metti in evidenza i tuoi contenuti aggiungendo immagini, GIF ed elementi multimediali alle tue pagine.";
@@ -3747,9 +3730,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "Nessun account trovato";
-
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Nessuna categoria";
 
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Nessuna connessione";
@@ -4191,9 +4171,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "Paginazione";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Categoria Genitore";
-
 /* Parenting site intent topic */
 "Parenting" = "Essere genitori";
 
@@ -4411,9 +4388,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Invia";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Categorie articoli";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "Impostazioni articolo";
@@ -4722,9 +4696,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "Rimuovi i metadati sulla localizzazione dalle tue foto prima di caricarle nel tuo sito.";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "La rimozione dei follower impedisce loro di ricevere aggiornamenti dal tuo sito. Se lo preferiscono, possono comunque visitare il tuo sito e seguirlo di nuovo.";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "Sostituisci blocco attuale";
@@ -5561,6 +5532,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "Motto";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Tag";
 
@@ -5657,6 +5629,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint, informing user the button can be used to visit the Gravatar website. */
 "Tap to visit the Gravatar website in an external browser" = "Tocca per visitare il sito web di Gravatar in un browser esterno";
+
+/* Label for viewing the custom taxonomies */
+"Taxonomies" = "Tassonomie";
 
 /* Technology site intent topic */
 "Technology" = "Tecnologia";
@@ -5946,9 +5921,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "Il codice di accesso è scaduto. Tocca il pulsante Scansiona di nuovo per scansionare nuovamente il codice.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "Questo elemento multimediale è stato eliminato.";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "Questo account utente non può essere chiuso se sono presenti revoche non risolte.";
 
@@ -6017,7 +5989,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Titolo";
@@ -6111,8 +6082,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "Trasforma il blocco...";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Elimina";
 
@@ -6209,9 +6179,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "Impossibile creare nuovi link di invito.";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "Non è possibile eliminare l'elemento multimediale. ";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "Impossibile disattivare i link di invito.";
 
@@ -6242,9 +6209,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "Impossibile caricare questo contenuto al momento.";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "Impossibile caricare il video.";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Impossibile riprodurre il video";
 
@@ -6253,9 +6217,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Impossibile ripristinare il sito";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "Impossibile salvare l'elemento multimediale";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "Impossibile condividere il link";
@@ -6412,9 +6373,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Upload fallito";
 
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Caricato";
-
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "1 articolo bozza e %ld file caricati";
 
@@ -6456,6 +6414,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The button title text for logging in with WP.com password instead of magic link. */
 "Use password to sign in" = "Usa la password per accedere";
+
+/* Option to enable theme styles in the block editor */
+"Use theme styles" = "Usa gli stili del tema";
 
 /* A placeholder for the twitter username
    Accessibility label for the username text field in the self-hosted login page.
@@ -6906,7 +6867,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "Mappa del mondo che mostra le visualizzazioni per Paese.";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "Desideri ancora rimuovere questa persona?";
 
 /* Button title. Opens the editor to write a new post.
@@ -7377,14 +7338,19 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Description for the prompt to upgrade to Application Passwords. The first argument is the name of the feature that requires Application Passwords. */
 "applicationPasswordRequired.description" = "Le password per applicazioni sono un modo più sicuro di connettersi al tuo sito ospitato personalmente e supportano funzioni quali %@.";
 
+/* Feature name for managing application passwords in the app */
+"applicationPasswordRequired.feature.applicationPasswords" = "Gestione delle password per applicazioni";
+
 /* Feature name for the block editor in application password required prompt */
 "applicationPasswordRequired.feature.blockEditor" = "Editor a blocchi";
+
+/* Feature name for managing terms and taxonomies in the app */
+"applicationPasswordRequired.feature.customTaxonomies" = "Gestione delle tassonomie";
 
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "Plugin di gestione";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "Gestione utente";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -7607,6 +7573,288 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 
 /* Post Editor / Button in the 'More' menu */
 "classicEditor.moreMenu.saveDraft" = "Salva bozza";
+
+/* Button to add more screenshots */
+"com.jetpack.support.addMoreScreenshots" = "Aggiungi altri screenshot";
+
+/* Button to add screenshots */
+"com.jetpack.support.addScreenshots" = "Screenshot";
+
+/* Header for application logs section */
+"com.jetpack.support.applicationLogs" = "Log applicazione";
+
+/* Description explaining why including logs is helpful */
+"com.jetpack.support.applicationLogsDescription" = "Includere i log può aiutare il nostro team a investigare i problemi. I log potrebbero contenere attività recenti delle app.";
+
+/* Navigation title for application logs screen */
+"com.jetpack.support.applicationLogsTitle" = "Log applicazione";
+
+/* Format string for attachment identifier */
+"com.jetpack.support.attachment" = "Allegato %@";
+
+/* Format string for attachment size limit. %1$@ is current size, %2$@ is maximum size */
+"com.jetpack.support.attachmentLimit" = "Limite allegato: %1$@ \/ %2$@";
+
+/* Bot greeting message. %1$@ is the user's name */
+"com.jetpack.support.botGreeting" = "Ciao, %1$@!";
+
+/* Bot introduction message explaining its purpose */
+"com.jetpack.support.botIntroduction" = "Sono il tuo assistente IA personale. Posso aiutarti in caso tu abbia domande sul tuo sito o sul tuo account.";
+
+/* Format string for cache file count and size. %1$d is the number of files, %2$@ is the formatted size. The system will pluralize 'files' based on the number – please specify it as the largest plural value */
+"com.jetpack.support.cacheFiles" = "%1$d file memorizzati nella cache (%2$@)";
+
+/* Message shown when cache has no files */
+"com.jetpack.support.cacheIsEmpty" = "La cache è vuota";
+
+/* Button to cancel current action */
+"com.jetpack.support.cancel" = "Annulla";
+
+/* Warning message that deleted logs cannot be recovered */
+"com.jetpack.support.cannotRecoverLogs" = "Non sarai in grado di recuperarli.";
+
+/* Button to clear all activity logs */
+"com.jetpack.support.clearAllActivityLogs" = "Cancella tutti i log delle vecchie attività";
+
+/* Button to clear disk cache */
+"com.jetpack.support.clearDiskCache" = "Cancella cache del disco";
+
+/* Description explaining the purpose of clearing disk cache */
+"com.jetpack.support.clearDiskCacheDescription" = "Rimuovi i file temporanei per liberare spazio o risolvere i problemi.";
+
+/* Progress text while clearing cache */
+"com.jetpack.support.clearing" = "Cancellazione in corso...";
+
+/* Message shown when cache clearing is complete */
+"com.jetpack.support.complete" = "Completata";
+
+/* Confirmation message when canceling a draft */
+"com.jetpack.support.confirmCancelMessage" = "Desideri annullare questo messaggio? Perderai tutti i dati inseriti";
+
+/* Title for alert confirming cancellation */
+"com.jetpack.support.confirmCancellation" = "Conferma cancellazione";
+
+/* Confirmation dialog title when deleting all logs */
+"com.jetpack.support.confirmDeleteAllLogs" = "Desideri eliminare tutti i log?";
+
+/* Section title for contact information */
+"com.jetpack.support.contactInformation" = "Informazioni di contatto";
+
+/* Button to continue editing a message */
+"com.jetpack.support.continueWriting" = "Continua a scrivere";
+
+/* Message shown at end of closed support conversation */
+"com.jetpack.support.conversationEnded" = "Fine della conversazione. Non sono possibili ulteriori risposte.";
+
+/* Navigation title for bot conversations list */
+"com.jetpack.support.conversations" = "Conversazioni";
+
+/* Button to delete all log files */
+"com.jetpack.support.deleteAllLogs" = "Elimina tutti i log";
+
+/* Description text for diagnostics screen */
+"com.jetpack.support.diagnosticsDescription" = "Esegui le attività di manutenzione e risoluzione dei problemi più comuni.";
+
+/* Navigation title for diagnostics screen */
+"com.jetpack.support.diagnosticsTitle" = "Diagnostica";
+
+/* Button to discard changes in a draft message */
+"com.jetpack.support.discardChanges" = "Rimuovi le modifiche";
+
+/* Notice explaining where support will send email responses */
+"com.jetpack.support.emailNotice" = "Ti invieremo un'e-mail a questo indirizzo.";
+
+/* Error title when logs fail to load */
+"com.jetpack.support.errorLoadingLogs" = "Errore durante il caricamento dei log";
+
+/* Error message when support conversations fail to load */
+"com.jetpack.support.errorLoadingSupportConversations" = "Errore durante il caricamento delle conversazioni di supporto";
+
+/* Title for error alerts */
+"com.jetpack.support.errorTitle" = "Errore";
+
+/* Option to export log as a file */
+"com.jetpack.support.exportAsFile" = "Esporta come file";
+
+/* Button to dismiss alerts. */
+"com.jetpack.support.gotIt" = "Ricevuto";
+
+/* Text on the support form to refer to what area the user has problem with. */
+"com.jetpack.support.iNeedHelp" = "Ho bisogno di aiuto con";
+
+/* Toggle label to include application logs in the support request */
+"com.jetpack.support.includeApplicationLogs" = "Includi log applicazione";
+
+/* Section title for issue details */
+"com.jetpack.support.issueDetails" = "Dettagli del problema";
+
+/* Format string for when conversation was last updated */
+"com.jetpack.support.lastUpdated" = "Ultimo aggiornamento %@";
+
+/* Progress message while loading conversation messages */
+"com.jetpack.support.loadingBotConversationMessages" = "Caricamento dei messaggi in corso";
+
+/* Progress message while loading bot conversations */
+"com.jetpack.support.loadingBotConversations" = "Caricamento delle conversazioni dei bot";
+
+/* Progress text while loading support conversations */
+"com.jetpack.support.loadingConversations" = "Caricamento delle conversazioni";
+
+/* Progress message while loading disk usage information */
+"com.jetpack.support.loadingDiskUsage" = "Caricamento dell'utilizzo del disco";
+
+/* Progress message while loading an image attachment */
+"com.jetpack.support.loadingImage" = "Caricamento dell'immagine";
+
+/* Progress message shown in overlay while refreshing content */
+"com.jetpack.support.loadingLatestContent" = "Caricamento del contenuto più recente";
+
+/* Progress message while loading application log content */
+"com.jetpack.support.loadingLogContent" = "Caricamento del contenuto dei log...";
+
+/* Progress message while loading log files */
+"com.jetpack.support.loadingLogs" = "Caricamento dei log...";
+
+/* Progress text while loading conversation messages */
+"com.jetpack.support.loadingMessages" = "Caricamento dei messaggi in corso";
+
+/* Progress message while loading a video attachment */
+"com.jetpack.support.loadingVideo" = "Caricamento dei video";
+
+/* Section header for log files sorted by date */
+"com.jetpack.support.logFilesByDate" = "File di log per data di creazione";
+
+/* Text indicating which log files will be included in the support request */
+"com.jetpack.support.logFilesToUpload" = "Verranno caricati i seguenti file di log:";
+
+/* Footer text explaining log retention policy */
+"com.jetpack.support.logRetentionNotice" = "I file di log vengono salvati per massimo sette giorni.";
+
+/* Section header for message text input */
+"com.jetpack.support.message" = "Messaggio";
+
+/* Success message when reply is sent successfully */
+"com.jetpack.support.messageSent" = "Messaggio inviato";
+
+/* Format string for number of messages in conversation */
+"com.jetpack.support.messagesCount" = "%d messaggi";
+
+/* The title of a new bot chat in the support area of the app */
+"com.jetpack.support.new-bot-chat" = "Nuova chat del bot";
+
+/* Option to create a new support ticket */
+"com.jetpack.support.newSupportTicket" = "Nuovo ticket di supporto";
+
+/* Label shown when there are no bot conversations */
+"com.jetpack.support.noConversations" = "Nessuna conversazione";
+
+/* Description shown when no log files are available */
+"com.jetpack.support.noLogsAvailable" = "Non sono disponibili log di attività";
+
+/* Label shown when no log files are available */
+"com.jetpack.support.noLogsFound" = "Nessun log trovato";
+
+/* Button to open a support ticket */
+"com.jetpack.support.openSupportTicket" = "Apri un ticket di supporto";
+
+/* Text indicating a field is optional */
+"com.jetpack.support.optional" = "(Opzionale)";
+
+/* Navigation title for replying to a support conversation */
+"com.jetpack.support.reply" = "Rispondi";
+
+/* Description for saving log as a file */
+"com.jetpack.support.saveAsFile" = "Salva come file da condividere o archiviare";
+
+/* Label for screenshots section */
+"com.jetpack.support.screenshots" = "Screenshot";
+
+/* Description for screenshots section */
+"com.jetpack.support.screenshotsDescription" = "Allegare degli screenshot può aiutarci a capire e risolvere il tuo problema più velocemente.";
+
+/* Button to send a message or reply */
+"com.jetpack.support.send" = "Invia";
+
+/* Description for sending logs to support */
+"com.jetpack.support.sendLogsToSupport" = "Invia i log direttamente al team di supporto";
+
+/* Progress text while sending a message */
+"com.jetpack.support.sending" = "Invio in corso";
+
+/* Progress message shown while sending a message */
+"com.jetpack.support.sendingMessage" = "Invio del messaggio";
+
+/* Button to share content */
+"com.jetpack.support.share" = "Condividi";
+
+/* Navigation title for sharing activity log */
+"com.jetpack.support.shareActivityLog" = "Condividi log attività";
+
+/* Message shown when sharing log with support */
+"com.jetpack.support.sharingWithSupport" = "Condivisione con il supporto!";
+
+/* Site Address title on the support form */
+"com.jetpack.support.siteAddress" = "Indirizzo del sito";
+
+/* Placeholder for site address field */
+"com.jetpack.support.siteAddressPlaceholder" = "https:\/\/yoursite.com";
+
+/* Description encouraging user to start a new conversation */
+"com.jetpack.support.startNewConversation" = "Inizia una nuova conversazione usando il pulsante sopra";
+
+/* Subject title on the support form */
+"com.jetpack.support.subject" = "Oggetto";
+
+/* Placeholder for subject field */
+"com.jetpack.support.subjectPlaceholder" = "Breve riassunto del problema";
+
+/* Button title to submit a support request. */
+"com.jetpack.support.submitRequest" = "Invia la richiesta di supporto";
+
+/* Navigation title for the support conversations list */
+"com.jetpack.support.supportConversations" = "Conversazioni del supporto";
+
+/* Title for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSent" = "Richiesta inviata!";
+
+/* Message for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSentMessage" = "La tua richiesta di supporto è stata inviata correttamente. Ti risponderemo al più presto via e-mail.";
+
+/* Progress message shown while bot is thinking */
+"com.jetpack.support.thinking" = "Sto pensando…";
+
+/* Title of the view for contacting support. */
+"com.jetpack.support.title" = "Contatta il supporto";
+
+/* Button to retry a failed operation */
+"com.jetpack.support.tryAgain" = "Riprova";
+
+/* Error title when log deletion fails */
+"com.jetpack.support.unableToDeleteLogs" = "Impossibile eliminare i log";
+
+/* Error message when conversation cannot be displayed */
+"com.jetpack.support.unableToDisplayConversation" = "Impossibile visualizzare la conversazione";
+
+/* Error title when video cannot be loaded or played */
+"com.jetpack.support.unableToDisplayVideo" = "Impossibile visualizzare il video";
+
+/* Error message when application logs cannot be loaded */
+"com.jetpack.support.unableToLoadApplicationLogs" = "Impossibile caricare i log dell'applicazione";
+
+/* Error title when bot conversations fail to load */
+"com.jetpack.support.unableToLoadConversations" = "Impossibile caricare le conversazioni";
+
+/* Error title when messages fail to load */
+"com.jetpack.support.unableToLoadMessages" = "Impossibile caricare i messaggi";
+
+/* Error title when message sending fails */
+"com.jetpack.support.unableToSendMessage" = "Impossibile inviare il messaggio";
+
+/* Button to view an attachment */
+"com.jetpack.support.view" = "Visualizza";
+
+/* Progress message shown during cache clearing operation */
+"com.jetpack.support.working" = "In elaborazione";
 
 /* Displayed in the confirmation alert when marking comment notifications as read. */
 "comment" = "commento";
@@ -7867,6 +8115,9 @@ Example: Reply to Pamela Nguyen */
 /* Weekly Roundup debug menu item */
 "debugMenu.weeklyRoundup" = "Resoconto settimanale";
 
+/* Title for selecting a default category for a post */
+"defaultCategory.title" = "Categoria predefinita";
+
 /* Error tilte */
 "discussionSettings.saveErrorTitle" = "Impossibile salvare le impostazioni";
 
@@ -8006,10 +8257,10 @@ Example: Reply to Pamela Nguyen */
 "double-tap to change unit" = "tocca due volte per modificare l'unità";
 
 /* Message for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.message" = "Sei sicuro di voler cancellare questo tag?";
+"edit.tag.delete.confirmation.message" = "Desideri eliminare questo elemento?";
 
-/* Title for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.title" = "Elimina tag";
+/* Title for delete a term confirmation dialog */
+"edit.tag.delete.confirmation.title" = "Elimina";
 
 /* Placeholder text for tag description field */
 "edit.tag.description.placeholder" = "Aggiungi una descrizione...";
@@ -8022,6 +8273,39 @@ Example: Reply to Pamela Nguyen */
 
 /* Section header for tag description in edit tag view */
 "edit.tag.section.description" = "Descrizione";
+
+/* Section header for tag name in edit tag view */
+"edit.tag.section.tag" = "Nome";
+
+/* Context menu action to insert a block */
+"editor.blockInserter.insertBlock" = "Inserisci blocco";
+
+/* Placeholder text for block search field */
+"editor.blockInserter.search" = "Cerca";
+
+/* Button title to collapse and show fewer blocks */
+"editor.blockInserter.showLess" = "Mostra meno";
+
+/* Button title to expand and show more blocks */
+"editor.blockInserter.showMore" = "Mostra altro";
+
+/* Error message when media insertion fails */
+"editor.media.failedToInsert" = "Inserimento file multimediali non riuscito";
+
+/* Category name for section showing all patterns */
+"editor.patterns.all" = "Tutti";
+
+/* Context menu action to insert a pattern */
+"editor.patterns.insertPattern" = "Inserisci pattern";
+
+/* Title shown when no patterns match the search */
+"editor.patterns.noPatternsFound" = "Nessun modello trovato";
+
+/* Navigation title for patterns view */
+"editor.patterns.title" = "Pattern";
+
+/* Category name for patterns without a category */
+"editor.patterns.uncategorized" = "Senza categoria";
 
 /* Register Domain - Address information field Number placeholder */
 "eg. 1122334455" = "ad esempio 1122334455";
@@ -8572,6 +8856,24 @@ Example: Reply to Pamela Nguyen */
 
 /* Write a blog prompt for the jetpack prologue */
 "jetpack.prologue.prompt.writeBlog" = "Scrivi un blog";
+
+/* Description for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.description" = "Chiunque può visualizzare questo articolo";
+
+/* Title for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.title" = "Tutti";
+
+/* Description for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.description" = "Solo gli abbonati a pagamento possono visualizzare questo articolo";
+
+/* Title for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.title" = "Abbonati a pagamento";
+
+/* Description for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.description" = "L'articolo è visibile a tutti gli abbonati, inclusi quelli gratuiti";
+
+/* Title for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.title" = "Tutti gli iscritti";
 
 /* Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account */
 "jetpackSite.connectToDefaultAccount" = "Devi accedere con %@ per poter utilizzare le Statistiche e le Notifiche.";
@@ -9144,6 +9446,12 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "Non disponi dell'autorizzazione per visualizzare questo blog privato.";
 
+/* Default empty state message format when there are no terms. %1$@ is the taxonomy name. */
+"localizedLabels.defaultNoTerms.format" = "Nessun %1$@";
+
+/* Default search placeholder format. %1$@ is the taxonomy name. */
+"localizedLabels.defaultSearch.format" = "Cerca %1$@";
+
 /* Button to dismiss the re-authentication view */
 "login.appPasswordReAuth.cancelButton" = "Annulla";
 
@@ -9279,17 +9587,23 @@ Example: Reply to Pamela Nguyen */
 /* Message about buying storage add-on */
 "mediaLibrary.storageDetails.buyStorage.message" = "Acquista spazio di archiviazione aggiuntivo";
 
-/* Message shown when all media items are attached */
-"mediaLibrary.storageDetails.cleanup.allAttached" = "Tutti gli elementi della Libreria multimediale sono allegati.";
+/* Label for audio media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.audio" = "Audio";
 
-/* Message shown while loading unattached media count */
-"mediaLibrary.storageDetails.cleanup.loading" = "Ricerca di eventuali elementi multimediali non allegati in corso...";
+/* Label for document media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.document" = "Documenti";
 
-/* Message about unattached media that can be cleaned up. %1$d is the count of unattached media. */
-"mediaLibrary.storageDetails.cleanup.message" = "%1$d elemento non allegato. Rimuovili per liberare spazio.";
+/* Label for image media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.image" = "Immagini";
 
-/* Title for cleanup section */
-"mediaLibrary.storageDetails.cleanup.title" = "Rimuovi elementi inutilizzati";
+/* Label for other/unknown media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.other" = "Altro";
+
+/* Label for PowerPoint/presentation media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.powerpoint" = "Presentazioni";
+
+/* Label for video media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.video" = "Video";
 
 /* Success message shown after upgrading plan */
 "mediaLibrary.storageDetails.purchase.plan.success" = "Il piano del sito è stato aggiornato!";
@@ -9675,6 +9989,12 @@ Example: Reply to Pamela Nguyen */
 /* Menu option for filtering posts by me */
 "pagesList.pagesByMe" = "Le mie pagine";
 
+/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
+"parentCategory.noCategory" = "Nessuna categoria";
+
+/* Title for selecting parent category of a category */
+"parentCategory.title" = "Categoria genitore";
+
 /* Title for the parent page picker screen */
 "parentPagePicker.title" = "Pagina principale";
 
@@ -9827,6 +10147,27 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the post author selection screen */
 "postAuthorPicker.title" = "Autore";
+
+/* Title for selecting categories for a post or a page */
+"postCategories.title" = "Categorie";
+
+/* Toggle label for allowing comments on post */
+"postDiscussion.allowComments.label" = "Consenti commenti";
+
+/* Toggle label for allowing pings/trackbacks on post */
+"postDiscussion.allowPings.label" = "Consenti pingback";
+
+/* Footer text when comments are disabled */
+"postDiscussion.comments.disabled.footer" = "I visitatori non possono aggiungere nuovi commenti o risposte. I commenti esistenti rimangono visibili.";
+
+/* Footer text when comments are enabled */
+"postDiscussion.comments.enabled.footer" = "I visitatori possono aggiungere nuovi commenti e risposte.";
+
+/* Link text for learning more about pingbacks and trackbacks */
+"postDiscussion.pingbacks.learnMore.text" = "Scopri di più su pingback e trackback";
+
+/* Navigation title for post discussion settings */
+"postDiscussion.title" = "Discussione";
 
 /* Button in an alert confirming discaring changes */
 "postEditor.closeConfirmationAlert.discardChanges" = "Annulla modifiche";
@@ -10059,6 +10400,9 @@ Example: Reply to Pamela Nguyen */
 /* A default value for an post without a title */
 "postSaveErrorMessage.postUntitled" = "Senza titolo";
 
+/* Section header for Access settings in Post Settings */
+"postSettings.access.header" = "Accesso";
+
 /* Label for the author field in Post Settings */
 "postSettings.author.label" = "Autore";
 
@@ -10077,6 +10421,18 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the discard changes confirmation dialog */
 "postSettings.discardChanges.title" = "Annullare le modifiche?";
+
+/* Status text when discussion (comments) is disabled */
+"postSettings.discussion.closed" = "Chiuso";
+
+/* Label for the discussion settings field in Post Settings */
+"postSettings.discussion.label" = "Discussione";
+
+/* Status text when discussion (comments) is enabled */
+"postSettings.discussion.open" = "Aperto";
+
+/* Label for the checkbox that lets you send a post to newsletter subscribers */
+"postSettings.emailToSubscribers.label" = "Invia un'e-mail agli abbonati";
 
 /* Character count for excerpt. %1$d is the number of characters. */
 "postSettings.excerpt.characterCount" = "%1$d caratteri";
@@ -10177,6 +10533,21 @@ Example: Reply to Pamela Nguyen */
 /* Cell title for the Top Level option case */
 "postSettings.parentPage.topLevel" = "Primo livello";
 
+/* Accessibility label for hide password button */
+"postSettings.passwordEntry.hidePassword" = "Nascondi password";
+
+/* Instructions for password entry */
+"postSettings.passwordEntry.instructions" = "Inserisci una password per proteggere questo articolo. Solo gli utenti con la password potranno visualizzarlo.";
+
+/* Navigation title for password entry screen */
+"postSettings.passwordEntry.navigationTitle" = "Inserisci password";
+
+/* Placeholder for password field */
+"postSettings.passwordEntry.placeholder" = "Inserisci password";
+
+/* Accessibility label for show password button */
+"postSettings.passwordEntry.showPassword" = "Mostra password";
+
 /* Message when trying to save a deleted post */
 "postSettings.postDeleted.message" = "Questo articolo è stato eliminato e non può più essere salvato.";
 
@@ -10195,17 +10566,59 @@ Example: Reply to Pamela Nguyen */
 /* Section header for General settings in Post Settings */
 "postSettings.section.general" = "Generale";
 
+/* Description text explaining what the slug editor does */
+"postSettings.slug.customizeDescription" = "Personalizza l'ultima parte del permalink.";
+
 /* Hint text for the slug field. Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso. */
 "postSettings.slug.hint" = "Lo slug è la versione URL friendly del titolo dell'articolo.";
 
 /* Label for the slug field. Should be the same as WP core. */
 "postSettings.slug.label" = "Abbreviazione";
 
+/* Button text to learn more about permalinks */
+"postSettings.slug.learnMore" = "Scopri di più";
+
+/* Label for the slug field. Should be the same as WP core. */
+"postSettings.slug.navigationTitle" = "Abbreviazione";
+
+/* Notice shown when the post doesn't have a remote and permalink template is missing */
+"postSettings.slug.permalinkDraftNotice" = "Il permalink suggerito verrà visualizzato quando la bozza viene salvata sul server";
+
+/* Label for the permalink preview */
+"postSettings.slug.permalinkLabel" = "Permalink";
+
+/* Section title for the permalink preview */
+"postSettings.slug.permalinkSection" = "Permalink";
+
 /* Placeholder for the slug field */
 "postSettings.slug.placeholder" = "Inserisci abbreviazione";
 
 /* Label for the preview button in Post Settings */
 "postSettings.socialSharing.header" = "Condivisione sui social";
+
+/* Label for the status field in Post Settings */
+"postSettings.status.label" = "Stato";
+
+/* Navigation title for status picker */
+"postSettings.statusPicker.navigationTitle" = "Stato e visibilità";
+
+/* Label showing the current password */
+"postSettings.statusPicker.passwordLabel" = "Password";
+
+/* Toggle label for password protection */
+"postSettings.statusPicker.passwordProtected" = "Protetto da password";
+
+/* Subtitle for password protected toggle */
+"postSettings.statusPicker.passwordProtectedSubtitle" = "Visibile solo da chi conosce la password";
+
+/* Label for schedule date row */
+"postSettings.statusPicker.scheduleDate" = "Data";
+
+/* Toggle label for sticky posts */
+"postSettings.statusPicker.sticky" = "In evidenza";
+
+/* Subtitle for sticky toggle */
+"postSettings.statusPicker.stickySubtitle" = "Aggiungi questo articolo alla parte superiore del blog";
 
 /* Label for the sticky post toggle. Sticky posts are displayed at the top of the blog. */
 "postSettings.stickyPost.label" = "In evidenza";
@@ -10225,14 +10638,53 @@ Example: Reply to Pamela Nguyen */
 /* Navigation bar title of the Post Stats screen */
 "postStats.title" = "Statistiche dell'articolo";
 
-/* Button to add a new tag. %1$@ is the tag name. */
-"postTags.addTag" = "Aggiungi tag";
+/* Post status title */
+"postStatus.deleted.details" = "Eliminato in modo permanente";
 
-/* Placeholder text for the tag search field */
-"postTags.searchOrAdd.placeholder" = "Cerca o aggiungi tag";
+/* Post status title */
+"postStatus.deleted.title" = "Eliminato";
 
-/* Title for the tags screen */
-"postTags.title" = "Tag";
+/* Post status details */
+"postStatus.draft.details" = "Non pronto per la pubblicazione";
+
+/* Post status title */
+"postStatus.draft.title" = "Bozza";
+
+/* Post status details */
+"postStatus.pending.details" = "In attesa di revisione prima della pubblicazione";
+
+/* Post status title */
+"postStatus.pending.title" = "In sospeso";
+
+/* Post status title */
+"postStatus.private.title" = "Privato";
+
+/* Post status details */
+"postStatus.published.details" = "Visibile a tutti";
+
+/* Post status title */
+"postStatus.published.title" = "Pubblicato";
+
+/* Post status details */
+"postStatus.scheduled.details" = "Pubblica automaticamente in una data stabilita";
+
+/* Post status title */
+"postStatus.scheduled.title" = "Pianificato";
+
+/* Post status title */
+"postStatus.trash.details" = "Cestinato ma non ancora eliminato";
+
+/* Post status title */
+"postStatus.trash.title" = "Cestinato";
+
+/* Button to add a new taxonomy term. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.addTag" = "Aggiungi %1$@";
+
+/* Placeholder text for the taxonomy search field. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.searchOrAdd.placeholder" = "Cerca o aggiungi %1$@";
+
+/* Message shown when no taxonomy terms are selected. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.selectionEmpty" = "Nessun %1$@ selezionato";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Annulla";
@@ -10308,9 +10760,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "Categorie";
-
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "Chiudi";
 
 /* Button to confirm discarding changes */
 "prepublishing.discardChanges.button" = "Rimuovi le modifiche";
@@ -10399,12 +10848,17 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "Attenzione";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "Messaggio";
+
+/* Placeholder text for the message field in Social Sharing */
+"prepublishing.socialAccounts.messagePlaceholder" = "Scrivi un breve messaggio da condividere sui social media insieme all'articolo";
 
 /* The navigation title for the pre-publishing social accounts screen. */
 "prepublishing.socialAccounts.navigationTitle" = "Social";
+
+/* Table section title */
+"prepublishing.socialAccounts.servicesSectionTitle" = "Servizi";
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.tags" = "Tag";
@@ -11336,6 +11790,18 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Button to progress to the next step after selecting domain in Site Creation */
 "siteCreation.domains.buttons.selectDomain" = "Seleziona il dominio";
 
+/* Default text for adding a new item when no label is provided */
+"siteCustomTaxonomies.defaultAddNew" = "Aggiungi";
+
+/* Description for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.description" = "Le tassonomie ti aiutano a organizzare i contenuti oltre le categorie e i tag standard.";
+
+/* Title for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.title" = "Nessuna tassonomia personalizzata";
+
+/* Navigation title for the custom taxonomies screen */
+"siteCustomTaxonomies.navigationTitle" = "Tassonomie";
+
 /* Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio. */
 "siteMedia.accessibilityLabelAudio" = "Audio, creato il giorno %@";
 
@@ -11353,6 +11819,75 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Accessibility hint for actions when displaying media items. */
 "siteMedia.cellAccessibilityHint" = "Seleziona elemento multimediale.";
+
+/* Label for the alt for a media asset (image) */
+"siteMedia.details.altText" = "Testo alternativo";
+
+/* Verb. Button title. Tapping cancels an action. */
+"siteMedia.details.cancel" = "Annulla";
+
+/* Noun. Label for the caption for a media asset (image / video) */
+"siteMedia.details.caption" = "Didascalia";
+
+/* Title for button that permanently deletes a media item (photo / video) */
+"siteMedia.details.delete" = "Elimina";
+
+/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
+"siteMedia.details.deleteConfirmation" = "Desideri eliminare in modo permanente questo elemento?";
+
+/* Text displayed in HUD after successfully deleting a media item */
+"siteMedia.details.deleted" = "Elemento eliminato.";
+
+/* Text displayed in HUD while a media item is being deleted. */
+"siteMedia.details.deleting" = "Eliminazione in corso…";
+
+/* Label for the description for a media asset (image / video) */
+"siteMedia.details.description" = "Descrizione";
+
+/* Label for the dimensions in pixels for a media asset (image / video) */
+"siteMedia.details.dimensions" = "Dimensioni";
+
+/* Label for the file name for a media asset (image / video) */
+"siteMedia.details.fileName" = "Nome file";
+
+/* Label for the file size for a media asset (image / video) */
+"siteMedia.details.fileSize" = "Dimensione del file";
+
+/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
+"siteMedia.details.fileType" = "Tipo di file";
+
+/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
+"siteMedia.details.mediaDeleted" = "Questo elemento multimediale è stato eliminato.";
+
+/* Noun. Label for the title of a media asset (image / video) */
+"siteMedia.details.title" = "Titolo";
+
+/* Accessibility label for trash buttons in nav bars */
+"siteMedia.details.trash" = "Cestino";
+
+/* Text displayed in HUD if there was an error attempting to delete a media item. */
+"siteMedia.details.unableToDeleteMedia" = "Impossibile eliminare l'elemento multimediale.";
+
+/* Error shown when the app fails to load a video from the user's media library. */
+"siteMedia.details.unableToLoadVideo" = "Impossibile caricare il video.";
+
+/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
+"siteMedia.details.unableToSaveMedia" = "Impossibile salvare l'elemento multimediale.";
+
+/* Label for the date a media asset (image / video) was uploaded */
+"siteMedia.details.uploaded" = "Caricato";
+
+/* Hint for image alt on image settings. */
+"siteMedia.hints.imageAlt" = "Alt immagine";
+
+/* Hint for image caption on image settings. */
+"siteMedia.hints.imageCaption" = "Didascalia immagine";
+
+/* Hint for image description on image settings. */
+"siteMedia.hints.imageDescription" = "Descrizione immagine";
+
+/* Hint for image title on image settings. */
+"siteMedia.hints.imageTitle" = "Titolo immagine";
 
 /* Accessibility hint for media item preview for user's viewing an item in their media library */
 "siteMediaItem.contentViewAccessibilityHint" = "Tocca per visualizzare l'elemento multimediale a schermo intero";
@@ -11450,6 +11985,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Privacy";
+
+/* Format string for adding a new taxonomy term. %1$@ is the taxonomy name. */
+"siteTaxonomy.addNew.format" = "Aggiungi %1$@";
 
 /* Hint for users when hidden privacy setting is set */
 "siteVisibility.hidden.hint" = "Il tuo sito resterà invisibile ai visitatori dietro un avviso \"Presto disponibile\" finché non sarà pronto per essere mostrato.";
@@ -12015,7 +12553,8 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Subject of new Zendesk ticket. */
 "support.zendesk.readerAppTicketSubject" = "Reader per supporto iOS";
 
-/* Description for empty state when there are no tags */
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
 "tags.empty.description" = "I tag aiutano a organizzare i tuoi contenuti e consentono ai lettori di trovare più facilmente gli articoli correlati.";
 
 /* Title for empty state when there are no tags */
@@ -12092,9 +12631,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "non lette";
-
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "Abbonati del sito";
 
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "Utenti del sito";
@@ -12180,9 +12716,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* The heading at the top of the user list */
 "userlist.title" = "Utenti";
-
-/* Site Subscribers */
-"users.list.title.subscribers" = "Iscritti";
 
 /* Screen title */
 "users.title" = "Utenti";

--- a/WordPress/Resources/ja.lproj/Localizable.strings
+++ b/WordPress/Resources/ja.lproj/Localizable.strings
@@ -1,6 +1,6 @@
-/* Translation-Revision-Date: 2025-09-16 09:54:09+0000 */
+/* Translation-Revision-Date: 2025-11-25 10:54:12+0000 */
 /* Plural-Forms: nplurals=1; plural=0; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: ja_JP */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -581,8 +581,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "もう少しで完了です。認証アプリから認証コードを入力してください。";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "代替テキスト";
 
 /* No comment provided by engineer. */
@@ -725,9 +724,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "このサイトから Jetpack の連携を解除してもよいですか ?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "この項目を完全に削除してもよいですか ?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "%2$@ から %1$@ を削除してもよいですか ?";
@@ -1082,7 +1078,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "キャンセル";
@@ -1110,8 +1105,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "決められませんか ? テーマはいつでも変更できます。";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "キャプション";
 
 /* Alert title. */
@@ -1777,8 +1771,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "デフォルト";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "デフォルトカテゴリー";
 
 /* Label for selecting the default post format
@@ -1787,9 +1780,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "新しい投稿のデフォルト";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "削除";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "メニューを削除";
@@ -1808,14 +1798,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "メニューを削除";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "削除しました。";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "サイトを削除中…";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "削除しています…";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "非承認";
@@ -1823,8 +1807,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "画像の目的を説明します。 デザインである場合は、空欄のままにします。";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "説明";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1842,9 +1825,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "新しいアカウントを作成しない場合は、 戻ってメールアドレスを再度入力してください。";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "サイズ";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "無効化";
@@ -2121,7 +2101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "この GIF を編集するとアニメーションが削除されます。";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "編集者";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2463,11 +2443,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "ファイルブロック設定";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "ファイル名";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "ファイルの種類";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "メディアファイルとしてサポートされていないファイルタイプです。";
@@ -2781,6 +2758,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post content used in the login prologue screens. */
 "I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next" = "写真家の Cameron Karsten 氏の作品にはとても感銘を受けました。 この技術を今度試すつもりです";
 
+/* Text on the support form to refer to what area the user has problem with. */
+"I need help with" = "サポートが必要な領域";
+
 /* Describes the IP address section in the comment detail screen. */
 "IP address" = "IP アドレス";
 
@@ -2826,9 +2806,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "画像のキャプション";
 
-/* Hint for image description on image settings. */
-"Image Description" = "画像の説明";
-
 /* Hint for image link on image settings. */
 "Image Link" = "画像リンク";
 
@@ -2840,9 +2817,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "画像ファイルが見つかりませんでした。";
-
-/* Hint for image title on image settings. */
-"Image title" = "画像タイトル";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "このサイトを短い文章で説明してください。";
@@ -3205,6 +3179,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the button that will dismiss this view. */
 "Let me know when finished!" = "完了時間を知らせてください !";
 
+/* Message info on the support screen. */
+"Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon." = "サイトアドレス (URL) をお知らせいただき、問題について可能な限り詳しくご説明ください。折り返しご連絡いたします。";
+
+/* Title to let the user know what do we want on the support screen. */
+"Let’s get this sorted" = "問題を解決しましょう";
+
 /* Lifestyle site intent topic */
 "Lifestyle" = "ライフスタイル";
 
@@ -3405,6 +3385,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Main Navigation" = "メインナビゲーション";
+
+/* Explanation for the option to enable theme styles */
+"Make the block editor look like your theme." = "ブロックエディターをテーマと同じ見た目にします。";
 
 /* No comment provided by engineer. */
 "Make your content stand out by adding images, gifs, videos, and embedded media to your pages." = "画像、gif、動画、埋め込みメディアをページに追加することで、コンテンツを差別化しましょう。";
@@ -3747,9 +3730,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "アカウントが見つかりません";
-
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "カテゴリーなし";
 
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "接続できません";
@@ -4191,9 +4171,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "ページング";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "親カテゴリー";
-
 /* Parenting site intent topic */
 "Parenting" = "育児";
 
@@ -4408,9 +4385,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "投稿";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "投稿カテゴリー";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "投稿設定";
@@ -4719,9 +4693,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "サイトにアップロードする前に、写真から位置情報メタデータを削除します。";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "フォロワーを削除すると、そのフォロワーにはお客様のサイトの更新情報が送信されなくなります。 そのフォロワーがお客様のサイトを再び訪問し、再度お客様のサイトをフォローすることもできます。";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "現在のブロックを置き換え";
@@ -5558,6 +5529,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "キャッチフレーズ";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "タグ";
 
@@ -5654,6 +5626,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint, informing user the button can be used to visit the Gravatar website. */
 "Tap to visit the Gravatar website in an external browser" = "タップして外部ブラウザーで Gravatar のサイトにアクセス";
+
+/* Label for viewing the custom taxonomies */
+"Taxonomies" = "タクソノミー";
 
 /* Technology site intent topic */
 "Technology" = "テクノロジー";
@@ -5943,9 +5918,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "このログインコードの有効期限は切れています。 「再スキャン」ボタンをタップしてコードをもう一度スキャンしてください。";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "このメディアファイルは削除されています。";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "未解決のチャージバックがある場合、このユーザーアカウントを閉鎖できません。";
 
@@ -6014,7 +5986,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "タイトル";
@@ -6108,8 +6079,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "ブロックを変換…";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "ゴミ箱";
 
@@ -6206,9 +6176,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "新規招待リストを作成できません。";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "メディアファイルを削除できません。";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "招待リンクを無効にできません。";
 
@@ -6239,9 +6206,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "現在このページを読み込めません。";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "動画を読み込めません。";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "動画を再生できません";
 
@@ -6250,9 +6214,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "サイトを復元できません";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "メディアファイルを保存できません。";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "リンクを共有できません";
@@ -6409,9 +6370,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "アップロードに失敗しました";
 
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "アップロード完了";
-
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "1件の下書き投稿、%ld個のファイルがアップロードされました";
 
@@ -6453,6 +6411,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The button title text for logging in with WP.com password instead of magic link. */
 "Use password to sign in" = "パスワードを使用してログイン";
+
+/* Option to enable theme styles in the block editor */
+"Use theme styles" = "テーマスタイルを使用";
 
 /* A placeholder for the twitter username
    Accessibility label for the username text field in the self-hosted login page.
@@ -6900,7 +6861,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "国別表示数の世界地図。";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "本当にこの人を削除しますか ?";
 
 /* Button title. Opens the editor to write a new post.
@@ -7371,14 +7332,19 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Description for the prompt to upgrade to Application Passwords. The first argument is the name of the feature that requires Application Passwords. */
 "applicationPasswordRequired.description" = "アプリケーションパスワードを使用するとインストール型のサイトにより安全に接続でき、%@ などの機能がサポートされます。";
 
+/* Feature name for managing application passwords in the app */
+"applicationPasswordRequired.feature.applicationPasswords" = "アプリケーションパスワード";
+
 /* Feature name for the block editor in application password required prompt */
 "applicationPasswordRequired.feature.blockEditor" = "ブロックエディター";
+
+/* Feature name for managing terms and taxonomies in the app */
+"applicationPasswordRequired.feature.customTaxonomies" = "タクソノミー管理";
 
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "プラグイン管理";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "ユーザー管理";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -7599,6 +7565,285 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 /* Post Editor / Button in the 'More' menu */
 "classicEditor.moreMenu.saveDraft" = "下書きを保存";
 
+/* Button to add more screenshots */
+"com.jetpack.support.addMoreScreenshots" = "スクリーンショットをさらに追加";
+
+/* Button to add screenshots */
+"com.jetpack.support.addScreenshots" = "スクリーンショットを追加";
+
+/* Header for application logs section */
+"com.jetpack.support.applicationLogs" = "アプリケーションログ";
+
+/* Description explaining why including logs is helpful */
+"com.jetpack.support.applicationLogsDescription" = "ログを添付すると問題の調査に役立ちます。 ログには最近のアプリのアクティビティが含まれている可能性があります。";
+
+/* Navigation title for application logs screen */
+"com.jetpack.support.applicationLogsTitle" = "アプリケーションログ";
+
+/* Format string for attachment identifier */
+"com.jetpack.support.attachment" = "添付ファイル%@";
+
+/* Format string for attachment size limit. %1$@ is current size, %2$@ is maximum size */
+"com.jetpack.support.attachmentLimit" = "添付ファイルの上限: %1$@ \/ %2$@";
+
+/* Bot greeting message. %1$@ is the user's name */
+"com.jetpack.support.botGreeting" = "%1$@さん、こんにちは！";
+
+/* Bot introduction message explaining its purpose */
+"com.jetpack.support.botIntroduction" = "あなたのパーソナル AI アシスタントです。 サイトやアカウントについての質問にお答えします。";
+
+/* Format string for cache file count and size. %1$d is the number of files, %2$@ is the formatted size. The system will pluralize 'files' based on the number – please specify it as the largest plural value */
+"com.jetpack.support.cacheFiles" = "%1$d件のキャッシュされたファイル (%2$@)";
+
+/* Message shown when cache has no files */
+"com.jetpack.support.cacheIsEmpty" = "キャッシュが空です";
+
+/* Button to cancel current action */
+"com.jetpack.support.cancel" = "キャンセル";
+
+/* Warning message that deleted logs cannot be recovered */
+"com.jetpack.support.cannotRecoverLogs" = "元に戻すことはできません。";
+
+/* Button to clear all activity logs */
+"com.jetpack.support.clearAllActivityLogs" = "すべてのアクティビティログを消去";
+
+/* Button to clear disk cache */
+"com.jetpack.support.clearDiskCache" = "ディスクキャッシュをを消去";
+
+/* Description explaining the purpose of clearing disk cache */
+"com.jetpack.support.clearDiskCacheDescription" = "一時ファイルを削除して空き容量を増やすか、問題を解決してください。";
+
+/* Progress text while clearing cache */
+"com.jetpack.support.clearing" = "消去中...";
+
+/* Message shown when cache clearing is complete */
+"com.jetpack.support.complete" = "完了";
+
+/* Confirmation message when canceling a draft */
+"com.jetpack.support.confirmCancelMessage" = "このメッセージをキャンセルしてもよいですか ? 入力したデータはすべて失われます";
+
+/* Title for alert confirming cancellation */
+"com.jetpack.support.confirmCancellation" = "キャンセルを実行";
+
+/* Confirmation dialog title when deleting all logs */
+"com.jetpack.support.confirmDeleteAllLogs" = "すべてのログを削除してもよいですか ?";
+
+/* Section title for contact information */
+"com.jetpack.support.contactInformation" = "連絡先情報";
+
+/* Button to continue editing a message */
+"com.jetpack.support.continueWriting" = "執筆を続行";
+
+/* Message shown at end of closed support conversation */
+"com.jetpack.support.conversationEnded" = "以上で会話を終了します。 これ以上返信することはできません。";
+
+/* Navigation title for bot conversations list */
+"com.jetpack.support.conversations" = "会話";
+
+/* Button to delete all log files */
+"com.jetpack.support.deleteAllLogs" = "すべてのログを削除";
+
+/* Description text for diagnostics screen */
+"com.jetpack.support.diagnosticsDescription" = "一般的なメンテナンスとトラブルシューティングのタスクを実行します。";
+
+/* Navigation title for diagnostics screen */
+"com.jetpack.support.diagnosticsTitle" = "診断";
+
+/* Button to discard changes in a draft message */
+"com.jetpack.support.discardChanges" = "変更を破棄";
+
+/* Notice explaining where support will send email responses */
+"com.jetpack.support.emailNotice" = "このアドレスにメールでお知らせします。";
+
+/* Error title when logs fail to load */
+"com.jetpack.support.errorLoadingLogs" = "ログの読み込みエラー";
+
+/* Error message when support conversations fail to load */
+"com.jetpack.support.errorLoadingSupportConversations" = "サポート会話の読み込みエラー";
+
+/* Title for error alerts */
+"com.jetpack.support.errorTitle" = "エラー";
+
+/* Option to export log as a file */
+"com.jetpack.support.exportAsFile" = "ファイルとしてエクスポート";
+
+/* Button to dismiss alerts. */
+"com.jetpack.support.gotIt" = "OK";
+
+/* Text on the support form to refer to what area the user has problem with. */
+"com.jetpack.support.iNeedHelp" = "サポートが必要な領域";
+
+/* Toggle label to include application logs in the support request */
+"com.jetpack.support.includeApplicationLogs" = "アプリケーションログを含める";
+
+/* Section title for issue details */
+"com.jetpack.support.issueDetails" = "問題の詳細";
+
+/* Format string for when conversation was last updated */
+"com.jetpack.support.lastUpdated" = "最終更新日時: %@";
+
+/* Progress message while loading conversation messages */
+"com.jetpack.support.loadingBotConversationMessages" = "メッセージを読み込んでいます";
+
+/* Progress message while loading bot conversations */
+"com.jetpack.support.loadingBotConversations" = "ボットの会話を読み込んでいます";
+
+/* Progress text while loading support conversations */
+"com.jetpack.support.loadingConversations" = "会話を読み込んでいます";
+
+/* Progress message while loading disk usage information */
+"com.jetpack.support.loadingDiskUsage" = "ディスク使用量を読み込んでいます";
+
+/* Progress message while loading an image attachment */
+"com.jetpack.support.loadingImage" = "画像を読み込んでいます";
+
+/* Progress message shown in overlay while refreshing content */
+"com.jetpack.support.loadingLatestContent" = "最新のコンテンツを読み込んでいます";
+
+/* Progress message while loading application log content */
+"com.jetpack.support.loadingLogContent" = "ログのコンテンツを読み込んでいます...";
+
+/* Progress message while loading log files */
+"com.jetpack.support.loadingLogs" = "ログを読み込んでいます...";
+
+/* Progress text while loading conversation messages */
+"com.jetpack.support.loadingMessages" = "メッセージを読み込んでいます";
+
+/* Progress message while loading a video attachment */
+"com.jetpack.support.loadingVideo" = "動画を読み込んでいます";
+
+/* Section header for log files sorted by date */
+"com.jetpack.support.logFilesByDate" = "ログファイル (作成日順)";
+
+/* Text indicating which log files will be included in the support request */
+"com.jetpack.support.logFilesToUpload" = "次のログファイルがアップロードされます:";
+
+/* Footer text explaining log retention policy */
+"com.jetpack.support.logRetentionNotice" = "最大7日間分のログが保存されます。";
+
+/* Section header for message text input */
+"com.jetpack.support.message" = "メッセージ";
+
+/* Success message when reply is sent successfully */
+"com.jetpack.support.messageSent" = "メッセージを送信しました";
+
+/* Format string for number of messages in conversation */
+"com.jetpack.support.messagesCount" = "%d件のメッセージ";
+
+/* The title of a new bot chat in the support area of the app */
+"com.jetpack.support.new-bot-chat" = "ボットの新しいチャット";
+
+/* Option to create a new support ticket */
+"com.jetpack.support.newSupportTicket" = "新しいサポートチケット";
+
+/* Label shown when there are no bot conversations */
+"com.jetpack.support.noConversations" = "会話がありません";
+
+/* Description shown when no log files are available */
+"com.jetpack.support.noLogsAvailable" = "表示できるアクティビティログがありません";
+
+/* Label shown when no log files are available */
+"com.jetpack.support.noLogsFound" = "ログが見つかりません";
+
+/* Button to open a support ticket */
+"com.jetpack.support.openSupportTicket" = "サポートチケットを開く";
+
+/* Text indicating a field is optional */
+"com.jetpack.support.optional" = "(オプション)";
+
+/* Navigation title for replying to a support conversation */
+"com.jetpack.support.reply" = "返信";
+
+/* Description for saving log as a file */
+"com.jetpack.support.saveAsFile" = "ファイル形式で保存して共有または保存";
+
+/* Label for screenshots section */
+"com.jetpack.support.screenshots" = "スクリーンショット";
+
+/* Description for screenshots section */
+"com.jetpack.support.screenshotsDescription" = "スクリーンショットを添付すると、問題の把握と解決がスムーズになります。";
+
+/* Button to send a message or reply */
+"com.jetpack.support.send" = "送信";
+
+/* Description for sending logs to support */
+"com.jetpack.support.sendLogsToSupport" = "サポートチームにログを直接送信";
+
+/* Progress text while sending a message */
+"com.jetpack.support.sending" = "送信中";
+
+/* Progress message shown while sending a message */
+"com.jetpack.support.sendingMessage" = "メッセージを送信しています";
+
+/* Button to share content */
+"com.jetpack.support.share" = "共有";
+
+/* Navigation title for sharing activity log */
+"com.jetpack.support.shareActivityLog" = "アクティビティログを共有";
+
+/* Message shown when sharing log with support */
+"com.jetpack.support.sharingWithSupport" = "サポートと共有しています";
+
+/* Site Address title on the support form */
+"com.jetpack.support.siteAddress" = "サイトのアドレス";
+
+/* Description encouraging user to start a new conversation */
+"com.jetpack.support.startNewConversation" = "上のボタンを使用して新しい会話を開始します";
+
+/* Subject title on the support form */
+"com.jetpack.support.subject" = "件名";
+
+/* Placeholder for subject field */
+"com.jetpack.support.subjectPlaceholder" = "問題の簡単な概要";
+
+/* Button title to submit a support request. */
+"com.jetpack.support.submitRequest" = "サポートリクエストを送信";
+
+/* Navigation title for the support conversations list */
+"com.jetpack.support.supportConversations" = "サポートの会話";
+
+/* Title for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSent" = "リクエストを送信しました。";
+
+/* Message for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSentMessage" = "サポートリクエストは正常に送信されました。 できるだけ早くメールで返信いたします。";
+
+/* Progress message shown while bot is thinking */
+"com.jetpack.support.thinking" = "考えています...";
+
+/* Title of the view for contacting support. */
+"com.jetpack.support.title" = "サポートに連絡";
+
+/* Button to retry a failed operation */
+"com.jetpack.support.tryAgain" = "もう一度試す";
+
+/* Error title when log deletion fails */
+"com.jetpack.support.unableToDeleteLogs" = "ログを削除できません";
+
+/* Error message when conversation cannot be displayed */
+"com.jetpack.support.unableToDisplayConversation" = "会話を表示できません";
+
+/* Error title when video cannot be loaded or played */
+"com.jetpack.support.unableToDisplayVideo" = "動画を表示できません";
+
+/* Error message when application logs cannot be loaded */
+"com.jetpack.support.unableToLoadApplicationLogs" = "アプリケーションログを読み込めません";
+
+/* Error title when bot conversations fail to load */
+"com.jetpack.support.unableToLoadConversations" = "会話を読み込めません";
+
+/* Error title when messages fail to load */
+"com.jetpack.support.unableToLoadMessages" = "メッセージを読み込めません";
+
+/* Error title when message sending fails */
+"com.jetpack.support.unableToSendMessage" = "メッセージを送信できません";
+
+/* Button to view an attachment */
+"com.jetpack.support.view" = "表示";
+
+/* Progress message shown during cache clearing operation */
+"com.jetpack.support.working" = "処理しています";
+
 /* Displayed in the confirmation alert when marking comment notifications as read. */
 "comment" = "コメント";
 
@@ -7685,6 +7930,12 @@ Example: Reply to Pamela Nguyen */
 
 /* Accessibility hint for create floating action button */
 "createPostSheet.createPostHint" = "投稿またはページを作成";
+
+/* Create Sheet button title */
+"createSheet.page" = "ページ";
+
+/* Create Sheet button title */
+"createSheet.post" = "投稿";
 
 /* Customize Insights description */
 "customizeInsightsCell.content" = "カスタマイズされたダッシュボードを作成して、表示するレポートを選択します。 最も重視するデータに集中できます。";
@@ -7852,6 +8103,9 @@ Example: Reply to Pamela Nguyen */
 /* Weekly Roundup debug menu item */
 "debugMenu.weeklyRoundup" = "1週間のまとめ";
 
+/* Title for selecting a default category for a post */
+"defaultCategory.title" = "デフォルトカテゴリー";
+
 /* Error tilte */
 "discussionSettings.saveErrorTitle" = "設定の保存に失敗しました";
 
@@ -7991,10 +8245,10 @@ Example: Reply to Pamela Nguyen */
 "double-tap to change unit" = "ダブルタップして単位を変更";
 
 /* Message for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.message" = "このタグを削除してもよいですか ?";
+"edit.tag.delete.confirmation.message" = "これを削除してもよろしいですか ?";
 
-/* Title for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.title" = "タグを削除";
+/* Title for delete a term confirmation dialog */
+"edit.tag.delete.confirmation.title" = "削除";
 
 /* Placeholder text for tag description field */
 "edit.tag.description.placeholder" = "説明を追加…";
@@ -8009,7 +8263,37 @@ Example: Reply to Pamela Nguyen */
 "edit.tag.section.description" = "説明";
 
 /* Section header for tag name in edit tag view */
-"edit.tag.section.tag" = "タグ";
+"edit.tag.section.tag" = "名前";
+
+/* Context menu action to insert a block */
+"editor.blockInserter.insertBlock" = "ブロックを挿入";
+
+/* Placeholder text for block search field */
+"editor.blockInserter.search" = "検索";
+
+/* Button title to collapse and show fewer blocks */
+"editor.blockInserter.showLess" = "簡易表示";
+
+/* Button title to expand and show more blocks */
+"editor.blockInserter.showMore" = "さらに表示";
+
+/* Error message when media insertion fails */
+"editor.media.failedToInsert" = "メディアの挿入に失敗しました";
+
+/* Category name for section showing all patterns */
+"editor.patterns.all" = "すべて";
+
+/* Context menu action to insert a pattern */
+"editor.patterns.insertPattern" = "パターンを挿入";
+
+/* Title shown when no patterns match the search */
+"editor.patterns.noPatternsFound" = "パターンが見つかりませんでした";
+
+/* Navigation title for patterns view */
+"editor.patterns.title" = "パターン";
+
+/* Category name for patterns without a category */
+"editor.patterns.uncategorized" = "未分類";
 
 /* Register Domain - Address information field Number placeholder */
 "eg. 1122334455" = "例「1122334455」";
@@ -8092,6 +8376,30 @@ Example: Reply to Pamela Nguyen */
 
 /* A footer retry button */
 "general.pagingFooterView.retry" = "再試行";
+
+/* Generated content length (needs to be short) */
+"generation.length.long" = "長い";
+
+/* Generated content length (needs to be short) */
+"generation.length.medium" = "中";
+
+/* Generated content length (needs to be short) */
+"generation.length.short" = "短い";
+
+/* AI generation style */
+"generation.style.conversational" = "会話的";
+
+/* AI generation style */
+"generation.style.engaging" = "やり取りしやすい";
+
+/* AI generation style */
+"generation.style.formal" = "フォーマル";
+
+/* AI generation style */
+"generation.style.professional" = "プロフェッショナル";
+
+/* AI generation style */
+"generation.style.witty" = "機知に富んでいる";
 
 /* A generic title for an error */
 "generic.error.title" = "エラー";
@@ -8206,6 +8514,27 @@ Example: Reply to Pamela Nguyen */
 
 /* Text for the Insights Overview stat difference label. Shows the change from the previous period. E.g.: +12.3K. %1$@ is the placeholder for the change sign ('-', '+', or none). %2$@ is the placeholder for the change numerical value. */
 "insights.visitorsLineChartCell.differenceLabelWithoutPercentage" = "%1$@%2$@";
+
+/* Message shown when Apple Intelligence is disabled */
+"intelligence.unavailableView.appleIntelligenceDisabled.message" = "AIで抜粋を生成するには、「設定」で Apple Intelligence を有効にします。 この機能は、デバイス上の処理を使ってプライバシーを保護します。";
+
+/* Button to open Apple Intelligence settings */
+"intelligence.unavailableView.appleIntelligenceDisabled.openSettings" = "設定を開く";
+
+/* Title shown when Apple Intelligence is disabled */
+"intelligence.unavailableView.appleIntelligenceDisabled.title" = "Apple Intelligence が必要です";
+
+/* Message shown when Apple Intelligence is unavailable */
+"intelligence.unavailableView.appleIntelligenceUnvailable.message" = "Apple Intelligence はこの端末では利用できません";
+
+/* Title shown when Apple Intelligence is unavailable */
+"intelligence.unavailableView.appleIntelligenceUnvailable.title" = "Apple Intelligence を利用できません";
+
+/* Description shown when the AI model is not ready */
+"intelligence.unavailableView.preparingModel.description" = "AI モデルはダウンロード中または準備中です。 しばらくしてから再度お試しください。";
+
+/* Title shown when the AI model is not ready */
+"intelligence.unavailableView.preparingModel.title" = "モデルを準備中…";
 
 /* Cancel dialog confirmation title */
 "inviteSubscribers.cancelConfirmationTitle" = "新しい購読者を破棄してもよいですか ?";
@@ -8519,6 +8848,24 @@ Example: Reply to Pamela Nguyen */
 /* Write a blog prompt for the jetpack prologue */
 "jetpack.prologue.prompt.writeBlog" = "ブログに投稿";
 
+/* Description for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.description" = "この投稿は誰でも閲覧できます";
+
+/* Title for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.title" = "全員";
+
+/* Description for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.description" = "有料購読者のみがこの投稿を閲覧可能";
+
+/* Title for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.title" = "有料購読者";
+
+/* Description for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.description" = "この投稿は無料購読者を含むすべての購読者に表示されます";
+
+/* Title for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.title" = "すべての購読者";
+
 /* Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account */
 "jetpackSite.connectToDefaultAccount" = "「統計と通知」を使用するには、%@ でログインする必要があります。";
 
@@ -8614,6 +8961,9 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for metric selection */
 "jetpackStats.addChart.selectMetric" = "メトリクスを選択";
+
+/* Today chart title */
+"jetpackStats.addChart.today" = "今日";
 
 /* Today option description
    Top list option description */
@@ -8931,6 +9281,12 @@ Example: Reply to Pamela Nguyen */
 /* Navigation title */
 "jetpackStats.postDetails.title" = "投稿統計情報";
 
+/* Section title */
+"jetpackStats.postDetails.top10" = "上位10";
+
+/* Section title */
+"jetpackStats.postDetails.top50" = "上位50";
+
 /* Must be short!Label for total email opens metric */
 "jetpackStats.postDetails.totalOpens" = "合計開封数";
 
@@ -9033,6 +9389,9 @@ Example: Reply to Pamela Nguyen */
 /* Stats screen title */
 "jetpackStats.title" = "統計";
 
+/* Today card title */
+"jetpackStats.todayCard.title" = "今日";
+
 /* Title for items with highest bounce rate */
 "jetpackStats.topList.highestBounceRate" = "バウンスレートが最高";
 
@@ -9077,6 +9436,12 @@ Example: Reply to Pamela Nguyen */
 
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "この非公開ブログの閲覧権限がありません。";
+
+/* Default empty state message format when there are no terms. %1$@ is the taxonomy name. */
+"localizedLabels.defaultNoTerms.format" = "%1$@はありません";
+
+/* Default search placeholder format. %1$@ is the taxonomy name. */
+"localizedLabels.defaultSearch.format" = "%1$@を検索";
 
 /* Button to dismiss the re-authentication view */
 "login.appPasswordReAuth.cancelButton" = "キャンセル";
@@ -9138,8 +9503,14 @@ Example: Reply to Pamela Nguyen */
 /* Button name in the more menu */
 "mediaLibrary.aspectRatioGrid" = "縦横比グリッド";
 
+/* Navigation bar button item */
+"mediaLibrary.buttonAddMedia" = "メディアを追加";
+
 /* Context menu button */
 "mediaLibrary.buttonDelete" = "削除";
+
+/* Navigation bar button item */
+"mediaLibrary.buttonFilter" = "フィルター";
 
 /* Media screen navigation bar button Select title */
 "mediaLibrary.buttonSelect" = "選択";
@@ -9198,6 +9569,51 @@ Example: Reply to Pamela Nguyen */
 /* Button name in the more menu */
 "mediaLibrary.squareGrid" = "正方形グリッド";
 
+/* Detail message for buying storage add-on */
+"mediaLibrary.storageDetails.buyStorage.detail" = "高画質の写真、動画、その他のメディア向けの容量を確保できます。";
+
+/* Message about buying storage add-on */
+"mediaLibrary.storageDetails.buyStorage.message" = "ストレージアドオンを購入";
+
+/* Label for audio media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.audio" = "音声ファイル";
+
+/* Label for document media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.document" = "文書";
+
+/* Label for image media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.image" = "画像";
+
+/* Label for other/unknown media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.other" = "その他";
+
+/* Label for PowerPoint/presentation media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.powerpoint" = "プレゼンテーション";
+
+/* Label for video media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.video" = "動画";
+
+/* Success message shown after upgrading plan */
+"mediaLibrary.storageDetails.purchase.plan.success" = "サイトプランがアップグレードされました。";
+
+/* Success message shown after purchasing storage add-on */
+"mediaLibrary.storageDetails.purchase.storage.success" = "サイトのメディアライブラリのストレージが増えました。";
+
+/* Title for the storage details screen */
+"mediaLibrary.storageDetails.title" = "メディアライブラリのストレージ";
+
+/* Detail message for upgrading plan */
+"mediaLibrary.storageDetails.upgradePlan.detail" = "ストレージ容量を増やすには、プランをアップグレードしてください。";
+
+/* Message about upgrading plan */
+"mediaLibrary.storageDetails.upgradePlan.message" = "プランをアップグレード";
+
+/* Storage usage message showing used space and total space. %1$@ is used space, %2$@ is total space. */
+"mediaLibrary.storageDetails.usage" = "%1$@ \/ %2$@ を利用中";
+
+/* Message shown while calculating storage usage */
+"mediaLibrary.storageDetails.usage.calculating" = "計算中...";
+
 /* Media screen navigation title */
 "mediaLibrary.title" = "メディア";
 
@@ -9251,6 +9667,9 @@ Example: Reply to Pamela Nguyen */
 
 /* The name of the action in the context menu */
 "mediaPicker.takeVideo" = "動画を撮影";
+
+/* The menu item of viewing media library usage */
+"mediaPicker.viewUsage" = "使用量を表示";
 
 /* Navigation title for media preview. Example: 1 of 3 */
 "mediaPreview.NofM" = "%1$@ \/ %2$@";
@@ -9558,6 +9977,12 @@ Example: Reply to Pamela Nguyen */
 /* Menu option for filtering posts by me */
 "pagesList.pagesByMe" = "自分のページ";
 
+/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
+"parentCategory.noCategory" = "カテゴリーなし";
+
+/* Title for selecting parent category of a category */
+"parentCategory.title" = "親カテゴリー";
+
 /* Title for the parent page picker screen */
 "parentPagePicker.title" = "親ページ";
 
@@ -9716,6 +10141,27 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the post author selection screen */
 "postAuthorPicker.title" = "投稿者";
+
+/* Title for selecting categories for a post or a page */
+"postCategories.title" = "カテゴリー";
+
+/* Toggle label for allowing comments on post */
+"postDiscussion.allowComments.label" = "コメントを許可";
+
+/* Toggle label for allowing pings/trackbacks on post */
+"postDiscussion.allowPings.label" = "ピンバックを許可";
+
+/* Footer text when comments are disabled */
+"postDiscussion.comments.disabled.footer" = "訪問者は新しいコメントや返信を追加できません。 既存のコメントは引き続き表示されます。";
+
+/* Footer text when comments are enabled */
+"postDiscussion.comments.enabled.footer" = "訪問者は新しいコメントや返信を追加できます。";
+
+/* Link text for learning more about pingbacks and trackbacks */
+"postDiscussion.pingbacks.learnMore.text" = "ピンバックとトラックバックについてさらに詳しく";
+
+/* Navigation title for post discussion settings */
+"postDiscussion.title" = "ディスカッション";
 
 /* Button in an alert confirming discaring changes */
 "postEditor.closeConfirmationAlert.discardChanges" = "変更を破棄";
@@ -9948,6 +10394,9 @@ Example: Reply to Pamela Nguyen */
 /* A default value for an post without a title */
 "postSaveErrorMessage.postUntitled" = "無題";
 
+/* Section header for Access settings in Post Settings */
+"postSettings.access.header" = "アクセス";
+
 /* Label for the author field in Post Settings */
 "postSettings.author.label" = "投稿者";
 
@@ -9967,8 +10416,62 @@ Example: Reply to Pamela Nguyen */
 /* Title for the discard changes confirmation dialog */
 "postSettings.discardChanges.title" = "変更を破棄しますか ?";
 
+/* Status text when discussion (comments) is disabled */
+"postSettings.discussion.closed" = "クローズド";
+
+/* Label for the discussion settings field in Post Settings */
+"postSettings.discussion.label" = "ディスカッション";
+
+/* Status text when discussion (comments) is enabled */
+"postSettings.discussion.open" = "オープン";
+
+/* Label for the checkbox that lets you send a post to newsletter subscribers */
+"postSettings.emailToSubscribers.label" = "購読者へのメール";
+
 /* Character count for excerpt. %1$d is the number of characters. */
 "postSettings.excerpt.characterCount" = "%1$d文字";
+
+/* Button to generate an excerpt using AI */
+"postSettings.excerpt.generateButton" = "生成";
+
+/* Character count display. %d is replaced with the number of characters. */
+"postSettings.excerpt.generator.characterCount" = "%d文字";
+
+/* Button to suggest (generate) more options */
+"postSettings.excerpt.generator.generateMore" = "その他のオプションを提案";
+
+/* Label for the length picker section */
+"postSettings.excerpt.generator.length" = "長さ";
+
+/* Accessibility label for the length adjustment slider */
+"postSettings.excerpt.generator.lengthSlider" = "長さスライダー";
+
+/* Button to make excerpts longer */
+"postSettings.excerpt.generator.longer" = "長い";
+
+/* Label for excerpt option number. %d is replaced with the option number. */
+"postSettings.excerpt.generator.option" = "オプション %d";
+
+/* Title shown when ready to generate excerpts */
+"postSettings.excerpt.generator.ready" = "生成準備完了";
+
+/* Description shown when ready to generate excerpts */
+"postSettings.excerpt.generator.readyDescription" = "タップして AI を活用した抜粋オプションを作成";
+
+/* Button to make excerpts shorter */
+"postSettings.excerpt.generator.shorter" = "短い";
+
+/* Title for the style picker section */
+"postSettings.excerpt.generator.style" = "文体";
+
+/* Label for the style picker section */
+"postSettings.excerpt.generator.styleLabel" = "スタイル";
+
+/* Accessibility label for the style picker */
+"postSettings.excerpt.generator.stylePicker" = "スタイル";
+
+/* Title for the excerpt generator popover */
+"postSettings.excerpt.generator.title" = "抜粋を生成";
 
 /* Section header for Excerpt in Post Settings */
 "postSettings.excerpt.header" = "抜粋";
@@ -10024,6 +10527,21 @@ Example: Reply to Pamela Nguyen */
 /* Cell title for the Top Level option case */
 "postSettings.parentPage.topLevel" = "トップレベル";
 
+/* Accessibility label for hide password button */
+"postSettings.passwordEntry.hidePassword" = "パスワードを隠す";
+
+/* Instructions for password entry */
+"postSettings.passwordEntry.instructions" = "この投稿を保護するためのパスワードを入力してください パスワードを持つユーザーのみが閲覧できます。";
+
+/* Navigation title for password entry screen */
+"postSettings.passwordEntry.navigationTitle" = "パスワードを入力";
+
+/* Placeholder for password field */
+"postSettings.passwordEntry.placeholder" = "パスワードを入力";
+
+/* Accessibility label for show password button */
+"postSettings.passwordEntry.showPassword" = "パスワードを表示";
+
 /* Label for the permalink field in Post Settings */
 "postSettings.permalink.label" = "パーマリンク";
 
@@ -10039,8 +10557,14 @@ Example: Reply to Pamela Nguyen */
 /* Label for the publish date field in Post Settings */
 "postSettings.publishDate.label" = "日付";
 
+/* Placeholder value for a publishing date in the prepublishing sheet when the date is not selected */
+"postSettings.publishDateImmediately" = "すぐに";
+
 /* Section header for General settings in Post Settings */
 "postSettings.section.general" = "一般";
+
+/* Description text explaining what the slug editor does */
+"postSettings.slug.customizeDescription" = "パーマリンクの最後の部分をカスタマイズします。";
 
 /* Hint text for the slug field. Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso. */
 "postSettings.slug.hint" = "スラッグは URL に適した形式の投稿タイトルです。";
@@ -10048,8 +10572,50 @@ Example: Reply to Pamela Nguyen */
 /* Label for the slug field. Should be the same as WP core. */
 "postSettings.slug.label" = "スラッグ";
 
+/* Button text to learn more about permalinks */
+"postSettings.slug.learnMore" = "さらに詳しく";
+
+/* Label for the slug field. Should be the same as WP core. */
+"postSettings.slug.navigationTitle" = "スラッグ";
+
+/* Notice shown when the post doesn't have a remote and permalink template is missing */
+"postSettings.slug.permalinkDraftNotice" = "下書きをサーバーに保存すると、パーマリンクの候補が表示されます";
+
+/* Label for the permalink preview */
+"postSettings.slug.permalinkLabel" = "パーマリンク";
+
+/* Section title for the permalink preview */
+"postSettings.slug.permalinkSection" = "パーマリンク";
+
 /* Placeholder for the slug field */
 "postSettings.slug.placeholder" = "スラッグを入力";
+
+/* Label for the preview button in Post Settings */
+"postSettings.socialSharing.header" = "ソーシャル共有";
+
+/* Label for the status field in Post Settings */
+"postSettings.status.label" = "ステータス";
+
+/* Navigation title for status picker */
+"postSettings.statusPicker.navigationTitle" = "ステータスと公開状態";
+
+/* Label showing the current password */
+"postSettings.statusPicker.passwordLabel" = "パスワード";
+
+/* Toggle label for password protection */
+"postSettings.statusPicker.passwordProtected" = "パスワード保護";
+
+/* Subtitle for password protected toggle */
+"postSettings.statusPicker.passwordProtectedSubtitle" = "パスワードを知っている人のみ閲覧可能";
+
+/* Label for schedule date row */
+"postSettings.statusPicker.scheduleDate" = "日付";
+
+/* Toggle label for sticky posts */
+"postSettings.statusPicker.sticky" = "先頭固定表示";
+
+/* Subtitle for sticky toggle */
+"postSettings.statusPicker.stickySubtitle" = "この投稿をブログの上部に固定";
 
 /* Label for the sticky post toggle. Sticky posts are displayed at the top of the blog. */
 "postSettings.stickyPost.label" = "先頭固定表示";
@@ -10060,11 +10626,62 @@ Example: Reply to Pamela Nguyen */
 /* Label for the tags field. Should be the same as WP core. */
 "postSettings.tags.label" = "タグ";
 
+/* Label for the tag suggestions section. */
+"postSettings.tags.suggestions" = "おすすめのタグ";
+
 /* Label for the visibility field in Post Settings */
 "postSettings.visibility.label" = "表示設定";
 
 /* Navigation bar title of the Post Stats screen */
 "postStats.title" = "投稿統計情報";
+
+/* Post status title */
+"postStatus.deleted.details" = "完全に削除しました";
+
+/* Post status title */
+"postStatus.deleted.title" = "削除済み";
+
+/* Post status details */
+"postStatus.draft.details" = "公開の準備ができていない";
+
+/* Post status title */
+"postStatus.draft.title" = "下書き";
+
+/* Post status details */
+"postStatus.pending.details" = "公開前のレビュー待ちです";
+
+/* Post status title */
+"postStatus.pending.title" = "保留中";
+
+/* Post status title */
+"postStatus.private.title" = "非公開";
+
+/* Post status details */
+"postStatus.published.details" = "すべての人に表示";
+
+/* Post status title */
+"postStatus.published.title" = "公開済み";
+
+/* Post status details */
+"postStatus.scheduled.details" = "選択した日付に自動で公開";
+
+/* Post status title */
+"postStatus.scheduled.title" = "予約済み";
+
+/* Post status title */
+"postStatus.trash.details" = "ゴミ箱に移動しましたが、まだ削除されていません";
+
+/* Post status title */
+"postStatus.trash.title" = "ゴミ箱に移動";
+
+/* Button to add a new taxonomy term. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.addTag" = "%1$@を追加";
+
+/* Placeholder text for the taxonomy search field. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.searchOrAdd.placeholder" = "%1$@を検索または追加";
+
+/* Message shown when no taxonomy terms are selected. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.selectionEmpty" = "%1$@が選択されていません";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "キャンセル";
@@ -10141,8 +10758,14 @@ Example: Reply to Pamela Nguyen */
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "カテゴリー";
 
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "閉じる";
+/* Button to confirm discarding changes */
+"prepublishing.discardChanges.button" = "変更を破棄";
+
+/* Message for the discard changes confirmation dialog */
+"prepublishing.discardChanges.message" = "投稿設定に対する変更が保存されていません。 これらを破棄してもよいですか ?";
+
+/* Title for the discard changes confirmation dialog */
+"prepublishing.discardChanges.title" = "変更を破棄しますか ?";
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.jetpackSocial" = "Jetpack ソーシャル";
@@ -10159,8 +10782,14 @@ Example: Reply to Pamela Nguyen */
 /* Placeholder value for a publishing date in the prepublishing sheet when the date is not selected */
 "prepublishing.publishDateImmediately" = "すぐに";
 
+/* The title of the top section that shows the site your are publishing to. Default is 'Ready to Publish?' */
+"prepublishing.publishingSectionTitle" = "公開する準備はできていますか ?";
+
 /* Label in the header in the pre-publishing sheet */
 "prepublishing.publishingTo" = "公開先";
+
+/* Button to confirm discarding changes */
+"prepublishing.saveChanges.button" = "変更を保存";
 
 /* Primary button label in the pre-publishing shee */
 "prepublishing.schedule" = "予約";
@@ -10213,15 +10842,23 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "警告";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "メッセージ";
+
+/* Placeholder text for the message field in Social Sharing */
+"prepublishing.socialAccounts.messagePlaceholder" = "投稿に添える短いメッセージを書いてソーシャルメディアで共有します";
 
 /* The navigation title for the pre-publishing social accounts screen. */
 "prepublishing.socialAccounts.navigationTitle" = "ソーシャル";
 
+/* Table section title */
+"prepublishing.socialAccounts.servicesSectionTitle" = "サービス";
+
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.tags" = "タグ";
+
+/* Navigation title */
+"prepublishing.title" = "公開";
 
 /* Details label for a publish button state in the pre-publishing sheet */
 "prepublishing.uploadMediaManyItemsRemaining" = "残り%@件のアイテム";
@@ -10297,6 +10934,9 @@ Tapping on this row allows the user to edit the sharing message. */
 
 /* Message of error prompt shown when no internet connection is available */
 "reachability-utils.alert.utils" = "インターネットに接続されていないようです。";
+
+/* Navigation title */
+"reader.article.summary" = "概要";
 
 /* Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog. */
 "reader.blocked.blog.message" = "ブログ %@ がリーダーに表示されなくなります。 タップして元に戻します。";
@@ -10578,6 +11218,9 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Context menu action */
 "reader.postContextMenu.showBlog" = "「ブログ」に移動";
+
+/* Context menu action */
+"reader.postContextMenu.summarize" = "まとめる";
 
 /* Context menu action */
 "reader.postContextMenu.viewInBrowser" = "ブラウザで表示";
@@ -11135,6 +11778,15 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Button to progress to the next step after selecting domain in Site Creation */
 "siteCreation.domains.buttons.selectDomain" = "ドメインを選択";
 
+/* Default text for adding a new item when no label is provided */
+"siteCustomTaxonomies.defaultAddNew" = "追加";
+
+/* Title for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.title" = "カスタムタクソノミーはありません";
+
+/* Navigation title for the custom taxonomies screen */
+"siteCustomTaxonomies.navigationTitle" = "タクソノミー";
+
 /* Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio. */
 "siteMedia.accessibilityLabelAudio" = "音声ファイル (%@)";
 
@@ -11153,8 +11805,77 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Accessibility hint for actions when displaying media items. */
 "siteMedia.cellAccessibilityHint" = "メディアを選択します。";
 
+/* Label for the alt for a media asset (image) */
+"siteMedia.details.altText" = "代替テキスト";
+
+/* Verb. Button title. Tapping cancels an action. */
+"siteMedia.details.cancel" = "キャンセル";
+
+/* Noun. Label for the caption for a media asset (image / video) */
+"siteMedia.details.caption" = "キャプション";
+
+/* Title for button that permanently deletes a media item (photo / video) */
+"siteMedia.details.delete" = "削除";
+
+/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
+"siteMedia.details.deleteConfirmation" = "この項目を完全に削除してもよいですか ?";
+
+/* Text displayed in HUD after successfully deleting a media item */
+"siteMedia.details.deleted" = "削除しました。";
+
+/* Text displayed in HUD while a media item is being deleted. */
+"siteMedia.details.deleting" = "削除しています…";
+
+/* Label for the description for a media asset (image / video) */
+"siteMedia.details.description" = "説明";
+
+/* Label for the dimensions in pixels for a media asset (image / video) */
+"siteMedia.details.dimensions" = "サイズ";
+
+/* Label for the file name for a media asset (image / video) */
+"siteMedia.details.fileName" = "ファイル名";
+
+/* Label for the file size for a media asset (image / video) */
+"siteMedia.details.fileSize" = "ファイルサイズ";
+
+/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
+"siteMedia.details.fileType" = "ファイルの種類";
+
+/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
+"siteMedia.details.mediaDeleted" = "このメディアファイルは削除されています。";
+
+/* Noun. Label for the title of a media asset (image / video) */
+"siteMedia.details.title" = "タイトル";
+
+/* Accessibility label for trash buttons in nav bars */
+"siteMedia.details.trash" = "ゴミ箱";
+
+/* Text displayed in HUD if there was an error attempting to delete a media item. */
+"siteMedia.details.unableToDeleteMedia" = "メディアファイルを削除できません。";
+
+/* Error shown when the app fails to load a video from the user's media library. */
+"siteMedia.details.unableToLoadVideo" = "動画を読み込めません。";
+
+/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
+"siteMedia.details.unableToSaveMedia" = "メディアファイルを保存できません。";
+
+/* Label for the date a media asset (image / video) was uploaded */
+"siteMedia.details.uploaded" = "アップロード済み";
+
 /* Title for the URL field */
 "siteMedia.details.url" = "URL";
+
+/* Hint for image alt on image settings. */
+"siteMedia.hints.imageAlt" = "画像代替テキスト";
+
+/* Hint for image caption on image settings. */
+"siteMedia.hints.imageCaption" = "画像のキャプション";
+
+/* Hint for image description on image settings. */
+"siteMedia.hints.imageDescription" = "画像の説明";
+
+/* Hint for image title on image settings. */
+"siteMedia.hints.imageTitle" = "画像タイトル";
 
 /* Accessibility hint for media item preview for user's viewing an item in their media library */
 "siteMediaItem.contentViewAccessibilityHint" = "タップしてメディアをフルスクリーンで表示";
@@ -11252,6 +11973,9 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "プライバシー";
+
+/* Format string for adding a new taxonomy term. %1$@ is the taxonomy name. */
+"siteTaxonomy.addNew.format" = "%1$@を追加";
 
 /* Hint for users when hidden privacy setting is set */
 "siteVisibility.hidden.hint" = "閲覧の準備が整うまでは「まもなく公開予定」の通知が表示され、訪問者はサイトを閲覧できないようになっています。";
@@ -11432,6 +12156,9 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Insights 'Total Subscribers' header */
 "stats.insights.totalSubscribers.title" = "購読者総数";
+
+/* Menu item to disable the new stats */
+"stats.menu.disableNewStats" = "新しい統計情報を無効化";
 
 /* Menu item to send feedback about new stats experience */
 "stats.menu.sendFeedback" = "フィードバックを送る";
@@ -11811,7 +12538,8 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Subject of new Zendesk ticket. */
 "support.zendesk.readerAppTicketSubject" = "Reader for iOS のサポート";
 
-/* Description for empty state when there are no tags */
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
 "tags.empty.description" = "タグを使用するとコンテンツを整理でき、読者が関連記事を探しやすくなります。";
 
 /* Title for empty state when there are no tags */
@@ -11888,9 +12616,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "未読";
-
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "サイトの購読者";
 
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "サイトのユーザー";
@@ -11976,9 +12701,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* The heading at the top of the user list */
 "userlist.title" = "ユーザー";
-
-/* Site Subscribers */
-"users.list.title.subscribers" = "購読者";
 
 /* Screen title */
 "users.title" = "ユーザー";

--- a/WordPress/Resources/ko.lproj/Localizable.strings
+++ b/WordPress/Resources/ko.lproj/Localizable.strings
@@ -1,6 +1,6 @@
-/* Translation-Revision-Date: 2025-10-10 09:54:08+0000 */
+/* Translation-Revision-Date: 2025-11-27 06:45:56+0000 */
 /* Plural-Forms: nplurals=1; plural=0; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: ko_KR */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -581,8 +581,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "마지막 부분입니다! 인증 앱의 확인 코드를 입력하세요.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "대체 텍스트";
 
 /* No comment provided by engineer. */
@@ -725,9 +724,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "사이트에서 젯팩 연결을 해제하시겠어요?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "이 항목을 영구적으로 삭제하시겠습니까?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "%2$@에서 %1$@을(를) 제거하시겠습니까?";
@@ -1082,7 +1078,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "취소";
@@ -1110,8 +1105,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "결정할 수 없나요? 언제든지 테마를 변경할 수 있습니다.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "캡션";
 
 /* Alert title. */
@@ -1777,8 +1771,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "기본";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "기본 카테고리";
 
 /* Label for selecting the default post format
@@ -1787,9 +1780,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "새 글의 기본값";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "삭제";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "메뉴 삭제";
@@ -1808,14 +1798,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "메뉴 지우기";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "삭제되었습니다.";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "사이트를 삭제하는 중…";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "삭제 중...";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "거부하기";
@@ -1823,8 +1807,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "이미지의 용도를 설명합니다. 장식용이면 비워둡니다.";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "설명";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1842,9 +1825,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "새 계정을 만들 계획이 없으신가요? 뒤로 이동하여 이메일 주소를 다시 입력하세요.";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "크기";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "비활성화";
@@ -2121,7 +2101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "이 GIF를 편집하면 애니메이션이 제거됩니다.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "에디터";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2463,11 +2443,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "파일 블록 설정";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "파일 이름";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "파일 형식";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "파일 유형이 미디어 파일로 지원되지 않습니다.";
@@ -2781,6 +2758,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post content used in the login prologue screens. */
 "I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next" = "저는 사진 작가 Cameron Karsten의 작업에서 많은 영감을 받았습니다. 다음 작업에서 이러한 기법을 시도해볼 생각합니다.";
 
+/* Text on the support form to refer to what area the user has problem with. */
+"I need help with" = "도움말이 필요한 영역";
+
 /* Describes the IP address section in the comment detail screen. */
 "IP address" = "IP 주소";
 
@@ -2826,9 +2806,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "이미지 캡션";
 
-/* Hint for image description on image settings. */
-"Image Description" = "이미지 설명";
-
 /* Hint for image link on image settings. */
 "Image Link" = "이미지 링크";
 
@@ -2840,9 +2817,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "이미지 파일을 찾을 수 없습니다.";
-
-/* Hint for image title on image settings. */
-"Image title" = "이미지 제목";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "이 사이트의 주제를 간략히 소개하세요.";
@@ -3205,6 +3179,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the button that will dismiss this view. */
 "Let me know when finished!" = "완료되면 알려주세요!";
 
+/* Message info on the support screen. */
+"Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon." = "사이트 주소(URL)를 알려주고 문제를 최대한 자세히 설명해 주시면 곧 연락드리겠습니다.";
+
+/* Title to let the user know what do we want on the support screen. */
+"Let’s get this sorted" = "상황 정리";
+
 /* Lifestyle site intent topic */
 "Lifestyle" = "라이프스타일";
 
@@ -3405,6 +3385,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Main Navigation" = "메인 내비게이션";
+
+/* Explanation for the option to enable theme styles */
+"Make the block editor look like your theme." = "블록 편집기를 테마와 비슷한 모양으로 만드세요.";
 
 /* No comment provided by engineer. */
 "Make your content stand out by adding images, gifs, videos, and embedded media to your pages." = "이미지, gif 파일, 비디오 또는 임베드된 미디어를 페이지에 추가하여 콘텐츠를 돋보이게 만드세요.";
@@ -3747,9 +3730,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "계정을 찾지 못함";
-
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "카테고리 없음";
 
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "연결 없음";
@@ -4191,9 +4171,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "페이징";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "상위 카테고리";
-
 /* Parenting site intent topic */
 "Parenting" = "육아";
 
@@ -4411,9 +4388,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "게시물";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "게시글 카테고리";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "글 설정";
@@ -4722,9 +4696,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "사진을 사이트에 업로드하기 전에 사진에서 위치 메타데이터를 제거합니다.";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "팔로워를 제거하면 회원님의 사이트에서 업데이트를 받지 못하게 됩니다. 팔로워 본인이 선택한 경우에는 회원님의 사이트를 방문하여 다시 팔로우할 수 있습니다.";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "현재 블록이 교체하기";
@@ -5561,6 +5532,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "태그라인";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "태그";
 
@@ -5657,6 +5629,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint, informing user the button can be used to visit the Gravatar website. */
 "Tap to visit the Gravatar website in an external browser" = "눌러서 외부 브라우저에서 그라바타 웹사이트 방문";
+
+/* Label for viewing the custom taxonomies */
+"Taxonomies" = "분류";
 
 /* Technology site intent topic */
 "Technology" = "기술";
@@ -5946,9 +5921,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "이 로그인 코드는 만료되었습니다. 다시 스캔 버튼을 눌러 코드를 다시 스캔하세요.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "이 미디어 항목은 삭제되었습니다.";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "해결되지 않는 결제 승인 거부가 있는 경우 이 계정을 종료할 수 없습니다.";
 
@@ -6017,7 +5989,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "제목";
@@ -6111,8 +6082,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "블록 변형…";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "휴지통";
 
@@ -6209,9 +6179,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "새 초대 링크를 만들 수 없습니다.";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "미디어 항목을 삭제할 수 없습니다.";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "초대 링크를 비활성화할 수 없습니다.";
 
@@ -6242,9 +6209,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "지금 이 콘텐츠를 로드할 수 없습니다.";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "비디오를 로드할 수 없습니다.";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "비디오를 재생할 수 없음";
 
@@ -6253,9 +6217,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "사이트를 복원할 수 없음";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "미디어 항목을 저장할 수 없습니다.";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "링크를 공유할 수 없음";
@@ -6412,9 +6373,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "업로드 실패";
 
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "업로드됨";
-
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "1개 임시글, %ld개 파일 업로드됨";
 
@@ -6456,6 +6414,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The button title text for logging in with WP.com password instead of magic link. */
 "Use password to sign in" = "로그인 비밀번호 사용";
+
+/* Option to enable theme styles in the block editor */
+"Use theme styles" = "테마 스타일 사용";
 
 /* A placeholder for the twitter username
    Accessibility label for the username text field in the self-hosted login page.
@@ -6906,7 +6867,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "국가별 조회 수가 표시된 세계 지도";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "그래도 이 사용자를 삭제하시겠습니까?";
 
 /* Button title. Opens the editor to write a new post.
@@ -7377,14 +7338,19 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Description for the prompt to upgrade to Application Passwords. The first argument is the name of the feature that requires Application Passwords. */
 "applicationPasswordRequired.description" = "애플리케이션 비밀번호를 사용하면 독립 호스트 사이트에 더욱 안전하게 연결할 수 있고 %@을(를) 비롯한 기능을 지원할 수 있습니다.";
 
+/* Feature name for managing application passwords in the app */
+"applicationPasswordRequired.feature.applicationPasswords" = "애플리케이션 비밀번호 관리";
+
 /* Feature name for the block editor in application password required prompt */
 "applicationPasswordRequired.feature.blockEditor" = "블록 에디터";
+
+/* Feature name for managing terms and taxonomies in the app */
+"applicationPasswordRequired.feature.customTaxonomies" = "분류 관리";
 
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "플러그인 관리";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "사용자 관리";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -7614,6 +7580,288 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 /* Post Editor / Button in the 'More' menu */
 "classicEditor.moreMenu.saveDraft" = "임시글 저장";
 
+/* Button to add more screenshots */
+"com.jetpack.support.addMoreScreenshots" = "스크린샷 더 추가";
+
+/* Button to add screenshots */
+"com.jetpack.support.addScreenshots" = "스크린샷 추가";
+
+/* Header for application logs section */
+"com.jetpack.support.applicationLogs" = "애플리케이션 로그";
+
+/* Description explaining why including logs is helpful */
+"com.jetpack.support.applicationLogsDescription" = "로그를 포함하면 팀에서 문제를 조사하는 데 도움이 될 수 있습니다. 로그에 최근 앱 활동이 포함될 수 있습니다.";
+
+/* Navigation title for application logs screen */
+"com.jetpack.support.applicationLogsTitle" = "애플리케이션 로그";
+
+/* Format string for attachment identifier */
+"com.jetpack.support.attachment" = "첨부 파일 %@";
+
+/* Format string for attachment size limit. %1$@ is current size, %2$@ is maximum size */
+"com.jetpack.support.attachmentLimit" = "첨부 파일 한도: %1$@\/%2$@";
+
+/* Bot greeting message. %1$@ is the user's name */
+"com.jetpack.support.botGreeting" = "%1$@ 님, 안녕하세요!";
+
+/* Bot introduction message explaining its purpose */
+"com.jetpack.support.botIntroduction" = "저는 개인 AI 도우미입니다. 사이트 또는 계정에 대한 질문에 도움을 드릴 수 있습니다.";
+
+/* Format string for cache file count and size. %1$d is the number of files, %2$@ is the formatted size. The system will pluralize 'files' based on the number – please specify it as the largest plural value */
+"com.jetpack.support.cacheFiles" = "캐시된 파일 %1$d개(%2$@)";
+
+/* Message shown when cache has no files */
+"com.jetpack.support.cacheIsEmpty" = "캐시가 비어 있음";
+
+/* Button to cancel current action */
+"com.jetpack.support.cancel" = "취소";
+
+/* Warning message that deleted logs cannot be recovered */
+"com.jetpack.support.cannotRecoverLogs" = "다시 가져올 수 없습니다.";
+
+/* Button to clear all activity logs */
+"com.jetpack.support.clearAllActivityLogs" = "모든 활동 로그 지우기";
+
+/* Button to clear disk cache */
+"com.jetpack.support.clearDiskCache" = "디스크 캐시 지우기";
+
+/* Description explaining the purpose of clearing disk cache */
+"com.jetpack.support.clearDiskCacheDescription" = "임시 파일을 제거하여 공간을 확보하거나 문제를 해결하세요.";
+
+/* Progress text while clearing cache */
+"com.jetpack.support.clearing" = "지우는 중...";
+
+/* Message shown when cache clearing is complete */
+"com.jetpack.support.complete" = "완료";
+
+/* Confirmation message when canceling a draft */
+"com.jetpack.support.confirmCancelMessage" = "이 메시지를 취소하시겠습니까? 입력한 모든 데이터가 손실됩니다.";
+
+/* Title for alert confirming cancellation */
+"com.jetpack.support.confirmCancellation" = "취소 확정";
+
+/* Confirmation dialog title when deleting all logs */
+"com.jetpack.support.confirmDeleteAllLogs" = "모든 로그를 삭제하시겠습니까?";
+
+/* Section title for contact information */
+"com.jetpack.support.contactInformation" = "연락처 정보";
+
+/* Button to continue editing a message */
+"com.jetpack.support.continueWriting" = "계속 작성";
+
+/* Message shown at end of closed support conversation */
+"com.jetpack.support.conversationEnded" = "대화의 끝입니다. 더는 답글을 달 수 없습니다.";
+
+/* Navigation title for bot conversations list */
+"com.jetpack.support.conversations" = "대화";
+
+/* Button to delete all log files */
+"com.jetpack.support.deleteAllLogs" = "모든 로그 삭제";
+
+/* Description text for diagnostics screen */
+"com.jetpack.support.diagnosticsDescription" = "일반적인 유지보수 및 문제 해결 작업을 실행하세요.";
+
+/* Navigation title for diagnostics screen */
+"com.jetpack.support.diagnosticsTitle" = "진단";
+
+/* Button to discard changes in a draft message */
+"com.jetpack.support.discardChanges" = "변경 사항 취소";
+
+/* Notice explaining where support will send email responses */
+"com.jetpack.support.emailNotice" = "이 주소로 이메일을 보내드리겠습니다.";
+
+/* Error title when logs fail to load */
+"com.jetpack.support.errorLoadingLogs" = "로그 로드 중 오류 발생";
+
+/* Error message when support conversations fail to load */
+"com.jetpack.support.errorLoadingSupportConversations" = "지원 대화 로드 중 오류 발생";
+
+/* Title for error alerts */
+"com.jetpack.support.errorTitle" = "오류";
+
+/* Option to export log as a file */
+"com.jetpack.support.exportAsFile" = "파일로 내보내기";
+
+/* Button to dismiss alerts. */
+"com.jetpack.support.gotIt" = "확인";
+
+/* Text on the support form to refer to what area the user has problem with. */
+"com.jetpack.support.iNeedHelp" = "도움말이 필요한 영역";
+
+/* Toggle label to include application logs in the support request */
+"com.jetpack.support.includeApplicationLogs" = "애플리케이션 로그 포함";
+
+/* Section title for issue details */
+"com.jetpack.support.issueDetails" = "문제 상세 정보";
+
+/* Format string for when conversation was last updated */
+"com.jetpack.support.lastUpdated" = "마지막 업데이트 %@";
+
+/* Progress message while loading conversation messages */
+"com.jetpack.support.loadingBotConversationMessages" = "메시지 로드 중";
+
+/* Progress message while loading bot conversations */
+"com.jetpack.support.loadingBotConversations" = "봇 대화 로드 중";
+
+/* Progress text while loading support conversations */
+"com.jetpack.support.loadingConversations" = "대화 로드 중";
+
+/* Progress message while loading disk usage information */
+"com.jetpack.support.loadingDiskUsage" = "디스크 사용량 로드 중";
+
+/* Progress message while loading an image attachment */
+"com.jetpack.support.loadingImage" = "이미지 로드 중";
+
+/* Progress message shown in overlay while refreshing content */
+"com.jetpack.support.loadingLatestContent" = "마지막 콘텐츠 로드 중";
+
+/* Progress message while loading application log content */
+"com.jetpack.support.loadingLogContent" = "콘텐츠 로드 중...";
+
+/* Progress message while loading log files */
+"com.jetpack.support.loadingLogs" = "로그 로드 중...";
+
+/* Progress text while loading conversation messages */
+"com.jetpack.support.loadingMessages" = "메시지 로드 중";
+
+/* Progress message while loading a video attachment */
+"com.jetpack.support.loadingVideo" = "비디오 로드 중";
+
+/* Section header for log files sorted by date */
+"com.jetpack.support.logFilesByDate" = "생성 날짜별 로그 파일";
+
+/* Text indicating which log files will be included in the support request */
+"com.jetpack.support.logFilesToUpload" = "다음과 같은 로그 파일이 업로드됩니다.";
+
+/* Footer text explaining log retention policy */
+"com.jetpack.support.logRetentionNotice" = "최대 7일 상당의 로그가 저장됩니다.";
+
+/* Section header for message text input */
+"com.jetpack.support.message" = "메시지";
+
+/* Success message when reply is sent successfully */
+"com.jetpack.support.messageSent" = "메시지 발송됨";
+
+/* Format string for number of messages in conversation */
+"com.jetpack.support.messagesCount" = "메시지 %d개";
+
+/* The title of a new bot chat in the support area of the app */
+"com.jetpack.support.new-bot-chat" = "새 봇 채팅";
+
+/* Option to create a new support ticket */
+"com.jetpack.support.newSupportTicket" = "새 지원 티켓";
+
+/* Label shown when there are no bot conversations */
+"com.jetpack.support.noConversations" = "대화 없음";
+
+/* Description shown when no log files are available */
+"com.jetpack.support.noLogsAvailable" = "사용 가능한 활동 로그가 없음";
+
+/* Label shown when no log files are available */
+"com.jetpack.support.noLogsFound" = "로그를 찾을 수 없음";
+
+/* Button to open a support ticket */
+"com.jetpack.support.openSupportTicket" = "지원 티켓 접수";
+
+/* Text indicating a field is optional */
+"com.jetpack.support.optional" = "(선택 사항)";
+
+/* Navigation title for replying to a support conversation */
+"com.jetpack.support.reply" = "답글";
+
+/* Description for saving log as a file */
+"com.jetpack.support.saveAsFile" = "공유 또는 저장할 파일로 저장";
+
+/* Label for screenshots section */
+"com.jetpack.support.screenshots" = "스크린샷";
+
+/* Description for screenshots section */
+"com.jetpack.support.screenshotsDescription" = "스크린샷을 추가하면 문제를 더 빨리 이해하고 해결하는 데 도움이 될 수 있습니다.";
+
+/* Button to send a message or reply */
+"com.jetpack.support.send" = "보내기";
+
+/* Description for sending logs to support */
+"com.jetpack.support.sendLogsToSupport" = "지원팀에 직접 로그 보내기";
+
+/* Progress text while sending a message */
+"com.jetpack.support.sending" = "보내는 중";
+
+/* Progress message shown while sending a message */
+"com.jetpack.support.sendingMessage" = "메시지 보내는 중";
+
+/* Button to share content */
+"com.jetpack.support.share" = "공유";
+
+/* Navigation title for sharing activity log */
+"com.jetpack.support.shareActivityLog" = "활동 로그 공유";
+
+/* Message shown when sharing log with support */
+"com.jetpack.support.sharingWithSupport" = "지원팀과 공유 중입니다!";
+
+/* Site Address title on the support form */
+"com.jetpack.support.siteAddress" = "사이트 주소";
+
+/* Placeholder for site address field */
+"com.jetpack.support.siteAddressPlaceholder" = "https:\/\/yoursite.com";
+
+/* Description encouraging user to start a new conversation */
+"com.jetpack.support.startNewConversation" = "위의 버튼을 사용하여 새 대화 시작";
+
+/* Subject title on the support form */
+"com.jetpack.support.subject" = "주제";
+
+/* Placeholder for subject field */
+"com.jetpack.support.subjectPlaceholder" = "간략한 문제 요약";
+
+/* Button title to submit a support request. */
+"com.jetpack.support.submitRequest" = "지원 요청 제출";
+
+/* Navigation title for the support conversations list */
+"com.jetpack.support.supportConversations" = "지원 대화";
+
+/* Title for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSent" = "요청이 발송되었습니다!";
+
+/* Message for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSentMessage" = "지원 요청이 발송되었습니다. 최대한 빨리 이메일로 회신하겠습니다.";
+
+/* Progress message shown while bot is thinking */
+"com.jetpack.support.thinking" = "생각 중...";
+
+/* Title of the view for contacting support. */
+"com.jetpack.support.title" = "지원 문의";
+
+/* Button to retry a failed operation */
+"com.jetpack.support.tryAgain" = "다시 시도";
+
+/* Error title when log deletion fails */
+"com.jetpack.support.unableToDeleteLogs" = "로그를 삭제할 수 없음";
+
+/* Error message when conversation cannot be displayed */
+"com.jetpack.support.unableToDisplayConversation" = "대화를 표시할 수 없음";
+
+/* Error title when video cannot be loaded or played */
+"com.jetpack.support.unableToDisplayVideo" = "비디오를 표시할 수 없음";
+
+/* Error message when application logs cannot be loaded */
+"com.jetpack.support.unableToLoadApplicationLogs" = "애플리케이션 로그를 로드할 수 없음";
+
+/* Error title when bot conversations fail to load */
+"com.jetpack.support.unableToLoadConversations" = "대화를 로드할 수 없음";
+
+/* Error title when messages fail to load */
+"com.jetpack.support.unableToLoadMessages" = "메시지를 로드할 수 없음";
+
+/* Error title when message sending fails */
+"com.jetpack.support.unableToSendMessage" = "메시지를 보낼 수 없음";
+
+/* Button to view an attachment */
+"com.jetpack.support.view" = "보기";
+
+/* Progress message shown during cache clearing operation */
+"com.jetpack.support.working" = "작업 중";
+
 /* Displayed in the confirmation alert when marking comment notifications as read. */
 "comment" = "댓글";
 
@@ -7706,6 +7954,9 @@ Example: Reply to Pamela Nguyen */
 
 /* Create Sheet button title */
 "createSheet.post" = "글";
+
+/* Create Sheet button title */
+"createSheet.postFromAudio" = "오디오에서 글 작성하기";
 
 /* Customize Insights description */
 "customizeInsightsCell.content" = "나만의 사용자 정의 알림판을 만들고 보고 싶은 보고서를 선택하세요. 가장 중요한 데이터에 집중하세요.";
@@ -7876,6 +8127,9 @@ Example: Reply to Pamela Nguyen */
 /* Weekly Roundup debug menu item */
 "debugMenu.weeklyRoundup" = "주간 총정리";
 
+/* Title for selecting a default category for a post */
+"defaultCategory.title" = "기본 카테고리";
+
 /* Error tilte */
 "discussionSettings.saveErrorTitle" = "설정 저장 실패";
 
@@ -8015,10 +8269,10 @@ Example: Reply to Pamela Nguyen */
 "double-tap to change unit" = "두 번 눌러 단위 변경하기";
 
 /* Message for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.message" = "이 태그를 삭제하시겠습니까?";
+"edit.tag.delete.confirmation.message" = "이 템플릿을 삭제하시겠습니까?";
 
-/* Title for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.title" = "태그 삭제";
+/* Title for delete a term confirmation dialog */
+"edit.tag.delete.confirmation.title" = "삭제";
 
 /* Placeholder text for tag description field */
 "edit.tag.description.placeholder" = "설명 추가...";
@@ -8033,7 +8287,37 @@ Example: Reply to Pamela Nguyen */
 "edit.tag.section.description" = "설명";
 
 /* Section header for tag name in edit tag view */
-"edit.tag.section.tag" = "태그";
+"edit.tag.section.tag" = "이름";
+
+/* Context menu action to insert a block */
+"editor.blockInserter.insertBlock" = "블록 삽입";
+
+/* Placeholder text for block search field */
+"editor.blockInserter.search" = "검색";
+
+/* Button title to collapse and show fewer blocks */
+"editor.blockInserter.showLess" = "간략히 표시";
+
+/* Button title to expand and show more blocks */
+"editor.blockInserter.showMore" = "자세히 표시";
+
+/* Error message when media insertion fails */
+"editor.media.failedToInsert" = "미디어 삽입 실패";
+
+/* Category name for section showing all patterns */
+"editor.patterns.all" = "모두";
+
+/* Context menu action to insert a pattern */
+"editor.patterns.insertPattern" = "패턴 삽입";
+
+/* Title shown when no patterns match the search */
+"editor.patterns.noPatternsFound" = "패턴을 찾을 수 없음";
+
+/* Navigation title for patterns view */
+"editor.patterns.title" = "패턴";
+
+/* Category name for patterns without a category */
+"editor.patterns.uncategorized" = "미분류";
 
 /* Register Domain - Address information field Number placeholder */
 "eg. 1122334455" = "예: 1122334455";
@@ -8587,6 +8871,24 @@ Example: Reply to Pamela Nguyen */
 
 /* Write a blog prompt for the jetpack prologue */
 "jetpack.prologue.prompt.writeBlog" = "블로그 작성";
+
+/* Description for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.description" = "누구나 이 글을 볼 수 있음";
+
+/* Title for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.title" = "모든 사람";
+
+/* Description for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.description" = "유료 구독자만 이 글을 볼 수 있음";
+
+/* Title for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.title" = "유료 구독자";
+
+/* Description for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.description" = "글이 무료 구독자를 포함한 모든 구독자에게 표시됨";
+
+/* Title for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.title" = "모든 구독자";
 
 /* Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account */
 "jetpackSite.connectToDefaultAccount" = "통계 및 알림을 사용하려면 %@(으)로 로그인해야 합니다.";
@@ -9177,6 +9479,12 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "이 비공개 블로그를 볼 권한이 없습니다.";
 
+/* Default empty state message format when there are no terms. %1$@ is the taxonomy name. */
+"localizedLabels.defaultNoTerms.format" = "%1$@ 없음";
+
+/* Default search placeholder format. %1$@ is the taxonomy name. */
+"localizedLabels.defaultSearch.format" = "%1$@ 검색";
+
 /* Button to dismiss the re-authentication view */
 "login.appPasswordReAuth.cancelButton" = "취소";
 
@@ -9312,17 +9620,23 @@ Example: Reply to Pamela Nguyen */
 /* Message about buying storage add-on */
 "mediaLibrary.storageDetails.buyStorage.message" = "스토리지 애드온 구입";
 
-/* Message shown when all media items are attached */
-"mediaLibrary.storageDetails.cleanup.allAttached" = "미디어 라이브러리의 모든 아이템이 첨부됩니다.";
+/* Label for audio media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.audio" = "오디오";
 
-/* Message shown while loading unattached media count */
-"mediaLibrary.storageDetails.cleanup.loading" = "첨부되지 않은 미디어 아이템이 있는지 확인 중...";
+/* Label for document media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.document" = "문서";
 
-/* Message about unattached media that can be cleaned up. %1$d is the count of unattached media. */
-"mediaLibrary.storageDetails.cleanup.message" = "%1$d 아이템이 첨부되지 않았습니다. 제거하고 공간을 확보하세요.";
+/* Label for image media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.image" = "이미지";
 
-/* Title for cleanup section */
-"mediaLibrary.storageDetails.cleanup.title" = "사용하지 않는 아이템 제거";
+/* Label for other/unknown media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.other" = "기타";
+
+/* Label for PowerPoint/presentation media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.powerpoint" = "프레젠테이션";
+
+/* Label for video media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.video" = "비디오";
 
 /* Success message shown after upgrading plan */
 "mediaLibrary.storageDetails.purchase.plan.success" = "사이트 요금제가 업데이트되었습니다!";
@@ -9708,6 +10022,12 @@ Example: Reply to Pamela Nguyen */
 /* Menu option for filtering posts by me */
 "pagesList.pagesByMe" = "내가 작성한 페이지";
 
+/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
+"parentCategory.noCategory" = "카테고리 없음";
+
+/* Title for selecting parent category of a category */
+"parentCategory.title" = "상위 카테고리";
+
 /* Title for the parent page picker screen */
 "parentPagePicker.title" = "상위 페이지";
 
@@ -9866,6 +10186,27 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the post author selection screen */
 "postAuthorPicker.title" = "글쓴이";
+
+/* Title for selecting categories for a post or a page */
+"postCategories.title" = "카테고리";
+
+/* Toggle label for allowing comments on post */
+"postDiscussion.allowComments.label" = "댓글 허용";
+
+/* Toggle label for allowing pings/trackbacks on post */
+"postDiscussion.allowPings.label" = "핑백 허용";
+
+/* Footer text when comments are disabled */
+"postDiscussion.comments.disabled.footer" = "방문자가 새 댓글 또는 답글을 추가할 수 없습니다. 기존 댓글이 계속 표시됩니다.";
+
+/* Footer text when comments are enabled */
+"postDiscussion.comments.enabled.footer" = "방문자가 새 댓글과 답글을 추가할 수 있습니다.";
+
+/* Link text for learning more about pingbacks and trackbacks */
+"postDiscussion.pingbacks.learnMore.text" = "핑백 및 트랙백에 대해 더 알아보기";
+
+/* Navigation title for post discussion settings */
+"postDiscussion.title" = "토론";
 
 /* Button in an alert confirming discaring changes */
 "postEditor.closeConfirmationAlert.discardChanges" = "변경사항 폐기";
@@ -10098,6 +10439,9 @@ Example: Reply to Pamela Nguyen */
 /* A default value for an post without a title */
 "postSaveErrorMessage.postUntitled" = "제목이 없습니다";
 
+/* Section header for Access settings in Post Settings */
+"postSettings.access.header" = "접근";
+
 /* Label for the author field in Post Settings */
 "postSettings.author.label" = "글쓴이";
 
@@ -10116,6 +10460,18 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the discard changes confirmation dialog */
 "postSettings.discardChanges.title" = "변경 사항을 취소할까요?";
+
+/* Status text when discussion (comments) is disabled */
+"postSettings.discussion.closed" = "닫힘";
+
+/* Label for the discussion settings field in Post Settings */
+"postSettings.discussion.label" = "토론";
+
+/* Status text when discussion (comments) is enabled */
+"postSettings.discussion.open" = "열기";
+
+/* Label for the checkbox that lets you send a post to newsletter subscribers */
+"postSettings.emailToSubscribers.label" = "구독자에게 이메일 보내기";
 
 /* Character count for excerpt. %1$d is the number of characters. */
 "postSettings.excerpt.characterCount" = "%1$d개 문자";
@@ -10219,6 +10575,21 @@ Example: Reply to Pamela Nguyen */
 /* Cell title for the Top Level option case */
 "postSettings.parentPage.topLevel" = "최상위";
 
+/* Accessibility label for hide password button */
+"postSettings.passwordEntry.hidePassword" = "비밀번호 숨기기";
+
+/* Instructions for password entry */
+"postSettings.passwordEntry.instructions" = "이 글을 보호할 비밀번호를 입력하세요. 비밀번호가 있는 사용자만 볼 수 있습니다.";
+
+/* Navigation title for password entry screen */
+"postSettings.passwordEntry.navigationTitle" = "비밀번호 입력";
+
+/* Placeholder for password field */
+"postSettings.passwordEntry.placeholder" = "비밀번호 입력";
+
+/* Accessibility label for show password button */
+"postSettings.passwordEntry.showPassword" = "비밀번호 표시";
+
 /* Label for the pending review toggle in Post Settings */
 "postSettings.pendingReview.label" = "검토 대기 중";
 
@@ -10246,17 +10617,59 @@ Example: Reply to Pamela Nguyen */
 /* Section header for General settings in Post Settings */
 "postSettings.section.general" = "일반";
 
+/* Description text explaining what the slug editor does */
+"postSettings.slug.customizeDescription" = "퍼머링크의 마지막 부분을 사용자 정의하세요.";
+
 /* Hint text for the slug field. Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso. */
 "postSettings.slug.hint" = "슬러그는 글 제목의 URL 친화적인 버전입니다.";
 
 /* Label for the slug field. Should be the same as WP core. */
 "postSettings.slug.label" = "슬러그";
 
+/* Button text to learn more about permalinks */
+"postSettings.slug.learnMore" = "더 알아보기";
+
+/* Label for the slug field. Should be the same as WP core. */
+"postSettings.slug.navigationTitle" = "슬러그";
+
+/* Notice shown when the post doesn't have a remote and permalink template is missing */
+"postSettings.slug.permalinkDraftNotice" = "임시글이 서버에 저장되면 제안된 퍼머링크가 표시됩니다.";
+
+/* Label for the permalink preview */
+"postSettings.slug.permalinkLabel" = "퍼머링크";
+
+/* Section title for the permalink preview */
+"postSettings.slug.permalinkSection" = "퍼머링크";
+
 /* Placeholder for the slug field */
 "postSettings.slug.placeholder" = "슬러그 입력";
 
 /* Label for the preview button in Post Settings */
 "postSettings.socialSharing.header" = "소셜 공유";
+
+/* Label for the status field in Post Settings */
+"postSettings.status.label" = "상태";
+
+/* Navigation title for status picker */
+"postSettings.statusPicker.navigationTitle" = "상태 및 표시 여부";
+
+/* Label showing the current password */
+"postSettings.statusPicker.passwordLabel" = "비밀번호";
+
+/* Toggle label for password protection */
+"postSettings.statusPicker.passwordProtected" = "비밀번호로 보호됨";
+
+/* Subtitle for password protected toggle */
+"postSettings.statusPicker.passwordProtectedSubtitle" = "비밀번호를 아는 사람에게만 표시";
+
+/* Label for schedule date row */
+"postSettings.statusPicker.scheduleDate" = "날짜";
+
+/* Toggle label for sticky posts */
+"postSettings.statusPicker.sticky" = "붙박이";
+
+/* Subtitle for sticky toggle */
+"postSettings.statusPicker.stickySubtitle" = "이 글을 블로그 상단에 고정";
 
 /* Label for the sticky post toggle. Sticky posts are displayed at the top of the blog. */
 "postSettings.stickyPost.label" = "붙박이";
@@ -10276,17 +10689,56 @@ Example: Reply to Pamela Nguyen */
 /* Navigation bar title of the Post Stats screen */
 "postStats.title" = "게시물 통계";
 
-/* Button to add a new tag. %1$@ is the tag name. */
-"postTags.addTag" = "태그 추가";
+/* Post status title */
+"postStatus.deleted.details" = "영구적으로 삭제됨";
 
-/* Placeholder text for the tag search field */
-"postTags.searchOrAdd.placeholder" = "태그 검색 또는 추가";
+/* Post status title */
+"postStatus.deleted.title" = "삭제됨";
 
-/* Message shown when no tags are selected */
-"postTags.selectionEmpty" = "선택한 태그 없음";
+/* Post status details */
+"postStatus.draft.details" = "발행 준비 안 됨";
 
-/* Title for the tags screen */
-"postTags.title" = "태그";
+/* Post status title */
+"postStatus.draft.title" = "임시글";
+
+/* Post status details */
+"postStatus.pending.details" = "발행 전 검토 대기 중";
+
+/* Post status title */
+"postStatus.pending.title" = "대기 중";
+
+/* Post status details */
+"postStatus.private.details" = "사이트 관리자와 편집자에게만 표시";
+
+/* Post status title */
+"postStatus.private.title" = "비공개";
+
+/* Post status details */
+"postStatus.published.details" = "모든 사람에게 표시";
+
+/* Post status title */
+"postStatus.published.title" = "발행됨";
+
+/* Post status details */
+"postStatus.scheduled.details" = "선택한 날짜에 자동으로 발행";
+
+/* Post status title */
+"postStatus.scheduled.title" = "예약됨";
+
+/* Post status title */
+"postStatus.trash.details" = "휴지통으로 이동되었지만, 아직 삭제 안 됨";
+
+/* Post status title */
+"postStatus.trash.title" = "삭제됨";
+
+/* Button to add a new taxonomy term. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.addTag" = "%1$@ 추가";
+
+/* Placeholder text for the taxonomy search field. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.searchOrAdd.placeholder" = "%1$@ 검색 또는 추가";
+
+/* Message shown when no taxonomy terms are selected. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.selectionEmpty" = "%1$@이 선택되지 않았습니다.";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "취소";
@@ -10362,9 +10814,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "카테고리";
-
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "닫기";
 
 /* Button to confirm discarding changes */
 "prepublishing.discardChanges.button" = "변경 사항 취소";
@@ -10453,12 +10902,17 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "경고";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "메시지";
+
+/* Placeholder text for the message field in Social Sharing */
+"prepublishing.socialAccounts.messagePlaceholder" = "간단한 메시지를 작성하여 글과 함께 소셜 미디어에서 공유";
 
 /* The navigation title for the pre-publishing social accounts screen. */
 "prepublishing.socialAccounts.navigationTitle" = "소셜";
+
+/* Table section title */
+"prepublishing.socialAccounts.servicesSectionTitle" = "서비스";
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.tags" = "태그";
@@ -11405,6 +11859,18 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Button to progress to the next step after selecting domain in Site Creation */
 "siteCreation.domains.buttons.selectDomain" = "도메인 선택";
 
+/* Default text for adding a new item when no label is provided */
+"siteCustomTaxonomies.defaultAddNew" = "추가";
+
+/* Description for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.description" = "분류는 표준 카테고리와 태그 이상으로 콘텐츠 구성에 도움이 됩니다.";
+
+/* Title for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.title" = "사용자 정의 분류 없음";
+
+/* Navigation title for the custom taxonomies screen */
+"siteCustomTaxonomies.navigationTitle" = "분류";
+
 /* Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio. */
 "siteMedia.accessibilityLabelAudio" = "오디오, %@";
 
@@ -11423,8 +11889,77 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Accessibility hint for actions when displaying media items. */
 "siteMedia.cellAccessibilityHint" = "미디어를 선택합니다.";
 
+/* Label for the alt for a media asset (image) */
+"siteMedia.details.altText" = "대체 텍스트";
+
+/* Verb. Button title. Tapping cancels an action. */
+"siteMedia.details.cancel" = "취소";
+
+/* Noun. Label for the caption for a media asset (image / video) */
+"siteMedia.details.caption" = "캡션";
+
+/* Title for button that permanently deletes a media item (photo / video) */
+"siteMedia.details.delete" = "삭제";
+
+/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
+"siteMedia.details.deleteConfirmation" = "이 항목을 영구적으로 삭제하시겠습니까?";
+
+/* Text displayed in HUD after successfully deleting a media item */
+"siteMedia.details.deleted" = "삭제되었습니다.";
+
+/* Text displayed in HUD while a media item is being deleted. */
+"siteMedia.details.deleting" = "삭제 중...";
+
+/* Label for the description for a media asset (image / video) */
+"siteMedia.details.description" = "설명";
+
+/* Label for the dimensions in pixels for a media asset (image / video) */
+"siteMedia.details.dimensions" = "규격";
+
+/* Label for the file name for a media asset (image / video) */
+"siteMedia.details.fileName" = "파일 이름";
+
+/* Label for the file size for a media asset (image / video) */
+"siteMedia.details.fileSize" = "파일 크기";
+
+/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
+"siteMedia.details.fileType" = "파일 형식";
+
+/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
+"siteMedia.details.mediaDeleted" = "이 미디어 항목은 삭제되었습니다.";
+
+/* Noun. Label for the title of a media asset (image / video) */
+"siteMedia.details.title" = "제목";
+
+/* Accessibility label for trash buttons in nav bars */
+"siteMedia.details.trash" = "휴지통";
+
+/* Text displayed in HUD if there was an error attempting to delete a media item. */
+"siteMedia.details.unableToDeleteMedia" = "미디어 항목을 삭제할 수 없습니다.";
+
+/* Error shown when the app fails to load a video from the user's media library. */
+"siteMedia.details.unableToLoadVideo" = "비디오를 로드할 수 없습니다.";
+
+/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
+"siteMedia.details.unableToSaveMedia" = "미디어 항목을 저장할 수 없습니다.";
+
+/* Label for the date a media asset (image / video) was uploaded */
+"siteMedia.details.uploaded" = "업로드됨";
+
 /* Title for the URL field */
 "siteMedia.details.url" = "URL";
+
+/* Hint for image alt on image settings. */
+"siteMedia.hints.imageAlt" = "이미지 대체";
+
+/* Hint for image caption on image settings. */
+"siteMedia.hints.imageCaption" = "이미지 캡션";
+
+/* Hint for image description on image settings. */
+"siteMedia.hints.imageDescription" = "이미지 설명";
+
+/* Hint for image title on image settings. */
+"siteMedia.hints.imageTitle" = "이미지 제목";
 
 /* Accessibility hint for media item preview for user's viewing an item in their media library */
 "siteMediaItem.contentViewAccessibilityHint" = "미디어를 눌러 전체 화면에서 보기";
@@ -11522,6 +12057,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "개인정보";
+
+/* Format string for adding a new taxonomy term. %1$@ is the taxonomy name. */
+"siteTaxonomy.addNew.format" = "%1$@ 추가";
 
 /* Hint for users when hidden privacy setting is set */
 "siteVisibility.hidden.hint" = "사이트가 완성될 때까지 “Coming Soon” 알림 뒤로 사이트를 숨겨둡니다.";
@@ -12090,7 +12628,8 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Subject of new Zendesk ticket. */
 "support.zendesk.readerAppTicketSubject" = "IOS용 리더 지원";
 
-/* Description for empty state when there are no tags */
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
 "tags.empty.description" = "태그를 사용하면 회원님이 콘텐츠를 구성하고 독자가 관련 글을 더 쉽게 찾는 데 도움이 됩니다.";
 
 /* Title for empty state when there are no tags */
@@ -12167,9 +12706,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "읽지 않음";
-
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "사이트 구독자";
 
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "사이트 사용자";
@@ -12255,9 +12791,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* The heading at the top of the user list */
 "userlist.title" = "사용자";
-
-/* Site Subscribers */
-"users.list.title.subscribers" = "구독자";
 
 /* Screen title */
 "users.title" = "사용자";

--- a/WordPress/Resources/nb.lproj/Localizable.strings
+++ b/WordPress/Resources/nb.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 /* Translation-Revision-Date: 2022-05-03 21:53:38+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: nb_NO */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -407,8 +407,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "Nesten fremme! Skriv inn verifiseringskoden fra autentiseringsappen din.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Alt-tekst";
 
 /* String displayed before offering alternative login methods */
@@ -499,9 +498,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "Er du sikker på at du vil koble fra Jetpack fra denne siden?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "Er du sikker på at du vil slette dette objektet permanent?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "Er du sikker på at du vil fjerne %1$@ fra %2$@?";
@@ -744,7 +740,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Avbryt";
@@ -766,8 +761,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "Avbryter...";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Bildetekst";
 
 /* Alert title. */
@@ -1183,8 +1177,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "Standard";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Standardkategori";
 
 /* Label for selecting the default post format
@@ -1193,9 +1186,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Standard for nye innlegg";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Slett";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Slett meny";
@@ -1211,20 +1201,13 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of alert when site deletion fails */
 "Delete Site Error" = "Feil under sletting av siden";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Slettet!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Sletter side...";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Sletter...";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "Nekte";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Beskrivelse";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1236,9 +1219,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Details button that appears in the Theme Browser Header
    Theme Details action title */
 "Details" = "Detaljer";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Dimensjoner";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "Slå av";
@@ -1410,7 +1390,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Edit video" = "Rediger video";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Redigerer";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -1638,11 +1618,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Period Stats 'File Downloads' header */
 "File Downloads" = "Filnedlastinger";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "Filnavn";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Filtype";
 
 /* Title for the find out more button in the What's New page. */
 "Find out more" = "Finn ut mer";
@@ -1836,9 +1813,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "Biltetekst";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Bildebeskrivelse";
-
 /* Hint for image link on image settings. */
 "Image Link" = "Bildelenke";
 
@@ -1847,9 +1821,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* translators: accessibility text. %s: image caption. */
 "Image caption. %s" = "Bildetekst. %s";
-
-/* Hint for image title on image settings. */
-"Image title" = "Bildetittel";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "Forklar hva siden er om med noen få ord.";
@@ -2445,9 +2416,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "Ingen brukerkonti funnet";
 
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Ingen kategori";
-
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Ingen forbindelse";
 
@@ -2777,9 +2745,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Settings: Comments Paging preferences */
 "Paging" = "Sider";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Foreldrekategori";
-
 /* Accessibility label for the password text field in the self-hosted login page.
    Label for entering password in password field
    Login dialog password placeholder
@@ -2952,9 +2917,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Publiser";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Innleggskategorier";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "Innleggsinnstillinger";
@@ -3840,6 +3802,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Tagline" = "Slagord";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Stikkord";
 
@@ -4081,9 +4044,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Informational text for the privacy policy link */
 "This information helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, and more as detailed in our privacy policy." = "Denne informasjonen hjelper oss med å forbedre produktere våre, gjøre markedsføring mer relevant, personliggjøre din WordPress.com-opplevelse og mer, som detaljert i våre retningslinjer for personvern.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "Dette medieobjektet har blitt slettet.";
-
 /* A description of the twitter sharing setting.
    Information about the twitter sharing feature. */
 "This will be included in tweets when people share using the Twitter button." = "Dette vil inkluderes i tweeter når folk deler ved hjelp av Twitter-knappen.";
@@ -4116,7 +4076,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Tittel";
@@ -4189,8 +4148,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Transform block…" = "Omform blokk...";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Slett";
 
@@ -4254,9 +4212,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title of error prompt shown when a sync the user initiated fails. */
 "Unable to Sync" = "Synkronosering feilet";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "Kunne ikke slette medieobjekt.";
-
 /* No comment provided by engineer. */
 "Unable to embed media" = "Kunne ikke bygge inn media";
 
@@ -4275,14 +4230,8 @@ translators: %s: Block name e.g. \"Image block\" */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "Kunne ikke laste inn dette innholdet akkurat nå.";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "Kunne ikke laste inn video.";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Kunne ikke spille av video";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "Kunne ikke lagre medieobjekt.";
 
 /* This is an error message that could be shown when updating Plans in the app. */
 "Unable to update plan prices. There is a problem with the supplied blog." = "Kunne ikke oppdatere abonnementspriser. Det er et problem med denne bloggen.";
@@ -4399,9 +4348,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Opplasting feilet";
-
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Lastet opp";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "Lastet opp 1 kladd, %ld filer";
@@ -4672,7 +4618,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "Verdenskart som viser visninger etter land.";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "Vil du fortsatt fjerne denne personen?";
 
 /* Button title. Opens the editor to write a new post.

--- a/WordPress/Resources/nl.lproj/Localizable.strings
+++ b/WordPress/Resources/nl.lproj/Localizable.strings
@@ -1,6 +1,6 @@
-/* Translation-Revision-Date: 2025-10-03 09:47:16+0000 */
+/* Translation-Revision-Date: 2025-11-24 11:42:53+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: nl */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -581,8 +581,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "Bijna klaar. Voer de verificatiecode in van je authenticatie-app.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Alt-tekst";
 
 /* No comment provided by engineer. */
@@ -725,9 +724,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "Weet je zeker dat je Jetpack wilt loskoppelen van jouw site?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "Weet je zeker dat je dit item permanent wilt verwijderen?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "Weet je zeker dat je %1$@ uit %2$@ wilt verwijderen?";
@@ -1082,7 +1078,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Annuleren";
@@ -1110,8 +1105,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "kun je niet kiezen? Je kunt op elk moment het thema veranderen.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Bijschrift";
 
 /* Alert title. */
@@ -1777,8 +1771,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "Standaard";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Standaard categorie";
 
 /* Label for selecting the default post format
@@ -1787,9 +1780,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Standaardinstellingen voor nieuwe berichten";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Verwijderen";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Menu verwijderen";
@@ -1808,14 +1798,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "Menu verwijderen";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Verwijderd!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Site verwijderen…";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Verwijderen...";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "Weigeren";
@@ -1823,8 +1807,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "Beschrijf het doel van de afbeelding. Laat dit veld leeg als de afbeelding decoratief is.";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Beschrijving";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1842,9 +1825,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "Wilde je geen nieuw account aanmaken? Ga terug om je e-mailadres opnieuw in te voeren.";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Afmetingen";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "Uitschakelen";
@@ -2121,7 +2101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "Deze GIF bewerken zal de animatie verwijderen.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Editor";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2463,11 +2443,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "Bewaar blok instellingen";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "Bestandsnaam";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Bestandstype";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "Bestandstype wordt niet ondersteund als mediabestand.";
@@ -2781,6 +2758,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post content used in the login prologue screens. */
 "I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next" = "Ik ben zo geïnspireerd door het werk van fotograaf Cameron Karsten. Ik ga deze technieken zeker proberen bij mijn volgende";
 
+/* Text on the support form to refer to what area the user has problem with. */
+"I need help with" = "Ik heb hulp nodig met";
+
 /* Describes the IP address section in the comment detail screen. */
 "IP address" = "IP-adres";
 
@@ -2826,9 +2806,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "Onderschrift voor afbeelding";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Afbeelding omschrijving";
-
 /* Hint for image link on image settings. */
 "Image Link" = "Afbeeldingslink";
 
@@ -2840,9 +2817,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "Bestand afbeelding niet gevonden.";
-
-/* Hint for image title on image settings. */
-"Image title" = "Titel voor afbeelding";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "Beschrijf in een paar woorden waar deze site over gaat.";
@@ -3205,6 +3179,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the button that will dismiss this view. */
 "Let me know when finished!" = "Laat het mij weten als het klaar is!";
 
+/* Message info on the support screen. */
+"Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon." = "Laat ons je siteadres (URL) weten en vertel ons zoveel mogelijk over het probleem, dan nemen we snel contact met je op.";
+
+/* Title to let the user know what do we want on the support screen. */
+"Let’s get this sorted" = "Laten we dit regelen";
+
 /* Lifestyle site intent topic */
 "Lifestyle" = "Lifestyle";
 
@@ -3405,6 +3385,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Hoofdnavigatie";
+
+/* Explanation for the option to enable theme styles */
+"Make the block editor look like your theme." = "Laat de blok-editor eruitzien als je thema.";
 
 /* No comment provided by engineer. */
 "Make your content stand out by adding images, gifs, videos, and embedded media to your pages." = "Laat je inhoud opvallen door afbeeldingen, gifs, video's, en ingesloten media aan je pagina's toe te voegen.";
@@ -3747,9 +3730,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "Geen accounts gevonden";
-
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Geen categorie";
 
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Geen verbinding";
@@ -4191,9 +4171,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "Paginatie";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Bovenliggende categorie";
-
 /* Parenting site intent topic */
 "Parenting" = "Ouderschap";
 
@@ -4411,9 +4388,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Publiceer";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Berichtcategorieën";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "Bericht instellingen";
@@ -4722,9 +4696,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "Verwijdert locatiegegevens uit foto's alvorens ze naar je site te uploaden.";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "Als je volgers verwijdert, ontvangen ze geen berichten meer vanuit je site. Als ze willen, kunnen ze je site nog altijd bezoeken en deze opnieuw volgen.";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "Vervang huidige blok";
@@ -5561,6 +5532,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "Slogan";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Tags";
 
@@ -5657,6 +5629,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint, informing user the button can be used to visit the Gravatar website. */
 "Tap to visit the Gravatar website in an external browser" = "Tikken om de site van Gravatar in een externe browser te openen";
+
+/* Label for viewing the custom taxonomies */
+"Taxonomies" = "Taxonomieën";
 
 /* Technology site intent topic */
 "Technology" = "Technologie";
@@ -5946,9 +5921,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "Deze inlogcode is verlopen. Tik op 'Opnieuw scannen' om de code opnieuw te scannen.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "Dit media-item is verwijderd.";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "Dit gebruikersaccount kan niet worden gesloten als er onopgeloste terugvorderingen zijn.";
 
@@ -6017,7 +5989,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Titel";
@@ -6111,8 +6082,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "Transformeer blok...";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Prullenmand";
 
@@ -6209,9 +6179,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "Het is niet mogelijk om nieuwe uitnodigingslinks te maken.";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "Niet mogelijk om media te verwijderen.";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "Kan uitnodigingslinks niet uitschakelen.";
 
@@ -6242,9 +6209,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "Deze inhoud kan momenteel niet geladen worden.";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "Kan video niet laden.";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Niet mogelijk video af te spelen";
 
@@ -6253,9 +6217,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Kan je site niet terugzetten";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "Niet mogelijk om media op te slaan.";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "Kan de link niet delen";
@@ -6412,9 +6373,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Uploaden mislukt";
 
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Geüpload";
-
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "1 conceptbericht geüpload, %ld bestanden";
 
@@ -6456,6 +6414,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The button title text for logging in with WP.com password instead of magic link. */
 "Use password to sign in" = "Gebruik je wachtwoord om je aan te melden";
+
+/* Option to enable theme styles in the block editor */
+"Use theme styles" = "Gebruik thema stijlen";
 
 /* A placeholder for the twitter username
    Accessibility label for the username text field in the self-hosted login page.
@@ -6906,7 +6867,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "Wereldkaart die het aantal weergaven per land toont.";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "Wil je deze persoon alsnog verwijderen?";
 
 /* Button title. Opens the editor to write a new post.
@@ -7377,14 +7338,19 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Description for the prompt to upgrade to Application Passwords. The first argument is the name of the feature that requires Application Passwords. */
 "applicationPasswordRequired.description" = "Applicatie wachtwoorden zijn een veiligere manier om verbinding te maken met je zelf-gehoste site, en inschakelen ondersteuning voor functies zoals %@.";
 
+/* Feature name for managing application passwords in the app */
+"applicationPasswordRequired.feature.applicationPasswords" = "Applicatie wachtwoordenbeheer";
+
 /* Feature name for the block editor in application password required prompt */
 "applicationPasswordRequired.feature.blockEditor" = "Blok-editor";
+
+/* Feature name for managing terms and taxonomies in the app */
+"applicationPasswordRequired.feature.customTaxonomies" = "Beheer van taxonomieën";
 
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "Pluginbeheer";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "Gebruikersbeheer";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -7613,6 +7579,288 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 
 /* Post Editor / Button in the 'More' menu */
 "classicEditor.moreMenu.saveDraft" = "Concept opslaan";
+
+/* Button to add more screenshots */
+"com.jetpack.support.addMoreScreenshots" = "Meer schermafbeeldingen toevoegen";
+
+/* Button to add screenshots */
+"com.jetpack.support.addScreenshots" = "Schermafbeeldingen toevoegen";
+
+/* Header for application logs section */
+"com.jetpack.support.applicationLogs" = "Applicatielogs";
+
+/* Description explaining why including logs is helpful */
+"com.jetpack.support.applicationLogsDescription" = "Het toevoegen van logs kan ons team helpen bij het onderzoeken van problemen. Logs kunnen recente app-activiteit bevatten.";
+
+/* Navigation title for application logs screen */
+"com.jetpack.support.applicationLogsTitle" = "Applicatielogs";
+
+/* Format string for attachment identifier */
+"com.jetpack.support.attachment" = "Bijlage %@";
+
+/* Format string for attachment size limit. %1$@ is current size, %2$@ is maximum size */
+"com.jetpack.support.attachmentLimit" = "Bijlage limiet: %1$@\/%2$@";
+
+/* Bot greeting message. %1$@ is the user's name */
+"com.jetpack.support.botGreeting" = "Hallo %1$@!";
+
+/* Bot introduction message explaining its purpose */
+"com.jetpack.support.botIntroduction" = "Ik ben je persoonlijke AI assistent. Ik kan je helpen met al je vragen over je site of account.";
+
+/* Format string for cache file count and size. %1$d is the number of files, %2$@ is the formatted size. The system will pluralize 'files' based on the number – please specify it as the largest plural value */
+"com.jetpack.support.cacheFiles" = "%1$d bestanden in cache (%2$@)";
+
+/* Message shown when cache has no files */
+"com.jetpack.support.cacheIsEmpty" = "Cache is leeg";
+
+/* Button to cancel current action */
+"com.jetpack.support.cancel" = "Annuleren";
+
+/* Warning message that deleted logs cannot be recovered */
+"com.jetpack.support.cannotRecoverLogs" = "Je zult niet in staat zijn om ze terug te krijgen.";
+
+/* Button to clear all activity logs */
+"com.jetpack.support.clearAllActivityLogs" = "Alle activiteiten logs wissen";
+
+/* Button to clear disk cache */
+"com.jetpack.support.clearDiskCache" = "Schijfcache wissen";
+
+/* Description explaining the purpose of clearing disk cache */
+"com.jetpack.support.clearDiskCacheDescription" = "Verwijder tijdelijke bestanden om ruimte vrij te maken of problemen op te lossen.";
+
+/* Progress text while clearing cache */
+"com.jetpack.support.clearing" = "Aan het opruimen…";
+
+/* Message shown when cache clearing is complete */
+"com.jetpack.support.complete" = "Afgerond";
+
+/* Confirmation message when canceling a draft */
+"com.jetpack.support.confirmCancelMessage" = "Weet je zeker dat je dit bericht wilt annuleren? Je verliest alle gegevens die je hebt ingevoerd";
+
+/* Title for alert confirming cancellation */
+"com.jetpack.support.confirmCancellation" = "Annulering bevestigen";
+
+/* Confirmation dialog title when deleting all logs */
+"com.jetpack.support.confirmDeleteAllLogs" = "Weet je zeker dat je alle logs wil verwijderen?";
+
+/* Section title for contact information */
+"com.jetpack.support.contactInformation" = "Contactgegevens";
+
+/* Button to continue editing a message */
+"com.jetpack.support.continueWriting" = "Doorgaan met schrijven";
+
+/* Message shown at end of closed support conversation */
+"com.jetpack.support.conversationEnded" = "Einde conversatie. Verdere antwoorden zijn niet mogelijk.";
+
+/* Navigation title for bot conversations list */
+"com.jetpack.support.conversations" = "Conversaties";
+
+/* Button to delete all log files */
+"com.jetpack.support.deleteAllLogs" = "Alle logs verwijderen";
+
+/* Description text for diagnostics screen */
+"com.jetpack.support.diagnosticsDescription" = "Uitvoeren veelvoorkomende onderhouds- en probleemoplossingstaken.";
+
+/* Navigation title for diagnostics screen */
+"com.jetpack.support.diagnosticsTitle" = "Diagnostiek";
+
+/* Button to discard changes in a draft message */
+"com.jetpack.support.discardChanges" = "Wijzigingen negeren";
+
+/* Notice explaining where support will send email responses */
+"com.jetpack.support.emailNotice" = "We e-mailen je op dit adres.";
+
+/* Error title when logs fail to load */
+"com.jetpack.support.errorLoadingLogs" = "Fout bij het laden van logs";
+
+/* Error message when support conversations fail to load */
+"com.jetpack.support.errorLoadingSupportConversations" = "Fout bij het laden van ondersteunende gesprekken";
+
+/* Title for error alerts */
+"com.jetpack.support.errorTitle" = "Fout";
+
+/* Option to export log as a file */
+"com.jetpack.support.exportAsFile" = "Exporteren als bestand";
+
+/* Button to dismiss alerts. */
+"com.jetpack.support.gotIt" = "Ik snap het";
+
+/* Text on the support form to refer to what area the user has problem with. */
+"com.jetpack.support.iNeedHelp" = "Ik heb hulp nodig met";
+
+/* Toggle label to include application logs in the support request */
+"com.jetpack.support.includeApplicationLogs" = "Applicatielogs opnemen";
+
+/* Section title for issue details */
+"com.jetpack.support.issueDetails" = "Probleem details";
+
+/* Format string for when conversation was last updated */
+"com.jetpack.support.lastUpdated" = "Laatst geüpdatet %@";
+
+/* Progress message while loading conversation messages */
+"com.jetpack.support.loadingBotConversationMessages" = "Berichten aan het laden";
+
+/* Progress message while loading bot conversations */
+"com.jetpack.support.loadingBotConversations" = "Bot conversaties aan het laden.";
+
+/* Progress text while loading support conversations */
+"com.jetpack.support.loadingConversations" = "Conversaties aan het laden";
+
+/* Progress message while loading disk usage information */
+"com.jetpack.support.loadingDiskUsage" = "Schijfgebruik aan het laden";
+
+/* Progress message while loading an image attachment */
+"com.jetpack.support.loadingImage" = "Afbeelding aan het laden";
+
+/* Progress message shown in overlay while refreshing content */
+"com.jetpack.support.loadingLatestContent" = "Nieuwste inhoud aan het laden";
+
+/* Progress message while loading application log content */
+"com.jetpack.support.loadingLogContent" = "Inhoud log aan het laden...";
+
+/* Progress message while loading log files */
+"com.jetpack.support.loadingLogs" = "Logs aan het laden...";
+
+/* Progress text while loading conversation messages */
+"com.jetpack.support.loadingMessages" = "Berichten aan het laden";
+
+/* Progress message while loading a video attachment */
+"com.jetpack.support.loadingVideo" = "Video aan het laden";
+
+/* Section header for log files sorted by date */
+"com.jetpack.support.logFilesByDate" = "Logbestanden op aanmaakdatum";
+
+/* Text indicating which log files will be included in the support request */
+"com.jetpack.support.logFilesToUpload" = "De volgende logbestanden worden geüpload:";
+
+/* Footer text explaining log retention policy */
+"com.jetpack.support.logRetentionNotice" = "Logs worden zeven dagen lang opgeslagen.";
+
+/* Section header for message text input */
+"com.jetpack.support.message" = "Bericht";
+
+/* Success message when reply is sent successfully */
+"com.jetpack.support.messageSent" = "Bericht verzonden";
+
+/* Format string for number of messages in conversation */
+"com.jetpack.support.messagesCount" = "%d berichten";
+
+/* The title of a new bot chat in the support area of the app */
+"com.jetpack.support.new-bot-chat" = "Nieuwe bot chat";
+
+/* Option to create a new support ticket */
+"com.jetpack.support.newSupportTicket" = "Nieuw ondersteuning ticket";
+
+/* Label shown when there are no bot conversations */
+"com.jetpack.support.noConversations" = "Geen conversaties";
+
+/* Description shown when no log files are available */
+"com.jetpack.support.noLogsAvailable" = "Er zijn geen activiteiten logs beschikbaar";
+
+/* Label shown when no log files are available */
+"com.jetpack.support.noLogsFound" = "Geen logs gevonden";
+
+/* Button to open a support ticket */
+"com.jetpack.support.openSupportTicket" = "Open een ondersteuningsticket";
+
+/* Text indicating a field is optional */
+"com.jetpack.support.optional" = "(Optioneel)";
+
+/* Navigation title for replying to a support conversation */
+"com.jetpack.support.reply" = "Beantwoorden";
+
+/* Description for saving log as a file */
+"com.jetpack.support.saveAsFile" = "Opslaan als bestand om te delen of op te slaan";
+
+/* Label for screenshots section */
+"com.jetpack.support.screenshots" = "Schermafbeeldingen";
+
+/* Description for screenshots section */
+"com.jetpack.support.screenshotsDescription" = "Door schermafbeeldingen toe te voegen kunnen we je probleem sneller begrijpen en oplossen.";
+
+/* Button to send a message or reply */
+"com.jetpack.support.send" = "Verzenden";
+
+/* Description for sending logs to support */
+"com.jetpack.support.sendLogsToSupport" = "Verzend logs rechtstreeks naar het ondersteuningsteam";
+
+/* Progress text while sending a message */
+"com.jetpack.support.sending" = "Aan het verzenden";
+
+/* Progress message shown while sending a message */
+"com.jetpack.support.sendingMessage" = "Bericht aan het verzenden";
+
+/* Button to share content */
+"com.jetpack.support.share" = "Delen";
+
+/* Navigation title for sharing activity log */
+"com.jetpack.support.shareActivityLog" = "Activiteiten log delen";
+
+/* Message shown when sharing log with support */
+"com.jetpack.support.sharingWithSupport" = "Delen met steun!";
+
+/* Site Address title on the support form */
+"com.jetpack.support.siteAddress" = "Siteadres";
+
+/* Placeholder for site address field */
+"com.jetpack.support.siteAddressPlaceholder" = "https:\/\/yoursite.com";
+
+/* Description encouraging user to start a new conversation */
+"com.jetpack.support.startNewConversation" = "Begin een nieuwe conversatie via de knop hierboven";
+
+/* Subject title on the support form */
+"com.jetpack.support.subject" = "Onderwerp";
+
+/* Placeholder for subject field */
+"com.jetpack.support.subjectPlaceholder" = "Korte samenvatting van je probleem";
+
+/* Button title to submit a support request. */
+"com.jetpack.support.submitRequest" = "Ondersteuningsverzoek indienen";
+
+/* Navigation title for the support conversations list */
+"com.jetpack.support.supportConversations" = "Gesprekken ondersteunen";
+
+/* Title for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSent" = "Aanvraag verzonden!";
+
+/* Message for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSentMessage" = "Je ondersteuningsverzoek is succesvol verzonden. We reageren zo snel mogelijk via e-mail.";
+
+/* Progress message shown while bot is thinking */
+"com.jetpack.support.thinking" = "Aan het denken ...";
+
+/* Title of the view for contacting support. */
+"com.jetpack.support.title" = "Neem contact op met ondersteuning";
+
+/* Button to retry a failed operation */
+"com.jetpack.support.tryAgain" = "Probeer opnieuw";
+
+/* Error title when log deletion fails */
+"com.jetpack.support.unableToDeleteLogs" = "Kan geen logs verwijderen";
+
+/* Error message when conversation cannot be displayed */
+"com.jetpack.support.unableToDisplayConversation" = "Conversatie kan niet worden getoond";
+
+/* Error title when video cannot be loaded or played */
+"com.jetpack.support.unableToDisplayVideo" = "Kan video niet tonen";
+
+/* Error message when application logs cannot be loaded */
+"com.jetpack.support.unableToLoadApplicationLogs" = "Kan applicatielogs niet laden";
+
+/* Error title when bot conversations fail to load */
+"com.jetpack.support.unableToLoadConversations" = "Conversaties kunnen niet worden geladen";
+
+/* Error title when messages fail to load */
+"com.jetpack.support.unableToLoadMessages" = "Berichten kunnen niet worden geladen";
+
+/* Error title when message sending fails */
+"com.jetpack.support.unableToSendMessage" = "Kan bericht niet verzenden";
+
+/* Button to view an attachment */
+"com.jetpack.support.view" = "Weergeven";
+
+/* Progress message shown during cache clearing operation */
+"com.jetpack.support.working" = "Werkend";
 
 /* Displayed in the confirmation alert when marking comment notifications as read. */
 "comment" = "reactie";
@@ -7879,6 +8127,9 @@ Example: Reply to Pamela Nguyen */
 /* Weekly Roundup debug menu item */
 "debugMenu.weeklyRoundup" = "Wekelijks overzicht";
 
+/* Title for selecting a default category for a post */
+"defaultCategory.title" = "Standaardcategorie";
+
 /* Error tilte */
 "discussionSettings.saveErrorTitle" = "Instellingen opslaan mislukt";
 
@@ -8018,10 +8269,10 @@ Example: Reply to Pamela Nguyen */
 "double-tap to change unit" = "twee keer tikken om de eenheid te wijzigen";
 
 /* Message for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.message" = "Weet je het zeker dat je deze tag wil verwijderen?";
+"edit.tag.delete.confirmation.message" = "Weet je zeker dat je dit wilt verwijderen?";
 
-/* Title for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.title" = "Tag verwijderen";
+/* Title for delete a term confirmation dialog */
+"edit.tag.delete.confirmation.title" = "Verwijderen";
 
 /* Placeholder text for tag description field */
 "edit.tag.description.placeholder" = "Een beschrijving toevoegen...";
@@ -8036,7 +8287,37 @@ Example: Reply to Pamela Nguyen */
 "edit.tag.section.description" = "Beschrijving";
 
 /* Section header for tag name in edit tag view */
-"edit.tag.section.tag" = "Tag";
+"edit.tag.section.tag" = "Naam";
+
+/* Context menu action to insert a block */
+"editor.blockInserter.insertBlock" = "Blok invoegen";
+
+/* Placeholder text for block search field */
+"editor.blockInserter.search" = "Zoeken";
+
+/* Button title to collapse and show fewer blocks */
+"editor.blockInserter.showLess" = "Toon minder";
+
+/* Button title to expand and show more blocks */
+"editor.blockInserter.showMore" = "Meer tonen";
+
+/* Error message when media insertion fails */
+"editor.media.failedToInsert" = "Media invoegen is mislukt";
+
+/* Category name for section showing all patterns */
+"editor.patterns.all" = "Alle";
+
+/* Context menu action to insert a pattern */
+"editor.patterns.insertPattern" = "Patroon invoegen";
+
+/* Title shown when no patterns match the search */
+"editor.patterns.noPatternsFound" = "Geen patronen gevonden";
+
+/* Navigation title for patterns view */
+"editor.patterns.title" = "Patronen";
+
+/* Category name for patterns without a category */
+"editor.patterns.uncategorized" = "Niet gecategoriseerd";
 
 /* Register Domain - Address information field Number placeholder */
 "eg. 1122334455" = "bijv. 1122334455";
@@ -8590,6 +8871,24 @@ Example: Reply to Pamela Nguyen */
 
 /* Write a blog prompt for the jetpack prologue */
 "jetpack.prologue.prompt.writeBlog" = "Schrijf een blog";
+
+/* Description for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.description" = "Iedereen kan dit bericht bekijken";
+
+/* Title for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.title" = "Iedereen";
+
+/* Description for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.description" = "Alleen betaalde abonnees kunnen dit bericht bekijken";
+
+/* Title for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.title" = "Betalende abonnees";
+
+/* Description for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.description" = "Het bericht is zichtbaar voor alle abonnees, ook de gratis abonnees";
+
+/* Title for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.title" = "Alle abonnees";
 
 /* Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account */
 "jetpackSite.connectToDefaultAccount" = "Je moet inloggen met %@ om statistieken en meldingen te gebruiken.";
@@ -9180,6 +9479,12 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "Je hebt geen toestemming om dit privéblog te bekijken.";
 
+/* Default empty state message format when there are no terms. %1$@ is the taxonomy name. */
+"localizedLabels.defaultNoTerms.format" = "Geen %1$@";
+
+/* Default search placeholder format. %1$@ is the taxonomy name. */
+"localizedLabels.defaultSearch.format" = "Zoeken %1$@";
+
 /* Button to dismiss the re-authentication view */
 "login.appPasswordReAuth.cancelButton" = "Annuleren";
 
@@ -9315,17 +9620,23 @@ Example: Reply to Pamela Nguyen */
 /* Message about buying storage add-on */
 "mediaLibrary.storageDetails.buyStorage.message" = "Koop opslag add-on";
 
-/* Message shown when all media items are attached */
-"mediaLibrary.storageDetails.cleanup.allAttached" = "Alle items in de mediabibliotheek zijn gekoppeld.";
+/* Label for audio media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.audio" = "Audio";
 
-/* Message shown while loading unattached media count */
-"mediaLibrary.storageDetails.cleanup.loading" = "Uitzoeken of er niet-gekoppelde media items zijn...";
+/* Label for document media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.document" = "Documenten";
 
-/* Message about unattached media that can be cleaned up. %1$d is the count of unattached media. */
-"mediaLibrary.storageDetails.cleanup.message" = "%1$d item losgekoppeld. Verwijder ze om wat ruimte vrij te maken.";
+/* Label for image media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.image" = "Afbeeldingen";
 
-/* Title for cleanup section */
-"mediaLibrary.storageDetails.cleanup.title" = "Ongebruikte items verwijderen";
+/* Label for other/unknown media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.other" = "Andere";
+
+/* Label for PowerPoint/presentation media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.powerpoint" = "Presentaties";
+
+/* Label for video media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.video" = "Video's";
 
 /* Success message shown after upgrading plan */
 "mediaLibrary.storageDetails.purchase.plan.success" = "Je site abonnement is geüpgraded!";
@@ -9711,6 +10022,12 @@ Example: Reply to Pamela Nguyen */
 /* Menu option for filtering posts by me */
 "pagesList.pagesByMe" = "Pagina's gemaakt door mij";
 
+/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
+"parentCategory.noCategory" = "Geen categorie";
+
+/* Title for selecting parent category of a category */
+"parentCategory.title" = "Hoofdcategorie";
+
 /* Title for the parent page picker screen */
 "parentPagePicker.title" = "Hoofdpagina";
 
@@ -9869,6 +10186,27 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the post author selection screen */
 "postAuthorPicker.title" = "Auteur";
+
+/* Title for selecting categories for a post or a page */
+"postCategories.title" = "Categorieën";
+
+/* Toggle label for allowing comments on post */
+"postDiscussion.allowComments.label" = "Reacties toestaan";
+
+/* Toggle label for allowing pings/trackbacks on post */
+"postDiscussion.allowPings.label" = "Pingbacks toestaan";
+
+/* Footer text when comments are disabled */
+"postDiscussion.comments.disabled.footer" = "Bezoekers kunnen geen nieuwe reacties of antwoorden toevoegen. Bestaande reacties blijven zichtbaar.";
+
+/* Footer text when comments are enabled */
+"postDiscussion.comments.enabled.footer" = "Bezoekers kunnen nieuwe reacties en antwoorden toevoegen.";
+
+/* Link text for learning more about pingbacks and trackbacks */
+"postDiscussion.pingbacks.learnMore.text" = "Lees verder over pingbacks & trackbacks";
+
+/* Navigation title for post discussion settings */
+"postDiscussion.title" = "Discussie";
 
 /* Button in an alert confirming discaring changes */
 "postEditor.closeConfirmationAlert.discardChanges" = "Wijzigingen negeren";
@@ -10101,6 +10439,9 @@ Example: Reply to Pamela Nguyen */
 /* A default value for an post without a title */
 "postSaveErrorMessage.postUntitled" = "Zonder titel";
 
+/* Section header for Access settings in Post Settings */
+"postSettings.access.header" = "Toegang";
+
 /* Label for the author field in Post Settings */
 "postSettings.author.label" = "Auteur";
 
@@ -10119,6 +10460,18 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the discard changes confirmation dialog */
 "postSettings.discardChanges.title" = "Wijzigingen verwijderen?";
+
+/* Status text when discussion (comments) is disabled */
+"postSettings.discussion.closed" = "Gesloten";
+
+/* Label for the discussion settings field in Post Settings */
+"postSettings.discussion.label" = "Discussie";
+
+/* Status text when discussion (comments) is enabled */
+"postSettings.discussion.open" = "Open";
+
+/* Label for the checkbox that lets you send a post to newsletter subscribers */
+"postSettings.emailToSubscribers.label" = "E-mail naar abonnees";
 
 /* Character count for excerpt. %1$d is the number of characters. */
 "postSettings.excerpt.characterCount" = "%1$d karakters";
@@ -10222,6 +10575,21 @@ Example: Reply to Pamela Nguyen */
 /* Cell title for the Top Level option case */
 "postSettings.parentPage.topLevel" = "Topniveau";
 
+/* Accessibility label for hide password button */
+"postSettings.passwordEntry.hidePassword" = "Verberg wachtwoord";
+
+/* Instructions for password entry */
+"postSettings.passwordEntry.instructions" = "Voer een wachtwoord in om dit bericht te beschermen. Alleen gebruikers met het wachtwoord kunnen het bekijken.";
+
+/* Navigation title for password entry screen */
+"postSettings.passwordEntry.navigationTitle" = "Wachtwoord invoeren";
+
+/* Placeholder for password field */
+"postSettings.passwordEntry.placeholder" = "Wachtwoord invoeren";
+
+/* Accessibility label for show password button */
+"postSettings.passwordEntry.showPassword" = "Wachtwoord weergeven";
+
 /* Label for the pending review toggle in Post Settings */
 "postSettings.pendingReview.label" = "In afwachting van beoordeling";
 
@@ -10249,17 +10617,59 @@ Example: Reply to Pamela Nguyen */
 /* Section header for General settings in Post Settings */
 "postSettings.section.general" = "Algemeen";
 
+/* Description text explaining what the slug editor does */
+"postSettings.slug.customizeDescription" = "Pas het laatste deel van de permalink aan.";
+
 /* Hint text for the slug field. Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso. */
 "postSettings.slug.hint" = "De slug is de URL-vriendelijke versie van de berichttitel.";
 
 /* Label for the slug field. Should be the same as WP core. */
 "postSettings.slug.label" = "Slug";
 
+/* Button text to learn more about permalinks */
+"postSettings.slug.learnMore" = "Lees verder";
+
+/* Label for the slug field. Should be the same as WP core. */
+"postSettings.slug.navigationTitle" = "Slug";
+
+/* Notice shown when the post doesn't have a remote and permalink template is missing */
+"postSettings.slug.permalinkDraftNotice" = "De voorgestelde permalink verschijnt wanneer het concept wordt opgeslagen op de server";
+
+/* Label for the permalink preview */
+"postSettings.slug.permalinkLabel" = "Permalink";
+
+/* Section title for the permalink preview */
+"postSettings.slug.permalinkSection" = "Permalink";
+
 /* Placeholder for the slug field */
 "postSettings.slug.placeholder" = "Slug invoeren";
 
 /* Label for the preview button in Post Settings */
 "postSettings.socialSharing.header" = "Sociaal delen";
+
+/* Label for the status field in Post Settings */
+"postSettings.status.label" = "Status";
+
+/* Navigation title for status picker */
+"postSettings.statusPicker.navigationTitle" = "Status & zichtbaarheid";
+
+/* Label showing the current password */
+"postSettings.statusPicker.passwordLabel" = "Wachtwoord";
+
+/* Toggle label for password protection */
+"postSettings.statusPicker.passwordProtected" = "Wachtwoord beveiligd";
+
+/* Subtitle for password protected toggle */
+"postSettings.statusPicker.passwordProtectedSubtitle" = "Alleen zichtbaar voor degenen die het wachtwoord kennen";
+
+/* Label for schedule date row */
+"postSettings.statusPicker.scheduleDate" = "Datum";
+
+/* Toggle label for sticky posts */
+"postSettings.statusPicker.sticky" = "Sticky";
+
+/* Subtitle for sticky toggle */
+"postSettings.statusPicker.stickySubtitle" = "Pin dit bericht aan de bovenkant van de blog";
 
 /* Label for the sticky post toggle. Sticky posts are displayed at the top of the blog. */
 "postSettings.stickyPost.label" = "Sticky";
@@ -10279,17 +10689,56 @@ Example: Reply to Pamela Nguyen */
 /* Navigation bar title of the Post Stats screen */
 "postStats.title" = "Berichtstatistieken";
 
-/* Button to add a new tag. %1$@ is the tag name. */
-"postTags.addTag" = "Tag toevoegen";
+/* Post status title */
+"postStatus.deleted.details" = "Permanent verwijderd";
 
-/* Placeholder text for the tag search field */
-"postTags.searchOrAdd.placeholder" = "Zoeken of tags toevoegen";
+/* Post status title */
+"postStatus.deleted.title" = "Verwijderd";
 
-/* Message shown when no tags are selected */
-"postTags.selectionEmpty" = "Er zijn geen tags geselecteerd";
+/* Post status details */
+"postStatus.draft.details" = "Niet klaar om te publiceren";
 
-/* Title for the tags screen */
-"postTags.title" = "Tags";
+/* Post status title */
+"postStatus.draft.title" = "Concept";
+
+/* Post status details */
+"postStatus.pending.details" = "Wachten op beoordeling alvorens te publiceren";
+
+/* Post status title */
+"postStatus.pending.title" = "In afwachting";
+
+/* Post status details */
+"postStatus.private.details" = "Alleen zichtbaar voor site beheerders en editors";
+
+/* Post status title */
+"postStatus.private.title" = "Privé";
+
+/* Post status details */
+"postStatus.published.details" = "Zichtbaar voor iedereen";
+
+/* Post status title */
+"postStatus.published.title" = "Gepubliceerd";
+
+/* Post status details */
+"postStatus.scheduled.details" = "Automatisch publiceren op een gekozen datum";
+
+/* Post status title */
+"postStatus.scheduled.title" = "Gepland";
+
+/* Post status title */
+"postStatus.trash.details" = "Nar prullenbak verplaatst maar nog niet verwijderd";
+
+/* Post status title */
+"postStatus.trash.title" = "Naar prullenbak verplaatst";
+
+/* Button to add a new taxonomy term. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.addTag" = "Toevoegen %1$@";
+
+/* Placeholder text for the taxonomy search field. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.searchOrAdd.placeholder" = "Zoeken of toevoegen %1$@";
+
+/* Message shown when no taxonomy terms are selected. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.selectionEmpty" = "Er zijn geen %1$@ geselecteerd";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Annuleren";
@@ -10365,9 +10814,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "Categorieën";
-
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "Sluiten";
 
 /* Button to confirm discarding changes */
 "prepublishing.discardChanges.button" = "Wijzigingen negeren";
@@ -10456,12 +10902,17 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "Waarschuwing";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "Bericht";
+
+/* Placeholder text for the message field in Social Sharing */
+"prepublishing.socialAccounts.messagePlaceholder" = "Schrijf een kort bericht om te delen op sociale media naast het bericht";
 
 /* The navigation title for the pre-publishing social accounts screen. */
 "prepublishing.socialAccounts.navigationTitle" = "Social";
+
+/* Table section title */
+"prepublishing.socialAccounts.servicesSectionTitle" = "Diensten";
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.tags" = "Tags";
@@ -11408,6 +11859,18 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Button to progress to the next step after selecting domain in Site Creation */
 "siteCreation.domains.buttons.selectDomain" = "Selecteer domein";
 
+/* Default text for adding a new item when no label is provided */
+"siteCustomTaxonomies.defaultAddNew" = "Toevoegen";
+
+/* Description for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.description" = "Taxonomieën helpen je bij het organiseren van inhoud die verder gaat dan standaardcategorieën en tags.";
+
+/* Title for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.title" = "Geen aangepaste taxonomieën";
+
+/* Navigation title for the custom taxonomies screen */
+"siteCustomTaxonomies.navigationTitle" = "Taxonomieën";
+
 /* Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio. */
 "siteMedia.accessibilityLabelAudio" = "Audio, %@";
 
@@ -11426,8 +11889,77 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Accessibility hint for actions when displaying media items. */
 "siteMedia.cellAccessibilityHint" = "Selecteer media.";
 
+/* Label for the alt for a media asset (image) */
+"siteMedia.details.altText" = "ALT-tekst";
+
+/* Verb. Button title. Tapping cancels an action. */
+"siteMedia.details.cancel" = "Annuleren";
+
+/* Noun. Label for the caption for a media asset (image / video) */
+"siteMedia.details.caption" = "Bijschrift";
+
+/* Title for button that permanently deletes a media item (photo / video) */
+"siteMedia.details.delete" = "Verwijderen";
+
+/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
+"siteMedia.details.deleteConfirmation" = "Weet je zeker dat je dit item permanent wilt verwijderen?";
+
+/* Text displayed in HUD after successfully deleting a media item */
+"siteMedia.details.deleted" = "Verwijderd!";
+
+/* Text displayed in HUD while a media item is being deleted. */
+"siteMedia.details.deleting" = "Verwijderen...";
+
+/* Label for the description for a media asset (image / video) */
+"siteMedia.details.description" = "Beschrijving";
+
+/* Label for the dimensions in pixels for a media asset (image / video) */
+"siteMedia.details.dimensions" = "Dimensies";
+
+/* Label for the file name for a media asset (image / video) */
+"siteMedia.details.fileName" = "Bestandsnaam";
+
+/* Label for the file size for a media asset (image / video) */
+"siteMedia.details.fileSize" = "Bestand grootte";
+
+/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
+"siteMedia.details.fileType" = "Bestandstype";
+
+/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
+"siteMedia.details.mediaDeleted" = "Dit media item is verwijderd.";
+
+/* Noun. Label for the title of a media asset (image / video) */
+"siteMedia.details.title" = "Titel";
+
+/* Accessibility label for trash buttons in nav bars */
+"siteMedia.details.trash" = "Prullenbak";
+
+/* Text displayed in HUD if there was an error attempting to delete a media item. */
+"siteMedia.details.unableToDeleteMedia" = "Kan media item niet verwijderen.";
+
+/* Error shown when the app fails to load a video from the user's media library. */
+"siteMedia.details.unableToLoadVideo" = "Kan video niet laden.";
+
+/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
+"siteMedia.details.unableToSaveMedia" = "Kan media item niet opslaan.";
+
+/* Label for the date a media asset (image / video) was uploaded */
+"siteMedia.details.uploaded" = "Geüpload";
+
 /* Title for the URL field */
 "siteMedia.details.url" = "URL";
+
+/* Hint for image alt on image settings. */
+"siteMedia.hints.imageAlt" = "Afbeelding Alt";
+
+/* Hint for image caption on image settings. */
+"siteMedia.hints.imageCaption" = "Afbeelding bijschrift";
+
+/* Hint for image description on image settings. */
+"siteMedia.hints.imageDescription" = "Afbeelding beschrijving";
+
+/* Hint for image title on image settings. */
+"siteMedia.hints.imageTitle" = "Afbeelding titel";
 
 /* Accessibility hint for media item preview for user's viewing an item in their media library */
 "siteMediaItem.contentViewAccessibilityHint" = "Klik om media op volledig scherm te bekijken";
@@ -11525,6 +12057,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Privacy";
+
+/* Format string for adding a new taxonomy term. %1$@ is the taxonomy name. */
+"siteTaxonomy.addNew.format" = "Toevoegen %1$@";
 
 /* Hint for users when hidden privacy setting is set */
 "siteVisibility.hidden.hint" = "Je site wordt verborgen voor bezoekers door middel van een melding 'Binnenkort beschikbaar' tot hij klaar is om bekeken te worden.";
@@ -12093,7 +12628,8 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Subject of new Zendesk ticket. */
 "support.zendesk.readerAppTicketSubject" = "Reader voor iOS ondersteuning";
 
-/* Description for empty state when there are no tags */
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
 "tags.empty.description" = "Tags helpen je inhoud te organiseren en maken het makkelijker voor lezers om gerelateerde berichten te vinden.";
 
 /* Title for empty state when there are no tags */
@@ -12170,9 +12706,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "ongelezen";
-
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "Site abonnee";
 
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "Site gebruiker";
@@ -12258,9 +12791,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* The heading at the top of the user list */
 "userlist.title" = "Gebruikers";
-
-/* Site Subscribers */
-"users.list.title.subscribers" = "Abonnees";
 
 /* Screen title */
 "users.title" = "Gebruikers";

--- a/WordPress/Resources/pl.lproj/Localizable.strings
+++ b/WordPress/Resources/pl.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 /* Translation-Revision-Date: 2025-07-14 07:37:10+0000 */
 /* Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2); */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: pl */
 
 /* Title of a list of buttons used for sharing content to other services. These buttons appear when the user taps a `More` button. */
@@ -374,7 +374,6 @@
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Anuluj";
@@ -385,8 +384,7 @@
 /* Error message shown when the input URL does not point to an existing site. */
 "Cannot access the site at this address. Please double-check and try again." = "Nie można uzyskać dostępu do witryny pod tym adresem. Sprawdź dokładnie i spróbuj ponownie.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Podpis";
 
 /* Alert title. */
@@ -664,9 +662,6 @@
 /* Action title. Noun. Opens the user's WordPress.com dashboard in an external browser. */
 "Dashboard" = "Kokplt";
 
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Usuń";
-
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Usuń menu";
 
@@ -678,17 +673,10 @@
 /* Title of alert when site deletion fails */
 "Delete Site Error" = "Błąd usuwania strony";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Usunięto!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Usuwanie witryny";
 
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Usuwanie…";
-
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Opis";
 
 /* Title for the desktop web preview */
@@ -697,9 +685,6 @@
 /* Details button that appears in the Theme Browser Header
    Theme Details action title */
 "Details" = "Szczegóły";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Wymiary";
 
 /* Adjective. Comment threading is disabled. */
 "Disabled" = "Wyłączono";
@@ -817,7 +802,7 @@
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "Edycja pliku GIF pozbawi go animacji.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Edytor";
 
 /* Education site intent topic */
@@ -917,9 +902,6 @@
 
 /* Label for list of file downloads. */
 "File" = "Plik";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Typ pliku";
 
 /* Film & Television site intent topic */
 "Film & Television" = "Film i telewizja";
@@ -1092,14 +1074,8 @@
 /* The instructions text about not being able to find the magic link email. */
 "If you can’t find the email, please check your junk or spam email folder" = "Jeśli nie można znaleźć wiadomości e-mail, proszę sprawdzić foldery: śmieci i spam";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Opis obrazka";
-
 /* No comment provided by engineer. */
 "Image file not found." = "Nie znaleziono obrazka.";
-
-/* Hint for image title on image settings. */
-"Image title" = "Tytuł obrazka";
 
 /* An error message shown when a user signed in with incorrect credentials. */
 "Incorrect username or password. Please try entering your login details again." = "Błędny login lub hasło. Spróbuj ponownie.";
@@ -1461,9 +1437,6 @@
    Title of a button. The text should be capitalized. */
 "Next" = "Następne";
 
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Brak kategorii";
-
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Brak połączenia";
 
@@ -1626,9 +1599,6 @@
    This is the section title
    Title of the screen showing the list of pages for a blog. */
 "Pages" = "Strony";
-
-/* Title for selecting parent category of a category */
-"Parent Category" = "Kategoria nadrzędna";
 
 /* Accessibility label for the password text field in the self-hosted login page.
    Label for entering password in password field
@@ -2185,6 +2155,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "System default" = "Domyślne ustawienie systemowe";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Tagi";
 
@@ -2302,7 +2273,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Tytuł";
@@ -2321,8 +2291,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title for the traffic section in site settings screen */
 "Traffic" = "Ruch";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Kosz";
 
@@ -2432,9 +2401,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Nie powiodło się przesyłanie";
-
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Wysłano";
 
 /* \"Uploading\" Status text */
 "Uploading" = "Przesyłanie";

--- a/WordPress/Resources/pt-BR.lproj/Localizable.strings
+++ b/WordPress/Resources/pt-BR.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 /* Translation-Revision-Date: 2025-03-26 18:26:36+0000 */
 /* Plural-Forms: nplurals=2; plural=n > 1; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: pt_BR */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -578,8 +578,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "Quase pronto! Informe o código de verificação do seu aplicativo de autenticação.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Texto alternativo";
 
 /* No comment provided by engineer. */
@@ -722,9 +721,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "Tem certeza de que deseja desconectar o Jetpack do seu site?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "Tem certeza de que deseja excluir permanentemente este item?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "Tem certeza de que deseja remover %1$@ de %2$@?";
@@ -1079,7 +1075,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Cancelar";
@@ -1107,8 +1102,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Não consegue decidir? Você pode mudar o tema a qualquer momento.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Legenda";
 
 /* Alert title. */
@@ -1771,8 +1765,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "Padrão";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Categoria padrão";
 
 /* Label for selecting the default post format
@@ -1781,9 +1774,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Padrões para novos posts";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Excluir";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Excluir menu";
@@ -1802,14 +1792,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "Excluir menu";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Excluido!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Apagando o site...";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Excluindo...";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "Negar";
@@ -1817,8 +1801,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "Descreva o objetivo da imagem. Deixe vazio caso a imagem seja decorativa.";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Descrição";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1836,9 +1819,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "Não queria criar uma conta nova? Volte para redigitar seu endereço de e-mail.";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Dimensões";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "Desativar";
@@ -2115,7 +2095,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "Editar o gif removerá sua animação.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Editor";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2454,11 +2434,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "Configurações do bloco Arquivo";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "Nome do arquivo";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Tipo de arquivo";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "O tipo de arquivo não é suportado como um arquivo de mídia.";
@@ -2817,9 +2794,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "Legenda da imagem";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Descrição da imagem";
-
 /* Hint for image link on image settings. */
 "Image Link" = "Link da imagem";
 
@@ -2831,9 +2805,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "Arquivo de imagem não encontrado.";
-
-/* Hint for image title on image settings. */
-"Image title" = "Título da imagem";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "Em poucas palavras, explique sobre o que é este site.";
@@ -3736,9 +3707,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "Nenhuma conta encontrada";
 
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Nenhuma categoria";
-
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Sem conexão";
 
@@ -4179,9 +4147,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "Paginação";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Categoria mãe";
-
 /* Parenting site intent topic */
 "Parenting" = "Criação de filhos";
 
@@ -4399,9 +4364,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Post";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Categorias de post";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "Configurações do post";
@@ -4710,9 +4672,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "Remove os metadados de localização das fotos antes de enviá-las para seu site.";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "Caso remova os seguidores, eles não receberão atualizações do seu site. Se eles quiserem, ainda poderão acessar seu site e voltar a segui-lo.";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "Substituir o bloco atual";
@@ -5546,6 +5505,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "Descrição";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Tags";
 
@@ -5931,9 +5891,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "Esse código de login expirou. Toque no botão de verificação novamente para reanalisar o código.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "Este item da biblioteca foi removido.";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "A conta não pode ser encerrada pois possui estornos não resolvidos.";
 
@@ -6002,7 +5959,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Título";
@@ -6096,8 +6052,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "Transformar bloco...";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Lixeira";
 
@@ -6194,9 +6149,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "Não foi possível criar novos links de convite.";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "Incapaz de excluir item de mídia.";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "Não foi possível desativar os links de convite.";
 
@@ -6227,9 +6179,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "Não foi possível carregar esse conteúdo no momento.";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "Não foi possível carregar o vídeo.";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Não foi possível reproduzir o vídeo";
 
@@ -6238,9 +6187,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Não foi possível restaurar o site";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "Incapaz de salvar item de média.";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "Não foi possível compartilhar o link";
@@ -6396,9 +6342,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Falha ao carregar";
-
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Enviado";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "1 rascunho de post e %ld arquivos enviados";
@@ -6888,7 +6831,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "Mapa do mundo mostrando visualizações por país.";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "Ainda gostaria de remover esta pessoa?";
 
 /* Button title. Opens the editor to write a new post.
@@ -7262,8 +7205,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "Gerenciamento de plugins";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "Gestão de usuários";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -9231,9 +9173,6 @@ Example: Reply to Pamela Nguyen */
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "Categorias";
 
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "Fechar";
-
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.jetpackSocial" = "Jetpack Social";
 
@@ -9306,8 +9245,7 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "Aviso";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "Mensagem";
 
 /* The navigation title for the pre-publishing social accounts screen. */
@@ -10715,9 +10653,6 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "não lida";
 
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "Assinante do site";
-
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "Usuário do site";
 
@@ -10802,9 +10737,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* The heading at the top of the user list */
 "userlist.title" = "Usuários";
-
-/* Site Subscribers */
-"users.list.title.subscribers" = "Assinantes";
 
 /* Verb. Dismiss the web view screen. */
 "webKit.button.dismiss" = "Dispensar";

--- a/WordPress/Resources/pt.lproj/Localizable.strings
+++ b/WordPress/Resources/pt.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 /* Translation-Revision-Date: 2022-05-03 21:58:48+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: pt */
 
 /* Title of a list of buttons used for sharing content to other services. These buttons appear when the user taps a `More` button. */
@@ -173,8 +173,7 @@
 /* A short description of the comment like sharing setting. */
 "Allow all comments to be Liked by you and your readers" = "Permitir que todos os comentários possam ter um Gosto atribuído pelos seus leitores.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Texto alternativo (Alt)";
 
 /* Error message shown when trying to view the Plugins feature and there is no internet connection.
@@ -349,7 +348,6 @@
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Cancelar";
@@ -365,8 +363,7 @@
 /* Share extension dialog dismiss button label - displayed when user is missing a login token. */
 "Cancel sharing" = "Cancelar partilha";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Legenda";
 
 /* Alert title. */
@@ -599,8 +596,7 @@
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "Por omissão";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Categoria por omissão";
 
 /* Label for selecting the default post format
@@ -609,9 +605,6 @@
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Por omissão para novos artigos";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Eliminar";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Eliminar menu";
@@ -627,25 +620,15 @@
 /* Title of alert when site deletion fails */
 "Delete Site Error" = "Erro ao eliminar site";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Eliminado!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "A eliminar site...";
 
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "A eliminar...";
-
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Descrição";
 
 /* Details button that appears in the Theme Browser Header
    Theme Details action title */
 "Details" = "Detalhes";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Dimensões";
 
 /* Adjective. Comment threading is disabled. */
 "Disabled" = "Desactivado";
@@ -732,7 +715,7 @@
 /* Title for the edit sharing buttons section */
 "Edit sharing buttons" = "Editar botões de partilha";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Editor";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -823,11 +806,8 @@
 /* A short message to inform the user data for their sites are being fetched. */
 "Fetching sites..." = "A obter sites...";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "Nome do ficheiro";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Tipo de ficheiro";
 
 /* Register Domain - Domain contact information field First name
    User's First Name */
@@ -947,17 +927,11 @@
 /* Hint for image caption on image settings. */
 "Image Caption" = "Legenda da imagem";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Descrição da imagem";
-
 /* Hint for image link on image settings. */
 "Image Link" = "Ligação da imagem";
 
 /* Title of the screen for choosing an image's size. */
 "Image Size" = "Tamanho da imagem";
-
-/* Hint for image title on image settings. */
-"Image title" = "Título da imagem";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "Em poucas palavras, explique sobre o que é este site.";
@@ -1288,9 +1262,6 @@
 /* Accessibility label for the next notification button */
 "Next notification" = "Notificação seguinte";
 
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Sem categoria";
-
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Sem ligação ao servidor";
 
@@ -1494,9 +1465,6 @@
    Settings: Comments Paging preferences */
 "Paging" = "Paginação";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Categoria superior";
-
 /* Accessibility label for the password text field in the self-hosted login page.
    Label for entering password in password field
    Login dialog password placeholder
@@ -1575,9 +1543,6 @@
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Publicar";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Categorias de conteúdo";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "Definições do Artigo";
@@ -2010,6 +1975,7 @@
 "Tagline" = "Descrição";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Etiquetas";
 
@@ -2108,9 +2074,6 @@
 /* An error message informing the user the email address they entered did not match a WordPress.com account. */
 "This email address is not registered on WordPress.com." = "Este endereço de email não está registado em WordPress.com.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "Este item multimédia foi eliminado.";
-
 /* A description of the twitter sharing setting.
    Information about the twitter sharing feature. */
 "This will be included in tweets when people share using the Twitter button." = "É incluido no tweet quando os seus artigos são partilhados com o botão do Twitter.";
@@ -2129,7 +2092,6 @@
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Título";
@@ -2157,8 +2119,7 @@
 /* Title for the traffic section in site settings screen */
 "Traffic" = "Tráfego";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Lixo";
 
@@ -2212,15 +2173,6 @@
 
 /* Title of error prompt shown when a sync the user initiated fails. */
 "Unable to Sync" = "Não é possível sincronizar";
-
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "Não é possível eliminar o item multimédia.";
-
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "Não é possível carregar o vídeo.";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "Não é possível guardar o item multimédia.";
 
 /* Error message displayed when an error occurred checking for email availability. */
 "Unable to verify the email address. Please try again later." = "Não foi possível verificar o endereço de email. Por favor tente mais tarde.";
@@ -2291,9 +2243,6 @@
 
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "O carregamento falhou.";
-
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Carregado";
 
 /* Title for the user uploaded themes section, should be the same as in Calypso */
 "Uploaded themes" = "Temas carregados";
@@ -2448,7 +2397,7 @@
 /* Link to a WordPress.org page for the plugin */
 "WordPress.org Plugin Page" = "Página do plugin em WordPress.org";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "Gostaria ainda assim de remover este utilizador?";
 
 /* Placeholder text for inline compose view */

--- a/WordPress/Resources/ro.lproj/Localizable.strings
+++ b/WordPress/Resources/ro.lproj/Localizable.strings
@@ -1,6 +1,6 @@
-/* Translation-Revision-Date: 2025-10-03 07:05:33+0000 */
+/* Translation-Revision-Date: 2025-11-24 11:33:04+0000 */
 /* Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n == 0 || n % 100 >= 2 && n % 100 <= 19) ? 1 : 2); */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: ro */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -507,7 +507,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "Address line %@" = "Linie adresă %@";
 
 /* Title for the advanced section in site settings screen */
-"Advanced" = "Avansat";
+"Advanced" = "Avansate";
 
 /* Screen reader text expressing the menu item is after another menu item. Argument is a name for another menu item. */
 "After %@" = "După %@";
@@ -581,8 +581,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "Aproape gata! Te rog să introduci codul de verificare din aplicația Authenticator.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Text alternativ";
 
 /* No comment provided by engineer. */
@@ -725,9 +724,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "Sigur vrei să deconectezi Jetpack de pe site?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "Sigur vrei să ștergi definitiv acest element?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "Sigur vrei să înlături %1$@ din %2$@?";
@@ -1082,7 +1078,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Anulare";
@@ -1110,8 +1105,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Nu te poți decide? Poți să schimbi tema oricând.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Text asociat";
 
 /* Alert title. */
@@ -1777,8 +1771,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "Implicit";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Categorie implicită";
 
 /* Label for selecting the default post format
@@ -1787,9 +1780,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Implicite pentru articole noi";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Ștergre";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Șterge meniul";
@@ -1808,14 +1798,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "Șterge meniul";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Șters!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Șterg site-ul...";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Șterg...";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "Refuză";
@@ -1823,8 +1807,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "Descrie scopul imaginii. Lasă gol dacă imaginea este doar decorativă.";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Descriere";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1842,9 +1825,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "Nu ai vrut să creezi un cont nou? Mergi înapoi și reintrodu adresa ta de email.";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Dimensiuni";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "Dezactivează";
@@ -2121,7 +2101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "Editarea acestui GIF îi va înlătura animația.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Editor";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2463,11 +2443,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "Setări bloc fișier";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "Nume fișier";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Tip de fișier";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "Tipul de fișier nu este acceptat ca fișier media.";
@@ -2781,6 +2758,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post content used in the login prologue screens. */
 "I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next" = "M-au inspirat foarte mult lucrările fotografului Cameron Karsten. Voi încerca aceste tehnici pe viitor";
 
+/* Text on the support form to refer to what area the user has problem with. */
+"I need help with" = "Am nevoie de ajutor cu";
+
 /* Describes the IP address section in the comment detail screen. */
 "IP address" = "Adresă IP";
 
@@ -2826,9 +2806,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "Text asociat imagine";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Descriere imagine";
-
 /* Hint for image link on image settings. */
 "Image Link" = "Legătură imagine";
 
@@ -2840,9 +2817,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "Nu am găsit fișierul imagine.";
-
-/* Hint for image title on image settings. */
-"Image title" = "Titlu imagine";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "Descrie în câteva cuvinte acest site.";
@@ -3205,6 +3179,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the button that will dismiss this view. */
 "Let me know when finished!" = "Anunță-mă când este gata!";
 
+/* Message info on the support screen. */
+"Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon." = "Dă-ne adresa site-ului tău (URL) și spune-ne cât mai multe despre problemă și te vom contacta în curând.";
+
+/* Title to let the user know what do we want on the support screen. */
+"Let’s get this sorted" = "Hai să rezolvăm asta";
+
 /* Lifestyle site intent topic */
 "Lifestyle" = "Stil de viață";
 
@@ -3405,6 +3385,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Navigare principală";
+
+/* Explanation for the option to enable theme styles */
+"Make the block editor look like your theme." = "Îți faci editorul de blocuri să arate ca tema ta.";
 
 /* No comment provided by engineer. */
 "Make your content stand out by adding images, gifs, videos, and embedded media to your pages." = "Îți scoți conținutul în evidență prin adăugarea de imagini, imagini GIF, videouri și elemente media înglobate în paginile tale.";
@@ -3747,9 +3730,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "Nu am găsit niciun cont";
-
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Nicio categorie";
 
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Nu ai conexiune";
@@ -4191,9 +4171,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "Paginare";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Categorie părinte";
-
 /* Parenting site intent topic */
 "Parenting" = "Creșterea și educarea copiilor";
 
@@ -4411,9 +4388,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Articol";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Categorii de articole";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "Setări articole";
@@ -4722,9 +4696,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "Înlătură metadatele locației din fotografii înainte de a le încărca pe site-ul tău.";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "Dacă înlături urmăritorii, ei nu vor mai primi actualizări de la site-ul tău. Dacă vor, pot să-ți viziteze site-ul și să-l urmărească din nou.";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "Înlocuiește blocul curent";
@@ -5561,6 +5532,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "Slogan";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Etichete";
 
@@ -5657,6 +5629,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint, informing user the button can be used to visit the Gravatar website. */
 "Tap to visit the Gravatar website in an external browser" = "Atinge pentru a vizita site-ul Gravatar într-un navigator extern";
+
+/* Label for viewing the custom taxonomies */
+"Taxonomies" = "Taxonomii";
 
 /* Technology site intent topic */
 "Technology" = "Tehnologie";
@@ -5946,9 +5921,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "Acest cod de autentificare a expirat. Te rog atinge butonul Scanează din nou pentru a scana din nou codul.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "Acest element media a fost șters.";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "Acest cont de utilizator nu poate fi închis dacă există restituiri nerezolvate.";
 
@@ -6017,7 +5989,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Titlu";
@@ -6111,8 +6082,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "Transformă blocul...";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Coș de gunoi";
 
@@ -6209,9 +6179,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "Nu pot să creez legături noi la invitații.";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "Nu pot șterge elementul media.";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "Nu pot să dezactivez legăturile la invitații.";
 
@@ -6242,20 +6209,14 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "Nu pot să încarc acest conținut chiar acum.";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "Nu pot încărca videoul.";
-
 /* Dialog box title for when the user is canceling an upload. */
-"Unable to play video" = "Nu pot rula videoul";
+"Unable to play video" = "Nu pot să rulez videoul";
 
 /* No comment provided by engineer. */
 "Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Nu pot să găsesc site-ul WordPress la acel URL. Atinge „Ai nevoi de mai mult ajutor?” pentru a vedea Întrebări frecvente.";
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Nu pot să restaurez site-ul";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "Nu pot salva elementul media.";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "Nu pot să partajez legătura";
@@ -6412,9 +6373,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Încărcarea a eșuat";
 
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Încărcat";
-
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "S-a încărcat o ciornă de articol, %ld fișiere";
 
@@ -6456,6 +6414,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The button title text for logging in with WP.com password instead of magic link. */
 "Use password to sign in" = "Folosește parola pentru autentificare";
+
+/* Option to enable theme styles in the block editor */
+"Use theme styles" = "Folosește stilurile temei";
 
 /* A placeholder for the twitter username
    Accessibility label for the username text field in the self-hosted login page.
@@ -6906,7 +6867,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "Harta lumii care arată vizualizările pe țară.";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "Mai vrei să înlături această persoană?";
 
 /* Button title. Opens the editor to write a new post.
@@ -7377,14 +7338,19 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Description for the prompt to upgrade to Application Passwords. The first argument is the name of the feature that requires Application Passwords. */
 "applicationPasswordRequired.description" = "Parolele aplicației sunt o modalitate mai sigură de a-ți conecta site-ul auto-găzduit și de a activa suportul pentru funcționalități, cum ar fi %@.";
 
+/* Feature name for managing application passwords in the app */
+"applicationPasswordRequired.feature.applicationPasswords" = "Administrare parole pentru aplicații";
+
 /* Feature name for the block editor in application password required prompt */
 "applicationPasswordRequired.feature.blockEditor" = "Editor de blocuri";
+
+/* Feature name for managing terms and taxonomies in the app */
+"applicationPasswordRequired.feature.customTaxonomies" = "Administrare taxonomii";
 
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "Administrare module";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "Administrare utilizatori";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -7613,6 +7579,288 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 
 /* Post Editor / Button in the 'More' menu */
 "classicEditor.moreMenu.saveDraft" = "Salvează ciorna";
+
+/* Button to add more screenshots */
+"com.jetpack.support.addMoreScreenshots" = "Adaugă mai multe capturi ecran";
+
+/* Button to add screenshots */
+"com.jetpack.support.addScreenshots" = "Adaugă capturi ecran";
+
+/* Header for application logs section */
+"com.jetpack.support.applicationLogs" = "Jurnale aplicație";
+
+/* Description explaining why including logs is helpful */
+"com.jetpack.support.applicationLogsDescription" = "Includerea jurnalelor poate ajuta echipa noastră să investigheze problemele. Jurnalele pot să conțină activități recente din aplicație.";
+
+/* Navigation title for application logs screen */
+"com.jetpack.support.applicationLogsTitle" = "Jurnale aplicație";
+
+/* Format string for attachment identifier */
+"com.jetpack.support.attachment" = "Atașament %@";
+
+/* Format string for attachment size limit. %1$@ is current size, %2$@ is maximum size */
+"com.jetpack.support.attachmentLimit" = "Limită pentru atașamente: %1$@\/%2$@";
+
+/* Bot greeting message. %1$@ is the user's name */
+"com.jetpack.support.botGreeting" = "Bună %1$@!";
+
+/* Bot introduction message explaining its purpose */
+"com.jetpack.support.botIntroduction" = "Sunt asistentul tău personal AI. Pot să te ajut cu orice fel de întrebări despre site-ul sau contul tău.";
+
+/* Format string for cache file count and size. %1$d is the number of files, %2$@ is the formatted size. The system will pluralize 'files' based on the number – please specify it as the largest plural value */
+"com.jetpack.support.cacheFiles" = "%1$d fișiere memorate în cache (%2$@)";
+
+/* Message shown when cache has no files */
+"com.jetpack.support.cacheIsEmpty" = "Cache-ul este gol";
+
+/* Button to cancel current action */
+"com.jetpack.support.cancel" = "Anulează";
+
+/* Warning message that deleted logs cannot be recovered */
+"com.jetpack.support.cannotRecoverLogs" = "Nu vei mai putea să le recuperezi.";
+
+/* Button to clear all activity logs */
+"com.jetpack.support.clearAllActivityLogs" = "Șterge toate jurnalele de activități";
+
+/* Button to clear disk cache */
+"com.jetpack.support.clearDiskCache" = "Șterge cache-ul pe disc";
+
+/* Description explaining the purpose of clearing disk cache */
+"com.jetpack.support.clearDiskCacheDescription" = "Înlătură fișierele temporare pentru a elibera spațiu sau rezolva problemele.";
+
+/* Progress text while clearing cache */
+"com.jetpack.support.clearing" = "Șterg...";
+
+/* Message shown when cache clearing is complete */
+"com.jetpack.support.complete" = "Finalizată";
+
+/* Confirmation message when canceling a draft */
+"com.jetpack.support.confirmCancelMessage" = "Sigur vrei să anulezi acest mesaj? Vei pierde toate datele pe care le-ai introdus";
+
+/* Title for alert confirming cancellation */
+"com.jetpack.support.confirmCancellation" = "Confirmă anularea";
+
+/* Confirmation dialog title when deleting all logs */
+"com.jetpack.support.confirmDeleteAllLogs" = "Sigur vrei să ștergi toate jurnalele?";
+
+/* Section title for contact information */
+"com.jetpack.support.contactInformation" = "Informații de contact";
+
+/* Button to continue editing a message */
+"com.jetpack.support.continueWriting" = "Continuă să scrii";
+
+/* Message shown at end of closed support conversation */
+"com.jetpack.support.conversationEnded" = "Sfârșitul conversației. Nu mai sunt posibile alte răspunsuri.";
+
+/* Navigation title for bot conversations list */
+"com.jetpack.support.conversations" = "Conversații";
+
+/* Button to delete all log files */
+"com.jetpack.support.deleteAllLogs" = "Șterge toate jurnalele";
+
+/* Description text for diagnostics screen */
+"com.jetpack.support.diagnosticsDescription" = "Rulează sarcini obișnuite de mentenanță și depanare.";
+
+/* Navigation title for diagnostics screen */
+"com.jetpack.support.diagnosticsTitle" = "Diagnosticare";
+
+/* Button to discard changes in a draft message */
+"com.jetpack.support.discardChanges" = "Renunță la modificări";
+
+/* Notice explaining where support will send email responses */
+"com.jetpack.support.emailNotice" = "Îți vom trimite un email la această adresă.";
+
+/* Error title when logs fail to load */
+"com.jetpack.support.errorLoadingLogs" = "Eroare la încărcarea jurnalelor";
+
+/* Error message when support conversations fail to load */
+"com.jetpack.support.errorLoadingSupportConversations" = "Eroare la încărcarea conversațiilor cu suportul";
+
+/* Title for error alerts */
+"com.jetpack.support.errorTitle" = "Eroare";
+
+/* Option to export log as a file */
+"com.jetpack.support.exportAsFile" = "Exportă ca fișier";
+
+/* Button to dismiss alerts. */
+"com.jetpack.support.gotIt" = "Am înțeles";
+
+/* Text on the support form to refer to what area the user has problem with. */
+"com.jetpack.support.iNeedHelp" = "Am nevoie de ajutor cu";
+
+/* Toggle label to include application logs in the support request */
+"com.jetpack.support.includeApplicationLogs" = "Include jurnalele aplicației";
+
+/* Section title for issue details */
+"com.jetpack.support.issueDetails" = "Detalii problemă";
+
+/* Format string for when conversation was last updated */
+"com.jetpack.support.lastUpdated" = "Ultima actualizare %@";
+
+/* Progress message while loading conversation messages */
+"com.jetpack.support.loadingBotConversationMessages" = "Încarc mesajele";
+
+/* Progress message while loading bot conversations */
+"com.jetpack.support.loadingBotConversations" = "Încarc conversațiile cu botul";
+
+/* Progress text while loading support conversations */
+"com.jetpack.support.loadingConversations" = "Încarc conversațiile";
+
+/* Progress message while loading disk usage information */
+"com.jetpack.support.loadingDiskUsage" = "Încarc utilizarea discului";
+
+/* Progress message while loading an image attachment */
+"com.jetpack.support.loadingImage" = "Încarc imaginea";
+
+/* Progress message shown in overlay while refreshing content */
+"com.jetpack.support.loadingLatestContent" = "Încarc ultimul conținut";
+
+/* Progress message while loading application log content */
+"com.jetpack.support.loadingLogContent" = "Încarc conținutul jurnalului...";
+
+/* Progress message while loading log files */
+"com.jetpack.support.loadingLogs" = "Încarc jurnale...";
+
+/* Progress text while loading conversation messages */
+"com.jetpack.support.loadingMessages" = "Încarc mesajele";
+
+/* Progress message while loading a video attachment */
+"com.jetpack.support.loadingVideo" = "Încarc videoul";
+
+/* Section header for log files sorted by date */
+"com.jetpack.support.logFilesByDate" = "Fișiere jurnal după data creării";
+
+/* Text indicating which log files will be included in the support request */
+"com.jetpack.support.logFilesToUpload" = "Vor fi încărcate următoarele fișiere jurnal:";
+
+/* Footer text explaining log retention policy */
+"com.jetpack.support.logRetentionNotice" = "Jurnalele sunt salvate pentru o perioadă de până la șapte zile.";
+
+/* Section header for message text input */
+"com.jetpack.support.message" = "Mesaj";
+
+/* Success message when reply is sent successfully */
+"com.jetpack.support.messageSent" = "Am trimis mesajul";
+
+/* Format string for number of messages in conversation */
+"com.jetpack.support.messagesCount" = "%d mesaje";
+
+/* The title of a new bot chat in the support area of the app */
+"com.jetpack.support.new-bot-chat" = "Chatbot nou";
+
+/* Option to create a new support ticket */
+"com.jetpack.support.newSupportTicket" = "Tichet nou pentru suport";
+
+/* Label shown when there are no bot conversations */
+"com.jetpack.support.noConversations" = "Nicio conversație";
+
+/* Description shown when no log files are available */
+"com.jetpack.support.noLogsAvailable" = "Nu sunt disponibile jurnale de activități";
+
+/* Label shown when no log files are available */
+"com.jetpack.support.noLogsFound" = "Nu am găsit niciun jurnal";
+
+/* Button to open a support ticket */
+"com.jetpack.support.openSupportTicket" = "Deschide un tichet pentru suport";
+
+/* Text indicating a field is optional */
+"com.jetpack.support.optional" = "(opțional)";
+
+/* Navigation title for replying to a support conversation */
+"com.jetpack.support.reply" = "Răspunde";
+
+/* Description for saving log as a file */
+"com.jetpack.support.saveAsFile" = "Salvează ca un fișier pentru partajare sau stocare";
+
+/* Label for screenshots section */
+"com.jetpack.support.screenshots" = "Capturi ecran";
+
+/* Description for screenshots section */
+"com.jetpack.support.screenshotsDescription" = "Adăugarea unor capturi ecran ne poate ajuta să înțelegem și să rezolvăm mai repede problema.";
+
+/* Button to send a message or reply */
+"com.jetpack.support.send" = "Trimite";
+
+/* Description for sending logs to support */
+"com.jetpack.support.sendLogsToSupport" = "Trimite jurnalele direct echipei pentru suport";
+
+/* Progress text while sending a message */
+"com.jetpack.support.sending" = "Trimit";
+
+/* Progress message shown while sending a message */
+"com.jetpack.support.sendingMessage" = "Trimit mesajul";
+
+/* Button to share content */
+"com.jetpack.support.share" = "Partajează";
+
+/* Navigation title for sharing activity log */
+"com.jetpack.support.shareActivityLog" = "Partajează jurnalul de activități";
+
+/* Message shown when sharing log with support */
+"com.jetpack.support.sharingWithSupport" = "Partajează cu suportul!";
+
+/* Site Address title on the support form */
+"com.jetpack.support.siteAddress" = "Adresă site";
+
+/* Placeholder for site address field */
+"com.jetpack.support.siteAddressPlaceholder" = "https:\/\/yoursite.com";
+
+/* Description encouraging user to start a new conversation */
+"com.jetpack.support.startNewConversation" = "Începe o conversație nouă folosind butonul de mai sus";
+
+/* Subject title on the support form */
+"com.jetpack.support.subject" = "Subiect";
+
+/* Placeholder for subject field */
+"com.jetpack.support.subjectPlaceholder" = "Un scurt rezumat al problemei";
+
+/* Button title to submit a support request. */
+"com.jetpack.support.submitRequest" = "Trimite cererea pentru suport";
+
+/* Navigation title for the support conversations list */
+"com.jetpack.support.supportConversations" = "Conversații cu suportul";
+
+/* Title for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSent" = "Am trimis cererea!";
+
+/* Message for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSentMessage" = "Cererea ta pentru suport a fost trimisă cu succes. Îți vom răspunde prin email cât mai repede posibil.";
+
+/* Progress message shown while bot is thinking */
+"com.jetpack.support.thinking" = "Gândesc...";
+
+/* Title of the view for contacting support. */
+"com.jetpack.support.title" = "Contactează suportul";
+
+/* Button to retry a failed operation */
+"com.jetpack.support.tryAgain" = "Încearcă din nou";
+
+/* Error title when log deletion fails */
+"com.jetpack.support.unableToDeleteLogs" = "Nu pot să șterg jurnalele";
+
+/* Error message when conversation cannot be displayed */
+"com.jetpack.support.unableToDisplayConversation" = "Nu pot să afișez conversația";
+
+/* Error title when video cannot be loaded or played */
+"com.jetpack.support.unableToDisplayVideo" = "Nu pot să afișez videoul";
+
+/* Error message when application logs cannot be loaded */
+"com.jetpack.support.unableToLoadApplicationLogs" = "Nu pot să încarc jurnalele aplicației";
+
+/* Error title when bot conversations fail to load */
+"com.jetpack.support.unableToLoadConversations" = "Nu pot să încarc conversații";
+
+/* Error title when messages fail to load */
+"com.jetpack.support.unableToLoadMessages" = "Nu pot să încarc mesaje";
+
+/* Error title when message sending fails */
+"com.jetpack.support.unableToSendMessage" = "Nu pot să trimit mesajul";
+
+/* Button to view an attachment */
+"com.jetpack.support.view" = "Vezi";
+
+/* Progress message shown during cache clearing operation */
+"com.jetpack.support.working" = "Lucrez";
 
 /* Displayed in the confirmation alert when marking comment notifications as read. */
 "comment" = "comentariu";
@@ -7879,6 +8127,9 @@ Example: Reply to Pamela Nguyen */
 /* Weekly Roundup debug menu item */
 "debugMenu.weeklyRoundup" = "Rezumat săptămânal";
 
+/* Title for selecting a default category for a post */
+"defaultCategory.title" = "Categorie implicită";
+
 /* Error tilte */
 "discussionSettings.saveErrorTitle" = "Salvarea setărilor a eșuat";
 
@@ -8018,10 +8269,10 @@ Example: Reply to Pamela Nguyen */
 "double-tap to change unit" = "atinge de două ori pentru a schimba unitatea";
 
 /* Message for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.message" = "Sigur vrei să ștergi această etichetă?";
+"edit.tag.delete.confirmation.message" = "Sigur vrei să ștergi asta?";
 
-/* Title for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.title" = "Șterge eticheta";
+/* Title for delete a term confirmation dialog */
+"edit.tag.delete.confirmation.title" = "Șterge";
 
 /* Placeholder text for tag description field */
 "edit.tag.description.placeholder" = "Adaugă o descriere...";
@@ -8036,7 +8287,37 @@ Example: Reply to Pamela Nguyen */
 "edit.tag.section.description" = "Descriere";
 
 /* Section header for tag name in edit tag view */
-"edit.tag.section.tag" = "Etichetă";
+"edit.tag.section.tag" = "Nume";
+
+/* Context menu action to insert a block */
+"editor.blockInserter.insertBlock" = "Inserează un bloc";
+
+/* Placeholder text for block search field */
+"editor.blockInserter.search" = "Căutare";
+
+/* Button title to collapse and show fewer blocks */
+"editor.blockInserter.showLess" = "Arată mai puțin";
+
+/* Button title to expand and show more blocks */
+"editor.blockInserter.showMore" = "Arată mai multe";
+
+/* Error message when media insertion fails */
+"editor.media.failedToInsert" = "Inserarea elementului media a eșuat";
+
+/* Category name for section showing all patterns */
+"editor.patterns.all" = "Toate";
+
+/* Context menu action to insert a pattern */
+"editor.patterns.insertPattern" = "Inserează un model";
+
+/* Title shown when no patterns match the search */
+"editor.patterns.noPatternsFound" = "Nu am găsit niciun model";
+
+/* Navigation title for patterns view */
+"editor.patterns.title" = "Modele";
+
+/* Category name for patterns without a category */
+"editor.patterns.uncategorized" = "Fără categorie";
 
 /* Register Domain - Address information field Number placeholder */
 "eg. 1122334455" = "de exemplu, 1122334455";
@@ -8590,6 +8871,24 @@ Example: Reply to Pamela Nguyen */
 
 /* Write a blog prompt for the jetpack prologue */
 "jetpack.prologue.prompt.writeBlog" = "Scrii un blog";
+
+/* Description for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.description" = "Oricine poate să vadă acest articol";
+
+/* Title for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.title" = "Oricine";
+
+/* Description for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.description" = "Numai abonații care plătesc pot să vadă acest articol";
+
+/* Title for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.title" = "Abonați care plătesc";
+
+/* Description for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.description" = "Articolul este vizibil pentru toți abonații, inclusiv pentru cei care nu plătesc";
+
+/* Title for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.title" = "Toți abonații";
 
 /* Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account */
 "jetpackSite.connectToDefaultAccount" = "Pentru a folosi Statistici și Notificări, trebuie să te autentifici cu %@.";
@@ -9180,6 +9479,12 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "Nu ai permisiunea să vezi acest blog privat.";
 
+/* Default empty state message format when there are no terms. %1$@ is the taxonomy name. */
+"localizedLabels.defaultNoTerms.format" = "Niciun %1$@";
+
+/* Default search placeholder format. %1$@ is the taxonomy name. */
+"localizedLabels.defaultSearch.format" = "Caută %1$@";
+
 /* Button to dismiss the re-authentication view */
 "login.appPasswordReAuth.cancelButton" = "Anulează";
 
@@ -9315,17 +9620,23 @@ Example: Reply to Pamela Nguyen */
 /* Message about buying storage add-on */
 "mediaLibrary.storageDetails.buyStorage.message" = "Cumpără un supliment pentru stocare";
 
-/* Message shown when all media items are attached */
-"mediaLibrary.storageDetails.cleanup.allAttached" = "Toate elementele din biblioteca Media sunt atașate.";
+/* Label for audio media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.audio" = "Audio";
 
-/* Message shown while loading unattached media count */
-"mediaLibrary.storageDetails.cleanup.loading" = "Cercetez dacă există elemente media neatașate...";
+/* Label for document media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.document" = "Documente";
 
-/* Message about unattached media that can be cleaned up. %1$d is the count of unattached media. */
-"mediaLibrary.storageDetails.cleanup.message" = "%1$d elemente nu sunt atașate. Înlătură-le pentru a elibera spațiu.";
+/* Label for image media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.image" = "Imagini";
 
-/* Title for cleanup section */
-"mediaLibrary.storageDetails.cleanup.title" = "Înlătură elementele nefolosite";
+/* Label for other/unknown media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.other" = "Altele";
+
+/* Label for PowerPoint/presentation media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.powerpoint" = "Prezentări";
+
+/* Label for video media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.video" = "Videouri";
 
 /* Success message shown after upgrading plan */
 "mediaLibrary.storageDetails.purchase.plan.success" = "Planul site-ului tău a fost actualizat!";
@@ -9711,6 +10022,12 @@ Example: Reply to Pamela Nguyen */
 /* Menu option for filtering posts by me */
 "pagesList.pagesByMe" = "Paginile mele";
 
+/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
+"parentCategory.noCategory" = "Fără categorie";
+
+/* Title for selecting parent category of a category */
+"parentCategory.title" = "Categorie părinte";
+
 /* Title for the parent page picker screen */
 "parentPagePicker.title" = "Pagină părinte";
 
@@ -9869,6 +10186,27 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the post author selection screen */
 "postAuthorPicker.title" = "Autor";
+
+/* Title for selecting categories for a post or a page */
+"postCategories.title" = "Categorii";
+
+/* Toggle label for allowing comments on post */
+"postDiscussion.allowComments.label" = "Permite comentarii";
+
+/* Toggle label for allowing pings/trackbacks on post */
+"postDiscussion.allowPings.label" = "Permite pingback-uri";
+
+/* Footer text when comments are disabled */
+"postDiscussion.comments.disabled.footer" = "Vizitatorii nu pot să adauge comentarii sau răspunsuri noi. Comentariile existente rămân vizibile.";
+
+/* Footer text when comments are enabled */
+"postDiscussion.comments.enabled.footer" = "Vizitatorii pot să adauge comentarii și răspunsuri noi.";
+
+/* Link text for learning more about pingbacks and trackbacks */
+"postDiscussion.pingbacks.learnMore.text" = "Învață mai multe despre pingback-uri și trackback-uri";
+
+/* Navigation title for post discussion settings */
+"postDiscussion.title" = "Discuție";
 
 /* Button in an alert confirming discaring changes */
 "postEditor.closeConfirmationAlert.discardChanges" = "Renunță la modificări";
@@ -10101,6 +10439,9 @@ Example: Reply to Pamela Nguyen */
 /* A default value for an post without a title */
 "postSaveErrorMessage.postUntitled" = "Fără titlu";
 
+/* Section header for Access settings in Post Settings */
+"postSettings.access.header" = "Acces";
+
 /* Label for the author field in Post Settings */
 "postSettings.author.label" = "Autor";
 
@@ -10119,6 +10460,18 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the discard changes confirmation dialog */
 "postSettings.discardChanges.title" = "Renunți la modificări?";
+
+/* Status text when discussion (comments) is disabled */
+"postSettings.discussion.closed" = "Închise";
+
+/* Label for the discussion settings field in Post Settings */
+"postSettings.discussion.label" = "Discuții";
+
+/* Status text when discussion (comments) is enabled */
+"postSettings.discussion.open" = "Deschise";
+
+/* Label for the checkbox that lets you send a post to newsletter subscribers */
+"postSettings.emailToSubscribers.label" = "Trimite emailuri abonaților";
 
 /* Character count for excerpt. %1$d is the number of characters. */
 "postSettings.excerpt.characterCount" = "%1$d caractere";
@@ -10222,6 +10575,21 @@ Example: Reply to Pamela Nguyen */
 /* Cell title for the Top Level option case */
 "postSettings.parentPage.topLevel" = "Nivel superior";
 
+/* Accessibility label for hide password button */
+"postSettings.passwordEntry.hidePassword" = "Ascunde parola";
+
+/* Instructions for password entry */
+"postSettings.passwordEntry.instructions" = "Introdu o parolă pentru a proteja acest articol. Numai utilizatorii care au parola îl vor putea vizualiza.";
+
+/* Navigation title for password entry screen */
+"postSettings.passwordEntry.navigationTitle" = "Introdu parola";
+
+/* Placeholder for password field */
+"postSettings.passwordEntry.placeholder" = "Introdu parola";
+
+/* Accessibility label for show password button */
+"postSettings.passwordEntry.showPassword" = "Arată parola";
+
 /* Label for the pending review toggle in Post Settings */
 "postSettings.pendingReview.label" = "Recenzie în așteptare";
 
@@ -10249,17 +10617,59 @@ Example: Reply to Pamela Nguyen */
 /* Section header for General settings in Post Settings */
 "postSettings.section.general" = "Generale";
 
+/* Description text explaining what the slug editor does */
+"postSettings.slug.customizeDescription" = "Personalizează ultima parte a legăturii permanente.";
+
 /* Hint text for the slug field. Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso. */
 "postSettings.slug.hint" = "Descriptorul este versiunea prietenoasă a URL-ului pentru titlul articolului.";
 
 /* Label for the slug field. Should be the same as WP core. */
 "postSettings.slug.label" = "Descriptor";
 
+/* Button text to learn more about permalinks */
+"postSettings.slug.learnMore" = "Învață mai multe";
+
+/* Label for the slug field. Should be the same as WP core. */
+"postSettings.slug.navigationTitle" = "Descriptor";
+
+/* Notice shown when the post doesn't have a remote and permalink template is missing */
+"postSettings.slug.permalinkDraftNotice" = "Legătura permanentă sugerată va apărea când ciorna este salvată pe server";
+
+/* Label for the permalink preview */
+"postSettings.slug.permalinkLabel" = "Legătură permanentă";
+
+/* Section title for the permalink preview */
+"postSettings.slug.permalinkSection" = "Legătură permanentă";
+
 /* Placeholder for the slug field */
 "postSettings.slug.placeholder" = "Introdu descriptorul";
 
 /* Label for the preview button in Post Settings */
 "postSettings.socialSharing.header" = "Partajare pe media socială";
+
+/* Label for the status field in Post Settings */
+"postSettings.status.label" = "Stare";
+
+/* Navigation title for status picker */
+"postSettings.statusPicker.navigationTitle" = "Stare și vizibilitate";
+
+/* Label showing the current password */
+"postSettings.statusPicker.passwordLabel" = "Parolă";
+
+/* Toggle label for password protection */
+"postSettings.statusPicker.passwordProtected" = "Protejat cu parolă";
+
+/* Subtitle for password protected toggle */
+"postSettings.statusPicker.passwordProtectedSubtitle" = "Este vizibil numai pentru cei care știu parola";
+
+/* Label for schedule date row */
+"postSettings.statusPicker.scheduleDate" = "Dată";
+
+/* Toggle label for sticky posts */
+"postSettings.statusPicker.sticky" = "Fix";
+
+/* Subtitle for sticky toggle */
+"postSettings.statusPicker.stickySubtitle" = "Fixează acest articol în partea de sus a blogului";
 
 /* Label for the sticky post toggle. Sticky posts are displayed at the top of the blog. */
 "postSettings.stickyPost.label" = "Reprezentativ";
@@ -10279,17 +10689,56 @@ Example: Reply to Pamela Nguyen */
 /* Navigation bar title of the Post Stats screen */
 "postStats.title" = "Statistici articol";
 
-/* Button to add a new tag. %1$@ is the tag name. */
-"postTags.addTag" = "Adaugă etichetă";
+/* Post status title */
+"postStatus.deleted.details" = "Șters definitiv";
 
-/* Placeholder text for the tag search field */
-"postTags.searchOrAdd.placeholder" = "Caută sau adaugă etichete";
+/* Post status title */
+"postStatus.deleted.title" = "Șters";
 
-/* Message shown when no tags are selected */
-"postTags.selectionEmpty" = "Nu ai selectat nicio etichetă";
+/* Post status details */
+"postStatus.draft.details" = "Nu este gata pentru publicare";
 
-/* Title for the tags screen */
-"postTags.title" = "Etichete";
+/* Post status title */
+"postStatus.draft.title" = "Ciornă";
+
+/* Post status details */
+"postStatus.pending.details" = "Așteaptă verificarea înainte de publicare";
+
+/* Post status title */
+"postStatus.pending.title" = "În așteptare";
+
+/* Post status details */
+"postStatus.private.details" = "Vizibil numai pentru administratorii și editorii site-ului";
+
+/* Post status title */
+"postStatus.private.title" = "Privat";
+
+/* Post status details */
+"postStatus.published.details" = "Vizibil pentru toată lumea";
+
+/* Post status title */
+"postStatus.published.title" = "Publicat";
+
+/* Post status details */
+"postStatus.scheduled.details" = "Publică automat la o dată stabilită";
+
+/* Post status title */
+"postStatus.scheduled.title" = "Programat";
+
+/* Post status title */
+"postStatus.trash.details" = "Aruncat la gunoi dar nu a fost încă șters";
+
+/* Post status title */
+"postStatus.trash.title" = "Aruncat la gunoi";
+
+/* Button to add a new taxonomy term. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.addTag" = "Adaugă %1$@";
+
+/* Placeholder text for the taxonomy search field. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.searchOrAdd.placeholder" = "Caută sau adaugă %1$@";
+
+/* Message shown when no taxonomy terms are selected. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.selectionEmpty" = "Nu ai selectat nicio %1$@";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Anulează";
@@ -10365,9 +10814,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "Categorii";
-
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "Închide";
 
 /* Button to confirm discarding changes */
 "prepublishing.discardChanges.button" = "Renunță la modificări";
@@ -10456,12 +10902,17 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "Avertizare";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "Mesaj";
+
+/* Placeholder text for the message field in Social Sharing */
+"prepublishing.socialAccounts.messagePlaceholder" = "Scrie un mesaj scurt pe care să-l partajezi pe media socială împreună cu articolul";
 
 /* The navigation title for the pre-publishing social accounts screen. */
 "prepublishing.socialAccounts.navigationTitle" = "Social";
+
+/* Table section title */
+"prepublishing.socialAccounts.servicesSectionTitle" = "Servicii";
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.tags" = "Etichete";
@@ -11408,6 +11859,18 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Button to progress to the next step after selecting domain in Site Creation */
 "siteCreation.domains.buttons.selectDomain" = "Selectează domeniul";
 
+/* Default text for adding a new item when no label is provided */
+"siteCustomTaxonomies.defaultAddNew" = "Adaugă";
+
+/* Description for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.description" = "Taxonomiile te ajută să organizezi conținutul în plus față de categoriile și etichetele standard.";
+
+/* Title for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.title" = "Nu există taxonomii personalizate";
+
+/* Navigation title for the custom taxonomies screen */
+"siteCustomTaxonomies.navigationTitle" = "Taxonomii";
+
 /* Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio. */
 "siteMedia.accessibilityLabelAudio" = "Audio, %@";
 
@@ -11424,10 +11887,79 @@ Feel free to replace it with other bracket types that you think looks better for
 "siteMedia.accessibilityUnknownCreationDate" = "Dată creare necunoscută";
 
 /* Accessibility hint for actions when displaying media items. */
-"siteMedia.cellAccessibilityHint" = "Selectează media.";
+"siteMedia.cellAccessibilityHint" = "Selectează elemente Media.";
+
+/* Label for the alt for a media asset (image) */
+"siteMedia.details.altText" = "Text alternativ";
+
+/* Verb. Button title. Tapping cancels an action. */
+"siteMedia.details.cancel" = "Anulează";
+
+/* Noun. Label for the caption for a media asset (image / video) */
+"siteMedia.details.caption" = "Text asociat";
+
+/* Title for button that permanently deletes a media item (photo / video) */
+"siteMedia.details.delete" = "Șterge";
+
+/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
+"siteMedia.details.deleteConfirmation" = "Sigur vrei să ștergi definitiv acest element?";
+
+/* Text displayed in HUD after successfully deleting a media item */
+"siteMedia.details.deleted" = "Șters!";
+
+/* Text displayed in HUD while a media item is being deleted. */
+"siteMedia.details.deleting" = "Șterg...";
+
+/* Label for the description for a media asset (image / video) */
+"siteMedia.details.description" = "Descriere";
+
+/* Label for the dimensions in pixels for a media asset (image / video) */
+"siteMedia.details.dimensions" = "Dimensiuni";
+
+/* Label for the file name for a media asset (image / video) */
+"siteMedia.details.fileName" = "Nume fișier";
+
+/* Label for the file size for a media asset (image / video) */
+"siteMedia.details.fileSize" = "Dimensiune fișier";
+
+/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
+"siteMedia.details.fileType" = "Tip de fișier";
+
+/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
+"siteMedia.details.mediaDeleted" = "Acest element media a fost șters.";
+
+/* Noun. Label for the title of a media asset (image / video) */
+"siteMedia.details.title" = "Titlu";
+
+/* Accessibility label for trash buttons in nav bars */
+"siteMedia.details.trash" = "Aruncă la gunoi";
+
+/* Text displayed in HUD if there was an error attempting to delete a media item. */
+"siteMedia.details.unableToDeleteMedia" = "Nu pot să șterg elementul Media.";
+
+/* Error shown when the app fails to load a video from the user's media library. */
+"siteMedia.details.unableToLoadVideo" = "Nu pot să încarc videoul.";
+
+/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
+"siteMedia.details.unableToSaveMedia" = "Nu pot să salvez elementul Media.";
+
+/* Label for the date a media asset (image / video) was uploaded */
+"siteMedia.details.uploaded" = "Încărcată";
 
 /* Title for the URL field */
 "siteMedia.details.url" = "URL";
+
+/* Hint for image alt on image settings. */
+"siteMedia.hints.imageAlt" = "Text alternativ imagine";
+
+/* Hint for image caption on image settings. */
+"siteMedia.hints.imageCaption" = "Text asociat imagine";
+
+/* Hint for image description on image settings. */
+"siteMedia.hints.imageDescription" = "Descriere imagine";
+
+/* Hint for image title on image settings. */
+"siteMedia.hints.imageTitle" = "Titlu imagine";
 
 /* Accessibility hint for media item preview for user's viewing an item in their media library */
 "siteMediaItem.contentViewAccessibilityHint" = "Atinge pentru a vizualiza elementul media pe ecran complet";
@@ -11525,6 +12057,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Confidențialitate";
+
+/* Format string for adding a new taxonomy term. %1$@ is the taxonomy name. */
+"siteTaxonomy.addNew.format" = "Adaugă %1$@";
 
 /* Hint for users when hidden privacy setting is set */
 "siteVisibility.hidden.hint" = "Până când va fi pregătit pentru vizualizare, site-ul tău este ascuns pentru vizitatori în spatele unei notificări „În curând”.";
@@ -12093,7 +12628,8 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Subject of new Zendesk ticket. */
 "support.zendesk.readerAppTicketSubject" = "Suport Cititor pentru iOS";
 
-/* Description for empty state when there are no tags */
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
 "tags.empty.description" = "Etichetele ajută la organizarea conținutului și facilitează cititorilor găsirea unor articole similare.";
 
 /* Title for empty state when there are no tags */
@@ -12170,9 +12706,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "necitite";
-
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "Abonat la site";
 
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "Utilizator pe site";
@@ -12258,9 +12791,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* The heading at the top of the user list */
 "userlist.title" = "Utilizatori";
-
-/* Site Subscribers */
-"users.list.title.subscribers" = "Abonați";
 
 /* Screen title */
 "users.title" = "Utilizatori";

--- a/WordPress/Resources/ru.lproj/Localizable.strings
+++ b/WordPress/Resources/ru.lproj/Localizable.strings
@@ -1,6 +1,6 @@
-/* Translation-Revision-Date: 2025-10-07 17:54:08+0000 */
+/* Translation-Revision-Date: 2025-11-25 17:54:10+0000 */
 /* Plural-Forms: nplurals=3; plural=(n % 10 == 1 && n % 100 != 11) ? 0 : ((n % 10 >= 2 && n % 10 <= 4 && (n % 100 < 12 || n % 100 > 14)) ? 1 : 2); */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: ru */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -581,8 +581,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "Почти готово! Введите проверочный код из приложения Authenticator.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Атрибут alt";
 
 /* No comment provided by engineer. */
@@ -725,9 +724,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "Вы уверены, что хотите отключить Jetpack от этого сайта?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "Вы хотите навсегда удалить этот элемент?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "Вы точно хотите удалить %1$@ из %2$@?";
@@ -1082,7 +1078,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Отменить";
@@ -1110,8 +1105,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Не можете выбрать? Изменить тему можно в любой момент.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Подпись";
 
 /* Alert title. */
@@ -1777,8 +1771,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "По умолчанию";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Основная рубрика";
 
 /* Label for selecting the default post format
@@ -1787,9 +1780,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Параметры по умолчанию для новых записей";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Удалить";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Удалить меню";
@@ -1808,14 +1798,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "Удалить меню";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Удалено";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Удаление сайта…";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Удаление...";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "Отклонить";
@@ -1823,8 +1807,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "Опишите назначение изображения. Оставьте поле пустым, если оно служит для оформления.";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Описание";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1842,9 +1825,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "Не планировали создание новой учётной записи? Перейдите назад и введите ваш адрес email.";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Размеры";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "Отключить";
@@ -2121,7 +2101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "Редактирование GIF изображения приведёт к потере анимации.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Редактор";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2463,11 +2443,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "Настройки блока файла";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "Имя файла";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Тип файла";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "Тип файла не поддерживается в качестве медиафайла.";
@@ -2668,7 +2645,7 @@ translators: %s: Block name e.g. \"Image block\" */
 "HTML Content" = "HTML-содержимое";
 
 /* Accessibility label for selecting h1 paragraph style button on the formatting toolbar. */
-"Header 1" = "Заголовок №1";
+"Header 1" = "Заголовок 1";
 
 /* Accessibility label for selecting h2 paragraph style button on the formatting toolbar. */
 "Header 2" = "Заголовок №2";
@@ -2781,6 +2758,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post content used in the login prologue screens. */
 "I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next" = "Меня восхищают работы фотографа Кэмерона Карстена. Я попробую его техники в будущем";
 
+/* Text on the support form to refer to what area the user has problem with. */
+"I need help with" = "Мне нужна помощь с";
+
 /* Describes the IP address section in the comment detail screen. */
 "IP address" = "IP-адрес";
 
@@ -2826,9 +2806,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "Подпись изображения";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Описание изображения";
-
 /* Hint for image link on image settings. */
 "Image Link" = "Ссылка на изображение";
 
@@ -2840,9 +2817,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "Файл изображения не найден.";
-
-/* Hint for image title on image settings. */
-"Image title" = "Заголовок изображения";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "Объясните в нескольких словах, о чём этот сайт.";
@@ -3205,6 +3179,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the button that will dismiss this view. */
 "Let me know when finished!" = "Дайте мне знать по завершению!";
 
+/* Message info on the support screen. */
+"Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon." = "Сообщите нам адрес своего сайта (URL-адрес) и расскажите подробно о проблеме. Мы вскоре свяжемся с вами.";
+
+/* Title to let the user know what do we want on the support screen. */
+"Let’s get this sorted" = "Давайте это отсортируем";
+
 /* Lifestyle site intent topic */
 "Lifestyle" = "Образ жизни";
 
@@ -3405,6 +3385,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Меню навигации";
+
+/* Explanation for the option to enable theme styles */
+"Make the block editor look like your theme." = "Стилизуйте редактор блоков в соответствии с вашей темой.";
 
 /* No comment provided by engineer. */
 "Make your content stand out by adding images, gifs, videos, and embedded media to your pages." = "Сделайте содержимое заметным, добавив на свои страницы изображения, GIF-анимацию, видео и встроенные мультимедиа.";
@@ -3747,9 +3730,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "Учетных записей не найдено";
-
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Без рубрики";
 
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Нет соединения";
@@ -4191,9 +4171,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "Разбиение на страницы";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Родительская рубрика";
-
 /* Parenting site intent topic */
 "Parenting" = "Воспитание детей";
 
@@ -4411,9 +4388,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Запись";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Рубрики записи";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "Настройки записи";
@@ -4722,9 +4696,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "Убирать метаданные местоположения из фотографий перед их загрузкой на сайт.";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "Если вы удалите подписчиков, они перестанут получать обновления с вашего сайта. При желании они по-прежнему смогут посещать ваш сайт и повторно подписаться на него.";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "Заменить текущий блок";
@@ -5561,6 +5532,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "Краткое описание";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Метки";
 
@@ -5657,6 +5629,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint, informing user the button can be used to visit the Gravatar website. */
 "Tap to visit the Gravatar website in an external browser" = "Нажмите, чтобы перейти на веб-сайт Gravatar во внешнем браузере";
+
+/* Label for viewing the custom taxonomies */
+"Taxonomies" = "Таксономии";
 
 /* Technology site intent topic */
 "Technology" = "Технологии";
@@ -5946,9 +5921,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "Истёк срок действия этого кода для входа. Нажмите \"Сканировать снова\", чтобы повторить процедуру.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "Этот медиафайл удалён.";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "Эту учетную запись пользователя нельзя закрыть, если есть неразрешенные возвратные платежи.";
 
@@ -6017,7 +5989,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Заголовок";
@@ -6111,8 +6082,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "Преобразовать блок...";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "В корзину";
 
@@ -6209,9 +6179,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "Нельзя создать новые пригласительные ссылки.";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "Невозможно удалить медиафайл.";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "Нельзя отключить пригласительные ссылки.";
 
@@ -6242,9 +6209,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "Сейчас невозможно загрузить это содержимое.";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "Невозможно загрузить видео.";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Невозможно вопроизвести видео";
 
@@ -6253,9 +6217,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Не удалось восстановить сайт";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "Невозможно сохранить медиафайл.";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "Не получается поделиться ссылкой";
@@ -6412,9 +6373,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Ошибка загрузки";
 
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Загружено";
-
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "Загружена 1 запись черновика, %ld файлов";
 
@@ -6456,6 +6414,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The button title text for logging in with WP.com password instead of magic link. */
 "Use password to sign in" = "Войти с паролем";
+
+/* Option to enable theme styles in the block editor */
+"Use theme styles" = "Применить стили темы";
 
 /* A placeholder for the twitter username
    Accessibility label for the username text field in the self-hosted login page.
@@ -6906,7 +6867,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "Карта мира с представлением просмотров по странам.";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "Всё равно удалить эту персону?";
 
 /* Button title. Opens the editor to write a new post.
@@ -7377,14 +7338,19 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Description for the prompt to upgrade to Application Passwords. The first argument is the name of the feature that requires Application Passwords. */
 "applicationPasswordRequired.description" = "Пароли приложений — это более надёжный способ подключения к автономным сайтам, дающий возможность поддержки таких функций, как %@.";
 
+/* Feature name for managing application passwords in the app */
+"applicationPasswordRequired.feature.applicationPasswords" = "Управление паролями приложений";
+
 /* Feature name for the block editor in application password required prompt */
 "applicationPasswordRequired.feature.blockEditor" = "Редактор блоков";
+
+/* Feature name for managing terms and taxonomies in the app */
+"applicationPasswordRequired.feature.customTaxonomies" = "Управление таксономиями";
 
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "Управление плагинами";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "Управление пользователями";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -7614,6 +7580,285 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 /* Post Editor / Button in the 'More' menu */
 "classicEditor.moreMenu.saveDraft" = "Сохранить черновик";
 
+/* Button to add more screenshots */
+"com.jetpack.support.addMoreScreenshots" = "Добавить другие снимки экрана";
+
+/* Button to add screenshots */
+"com.jetpack.support.addScreenshots" = "Добавить снимки экрана";
+
+/* Header for application logs section */
+"com.jetpack.support.applicationLogs" = "Журналы приложения";
+
+/* Description explaining why including logs is helpful */
+"com.jetpack.support.applicationLogsDescription" = "Приложенные журналы помогут нам понять, в чём причина проблем. Журналы могут содержать сведения о последних действиях в приложении.";
+
+/* Navigation title for application logs screen */
+"com.jetpack.support.applicationLogsTitle" = "Журналы приложения";
+
+/* Format string for attachment identifier */
+"com.jetpack.support.attachment" = "Вложение %@";
+
+/* Format string for attachment size limit. %1$@ is current size, %2$@ is maximum size */
+"com.jetpack.support.attachmentLimit" = "Лимит вложений: %1$@ \/ %2$@";
+
+/* Bot greeting message. %1$@ is the user's name */
+"com.jetpack.support.botGreeting" = "Здравствуйте, %1$@!";
+
+/* Bot introduction message explaining its purpose */
+"com.jetpack.support.botIntroduction" = "Я ваш персональный помощник на базе ИИ. Я могу ответить вам на любые вопросы о вашем сайте или учётной записи.";
+
+/* Format string for cache file count and size. %1$d is the number of files, %2$@ is the formatted size. The system will pluralize 'files' based on the number – please specify it as the largest plural value */
+"com.jetpack.support.cacheFiles" = "Кешированные файлы: %1$d (%2$@)";
+
+/* Message shown when cache has no files */
+"com.jetpack.support.cacheIsEmpty" = "Кеш пуст";
+
+/* Button to cancel current action */
+"com.jetpack.support.cancel" = "Отмена";
+
+/* Warning message that deleted logs cannot be recovered */
+"com.jetpack.support.cannotRecoverLogs" = "Восстановить их будет невозможно.";
+
+/* Button to clear all activity logs */
+"com.jetpack.support.clearAllActivityLogs" = "Очистить все журналы действий";
+
+/* Button to clear disk cache */
+"com.jetpack.support.clearDiskCache" = "Очистить кеш диска";
+
+/* Description explaining the purpose of clearing disk cache */
+"com.jetpack.support.clearDiskCacheDescription" = "Удалите временные файлы, чтобы освободить место или устранить ошибки.";
+
+/* Progress text while clearing cache */
+"com.jetpack.support.clearing" = "Очистка...";
+
+/* Message shown when cache clearing is complete */
+"com.jetpack.support.complete" = "Выполнено";
+
+/* Confirmation message when canceling a draft */
+"com.jetpack.support.confirmCancelMessage" = "Вы действительно хотите отменить это сообщение? Все введённые данные будут утрачены";
+
+/* Title for alert confirming cancellation */
+"com.jetpack.support.confirmCancellation" = "Подтвердить отмену";
+
+/* Confirmation dialog title when deleting all logs */
+"com.jetpack.support.confirmDeleteAllLogs" = "Вы действительно хотите удалить все журналы ?";
+
+/* Section title for contact information */
+"com.jetpack.support.contactInformation" = "Контактная информация";
+
+/* Button to continue editing a message */
+"com.jetpack.support.continueWriting" = "Продолжить писать";
+
+/* Message shown at end of closed support conversation */
+"com.jetpack.support.conversationEnded" = "Конец беседы. Дальнейшие ответы невозможны.";
+
+/* Navigation title for bot conversations list */
+"com.jetpack.support.conversations" = "Беседы";
+
+/* Button to delete all log files */
+"com.jetpack.support.deleteAllLogs" = "Удалить все журналы";
+
+/* Description text for diagnostics screen */
+"com.jetpack.support.diagnosticsDescription" = "Выполните стандартные задачи по обслуживанию и устранению неполадок.";
+
+/* Navigation title for diagnostics screen */
+"com.jetpack.support.diagnosticsTitle" = "Диагностика";
+
+/* Button to discard changes in a draft message */
+"com.jetpack.support.discardChanges" = "Отменить изменения";
+
+/* Notice explaining where support will send email responses */
+"com.jetpack.support.emailNotice" = "Мы отправим письмо по этому адресу.";
+
+/* Error title when logs fail to load */
+"com.jetpack.support.errorLoadingLogs" = "Ошибка при загрузке журналов";
+
+/* Error message when support conversations fail to load */
+"com.jetpack.support.errorLoadingSupportConversations" = "Ошибка при загрузке бесед со службой поддержки";
+
+/* Title for error alerts */
+"com.jetpack.support.errorTitle" = "Ошибка";
+
+/* Option to export log as a file */
+"com.jetpack.support.exportAsFile" = "Экспортировать как файл";
+
+/* Button to dismiss alerts. */
+"com.jetpack.support.gotIt" = "Понятно";
+
+/* Text on the support form to refer to what area the user has problem with. */
+"com.jetpack.support.iNeedHelp" = "Мне нужна помощь с";
+
+/* Toggle label to include application logs in the support request */
+"com.jetpack.support.includeApplicationLogs" = "Вложить журналы приложения";
+
+/* Section title for issue details */
+"com.jetpack.support.issueDetails" = "Подробные сведения о проблеме";
+
+/* Format string for when conversation was last updated */
+"com.jetpack.support.lastUpdated" = "Последнее обновление: %@";
+
+/* Progress message while loading conversation messages */
+"com.jetpack.support.loadingBotConversationMessages" = "Загрузка сообщений";
+
+/* Progress message while loading bot conversations */
+"com.jetpack.support.loadingBotConversations" = "Загрузка бесед с ботами";
+
+/* Progress text while loading support conversations */
+"com.jetpack.support.loadingConversations" = "Загрузка бесед";
+
+/* Progress message while loading disk usage information */
+"com.jetpack.support.loadingDiskUsage" = "Загрузка сведений об использовании диска";
+
+/* Progress message while loading an image attachment */
+"com.jetpack.support.loadingImage" = "Загрузка изображения";
+
+/* Progress message shown in overlay while refreshing content */
+"com.jetpack.support.loadingLatestContent" = "Загрузка последнего контента";
+
+/* Progress message while loading application log content */
+"com.jetpack.support.loadingLogContent" = "Загрузка контента журналов...";
+
+/* Progress message while loading log files */
+"com.jetpack.support.loadingLogs" = "Загрузка журналов";
+
+/* Progress text while loading conversation messages */
+"com.jetpack.support.loadingMessages" = "Загрузка сообщений";
+
+/* Progress message while loading a video attachment */
+"com.jetpack.support.loadingVideo" = "Загрузка видео";
+
+/* Section header for log files sorted by date */
+"com.jetpack.support.logFilesByDate" = "Файлы журнала по дате создания";
+
+/* Text indicating which log files will be included in the support request */
+"com.jetpack.support.logFilesToUpload" = "Будут загружены следующие файлы журнала:";
+
+/* Footer text explaining log retention policy */
+"com.jetpack.support.logRetentionNotice" = "Журналы хранятся в течение 7 дней.";
+
+/* Section header for message text input */
+"com.jetpack.support.message" = "Сообщение";
+
+/* Success message when reply is sent successfully */
+"com.jetpack.support.messageSent" = "Сообщение отправлено";
+
+/* Format string for number of messages in conversation */
+"com.jetpack.support.messagesCount" = "Сообщения: %d";
+
+/* The title of a new bot chat in the support area of the app */
+"com.jetpack.support.new-bot-chat" = "Новый бот-чат";
+
+/* Option to create a new support ticket */
+"com.jetpack.support.newSupportTicket" = "Новый тикет службы поддержки";
+
+/* Label shown when there are no bot conversations */
+"com.jetpack.support.noConversations" = "Нет обсуждений";
+
+/* Description shown when no log files are available */
+"com.jetpack.support.noLogsAvailable" = "Нет доступных журналов действий";
+
+/* Label shown when no log files are available */
+"com.jetpack.support.noLogsFound" = "Журналов не найдено";
+
+/* Button to open a support ticket */
+"com.jetpack.support.openSupportTicket" = "Создать тикет в службе поддержки";
+
+/* Text indicating a field is optional */
+"com.jetpack.support.optional" = "(Не обязательно)";
+
+/* Navigation title for replying to a support conversation */
+"com.jetpack.support.reply" = "Ответить";
+
+/* Description for saving log as a file */
+"com.jetpack.support.saveAsFile" = "Сохранить как файл для публикации или хранения";
+
+/* Label for screenshots section */
+"com.jetpack.support.screenshots" = "Снимки экрана";
+
+/* Description for screenshots section */
+"com.jetpack.support.screenshotsDescription" = "Приложенные снимки экрана помогут нам быстрее понять, в чём заключается проблема, и решить её.";
+
+/* Button to send a message or reply */
+"com.jetpack.support.send" = "Отправить";
+
+/* Description for sending logs to support */
+"com.jetpack.support.sendLogsToSupport" = "Отправлять журналы напрямую в службу поддержки";
+
+/* Progress text while sending a message */
+"com.jetpack.support.sending" = "Отправка";
+
+/* Progress message shown while sending a message */
+"com.jetpack.support.sendingMessage" = "Отправка сообщения";
+
+/* Button to share content */
+"com.jetpack.support.share" = "Поделиться";
+
+/* Navigation title for sharing activity log */
+"com.jetpack.support.shareActivityLog" = "Передать журнал действий";
+
+/* Message shown when sharing log with support */
+"com.jetpack.support.sharingWithSupport" = "Передача в службу поддержки";
+
+/* Site Address title on the support form */
+"com.jetpack.support.siteAddress" = "Адрес сайта";
+
+/* Description encouraging user to start a new conversation */
+"com.jetpack.support.startNewConversation" = "Начать новую беседу, нажав кнопку выше";
+
+/* Subject title on the support form */
+"com.jetpack.support.subject" = "Тема";
+
+/* Placeholder for subject field */
+"com.jetpack.support.subjectPlaceholder" = "Краткое описание проблемы";
+
+/* Button title to submit a support request. */
+"com.jetpack.support.submitRequest" = "Отправить запрос в службу поддержки";
+
+/* Navigation title for the support conversations list */
+"com.jetpack.support.supportConversations" = "Беседы со службой поддержки";
+
+/* Title for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSent" = "Запрос отправлен.";
+
+/* Message for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSentMessage" = "Запрос в службу поддержки отправлен. Мы постараемся ответить вам по эл. почте как можно скорее.";
+
+/* Progress message shown while bot is thinking */
+"com.jetpack.support.thinking" = "Я думаю…";
+
+/* Title of the view for contacting support. */
+"com.jetpack.support.title" = "Обратиться в службу поддержки";
+
+/* Button to retry a failed operation */
+"com.jetpack.support.tryAgain" = "Повторить попытку";
+
+/* Error title when log deletion fails */
+"com.jetpack.support.unableToDeleteLogs" = "Не удалось удалить журналы";
+
+/* Error message when conversation cannot be displayed */
+"com.jetpack.support.unableToDisplayConversation" = "Не удалось показать беседу";
+
+/* Error title when video cannot be loaded or played */
+"com.jetpack.support.unableToDisplayVideo" = "Не удалось воспроизвести видео";
+
+/* Error message when application logs cannot be loaded */
+"com.jetpack.support.unableToLoadApplicationLogs" = "Не удалось загрузить журналы приложений";
+
+/* Error title when bot conversations fail to load */
+"com.jetpack.support.unableToLoadConversations" = "Не удалось загрузить беседы";
+
+/* Error title when messages fail to load */
+"com.jetpack.support.unableToLoadMessages" = "Не удалось загрузить сообщения";
+
+/* Error title when message sending fails */
+"com.jetpack.support.unableToSendMessage" = "Не удалось отправить сообщение";
+
+/* Button to view an attachment */
+"com.jetpack.support.view" = "Просмотр";
+
+/* Progress message shown during cache clearing operation */
+"com.jetpack.support.working" = "В процессе";
+
 /* Displayed in the confirmation alert when marking comment notifications as read. */
 "comment" = "комментарий";
 
@@ -7706,6 +7951,9 @@ Example: Reply to Pamela Nguyen */
 
 /* Create Sheet button title */
 "createSheet.post" = "Запись";
+
+/* Create Sheet button title */
+"createSheet.postFromAudio" = "Публикация из аудио";
 
 /* Customize Insights description */
 "customizeInsightsCell.content" = "Настройте вашу консоль и выберите отчёты, которые хотите видеть. Сфокусируйтесь на данных, которые вам наиболее важны.";
@@ -7876,6 +8124,9 @@ Example: Reply to Pamela Nguyen */
 /* Weekly Roundup debug menu item */
 "debugMenu.weeklyRoundup" = "За неделю";
 
+/* Title for selecting a default category for a post */
+"defaultCategory.title" = "Рубрика по умолчанию";
+
 /* Error tilte */
 "discussionSettings.saveErrorTitle" = "Не удалось сохранить настройки";
 
@@ -8015,10 +8266,10 @@ Example: Reply to Pamela Nguyen */
 "double-tap to change unit" = "нажмите дважды для смены единиц";
 
 /* Message for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.message" = "Вы уверены, что хотите удалить эту метку?";
+"edit.tag.delete.confirmation.message" = "Вы действительно хотите это удалить?";
 
-/* Title for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.title" = "Удалить метку";
+/* Title for delete a term confirmation dialog */
+"edit.tag.delete.confirmation.title" = "Удалить";
 
 /* Placeholder text for tag description field */
 "edit.tag.description.placeholder" = "Добавить описание…";
@@ -8033,7 +8284,37 @@ Example: Reply to Pamela Nguyen */
 "edit.tag.section.description" = "Описание";
 
 /* Section header for tag name in edit tag view */
-"edit.tag.section.tag" = "Метка";
+"edit.tag.section.tag" = "Имя";
+
+/* Context menu action to insert a block */
+"editor.blockInserter.insertBlock" = "Вставить блок";
+
+/* Placeholder text for block search field */
+"editor.blockInserter.search" = "Поиск";
+
+/* Button title to collapse and show fewer blocks */
+"editor.blockInserter.showLess" = "Свернуть";
+
+/* Button title to expand and show more blocks */
+"editor.blockInserter.showMore" = "Развернуть";
+
+/* Error message when media insertion fails */
+"editor.media.failedToInsert" = "Не удалось вставить медиафайл";
+
+/* Category name for section showing all patterns */
+"editor.patterns.all" = "Все";
+
+/* Context menu action to insert a pattern */
+"editor.patterns.insertPattern" = "Вставить паттерн";
+
+/* Title shown when no patterns match the search */
+"editor.patterns.noPatternsFound" = "Паттернов не найдено";
+
+/* Navigation title for patterns view */
+"editor.patterns.title" = "Паттерны";
+
+/* Category name for patterns without a category */
+"editor.patterns.uncategorized" = "Без рубрики";
 
 /* Register Domain - Address information field Number placeholder */
 "eg. 1122334455" = "например: 1122334455";
@@ -8587,6 +8868,24 @@ Example: Reply to Pamela Nguyen */
 
 /* Write a blog prompt for the jetpack prologue */
 "jetpack.prologue.prompt.writeBlog" = "Ведение блога";
+
+/* Description for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.description" = "Это общедоступная запись";
+
+/* Title for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.title" = "Все";
+
+/* Description for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.description" = "Это запись только для платных подписчиков";
+
+/* Title for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.title" = "Платные подписчики";
+
+/* Description for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.description" = "Это запись только для подписчиков, в том числе бесплатных";
+
+/* Title for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.title" = "Все подписчики";
 
 /* Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account */
 "jetpackSite.connectToDefaultAccount" = "Необходимо выполнить вход с %@, чтобы пользоваться статистикой и уведомлениями.";
@@ -9177,6 +9476,12 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "У вас нет разрешения на доступ к этому закрытому блогу.";
 
+/* Default empty state message format when there are no terms. %1$@ is the taxonomy name. */
+"localizedLabels.defaultNoTerms.format" = "Нет %1$@";
+
+/* Default search placeholder format. %1$@ is the taxonomy name. */
+"localizedLabels.defaultSearch.format" = "Поиск %1$@";
+
 /* Button to dismiss the re-authentication view */
 "login.appPasswordReAuth.cancelButton" = "Отмена";
 
@@ -9312,17 +9617,23 @@ Example: Reply to Pamela Nguyen */
 /* Message about buying storage add-on */
 "mediaLibrary.storageDetails.buyStorage.message" = "Купить дополнительный объём хранилища";
 
-/* Message shown when all media items are attached */
-"mediaLibrary.storageDetails.cleanup.allAttached" = "Все элементы в библиотеке медиафайлов прикреплены.";
+/* Label for audio media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.audio" = "Аудио";
 
-/* Message shown while loading unattached media count */
-"mediaLibrary.storageDetails.cleanup.loading" = "Проверяем, нет ли неприкреплённых медиафайлов...";
+/* Label for document media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.document" = "Документы";
 
-/* Message about unattached media that can be cleaned up. %1$d is the count of unattached media. */
-"mediaLibrary.storageDetails.cleanup.message" = "Неприкреплённых медиафайлов: %1$d Удалите их, чтобы освободить место.";
+/* Label for image media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.image" = "Изображения";
 
-/* Title for cleanup section */
-"mediaLibrary.storageDetails.cleanup.title" = "Удалить неиспользуемые элементы";
+/* Label for other/unknown media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.other" = "Другое";
+
+/* Label for PowerPoint/presentation media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.powerpoint" = "Презентации";
+
+/* Label for video media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.video" = "Видео";
 
 /* Success message shown after upgrading plan */
 "mediaLibrary.storageDetails.purchase.plan.success" = "Уровень тарифного плана вашего сайта повышен!";
@@ -9708,6 +10019,12 @@ Example: Reply to Pamela Nguyen */
 /* Menu option for filtering posts by me */
 "pagesList.pagesByMe" = "Мои страницы";
 
+/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
+"parentCategory.noCategory" = "Без рубрики";
+
+/* Title for selecting parent category of a category */
+"parentCategory.title" = "Родительская рубрика";
+
 /* Title for the parent page picker screen */
 "parentPagePicker.title" = "Родительская страница";
 
@@ -9866,6 +10183,27 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the post author selection screen */
 "postAuthorPicker.title" = "Автор";
+
+/* Title for selecting categories for a post or a page */
+"postCategories.title" = "Рубрики";
+
+/* Toggle label for allowing comments on post */
+"postDiscussion.allowComments.label" = "Разрешить комментарии";
+
+/* Toggle label for allowing pings/trackbacks on post */
+"postDiscussion.allowPings.label" = "Разрешить уведомления о размещении ссылок на других ресурсах";
+
+/* Footer text when comments are disabled */
+"postDiscussion.comments.disabled.footer" = "Посетители не могут оставлять комментарии или ответы. Уже опубликованные комментарии остаются видимыми.";
+
+/* Footer text when comments are enabled */
+"postDiscussion.comments.enabled.footer" = "Посетители могут оставлять комментарии и ответы.";
+
+/* Link text for learning more about pingbacks and trackbacks */
+"postDiscussion.pingbacks.learnMore.text" = "Подробнее об уведомлениях и обратных ссылках";
+
+/* Navigation title for post discussion settings */
+"postDiscussion.title" = "Обсуждение";
 
 /* Button in an alert confirming discaring changes */
 "postEditor.closeConfirmationAlert.discardChanges" = "Отменить изменения";
@@ -10098,6 +10436,9 @@ Example: Reply to Pamela Nguyen */
 /* A default value for an post without a title */
 "postSaveErrorMessage.postUntitled" = "Без названия";
 
+/* Section header for Access settings in Post Settings */
+"postSettings.access.header" = "Доступ";
+
 /* Label for the author field in Post Settings */
 "postSettings.author.label" = "Автор";
 
@@ -10116,6 +10457,18 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the discard changes confirmation dialog */
 "postSettings.discardChanges.title" = "Отменить изменения?";
+
+/* Status text when discussion (comments) is disabled */
+"postSettings.discussion.closed" = "Закрыто";
+
+/* Label for the discussion settings field in Post Settings */
+"postSettings.discussion.label" = "Обсуждение";
+
+/* Status text when discussion (comments) is enabled */
+"postSettings.discussion.open" = "Открыть";
+
+/* Label for the checkbox that lets you send a post to newsletter subscribers */
+"postSettings.emailToSubscribers.label" = "Разослать подписчикам";
 
 /* Character count for excerpt. %1$d is the number of characters. */
 "postSettings.excerpt.characterCount" = "Символов: %1$d";
@@ -10219,6 +10572,21 @@ Example: Reply to Pamela Nguyen */
 /* Cell title for the Top Level option case */
 "postSettings.parentPage.topLevel" = "Верхний уровень";
 
+/* Accessibility label for hide password button */
+"postSettings.passwordEntry.hidePassword" = "Скрыть пароль";
+
+/* Instructions for password entry */
+"postSettings.passwordEntry.instructions" = "Введите пароль для защиты этой записи. Её смогут просматривать только пользователи, которые знают пароль.";
+
+/* Navigation title for password entry screen */
+"postSettings.passwordEntry.navigationTitle" = "Введите пароль";
+
+/* Placeholder for password field */
+"postSettings.passwordEntry.placeholder" = "Введите пароль";
+
+/* Accessibility label for show password button */
+"postSettings.passwordEntry.showPassword" = "Показать пароль";
+
 /* Label for the pending review toggle in Post Settings */
 "postSettings.pendingReview.label" = "Отзыв ожидает утверждения";
 
@@ -10246,17 +10614,59 @@ Example: Reply to Pamela Nguyen */
 /* Section header for General settings in Post Settings */
 "postSettings.section.general" = "Общие";
 
+/* Description text explaining what the slug editor does */
+"postSettings.slug.customizeDescription" = "Настройте финальную часть постоянной ссылки.";
+
 /* Hint text for the slug field. Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso. */
 "postSettings.slug.hint" = "Слаг — это усечённая версия названия записи для включения в URL-адрес.";
 
 /* Label for the slug field. Should be the same as WP core. */
 "postSettings.slug.label" = "Слаг";
 
+/* Button text to learn more about permalinks */
+"postSettings.slug.learnMore" = "Подробнее";
+
+/* Label for the slug field. Should be the same as WP core. */
+"postSettings.slug.navigationTitle" = "Слаг";
+
+/* Notice shown when the post doesn't have a remote and permalink template is missing */
+"postSettings.slug.permalinkDraftNotice" = "Предложенная постоянная ссылка отобразится при сохранении черновика на сервере";
+
+/* Label for the permalink preview */
+"postSettings.slug.permalinkLabel" = "Постоянная ссылка";
+
+/* Section title for the permalink preview */
+"postSettings.slug.permalinkSection" = "Постоянная ссылка";
+
 /* Placeholder for the slug field */
 "postSettings.slug.placeholder" = "Введите слаг";
 
 /* Label for the preview button in Post Settings */
 "postSettings.socialSharing.header" = "Поделиться в соцсетях";
+
+/* Label for the status field in Post Settings */
+"postSettings.status.label" = "Статус";
+
+/* Navigation title for status picker */
+"postSettings.statusPicker.navigationTitle" = "Статус и видимость";
+
+/* Label showing the current password */
+"postSettings.statusPicker.passwordLabel" = "Пароль";
+
+/* Toggle label for password protection */
+"postSettings.statusPicker.passwordProtected" = "Защищено паролем";
+
+/* Subtitle for password protected toggle */
+"postSettings.statusPicker.passwordProtectedSubtitle" = "Видно только тем, кто знает пароль";
+
+/* Label for schedule date row */
+"postSettings.statusPicker.scheduleDate" = "Дата";
+
+/* Toggle label for sticky posts */
+"postSettings.statusPicker.sticky" = "Прикреплено";
+
+/* Subtitle for sticky toggle */
+"postSettings.statusPicker.stickySubtitle" = "Закрепить эту запись в верхней части блога";
 
 /* Label for the sticky post toggle. Sticky posts are displayed at the top of the blog. */
 "postSettings.stickyPost.label" = "Прикреплено";
@@ -10276,14 +10686,56 @@ Example: Reply to Pamela Nguyen */
 /* Navigation bar title of the Post Stats screen */
 "postStats.title" = "Статистика по записям";
 
-/* Button to add a new tag. %1$@ is the tag name. */
-"postTags.addTag" = "Добавить метку";
+/* Post status title */
+"postStatus.deleted.details" = "Удалено навсегда.";
 
-/* Placeholder text for the tag search field */
-"postTags.searchOrAdd.placeholder" = "Искать или добавить метки";
+/* Post status title */
+"postStatus.deleted.title" = "Удалено";
 
-/* Title for the tags screen */
-"postTags.title" = "Метки";
+/* Post status details */
+"postStatus.draft.details" = "Не готово к публикации";
+
+/* Post status title */
+"postStatus.draft.title" = "Черновик";
+
+/* Post status details */
+"postStatus.pending.details" = "Ожидает проверки перед публикацией";
+
+/* Post status title */
+"postStatus.pending.title" = "Ожидает проверки";
+
+/* Post status details */
+"postStatus.private.details" = "Видна только администраторам и редакторам";
+
+/* Post status title */
+"postStatus.private.title" = "Закрытая";
+
+/* Post status details */
+"postStatus.published.details" = "Видна всем";
+
+/* Post status title */
+"postStatus.published.title" = "Опубликована";
+
+/* Post status details */
+"postStatus.scheduled.details" = "Опубликовать автоматически в выбранную дату";
+
+/* Post status title */
+"postStatus.scheduled.title" = "Запланирована";
+
+/* Post status title */
+"postStatus.trash.details" = "В корзине, но не удалена окончательно";
+
+/* Post status title */
+"postStatus.trash.title" = "В корзине";
+
+/* Button to add a new taxonomy term. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.addTag" = "Добавить %1$@";
+
+/* Placeholder text for the taxonomy search field. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.searchOrAdd.placeholder" = "Искать или добавить %1$@";
+
+/* Message shown when no taxonomy terms are selected. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.selectionEmpty" = "%1$@ не выбрано";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Отмена";
@@ -10359,9 +10811,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "Рубрики";
-
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "Закрыть";
 
 /* Button to confirm discarding changes */
 "prepublishing.discardChanges.button" = "Отменить изменения";
@@ -10450,12 +10899,17 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "Предупреждение";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "Сообщение";
+
+/* Placeholder text for the message field in Social Sharing */
+"prepublishing.socialAccounts.messagePlaceholder" = "Напишите короткий анонс записи для публикации в соцсетях";
 
 /* The navigation title for the pre-publishing social accounts screen. */
 "prepublishing.socialAccounts.navigationTitle" = "Социальные сети";
+
+/* Table section title */
+"prepublishing.socialAccounts.servicesSectionTitle" = "Услуги";
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.tags" = "Теги";
@@ -11402,6 +11856,18 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Button to progress to the next step after selecting domain in Site Creation */
 "siteCreation.domains.buttons.selectDomain" = "Выберите домен";
 
+/* Default text for adding a new item when no label is provided */
+"siteCustomTaxonomies.defaultAddNew" = "Добавить";
+
+/* Description for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.description" = "Таксономии помогают упорядочивать контент, не отвечающий стандартным категориям и меткам.";
+
+/* Title for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.title" = "Нет пользовательских таксономий";
+
+/* Navigation title for the custom taxonomies screen */
+"siteCustomTaxonomies.navigationTitle" = "Таксономии";
+
 /* Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio. */
 "siteMedia.accessibilityLabelAudio" = "Аудиозапись, %@";
 
@@ -11420,8 +11886,77 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Accessibility hint for actions when displaying media items. */
 "siteMedia.cellAccessibilityHint" = "Выберите медиафайл.";
 
+/* Label for the alt for a media asset (image) */
+"siteMedia.details.altText" = "Замещающий текст";
+
+/* Verb. Button title. Tapping cancels an action. */
+"siteMedia.details.cancel" = "Отмена";
+
+/* Noun. Label for the caption for a media asset (image / video) */
+"siteMedia.details.caption" = "Подпись";
+
+/* Title for button that permanently deletes a media item (photo / video) */
+"siteMedia.details.delete" = "Удалить";
+
+/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
+"siteMedia.details.deleteConfirmation" = "Вы хотите навсегда удалить этот элемент?";
+
+/* Text displayed in HUD after successfully deleting a media item */
+"siteMedia.details.deleted" = "Удалено.";
+
+/* Text displayed in HUD while a media item is being deleted. */
+"siteMedia.details.deleting" = "Удаление...";
+
+/* Label for the description for a media asset (image / video) */
+"siteMedia.details.description" = "Описание";
+
+/* Label for the dimensions in pixels for a media asset (image / video) */
+"siteMedia.details.dimensions" = "Размеры";
+
+/* Label for the file name for a media asset (image / video) */
+"siteMedia.details.fileName" = "Имя файла";
+
+/* Label for the file size for a media asset (image / video) */
+"siteMedia.details.fileSize" = "Размер файла";
+
+/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
+"siteMedia.details.fileType" = "Тип файла";
+
+/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
+"siteMedia.details.mediaDeleted" = "Этот медиафайл удалён.";
+
+/* Noun. Label for the title of a media asset (image / video) */
+"siteMedia.details.title" = "Заголовок";
+
+/* Accessibility label for trash buttons in nav bars */
+"siteMedia.details.trash" = "Корзина";
+
+/* Text displayed in HUD if there was an error attempting to delete a media item. */
+"siteMedia.details.unableToDeleteMedia" = "Невозможно удалить медиафайл.";
+
+/* Error shown when the app fails to load a video from the user's media library. */
+"siteMedia.details.unableToLoadVideo" = "Невозможно загрузить видео.";
+
+/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
+"siteMedia.details.unableToSaveMedia" = "Невозможно сохранить медиафайл.";
+
+/* Label for the date a media asset (image / video) was uploaded */
+"siteMedia.details.uploaded" = "Загружено";
+
 /* Title for the URL field */
 "siteMedia.details.url" = "URL-адрес";
+
+/* Hint for image alt on image settings. */
+"siteMedia.hints.imageAlt" = "Замещающий текст изображения";
+
+/* Hint for image caption on image settings. */
+"siteMedia.hints.imageCaption" = "Подпись к изображению";
+
+/* Hint for image description on image settings. */
+"siteMedia.hints.imageDescription" = "Описание изображения";
+
+/* Hint for image title on image settings. */
+"siteMedia.hints.imageTitle" = "Заголовок изображения";
 
 /* Accessibility hint for media item preview for user's viewing an item in their media library */
 "siteMediaItem.contentViewAccessibilityHint" = "Нажмите для просмотра медиафайла на полном экране";
@@ -11519,6 +12054,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Конфиденциальность";
+
+/* Format string for adding a new taxonomy term. %1$@ is the taxonomy name. */
+"siteTaxonomy.addNew.format" = "Добавить %1$@";
 
 /* Hint for users when hidden privacy setting is set */
 "siteVisibility.hidden.hint" = "Ваш сайт скрыт от посетителей табличкой \"Скоро запуск\" до готовности.";
@@ -12087,7 +12625,8 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Subject of new Zendesk ticket. */
 "support.zendesk.readerAppTicketSubject" = "Поддержка «Читалки» в iOS";
 
-/* Description for empty state when there are no tags */
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
 "tags.empty.description" = "Метки помогают упорядочивать контент и облегчают читателям поиск похожих записей.";
 
 /* Title for empty state when there are no tags */
@@ -12164,9 +12703,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "непрочитано";
-
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "Подписчик сайта";
 
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "Пользователь сайта";
@@ -12252,9 +12788,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* The heading at the top of the user list */
 "userlist.title" = "Пользователи";
-
-/* Site Subscribers */
-"users.list.title.subscribers" = "Подписчики";
 
 /* Screen title */
 "users.title" = "Пользователи";

--- a/WordPress/Resources/sk.lproj/Localizable.strings
+++ b/WordPress/Resources/sk.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 /* Translation-Revision-Date: 2025-01-08 15:01:32+0000 */
 /* Plural-Forms: nplurals=3; plural=(n == 1) ? 0 : ((n >= 2 && n <= 4) ? 1 : 2); */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: sk */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -247,8 +247,7 @@
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "Už to skoro je hotové! Prosím zadajte overovací kód z aplikácie overovania.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Alt Text";
 
 /* String displayed before offering alternative login methods */
@@ -323,9 +322,6 @@
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "Určite chcete odpojiť Jetpack z webovej stránky?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "Naozaj chcete túto položku natrvalo odstrániť?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "Určite chcete odstrániť %1$@ z %2$@?";
@@ -472,7 +468,6 @@
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Zrušiť";
@@ -491,8 +486,7 @@
 /* A short message that informs the user the share extension is being canceled. */
 "Canceling..." = "Ruší sa...";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Titulok";
 
 /* Alert title. */
@@ -797,8 +791,7 @@
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "Predvolené";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Predvolená kategória";
 
 /* Label for selecting the default post format
@@ -807,9 +800,6 @@
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Základné pre nové príspevky";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Odstrániť";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Zmazať menu";
@@ -825,25 +815,15 @@
 /* Title of alert when site deletion fails */
 "Delete Site Error" = "Chyba pri mazaní stránky";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Zmazané!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Mazanie webu...";
 
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Vymazáva sa...";
-
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Popis";
 
 /* Details button that appears in the Theme Browser Header
    Theme Details action title */
 "Details" = "Detaily";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Rozmery";
 
 /* Adjective. Comment threading is disabled. */
 "Disabled" = "Zablokované";
@@ -942,7 +922,7 @@
 /* Title for the edit sharing buttons section */
 "Edit sharing buttons" = "Upraviť tlačidlo zdieľania";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Editor";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -1109,11 +1089,8 @@
 /* A short message to inform the user data for their sites are being fetched. */
 "Fetching sites..." = "Stránka sa načítava...";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "Názov súboru";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Typ súboru";
 
 /* Register Domain - Domain contact information field First name
    User's First Name */
@@ -1274,17 +1251,11 @@
 /* Hint for image caption on image settings. */
 "Image Caption" = "Titulok obrázka";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Popis obrázku";
-
 /* Hint for image link on image settings. */
 "Image Link" = "Odkaz obrázku";
 
 /* Title of the screen for choosing an image's size. */
 "Image Size" = "Veľkosť obrázka";
-
-/* Hint for image title on image settings. */
-"Image title" = "Nadpis obrázka";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "Pár slovami povedzte niečo o tejto stránke.";
@@ -1752,9 +1723,6 @@
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "Neboli nájdené žiadne účty";
 
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Žiadna kategória";
-
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Žiadne pripojenie";
 
@@ -1992,9 +1960,6 @@
    Settings: Comments Paging preferences */
 "Paging" = "Stránkovanie";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Nadradená kategória";
-
 /* Accessibility label for the password text field in the self-hosted login page.
    Label for entering password in password field
    Login dialog password placeholder
@@ -2097,9 +2062,6 @@
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Článok";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Kategórie článku";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "Nastavenia článku";
@@ -2742,6 +2704,7 @@
 "Tagline" = "Slogan";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Značky";
 
@@ -2905,9 +2868,6 @@
 /* Informational text for the privacy policy link */
 "This information helps us improve our products, make marketing to you more relevant, personalize your WordPress.com experience, and more as detailed in our privacy policy." = "Tieto informácie nám pomáhajú zlepšiť naše produkty, urobiť marketing relevantnejším, personalizovať vašu skúsenosť s WordPress.com, viac nájdete v našich zásadách ochrany osobných údajov.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "Táto mediálna položka bola odstránená.";
-
 /* A description of the twitter sharing setting.
    Information about the twitter sharing feature. */
 "This will be included in tweets when people share using the Twitter button." = "Toto bude zahrnuté v tweetoch, ktoré budú ľudia zdieľať pomocou Twitter tlačidla.";
@@ -2940,7 +2900,6 @@
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Nadpis";
@@ -2984,8 +2943,7 @@
 /* Title for the traffic section in site settings screen */
 "Traffic" = "Prenos";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Kôš";
 
@@ -3043,23 +3001,14 @@
 /* Title of error prompt shown when a sync the user initiated fails. */
 "Unable to Sync" = "Nie je možné synchronizovať";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "Nedá sa zmazať mediálny súbor.";
-
 /* Text displayed in HUD if there was an error attempting to load a media image. */
 "Unable to load the image. Please choose a different one or try again later." = "Nepodarilo sa načítať obrázok. Prosím vyberte iný alebo pokus zopakujte neskôr.";
-
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "Nie je možné načítať video.";
 
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Nepodarilo sa prehrať video";
 
 /* No comment provided by engineer. */
 "Unable to read the WordPress site at that URL. Tap 'Need more help?' to view the FAQ." = "Nenašla sa webová stránka WordPress na tejto URL adrese. Ťuknite \"Potrebujete pomoc?\" na zobrazenie FAQ.";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "Nedá sa uložiť mediálny súbor.";
 
 /* Error informing the user that their homepage settings could not be updated */
 "Unable to update homepage settings" = "Nie je možné aktualizovať nastavenia domovskej stránky";
@@ -3146,9 +3095,6 @@
 
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Nahrávanie zlyhalo";
-
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Nahraté";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "Nahraný 1 koncept príspevku, %ld súborov";
@@ -3392,7 +3338,7 @@
 /* Link to a WordPress.org page for the plugin */
 "WordPress.org Plugin Page" = "WordPress.org Plugin stránka";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "Stále si prajete odstrániť tohto používateľa?";
 
 /* Button title. Opens the editor to write a new post.

--- a/WordPress/Resources/sq.lproj/Localizable.strings
+++ b/WordPress/Resources/sq.lproj/Localizable.strings
@@ -1,6 +1,6 @@
-/* Translation-Revision-Date: 2025-03-07 16:30:37+0000 */
+/* Translation-Revision-Date: 2025-11-16 10:15:08+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: sq_AL */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -338,6 +338,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Link to About screen for Jetpack for iOS */
 "About Jetpack for iOS" = "Mbi Jetpack-un për iOS";
 
+/* Link to About screen for Jetpack for iOS */
+"About Reader for iOS" = "Mbi Lexues për iOS";
+
 /* Link to About screen for WordPress for iOS */
 "About WordPress" = "Rreth WordPress-it";
 
@@ -578,8 +581,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "Thuajse arritëm! Ju lutemi, jepni kodin e verifikimit prej aplikacionit tuaj Authenticator.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Tekst Alternativ";
 
 /* No comment provided by engineer. */
@@ -722,9 +724,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "Jeni i sigurt se doni të shkëputet Jetpack-u nga sajti?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "Jeni i sigurt që doni të fshihet përgjithmonë ky objekt?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "Jeni i sigurt se doni të hiqet %1$@ nga %2$@?";
@@ -1076,7 +1075,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Anuloje";
@@ -1104,8 +1102,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "S’e ndani dot mendjen? Temën mund ta ndryshoni kurdo.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Legjendë";
 
 /* Alert title. */
@@ -1604,6 +1601,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Message to show to user when he tries to add a self-hosted site but the host returned a 405 error, meaning that the host is blocking POST requests on /xmlrpc.php file. */
 "Couldn't connect. Your host is blocking POST requests, and the app needs that in order to communicate with your site. Please contact your hosting provider to solve this problem." = "S’u bë dot lidhja. Strehuesi juaj i bllokon kërkesat POST, dhe aplikacionit i duhen që të mund të komunikojë me sajtin tuaj. Ju lutemi, lidhuni me shërbimin strehues tuaj që ta zgjidhni këtë problem.";
 
+/* Content show when the dashboard fails to load */
+"Couldn't load data. Please refresh again later." = "S’u ngarkuan dot të dhëna. Ju lutemi, rifreskojeni më vonë";
+
 /* Error message when tag loading failed */
 "Couldn't load tags. Tap to retry." = "S’u ngarkuan dot etiketa. Prekeni, që të riprovohet.";
 
@@ -1765,8 +1765,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "Parazgjedhje";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Kategori Parazgjedhje";
 
 /* Label for selecting the default post format
@@ -1775,9 +1774,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Parazgjedhje për Postime të Reja";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Fshije";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Fshije Menunë";
@@ -1796,14 +1792,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "Fshije menunë";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "U fshi!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Po fshihet sajti…";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Po fshihet…";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "Mohoje";
@@ -1811,8 +1801,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "Përshkruani qëllimin e figurës. Lëreni të zbrazët, në qoftë dekorative.";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Përshkrim";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1830,9 +1819,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "S’e kishit fjalën për të krijuar një llogari të re? Shkoni mbrapsht, që të rijepni adresën tuaj email.";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Përmasa";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "Çaktivizoje";
@@ -2109,7 +2095,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "Përpunimi i këtij GIF do të heqë animacionin e tij.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Redaktor";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2403,6 +2389,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Failed to insert media.\nTap for more info." = "S’u arrit të futej media.\nPrekeni për më tepër hollësi.";
 
+/* A message indicating that we couldn't load the user's settings. */
+"Failed to load settings" = "S’u arrit të ngarkohen rregullime";
+
 /* No comment provided by engineer. */
 "Failed to save files.\nPlease tap for options." = "S’u arrit të ruhen kartela.\nJu lutemi, prekeni për mundësi.";
 
@@ -2448,11 +2437,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "Rregullime blloku kartelash";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "Emër kartele";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Lloj kartele";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "Lloj kartelash i pambuluar si kartelë media.";
@@ -2808,9 +2794,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "Përshkrim Figure";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Përshkrim Figure";
-
 /* Hint for image link on image settings. */
 "Image Link" = "Lidhje Figure";
 
@@ -2822,9 +2805,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "S’u gjet kartelë figure.";
-
-/* Hint for image title on image settings. */
-"Image title" = "Titull figure";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "Shpjegoni, me pak fjalë, se për çfarë është ky sajt.";
@@ -3362,6 +3342,9 @@ translators: %s: Block name e.g. \"Image block\" */
 "Log out of Jetpack?" = "Të dilet nga Jetpack-u?";
 
 /* LogOut confirmation text, whenever there are no local changes */
+"Log out of Reader?" = "Të dilet nga Lexues?";
+
+/* LogOut confirmation text, whenever there are no local changes */
 "Log out of WordPress?" = "Të dilet nga WordPress-i?";
 
 /* Login Request Expired */
@@ -3726,9 +3709,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "S’u Gjetën Llogari";
-
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Pa Kategori";
 
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Pa lidhje";
@@ -4170,9 +4150,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "Faqosje";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Kategori Mëmë";
-
 /* Accessibility label for the password text field in the self-hosted login page.
    Label for entering password in password field
    Login dialog password placeholder
@@ -4387,9 +4364,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Postim";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Kategori Postimesh";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "Rregullime Postimi";
@@ -4698,9 +4672,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "Heq prej fotove tejtëdhëna vendi përpara se të ngarkohen në sajtin tuaj.";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "Heqja e ndjekësve bën që ata të reshtin së marri përditësime nga sajti juaj. Nëse vendosin kështu, prapë mund të vizitojnë sajtin tuaj dhe ta ndjekin sërish.";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "Zëvendëso Bllokun e Tanishëm";
@@ -5120,6 +5091,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Share Jetpack with a friend" = "Jepjani WordPress-in një shoku";
 
 /* Title for a button that recommends the app to others */
+"Share Reader with a friend" = "Ndajeni Lexuesin me një shok";
+
+/* Title for a button that recommends the app to others */
 "Share WordPress with a friend" = "Jepjani WordPress-in një shoku";
 
 /* Accessibility label for button to share a comment from a notification */
@@ -5531,6 +5505,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "Përmbledhtas";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Etiketa";
 
@@ -5916,9 +5891,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "Ky kod hyrjeje ka skaduar. Ju lutemi, prekni butonin “Riskanoje” që të riskanohet kodi.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "Ky objekt media është fshirë.";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "Kjo llogari përdoruesi s’mund të mbyllet, nëse ka pagesa të prapambetura të pakryera.";
 
@@ -5987,7 +5959,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Titull";
@@ -6081,8 +6052,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "Shndërro bllokun…";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Në hedhurina";
 
@@ -6179,9 +6149,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "S’arrihet të krijohen lidhje të reja ftese.";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "S’arrihet të fshihet objekt media.";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "S’arrihet të çaktivizohen lidhje ftesash.";
 
@@ -6212,9 +6179,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "S’arrihet të ngarkohet kjo lëndë këtë çast.";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "S’arrihet të ngarkohet videoja.";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "S’arrihet të luhet videoja";
 
@@ -6223,9 +6187,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "S’arrihet të rikthehet sajti juaj";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "S’arrihet të ruhet objekt media.";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "S’arrihet t’u jepet lidhja të tjerëve";
@@ -6381,9 +6342,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Ngarkimi dështoi";
-
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "U ngarkua";
 
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "U ngarkua 1 skicë postimi, %ld kartela";
@@ -6778,6 +6736,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "What's New in Jetpack" = "Ç’ka të Re në Jetpack";
 
 /* Opens the What's New / Feature Announcement modal */
+"What's New in Reader" = "Çka të Re në Lexues";
+
+/* Opens the What's New / Feature Announcement modal */
 "What's New in WordPress" = "Ç’ka të Re në WordPress";
 
 /* Title of alert helping users understand their site address */
@@ -6873,7 +6834,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "Hartë e botës që tregon parje sipas vendesh.";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "Doni ende të hiqet ky person?";
 
 /* Button title. Opens the editor to write a new post.
@@ -7070,6 +7031,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Help text that describes how the password should be. It appears while editing the password */
 "Your password should be at least six characters long. To make it stronger, use upper and lower case letters, numbers, and symbols like ! \" ? $ % ^ & )." = "Fjalëkalimi juaj duhet të jetë të paktën gjashtë shenja i gjatë. Për ta bërë më të fortë, përdorni shkronja me të mëdha dhe me të vogla, numra, dhe simbole të tillë si ! \" ? $ % ^ & ).";
 
+/* Message of Export Content confirmation alert */
+"Your posts, pages, and settings will be mailed to the account's email address." = "Postimet, faqet dhe rregullimet tuaja do të dërgohen te adresa email e llogarisë.";
+
 /* Message of Export Content confirmation alert; substitution is user's email address */
 "Your posts, pages, and settings will be mailed to you at %@." = "Postimet, faqet dhe rregullimet tuaja do t’ju dërgohen me email te %@.";
 
@@ -7136,6 +7100,58 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* The title for the list of third-party software we use */
 "acknowledgements.title" = "Falënderime";
 
+/* Placeholder text shown when the activity actor's display name is empty */
+"activity.unknownUser" = "Përdorues i Panjohur";
+
+/* Button title for downloading a backup */
+"activityDetail.download.button" = "Shkarkoje";
+
+/* Button title for restoring a backup */
+"activityDetail.restore.button" = "Riktheje";
+
+/* Section title for restore site actions */
+"activityDetail.section.restoreSite" = "Riktheni Sajtin";
+
+/* Section title for user information */
+"activityDetail.section.user" = "Përdorues";
+
+/* Title for the activity detail view */
+"activityDetail.title" = "Veprimtari";
+
+/* Deselect all button */
+"activityLogs.activityTypes.deselectAll" = "Shpërzgjidhi Krejt";
+
+/* Empty state message when no activity types are available */
+"activityLogs.activityTypes.empty" = "S’ka lloje veprimtarie të gatshëm";
+
+/* Select all button */
+"activityLogs.activityTypes.selectAll" = "Përzgjidhi Krejt";
+
+/* Activity type selection screen title */
+"activityLogs.activityTypes.title" = "Lloje Veprimtarish";
+
+/* Empty state message for activity logs */
+"activityLogs.empty" = "S’ka Veprimtari";
+
+/* Activity types filter label */
+"activityLogs.filter.activityTypes" = "Lloje Veprimtarish";
+
+/* End date filter label */
+"activityLogs.filter.endDate" = "Datë Përfundimi";
+
+/* Reset filters button label */
+"activityLogs.filter.reset" = "Riktheji Filtrat Te Parazgjedhjet";
+
+/* Start date filter label */
+"activityLogs.filter.startDate" = "Datë Fillimi";
+
+/* Notice shown to free plan users about limited activity log events */
+"activityLogs.freePlan.notice" = "Meqë jeni nën një plan falas, te Regjistri juaj i Veprimtarisë do të shihni veprimtari të kufizuara.";
+
+/* Title for activity logs screen
+   Title for the activity logs screen */
+"activityLogs.title" = "Veprimtari";
+
 /* Screen title */
 "addCategory.navigationTitle" = "Shtoni Kategori";
 
@@ -7148,11 +7164,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility identifier for an 'Add Comment' button */
 "addCommentButton.accessibilityIdentifity" = "Shtoni Koment";
 
+/* Error message when user cancels login */
+"addSite.selfHosted.cancelled" = "Hyrja është anuluar";
+
 /* A message to inform users to type the site address in the text field. */
 "addSite.selfHosted.enterSiteAddress" = "Jepni adresën e sajtit WordPress te i cili do të donit të lidheshit.";
 
 /* Error message shown when failing to load details from a self-hosted WordPress site */
 "addSite.selfHosted.loadingSiteInfoFailure" = "S’ngarkohen dot hollësi sajti WordPress";
+
+/* Error message when user signs in with an unexpected usern. The first argument is the expected username */
+"addSite.selfHosted.mismatchUser" = "Ju lutemi, bëni hyrjen me përdoruesin e futur. Emër përdoruesi: %@";
 
 /* Error message shown when failing to save a self-hosted site to user's device */
 "addSite.selfHosted.savingSiteFailure" = "S’mund të ruhet sajti WordPress, ju lutemi, riprovoni më vonë.";
@@ -7160,11 +7182,17 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of the page to add a self-hosted site */
 "addSite.selfHosted.title" = "Shtoni Sajt të Vetëstrehuar";
 
+/* Error message when XML-RPC is disabled on the WordPress site. The first argument is detailed error message */
+"addSite.selfHosted.xmlrpcDisabled" = "S’u bë dot lidhje me sajtin WordPress. XML-RPC mund të jetë çaktivizuar te shërbyesi. Për të zgjidhur këtë problem, ju lutemi, lidhuni me shërbimin tuaj të strehimit.";
+
 /* Age between dates equaling one hour. */
 "an hour" = "një orë";
 
 /* This is the string we display when prompting the user to review the Jetpack app */
 "appRatings.jetpack.prompt" = "Si ju duket Jetpack-u?";
+
+/* This is the string we display when prompting the user to review the Reader app */
+"appRatings.reader.prompt" = "Ç’mendoni për Lexuesin?";
 
 /* This is the string we display when prompting the user to review the WordPress app */
 "appRatings.wordpress.prompt" = "Si ju duket WordPress-i?";
@@ -7214,11 +7242,26 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* The list item of experimental features that users can choose to enable */
 "application-settings.experimental-features" = "Veçori Eksperimentale";
 
+/* Complete information about application passwords with security benefits, creation process, management instructions, and revocation warning */
+"applicationPassword.info.content" = "Fjalëkalimet e aplikacioneve janë një rrugë më e siguruar që ky aplikacion të hyjë në lëndën e sajtit tuaj pa përdorur fjalëkalimin tuaj faktik të llogarisë.\n\nKur shtoni sajte te aplikacioni, fjalëkalimet e aplikacionit do të krijohen automatikisht, sipas nevojës.\n\nKëto fjalëkalime mund t’i shihni dhe administroni te profili juaj i përdoruesit, brenda panelit të përgjegjësit të sajtit tuaj WordPress.\n\nJu lutemi, kini parasysh se shfuqizimi i fjalëkalimeve të aplikacionit të përdorura prej tij do t’i japin fund hyrjes së aplikacionit në sajtin tuaj. Bëni kujdes kur shfuqizoni fjalëkalime aplikacioni të krijuar nga aplikacioni vetë.";
+
+/* Button to dismiss the application password information view */
+"applicationPassword.info.gotIt.button" = "E kuptova";
+
+/* Title for the application passwords information view */
+"applicationPassword.info.title" = "Rreth Fjalëkalime Aplikacionesh";
+
 /* Title of row for displaying an application password's creation date */
 "applicationPassword.item.creationDate" = "Datë Krijimi";
 
+/* Footer message indicating that this application password is currently active and being used by the app */
+"applicationPassword.item.currentlyInUse" = "Ky fjalëkalim aplikacioni përdoret aktualisht nga aplikacioni.";
+
 /* Title of row for displaying an application password's last used date */
 "applicationPassword.item.lastUsed" = "Përdorur Së Fundi Më";
+
+/* Title of row for displaying an application password's last used IP address */
+"applicationPassword.item.lastUsedIp" = "Adresa IP e fundit";
 
 /* Title of row for displaying an application password name */
 "applicationPassword.item.name" = "Emër";
@@ -7226,11 +7269,14 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Title of section for displaying application password details */
 "applicationPassword.item.section.security" = "Siguri";
 
+/* String format of creation date of an application password. There is one argument: the creation date relative to now (i.e. 5 days ago). */
+"applicationPassword.list.item.created-date-format" = "Krijuar më %@";
+
 /* String format of last used time of an application password. There is one argument: the last used time relative to now (i.e. 5 days ago). */
 "applicationPassword.list.item.last-used-format" = "Përdorur së fundi më %@";
 
 /* Last used time of an application password if it's never been used */
-"applicationPassword.list.item.unused" = "Ende i papërdorur";
+"applicationPassword.list.item.unused" = "Ende i papërdorur.";
 
 /* Title of application passwords list */
 "applicationPassword.list.title" = "Fjalëkalime Aplikacionesh";
@@ -7238,17 +7284,31 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message when the current site's url cannot be found */
 "applicationPasswordMigration.error.siteUrlNotFound" = "S’gjendet dot URL-ja e sajtit të tanishëm";
 
+/* Error message shown when the site doesn't support Application Passwords feature */
+"applicationPasswordMigration.error.unsupported" = "Ky sajt s’mbulon Fjalëkalim Aplikacioni.";
+
 /* Error message when the username does not match the signed-in user. The first argument is the currently signed in user's user login name */
 "applicationPasswordMigration.error.usernameMismatch" = "Lypset të bëni hyrjen me përdorues “%@”";
+
+/* Error message when the site's REST API is not accessible for application password creation */
+"applicationPasswordRepository.error.restApiInaccessible" = "S’arrihet të hyhet te API REST e sajtit";
+
+/* Error message when application password creation fails for unknown reasons */
+"applicationPasswordRepository.error.unknown" = "S’arrihet të krijohet fjalëkalim aplikacioni";
+
+/* Error message when the username cannot be found for application password creation */
+"applicationPasswordRepository.error.usernameNotFound" = "S’arrihet të gjendet emër përdoruesi për sajtin";
 
 /* Description for the prompt to upgrade to Application Passwords. The first argument is the name of the feature that requires Application Passwords. */
 "applicationPasswordRequired.description" = "Fjalëkalimet e aplikacioneve janë një rrugë më e sigurt për t’u lidhur me sajtin tuaj të vetëstrehuar dhe lejojnë mbulim veçorisht të tilla si %@.";
 
+/* Feature name for the block editor in application password required prompt */
+"applicationPasswordRequired.feature.blockEditor" = "Përpunues Me Blloqe";
+
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "Administrim Shtojcash";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "Administrim Përdoruesish";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -7283,6 +7343,34 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* User action to dismiss media options. */
 "aztecPost.mediaAttachmentActionSheet.dismiss" = "Hidhe tej";
+
+/* Download button title */
+"backup.download.header.download" = "Shkarkim";
+
+/* Shows when the download link will expire. %@ is the relative time (e.g., 'in 2 hours') */
+"backup.download.header.expiresIn" = "Skadon më %@";
+
+/* Message displayed when a backup has finished. %@ is the date and time. */
+"backup.download.header.message" = "Kopjeruajtja juaj prej %@ është gati";
+
+/* Title shown when a backup is ready to download */
+"backup.download.header.title" = "Kopjeruajtje gati për shkarkim";
+
+/* Message shown when a downloadable backup is in progress */
+"backup.inProgress.message" = "Po përgatitet kopjeruajtja e sajtit tuaj për shkarkim";
+
+/* Title shown when a downloadable backup is being created */
+"backup.inProgress.title" = "Po krijohet kopjeruajtje e shkarkueshme";
+
+/* Text displayed in the view when there aren't any Backups to display */
+"backups.empty.subtitle" = "Kopjeruajtja juaj e parë do të shfaqet këtu brenda 24 orësh dhe do të merrni një njoftim sapo kopjeruajtja të jetë plotësuar";
+
+/* Title for the view when there aren't any Backups to display */
+"backups.empty.title" = "Kopjeruajtja juaj e parë do të jetë gati së shpejti";
+
+/* Title for backups screen
+   Title for the backups screen */
+"backups.title" = "Kopjeruajtje";
 
 /* Button title for the button that shows the Blaze flow when tapped. */
 "blaze.campaigns.create.button.title" = "Krijoni";
@@ -7536,6 +7624,15 @@ Example: Reply to Pamela Nguyen */
 
 /* Accessibility hint for create floating action button */
 "createPostSheet.createPostHint" = "Krijoni një postim, ose faqe";
+
+/* Create Sheet button title */
+"createSheet.page" = "Faqe";
+
+/* Create Sheet button title */
+"createSheet.post" = "Postim";
+
+/* Create Sheet button title */
+"createSheet.postFromAudio" = "Postim që nga Audio";
 
 /* Customize Insights description */
 "customizeInsightsCell.content" = "Krijoni pultin tuaj të përshtatur dhe zgjidhni cilët raporte të shihen. Përqendrohuni te të dhënat për të cilat merakoseni më shumë.";
@@ -7841,6 +7938,18 @@ Example: Reply to Pamela Nguyen */
 /* No comment provided by engineer. */
 "double-tap to change unit" = "që të ndryshoni njësinë, prekeni dy herë";
 
+/* Placeholder text for tag description field */
+"edit.tag.description.placeholder" = "Shtoni një përshkrim…";
+
+/* Placeholder text for tag name field */
+"edit.tag.name.placeholder" = "Emër etikete";
+
+/* Navigation title for new tag creation */
+"edit.tag.new.title" = "Etiketë e Re";
+
+/* Section header for tag description in edit tag view */
+"edit.tag.section.description" = "Përshkrim";
+
 /* Register Domain - Address information field Number placeholder */
 "eg. 1122334455" = "p.sh., 1122334455";
 
@@ -7874,6 +7983,9 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the alert asking for feedback */
 "experimentalFeatures.editorFeedbackTitle" = "Jepni Përshtypje";
+
+/* Communicates the future removal of the option to disable the experimental editor, displayed beneath the experimental features list */
+"experimentalFeatures.editorNote" = "Përpunuesi eksprerimental me blloqe do të bëhet parazgjedhja, në një hedhje të ardhshme në qarkullim dhe aftësia për ta aktivizuar do të hiqet.";
 
 /* The title for the experimental features list */
 "experimentalFeaturesList.heading" = "Veçori Eksperimentale";
@@ -7916,6 +8028,27 @@ Example: Reply to Pamela Nguyen */
 
 /* A footer retry button */
 "general.pagingFooterView.retry" = "Riprovoni";
+
+/* Generated content length (needs to be short) */
+"generation.length.long" = "I gjatë";
+
+/* Generated content length (needs to be short) */
+"generation.length.medium" = "Mesatar";
+
+/* Generated content length (needs to be short) */
+"generation.length.short" = "I shkurtër";
+
+/* AI generation style */
+"generation.style.conversational" = "Bisedimor";
+
+/* AI generation style */
+"generation.style.engaging" = "Angazhues";
+
+/* AI generation style */
+"generation.style.formal" = "Formal";
+
+/* AI generation style */
+"generation.style.professional" = "Profesional";
 
 /* A generic title for an error */
 "generic.error.title" = "Gabim";
@@ -8031,6 +8164,48 @@ Example: Reply to Pamela Nguyen */
 /* Text for the Insights Overview stat difference label. Shows the change from the previous period. E.g.: +12.3K. %1$@ is the placeholder for the change sign ('-', '+', or none). %2$@ is the placeholder for the change numerical value. */
 "insights.visitorsLineChartCell.differenceLabelWithoutPercentage" = "%1$@%2$@";
 
+/* Message shown when Apple Intelligence is disabled */
+"intelligence.unavailableView.appleIntelligenceDisabled.message" = "Që të prodhohen copëza me IA, ju lutemi, aktivizoni te Rregullimet Apple Intelligence. Kjo veçori përdor përpunim brenda në pajisje, për të mbrojtur privatësinë tuaj.";
+
+/* Button to open Apple Intelligence settings */
+"intelligence.unavailableView.appleIntelligenceDisabled.openSettings" = "Hap Rregullimet";
+
+/* Title shown when Apple Intelligence is disabled */
+"intelligence.unavailableView.appleIntelligenceDisabled.title" = "Duhet Apple Intelligence";
+
+/* Message shown when Apple Intelligence is unavailable */
+"intelligence.unavailableView.appleIntelligenceUnvailable.message" = "Apple Intelligence s’është gati në këtë pajisje";
+
+/* Title shown when Apple Intelligence is unavailable */
+"intelligence.unavailableView.appleIntelligenceUnvailable.title" = "S’ka Apple Intelligence";
+
+/* Description shown when the AI model is not ready */
+"intelligence.unavailableView.preparingModel.description" = "Modeli IA po shkarkohet dhe po përgatitet. Ju lutemi, riprovoni pas një çasti.";
+
+/* Title shown when the AI model is not ready */
+"intelligence.unavailableView.preparingModel.title" = "Po përgatitet model…";
+
+/* Cancel dialog confirmation title */
+"inviteSubscribers.cancelConfirmationTitle" = "Jeni i sigurt se doni të hidhen tej pajtimtarët e rinj?";
+
+/* Cancel dialog confirmation button */
+"inviteSubscribers.discardChanges" = "Hidhi Tej Ndryshimet";
+
+/* A footer view (small text). The button title is inserted by the app via a parameter. */
+"inviteSubscribers.disclosure" = "Duke klikuar \"%@,\" pohoni se keni marrë pranimin e duhur për t’i dërguar email secilit person. Ankesa për mesazhe të padëshiruar, apo nivel i lartë kthimesh prapa të mesazheve nga pajtimtarët tuaj mund të shpien në veprime kundër llogarisë tuaj.";
+
+/* Field title (not shown, accessibility) */
+"inviteSubscribers.fieldTitleEmail" = "Email";
+
+/* Import success snackbar title */
+"inviteSubscribers.importSuccessMessage" = "Mund të duhen pak minuta, para se të plotësohet importimi";
+
+/* Import success snackbar title */
+"inviteSubscribers.importSuccessTitle" = "Importi Filloi";
+
+/* Screen title */
+"inviteSubscribers.title" = "Shtoni Pajtimtarë";
+
 /* Footer text for Invite Links section of the Invite People screen. */
 "invite_people_invite_link_footer" = "Përdoreni këtë lidhje për mirëseardhjen e anëtarëve të ekipit tuaj, pa pasur nevojë t’i ftoni ata tek për tek. Cilido që viziton këtë URL, do të jetë në gjendje të regjistrohet në entin tuaj, madje edhe nëse lidhjen e morën nga dikush tjetër, ndaj kujdesuni t’ua jepni personave të besuar.";
 
@@ -8090,6 +8265,42 @@ Example: Reply to Pamela Nguyen */
 
 /* Title of the Jetpack powered overlay. */
 "jetpack.branding.overlay.title" = "WordPress-i është më i mirë me Jetpack-un";
+
+/* Title for the button that starts the Jetpack connection process */
+"jetpack.connection.connect.button" = "Lidhni sajtin tuaj";
+
+/* Error message shown when WordPress.com authentication fails */
+"jetpack.connection.error.authentication" = "Llogari WordPress.com e pavlefshme";
+
+/* Error message shown when a connection step is attempted in an invalid order */
+"jetpack.connection.error.context" = "Ky hap s’është ende gati";
+
+/* Title for the retry button shown when a connection step fails */
+"jetpack.connection.retry.button" = "Riprovo";
+
+/* Status message when a connection step is pending */
+"jetpack.connection.stage.pending" = "Po pritet të fillohet";
+
+/* Status message when a connection step is in progress */
+"jetpack.connection.stage.processing" = "Në ecuri e sipër…";
+
+/* Status message when a connection step is completed successfully */
+"jetpack.connection.stage.success" = "E përfunduar";
+
+/* Title for the finalization step in Jetpack connection flow */
+"jetpack.connection.step.finalize.title" = "Finalizoni Lidhjen";
+
+/* Title for the install step in Jetpack connection flow */
+"jetpack.connection.step.install.title" = "Instaloni Jetpack-un";
+
+/* Title for the login step in Jetpack connection flow */
+"jetpack.connection.step.login.title" = "Hyni në WordPress.com";
+
+/* Title for the site connection step in Jetpack connection flow */
+"jetpack.connection.step.site.title" = "Lidheni te sajti juaj";
+
+/* Title for the user connection step in Jetpack connection flow */
+"jetpack.connection.step.user.title" = "Lidheni me llogarinë tuaj WordPress.com";
 
 /* Title of a button that navigates the user to the Jetpack app if installed, or to the app store. */
 "jetpack.fullscreen.overlay.early.switch.title" = "Kalo në aplikacionin e ri Jetpack";
@@ -8289,6 +8500,559 @@ Example: Reply to Pamela Nguyen */
 /* Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account */
 "jetpackSite.connectToDefaultAccount" = "Që të përdorni Statistika dhe Njoftime, duhet të bëni hyrjen me %@.";
 
+/* Accessibility label for add card button */
+"jetpackStats.accessibility.addCardButton" = "Shtoni kartë të re statistikash";
+
+/* Accessibility label for back navigation */
+"jetpackStats.accessibility.backToStats" = "Mbrapsht te statistikat";
+
+/* Card title accessibility label. %1$@ is the card title. */
+"jetpackStats.accessibility.cardTitle" = "Kartë %1$@";
+
+/* Accessibility label for chart container */
+"jetpackStats.accessibility.chartContainer" = "Grafik statistikash";
+
+/* Chart trend accessibility label. %1$@ is metric name, %2$@ is trend description. */
+"jetpackStats.accessibility.chartTrend" = "%1$@ %2$@";
+
+/* Chart data point accessibility label. %1$@ is metric name, %2$@ is value, %3$@ is date. */
+"jetpackStats.accessibility.chartValue" = "%1$@: %2$@ më %3$@";
+
+/* Selected date range accessibility label. %1$@ is the range. */
+"jetpackStats.accessibility.dateRangeSelected" = "Interval datash: %1$@";
+
+/* Accessibility label for error state */
+"jetpackStats.accessibility.errorLoadingStats" = "Gabim gjatë ngarkimit të statistikave";
+
+/* Accessibility label for loading state */
+"jetpackStats.accessibility.loadingStats" = "Po ngarkohen statistika";
+
+/* Accessibility label for more options menu */
+"jetpackStats.accessibility.moreOptions" = "Më tepër mundësi";
+
+/* Accessibility hint for next period navigation */
+"jetpackStats.accessibility.navigateToNextDateRange" = "Kaloni te interval pasues datash";
+
+/* Accessibility hint for previous period navigation */
+"jetpackStats.accessibility.navigateToPreviousDateRange" = "Kaloni te interval i mëparshëm datash";
+
+/* Accessibility label for next period navigation button */
+"jetpackStats.accessibility.nextPeriod" = "Periudha pasuese";
+
+/* Accessibility label for empty data state */
+"jetpackStats.accessibility.noDataAvailable" = "S’ka të dhëna të gatshme për këtë periudhë";
+
+/* Accessibility label for opening link in browser */
+"jetpackStats.accessibility.openInBrowser" = "Hape në shfletues";
+
+/* Accessibility label for previous period navigation button */
+"jetpackStats.accessibility.previousPeriod" = "Periudha e mëparshme";
+
+/* Accessibility label for realtime visitor count */
+"jetpackStats.accessibility.realtimeVisitorCount" = "Vizitorë aktualisht në linjë";
+
+/* Accessibility hint for retry action */
+"jetpackStats.accessibility.retryLoadingStats" = "Prekeni dy herë që të riprovohet të ngarkohen statistika";
+
+/* Accessibility hint for date range selection */
+"jetpackStats.accessibility.selectDateRange" = "Përzgjidhni interval datash";
+
+/* Accessibility hint for tab selection. %1$@ is the tab name. */
+"jetpackStats.accessibility.selectTab" = "Përzgjidhni skedën %1$@";
+
+/* Accessibility announcement when stats finish loading */
+"jetpackStats.accessibility.statsLoaded" = "Statistikat u ngarkuan";
+
+/* Accessibility label for stats tab bar */
+"jetpackStats.accessibility.statsTabBar" = "Skeda lëvizjeje nëpër statistika";
+
+/* Accessibility announcement when a tab is selected. %1$@ is the tab name. */
+"jetpackStats.accessibility.tabSelected" = "U përzgjodh skeda %1$@";
+
+/* Top list item accessibility label. %1$d is rank, %2$@ is title, %3$@ is value. */
+"jetpackStats.accessibility.topListItem" = "Renditje %1$d: %2$@, %3$@";
+
+/* Accessibility hint for viewing chart data */
+"jetpackStats.accessibility.viewChartData" = "Shihni të dhëna të hollësishme grafiku";
+
+/* Accessibility hint for items that can show more details */
+"jetpackStats.accessibility.viewMoreDetails" = "Prekeni dy herë që të shihni më tepër hollësi";
+
+/* Singular visitor count. %1$d is the number. */
+"jetpackStats.accessibility.visitorNow" = "%1$d vizitor në linjë tani";
+
+/* Plural visitors count. %1$d is the number. */
+"jetpackStats.accessibility.visitorsNow" = "%1$d vizitorë në linjë tani";
+
+/* Chart option description */
+"jetpackStats.addChart.chartDescription" = "Shfaq prirje përgjatë kohës";
+
+/* Chart option title */
+"jetpackStats.addChart.chartOption" = "Grafik";
+
+/* Title for data type selection */
+"jetpackStats.addChart.selectDataType" = "Përzgjidhni Lloj të Dhënash";
+
+/* Title for metric selection */
+"jetpackStats.addChart.selectMetric" = "Përzgjidhni Përmasa";
+
+/* Today chart title */
+"jetpackStats.addChart.today" = "Sot";
+
+/* Today option description
+   Top list option description */
+"jetpackStats.addChart.topListDescription" = "Shihni lëndën tuaj që ecën më mirë nga gjithçka tjetër";
+
+/* Plural item count for archive sections. %1$d is the number. */
+"jetpackStats.archiveSections.itemCount.plural" = "%1$d objekte";
+
+/* Singular item count for archive sections. %1$d is the number. */
+"jetpackStats.archiveSections.itemCount.singular" = "%1$d objekt";
+
+/* Title for the author details screen */
+"jetpackStats.authorDetails.title" = "Autor";
+
+/* Button to add a new chart */
+"jetpackStats.button.addCard" = "Shtoni Kartë";
+
+/* Apply button */
+"jetpackStats.button.apply" = "Aplikoje";
+
+/* Cancel button */
+"jetpackStats.button.cancel" = "Anuloje";
+
+/* Button to customize a chart or widget */
+"jetpackStats.button.customize" = "Përpunoni Kartën";
+
+/* Button to delete a chart or widget */
+"jetpackStats.button.deleteWidget" = "Fshije Kartën";
+
+/* Done button */
+"jetpackStats.button.done" = "U bë";
+
+/* Button to download data as CSV file */
+"jetpackStats.button.downloadCSV" = "Shkarkojeni si CSV";
+
+/* Learn more about stats button */
+"jetpackStats.button.learnMore" = "Mësoni Më Tepër";
+
+/* Button to move a card */
+"jetpackStats.button.moveCard" = "Lëvize Kartën";
+
+/* Button to move card down */
+"jetpackStats.button.moveDown" = "Zbrite Poshtë";
+
+/* Button to move card to the bottom */
+"jetpackStats.button.moveToBottom" = "Kaloje në Fund";
+
+/* Button to move card to the top */
+"jetpackStats.button.moveToTop" = "Ngjite në Krye";
+
+/* Button to move card up */
+"jetpackStats.button.moveUp" = "Ngjite Sipër";
+
+/* OK button */
+"jetpackStats.button.ok" = "OK";
+
+/* Button to reset chart settings to default */
+"jetpackStats.button.resetSettings" = "Rikthe Rregullimet te Parazgjedhjet";
+
+/* Share chart menu item */
+"jetpackStats.button.share" = "Ndajeni me të tjerë";
+
+/* Button title */
+"jetpackStats.button.showAll" = "Shfaqi Krejt";
+
+/* Button to collapse and show fewer items */
+"jetpackStats.button.showLess" = "Shfaq Më Pak";
+
+/* Button to expand and show more items */
+"jetpackStats.button.showMore" = "Shfaq Më Tepër";
+
+/* Last 10 years date range */
+"jetpackStats.calendar.last10Years" = "10 Vjetët e Fundit";
+
+/* Last 12 months date range */
+"jetpackStats.calendar.last12Months" = "12 Muajt e Fundit";
+
+/* Last 12 weeks (84 days) date range */
+"jetpackStats.calendar.last12Weeks" = "12 Javët e Fundit";
+
+/* Last 28 days date range */
+"jetpackStats.calendar.last28Days" = "28 Ditët e Fundit";
+
+/* Last 30 days date range */
+"jetpackStats.calendar.last30Days" = "30 Ditët e Fundit";
+
+/* Last 3 years date range */
+"jetpackStats.calendar.last3Years" = "3 Vjetët e Fundit";
+
+/* Last 6 months date range */
+"jetpackStats.calendar.last6Months" = "6 Muajt e Fundit";
+
+/* Last 7 days date range */
+"jetpackStats.calendar.last7Days" = "7 Ditët e Fundit";
+
+/* Month time period */
+"jetpackStats.calendar.month" = "Muaj";
+
+/* Quarter time period */
+"jetpackStats.calendar.quarter" = "Katërmujor";
+
+/* This month date range */
+"jetpackStats.calendar.thisMonth" = "Këtë Muaj";
+
+/* This quarter date range */
+"jetpackStats.calendar.thisQuarter" = "Këtë Katërmujor";
+
+/* This week date range */
+"jetpackStats.calendar.thisWeek" = "Këtë Javë";
+
+/* This year date range */
+"jetpackStats.calendar.thisYear" = "Këtë Vit";
+
+/* Today date range */
+"jetpackStats.calendar.today" = "Sot";
+
+/* Week time period */
+"jetpackStats.calendar.week" = "Javë";
+
+/* Year time period */
+"jetpackStats.calendar.year" = "Vit";
+
+/* Bar chart type */
+"jetpackStats.chart.barChart" = "Shtylla";
+
+/* Shown for empty states */
+"jetpackStats.chart.dataEmpty" = "S’ka të dhëna për periudhën";
+
+/* Genertic error message */
+"jetpackStats.chart.generitcError" = "Diç shkoi ters";
+
+/* Shown for metrics that don't support hourly data */
+"jetpackStats.chart.hourlyDataNotAvailable" = "S’ka të dhëna për orën";
+
+/* Shown when current period data might be incomplete */
+"jetpackStats.chart.incompleteData" = "Mund të shfaqë të dhëna të paplota";
+
+/* Line chart type */
+"jetpackStats.chart.lineChart" = "Rreshta";
+
+/* Show chart data menu item */
+"jetpackStats.chart.showData" = "Shfaq të Dhëna";
+
+/* Label for change value */
+"jetpackStats.chartData.change" = "Ndryshoje";
+
+/* Column header for date */
+"jetpackStats.chartData.date" = "DATË";
+
+/* Section title for detailed data */
+"jetpackStats.chartData.detailedData" = "Të Dhëna të Hollësishme";
+
+/* Title for chart data screen */
+"jetpackStats.chartData.title" = "Të dhëna Grafiku";
+
+/* Label for total value */
+"jetpackStats.chartData.total" = "Gjithsej";
+
+/* Column header for value */
+"jetpackStats.chartData.value" = "VLERË";
+
+/* Context menu action to copy country name */
+"jetpackStats.contextMenu.copyCountryName" = "Kopjo Emër Vendi";
+
+/* Context menu action to copy domain */
+"jetpackStats.contextMenu.copyDomain" = "Kopjo Përkatësi";
+
+/* Context menu action to copy file name */
+"jetpackStats.contextMenu.copyFileName" = "Kopjo Emër Kartele";
+
+/* Context menu action to copy file path */
+"jetpackStats.contextMenu.copyFilePath" = "Kopjo Shteg Kartele";
+
+/* Context menu action to copy name */
+"jetpackStats.contextMenu.copyName" = "Kopjoji Emrin";
+
+/* Context menu action to copy search term */
+"jetpackStats.contextMenu.copySearchTerm" = "Kopjo Term Kërkimi";
+
+/* Context menu action to copy title */
+"jetpackStats.contextMenu.copyTitle" = "Kopjoji Titullin";
+
+/* Context menu action to copy URL */
+"jetpackStats.contextMenu.copyURL" = "Kopjoji URL-në";
+
+/* Context menu action to copy video URL */
+"jetpackStats.contextMenu.copyVideoURL" = "Kopjoji URL-në Videos";
+
+/* Context menu action to open link in browser */
+"jetpackStats.contextMenu.openInBrowser" = "Hape në Shfletues";
+
+/* Context menu action to search term in Google */
+"jetpackStats.contextMenu.searchInGoogle" = "Kërkoni me Google";
+
+/* Message shown when a country has no views */
+"jetpackStats.countries.noViews" = "Pa parje";
+
+/* CSV header for country column */
+"jetpackStats.csv.country" = "Vend";
+
+/* CSV header for country code column */
+"jetpackStats.csv.countryCode" = "Kod Vendi";
+
+/* CSV header for date column */
+"jetpackStats.csv.date" = "Datë";
+
+/* CSV header for domain column */
+"jetpackStats.csv.domain" = "Përkatësi";
+
+/* CSV header for file name column */
+"jetpackStats.csv.fileName" = "Emër Kartele";
+
+/* CSV header for file path column */
+"jetpackStats.csv.filePath" = "Shteg Kartele";
+
+/* CSV header for name column */
+"jetpackStats.csv.name" = "Emër";
+
+/* CSV header for role column */
+"jetpackStats.csv.role" = "Rol";
+
+/* CSV header for search term column */
+"jetpackStats.csv.searchTerm" = "Term Kërkimi";
+
+/* CSV header for section column */
+"jetpackStats.csv.section" = "Ndarje";
+
+/* CSV header for title column */
+"jetpackStats.csv.title" = "Titull";
+
+/* CSV header for type column */
+"jetpackStats.csv.type" = "Lloj";
+
+/* CSV header for URL column */
+"jetpackStats.csv.url" = "URL";
+
+/* CSV header for video URL column */
+"jetpackStats.csv.videoURL" = "URL Videoje";
+
+/* Title for comparison menu */
+"jetpackStats.datePicker.compareWith" = "Krahasojeni Me…";
+
+/* Title for custom date range picker */
+"jetpackStats.datePicker.customRange" = "Interval Vetjak";
+
+/* Menu item for custom date range picker */
+"jetpackStats.datePicker.customRangeMenu" = "Interval Vetjak…";
+
+/* From date label */
+"jetpackStats.datePicker.from" = "Prej";
+
+/* Compare with same period last year option */
+"jetpackStats.datePicker.lastYear" = "Vitin e Kaluar";
+
+/* Menu item for more date period options */
+"jetpackStats.datePicker.more" = "Më Tepër…";
+
+/* Compare with preceding period option */
+"jetpackStats.datePicker.precedingPeriod" = "Periudha Pararendëse";
+
+/* Label for quick period selection */
+"jetpackStats.datePicker.quickPeriodsForStartDate" = "Periudha të shpejta për datë nisjeje";
+
+/* Site time zone header */
+"jetpackStats.datePicker.siteTimeZone" = "Zonë Kohore e Sajtit";
+
+/* Explanation of how stats are reported in site time zone */
+"jetpackStats.datePicker.siteTimeZoneDescription" = "Statistika raportohen dhe shfaqen në zonën kohore të sajtit tuaj. Nëse një vizitor vjen te sajti juaj të Martën në zonën e vet kohore, por në zonën kohore të sajtit tuaj është e Hënë, vizita regjistrohet si e të Hënës.";
+
+/* Message explaining how to use the date range control */
+"jetpackStats.dateRangeTip.message" = "Shihni ditë, javë, muaj, vite së fundi, ose përzgjidhni intervale vetjakë datash.";
+
+/* Title for stats date range control tip */
+"jetpackStats.dateRangeTip.title" = "Lëvizni Nëpër Kohë";
+
+/* Section title for the list of child links */
+"jetpackStats.externalLinkDetails.childLinks" = "Nënlidhje";
+
+/* Button to open the external link in browser */
+"jetpackStats.externalLinkDetails.openLink" = "Hape Lidhjen";
+
+/* Title for the external link details screen */
+"jetpackStats.externalLinkDetails.title" = "Lidhje e Jashtme";
+
+/* Label for daily average in tooltip */
+"jetpackStats.postDetails.dailyAverage" = "Mesatare Ditore";
+
+/* Title for email metrics card */
+"jetpackStats.postDetails.emailMetrics" = "Email-e";
+
+/* Must be short!Label for emails sent metric */
+"jetpackStats.postDetails.emailsSent" = "Email-e të Dërguar";
+
+/* Legend label for lower activity */
+"jetpackStats.postDetails.less" = "Më pak";
+
+/* Singular like count. %1$d is the number. */
+"jetpackStats.postDetails.like" = "%1$d pëlqim";
+
+/* Plural likes count. %1$d is the number. */
+"jetpackStats.postDetails.likes" = "%1$d pëlqime";
+
+/* Title for monthly activity heatmap */
+"jetpackStats.postDetails.monthsAndYears" = "Muajt e Fundit";
+
+/* Legend label for higher activity */
+"jetpackStats.postDetails.more" = "Më tepër";
+
+/* Label */
+"jetpackStats.postDetails.noLikesYet" = "Ende pa pëlqime";
+
+/* Shows when the post was published. %1$@ is the formatted date. */
+"jetpackStats.postDetails.published" = "U botua %1$@";
+
+/* Title for recent weeks activity heatmap */
+"jetpackStats.postDetails.recentWeeks" = "Javë Së Fundi";
+
+/* Navigation title */
+"jetpackStats.postDetails.title" = "Statistika Postimi";
+
+/* Section title */
+"jetpackStats.postDetails.top10" = "10 Kryesuesit";
+
+/* Section title */
+"jetpackStats.postDetails.top50" = "50 Kryesuesit";
+
+/* Must be short!Label for total email opens metric */
+"jetpackStats.postDetails.totalOpens" = "Hapje Githsej";
+
+/* Must be short!Label for unique email opens metric */
+"jetpackStats.postDetails.uniqueOpens" = "Hapje Unike";
+
+/* Label for week-over-week comparison in tooltip */
+"jetpackStats.postDetails.weekOverWeek" = "Javë Pas Jave";
+
+/* Label for weekly total in tooltip */
+"jetpackStats.postDetails.weekTotal" = "Gjithsej Në Javë";
+
+/* Title for weekly activity heatmap */
+"jetpackStats.postDetails.weeklyActivity" = "Veprimtari Javore";
+
+/* Title for error alert when marking referrer as spam fails */
+"jetpackStats.referrerDetails.errorAlertTitle" = "Gabim";
+
+/* Button to mark a referrer as spam */
+"jetpackStats.referrerDetails.markAsSpam" = "Vëri shenjë si i Padëshiruar";
+
+/* Error message when marking a referrer as spam fails */
+"jetpackStats.referrerDetails.markAsSpamError" = "S’u arri t’i vihej shenjë si i padëshiruar";
+
+/* Label shown when a referrer is already marked as spam */
+"jetpackStats.referrerDetails.markedAsSpam" = "Iu vu shenjë si i Padëshiruar";
+
+/* Section title for the list of referral sources */
+"jetpackStats.referrerDetails.referralSources" = "Burime Referuese";
+
+/* Title for the referrer details screen */
+"jetpackStats.referrerDetails.title" = "Referues";
+
+/* Archive data type */
+"jetpackStats.siteDataTypes.archive" = "Arkiv";
+
+/* Authors data type */
+"jetpackStats.siteDataTypes.authors" = "Autorë";
+
+/* External links data type */
+"jetpackStats.siteDataTypes.externalLinks" = "Lidhje të Jashtme";
+
+/* File downloads data type */
+"jetpackStats.siteDataTypes.fileDownloads" = "Shkarkime Kartelash";
+
+/* Locations data type */
+"jetpackStats.siteDataTypes.locations" = "Vendndodhje";
+
+/* Posts and pages data type */
+"jetpackStats.siteDataTypes.postsAndPages" = "Postime &amp; Faqe";
+
+/* Referrers data type */
+"jetpackStats.siteDataTypes.referrers" = "Referues";
+
+/* Search terms data type */
+"jetpackStats.siteDataTypes.searchTerms" = "Terma Kërkimesh";
+
+/* Videos data type */
+"jetpackStats.siteDataTypes.videos" = "Video";
+
+/* Bounce rate metric */
+"jetpackStats.siteMetrics.bounceRate" = "Mesatare Kthimesh";
+
+/* Site comments metric */
+"jetpackStats.siteMetrics.comments" = "Komente";
+
+/* Download count */
+"jetpackStats.siteMetrics.downloads" = "Shkarkime";
+
+/* Site likes metric */
+"jetpackStats.siteMetrics.likes" = "Pëlqime";
+
+/* Site posts metric */
+"jetpackStats.siteMetrics.posts" = "Postime";
+
+/* Time on site metric */
+"jetpackStats.siteMetrics.timeOnSite" = "Koha në Sajt";
+
+/* Site views metric */
+"jetpackStats.siteMetrics.views" = "Parje";
+
+/* Site visitors metric */
+"jetpackStats.siteMetrics.visitors" = "Vizitorë";
+
+/* Current active visitors metric */
+"jetpackStats.siteMetrics.visitorsNow" = "Vizitorë Tani";
+
+/* Insights tab */
+"jetpackStats.tabs.insights" = "Tendenca";
+
+/* Realtime tab */
+"jetpackStats.tabs.realtime" = "Aty për aty";
+
+/* Subscribers tab */
+"jetpackStats.tabs.subscribers" = "Pajtimtarë";
+
+/* Traffic tab */
+"jetpackStats.tabs.traffic" = "Trafik";
+
+/* Stats screen title */
+"jetpackStats.title" = "Statistika";
+
+/* Today card title */
+"jetpackStats.todayCard.title" = "Sot";
+
+/* Title for items with highest bounce rate */
+"jetpackStats.topList.highestBounceRate" = "Mesatarja Më e Lartë e Kthimeve";
+
+/* Title for items with longest time on site */
+"jetpackStats.topList.longestTimeOnSite" = "Ndenja Më e Gjatë në Sajt";
+
+/* Title for most commented items */
+"jetpackStats.topList.mostCommented" = "Më të Komentuarat";
+
+/* Title for chart */
+"jetpackStats.topList.mostDownloads" = "Më të Shkarkuarat";
+
+/* Title for most liked items */
+"jetpackStats.topList.mostLiked" = "Më të Pëlqyerat";
+
+/* Title for most posts (per author) */
+"jetpackStats.topList.mostPosts" = "Shumica e Postimeve";
+
+/* Title for most viewed items */
+"jetpackStats.topList.mostViewed" = "Më të Parat";
+
+/* Title for items with most visitors */
+"jetpackStats.topList.mostVisitors" = "Shumica e Vizitorëve";
+
 /* Title for a call-to-action button on the Jetpack install card. */
 "jetpackinstallcard.button.learn" = "Mësoni më tepër";
 
@@ -8310,11 +9074,44 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "S’keni leje të shihni këtë blog privat.";
 
+/* Button to dismiss the re-authentication view */
+"login.appPasswordReAuth.cancelButton" = "Anuloje";
+
+/* Description explaining why the user needs to re-authenticate */
+"login.appPasswordReAuth.description" = "Fjalëkalimi i aplikacionit caktuar atij s’ekziston më në profilin tuaj.\nJu lutemi, ribëni hyrjen, që të krijoni një fjalëkalim të ri aplikacioni\nqë të përdoret prej aplikacionit.";
+
+/* Button to start the re-authentication process */
+"login.appPasswordReAuth.signInButton" = "Hyni";
+
+/* Title shown when the application password is invalid */
+"login.appPasswordReAuth.title" = "Fjalëkalim i pavlefshëm aplikacioni";
+
 /* Instruction label in the two-factor authorization screen WordPress.com login authentication. Note: it has to mention that it's for a WordPress.com account. */
 "login.twoFactorInstructions.details" = "Ju lutemi, jepni kodin e verifikimit për llogarinë tuaj WordPress.com prej aplikacionit tuaj të mirëfilltësimeve.";
 
 /* Indicating that referrer was marked as spam */
 "marked as spam" = "iu vu shenjë si i padëshiruar";
+
+/* Button title when verification link sending failed */
+"me.verifyEmail.button.retry" = "Riprovoni";
+
+/* Button title to send verification link */
+"me.verifyEmail.button.send" = "Ridërgo email";
+
+/* Button title while verification link is being sent */
+"me.verifyEmail.button.sending" = "Po dërgohet…";
+
+/* Button title after verification link is sent */
+"me.verifyEmail.button.sent" = "Email-i u dërgua";
+
+/* Message for email verification card */
+"me.verifyEmail.message.noEmail" = "Verifikoni email-in tuaj, që të siguroni llogarinë tuaj dhe të përdorni më tepër veçori.\nShihni te email-et tuaj për email-in e ripohimit, ose klikoni mbi '%@' që të merrni një të ri…";
+
+/* Message for email verification card with email address */
+"me.verifyEmail.message.withEmail" = "Verifikoni email-in tuaj, që të siguroni llogarinë tuaj dhe të përdorni më tepër veçori.\nShihni te email-et tuaj te %1$@ për email-in e ripohimit, ose klikoni mbi '%2$@' që të merrni një të ri.";
+
+/* Title for email verification card */
+"me.verifyEmail.title" = "Verifikoni Email-in Tuaj";
 
 /* Me tab menu items */
 "meMenu.submitFeedback" = "Dërgoni Përshtypjet";
@@ -8340,8 +9137,14 @@ Example: Reply to Pamela Nguyen */
 /* Button name in the more menu */
 "mediaLibrary.aspectRatioGrid" = "Rrjetë Përpjestimore";
 
+/* Navigation bar button item */
+"mediaLibrary.buttonAddMedia" = "Shtoni Media";
+
 /* Context menu button */
 "mediaLibrary.buttonDelete" = "Fshije";
+
+/* Navigation bar button item */
+"mediaLibrary.buttonFilter" = "Filtroji";
 
 /* Media screen navigation bar button Select title */
 "mediaLibrary.buttonSelect" = "Përzgjidhni";
@@ -8371,6 +9174,9 @@ Example: Reply to Pamela Nguyen */
 "mediaLibrary.filterAudio" = "Audio";
 
 /* The name of the media filter */
+"mediaLibrary.filterDefault" = "Parazgjedhje (Krejt)";
+
+/* The name of the media filter */
 "mediaLibrary.filterDocuments" = "Dokumente";
 
 /* The name of the media filter */
@@ -8396,6 +9202,33 @@ Example: Reply to Pamela Nguyen */
 
 /* Button name in the more menu */
 "mediaLibrary.squareGrid" = "Rrjetë Katrore";
+
+/* Detail message for buying storage add-on */
+"mediaLibrary.storageDetails.buyStorage.detail" = "Hapni më tepër vend për foto, video dhe tjetër media me cilësi të lartë.";
+
+/* Message about buying storage add-on */
+"mediaLibrary.storageDetails.buyStorage.message" = "Blini shtesë depozitimi";
+
+/* Success message shown after upgrading plan */
+"mediaLibrary.storageDetails.purchase.plan.success" = "Plani juaj për sajtin u përmirësua!";
+
+/* Success message shown after purchasing storage add-on */
+"mediaLibrary.storageDetails.purchase.storage.success" = "Depozita për Mediatekën e sajtit tuaj është shtuar!";
+
+/* Title for the storage details screen */
+"mediaLibrary.storageDetails.title" = "Depozitim Mediateke";
+
+/* Detail message for upgrading plan */
+"mediaLibrary.storageDetails.upgradePlan.detail" = "Që të rritet hapësira e depozitimit, përmirësoni planin tuaj.";
+
+/* Message about upgrading plan */
+"mediaLibrary.storageDetails.upgradePlan.message" = "Përmirësoni Planin";
+
+/* Storage usage message showing used space and total space. %1$@ is used space, %2$@ is total space. */
+"mediaLibrary.storageDetails.usage" = "Të përdorur %1$@ nga %2$@ gjithsej";
+
+/* Message shown while calculating storage usage */
+"mediaLibrary.storageDetails.usage.calculating" = "Po llogariten…";
 
 /* Media screen navigation title */
 "mediaLibrary.title" = "Media";
@@ -8447,6 +9280,9 @@ Example: Reply to Pamela Nguyen */
 
 /* The name of the action in the context menu */
 "mediaPicker.takeVideo" = "Bëni Video";
+
+/* The menu item of viewing media library usage */
+"mediaPicker.viewUsage" = "Shihni Përdorim";
 
 /* Navigation title for media preview. Example: 1 of 3 */
 "mediaPreview.NofM" = "%1$@ nga %2$@";
@@ -8589,6 +9425,12 @@ Example: Reply to Pamela Nguyen */
 /* Title of the domain focus card on My Site */
 "mySite.domain.focus.cardView.title" = "Kërkoni Përkatësitë tuaja Google";
 
+/* Title for the menu item */
+"mySite.menu.subscribers" = "Pajtimtarë";
+
+/* Title for the menu item */
+"mySite.menu.users" = "Përdorues";
+
 /* Button title. Displays the account and setting screen. */
 "mySite.noSites.button.accountAndSettings" = "Llogari dhe rregullime";
 
@@ -8710,7 +9552,7 @@ Example: Reply to Pamela Nguyen */
 "notifications.share.messageWithPost" = "Shihni postimin tim “%@”:";
 
 /* Message to use along with the post URL when sharing a post */
-"notifications.share.messageWithoutPost" = "Shihni postimin tim";
+"notifications.share.messageWithoutPost" = "Shihni postimin tim:";
 
 /* Marks all notifications under the filter as read */
 "notificationsViewController.navigationBar.action.markAllAsRead" = "Vëru Krejt Shenjë Si të Lexuar";
@@ -8747,6 +9589,9 @@ Example: Reply to Pamela Nguyen */
 
 /* Menu option for filtering posts by me */
 "pagesList.pagesByMe" = "Faqe nga unë";
+
+/* Title for the parent page picker screen */
+"parentPagePicker.title" = "Faqe Mëmë";
 
 /* Navigation title displayed on the navigation bar */
 "parentPageSettings.title" = "Faqe Mëmë";
@@ -8856,6 +9701,9 @@ Example: Reply to Pamela Nguyen */
 /* Message shown while loading plugin details */
 "pluginDetails.loading" = "Po ngarkohen hollësi shtojce…";
 
+/* Placeholder message shown when a plugin has no description */
+"pluginDetails.noDescription" = "Kjo shtojcë s’ka dhënë ndonjë përshkrim.";
+
 /* Title of the changelog section in plugin details */
 "pluginDetails.section.changelog" = "Regjistër ndryshimesh";
 
@@ -8894,6 +9742,9 @@ Example: Reply to Pamela Nguyen */
 
 /* Button label to view plugin on WordPress.org */
 "pluginDetails.viewOnWordPressOrg.button" = "Shiheni në WordPress.org";
+
+/* Title for the post author selection screen */
+"postAuthorPicker.title" = "Autor";
 
 /* Button in an alert confirming discaring changes */
 "postEditor.closeConfirmationAlert.discardChanges" = "Hidhi Tej Ndryshimet";
@@ -8969,6 +9820,18 @@ Example: Reply to Pamela Nguyen */
 
 /* Saving draft to generate a preview (status message */
 "postEditor.savingDraftForPreview" = "Po ruhet skica…";
+
+/* Empty state description when no post formats are available */
+"postFormatPicker.emptyState.description" = "Për këtë sajt s’janë formësuar formate postimi.";
+
+/* Empty state title when no post formats are available */
+"postFormatPicker.emptyState.title" = "S’ka Formate të Gatshëm Postimi";
+
+/* Navigation bar title for the Post Format picker */
+"postFormatPicker.navigationTitle" = "Format Postimesh";
+
+/* Error message when post formats refresh fails */
+"postFormatPicker.refreshErrorMessage" = "S’u arrit të rifreskoheshin formate postimesh";
 
 /* Button title */
 "postFromAudio.beginRecording" = "Filloni Incizimin";
@@ -9114,8 +9977,84 @@ Example: Reply to Pamela Nguyen */
 /* A default value for an post without a title */
 "postSaveErrorMessage.postUntitled" = "Pa titull";
 
+/* Label for the author field in Post Settings */
+"postSettings.author.label" = "Autor";
+
+/* Label for the add category button field. Should be the same as WP core. */
+"postSettings.categories.addCategoryButton" = "Shtoni Kategori";
+
+/* Label for the categories field. Should be the same as WP core.
+   Label for the category field. Should be the same as WP core. */
+"postSettings.categories.label" = "Kategori";
+
+/* Button to confirm discarding changes */
+"postSettings.discardChanges.button" = "Hidhi Tej Ndryshimet";
+
+/* Message for the discard changes confirmation dialog */
+"postSettings.discardChanges.message" = "Keni ndryshime të paruajtura. Jeni i sigurt se doni të hidhen tej?";
+
+/* Title for the discard changes confirmation dialog */
+"postSettings.discardChanges.title" = "Të Hidhen Tej Ndryshimet?";
+
+/* Character count for excerpt. %1$d is the number of characters. */
+"postSettings.excerpt.characterCount" = "%1$d shenja";
+
+/* Button to generate an excerpt using AI */
+"postSettings.excerpt.generateButton" = "Prodhoje";
+
+/* Character count display. %d is replaced with the number of characters. */
+"postSettings.excerpt.generator.characterCount" = "%d shenja";
+
+/* Button to suggest (generate) more options */
+"postSettings.excerpt.generator.generateMore" = "Sugjero Më Tepër Mundësi";
+
+/* Label for the length picker section */
+"postSettings.excerpt.generator.length" = "Gjatësi";
+
+/* Accessibility label for the length adjustment slider */
+"postSettings.excerpt.generator.lengthSlider" = "Rrëshqitës Gjatësish";
+
+/* Button to make excerpts longer */
+"postSettings.excerpt.generator.longer" = "Më e gjatë";
+
+/* Label for excerpt option number. %d is replaced with the option number. */
+"postSettings.excerpt.generator.option" = "Mundësi %d";
+
+/* Title shown when ready to generate excerpts */
+"postSettings.excerpt.generator.ready" = "Gati Për Ta Prodhuar";
+
+/* Description shown when ready to generate excerpts */
+"postSettings.excerpt.generator.readyDescription" = "Prekeni që të krijohen mundësi copëzash me bazë IA-në";
+
+/* Button to make excerpts shorter */
+"postSettings.excerpt.generator.shorter" = "Më e shkurtër";
+
+/* Title for the style picker section */
+"postSettings.excerpt.generator.style" = "Stil Shkrimi";
+
+/* Label for the style picker section */
+"postSettings.excerpt.generator.styleLabel" = "Stil";
+
+/* Accessibility label for the style picker */
+"postSettings.excerpt.generator.stylePicker" = "Stil";
+
+/* Title for the excerpt generator popover */
+"postSettings.excerpt.generator.title" = "Prodho Copëz";
+
+/* Section header for Excerpt in Post Settings */
+"postSettings.excerpt.header" = "Copëz";
+
+/* Placeholder text for the excerpt field in Post Settings */
+"postSettings.excerpt.placeholder" = "Shkruani një përmbledhje të shkurtër të postimit tuaj, për ta shfaqur në tregues blogjesh, arkiva dhe përfundime kërkimi.";
+
+/* Word count for excerpt. %1$d is the number of words. */
+"postSettings.excerpt.wordCount" = "%1$d fjalë";
+
 /* Cancel upload button in Post Settings / Featured Image cell */
 "postSettings.featuredImage.cancelUpload" = "Anuloje Ngarkimin";
+
+/* Section header for Featured Image in Post Settings */
+"postSettings.featuredImage.header" = "Figurë e Zgjedhur";
 
 /* Replace image upload button in Post Settings / Featured Image cell */
 "postSettings.featuredImage.replaceImage" = "Zëvendësoje";
@@ -9128,6 +10067,93 @@ Example: Reply to Pamela Nguyen */
 
 /* Post Settings */
 "postSettings.featuredImage.uploading" = "Po ngarkohet…";
+
+/* Label for the last edited field in Post Settings */
+"postSettings.lastEdited.label" = "Përpunuar Së Fundi Më";
+
+/* Section header for Info in Post Settings */
+"postSettings.metadata.header" = "Info";
+
+/* Section header for More Options in Post Settings. Should use the same translation as core WP. */
+"postSettings.moreOptions.header" = "Më Tepër Mundësi";
+
+/* The title of the Page Settings screen. */
+"postSettings.navigationTitle.page" = "Rregullime Faqeje";
+
+/* The title of the Post Settings screen. */
+"postSettings.navigationTitle.post" = "Rregullime Postimi";
+
+/* Label for the Organization area (categories, keywords, ...) in post settings. */
+"postSettings.organization.header" = "Ent";
+
+/* Message when trying to save a deleted page */
+"postSettings.pageDeleted.message" = "Kjo faqe është fshirë dhe s’mund të ruhet më.";
+
+/* Title of alert when trying to save a deleted page */
+"postSettings.pageDeleted.title" = "Faqja u Fshi";
+
+/* Label for the parent page field */
+"postSettings.parentPage.label" = "Faqe Mëmë";
+
+/* Cell title for the Top Level option case */
+"postSettings.parentPage.topLevel" = "Shkalla e epërme";
+
+/* Label for the pending review toggle in Post Settings */
+"postSettings.pendingReview.label" = "Në Pritje të Shqyrtimit";
+
+/* Label for the permalink field in Post Settings */
+"postSettings.permalink.label" = "Permalidhje";
+
+/* Message when trying to save a deleted post */
+"postSettings.postDeleted.message" = "Ky postim është fshirë dhe s’mund të ruhet më.";
+
+/* Title of alert when trying to save a deleted post */
+"postSettings.postDeleted.title" = "Postimi u Fshi";
+
+/* Label for the post format field. Should be the same as WP core. */
+"postSettings.postFormat.label" = "Format Postimesh";
+
+/* Label for the post ID field in Post Settings */
+"postSettings.postID.label" = "ID";
+
+/* Label for the publish date field in Post Settings */
+"postSettings.publishDate.label" = "Datë";
+
+/* Placeholder value for a publishing date in the prepublishing sheet when the date is not selected */
+"postSettings.publishDateImmediately" = "Menjëherë";
+
+/* Section header for General settings in Post Settings */
+"postSettings.section.general" = "Të përgjithshme";
+
+/* Hint text for the slug field. Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso. */
+"postSettings.slug.hint" = "Identifikuesi është versioni në trajtë URL-je i titullit të postimit.";
+
+/* Label for the slug field. Should be the same as WP core. */
+"postSettings.slug.label" = "Identifikues";
+
+/* Placeholder for the slug field */
+"postSettings.slug.placeholder" = "Jepni identifikuesin";
+
+/* Label for the preview button in Post Settings */
+"postSettings.socialSharing.header" = "Ndarje Me të Tjerë Në Rrjete Shoqërorë";
+
+/* Label for the sticky post toggle. Sticky posts are displayed at the top of the blog. */
+"postSettings.stickyPost.label" = "Ngjitës";
+
+/* Label for the add tags button field. Should be the same as WP core. */
+"postSettings.tags.addTagsButton" = "Shtoni Etiketa";
+
+/* Label for the tags field. Should be the same as WP core. */
+"postSettings.tags.label" = "Etiketa";
+
+/* Label for the tag suggestions section. */
+"postSettings.tags.suggestions" = "Etiketa të Sugjeruara";
+
+/* Label for the visibility field in Post Settings */
+"postSettings.visibility.label" = "Dukshmëri";
+
+/* Navigation bar title of the Post Stats screen */
+"postStats.title" = "Statistika Postimi";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Anuloje";
@@ -9204,8 +10230,14 @@ Example: Reply to Pamela Nguyen */
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "Kategori";
 
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "Mbylle";
+/* Button to confirm discarding changes */
+"prepublishing.discardChanges.button" = "Hidhi Tej Ndryshimet";
+
+/* Message for the discard changes confirmation dialog */
+"prepublishing.discardChanges.message" = "Keni ndryshime të paruajtura te rregullimet e postimit. Jeni i sigurt se doni të hidhen tej ato?";
+
+/* Title for the discard changes confirmation dialog */
+"prepublishing.discardChanges.title" = "Të Hidhen Tej Ndryshimet?";
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.jetpackSocial" = "Jetpack Social";
@@ -9225,8 +10257,14 @@ Example: Reply to Pamela Nguyen */
 /* Placeholder value for a publishing date in the prepublishing sheet when the date is not selected */
 "prepublishing.publishDateImmediately" = "Menjëherë";
 
+/* The title of the top section that shows the site your are publishing to. Default is 'Ready to Publish?' */
+"prepublishing.publishingSectionTitle" = "Gati për Botim?";
+
 /* Label in the header in the pre-publishing sheet */
 "prepublishing.publishingTo" = "Botim te";
+
+/* Button to confirm discarding changes */
+"prepublishing.saveChanges.button" = "Ruaji Ndryshimet";
 
 /* Primary button label in the pre-publishing shee */
 "prepublishing.schedule" = "Vëreni në plan";
@@ -9279,8 +10317,7 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "Kujdes";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "Mesazh";
 
 /* The navigation title for the pre-publishing social accounts screen. */
@@ -9300,6 +10337,9 @@ Tapping on this row allows the user to edit the sharing message. */
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.visibility" = "Dukshmëri";
+
+/* An error message displayed when attempting to update their profile while the user's email address is not verified. */
+"profile.update.email.verification.required" = "Që të përditësoni profilin tuaj, lypset të verifikohet adresa juaj email së pari.";
 
 /* Caption displayed in promotional screens shown during the login flow. */
 "prologue.title.reader" = "Pajtohuni te sajtet tuaj të parapëlqyer dhe zbuloni blogje të rinj.";
@@ -9349,6 +10389,21 @@ Tapping on this row allows the user to edit the sharing message. */
 /* Title for the success view when the user has successfully logged in */
 "qrLoginVerifyAuthorization.completedInstructions.title" = "Jeni i futur!";
 
+/* No comment provided by engineer. */
+"reachability-utils.alert.cancel" = "OK";
+
+/* No comment provided by engineer. */
+"reachability-utils.alert.retry" = "Të riprovohet?";
+
+/* No comment provided by engineer. */
+"reachability-utils.alert.title" = "S’ka Lidhje";
+
+/* Message of error prompt shown when no internet connection is available */
+"reachability-utils.alert.utils" = "Lidhja internet duket se është jashtë linje.";
+
+/* Navigation title */
+"reader.article.summary" = "Përmbledhje";
+
 /* Message expliaining that the specified blog will no longer appear in the user's reader.  The '%@' characters are a placeholder for the title of the blog. */
 "reader.blocked.blog.message" = "Blogu %@ s’do të shfaqet më në lexuesin tuaj. Prekeni që të zhbëhet.";
 
@@ -9385,8 +10440,26 @@ Tapping on this row allows the user to edit the sharing message. */
 /* A shared button title for Reader */
 "reader.button.unsubscribe" = "Shpajtohuni";
 
+/* Button title. Follow the comments on a post. */
+"reader.comments.buttonFollow" = "Ndiqeni";
+
 /* Informational message, should be short. */
 "reader.comments.commentsClosed" = "Komentet Janë Mbyllur";
+
+/* Empty state view title */
+"reader.comments.emptyStateTitle" = "Bëhuni i pari që lë një koment.";
+
+/* Empty state view title */
+"reader.comments.errorLoadingComments" = "Pati një gabim të papritur teksa ngarkoheshin komente.";
+
+/* VoiceOver hint */
+"reader.comments.followingSettingAccessibilityIdentifier" = "Hapni rregullime njoftimi për postimin";
+
+/* Error message that informs reader comments from a private blog cannot be fetched. */
+"reader.comments.noPermissionToViewPrivateBlog" = "S’keni leje të shihni këtë blog privat.";
+
+/* Navigation title */
+"reader.comments.title" = "Komente";
 
 /* Accessibility hint to inform that the author section can be tapped to see posts from the site. */
 "reader.detail.header.authorInfo.a11y.hint" = "Shihni postime nga sajti";
@@ -9464,8 +10537,23 @@ but tapping on this button will remove their like from the post. */
 /* Screen header details */
 "reader.following.header.details" = "Ndiqni blogjet te të cilët jeni pajtuar.";
 
+/* Empty state view */
+"reader.following.lists.emptyTitle" = "Lista të Zbrazëta";
+
+/* Screen header details */
+"reader.home.header.details" = "Ndiqni blogjet te të cilët jeni pajtuar.";
+
+/* Used in multiple contexts, usually as a screen title */
+"reader.home.title" = "Kreu";
+
+/* Used in multiple contexts, usually as a screen title */
+"reader.library.title" = "Bibliotekë";
+
 /* Used in multiple contexts, usually as a screen title */
 "reader.likes.title" = "Pëlqime";
+
+/* Used in multiple contexts, usually as a screen title */
+"reader.lists.title" = "Lista";
 
 /* Reader logged-out screen details */
 "reader.loggedOut.details" = "Që të ndiqni blogjet tuaj të parapëlqyer, bëni hyrjen me një llogari WordPress.com";
@@ -9596,6 +10684,9 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Context menu action */
 "reader.postContextMenu.showBlog" = "Shkoni te Blogu";
+
+/* Context menu action */
+"reader.postContextMenu.summarize" = "Përmblidhe";
 
 /* Context menu action */
 "reader.postContextMenu.viewInBrowser" = "Shiheni në Shfletues";
@@ -9740,6 +10831,9 @@ Feel free to replace it with other bracket types that you think looks better for
 "reader.sidebar.section.favorites.title" = "Të parapëlqyer";
 
 /* Reader sidebar section title */
+"reader.sidebar.section.library.title" = "Bibliotekë";
+
+/* Reader sidebar section title */
 "reader.sidebar.section.lists.title" = "Lista";
 
 /* Reader sidebar section title */
@@ -9817,11 +10911,29 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Verb. Button title. The user is following a tag. */
 "reader.tags.following.button.title" = "Ndiqeni";
 
+/* Used in multiple contexts, usually as a screen title */
+"reader.tags.title" = "Etiketa";
+
 /* Accessibility label for unsubscribing from a tag */
 "reader.tags.unfollow.accessibility.label" = "Hiqe ndjekjen e %@";
 
 /* Field title */
 "reader.userProfile.site" = "Sajt";
+
+/* Reader Welcome screen login button */
+"reader.welcome.continueText" = "Vazhdoni me WordPress.com";
+
+/* Reader Welcome screen */
+"reader.welcome.subtitle" = "Bëhuni pjesë e bashkësisë më të madhe të blogimit";
+
+/* Reader app primary navigation tab bar */
+"readerApp.tabBar.discover" = "Zbuloni";
+
+/* Reader app primary navigation tab bar */
+"readerApp.tabBar.me" = "Unë";
+
+/* Reader app primary navigation tab bar */
+"readerApp.tabBar.notifications" = "Njoftime";
 
 /* Spoken accessibility label */
 "readerDetail.backButton.accessibilityLabel" = "Mbrapsht";
@@ -9953,6 +11065,9 @@ Feel free to replace it with other bracket types that you think looks better for
 "shared.button.cancel" = "Anuloje";
 
 /* A shared button title used in different contexts */
+"shared.button.clear" = "Spastroje";
+
+/* A shared button title used in different contexts */
 "shared.button.close" = "Mbylle";
 
 /* A shared button title used in different contexts */
@@ -9985,6 +11100,9 @@ Feel free to replace it with other bracket types that you think looks better for
 /* A shared button title used in different contexts */
 "shared.button.save" = "Ruaje";
 
+/* A shared button title used in different contexts (send email, send message, sent invites) */
+"shared.button.send" = "Dërgoje";
+
 /* A shared button title used in different contexts */
 "shared.button.share" = "Ndajeni me të tjerët";
 
@@ -9995,10 +11113,31 @@ Feel free to replace it with other bracket types that you think looks better for
 "shared.button.view" = "Shiheni";
 
 /* A generic error title indicating that a screen failed to fetch the latest data */
-"shared.error.failiedToReloadData" = "S’u arrit të përditësohen të dhëna.";
+"shared.error.failiedToReloadData" = "S’u arrit të përditësohen të dhëna";
 
 /* A generic error message */
 "shared.error.geneirc" = "Diç shkoi ters";
+
+/* A generic error message */
+"shared.error.generic" = "Diç shkoi ters";
+
+/* As in default value */
+"shared.misc.default" = "Parazgjedhje";
+
+/* Default value with a value. Example usage when ordering items: Default (Date Edited). */
+"shared.misc.defaultWithValue" = "Parazgjedhje (%@)";
+
+/* A default filter value */
+"shared.misc.showAll" = "Shfaqi Krejt";
+
+/* Sort ordering */
+"shared.misc.sortAascending" = "Rritës";
+
+/* A button title used in different contexts */
+"shared.misc.sortBy" = "Renditi Sipas";
+
+/* Sort ordering */
+"shared.misc.sortDescending" = "Zbritës";
 
 /* Sidebar button title on iPad */
 "sidebar.addSite" = "Shtoni Sajt";
@@ -10099,8 +11238,14 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Message shown when there are no inactive plugins on the site */
 "site.plugins.empty.inactive" = "S’ka shtojca joaktive";
 
+/* The plugin fillter option for displaying active plugins */
+"site.plugins.filter.option.active" = "Aktive";
+
 /* The plugin fillter option for displaying all plugins */
 "site.plugins.filter.option.all" = "Krejt";
+
+/* The plugin fillter option for displaying inactive plugins */
+"site.plugins.filter.option.inactive" = "Jo aktive";
 
 /* Title of the plugin filter picker */
 "site.plugins.filter.title" = "Filtrojini";
@@ -10418,6 +11563,15 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Insights 'Total Subscribers' header */
 "stats.insights.totalSubscribers.title" = "Pajtimtarë Gjithsej";
 
+/* Menu item to disable the new stats */
+"stats.menu.disableNewStats" = "Çaktivizo Statistikat e Reja";
+
+/* Menu item to send feedback about new stats experience */
+"stats.menu.sendFeedback" = "Dërgoji Përshtypjet";
+
+/* Menu item to enable new stats experience */
+"stats.menu.tryNewStats" = "Provoni Statistikat e Reja";
+
 /* Text for the Stats Traffic Overview stat difference label. Shows the change from the previous period, including the percentage value. E.g.: +12.3K (5%). %1$@ is the placeholder for the change sign ('-', '+', or none). %2$@ is the placeholder for the change numerical value. %3$@ is the placeholder for the change percentage value. */
 "stats.overview.differenceLabelWithNumber" = "%1$@%2$@ (%3$@)";
 
@@ -10456,6 +11610,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* The label for the option to show Stats Traffic chart for Days. */
 "stats.traffic.days" = "Ditë";
+
+/* The label for the option to show Stats Traffic chart for Days. */
+"stats.traffic.hours" = "Orë";
 
 /* The label for the option to show Stats Traffic chart for Months. */
 "stats.traffic.months" = "Muaj";
@@ -10508,11 +11665,149 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Submit feedback screen submit fsuccess notice title */
 "submitFeedback.successNoticeTitle" = "Përshtypjet u dërguan";
 
+/* Button title */
+"subscriberDetails.buttonDeleteSubscriber" = "Fshi Pajtimtar";
+
+/* Remove subscriber confirmation dialog message; subscriber name as input. */
+"subscriberDetails.deleteSubscriberConfirmationDialog.message" = "Jeni i sigurt se doni të hiqet %@? S’do të marrë më njoftime të reja nga sajti juaj.";
+
+/* Remove subscriber confirmation dialog title */
+"subscriberDetails.deleteSubscriberConfirmationDialog.title" = "Fshije pajtimtarin";
+
+/* Form field name */
+"subscriberDetails.fieldName.country" = "Vend";
+
+/* Form field name */
+"subscriberDetails.fieldName.email" = "Email";
+
+/* Form field name */
+"subscriberDetails.fieldName.paidUpgrade" = "Përmirësim Me Pagesë";
+
+/* Form field name */
+"subscriberDetails.fieldName.plan" = "Plan";
+
+/* Form field name */
+"subscriberDetails.fieldName.planEndDate" = "Datë Përfundimi";
+
+/* Form field name */
+"subscriberDetails.fieldName.planStartDate" = "Datë Fillimi";
+
+/* Form field name */
+"subscriberDetails.fieldName.planStatus" = "Gjendje Plani";
+
+/* Form field name */
+"subscriberDetails.fieldName.renewalInterval" = "Interval Rinovimi";
+
+/* Form field name */
+"subscriberDetails.fieldName.renewalPrice" = "Çmim Rinovimi";
+
+/* Form field name */
+"subscriberDetails.fieldName.site" = "Sajt";
+
+/* Form field name (has to be short!) */
+"subscriberDetails.fieldName.statsClickedEmails" = "Të klikuara";
+
+/* Form field name (has to be short!) */
+"subscriberDetails.fieldName.statsEmailCount" = "Email-e";
+
+/* Form field name (has to be short!) */
+"subscriberDetails.fieldName.statsOpenedEmails" = "Të hapura";
+
+/* Form field name */
+"subscriberDetails.fieldName.subscriptionDate" = "Datë Pajtimi";
+
+/* Name of a free plan */
+"subscriberDetails.plan.free" = "Falas";
+
+/* Newsletter subscription plan type */
+"subscriberDetails.plan.gift" = "Dhuratë";
+
+/* Card section title */
+"subscriberDetails.section.newletterSubscription" = "Pajtim te Buletini";
+
+/* Card section title */
+"subscriberDetails.section.subscriberDetails" = "Hollësi Pajtimtari";
+
+/* Button title */
+"subscribers.buttonDeleteSubscriber" = "Fshije Pajtimtarin";
+
+/* Remove subscriber confirmation dialog message; subscriber name as input. */
+"subscribers.deleteSubscriberConfirmationDialog.message" = "Jeni i sigurt se doni të hiqet %@? S’do të marrë më njoftime të reja nga sajti juaj.";
+
+/* Remove subscriber confirmation dialog title */
+"subscribers.deleteSubscriberConfirmationDialog.title" = "Fshije pajtimtarin";
+
+/* Empty state view title */
+"subscribers.empty" = "S’ka Pajtimtarë";
+
+/* Empty state view title */
+"subscribers.filter.emailSubscription" = "Pajtim Përmes Email-i";
+
+/* Empty state view title */
+"subscribers.filter.paymentType" = "Pagesë";
+
+/* Email subscription type filter */
+"subscribers.filterByEmailSubscriptionType.blocked" = "S’po Dërgohet";
+
+/* Email subscription type filter */
+"subscribers.filterByEmailSubscriptionType.email" = "I pajtuar";
+
+/* Email subscription type filter */
+"subscribers.filterByEmailSubscriptionType.reader" = "Jo i Pajtuar";
+
+/* Email subscription type filter */
+"subscribers.filterByEmailSubscriptionType.unconfirmed" = "Jo i Ripohuar";
+
+/* Subscription type filter */
+"subscribers.filterBySubscriptionType.free" = "Falas";
+
+/* Subscription type filter */
+"subscribers.filterBySubscriptionType.paid" = "Me Pagesë";
+
+/* Part of the label in the menu showing how many subscribers are displayed (has to have two arguments!) */
+"subscribers.menu.nOutOf" = "%1$@ nga %2$@ gjithsej";
+
+/* Part of the label in the menu showing how many subscribers are displayed */
+"subscribers.menu.subscribers" = "Pajtimtarë:";
+
+/* Subscribers sort by field */
+"subscribers.sortField.dateSubscribed" = "Datë Pajtimi";
+
+/* Subscribers sort by field */
+"subscribers.sortField.email" = "Email";
+
+/* Subscribers sort by field */
+"subscribers.sortField.name" = "Emër";
+
+/* Subscribers sort by field */
+"subscribers.sortField.plan" = "Plan";
+
+/* Subscribers sort by field */
+"subscribers.sortField.subscriptionStatus" = "Pajtim Përmes Email-i";
+
+/* Screen title */
+"subscribers.title" = "Pajtimtarë";
+
 /* Section title for prominent suggestions */
 "suggestions.section.prominent" = "Në këtë bisedë";
 
 /* Section title for regular suggestions */
 "suggestions.section.regular" = "Anëtarë sajti";
+
+/* Label for the current activity log file in the list. */
+"support.activityLogs.currentLogTilte" = "I tanishmi";
+
+/* Message shown in the alert when attempting to clear old activity logs. */
+"support.activityLogs.deleteLogsAlert.message" = "Jeni i sigurt se doni të fshihen krejt regjistrat e veprimtarisë?";
+
+/* Title shown in the alert when attempting to clear old activity logs. */
+"support.activityLogs.deleteLogsAlert.title" = "Fshi Regjistra";
+
+/* Title shown in the navigation bar of the Activity Logs screen. */
+"support.activityLogs.navigationTitle" = "Regjistra Veprimtarie";
+
+/* Footer text explaining the log retention policy in the Activity Logs screen. */
+"support.activityLogs.sectionFooter" = "Ruhen regjistrime deri për shtatë ditë.";
 
 /* Dismiss the current view */
 "support.button.close.title" = "U bë";
@@ -10652,11 +11947,51 @@ Feel free to replace it with other bracket types that you think looks better for
 /* View title for Help & Support page. */
 "support.title" = "Ndihmë";
 
+/* Subject of new Zendesk ticket. */
+"support.zendesk.readerAppTicketSubject" = "Asistencë mbi Lexues për iOS";
+
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
+"tags.empty.description" = "Etiketa ndihmojnë të sistemohet lënda juaj dhe të bëhet më e kollajtë për lexuesit të gjejnë postimet përkatëse.";
+
+/* Title for empty state when there are no tags */
+"tags.empty.title" = "S’ka Etiketa";
+
+/* Error message when tag data is invalid */
+"tags.error.invalid_tag" = "Hollësitë për etiketën janë të pavlefshme. Ju lutemi, riprovoni.";
+
+/* Error message when the tags service cannot connect to the remote site */
+"tags.error.no_remote_service" = "S’arrihet të lidhet te sajti juaj. Ju lutemi, kontrolloni lidhjen tuaj dhe riprovoni.";
+
+/* Button to remove a selected tag. %1$@ is the tag name. */
+"tags.remove.button" = "Hiqe %1$@";
+
+/* Placeholder text for the tag search field */
+"tags.search.placeholder" = "Kërkoni te etiketa";
+
+/* Title for the tags screen */
+"tags.title" = "Etiketa";
+
 /* Title for placeholder in Tenor picker */
 "tenor.welcomeMessage" = "Kërkoni për të gjetur GIF-e që t’i shtoni te Mediateka juaj!";
 
 /* Header of delete screen section listing things that will be deleted. */
 "these items will be deleted:" = "këto objekte do të fshihen:";
+
+/* Section title for suggested timezones */
+"timeZoneSelector.suggested" = "E këshilluar";
+
+/* Title for the time zone selector */
+"timeZoneSelector.title" = "Zonë Kohore";
+
+/* Action button title to enable new stats from tip */
+"tips.newStats.action" = "Aktivizojeni Tani";
+
+/* Tip for new stats feature */
+"tips.newStats.message" = "Shijoni statistika të reja të hajthme dhe të fuqishme. Rikthehuni te të vjetrat kur të doni.";
+
+/* Tip for new stats feature */
+"tips.newStats.title" = "Provoni Statistikat e Reja";
 
 /* Tip for sidebar */
 "tips.sidebar.message" = "Fërkojeni për djathtas që të përdorni sajtet tuaj, Lexuesin, njoftime dhe profilin";
@@ -10669,6 +12004,12 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Tip for site picker */
 "tips.sitePickerTip.title" = "Sajtet Tuaj";
+
+/* Message explaining how to use the date range control */
+"tips.statsDateRange.message" = "Përdorni kalendarin për të përzgjedhur ditë, muaj, vite, ose zgjidhni intervale vetjakë datash për të parë statistikat tuaja.";
+
+/* Title for stats date range control tip */
+"tips.statsDateRange.title" = "Lëvizni Nëpër Kohë";
 
 /* The part of the nudge title that should be emphasized, this content needs to match a string in 'If you want to try get more...' */
 "top tips" = "ndihmëza kryesuese";
@@ -10687,9 +12028,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "të palexuar";
-
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "Pajtimtar Sajti";
 
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "Përdorues Sajti";
@@ -10726,7 +12064,7 @@ Feel free to replace it with other bracket types that you think looks better for
 "userDetails.alert.deleteUserConfirmationTitle" = "Ripohim Fshirjeje";
 
 /* The message in the alert that appears when deleting a user */
-"userDetails.alert.deleteUserErrorAlertMessage" = "Pati një gabim në fshirjen e përdoruesit";
+"userDetails.alert.deleteUserErrorAlertMessage" = "Pati një gabim në fshirjen e përdoruesit.";
 
 /* The title of the alert that appears when deleting a user */
 "userDetails.alert.deleteUserErrorAlertTitle" = "Gabim";
@@ -10776,8 +12114,8 @@ Feel free to replace it with other bracket types that you think looks better for
 /* The heading at the top of the user list */
 "userlist.title" = "Përdorues";
 
-/* Site Subscribers */
-"users.list.title.subscribers" = "Pajtimtarë";
+/* Screen title */
+"users.title" = "Përdorues";
 
 /* Verb. Dismiss the web view screen. */
 "webKit.button.dismiss" = "Hidhe tej";
@@ -10871,6 +12209,21 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Error message when user signs in with an unexpected email address. The first argument is the expected email address */
 "wpComLogin.error.mismatchedEmail" = "Ju lutemi, bëni hyrjen me adresën email %@";
+
+/* Message shown when user denies WordPress.com login, offering option to try with different account */
+"wpComLogin.loginDenied.message" = "Mund të bëni hyrjen me një llogari tjetër, nëse ju duhet një e ndryshme. Prekni mbi “%@” që t’ia fillohet.";
+
+/* Title of alert shown when user cancels WordPress.com login */
+"wpComLogin.loginDenied.title" = "Hyrja u Anulua";
+
+/* Button title for signing in with a different WordPress.com account */
+"wpComLogin.loginDenied.useDifferentAccount" = "Përdorni Një Tjetër Llogari";
+
+/* Button title to log out the current WordPress.com account */
+"wpcom.token.alert.button.logout" = "Dilni";
+
+/* Button title to Sign In to WordPress.com */
+"wpcom.token.alert.button.signin" = "Hyni";
 
 /* Message title to be displayed when the user needs to re-authenticate their WordPress.com account. */
 "wpcom.token.fix.signin" = "Hyni në WordPress.com";

--- a/WordPress/Resources/sv.lproj/Localizable.strings
+++ b/WordPress/Resources/sv.lproj/Localizable.strings
@@ -1,6 +1,6 @@
-/* Translation-Revision-Date: 2025-10-07 15:54:10+0000 */
+/* Translation-Revision-Date: 2025-11-25 11:54:10+0000 */
 /* Plural-Forms: nplurals=2; plural=n != 1; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: sv_SE */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -581,8 +581,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "Nästan klart! Skriv in verifieringskoden från din autentiserings-app.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Alt-text";
 
 /* No comment provided by engineer. */
@@ -725,9 +724,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "Är du säker på att du vill koppla bort Jetpack från webbplatsen?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "Är du säker på att du vill ta bort detta objekt permanent?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "Är du säker på att du vill ta bort %1$@ från %2$@?";
@@ -1082,7 +1078,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "Avbryt";
@@ -1110,8 +1105,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Kan du inte bestämma dig? Du kan byta tema när som helst.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Bildtext";
 
 /* Alert title. */
@@ -1777,8 +1771,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "Standard";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Standardkategori";
 
 /* Label for selecting the default post format
@@ -1787,9 +1780,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Standard för nya inlägg";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Kasta i papperskorgen";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Radera meny";
@@ -1808,14 +1798,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "Ta bort meny";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Raderat!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Tar bort webbplats …";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Tar bort …";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "Neka";
@@ -1823,8 +1807,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "Beskriv syftet med bilden. Lämna tomt om det är dekorativt.";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Beskrivning";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1842,9 +1825,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "Vill du inte registrera ett nytt konto? Gå tillbaka för att mata in e-postadressen igen.";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Storlekar";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "Inaktivera";
@@ -2121,7 +2101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "Om du redigerar den här GIF-bilden tas animeringen bort.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Redigerare";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2463,11 +2443,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "Inställningar för filblock";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "Filnamn";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Filtyp";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "Filtypen stöds inte som en mediafil.";
@@ -2781,6 +2758,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post content used in the login prologue screens. */
 "I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next" = "Jag är så inspirerad av fotografen Cameron Karstens arbete. Jag kommer att prova dessa tekniker nästa gång";
 
+/* Text on the support form to refer to what area the user has problem with. */
+"I need help with" = "Jag behöver hjälp med";
+
 /* Describes the IP address section in the comment detail screen. */
 "IP address" = "IP-adress";
 
@@ -2826,9 +2806,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "Bildtext";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Bildbeskrivning";
-
 /* Hint for image link on image settings. */
 "Image Link" = "Bildlänk";
 
@@ -2840,9 +2817,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "Bildfilen hittades inte.";
-
-/* Hint for image title on image settings. */
-"Image title" = "Bildrubrik";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "Med några ord, berätta vad denna webbplats handlar om.";
@@ -3205,6 +3179,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the button that will dismiss this view. */
 "Let me know when finished!" = "Berätta för mig när det är klart!";
 
+/* Message info on the support screen. */
+"Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon." = "Meddela oss din webbplatsadress (URL) och berätta så mycket du kan om problemet, så kommer vi att kontakta dig snart.";
+
+/* Title to let the user know what do we want on the support screen. */
+"Let’s get this sorted" = "Låt oss ordna detta";
+
 /* Lifestyle site intent topic */
 "Lifestyle" = "Livsstil";
 
@@ -3405,6 +3385,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Huvudnavigering";
+
+/* Explanation for the option to enable theme styles */
+"Make the block editor look like your theme." = "Gör blockredigeraren att se ut som ditt tema.";
 
 /* No comment provided by engineer. */
 "Make your content stand out by adding images, gifs, videos, and embedded media to your pages." = "Förstärk ditt innehåll genom att lägga till bilder, gif-illustrationer, videoklipp och inbäddade media i ditt sidinnehåll.";
@@ -3747,9 +3730,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "Inga konton hittades";
-
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Ingen kategori";
 
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Ingen anslutning";
@@ -4191,9 +4171,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "Paginering";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Överordnad kategori";
-
 /* Parenting site intent topic */
 "Parenting" = "Föräldraskap";
 
@@ -4411,9 +4388,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Skicka";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Inläggskategorier";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "Inläggsinställningar";
@@ -4722,9 +4696,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "Rensar bort metadata om plats från foton innan de laddas upp till din webbplats.";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "Borttagning av följare gör att de slutar ta emot uppdateringar från din webbplats. Om de vill, kan de fortfarande besöka din webbplats och följa den igen.";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "Ersätt aktuellt block";
@@ -5561,6 +5532,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "Slogan";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Etiketter";
 
@@ -5657,6 +5629,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint, informing user the button can be used to visit the Gravatar website. */
 "Tap to visit the Gravatar website in an external browser" = "Tryck för att besöka webbplatsen för Gravatar i en extern webbläsare";
+
+/* Label for viewing the custom taxonomies */
+"Taxonomies" = "Taxonomier";
 
 /* Technology site intent topic */
 "Technology" = "Teknologi";
@@ -5946,9 +5921,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "Denna inloggningskod gäller inte längre. Tryck på knappen ”skanna igen” för att skanna på nytt.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "Detta medieobjekt har raderats.";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "Detta användarkonto kan inte avslutas eftersom det fortfarande finns någon oavslutad chargeback.";
 
@@ -6017,7 +5989,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Rubrik";
@@ -6111,8 +6082,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "Omvandla block …";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Släng";
 
@@ -6209,9 +6179,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "Det gick inte att skapa nya inbjudningslänkar.";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "Kan inte radera medieobjekt.";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "Det gick inte att inaktivera inbjudningslänken.";
 
@@ -6242,9 +6209,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "Det går inte att ladda detta inlägg just nu.";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "Det går inte att ladda in videoklippet.";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Det går inte att spela video";
 
@@ -6253,9 +6217,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Kan inte återställa din webbplats";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "Kan inte spara medieobjket.";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "Kan inte dela länken";
@@ -6412,9 +6373,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Uppladdning misslyckades";
 
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Uppladdad";
-
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "Har laddat upp utkast för 1 inlägg, %ld filer";
 
@@ -6456,6 +6414,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The button title text for logging in with WP.com password instead of magic link. */
 "Use password to sign in" = "Använd lösenord för att logga in";
+
+/* Option to enable theme styles in the block editor */
+"Use theme styles" = "Använd temastilar";
 
 /* A placeholder for the twitter username
    Accessibility label for the username text field in the self-hosted login page.
@@ -6906,7 +6867,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "Världskarta med antal visningar per land.";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "Vill du fortfarande ta bort den här personen?";
 
 /* Button title. Opens the editor to write a new post.
@@ -7377,14 +7338,19 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Description for the prompt to upgrade to Application Passwords. The first argument is the name of the feature that requires Application Passwords. */
 "applicationPasswordRequired.description" = "Applikationslösenord är ett säkrare sätt att ansluta till din webbplats som drivs på egen server och möjliggör stöd för funktioner som %@.";
 
+/* Feature name for managing application passwords in the app */
+"applicationPasswordRequired.feature.applicationPasswords" = "Applikationslösenordshantering";
+
 /* Feature name for the block editor in application password required prompt */
 "applicationPasswordRequired.feature.blockEditor" = "Blockredigerare";
+
+/* Feature name for managing terms and taxonomies in the app */
+"applicationPasswordRequired.feature.customTaxonomies" = "Taxonomihantering";
 
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "Hantering av tillägg";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "Användarhantering";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -7613,6 +7579,285 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 
 /* Post Editor / Button in the 'More' menu */
 "classicEditor.moreMenu.saveDraft" = "Spara utkast";
+
+/* Button to add more screenshots */
+"com.jetpack.support.addMoreScreenshots" = "Lägg till fler skärmdumpar";
+
+/* Button to add screenshots */
+"com.jetpack.support.addScreenshots" = "Lägg till skärmdumpar";
+
+/* Header for application logs section */
+"com.jetpack.support.applicationLogs" = "Applikationsloggar";
+
+/* Description explaining why including logs is helpful */
+"com.jetpack.support.applicationLogsDescription" = "Att inkludera loggar kan hjälpa vårt team att undersöka problem. Loggar kan innehålla den senaste appaktiviteten.";
+
+/* Navigation title for application logs screen */
+"com.jetpack.support.applicationLogsTitle" = "Applikationsloggar";
+
+/* Format string for attachment identifier */
+"com.jetpack.support.attachment" = "Bilaga %@";
+
+/* Format string for attachment size limit. %1$@ is current size, %2$@ is maximum size */
+"com.jetpack.support.attachmentLimit" = "Gräns för bilagor: %1$@ \/ %2$@";
+
+/* Bot greeting message. %1$@ is the user's name */
+"com.jetpack.support.botGreeting" = "Hej %1$@!";
+
+/* Bot introduction message explaining its purpose */
+"com.jetpack.support.botIntroduction" = "Jag är din personliga AI-assistent. Jag kan hjälpa till med frågor om din webbplats eller ditt konto.";
+
+/* Format string for cache file count and size. %1$d is the number of files, %2$@ is the formatted size. The system will pluralize 'files' based on the number – please specify it as the largest plural value */
+"com.jetpack.support.cacheFiles" = "%1$d cachelagrade filer (%2$@)";
+
+/* Message shown when cache has no files */
+"com.jetpack.support.cacheIsEmpty" = "Cachelagringen är tom";
+
+/* Button to cancel current action */
+"com.jetpack.support.cancel" = "Avbryt";
+
+/* Warning message that deleted logs cannot be recovered */
+"com.jetpack.support.cannotRecoverLogs" = "Du kommer inte att kunna få tillbaka dem.";
+
+/* Button to clear all activity logs */
+"com.jetpack.support.clearAllActivityLogs" = "Rensa alla aktivitetsloggar";
+
+/* Button to clear disk cache */
+"com.jetpack.support.clearDiskCache" = "Rensa diskcache";
+
+/* Description explaining the purpose of clearing disk cache */
+"com.jetpack.support.clearDiskCacheDescription" = "Ta bort tillfälliga filer för att frigöra utrymme eller lösa problem.";
+
+/* Progress text while clearing cache */
+"com.jetpack.support.clearing" = "Rensar…";
+
+/* Message shown when cache clearing is complete */
+"com.jetpack.support.complete" = "Slutförd";
+
+/* Confirmation message when canceling a draft */
+"com.jetpack.support.confirmCancelMessage" = "Är du säker på att du vill avbryta detta meddelande? Du kommer att förlora alla data du har angett";
+
+/* Title for alert confirming cancellation */
+"com.jetpack.support.confirmCancellation" = "Bekräfta avslut";
+
+/* Confirmation dialog title when deleting all logs */
+"com.jetpack.support.confirmDeleteAllLogs" = "Är du säker på att du vill ta bort alla loggar?";
+
+/* Section title for contact information */
+"com.jetpack.support.contactInformation" = "Kontaktinformation";
+
+/* Button to continue editing a message */
+"com.jetpack.support.continueWriting" = "Fortsätt skriva";
+
+/* Message shown at end of closed support conversation */
+"com.jetpack.support.conversationEnded" = "Slut på konversation. Inga ytterligare svar är möjliga.";
+
+/* Navigation title for bot conversations list */
+"com.jetpack.support.conversations" = "Konversationer";
+
+/* Button to delete all log files */
+"com.jetpack.support.deleteAllLogs" = "Ta bort alla loggar";
+
+/* Description text for diagnostics screen */
+"com.jetpack.support.diagnosticsDescription" = "Kör vanliga underhålls- och felsökningsåtgärder.";
+
+/* Navigation title for diagnostics screen */
+"com.jetpack.support.diagnosticsTitle" = "Diagnostik";
+
+/* Button to discard changes in a draft message */
+"com.jetpack.support.discardChanges" = "Ignorera ändringarna";
+
+/* Notice explaining where support will send email responses */
+"com.jetpack.support.emailNotice" = "Vi skickar ett e-postmeddelande till den här adressen.";
+
+/* Error title when logs fail to load */
+"com.jetpack.support.errorLoadingLogs" = "Fel vid inläsning av loggar";
+
+/* Error message when support conversations fail to load */
+"com.jetpack.support.errorLoadingSupportConversations" = "Fel vid inläsning av supportkonversationer";
+
+/* Title for error alerts */
+"com.jetpack.support.errorTitle" = "Fel";
+
+/* Option to export log as a file */
+"com.jetpack.support.exportAsFile" = "Exportera som fil";
+
+/* Button to dismiss alerts. */
+"com.jetpack.support.gotIt" = "Jag förstår";
+
+/* Text on the support form to refer to what area the user has problem with. */
+"com.jetpack.support.iNeedHelp" = "Jag behöver hjälp med";
+
+/* Toggle label to include application logs in the support request */
+"com.jetpack.support.includeApplicationLogs" = "Inkludera applikationsloggar";
+
+/* Section title for issue details */
+"com.jetpack.support.issueDetails" = "Probleminformation";
+
+/* Format string for when conversation was last updated */
+"com.jetpack.support.lastUpdated" = "Senaste uppdatering %@";
+
+/* Progress message while loading conversation messages */
+"com.jetpack.support.loadingBotConversationMessages" = "Läser in meddelanden";
+
+/* Progress message while loading bot conversations */
+"com.jetpack.support.loadingBotConversations" = "Läser in robotkonversationer";
+
+/* Progress text while loading support conversations */
+"com.jetpack.support.loadingConversations" = "Laddar in konversationer";
+
+/* Progress message while loading disk usage information */
+"com.jetpack.support.loadingDiskUsage" = "Läser in diskanvändning";
+
+/* Progress message while loading an image attachment */
+"com.jetpack.support.loadingImage" = "Laddar in bild";
+
+/* Progress message shown in overlay while refreshing content */
+"com.jetpack.support.loadingLatestContent" = "Läser in senaste innehåll";
+
+/* Progress message while loading application log content */
+"com.jetpack.support.loadingLogContent" = "Läser in logginnehåll...";
+
+/* Progress message while loading log files */
+"com.jetpack.support.loadingLogs" = "Laddar in loggar …";
+
+/* Progress text while loading conversation messages */
+"com.jetpack.support.loadingMessages" = "Laddar in meddelanden";
+
+/* Progress message while loading a video attachment */
+"com.jetpack.support.loadingVideo" = "Laddar in videoklipp";
+
+/* Section header for log files sorted by date */
+"com.jetpack.support.logFilesByDate" = "Loggfiler efter skapandedatum";
+
+/* Text indicating which log files will be included in the support request */
+"com.jetpack.support.logFilesToUpload" = "Följande loggfiler kommer att laddas upp:";
+
+/* Footer text explaining log retention policy */
+"com.jetpack.support.logRetentionNotice" = "Upp till sju dagar med loggar sparas.";
+
+/* Section header for message text input */
+"com.jetpack.support.message" = "Meddelande";
+
+/* Success message when reply is sent successfully */
+"com.jetpack.support.messageSent" = "Meddelande skickat";
+
+/* Format string for number of messages in conversation */
+"com.jetpack.support.messagesCount" = "%d meddelanden";
+
+/* The title of a new bot chat in the support area of the app */
+"com.jetpack.support.new-bot-chat" = "Ny robotchatt";
+
+/* Option to create a new support ticket */
+"com.jetpack.support.newSupportTicket" = "Nytt supportärende";
+
+/* Label shown when there are no bot conversations */
+"com.jetpack.support.noConversations" = "Inga konversationer";
+
+/* Description shown when no log files are available */
+"com.jetpack.support.noLogsAvailable" = "Det finns inga aktivitetsloggar tillgängliga";
+
+/* Label shown when no log files are available */
+"com.jetpack.support.noLogsFound" = "Inga loggar hittades";
+
+/* Button to open a support ticket */
+"com.jetpack.support.openSupportTicket" = "Öppna ett supportärende";
+
+/* Text indicating a field is optional */
+"com.jetpack.support.optional" = "(Valfritt)";
+
+/* Navigation title for replying to a support conversation */
+"com.jetpack.support.reply" = "Svara";
+
+/* Description for saving log as a file */
+"com.jetpack.support.saveAsFile" = "Spara som en fil för att dela eller lagra";
+
+/* Label for screenshots section */
+"com.jetpack.support.screenshots" = "Skärmdumpar";
+
+/* Description for screenshots section */
+"com.jetpack.support.screenshotsDescription" = "Att lägga till skärmbilder kan hjälpa oss att förstå och lösa ditt problem snabbare.";
+
+/* Button to send a message or reply */
+"com.jetpack.support.send" = "Skicka";
+
+/* Description for sending logs to support */
+"com.jetpack.support.sendLogsToSupport" = "Skicka loggar direkt till supportteamet";
+
+/* Progress text while sending a message */
+"com.jetpack.support.sending" = "Skickar";
+
+/* Progress message shown while sending a message */
+"com.jetpack.support.sendingMessage" = "Skickar meddelande";
+
+/* Button to share content */
+"com.jetpack.support.share" = "Dela";
+
+/* Navigation title for sharing activity log */
+"com.jetpack.support.shareActivityLog" = "Dela aktivitetslogg";
+
+/* Message shown when sharing log with support */
+"com.jetpack.support.sharingWithSupport" = "Delar med support!";
+
+/* Site Address title on the support form */
+"com.jetpack.support.siteAddress" = "Webbplatsadress";
+
+/* Description encouraging user to start a new conversation */
+"com.jetpack.support.startNewConversation" = "Starta en ny konversation med hjälp av knappen ovan";
+
+/* Subject title on the support form */
+"com.jetpack.support.subject" = "Ämne";
+
+/* Placeholder for subject field */
+"com.jetpack.support.subjectPlaceholder" = "Kort sammanfattning av ditt problem";
+
+/* Button title to submit a support request. */
+"com.jetpack.support.submitRequest" = "Skicka supportförfrågan";
+
+/* Navigation title for the support conversations list */
+"com.jetpack.support.supportConversations" = "Supportkonversationer";
+
+/* Title for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSent" = "Förfrågan skickad!";
+
+/* Message for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSentMessage" = "Din supportförfrågan har skickats. Vi kommer att svara via e-post så snart vi kan.";
+
+/* Progress message shown while bot is thinking */
+"com.jetpack.support.thinking" = "Tänker …";
+
+/* Title of the view for contacting support. */
+"com.jetpack.support.title" = "Kontakta support";
+
+/* Button to retry a failed operation */
+"com.jetpack.support.tryAgain" = "Försök igen";
+
+/* Error title when log deletion fails */
+"com.jetpack.support.unableToDeleteLogs" = "Kan inte ta bort loggar";
+
+/* Error message when conversation cannot be displayed */
+"com.jetpack.support.unableToDisplayConversation" = "Det gick inte att visa konversationen";
+
+/* Error title when video cannot be loaded or played */
+"com.jetpack.support.unableToDisplayVideo" = "Det gick inte att spela upp videoklippet";
+
+/* Error message when application logs cannot be loaded */
+"com.jetpack.support.unableToLoadApplicationLogs" = "Det gick inte att läsa in applikationsloggarna";
+
+/* Error title when bot conversations fail to load */
+"com.jetpack.support.unableToLoadConversations" = "Det gick inte att läsa in konversationerna";
+
+/* Error title when messages fail to load */
+"com.jetpack.support.unableToLoadMessages" = "Det gick inte att läsa in meddelandena";
+
+/* Error title when message sending fails */
+"com.jetpack.support.unableToSendMessage" = "Kan inte skicka meddelande";
+
+/* Button to view an attachment */
+"com.jetpack.support.view" = "Visa";
+
+/* Progress message shown during cache clearing operation */
+"com.jetpack.support.working" = "Arbetar";
 
 /* Displayed in the confirmation alert when marking comment notifications as read. */
 "comment" = "kommentera";
@@ -7879,6 +8124,9 @@ Example: Reply to Pamela Nguyen */
 /* Weekly Roundup debug menu item */
 "debugMenu.weeklyRoundup" = "Veckosammanfattning";
 
+/* Title for selecting a default category for a post */
+"defaultCategory.title" = "Standardkategori";
+
 /* Error tilte */
 "discussionSettings.saveErrorTitle" = "Misslyckades att spara inställningar";
 
@@ -8018,10 +8266,10 @@ Example: Reply to Pamela Nguyen */
 "double-tap to change unit" = "dubbeltryck för att ändra enhet";
 
 /* Message for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.message" = "Är du säker på att du vill ta bort den här etiketten?";
+"edit.tag.delete.confirmation.message" = "Är du säker på att du vill ta bort det här?";
 
-/* Title for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.title" = "Ta bort etikett";
+/* Title for delete a term confirmation dialog */
+"edit.tag.delete.confirmation.title" = "Ta bort";
 
 /* Placeholder text for tag description field */
 "edit.tag.description.placeholder" = "Lägg till en beskrivning …";
@@ -8036,7 +8284,37 @@ Example: Reply to Pamela Nguyen */
 "edit.tag.section.description" = "Beskrivning";
 
 /* Section header for tag name in edit tag view */
-"edit.tag.section.tag" = "Etikett";
+"edit.tag.section.tag" = "Namn";
+
+/* Context menu action to insert a block */
+"editor.blockInserter.insertBlock" = "Infoga block";
+
+/* Placeholder text for block search field */
+"editor.blockInserter.search" = "Sök";
+
+/* Button title to collapse and show fewer blocks */
+"editor.blockInserter.showLess" = "Visa färre";
+
+/* Button title to expand and show more blocks */
+"editor.blockInserter.showMore" = "Visa fler";
+
+/* Error message when media insertion fails */
+"editor.media.failedToInsert" = "Misslyckades att infoga media";
+
+/* Category name for section showing all patterns */
+"editor.patterns.all" = "Alla";
+
+/* Context menu action to insert a pattern */
+"editor.patterns.insertPattern" = "Infoga mönster";
+
+/* Title shown when no patterns match the search */
+"editor.patterns.noPatternsFound" = "Inga mönster hittades";
+
+/* Navigation title for patterns view */
+"editor.patterns.title" = "Mönster";
+
+/* Category name for patterns without a category */
+"editor.patterns.uncategorized" = "Okategoriserat";
 
 /* Register Domain - Address information field Number placeholder */
 "eg. 1122334455" = "till exempel 1122334455";
@@ -8590,6 +8868,24 @@ Example: Reply to Pamela Nguyen */
 
 /* Write a blog prompt for the jetpack prologue */
 "jetpack.prologue.prompt.writeBlog" = "Skriv en blogg";
+
+/* Description for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.description" = "Vem som helst kan visa detta inlägg";
+
+/* Title for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.title" = "Vem som helst";
+
+/* Description for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.description" = "Endast betalande prenumeranter kan visa detta inlägg";
+
+/* Title for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.title" = "Betalande prenumeranter";
+
+/* Description for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.description" = "Inlägget är synligt för alla prenumeranter, inklusive gratisprenumeranter";
+
+/* Title for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.title" = "Alla prenumeranter";
 
 /* Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account */
 "jetpackSite.connectToDefaultAccount" = "Du behöver logga in med %@ för att använda statistik och aviseringar.";
@@ -9180,6 +9476,12 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "Du har inte behörighet att visa den här privata bloggen.";
 
+/* Default empty state message format when there are no terms. %1$@ is the taxonomy name. */
+"localizedLabels.defaultNoTerms.format" = "Ingen %1$@";
+
+/* Default search placeholder format. %1$@ is the taxonomy name. */
+"localizedLabels.defaultSearch.format" = "Sök %1$@";
+
 /* Button to dismiss the re-authentication view */
 "login.appPasswordReAuth.cancelButton" = "Avbryt";
 
@@ -9315,17 +9617,23 @@ Example: Reply to Pamela Nguyen */
 /* Message about buying storage add-on */
 "mediaLibrary.storageDetails.buyStorage.message" = "Köp lagringsutrymmesutökning";
 
-/* Message shown when all media items are attached */
-"mediaLibrary.storageDetails.cleanup.allAttached" = "Alla objekt i mediebiblioteket är bifogade.";
+/* Label for audio media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.audio" = "Ljud";
 
-/* Message shown while loading unattached media count */
-"mediaLibrary.storageDetails.cleanup.loading" = "Tar reda på om det finns några ej bifogade mediaobjekt...";
+/* Label for document media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.document" = "Dokument";
 
-/* Message about unattached media that can be cleaned up. %1$d is the count of unattached media. */
-"mediaLibrary.storageDetails.cleanup.message" = "%1$d objekt bifogat Ta bort dem för att frigöra lite utrymme.";
+/* Label for image media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.image" = "Bilder";
 
-/* Title for cleanup section */
-"mediaLibrary.storageDetails.cleanup.title" = "Ta bort oanvända objekt";
+/* Label for other/unknown media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.other" = "Annat";
+
+/* Label for PowerPoint/presentation media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.powerpoint" = "Presentationer";
+
+/* Label for video media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.video" = "Videoklipp";
 
 /* Success message shown after upgrading plan */
 "mediaLibrary.storageDetails.purchase.plan.success" = "Ditt webbplatspaket har uppgraderats!";
@@ -9711,6 +10019,12 @@ Example: Reply to Pamela Nguyen */
 /* Menu option for filtering posts by me */
 "pagesList.pagesByMe" = "Sidor av mig";
 
+/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
+"parentCategory.noCategory" = "Ingen kategori";
+
+/* Title for selecting parent category of a category */
+"parentCategory.title" = "Överordnad kategori";
+
 /* Title for the parent page picker screen */
 "parentPagePicker.title" = "Överordnad sida";
 
@@ -9869,6 +10183,27 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the post author selection screen */
 "postAuthorPicker.title" = "Författare";
+
+/* Title for selecting categories for a post or a page */
+"postCategories.title" = "Kategorier";
+
+/* Toggle label for allowing comments on post */
+"postDiscussion.allowComments.label" = "Tillåt kommentarer";
+
+/* Toggle label for allowing pings/trackbacks on post */
+"postDiscussion.allowPings.label" = "Tillåt pingbacks";
+
+/* Footer text when comments are disabled */
+"postDiscussion.comments.disabled.footer" = "Besökare kan inte lägga till nya kommentarer eller svar. Befintliga kommentarer förblir synliga.";
+
+/* Footer text when comments are enabled */
+"postDiscussion.comments.enabled.footer" = "Besökare kan lägga till nya kommentarer och svar.";
+
+/* Link text for learning more about pingbacks and trackbacks */
+"postDiscussion.pingbacks.learnMore.text" = "Lär dig mer om pingbacks och trackbacks";
+
+/* Navigation title for post discussion settings */
+"postDiscussion.title" = "Diskussion";
 
 /* Button in an alert confirming discaring changes */
 "postEditor.closeConfirmationAlert.discardChanges" = "Kasta ändringar";
@@ -10101,6 +10436,9 @@ Example: Reply to Pamela Nguyen */
 /* A default value for an post without a title */
 "postSaveErrorMessage.postUntitled" = "Utan rubrik";
 
+/* Section header for Access settings in Post Settings */
+"postSettings.access.header" = "Åtkomst";
+
 /* Label for the author field in Post Settings */
 "postSettings.author.label" = "Författare";
 
@@ -10119,6 +10457,18 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the discard changes confirmation dialog */
 "postSettings.discardChanges.title" = "Kasta ändringar?";
+
+/* Status text when discussion (comments) is disabled */
+"postSettings.discussion.closed" = "Stängd";
+
+/* Label for the discussion settings field in Post Settings */
+"postSettings.discussion.label" = "Diskussion";
+
+/* Status text when discussion (comments) is enabled */
+"postSettings.discussion.open" = "Öppen";
+
+/* Label for the checkbox that lets you send a post to newsletter subscribers */
+"postSettings.emailToSubscribers.label" = "E-post till prenumeranter";
 
 /* Character count for excerpt. %1$d is the number of characters. */
 "postSettings.excerpt.characterCount" = "%1$d tecken";
@@ -10222,6 +10572,21 @@ Example: Reply to Pamela Nguyen */
 /* Cell title for the Top Level option case */
 "postSettings.parentPage.topLevel" = "Toppnivå";
 
+/* Accessibility label for hide password button */
+"postSettings.passwordEntry.hidePassword" = "Dölj lösenord";
+
+/* Instructions for password entry */
+"postSettings.passwordEntry.instructions" = "Ange ett lösenord för att skydda detta inlägg Endast användare med lösenordet kommer att kunna se det.";
+
+/* Navigation title for password entry screen */
+"postSettings.passwordEntry.navigationTitle" = "Ange lösenord";
+
+/* Placeholder for password field */
+"postSettings.passwordEntry.placeholder" = "Ange lösenord";
+
+/* Accessibility label for show password button */
+"postSettings.passwordEntry.showPassword" = "Visa lösenord";
+
 /* Label for the pending review toggle in Post Settings */
 "postSettings.pendingReview.label" = "Inväntar granskning";
 
@@ -10249,17 +10614,59 @@ Example: Reply to Pamela Nguyen */
 /* Section header for General settings in Post Settings */
 "postSettings.section.general" = "Allmänt";
 
+/* Description text explaining what the slug editor does */
+"postSettings.slug.customizeDescription" = "Anpassa den sista delen av permalänken.";
+
 /* Hint text for the slug field. Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso. */
 "postSettings.slug.hint" = "En slug är den URL-vänliga versionen av inläggets titel.";
 
 /* Label for the slug field. Should be the same as WP core. */
 "postSettings.slug.label" = "Slug";
 
+/* Button text to learn more about permalinks */
+"postSettings.slug.learnMore" = "Lär dig mer";
+
+/* Label for the slug field. Should be the same as WP core. */
+"postSettings.slug.navigationTitle" = "Slug";
+
+/* Notice shown when the post doesn't have a remote and permalink template is missing */
+"postSettings.slug.permalinkDraftNotice" = "Den föreslagna permalänken visas när utkastet sparas på servern";
+
+/* Label for the permalink preview */
+"postSettings.slug.permalinkLabel" = "Permalänk";
+
+/* Section title for the permalink preview */
+"postSettings.slug.permalinkSection" = "Permalänk";
+
 /* Placeholder for the slug field */
 "postSettings.slug.placeholder" = "Ange slug";
 
 /* Label for the preview button in Post Settings */
 "postSettings.socialSharing.header" = "Social delning";
+
+/* Label for the status field in Post Settings */
+"postSettings.status.label" = "Status";
+
+/* Navigation title for status picker */
+"postSettings.statusPicker.navigationTitle" = "Status och synlighet";
+
+/* Label showing the current password */
+"postSettings.statusPicker.passwordLabel" = "Lösenord";
+
+/* Toggle label for password protection */
+"postSettings.statusPicker.passwordProtected" = "Lösenordsskyddat";
+
+/* Subtitle for password protected toggle */
+"postSettings.statusPicker.passwordProtectedSubtitle" = "Visas endast för dem som känner till lösenordet";
+
+/* Label for schedule date row */
+"postSettings.statusPicker.scheduleDate" = "Datum";
+
+/* Toggle label for sticky posts */
+"postSettings.statusPicker.sticky" = "Klistrat";
+
+/* Subtitle for sticky toggle */
+"postSettings.statusPicker.stickySubtitle" = "Fäst detta inlägg högst upp på bloggen";
 
 /* Label for the sticky post toggle. Sticky posts are displayed at the top of the blog. */
 "postSettings.stickyPost.label" = "Klistrat";
@@ -10279,17 +10686,56 @@ Example: Reply to Pamela Nguyen */
 /* Navigation bar title of the Post Stats screen */
 "postStats.title" = "Inläggsstatistik";
 
-/* Button to add a new tag. %1$@ is the tag name. */
-"postTags.addTag" = "Lägg till etikett";
+/* Post status title */
+"postStatus.deleted.details" = "Permanent borttagen";
 
-/* Placeholder text for the tag search field */
-"postTags.searchOrAdd.placeholder" = "Sök eller lägg till etiketter";
+/* Post status title */
+"postStatus.deleted.title" = "Borttaget";
 
-/* Message shown when no tags are selected */
-"postTags.selectionEmpty" = "Inga etiketter är valda";
+/* Post status details */
+"postStatus.draft.details" = "Inte redo för publicering";
 
-/* Title for the tags screen */
-"postTags.title" = "Etiketter";
+/* Post status title */
+"postStatus.draft.title" = "Utkast";
+
+/* Post status details */
+"postStatus.pending.details" = "Väntar på granskning innan publicering";
+
+/* Post status title */
+"postStatus.pending.title" = "Väntar";
+
+/* Post status details */
+"postStatus.private.details" = "Endast synligt för webbplatsadministratörer och redigerare.";
+
+/* Post status title */
+"postStatus.private.title" = "Privat";
+
+/* Post status details */
+"postStatus.published.details" = "Synligt för alla";
+
+/* Post status title */
+"postStatus.published.title" = "Publicerat";
+
+/* Post status details */
+"postStatus.scheduled.details" = "Publicera automatiskt på ett valt datum";
+
+/* Post status title */
+"postStatus.scheduled.title" = "Schemalagt";
+
+/* Post status title */
+"postStatus.trash.details" = "Borttaget men inte borttaget permanent än";
+
+/* Post status title */
+"postStatus.trash.title" = "Borttaget";
+
+/* Button to add a new taxonomy term. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.addTag" = "Lägg till %1$@";
+
+/* Placeholder text for the taxonomy search field. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.searchOrAdd.placeholder" = "Sök eller lägg till %1$@";
+
+/* Message shown when no taxonomy terms are selected. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.selectionEmpty" = "Ingen %1$@ är vald";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "Avbryt";
@@ -10365,9 +10811,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "Kategorier";
-
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "Stäng";
 
 /* Button to confirm discarding changes */
 "prepublishing.discardChanges.button" = "Ignorera ändringarna";
@@ -10456,12 +10899,17 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "Varning";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "Meddelande";
+
+/* Placeholder text for the message field in Social Sharing */
+"prepublishing.socialAccounts.messagePlaceholder" = "Skriv ett kort meddelande att dela på sociala medier tillsammans med inlägget";
 
 /* The navigation title for the pre-publishing social accounts screen. */
 "prepublishing.socialAccounts.navigationTitle" = "Socialt";
+
+/* Table section title */
+"prepublishing.socialAccounts.servicesSectionTitle" = "Tjänster";
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.tags" = "Etiketter";
@@ -11408,6 +11856,18 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Button to progress to the next step after selecting domain in Site Creation */
 "siteCreation.domains.buttons.selectDomain" = "Välj domän";
 
+/* Default text for adding a new item when no label is provided */
+"siteCustomTaxonomies.defaultAddNew" = "Lägg till";
+
+/* Description for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.description" = "Taxonomier hjälper dig att organisera innehåll utöver standardkategorier och etiketter.";
+
+/* Title for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.title" = "Inga anpassade taxonomier";
+
+/* Navigation title for the custom taxonomies screen */
+"siteCustomTaxonomies.navigationTitle" = "Taxonomier";
+
 /* Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio. */
 "siteMedia.accessibilityLabelAudio" = "Ljud, %@";
 
@@ -11426,8 +11886,77 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Accessibility hint for actions when displaying media items. */
 "siteMedia.cellAccessibilityHint" = "Välj media.";
 
+/* Label for the alt for a media asset (image) */
+"siteMedia.details.altText" = "Alternativ text";
+
+/* Verb. Button title. Tapping cancels an action. */
+"siteMedia.details.cancel" = "Avbryt";
+
+/* Noun. Label for the caption for a media asset (image / video) */
+"siteMedia.details.caption" = "Bildtext";
+
+/* Title for button that permanently deletes a media item (photo / video) */
+"siteMedia.details.delete" = "Ta bort";
+
+/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
+"siteMedia.details.deleteConfirmation" = "Är du säker på att du vill ta bort det här objektet permanent?";
+
+/* Text displayed in HUD after successfully deleting a media item */
+"siteMedia.details.deleted" = "Borttaget!";
+
+/* Text displayed in HUD while a media item is being deleted. */
+"siteMedia.details.deleting" = "Tar bort …";
+
+/* Label for the description for a media asset (image / video) */
+"siteMedia.details.description" = "Beskrivning";
+
+/* Label for the dimensions in pixels for a media asset (image / video) */
+"siteMedia.details.dimensions" = "Dimensioner";
+
+/* Label for the file name for a media asset (image / video) */
+"siteMedia.details.fileName" = "Filnamn";
+
+/* Label for the file size for a media asset (image / video) */
+"siteMedia.details.fileSize" = "Filstorlek";
+
+/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
+"siteMedia.details.fileType" = "Filtyp";
+
+/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
+"siteMedia.details.mediaDeleted" = "Detta medieobjekt har tagits bort.";
+
+/* Noun. Label for the title of a media asset (image / video) */
+"siteMedia.details.title" = "Rubrik";
+
+/* Accessibility label for trash buttons in nav bars */
+"siteMedia.details.trash" = "Papperskorg";
+
+/* Text displayed in HUD if there was an error attempting to delete a media item. */
+"siteMedia.details.unableToDeleteMedia" = "Kan inte ta bort mediaobjekt.";
+
+/* Error shown when the app fails to load a video from the user's media library. */
+"siteMedia.details.unableToLoadVideo" = "Kan inte ladda videoklipp.";
+
+/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
+"siteMedia.details.unableToSaveMedia" = "Kan inte spara mediaobjekt.";
+
+/* Label for the date a media asset (image / video) was uploaded */
+"siteMedia.details.uploaded" = "Uppladdat";
+
 /* Title for the URL field */
 "siteMedia.details.url" = "-URL";
+
+/* Hint for image alt on image settings. */
+"siteMedia.hints.imageAlt" = "Alt-text för bild";
+
+/* Hint for image caption on image settings. */
+"siteMedia.hints.imageCaption" = "Bildtext";
+
+/* Hint for image description on image settings. */
+"siteMedia.hints.imageDescription" = "Bildbeskrivning";
+
+/* Hint for image title on image settings. */
+"siteMedia.hints.imageTitle" = "Bildrubrik";
 
 /* Accessibility hint for media item preview for user's viewing an item in their media library */
 "siteMediaItem.contentViewAccessibilityHint" = "Tryck för att visa media i helskärm";
@@ -11525,6 +12054,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Integritet";
+
+/* Format string for adding a new taxonomy term. %1$@ is the taxonomy name. */
+"siteTaxonomy.addNew.format" = "Lägg till %1$@";
 
 /* Hint for users when hidden privacy setting is set */
 "siteVisibility.hidden.hint" = "Din webbplats döljs för besökare bakom ett \"Kommer snart\"-meddelande tills den är klar att visas.";
@@ -12093,7 +12625,8 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Subject of new Zendesk ticket. */
 "support.zendesk.readerAppTicketSubject" = "Läsare för iOS-support";
 
-/* Description for empty state when there are no tags */
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
 "tags.empty.description" = "Etiketter hjälper till att organisera ditt innehåll och gör det lättare för läsare att hitta relaterade inlägg.";
 
 /* Title for empty state when there are no tags */
@@ -12170,9 +12703,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "ej läst";
-
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "Webbplatsens prenumerant";
 
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "Webbplatsens användare";
@@ -12258,9 +12788,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* The heading at the top of the user list */
 "userlist.title" = "Användare";
-
-/* Site Subscribers */
-"users.list.title.subscribers" = "Prenumeranter";
 
 /* Screen title */
 "users.title" = "Användare";

--- a/WordPress/Resources/th.lproj/Localizable.strings
+++ b/WordPress/Resources/th.lproj/Localizable.strings
@@ -1,6 +1,6 @@
 /* Translation-Revision-Date: 2022-05-03 21:58:56+0000 */
 /* Plural-Forms: nplurals=1; plural=0; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: th */
 
 /* Label displaying the author and post title for a Comment. %1$@ is a placeholder for the author. %2$@ is a placeholder for the post title. */
@@ -83,8 +83,7 @@
 /* Settings: Comments Enabled */
 "Allow Comments" = "อนุญาตความเห็น";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Alt Text";
 
 /* The title of the app appearance settings screen */
@@ -187,7 +186,6 @@
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "ยกเลิก";
@@ -195,8 +193,7 @@
 /* Dialog box title for when the user is canceling an upload. */
 "Cancel media uploads" = "ยกเลิกการอัปโหลดไฟล์สื่อ";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "คำอธิบาย";
 
 /* Alert title. */
@@ -310,8 +307,7 @@
 /* Action title. Noun. Opens the user's WordPress.com dashboard in an external browser. */
 "Dashboard" = "หน้าควบคุม";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "หมวดหมู่ค่าเริ่มต้น";
 
 /* Label for selecting the default post format
@@ -321,14 +317,10 @@
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "ค่าเริ่มต้นสำหรับเรื่องใหม่";
 
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "ลบ";
-
 /* Title for button on the comment details page that deletes the comment when tapped. */
 "Delete Permanently" = "ลบอย่างถาวร";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "คำขยายความ";
 
 /* Details button that appears in the Theme Browser Header
@@ -396,7 +388,7 @@
 /* Accessibility label for button to edit a comment from a notification */
 "Edit comment" = "แก้ไขความเห็น";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "ตัวแก้ไข";
 
 /* Accessibility label for the Email text field.
@@ -823,9 +815,6 @@
    Settings: Comments Paging preferences */
 "Paging" = "การใส่เลขหน้า";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "หมวดหมู่หลัก";
-
 /* Accessibility label for the password text field in the self-hosted login page.
    Label for entering password in password field
    Login dialog password placeholder
@@ -876,9 +865,6 @@
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "เรื่อง";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "หมวดหมู่เรื่อง";
 
 /* All Time Stats 'Posts' label
    Insights 'Posts' header
@@ -1160,6 +1146,7 @@
 "Tagline" = "คำอธิบาย";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "ป้ายกำกับ";
 
@@ -1249,7 +1236,6 @@
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "หัวข้อ";
@@ -1265,8 +1251,7 @@
 /* Shortened version of the main title to be used in back navigation */
 "Topic" = "กระทู้";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "ถังขยะ";
 
@@ -1345,9 +1330,6 @@
 
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "การอัปโหลดล้มเหลว";
-
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "อัปโหลดแล้ว";
 
 /* \"Uploading\" Status text */
 "Uploading" = "กำลังอัปโหลด";

--- a/WordPress/Resources/tr.lproj/Localizable.strings
+++ b/WordPress/Resources/tr.lproj/Localizable.strings
@@ -1,6 +1,6 @@
-/* Translation-Revision-Date: 2025-10-07 13:54:10+0000 */
+/* Translation-Revision-Date: 2025-11-25 20:54:10+0000 */
 /* Plural-Forms: nplurals=2; plural=n > 1; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: tr */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -338,6 +338,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Link to About screen for Jetpack for iOS */
 "About Jetpack for iOS" = "İOS için Jetpack hakkında";
 
+/* Link to About screen for Jetpack for iOS */
+"About Reader for iOS" = "iOS için okuyucu hakkında";
+
 /* Link to About screen for WordPress for iOS */
 "About WordPress" = "WordPress hakkında";
 
@@ -578,8 +581,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "Neredeyse bitiyor! Lütfen doğrulama uygulamanızdan alacağınız kodu yazın.";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "Alternatif metin";
 
 /* No comment provided by engineer. */
@@ -722,9 +724,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "Jetpack ile site bağlantısını kesmek istediğinize emin misiniz?";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "Bu ögeyi kalıcı olarak silmek istediğinize emin misiniz?";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "%2$@ sitesinden %1$@ eklentisini kaldırmak istediğinize emin misiniz?";
@@ -1079,7 +1078,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "İptal";
@@ -1107,8 +1105,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "Karar veremiyor musunuz? Temayı istediğiniz zaman değiştirebilirsiniz.";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "Alt yazı";
 
 /* Alert title. */
@@ -1774,8 +1771,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "Varsayılan";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "Varsayılan kategori";
 
 /* Label for selecting the default post format
@@ -1784,9 +1780,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "Yeni yazı varsayılanları";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "Sil";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "Menüyü sil";
@@ -1805,14 +1798,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "Menüyü sil";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "Silindi!";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "Site siliniyor…";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "Siliniyor...";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "Reddet";
@@ -1820,8 +1807,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "Görselin amacını açıklayın. Süs amaçlıysa boş bırakın.";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "Açıklama";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1839,9 +1825,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "Yeni bir hesap açmak istemediniz mi? E-posta adresinizi yeniden yazmak için geri dönün.";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "Boyutlar";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "Etkisizleştir";
@@ -2118,7 +2101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "Bu GIF düzenlendiğinde canlandırma kaldırılır.";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "Düzenleyici";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2460,11 +2443,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "Dosya blok ayarları";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "Dosya adı";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "Dosya türü";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "Dosya türü bir ortam dosyası olarak desteklenmiyor.";
@@ -2778,6 +2758,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post content used in the login prologue screens. */
 "I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next" = "Fotoğrafçı Cameron Karsten'in çalışmalarından çok ilham alıyorum. Bu teknikleri bir sonraki adımda deneyeceğim";
 
+/* Text on the support form to refer to what area the user has problem with. */
+"I need help with" = "Şu konuda yardıma ihtiyacım var";
+
 /* Describes the IP address section in the comment detail screen. */
 "IP address" = "IP adresi";
 
@@ -2823,9 +2806,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "Görsel alt yazısı";
 
-/* Hint for image description on image settings. */
-"Image Description" = "Görsel açıklaması";
-
 /* Hint for image link on image settings. */
 "Image Link" = "Görsel bağlantısı";
 
@@ -2837,9 +2817,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "Görsel dosyası bulunamadı.";
-
-/* Hint for image title on image settings. */
-"Image title" = "Görsel başlığı";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "Bir kaç sözcük ile bu sitenin ne ile ilgili olduğunu anlatın.";
@@ -3202,6 +3179,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the button that will dismiss this view. */
 "Let me know when finished!" = "Bittiğinde bana haber ver!";
 
+/* Message info on the support screen. */
+"Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon." = "Site adresinizi (URL) bize bildirin ve sorunla ilgili bize mümkün olduğunca çok şey anlatın, yakında sizinle iletişime geçeceğiz.";
+
+/* Title to let the user know what do we want on the support screen. */
+"Let’s get this sorted" = "Bunu sıralayalım";
+
 /* Lifestyle site intent topic */
 "Lifestyle" = "Yaşam tarzı";
 
@@ -3402,6 +3385,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Main Navigation" = "Ana gezinme";
+
+/* Explanation for the option to enable theme styles */
+"Make the block editor look like your theme." = "Blok düzenleyiciyi temanız gibi gösterin.";
 
 /* No comment provided by engineer. */
 "Make your content stand out by adding images, gifs, videos, and embedded media to your pages." = "Sayfalarınıza görsel, gif, video ve gömülü ortam ekleyerek içeriğinizin öne çıkmasını sağlayın.";
@@ -3744,9 +3730,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "Herhangi bir hesap bulunamadı";
-
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "Kategori yok";
 
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "Bağlantı yok";
@@ -4188,9 +4171,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "Sayfalama";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "Üst kategori";
-
 /* Parenting site intent topic */
 "Parenting" = "Ebeveynlik";
 
@@ -4408,9 +4388,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "Yazı";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "Yazı kategorileri";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "Yazı ayarları";
@@ -4719,9 +4696,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "Siteye yüklenmeden önce fotoğraflardaki konum üst verilerini kaldırır.";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "Takipçileri takipten çıkarırsanız sitenizden güncelleme alamazlar. İsterlerse sitenizi yine ziyaret edip takip edebilirler.";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "Geçerli bloğu değiştir";
@@ -5558,6 +5532,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "Slogan";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "Etiketler";
 
@@ -5654,6 +5629,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint, informing user the button can be used to visit the Gravatar website. */
 "Tap to visit the Gravatar website in an external browser" = "Gravatar sitesini bir dış tarayıcı ile açmak için dokunun";
+
+/* Label for viewing the custom taxonomies */
+"Taxonomies" = "Sınıflandırmalar";
 
 /* Technology site intent topic */
 "Technology" = "Teknoloji";
@@ -5943,9 +5921,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "Bu oturum açma kodunun süresi dolmulş. Lütfen Yeniden tara düğmesine tıklayarak kodu yeniden taratın.";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "Bu ortam ögesi silindi.";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "Çözümlenmemiş bir geri ödemesi varsa bu kullanıcı hesabı kapatılamaz.";
 
@@ -6014,7 +5989,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "Başlık";
@@ -6108,8 +6082,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "Bloğu dönüştür…";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "Çöp";
 
@@ -6206,9 +6179,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "Yeni davet bağlantıları oluşturulamadı.";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "Ortam ögesi silinemedi.";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "Davet bağlantıları etkisizleştirilemedi.";
 
@@ -6239,9 +6209,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "Bu içerik şu an yüklenemiyor.";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "Video yüklenemedi.";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "Video oynatılamıyor";
 
@@ -6250,9 +6217,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "Siteniz geri yüklenemedi";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "Ortam ögesi kaydedilemedi.";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "Bağlantı paylaşılamadı";
@@ -6409,9 +6373,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "Yüklenemedi";
 
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "Yüklendi";
-
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "1 taslak yazı ve %ld dosya yüklendi";
 
@@ -6453,6 +6414,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The button title text for logging in with WP.com password instead of magic link. */
 "Use password to sign in" = "Oturum açmak için parolayı kullanın";
+
+/* Option to enable theme styles in the block editor */
+"Use theme styles" = "Tema stillerini kullan";
 
 /* A placeholder for the twitter username
    Accessibility label for the username text field in the self-hosted login page.
@@ -6903,7 +6867,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "Ülkelere göre görünümlerini gösteren Dünya haritası.";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "Bu kişiyi hala kaldırmak istiyor musunuz?";
 
 /* Button title. Opens the editor to write a new post.
@@ -7374,14 +7338,19 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Description for the prompt to upgrade to Application Passwords. The first argument is the name of the feature that requires Application Passwords. */
 "applicationPasswordRequired.description" = "Uygulama şifreleri, kullanıcı tarafından barındırılan sitelerinizi bağlamanız ve %@ gibi özellikler için destek sağlamanın daha güvenli bir yoludur.";
 
+/* Feature name for managing application passwords in the app */
+"applicationPasswordRequired.feature.applicationPasswords" = "Uygulama Şifreleri Yönetimi";
+
 /* Feature name for the block editor in application password required prompt */
 "applicationPasswordRequired.feature.blockEditor" = "Blok Düzenleyici";
+
+/* Feature name for managing terms and taxonomies in the app */
+"applicationPasswordRequired.feature.customTaxonomies" = "Sınıflandırma Yönetimi";
 
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "Eklenti Yönetimi";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "Kullanıcı Yönetimi";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -7611,6 +7580,285 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 /* Post Editor / Button in the 'More' menu */
 "classicEditor.moreMenu.saveDraft" = "Taslağı Kaydet";
 
+/* Button to add more screenshots */
+"com.jetpack.support.addMoreScreenshots" = "Daha Fazla Ekran Görüntüsü Ekle";
+
+/* Button to add screenshots */
+"com.jetpack.support.addScreenshots" = "Ekran Görüntüleri Ekle";
+
+/* Header for application logs section */
+"com.jetpack.support.applicationLogs" = "Uygulama Günlükleri";
+
+/* Description explaining why including logs is helpful */
+"com.jetpack.support.applicationLogsDescription" = "Günlükleri dahil etmek, ekibimizin sorunları araştırmasına yardımcı olabilir. Günlükler son uygulama etkinliğini içerebilir.";
+
+/* Navigation title for application logs screen */
+"com.jetpack.support.applicationLogsTitle" = "Uygulama Günlükleri";
+
+/* Format string for attachment identifier */
+"com.jetpack.support.attachment" = "Ek %@";
+
+/* Format string for attachment size limit. %1$@ is current size, %2$@ is maximum size */
+"com.jetpack.support.attachmentLimit" = "Ek Sınırı: %1$@\/%2$@";
+
+/* Bot greeting message. %1$@ is the user's name */
+"com.jetpack.support.botGreeting" = "Selam %1$@!";
+
+/* Bot introduction message explaining its purpose */
+"com.jetpack.support.botIntroduction" = "Ben sizin kişisel yapay zeka asistanınızım. Siteniz veya hesabınız hakkındaki tüm sorularınızda yardımcı olabilirim.";
+
+/* Format string for cache file count and size. %1$d is the number of files, %2$@ is the formatted size. The system will pluralize 'files' based on the number – please specify it as the largest plural value */
+"com.jetpack.support.cacheFiles" = "%1$d önbelleğe alınan dosya (%2$@)";
+
+/* Message shown when cache has no files */
+"com.jetpack.support.cacheIsEmpty" = "Önbellek boş";
+
+/* Button to cancel current action */
+"com.jetpack.support.cancel" = "İptal Et";
+
+/* Warning message that deleted logs cannot be recovered */
+"com.jetpack.support.cannotRecoverLogs" = "Bunları geri getiremeyeceksiniz.";
+
+/* Button to clear all activity logs */
+"com.jetpack.support.clearAllActivityLogs" = "Tüm Etkinlik Günlüklerini Temizle";
+
+/* Button to clear disk cache */
+"com.jetpack.support.clearDiskCache" = "Disk Önbelleğini Temizle";
+
+/* Description explaining the purpose of clearing disk cache */
+"com.jetpack.support.clearDiskCacheDescription" = "Yer açmak veya sorunları çözmek için geçici dosyaları kaldırın.";
+
+/* Progress text while clearing cache */
+"com.jetpack.support.clearing" = "Temizleniyor…";
+
+/* Message shown when cache clearing is complete */
+"com.jetpack.support.complete" = "Tamamla";
+
+/* Confirmation message when canceling a draft */
+"com.jetpack.support.confirmCancelMessage" = "Bu mesajı iptal etmek istediğinizden emin misiniz? Girdiğiniz tüm verileri kaybedeceksiniz";
+
+/* Title for alert confirming cancellation */
+"com.jetpack.support.confirmCancellation" = "İptali Onayla";
+
+/* Confirmation dialog title when deleting all logs */
+"com.jetpack.support.confirmDeleteAllLogs" = "Tüm günlükleri silmek istediğinizden emin misiniz?";
+
+/* Section title for contact information */
+"com.jetpack.support.contactInformation" = "İletişim Bilgisi";
+
+/* Button to continue editing a message */
+"com.jetpack.support.continueWriting" = "Yazmaya Devam Edin";
+
+/* Message shown at end of closed support conversation */
+"com.jetpack.support.conversationEnded" = "Sohbetin sonu. Başka yanıt mümkün değil.";
+
+/* Navigation title for bot conversations list */
+"com.jetpack.support.conversations" = "Sohbetler";
+
+/* Button to delete all log files */
+"com.jetpack.support.deleteAllLogs" = "Tüm Günlükleri Sil";
+
+/* Description text for diagnostics screen */
+"com.jetpack.support.diagnosticsDescription" = "Yaygın bakım ve sorun giderme işlemlerini yürütün.";
+
+/* Navigation title for diagnostics screen */
+"com.jetpack.support.diagnosticsTitle" = "Tanı";
+
+/* Button to discard changes in a draft message */
+"com.jetpack.support.discardChanges" = "Değişiklikleri İptal Et";
+
+/* Notice explaining where support will send email responses */
+"com.jetpack.support.emailNotice" = "Size bu adresten e-posta göndereceğiz.";
+
+/* Error title when logs fail to load */
+"com.jetpack.support.errorLoadingLogs" = "Günlükler yüklenirken hata oluştu";
+
+/* Error message when support conversations fail to load */
+"com.jetpack.support.errorLoadingSupportConversations" = "Destek sohbetleri yüklenirken hata oluştu";
+
+/* Title for error alerts */
+"com.jetpack.support.errorTitle" = "Hata";
+
+/* Option to export log as a file */
+"com.jetpack.support.exportAsFile" = "Dosya olarak dışa aktar";
+
+/* Button to dismiss alerts. */
+"com.jetpack.support.gotIt" = "Anladım";
+
+/* Text on the support form to refer to what area the user has problem with. */
+"com.jetpack.support.iNeedHelp" = "Şu konuda yardıma ihtiyacım var";
+
+/* Toggle label to include application logs in the support request */
+"com.jetpack.support.includeApplicationLogs" = "Uygulama günlüklerini dahil et";
+
+/* Section title for issue details */
+"com.jetpack.support.issueDetails" = "Sorun Ayrıntıları";
+
+/* Format string for when conversation was last updated */
+"com.jetpack.support.lastUpdated" = "Son güncellenme: %@";
+
+/* Progress message while loading conversation messages */
+"com.jetpack.support.loadingBotConversationMessages" = "Mesajlar Yükleniyor";
+
+/* Progress message while loading bot conversations */
+"com.jetpack.support.loadingBotConversations" = "Robot Sohbetleri Yükleniyor";
+
+/* Progress text while loading support conversations */
+"com.jetpack.support.loadingConversations" = "Sohbetler Yükleniyor";
+
+/* Progress message while loading disk usage information */
+"com.jetpack.support.loadingDiskUsage" = "Disk Kullanımı Yükleniyor";
+
+/* Progress message while loading an image attachment */
+"com.jetpack.support.loadingImage" = "Görsel Yükleniyor";
+
+/* Progress message shown in overlay while refreshing content */
+"com.jetpack.support.loadingLatestContent" = "En son içerik yükleniyor";
+
+/* Progress message while loading application log content */
+"com.jetpack.support.loadingLogContent" = "Günlük içeriği yükleniyor...";
+
+/* Progress message while loading log files */
+"com.jetpack.support.loadingLogs" = "Günlükler yükleniyor...";
+
+/* Progress text while loading conversation messages */
+"com.jetpack.support.loadingMessages" = "Mesajlar Yükleniyor";
+
+/* Progress message while loading a video attachment */
+"com.jetpack.support.loadingVideo" = "Video Yükleniyor";
+
+/* Section header for log files sorted by date */
+"com.jetpack.support.logFilesByDate" = "Oluşturma tarihine göre günlük dosyaları";
+
+/* Text indicating which log files will be included in the support request */
+"com.jetpack.support.logFilesToUpload" = "Şu günlük dosyaları karşıya yüklenecek:";
+
+/* Footer text explaining log retention policy */
+"com.jetpack.support.logRetentionNotice" = "Yedi güne kadar olan günlükler kaydedilir.";
+
+/* Section header for message text input */
+"com.jetpack.support.message" = "Mesaj";
+
+/* Success message when reply is sent successfully */
+"com.jetpack.support.messageSent" = "Mesaj Gönderildi";
+
+/* Format string for number of messages in conversation */
+"com.jetpack.support.messagesCount" = "%d Mesaj";
+
+/* The title of a new bot chat in the support area of the app */
+"com.jetpack.support.new-bot-chat" = "Yeni Robot Sohbeti";
+
+/* Option to create a new support ticket */
+"com.jetpack.support.newSupportTicket" = "Yeni Destek Bileti";
+
+/* Label shown when there are no bot conversations */
+"com.jetpack.support.noConversations" = "Sohbet Yok";
+
+/* Description shown when no log files are available */
+"com.jetpack.support.noLogsAvailable" = "Kullanılabilir etkinlik günlüğü yok";
+
+/* Label shown when no log files are available */
+"com.jetpack.support.noLogsFound" = "Günlük Bulunamadı";
+
+/* Button to open a support ticket */
+"com.jetpack.support.openSupportTicket" = "Bir Destek Bileti Aç";
+
+/* Text indicating a field is optional */
+"com.jetpack.support.optional" = "(İsteğe bağlı)";
+
+/* Navigation title for replying to a support conversation */
+"com.jetpack.support.reply" = "Yanıtla";
+
+/* Description for saving log as a file */
+"com.jetpack.support.saveAsFile" = "Paylaşılacak veya depolanacak bir dosya olarak kaydet";
+
+/* Label for screenshots section */
+"com.jetpack.support.screenshots" = "Ekran görüntüleri";
+
+/* Description for screenshots section */
+"com.jetpack.support.screenshotsDescription" = "Ekran görüntüsü eklemek, sorununuzu daha hızlı anlamamıza ve çözmemize yardımcı olabilir.";
+
+/* Button to send a message or reply */
+"com.jetpack.support.send" = "Gönder";
+
+/* Description for sending logs to support */
+"com.jetpack.support.sendLogsToSupport" = "Kayıtları doğrudan destek ekibine gönderin";
+
+/* Progress text while sending a message */
+"com.jetpack.support.sending" = "Gönderiliyor";
+
+/* Progress message shown while sending a message */
+"com.jetpack.support.sendingMessage" = "Mesaj Gönderiliyor";
+
+/* Button to share content */
+"com.jetpack.support.share" = "Paylaş";
+
+/* Navigation title for sharing activity log */
+"com.jetpack.support.shareActivityLog" = "Etkinlik Günlüğünü Paylaş";
+
+/* Message shown when sharing log with support */
+"com.jetpack.support.sharingWithSupport" = "Destekle paylaşılıyor!";
+
+/* Site Address title on the support form */
+"com.jetpack.support.siteAddress" = "Site Adresi";
+
+/* Description encouraging user to start a new conversation */
+"com.jetpack.support.startNewConversation" = "Yukarıdaki düğmeyi kullanarak yeni bir sohbet başlatın";
+
+/* Subject title on the support form */
+"com.jetpack.support.subject" = "Konu";
+
+/* Placeholder for subject field */
+"com.jetpack.support.subjectPlaceholder" = "Sorununuzun kısa bir özeti";
+
+/* Button title to submit a support request. */
+"com.jetpack.support.submitRequest" = "Destek Talebi Gönder";
+
+/* Navigation title for the support conversations list */
+"com.jetpack.support.supportConversations" = "Destek Sohbetleri";
+
+/* Title for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSent" = "Talep gönderildi!";
+
+/* Message for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSentMessage" = "Destek talebiniz başarıyla gönderildi. Mümkün olan en kısa sürede e-posta yoluyla yanıt vereceğiz.";
+
+/* Progress message shown while bot is thinking */
+"com.jetpack.support.thinking" = "Düşünüyor...";
+
+/* Title of the view for contacting support. */
+"com.jetpack.support.title" = "Desteğe Başvurun";
+
+/* Button to retry a failed operation */
+"com.jetpack.support.tryAgain" = "Yeniden Dene";
+
+/* Error title when log deletion fails */
+"com.jetpack.support.unableToDeleteLogs" = "Günlükler silinemedi";
+
+/* Error message when conversation cannot be displayed */
+"com.jetpack.support.unableToDisplayConversation" = "Sohbet görüntülenemiyor";
+
+/* Error title when video cannot be loaded or played */
+"com.jetpack.support.unableToDisplayVideo" = "Video görüntülenemiyor";
+
+/* Error message when application logs cannot be loaded */
+"com.jetpack.support.unableToLoadApplicationLogs" = "Uygulama günlükleri yüklenemiyor";
+
+/* Error title when bot conversations fail to load */
+"com.jetpack.support.unableToLoadConversations" = "Sohbetler yüklenemiyor";
+
+/* Error title when messages fail to load */
+"com.jetpack.support.unableToLoadMessages" = "Mesajlar Yüklenemiyor";
+
+/* Error title when message sending fails */
+"com.jetpack.support.unableToSendMessage" = "Mesaj gönderilemiyor";
+
+/* Button to view an attachment */
+"com.jetpack.support.view" = "Görüntüle";
+
+/* Progress message shown during cache clearing operation */
+"com.jetpack.support.working" = "Çalışılıyor";
+
 /* Displayed in the confirmation alert when marking comment notifications as read. */
 "comment" = "yorum";
 
@@ -7703,6 +7951,9 @@ Example: Reply to Pamela Nguyen */
 
 /* Create Sheet button title */
 "createSheet.post" = "Gönderi";
+
+/* Create Sheet button title */
+"createSheet.postFromAudio" = "Sesten Gönderi Oluştur";
 
 /* Customize Insights description */
 "customizeInsightsCell.content" = "Kendi özelleştirilmiş panonuzu oluşturun ve görmek istediğiniz raporları seçin. Sizi en çok ilgilendiren verilere odaklanın.";
@@ -7873,6 +8124,9 @@ Example: Reply to Pamela Nguyen */
 /* Weekly Roundup debug menu item */
 "debugMenu.weeklyRoundup" = "Haftalık özet";
 
+/* Title for selecting a default category for a post */
+"defaultCategory.title" = "Varsayılan kategori";
+
 /* Error tilte */
 "discussionSettings.saveErrorTitle" = "Ayarlar kaydedilemedi";
 
@@ -8012,10 +8266,10 @@ Example: Reply to Pamela Nguyen */
 "double-tap to change unit" = "birimi değiştirmek için çift dokunun";
 
 /* Message for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.message" = "Bu etiketi silmek istediğinizden emin misiniz?";
+"edit.tag.delete.confirmation.message" = "Bunu silmek istediğinizden emin misiniz?";
 
-/* Title for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.title" = "Etiketi Silin";
+/* Title for delete a term confirmation dialog */
+"edit.tag.delete.confirmation.title" = "Sil";
 
 /* Placeholder text for tag description field */
 "edit.tag.description.placeholder" = "Açıklama ekleyin...";
@@ -8030,7 +8284,37 @@ Example: Reply to Pamela Nguyen */
 "edit.tag.section.description" = "Açıklama";
 
 /* Section header for tag name in edit tag view */
-"edit.tag.section.tag" = "Etiket";
+"edit.tag.section.tag" = "Ad";
+
+/* Context menu action to insert a block */
+"editor.blockInserter.insertBlock" = "Blok Ekleyin";
+
+/* Placeholder text for block search field */
+"editor.blockInserter.search" = "Arama";
+
+/* Button title to collapse and show fewer blocks */
+"editor.blockInserter.showLess" = "Daha Az Göster";
+
+/* Button title to expand and show more blocks */
+"editor.blockInserter.showMore" = "Daha Fazla Göster";
+
+/* Error message when media insertion fails */
+"editor.media.failedToInsert" = "Ortam eklenemedi";
+
+/* Category name for section showing all patterns */
+"editor.patterns.all" = "Tümü";
+
+/* Context menu action to insert a pattern */
+"editor.patterns.insertPattern" = "Model Ekle";
+
+/* Title shown when no patterns match the search */
+"editor.patterns.noPatternsFound" = "Model Bulunamadı";
+
+/* Navigation title for patterns view */
+"editor.patterns.title" = "Desenler";
+
+/* Category name for patterns without a category */
+"editor.patterns.uncategorized" = "Sınıflandırılmamış";
 
 /* Register Domain - Address information field Number placeholder */
 "eg. 1122334455" = "Örnek: 1122334455";
@@ -8585,6 +8869,24 @@ Example: Reply to Pamela Nguyen */
 /* Write a blog prompt for the jetpack prologue */
 "jetpack.prologue.prompt.writeBlog" = "Blog yazın";
 
+/* Description for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.description" = "Bu gönderiyi herkes görüntüleyebilir";
+
+/* Title for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.title" = "Herkes";
+
+/* Description for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.description" = "Bu gönderiyi yalnızca ücretli aboneler görüntüleyebilir";
+
+/* Title for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.title" = "Ücretli Aboneler";
+
+/* Description for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.description" = "Gönderi, ücretsiz olanlar dahil tüm aboneler tarafından görülebilir";
+
+/* Title for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.title" = "Tüm Aboneler";
+
 /* Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account */
 "jetpackSite.connectToDefaultAccount" = "İstatistikler ve Bildirimler'i kullanmak için %@ ile oturum açmanız gerekir.";
 
@@ -8599,6 +8901,9 @@ Example: Reply to Pamela Nguyen */
 
 /* Accessibility label for chart container */
 "jetpackStats.accessibility.chartContainer" = "İstatistik çizelgesi";
+
+/* Chart trend accessibility label. %1$@ is metric name, %2$@ is trend description. */
+"jetpackStats.accessibility.chartTrend" = "%1$@ %2$@";
 
 /* Chart data point accessibility label. %1$@ is metric name, %2$@ is value, %3$@ is date. */
 "jetpackStats.accessibility.chartValue" = "%1$@: %3$@ tarihinde %2$@";
@@ -8919,6 +9224,12 @@ Example: Reply to Pamela Nguyen */
 /* CSV header for title column */
 "jetpackStats.csv.title" = "Başlık";
 
+/* CSV header for type column */
+"jetpackStats.csv.type" = "Tip";
+
+/* CSV header for URL column */
+"jetpackStats.csv.url" = "Web adresi";
+
 /* CSV header for video URL column */
 "jetpackStats.csv.videoURL" = "Video URL'si";
 
@@ -8999,6 +9310,9 @@ Example: Reply to Pamela Nguyen */
 
 /* Must be short! Label for email open rate metric */
 "jetpackStats.postDetails.openRate" = "Açma Oranı";
+
+/* Shows when the post was published. %1$@ is the formatted date. */
+"jetpackStats.postDetails.published" = "Yayınlanma %1$@";
 
 /* Title for recent weeks activity heatmap */
 "jetpackStats.postDetails.recentWeeks" = "Son Haftalar";
@@ -9162,6 +9476,12 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "Bu özel blogu görüntülemek için izniniz yok.";
 
+/* Default empty state message format when there are no terms. %1$@ is the taxonomy name. */
+"localizedLabels.defaultNoTerms.format" = "%1$@ yok";
+
+/* Default search placeholder format. %1$@ is the taxonomy name. */
+"localizedLabels.defaultSearch.format" = "%1$@ Arayın";
+
 /* Button to dismiss the re-authentication view */
 "login.appPasswordReAuth.cancelButton" = "İptal Et";
 
@@ -9297,17 +9617,23 @@ Example: Reply to Pamela Nguyen */
 /* Message about buying storage add-on */
 "mediaLibrary.storageDetails.buyStorage.message" = "Depolama eklentisi satın alın";
 
-/* Message shown when all media items are attached */
-"mediaLibrary.storageDetails.cleanup.allAttached" = "Ortam Kütüphanesindeki tüm öğeler ekli.";
+/* Label for audio media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.audio" = "Ses";
 
-/* Message shown while loading unattached media count */
-"mediaLibrary.storageDetails.cleanup.loading" = "Eklenmemiş ortam öğesi olup olmadığı öğreniliyor...";
+/* Label for document media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.document" = "Belgeler";
 
-/* Message about unattached media that can be cleaned up. %1$d is the count of unattached media. */
-"mediaLibrary.storageDetails.cleanup.message" = "%1$d öğe kaldırıldı Yer açmak için çıkarın.";
+/* Label for image media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.image" = "Görseller";
 
-/* Title for cleanup section */
-"mediaLibrary.storageDetails.cleanup.title" = "Kullanılmayan öğeleri kaldır";
+/* Label for other/unknown media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.other" = "Diğer";
+
+/* Label for PowerPoint/presentation media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.powerpoint" = "Sunumlar";
+
+/* Label for video media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.video" = "Videolar";
 
 /* Success message shown after upgrading plan */
 "mediaLibrary.storageDetails.purchase.plan.success" = "Site paketiniz yükseltildi!";
@@ -9693,6 +10019,12 @@ Example: Reply to Pamela Nguyen */
 /* Menu option for filtering posts by me */
 "pagesList.pagesByMe" = "Benim sayfalarım";
 
+/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
+"parentCategory.noCategory" = "Kategori yok";
+
+/* Title for selecting parent category of a category */
+"parentCategory.title" = "Üst Kategori";
+
 /* Title for the parent page picker screen */
 "parentPagePicker.title" = "Üst Sayfa";
 
@@ -9851,6 +10183,27 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the post author selection screen */
 "postAuthorPicker.title" = "Yazar";
+
+/* Title for selecting categories for a post or a page */
+"postCategories.title" = "Kategoriler";
+
+/* Toggle label for allowing comments on post */
+"postDiscussion.allowComments.label" = "Yorumlara İzin Ver";
+
+/* Toggle label for allowing pings/trackbacks on post */
+"postDiscussion.allowPings.label" = "Pingback'lere İzin Ver";
+
+/* Footer text when comments are disabled */
+"postDiscussion.comments.disabled.footer" = "Ziyaretçiler yeni yorum veya cevap ekleyemezler. Mevcut yorumlar görünür kalır.";
+
+/* Footer text when comments are enabled */
+"postDiscussion.comments.enabled.footer" = "Ziyaretçiler yeni yorum ve cevap ekleyebilir.";
+
+/* Link text for learning more about pingbacks and trackbacks */
+"postDiscussion.pingbacks.learnMore.text" = "Pingback'ler ve geri izlemeler hakkında daha fazla bilgi edinin";
+
+/* Navigation title for post discussion settings */
+"postDiscussion.title" = "Tartışma";
 
 /* Button in an alert confirming discaring changes */
 "postEditor.closeConfirmationAlert.discardChanges" = "Değişiklikleri İptal Et";
@@ -10083,6 +10436,9 @@ Example: Reply to Pamela Nguyen */
 /* A default value for an post without a title */
 "postSaveErrorMessage.postUntitled" = "Başlıksız";
 
+/* Section header for Access settings in Post Settings */
+"postSettings.access.header" = "Erişim";
+
 /* Label for the author field in Post Settings */
 "postSettings.author.label" = "Yazar";
 
@@ -10101,6 +10457,18 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the discard changes confirmation dialog */
 "postSettings.discardChanges.title" = "Değişiklikler İptal Edilsin Mi?";
+
+/* Status text when discussion (comments) is disabled */
+"postSettings.discussion.closed" = "Kapalı";
+
+/* Label for the discussion settings field in Post Settings */
+"postSettings.discussion.label" = "Tartışma";
+
+/* Status text when discussion (comments) is enabled */
+"postSettings.discussion.open" = "Açık";
+
+/* Label for the checkbox that lets you send a post to newsletter subscribers */
+"postSettings.emailToSubscribers.label" = "Abonelere e-posta gönder";
 
 /* Character count for excerpt. %1$d is the number of characters. */
 "postSettings.excerpt.characterCount" = "%1$d karakter";
@@ -10204,6 +10572,21 @@ Example: Reply to Pamela Nguyen */
 /* Cell title for the Top Level option case */
 "postSettings.parentPage.topLevel" = "Üst seviye";
 
+/* Accessibility label for hide password button */
+"postSettings.passwordEntry.hidePassword" = "Şifreyi gizle";
+
+/* Instructions for password entry */
+"postSettings.passwordEntry.instructions" = "Bu gönderiyi korumak için bir şifre girin. Yalnızca şifreye sahip kullanıcılar bunu görüntüleyebilecek.";
+
+/* Navigation title for password entry screen */
+"postSettings.passwordEntry.navigationTitle" = "Şifre Girin";
+
+/* Placeholder for password field */
+"postSettings.passwordEntry.placeholder" = "Şifre girin";
+
+/* Accessibility label for show password button */
+"postSettings.passwordEntry.showPassword" = "Şifreyi göster";
+
 /* Label for the pending review toggle in Post Settings */
 "postSettings.pendingReview.label" = "İnceleme Bekliyor";
 
@@ -10231,17 +10614,59 @@ Example: Reply to Pamela Nguyen */
 /* Section header for General settings in Post Settings */
 "postSettings.section.general" = "Genel";
 
+/* Description text explaining what the slug editor does */
+"postSettings.slug.customizeDescription" = "Kalıcı bağlantının son kısmını özelleştirin.";
+
 /* Hint text for the slug field. Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso. */
 "postSettings.slug.hint" = "Kısaltma, gönderi başlığının URL dostu versiyonudur.";
 
 /* Label for the slug field. Should be the same as WP core. */
 "postSettings.slug.label" = "Kısaltma";
 
+/* Button text to learn more about permalinks */
+"postSettings.slug.learnMore" = "Daha fazla bilgi edinin";
+
+/* Label for the slug field. Should be the same as WP core. */
+"postSettings.slug.navigationTitle" = "Kısaltma";
+
+/* Notice shown when the post doesn't have a remote and permalink template is missing */
+"postSettings.slug.permalinkDraftNotice" = "Taslak sunucuya kaydedildiğinde önerilen kalıcı bağlantı görünür";
+
+/* Label for the permalink preview */
+"postSettings.slug.permalinkLabel" = "Kalıcı Bağlantı";
+
+/* Section title for the permalink preview */
+"postSettings.slug.permalinkSection" = "Kalıcı Bağlantı";
+
 /* Placeholder for the slug field */
 "postSettings.slug.placeholder" = "Kısaltma gir";
 
 /* Label for the preview button in Post Settings */
 "postSettings.socialSharing.header" = "Sosyal Paylaşım";
+
+/* Label for the status field in Post Settings */
+"postSettings.status.label" = "Durum";
+
+/* Navigation title for status picker */
+"postSettings.statusPicker.navigationTitle" = "Durum ve Görünürlük";
+
+/* Label showing the current password */
+"postSettings.statusPicker.passwordLabel" = "Şifre";
+
+/* Toggle label for password protection */
+"postSettings.statusPicker.passwordProtected" = "Şifre Korumalı";
+
+/* Subtitle for password protected toggle */
+"postSettings.statusPicker.passwordProtectedSubtitle" = "Sadece şifreyi bilenlere görünür";
+
+/* Label for schedule date row */
+"postSettings.statusPicker.scheduleDate" = "Tarih";
+
+/* Toggle label for sticky posts */
+"postSettings.statusPicker.sticky" = "Yapışkan";
+
+/* Subtitle for sticky toggle */
+"postSettings.statusPicker.stickySubtitle" = "Bu gönderiyi blogun üstüne sabitleyin";
 
 /* Label for the sticky post toggle. Sticky posts are displayed at the top of the blog. */
 "postSettings.stickyPost.label" = "Yapışkan";
@@ -10261,17 +10686,53 @@ Example: Reply to Pamela Nguyen */
 /* Navigation bar title of the Post Stats screen */
 "postStats.title" = "Gönderi İstatistikleri";
 
-/* Button to add a new tag. %1$@ is the tag name. */
-"postTags.addTag" = "Etiket ekle";
+/* Post status title */
+"postStatus.deleted.details" = "Kalıcı olarak silindi";
 
-/* Placeholder text for the tag search field */
-"postTags.searchOrAdd.placeholder" = "Etiketleri ara veya ekle";
+/* Post status title */
+"postStatus.deleted.title" = "Silindi";
 
-/* Message shown when no tags are selected */
-"postTags.selectionEmpty" = "Hiç etiket seçilmedi";
+/* Post status details */
+"postStatus.draft.details" = "Yayımlanmaya hazır değil";
 
-/* Title for the tags screen */
-"postTags.title" = "Etiketler";
+/* Post status title */
+"postStatus.draft.title" = "Taslak";
+
+/* Post status details */
+"postStatus.pending.details" = "Yayımlamadan önce inceleme bekliyor";
+
+/* Post status title */
+"postStatus.pending.title" = "Beklemede";
+
+/* Post status title */
+"postStatus.private.title" = "Gizli";
+
+/* Post status details */
+"postStatus.published.details" = "Herkes tarafından görülebilir";
+
+/* Post status title */
+"postStatus.published.title" = "Yayımlandı";
+
+/* Post status details */
+"postStatus.scheduled.details" = "Seçilen bir tarihte otomatik olarak yayımla";
+
+/* Post status title */
+"postStatus.scheduled.title" = "Zamanlandı";
+
+/* Post status title */
+"postStatus.trash.details" = "Çöpe atıldı ancak henüz silinmedi";
+
+/* Post status title */
+"postStatus.trash.title" = "Çöpe atıldı";
+
+/* Button to add a new taxonomy term. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.addTag" = "%1$@ ekle";
+
+/* Placeholder text for the taxonomy search field. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.searchOrAdd.placeholder" = "%1$@ arayın veya ekleyin";
+
+/* Message shown when no taxonomy terms are selected. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.selectionEmpty" = "Hiçbir %1$@ seçilmedi";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "İptal Et";
@@ -10347,9 +10808,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "Kategoriler";
-
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "Kapat";
 
 /* Button to confirm discarding changes */
 "prepublishing.discardChanges.button" = "Değişiklikleri İptal Et";
@@ -10438,12 +10896,17 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "Uyarı";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "İleti";
+
+/* Placeholder text for the message field in Social Sharing */
+"prepublishing.socialAccounts.messagePlaceholder" = "Gönderinin yanında sosyal medyada paylaşmak için kısa bir mesaj yazın";
 
 /* The navigation title for the pre-publishing social accounts screen. */
 "prepublishing.socialAccounts.navigationTitle" = "Sosyal ağ";
+
+/* Table section title */
+"prepublishing.socialAccounts.servicesSectionTitle" = "Hizmetler";
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.tags" = "Etiketler";
@@ -11052,6 +11515,9 @@ Feel free to replace it with other bracket types that you think looks better for
 "reader.welcome.subtitle" = "En büyük blog topluluğuna katılın";
 
 /* Reader app primary navigation tab bar */
+"readerApp.tabBar.discover" = "Keşfet";
+
+/* Reader app primary navigation tab bar */
 "readerApp.tabBar.me" = "Ben";
 
 /* Reader app primary navigation tab bar */
@@ -11387,6 +11853,18 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Button to progress to the next step after selecting domain in Site Creation */
 "siteCreation.domains.buttons.selectDomain" = "Etki alanı seçin";
 
+/* Default text for adding a new item when no label is provided */
+"siteCustomTaxonomies.defaultAddNew" = "Ekle";
+
+/* Description for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.description" = "Sınıflandırmalar, standart kategoriler ve etiketler dışındaki içerikleri düzenlemenize yardımcı olur.";
+
+/* Title for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.title" = "Özel sınıflandırma yok";
+
+/* Navigation title for the custom taxonomies screen */
+"siteCustomTaxonomies.navigationTitle" = "Sınıflandırmalar";
+
 /* Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio. */
 "siteMedia.accessibilityLabelAudio" = "Ses, %@";
 
@@ -11405,8 +11883,77 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Accessibility hint for actions when displaying media items. */
 "siteMedia.cellAccessibilityHint" = "Ortam dosyası seçin.";
 
+/* Label for the alt for a media asset (image) */
+"siteMedia.details.altText" = "Alternatif Metin";
+
+/* Verb. Button title. Tapping cancels an action. */
+"siteMedia.details.cancel" = "İptal Et";
+
+/* Noun. Label for the caption for a media asset (image / video) */
+"siteMedia.details.caption" = "Altyazı";
+
+/* Title for button that permanently deletes a media item (photo / video) */
+"siteMedia.details.delete" = "Sil";
+
+/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
+"siteMedia.details.deleteConfirmation" = "Bu ögeyi kalıcı olarak silmek istediğinizden emin misiniz?";
+
+/* Text displayed in HUD after successfully deleting a media item */
+"siteMedia.details.deleted" = "Silindi!";
+
+/* Text displayed in HUD while a media item is being deleted. */
+"siteMedia.details.deleting" = "Siliniyor...";
+
+/* Label for the description for a media asset (image / video) */
+"siteMedia.details.description" = "Açıklama";
+
+/* Label for the dimensions in pixels for a media asset (image / video) */
+"siteMedia.details.dimensions" = "Boyutlar";
+
+/* Label for the file name for a media asset (image / video) */
+"siteMedia.details.fileName" = "Dosya Adı";
+
+/* Label for the file size for a media asset (image / video) */
+"siteMedia.details.fileSize" = "Dosya Boyutu";
+
+/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
+"siteMedia.details.fileType" = "Dosya Türü";
+
+/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
+"siteMedia.details.mediaDeleted" = "Bu ortam öğesi silinmiş.";
+
+/* Noun. Label for the title of a media asset (image / video) */
+"siteMedia.details.title" = "Başlık";
+
+/* Accessibility label for trash buttons in nav bars */
+"siteMedia.details.trash" = "Çöp";
+
+/* Text displayed in HUD if there was an error attempting to delete a media item. */
+"siteMedia.details.unableToDeleteMedia" = "Ortam öğesi silinemiyor.";
+
+/* Error shown when the app fails to load a video from the user's media library. */
+"siteMedia.details.unableToLoadVideo" = "Video yüklenemedi.";
+
+/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
+"siteMedia.details.unableToSaveMedia" = "Ortam öğesi kaydedilemedi.";
+
+/* Label for the date a media asset (image / video) was uploaded */
+"siteMedia.details.uploaded" = "Karşıya Yüklendi";
+
 /* Title for the URL field */
 "siteMedia.details.url" = "URL";
+
+/* Hint for image alt on image settings. */
+"siteMedia.hints.imageAlt" = "Görsel Alternatif Metni";
+
+/* Hint for image caption on image settings. */
+"siteMedia.hints.imageCaption" = "Görsel Yazısı";
+
+/* Hint for image description on image settings. */
+"siteMedia.hints.imageDescription" = "Görsel Açıklaması";
+
+/* Hint for image title on image settings. */
+"siteMedia.hints.imageTitle" = "Görsel başlığı";
 
 /* Accessibility hint for media item preview for user's viewing an item in their media library */
 "siteMediaItem.contentViewAccessibilityHint" = "Ortamı tam ekranda görüntülemek için dokunun";
@@ -11504,6 +12051,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "Gizlilik";
+
+/* Format string for adding a new taxonomy term. %1$@ is the taxonomy name. */
+"siteTaxonomy.addNew.format" = "%1$@ ekle";
 
 /* Hint for users when hidden privacy setting is set */
 "siteVisibility.hidden.hint" = "Siteniz görüntülenmeye hazır oluncaya kadar “Yakında” uyarısıyla birlikte ziyaretçilerden gizlenir.";
@@ -12069,7 +12619,11 @@ Feel free to replace it with other bracket types that you think looks better for
 /* View title for Help & Support page. */
 "support.title" = "Yardım";
 
-/* Description for empty state when there are no tags */
+/* Subject of new Zendesk ticket. */
+"support.zendesk.readerAppTicketSubject" = "iOS için okuyucu desteği";
+
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
 "tags.empty.description" = "Etiketler içeriğinizi düzenlemenize ve okurların ilgili gönderileri bulmasını kolaylaştırmanıza yardımcı olur.";
 
 /* Title for empty state when there are no tags */
@@ -12146,9 +12700,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "okunmamış";
-
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "Sitenin Abonesi";
 
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "Sitenin Kullanıcısı";
@@ -12234,9 +12785,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* The heading at the top of the user list */
 "userlist.title" = "Kullanıcılar";
-
-/* Site Subscribers */
-"users.list.title.subscribers" = "Aboneler";
 
 /* Screen title */
 "users.title" = "Kullanıcılar";

--- a/WordPress/Resources/zh-Hans.lproj/Localizable.strings
+++ b/WordPress/Resources/zh-Hans.lproj/Localizable.strings
@@ -1,6 +1,6 @@
-/* Translation-Revision-Date: 2025-10-07 15:54:10+0000 */
+/* Translation-Revision-Date: 2025-11-25 09:54:12+0000 */
 /* Plural-Forms: nplurals=1; plural=0; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: zh_CN */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -581,8 +581,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "马上就好！请输入验证器应用程序中的验证码。";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "替代文本";
 
 /* No comment provided by engineer. */
@@ -725,9 +724,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "确定要断开 Jetpack 与该站点的连接吗？";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "是否确定要永久删除此项目？";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "是否确定要从 %2$@ 中删除 %1$@？";
@@ -1082,7 +1078,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "取消";
@@ -1110,8 +1105,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "决定不了？ 您可以随时更改主题。";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "标题";
 
 /* Alert title. */
@@ -1777,8 +1771,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "默认";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "默认分类";
 
 /* Label for selecting the default post format
@@ -1787,9 +1780,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "新文章的默认设置";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "删除";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "删除菜单";
@@ -1808,14 +1798,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "删除菜单";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "已删除！";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "正在删除站点…";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "正在删除...";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "拒绝";
@@ -1823,8 +1807,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "描述图像的用途。 如果作装饰用，请留空。";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "描述";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1842,9 +1825,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "不打算创建新账户？ 返回以重新输入您的电子邮件地址。";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "尺寸";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "禁用";
@@ -2121,7 +2101,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "编辑此 GIF 将删除其动画。";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "编辑器";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2463,11 +2443,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "文件区块设置";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "文件名";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "文件类型";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "不支持的媒体文件类型。";
@@ -2781,6 +2758,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post content used in the login prologue screens. */
 "I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next" = "摄影师Cameron Karsten的作品给了我很大的启发。我将在我的下一个作品中尝试这些技术。";
 
+/* Text on the support form to refer to what area the user has problem with. */
+"I need help with" = "我需要以下方面的帮助";
+
 /* Describes the IP address section in the comment detail screen. */
 "IP address" = "IP地址";
 
@@ -2826,9 +2806,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "图片说明";
 
-/* Hint for image description on image settings. */
-"Image Description" = "图片描述";
-
 /* Hint for image link on image settings. */
 "Image Link" = "图片链接";
 
@@ -2840,9 +2817,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "找不到图像文件。";
-
-/* Hint for image title on image settings. */
-"Image title" = "图像标题";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "简要描述该站点。";
@@ -3205,6 +3179,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the button that will dismiss this view. */
 "Let me know when finished!" = "完成时通知我！";
 
+/* Message info on the support screen. */
+"Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon." = "告诉我们您的站点地址 (URL)，并尽量详细地说明有关这个问题的信息，我们将会尽快联系您。";
+
+/* Title to let the user know what do we want on the support screen. */
+"Let’s get this sorted" = "我们来把一切准备就绪";
+
 /* Lifestyle site intent topic */
 "Lifestyle" = "生活方式";
 
@@ -3405,6 +3385,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Main Navigation" = "主要导航";
+
+/* Explanation for the option to enable theme styles */
+"Make the block editor look like your theme." = "让区块编辑器的外观符合您的主题风格。";
 
 /* No comment provided by engineer. */
 "Make your content stand out by adding images, gifs, videos, and embedded media to your pages." = "将图像、GIF、视频和嵌入式媒体添加到您的页面，让您的内容脱颖而出。";
@@ -3747,9 +3730,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "未找到任何账户";
-
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "没有分类";
 
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "无连接";
@@ -4191,9 +4171,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "分页";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "父级分类目录";
-
 /* Parenting site intent topic */
 "Parenting" = "育儿";
 
@@ -4411,9 +4388,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "发布";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "文章类别";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "文章设置";
@@ -4722,9 +4696,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "请先删除照片中的位置元数据，然后再将其上传至您的站点。";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "删除粉丝后，他们将不再接收来自您站点的更新。 但他们仍然可以访问您的站点，也可以再次关注站点。";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "替换现有区块";
@@ -5561,6 +5532,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "标语";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "标签";
 
@@ -5657,6 +5629,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint, informing user the button can be used to visit the Gravatar website. */
 "Tap to visit the Gravatar website in an external browser" = "轻点以在外部浏览器中访问 Gravatar 网站";
+
+/* Label for viewing the custom taxonomies */
+"Taxonomies" = "分类";
 
 /* Technology site intent topic */
 "Technology" = "科技";
@@ -5946,9 +5921,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "此登录代码已过期。 请点击“再次扫描”按钮，重新扫描代码。";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "此媒体项目已被删除。";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "这个用户账户在未解决的退款时不能被关闭。";
 
@@ -6017,7 +5989,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "标题";
@@ -6111,8 +6082,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "转换区块…";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "移到回收站";
 
@@ -6209,9 +6179,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "无法创建新的邀请链接。";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "无法删除媒体项目。";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "无法禁用邀请链接。";
 
@@ -6242,9 +6209,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "无法立即加载此内容。";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "无法加载视频。";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "无法播放视频";
 
@@ -6253,9 +6217,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "无法恢复您的站点";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "无法保存媒体项目。";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "无法共享链接";
@@ -6412,9 +6373,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "上传失败";
 
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "已上传";
-
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "已上传 1 篇草稿文章、%ld 个文件";
 
@@ -6456,6 +6414,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The button title text for logging in with WP.com password instead of magic link. */
 "Use password to sign in" = "使用密码登录";
+
+/* Option to enable theme styles in the block editor */
+"Use theme styles" = "使用主题样式";
 
 /* A placeholder for the twitter username
    Accessibility label for the username text field in the self-hosted login page.
@@ -6906,7 +6867,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "按国家\/地区显示查看次数世界地图";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "是否仍要删除此人？";
 
 /* Button title. Opens the editor to write a new post.
@@ -7377,14 +7338,19 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Description for the prompt to upgrade to Application Passwords. The first argument is the name of the feature that requires Application Passwords. */
 "applicationPasswordRequired.description" = "应用程序密码能让您更安全地连接到您的自托管站点，并且支持 %@ 等功能。";
 
+/* Feature name for managing application passwords in the app */
+"applicationPasswordRequired.feature.applicationPasswords" = "应用程序密码管理";
+
 /* Feature name for the block editor in application password required prompt */
 "applicationPasswordRequired.feature.blockEditor" = "区块编辑器";
+
+/* Feature name for managing terms and taxonomies in the app */
+"applicationPasswordRequired.feature.customTaxonomies" = "分类管理";
 
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "插件管理";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "用户管理";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -7613,6 +7579,285 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 
 /* Post Editor / Button in the 'More' menu */
 "classicEditor.moreMenu.saveDraft" = "保存草稿";
+
+/* Button to add more screenshots */
+"com.jetpack.support.addMoreScreenshots" = "添加更多屏幕截图";
+
+/* Button to add screenshots */
+"com.jetpack.support.addScreenshots" = "添加屏幕截图";
+
+/* Header for application logs section */
+"com.jetpack.support.applicationLogs" = "应用程序日志";
+
+/* Description explaining why including logs is helpful */
+"com.jetpack.support.applicationLogsDescription" = "包含日志可以帮助我们的团队调查问题。 日志可能包含最近的应用程序活动。";
+
+/* Navigation title for application logs screen */
+"com.jetpack.support.applicationLogsTitle" = "应用程序日志";
+
+/* Format string for attachment identifier */
+"com.jetpack.support.attachment" = "附件 %@";
+
+/* Format string for attachment size limit. %1$@ is current size, %2$@ is maximum size */
+"com.jetpack.support.attachmentLimit" = "附件限制：%1$@ \/ %2$@";
+
+/* Bot greeting message. %1$@ is the user's name */
+"com.jetpack.support.botGreeting" = "%1$@，您好！";
+
+/* Bot introduction message explaining its purpose */
+"com.jetpack.support.botIntroduction" = "我是您的个人 AI 助手。 我可以协助解答关于您站点或账户的任何问题。";
+
+/* Format string for cache file count and size. %1$d is the number of files, %2$@ is the formatted size. The system will pluralize 'files' based on the number – please specify it as the largest plural value */
+"com.jetpack.support.cacheFiles" = "%1$d 个缓存文件 (%2$@)";
+
+/* Message shown when cache has no files */
+"com.jetpack.support.cacheIsEmpty" = "缓存为空";
+
+/* Button to cancel current action */
+"com.jetpack.support.cancel" = "取消";
+
+/* Warning message that deleted logs cannot be recovered */
+"com.jetpack.support.cannotRecoverLogs" = "一旦清除，您将无法找回。";
+
+/* Button to clear all activity logs */
+"com.jetpack.support.clearAllActivityLogs" = "清除所有活动日志";
+
+/* Button to clear disk cache */
+"com.jetpack.support.clearDiskCache" = "清除磁盘缓存";
+
+/* Description explaining the purpose of clearing disk cache */
+"com.jetpack.support.clearDiskCacheDescription" = "删除临时文件以释放空间或解决问题。";
+
+/* Progress text while clearing cache */
+"com.jetpack.support.clearing" = "正在清除…";
+
+/* Message shown when cache clearing is complete */
+"com.jetpack.support.complete" = "完成";
+
+/* Confirmation message when canceling a draft */
+"com.jetpack.support.confirmCancelMessage" = "是否确定要取消此消息？ 您将丢失已输入的所有数据";
+
+/* Title for alert confirming cancellation */
+"com.jetpack.support.confirmCancellation" = "确认取消";
+
+/* Confirmation dialog title when deleting all logs */
+"com.jetpack.support.confirmDeleteAllLogs" = "是否确定要删除所有日志？";
+
+/* Section title for contact information */
+"com.jetpack.support.contactInformation" = "联系信息";
+
+/* Button to continue editing a message */
+"com.jetpack.support.continueWriting" = "继续撰写";
+
+/* Message shown at end of closed support conversation */
+"com.jetpack.support.conversationEnded" = "对话结束。 无法再进行回复。";
+
+/* Navigation title for bot conversations list */
+"com.jetpack.support.conversations" = "对话";
+
+/* Button to delete all log files */
+"com.jetpack.support.deleteAllLogs" = "删除所有日志";
+
+/* Description text for diagnostics screen */
+"com.jetpack.support.diagnosticsDescription" = "执行常规维护和问题排查任务。";
+
+/* Navigation title for diagnostics screen */
+"com.jetpack.support.diagnosticsTitle" = "诊断";
+
+/* Button to discard changes in a draft message */
+"com.jetpack.support.discardChanges" = "放弃更改";
+
+/* Notice explaining where support will send email responses */
+"com.jetpack.support.emailNotice" = "我们将通过此地址向您发送电子邮件。";
+
+/* Error title when logs fail to load */
+"com.jetpack.support.errorLoadingLogs" = "加载日志时出错";
+
+/* Error message when support conversations fail to load */
+"com.jetpack.support.errorLoadingSupportConversations" = "加载支持对话时出错";
+
+/* Title for error alerts */
+"com.jetpack.support.errorTitle" = "错误";
+
+/* Option to export log as a file */
+"com.jetpack.support.exportAsFile" = "导出为文件";
+
+/* Button to dismiss alerts. */
+"com.jetpack.support.gotIt" = "知道了";
+
+/* Text on the support form to refer to what area the user has problem with. */
+"com.jetpack.support.iNeedHelp" = "我需要以下方面的帮助";
+
+/* Toggle label to include application logs in the support request */
+"com.jetpack.support.includeApplicationLogs" = "包括应用程序日志";
+
+/* Section title for issue details */
+"com.jetpack.support.issueDetails" = "问题详情";
+
+/* Format string for when conversation was last updated */
+"com.jetpack.support.lastUpdated" = "上次更新时间：%@";
+
+/* Progress message while loading conversation messages */
+"com.jetpack.support.loadingBotConversationMessages" = "正在加载消息";
+
+/* Progress message while loading bot conversations */
+"com.jetpack.support.loadingBotConversations" = "正在加载机器人对话";
+
+/* Progress text while loading support conversations */
+"com.jetpack.support.loadingConversations" = "正在加载对话";
+
+/* Progress message while loading disk usage information */
+"com.jetpack.support.loadingDiskUsage" = "正在加载磁盘使用情况";
+
+/* Progress message while loading an image attachment */
+"com.jetpack.support.loadingImage" = "正在加载图片";
+
+/* Progress message shown in overlay while refreshing content */
+"com.jetpack.support.loadingLatestContent" = "正在加载最新内容";
+
+/* Progress message while loading application log content */
+"com.jetpack.support.loadingLogContent" = "正在加载日志内容…";
+
+/* Progress message while loading log files */
+"com.jetpack.support.loadingLogs" = "正在加载日志…";
+
+/* Progress text while loading conversation messages */
+"com.jetpack.support.loadingMessages" = "正在加载消息";
+
+/* Progress message while loading a video attachment */
+"com.jetpack.support.loadingVideo" = "正在加载视频";
+
+/* Section header for log files sorted by date */
+"com.jetpack.support.logFilesByDate" = "日志文件（按创建日期排序）";
+
+/* Text indicating which log files will be included in the support request */
+"com.jetpack.support.logFilesToUpload" = "将上传以下日志文件：";
+
+/* Footer text explaining log retention policy */
+"com.jetpack.support.logRetentionNotice" = "最多可保存七天的日志。";
+
+/* Section header for message text input */
+"com.jetpack.support.message" = "消息";
+
+/* Success message when reply is sent successfully */
+"com.jetpack.support.messageSent" = "消息已发送";
+
+/* Format string for number of messages in conversation */
+"com.jetpack.support.messagesCount" = "%d 条消息";
+
+/* The title of a new bot chat in the support area of the app */
+"com.jetpack.support.new-bot-chat" = "新建机器人聊天";
+
+/* Option to create a new support ticket */
+"com.jetpack.support.newSupportTicket" = "新建支持工单";
+
+/* Label shown when there are no bot conversations */
+"com.jetpack.support.noConversations" = "无对话";
+
+/* Description shown when no log files are available */
+"com.jetpack.support.noLogsAvailable" = "没有可用的活动日志";
+
+/* Label shown when no log files are available */
+"com.jetpack.support.noLogsFound" = "未找到日志";
+
+/* Button to open a support ticket */
+"com.jetpack.support.openSupportTicket" = "提交支持工单";
+
+/* Text indicating a field is optional */
+"com.jetpack.support.optional" = "（可选）";
+
+/* Navigation title for replying to a support conversation */
+"com.jetpack.support.reply" = "回复";
+
+/* Description for saving log as a file */
+"com.jetpack.support.saveAsFile" = "保存为文件以便共享或存储";
+
+/* Label for screenshots section */
+"com.jetpack.support.screenshots" = "屏幕截图";
+
+/* Description for screenshots section */
+"com.jetpack.support.screenshotsDescription" = "添加屏幕截图可以帮助我们更快了解并解决您所遇到的问题。";
+
+/* Button to send a message or reply */
+"com.jetpack.support.send" = "发送";
+
+/* Description for sending logs to support */
+"com.jetpack.support.sendLogsToSupport" = "将日志直接发送给支持团队";
+
+/* Progress text while sending a message */
+"com.jetpack.support.sending" = "正在发送";
+
+/* Progress message shown while sending a message */
+"com.jetpack.support.sendingMessage" = "正在发送消息";
+
+/* Button to share content */
+"com.jetpack.support.share" = "共享";
+
+/* Navigation title for sharing activity log */
+"com.jetpack.support.shareActivityLog" = "共享活动日志";
+
+/* Message shown when sharing log with support */
+"com.jetpack.support.sharingWithSupport" = "与支持人员共享！";
+
+/* Site Address title on the support form */
+"com.jetpack.support.siteAddress" = "站点地址";
+
+/* Description encouraging user to start a new conversation */
+"com.jetpack.support.startNewConversation" = "点击上方按钮开始新对话";
+
+/* Subject title on the support form */
+"com.jetpack.support.subject" = "主题";
+
+/* Placeholder for subject field */
+"com.jetpack.support.subjectPlaceholder" = "关于您所遇问题的简要概述";
+
+/* Button title to submit a support request. */
+"com.jetpack.support.submitRequest" = "提交支持请求";
+
+/* Navigation title for the support conversations list */
+"com.jetpack.support.supportConversations" = "支持对话";
+
+/* Title for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSent" = "请求已发送！";
+
+/* Message for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSentMessage" = "您的支持请求已成功发送。 我们将尽快通过电子邮件回复您。";
+
+/* Progress message shown while bot is thinking */
+"com.jetpack.support.thinking" = "正在思考...";
+
+/* Title of the view for contacting support. */
+"com.jetpack.support.title" = "联系支持人员";
+
+/* Button to retry a failed operation */
+"com.jetpack.support.tryAgain" = "重试";
+
+/* Error title when log deletion fails */
+"com.jetpack.support.unableToDeleteLogs" = "无法删除日志";
+
+/* Error message when conversation cannot be displayed */
+"com.jetpack.support.unableToDisplayConversation" = "无法显示对话";
+
+/* Error title when video cannot be loaded or played */
+"com.jetpack.support.unableToDisplayVideo" = "无法显示视频";
+
+/* Error message when application logs cannot be loaded */
+"com.jetpack.support.unableToLoadApplicationLogs" = "无法加载应用程序日志";
+
+/* Error title when bot conversations fail to load */
+"com.jetpack.support.unableToLoadConversations" = "无法加载对话";
+
+/* Error title when messages fail to load */
+"com.jetpack.support.unableToLoadMessages" = "无法加载消息";
+
+/* Error title when message sending fails */
+"com.jetpack.support.unableToSendMessage" = "无法发送消息";
+
+/* Button to view an attachment */
+"com.jetpack.support.view" = "查看";
+
+/* Progress message shown during cache clearing operation */
+"com.jetpack.support.working" = "工作中";
 
 /* Displayed in the confirmation alert when marking comment notifications as read. */
 "comment" = "评论";
@@ -7876,6 +8121,9 @@ Example: Reply to Pamela Nguyen */
 /* Weekly Roundup debug menu item */
 "debugMenu.weeklyRoundup" = "每周综述";
 
+/* Title for selecting a default category for a post */
+"defaultCategory.title" = "默认分类";
+
 /* Error tilte */
 "discussionSettings.saveErrorTitle" = "保存设置失败";
 
@@ -8015,10 +8263,10 @@ Example: Reply to Pamela Nguyen */
 "double-tap to change unit" = "双击更改单位";
 
 /* Message for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.message" = "是否确定要删除此标签？";
+"edit.tag.delete.confirmation.message" = "是否确定要删除此项？";
 
-/* Title for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.title" = "删除标签";
+/* Title for delete a term confirmation dialog */
+"edit.tag.delete.confirmation.title" = "删除";
 
 /* Placeholder text for tag description field */
 "edit.tag.description.placeholder" = "添加描述...";
@@ -8033,7 +8281,37 @@ Example: Reply to Pamela Nguyen */
 "edit.tag.section.description" = "描述";
 
 /* Section header for tag name in edit tag view */
-"edit.tag.section.tag" = "标签";
+"edit.tag.section.tag" = "姓名";
+
+/* Context menu action to insert a block */
+"editor.blockInserter.insertBlock" = "插入区块";
+
+/* Placeholder text for block search field */
+"editor.blockInserter.search" = "搜索";
+
+/* Button title to collapse and show fewer blocks */
+"editor.blockInserter.showLess" = "显示更少";
+
+/* Button title to expand and show more blocks */
+"editor.blockInserter.showMore" = "显示更多";
+
+/* Error message when media insertion fails */
+"editor.media.failedToInsert" = "插入媒体失败";
+
+/* Category name for section showing all patterns */
+"editor.patterns.all" = "全部";
+
+/* Context menu action to insert a pattern */
+"editor.patterns.insertPattern" = "插入样板";
+
+/* Title shown when no patterns match the search */
+"editor.patterns.noPatternsFound" = "未找到样板";
+
+/* Navigation title for patterns view */
+"editor.patterns.title" = "样板";
+
+/* Category name for patterns without a category */
+"editor.patterns.uncategorized" = "未分类";
 
 /* Register Domain - Address information field Number placeholder */
 "eg. 1122334455" = "例如 1122334455";
@@ -8587,6 +8865,24 @@ Example: Reply to Pamela Nguyen */
 
 /* Write a blog prompt for the jetpack prologue */
 "jetpack.prologue.prompt.writeBlog" = "撰写博客";
+
+/* Description for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.description" = "任何人都可以查看此文章";
+
+/* Title for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.title" = "所有人";
+
+/* Description for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.description" = "只有付费订阅者才能查看此文章";
+
+/* Title for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.title" = "付费订阅者";
+
+/* Description for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.description" = "此文章对所有订阅者可见，包括免费订阅者";
+
+/* Title for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.title" = "所有订阅者";
 
 /* Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account */
 "jetpackSite.connectToDefaultAccount" = "您需要通过 %@ 登录才能使用统计信息和通知功能。";
@@ -9177,6 +9473,12 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "您无权查看此私人博客。";
 
+/* Default empty state message format when there are no terms. %1$@ is the taxonomy name. */
+"localizedLabels.defaultNoTerms.format" = "无 %1$@";
+
+/* Default search placeholder format. %1$@ is the taxonomy name. */
+"localizedLabels.defaultSearch.format" = "搜索 %1$@";
+
 /* Button to dismiss the re-authentication view */
 "login.appPasswordReAuth.cancelButton" = "取消";
 
@@ -9312,17 +9614,23 @@ Example: Reply to Pamela Nguyen */
 /* Message about buying storage add-on */
 "mediaLibrary.storageDetails.buyStorage.message" = "购买存储空间加载项";
 
-/* Message shown when all media items are attached */
-"mediaLibrary.storageDetails.cleanup.allAttached" = "媒体库中的所有项目均已附加。";
+/* Label for audio media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.audio" = "音频";
 
-/* Message shown while loading unattached media count */
-"mediaLibrary.storageDetails.cleanup.loading" = "正在检查是否存在任何尚未附加的媒体项目…";
+/* Label for document media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.document" = "文档";
 
-/* Message about unattached media that can be cleaned up. %1$d is the count of unattached media. */
-"mediaLibrary.storageDetails.cleanup.message" = "%1$d 个项目尚未附加。 移除它们以释放一些空间。";
+/* Label for image media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.image" = "图片";
 
-/* Title for cleanup section */
-"mediaLibrary.storageDetails.cleanup.title" = "移除未使用的项目";
+/* Label for other/unknown media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.other" = "其他";
+
+/* Label for PowerPoint/presentation media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.powerpoint" = "演示文稿";
+
+/* Label for video media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.video" = "视频";
 
 /* Success message shown after upgrading plan */
 "mediaLibrary.storageDetails.purchase.plan.success" = "您的站点套餐已升级！";
@@ -9708,6 +10016,12 @@ Example: Reply to Pamela Nguyen */
 /* Menu option for filtering posts by me */
 "pagesList.pagesByMe" = "我的页面";
 
+/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
+"parentCategory.noCategory" = "无分类";
+
+/* Title for selecting parent category of a category */
+"parentCategory.title" = "父级分类";
+
 /* Title for the parent page picker screen */
 "parentPagePicker.title" = "父页面";
 
@@ -9866,6 +10180,27 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the post author selection screen */
 "postAuthorPicker.title" = "作者";
+
+/* Title for selecting categories for a post or a page */
+"postCategories.title" = "分类";
+
+/* Toggle label for allowing comments on post */
+"postDiscussion.allowComments.label" = "允许评论";
+
+/* Toggle label for allowing pings/trackbacks on post */
+"postDiscussion.allowPings.label" = "允许 Pingback";
+
+/* Footer text when comments are disabled */
+"postDiscussion.comments.disabled.footer" = "访客不能添加新评论或回复。 现有评论仍然可见。";
+
+/* Footer text when comments are enabled */
+"postDiscussion.comments.enabled.footer" = "访客可以添加新评论或回复。";
+
+/* Link text for learning more about pingbacks and trackbacks */
+"postDiscussion.pingbacks.learnMore.text" = "详细了解 Pingback 和 Trackback";
+
+/* Navigation title for post discussion settings */
+"postDiscussion.title" = "讨论";
 
 /* Button in an alert confirming discaring changes */
 "postEditor.closeConfirmationAlert.discardChanges" = "放弃更改";
@@ -10098,6 +10433,9 @@ Example: Reply to Pamela Nguyen */
 /* A default value for an post without a title */
 "postSaveErrorMessage.postUntitled" = "无标题";
 
+/* Section header for Access settings in Post Settings */
+"postSettings.access.header" = "访问";
+
 /* Label for the author field in Post Settings */
 "postSettings.author.label" = "作者";
 
@@ -10116,6 +10454,18 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the discard changes confirmation dialog */
 "postSettings.discardChanges.title" = "放弃更改？";
+
+/* Status text when discussion (comments) is disabled */
+"postSettings.discussion.closed" = "已关闭";
+
+/* Label for the discussion settings field in Post Settings */
+"postSettings.discussion.label" = "讨论";
+
+/* Status text when discussion (comments) is enabled */
+"postSettings.discussion.open" = "打开";
+
+/* Label for the checkbox that lets you send a post to newsletter subscribers */
+"postSettings.emailToSubscribers.label" = "向订阅者发送电子邮件";
 
 /* Character count for excerpt. %1$d is the number of characters. */
 "postSettings.excerpt.characterCount" = "%1$d 个字符";
@@ -10216,6 +10566,21 @@ Example: Reply to Pamela Nguyen */
 /* Cell title for the Top Level option case */
 "postSettings.parentPage.topLevel" = "顶级";
 
+/* Accessibility label for hide password button */
+"postSettings.passwordEntry.hidePassword" = "隐藏密码";
+
+/* Instructions for password entry */
+"postSettings.passwordEntry.instructions" = "输入密码以保护此文章。 只有拥有密码的用户才能查看。";
+
+/* Navigation title for password entry screen */
+"postSettings.passwordEntry.navigationTitle" = "输入密码";
+
+/* Placeholder for password field */
+"postSettings.passwordEntry.placeholder" = "输入密码";
+
+/* Accessibility label for show password button */
+"postSettings.passwordEntry.showPassword" = "显示密码";
+
 /* Label for the permalink field in Post Settings */
 "postSettings.permalink.label" = "固定链接";
 
@@ -10240,17 +10605,59 @@ Example: Reply to Pamela Nguyen */
 /* Section header for General settings in Post Settings */
 "postSettings.section.general" = "常规";
 
+/* Description text explaining what the slug editor does */
+"postSettings.slug.customizeDescription" = "自定义固定链接的最后一部分。";
+
 /* Hint text for the slug field. Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso. */
 "postSettings.slug.hint" = "别名是适合在 URL 中使用的文章标题版本。";
 
 /* Label for the slug field. Should be the same as WP core. */
 "postSettings.slug.label" = "别名";
 
+/* Button text to learn more about permalinks */
+"postSettings.slug.learnMore" = "了解更多";
+
+/* Label for the slug field. Should be the same as WP core. */
+"postSettings.slug.navigationTitle" = "别名";
+
+/* Notice shown when the post doesn't have a remote and permalink template is missing */
+"postSettings.slug.permalinkDraftNotice" = "系统将在草稿保存至服务器时显示建议的固定链接";
+
+/* Label for the permalink preview */
+"postSettings.slug.permalinkLabel" = "固定链接";
+
+/* Section title for the permalink preview */
+"postSettings.slug.permalinkSection" = "固定链接";
+
 /* Placeholder for the slug field */
 "postSettings.slug.placeholder" = "输入别名";
 
 /* Label for the preview button in Post Settings */
 "postSettings.socialSharing.header" = "社交共享";
+
+/* Label for the status field in Post Settings */
+"postSettings.status.label" = "状态";
+
+/* Navigation title for status picker */
+"postSettings.statusPicker.navigationTitle" = "状态和可见性";
+
+/* Label showing the current password */
+"postSettings.statusPicker.passwordLabel" = "密码";
+
+/* Toggle label for password protection */
+"postSettings.statusPicker.passwordProtected" = "受密码保护";
+
+/* Subtitle for password protected toggle */
+"postSettings.statusPicker.passwordProtectedSubtitle" = "仅对知道密码的人可见";
+
+/* Label for schedule date row */
+"postSettings.statusPicker.scheduleDate" = "日期";
+
+/* Toggle label for sticky posts */
+"postSettings.statusPicker.sticky" = "置顶";
+
+/* Subtitle for sticky toggle */
+"postSettings.statusPicker.stickySubtitle" = "在博客内置顶此文章";
 
 /* Label for the sticky post toggle. Sticky posts are displayed at the top of the blog. */
 "postSettings.stickyPost.label" = "置顶";
@@ -10270,14 +10677,53 @@ Example: Reply to Pamela Nguyen */
 /* Navigation bar title of the Post Stats screen */
 "postStats.title" = "文章统计数据";
 
-/* Button to add a new tag. %1$@ is the tag name. */
-"postTags.addTag" = "添加标签";
+/* Post status title */
+"postStatus.deleted.details" = "已永久删除";
 
-/* Placeholder text for the tag search field */
-"postTags.searchOrAdd.placeholder" = "搜索或添加标签";
+/* Post status title */
+"postStatus.deleted.title" = "已删除";
 
-/* Title for the tags screen */
-"postTags.title" = "标签";
+/* Post status details */
+"postStatus.draft.details" = "尚未准备好发布";
+
+/* Post status title */
+"postStatus.draft.title" = "草稿";
+
+/* Post status details */
+"postStatus.pending.details" = "待审核后发布";
+
+/* Post status title */
+"postStatus.pending.title" = "待处理";
+
+/* Post status title */
+"postStatus.private.title" = "私人";
+
+/* Post status details */
+"postStatus.published.details" = "所有人可见";
+
+/* Post status title */
+"postStatus.published.title" = "已发布";
+
+/* Post status details */
+"postStatus.scheduled.details" = "在选定的日期自动发布";
+
+/* Post status title */
+"postStatus.scheduled.title" = "已预发布";
+
+/* Post status title */
+"postStatus.trash.details" = "已移至回收站但尚未删除";
+
+/* Post status title */
+"postStatus.trash.title" = "已移至回收站";
+
+/* Button to add a new taxonomy term. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.addTag" = "添加 %1$@";
+
+/* Placeholder text for the taxonomy search field. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.searchOrAdd.placeholder" = "搜索或添加 %1$@";
+
+/* Message shown when no taxonomy terms are selected. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.selectionEmpty" = "未选中任何 %1$@";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "取消";
@@ -10353,9 +10799,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "分类";
-
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "关闭";
 
 /* Button to confirm discarding changes */
 "prepublishing.discardChanges.button" = "放弃更改";
@@ -10444,12 +10887,17 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "警告";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "消息";
+
+/* Placeholder text for the message field in Social Sharing */
+"prepublishing.socialAccounts.messagePlaceholder" = "撰写简短消息，在社交媒体上随文章一同分享";
 
 /* The navigation title for the pre-publishing social accounts screen. */
 "prepublishing.socialAccounts.navigationTitle" = "社交";
+
+/* Table section title */
+"prepublishing.socialAccounts.servicesSectionTitle" = "服务";
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.tags" = "标签";
@@ -11393,6 +11841,18 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Button to progress to the next step after selecting domain in Site Creation */
 "siteCreation.domains.buttons.selectDomain" = "选择域名";
 
+/* Default text for adding a new item when no label is provided */
+"siteCustomTaxonomies.defaultAddNew" = "添加";
+
+/* Description for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.description" = "分类可帮助您在标准分类和标签之外组织内容。";
+
+/* Title for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.title" = "无自定义分类";
+
+/* Navigation title for the custom taxonomies screen */
+"siteCustomTaxonomies.navigationTitle" = "分类";
+
 /* Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio. */
 "siteMedia.accessibilityLabelAudio" = "音频，%@";
 
@@ -11411,8 +11871,77 @@ Feel free to replace it with other bracket types that you think looks better for
 /* Accessibility hint for actions when displaying media items. */
 "siteMedia.cellAccessibilityHint" = "选择媒体。";
 
+/* Label for the alt for a media asset (image) */
+"siteMedia.details.altText" = "替代文本";
+
+/* Verb. Button title. Tapping cancels an action. */
+"siteMedia.details.cancel" = "取消";
+
+/* Noun. Label for the caption for a media asset (image / video) */
+"siteMedia.details.caption" = "说明";
+
+/* Title for button that permanently deletes a media item (photo / video) */
+"siteMedia.details.delete" = "删除";
+
+/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
+"siteMedia.details.deleteConfirmation" = "是否确定要永久删除此项目？";
+
+/* Text displayed in HUD after successfully deleting a media item */
+"siteMedia.details.deleted" = "已删除！";
+
+/* Text displayed in HUD while a media item is being deleted. */
+"siteMedia.details.deleting" = "正在删除...";
+
+/* Label for the description for a media asset (image / video) */
+"siteMedia.details.description" = "描述";
+
+/* Label for the dimensions in pixels for a media asset (image / video) */
+"siteMedia.details.dimensions" = "尺寸";
+
+/* Label for the file name for a media asset (image / video) */
+"siteMedia.details.fileName" = "文件名";
+
+/* Label for the file size for a media asset (image / video) */
+"siteMedia.details.fileSize" = "文件大小";
+
+/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
+"siteMedia.details.fileType" = "文件类型";
+
+/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
+"siteMedia.details.mediaDeleted" = "此媒体项目已被删除。";
+
+/* Noun. Label for the title of a media asset (image / video) */
+"siteMedia.details.title" = "标题";
+
+/* Accessibility label for trash buttons in nav bars */
+"siteMedia.details.trash" = "移至回收站";
+
+/* Text displayed in HUD if there was an error attempting to delete a media item. */
+"siteMedia.details.unableToDeleteMedia" = "无法删除媒体项目。";
+
+/* Error shown when the app fails to load a video from the user's media library. */
+"siteMedia.details.unableToLoadVideo" = "无法加载视频。";
+
+/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
+"siteMedia.details.unableToSaveMedia" = "无法保存媒体项目。";
+
+/* Label for the date a media asset (image / video) was uploaded */
+"siteMedia.details.uploaded" = "已上传";
+
 /* Title for the URL field */
 "siteMedia.details.url" = "URL";
+
+/* Hint for image alt on image settings. */
+"siteMedia.hints.imageAlt" = "图片替代文本";
+
+/* Hint for image caption on image settings. */
+"siteMedia.hints.imageCaption" = "图片说明";
+
+/* Hint for image description on image settings. */
+"siteMedia.hints.imageDescription" = "图片描述";
+
+/* Hint for image title on image settings. */
+"siteMedia.hints.imageTitle" = "图片标题";
 
 /* Accessibility hint for media item preview for user's viewing an item in their media library */
 "siteMediaItem.contentViewAccessibilityHint" = "轻点可全屏查看媒体";
@@ -11510,6 +12039,9 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "隐私";
+
+/* Format string for adding a new taxonomy term. %1$@ is the taxonomy name. */
+"siteTaxonomy.addNew.format" = "添加 %1$@";
 
 /* Hint for users when hidden privacy setting is set */
 "siteVisibility.hidden.hint" = "在站点可以查看之前，访客只能看到“即将推出”的通知。";
@@ -12075,7 +12607,8 @@ Feel free to replace it with other bracket types that you think looks better for
 /* View title for Help & Support page. */
 "support.title" = "帮助";
 
-/* Description for empty state when there are no tags */
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
 "tags.empty.description" = "标签可以帮助您整理内容，让读者更容易找到相关文章。";
 
 /* Title for empty state when there are no tags */
@@ -12152,9 +12685,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "未读";
-
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "站点订阅者";
 
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "站点用户";
@@ -12240,9 +12770,6 @@ Feel free to replace it with other bracket types that you think looks better for
 
 /* The heading at the top of the user list */
 "userlist.title" = "用户";
-
-/* Site Subscribers */
-"users.list.title.subscribers" = "订阅者";
 
 /* Screen title */
 "users.title" = "用户";

--- a/WordPress/Resources/zh-Hant.lproj/Localizable.strings
+++ b/WordPress/Resources/zh-Hant.lproj/Localizable.strings
@@ -1,6 +1,6 @@
-/* Translation-Revision-Date: 2025-10-07 09:54:10+0000 */
+/* Translation-Revision-Date: 2025-11-25 10:54:12+0000 */
 /* Plural-Forms: nplurals=1; plural=0; */
-/* Generator: GlotPress/4.0.1 */
+/* Generator: GlotPress/4.0.3 */
 /* Language: zh_TW */
 
 /* Message to ask the user to send us an email to clear their content. */
@@ -581,8 +581,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Instructions for users with two-factor authentication enabled. */
 "Almost there! Please enter the verification code from your authenticator app." = "快完成了！請輸入驗證器應用程式上的驗證碼。";
 
-/* Image alt attribute option title.
-   Label for the alt for a media asset (image) */
+/* Image alt attribute option title. */
 "Alt Text" = "替代文字";
 
 /* No comment provided by engineer. */
@@ -725,9 +724,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Message prompting the user to confirm that they want to disconnect Jetpack from the site. */
 "Are you sure you want to disconnect Jetpack from the site?" = "你確定要中斷Jetpack？";
-
-/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
-"Are you sure you want to permanently delete this item?" = "確定要永久刪除這些項目？";
 
 /* Text for the alert to confirm a plugin removal. %1$@ is the plugin name, %2$@ is the site title. */
 "Are you sure you want to remove %1$@ from %2$@?" = "確定要從 %2$@ 移除 %1$@？";
@@ -1082,7 +1078,6 @@ translators: %s: Block name e.g. \"Image block\" */
    Title. Title of a cancel button. Tapping disnisses an alert.
    Verb. A button title.
    Verb. A button title. Tapping cancels an action.
-   Verb. Button title. Tapping cancels an action.
    Verb. Tapping cancels the publicize account selection.
    Verb. Title for Jetpack Restore cancel button. */
 "Cancel" = "取消";
@@ -1110,8 +1105,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Helper text that appears at the bottom of the design screen. */
 "Can’t decide? You can change the theme at any time." = "下不了決定嗎？ 你可以隨時變更佈景主題。";
 
-/* Image caption field label (for editing)
-   Noun. Label for the caption for a media asset (image / video) */
+/* Image caption field label (for editing) */
 "Caption" = "媒體說明文字";
 
 /* Alert title. */
@@ -1777,8 +1771,7 @@ translators: %s: Block name e.g. \"Image block\" */
    Placeholder text displayed in the share extension's summary view. It lets the user know the default category will be used on their post. */
 "Default" = "預設";
 
-/* Label for selecting the default category of a post
-   Title for selecting a default category for a post */
+/* Label for selecting the default category of a post */
 "Default Category" = "預設類別";
 
 /* Label for selecting the default post format
@@ -1787,9 +1780,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Discussion Settings: Posts Section */
 "Defaults for New Posts" = "新文章預設值";
-
-/* Title for button that permanently deletes a media item (photo / video) */
-"Delete" = "刪除";
 
 /* Menus confirmation button for deleting a menu. */
 "Delete Menu" = "刪除選單";
@@ -1808,14 +1798,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Screen Reader: Button that deletes a menu. */
 "Delete menu" = "刪除選單";
 
-/* Text displayed in HUD after successfully deleting a media item */
-"Deleted!" = "已刪除！";
-
 /* Overlay message displayed while deleting site */
 "Deleting site…" = "正在刪除網站…";
-
-/* Text displayed in HUD while a media item is being deleted. */
-"Deleting..." = "正在刪除…";
 
 /* Verb. Denies a 2fa authentication challenge. */
 "Deny" = "拒絕";
@@ -1823,8 +1807,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "Describe the purpose of the image. Leave empty if decorative." = "請說明圖片用途。 如果是為了裝飾，請保留空白。";
 
-/* Label for the description for a media asset (image / video)
-   Title of section that contains plugins' description */
+/* Title of section that contains plugins' description */
 "Description" = "敘述";
 
 /* Shortened version of the main title to be used in back navigation. */
@@ -1842,9 +1825,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* Instructions after a Magic Link was sent, but email is incorrect. */
 "Didn't mean to create a new account? Go back to re-enter your email address." = "並不是想要建立新帳號嗎？ 返回並重新輸入電子郵件地址。";
-
-/* Label for the dimensions in pixels for a media asset (image / video) */
-"Dimensions" = "尺寸";
 
 /* Title. Title of a button that will disable group invite links when tapped. */
 "Disable" = "停用";
@@ -2118,7 +2098,7 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Editing GIF alert message. */
 "Editing this GIF will remove its animation." = "編輯此 GIF 會移除動畫。";
 
-/* Title for the editor settings section */
+/* Title for the editor section in site settings screen */
 "Editor" = "編輯器";
 
 /* VoiceOver accessibility hint, informing the user the button can be used to Edit the Comment. */
@@ -2460,11 +2440,8 @@ translators: %s: Block name e.g. \"Image block\" */
 /* No comment provided by engineer. */
 "File block settings" = "檔案區塊設定";
 
-/* Label for the file name for a media asset (image / video) */
+/* No comment provided by engineer. */
 "File name" = "檔案名稱";
-
-/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
-"File type" = "檔案類型";
 
 /* No comment provided by engineer. */
 "File type not supported as a media file." = "媒體檔案不支援的檔案類型。";
@@ -2778,6 +2755,9 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Example post content used in the login prologue screens. */
 "I am so inspired by photographer Cameron Karsten's work. I will be trying these techniques on my next" = "攝影師 Cameron Karsten 的作品讓我深受啟發。 我下次會嘗試這些技巧";
 
+/* Text on the support form to refer to what area the user has problem with. */
+"I need help with" = "我需要協助處理";
+
 /* Describes the IP address section in the comment detail screen. */
 "IP address" = "IP 位址";
 
@@ -2823,9 +2803,6 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Hint for image caption on image settings. */
 "Image Caption" = "圖片說明";
 
-/* Hint for image description on image settings. */
-"Image Description" = "圖片內容說明";
-
 /* Hint for image link on image settings. */
 "Image Link" = "圖片連結";
 
@@ -2837,9 +2814,6 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Image file not found." = "找不到圖片檔案。";
-
-/* Hint for image title on image settings. */
-"Image title" = "圖片標題";
 
 /* Explain what is the purpose of the tagline */
 "In a few words, explain what this site is about." = "請用簡單幾字描述此網站的內容。";
@@ -3202,6 +3176,12 @@ translators: %s: Block name e.g. \"Image block\" */
 /* Title for the button that will dismiss this view. */
 "Let me know when finished!" = "完成時通知我！";
 
+/* Message info on the support screen. */
+"Let us know your site address (URL) and tell us as much as you can about the problem, and we will be in touch soon." = "請告訴我們你的網站位址 (URL)，並盡可能詳盡描述你的問題，我們會盡速與你聯絡。";
+
+/* Title to let the user know what do we want on the support screen. */
+"Let’s get this sorted" = "讓我們準備好所需資訊";
+
 /* Lifestyle site intent topic */
 "Lifestyle" = "生活風格";
 
@@ -3402,6 +3382,9 @@ translators: %s: Block name e.g. \"Image block\" */
 
 /* No comment provided by engineer. */
 "Main Navigation" = "主導覽";
+
+/* Explanation for the option to enable theme styles */
+"Make the block editor look like your theme." = "讓區塊編輯器看起來像你的佈景主題。";
 
 /* No comment provided by engineer. */
 "Make your content stand out by adding images, gifs, videos, and embedded media to your pages." = "為頁面新增圖片、GIF、影片和嵌入式媒體，讓你的內容脫穎而出。";
@@ -3744,9 +3727,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Title of an error message. There were no third-party service accounts found to setup sharing. */
 "No Accounts Found" = "找不到帳號";
-
-/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
-"No Category" = "無類別";
 
 /* Title of error prompt when no internet connection is available. */
 "No Connection" = "沒有連線";
@@ -4188,9 +4168,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
    Settings: Comments Paging preferences */
 "Paging" = "分頁";
 
-/* Title for selecting parent category of a category */
-"Parent Category" = "上層分類";
-
 /* Parenting site intent topic */
 "Parenting" = "育兒";
 
@@ -4405,9 +4382,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 /* Noun. Type of content being selected is a blog post
    Title shown when selecting a post type of Post from the Share Extension. */
 "Post" = "張貼";
-
-/* Title for selecting categories for a post */
-"Post Categories" = "文章類別";
 
 /* Name of the button to open the post settings */
 "Post Settings" = "文章設定";
@@ -4716,9 +4690,6 @@ translators: %s: Select control button label e.g. \"Button width\" */
 
 /* Explanatory text for removing the location from uploaded media. */
 "Removes location metadata from photos before uploading them to your site." = "將相片上傳至網站前，請先從相片移除位置中繼資料。";
-
-/* First line of remove follower warning in confirmation dialog. */
-"Removing followers makes them stop receiving updates from your site. If they choose to, they can still visit your site, and follow it again." = "移除追蹤者，使其停止接收網站的更新內容。 如果他們願意，仍可造訪你的網站並再次追蹤。";
 
 /* No comment provided by engineer. */
 "Replace Current Block" = "取代目前區塊";
@@ -5555,6 +5526,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 "Tagline" = "標語";
 
 /* Label for selecting the blogs tags
+   Post tags.
    Tags menu item in share extension. */
 "Tags" = "標籤";
 
@@ -5651,6 +5623,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility hint, informing user the button can be used to visit the Gravatar website. */
 "Tap to visit the Gravatar website in an external browser" = "點選即可透過外部瀏覽器造訪 Gravatar 網站";
+
+/* Label for viewing the custom taxonomies */
+"Taxonomies" = "分類法";
 
 /* Technology site intent topic */
 "Technology" = "科技";
@@ -5940,9 +5915,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Error message shown when the user scanned an expired log in code. */
 "This log in code has expired. Please tap the Scan Again button to rescan the code." = "此登入碼已過期。 請點選「重新掃描」按鈕以重新掃描代碼。";
 
-/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
-"This media item has been deleted." = "此媒體項目已刪除。";
-
 /* Error message displayed when unable to close user account due to unresolved chargebacks. */
 "This user account cannot be closed if there are unresolved chargebacks." = "如果有未解決的退款，將無法關閉此使用者帳號。";
 
@@ -6011,7 +5983,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Accessibility label for web page preview title
    Label for list of stats by content title.
-   Noun. Label for the title of a media asset (image / video)
    Placeholder for the post title.
    Post title */
 "Title" = "標題";
@@ -6105,8 +6076,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* No comment provided by engineer. */
 "Transform block…" = "轉換區塊…";
 
-/* Accessibility label for trash buttons in nav bars
-   Trashes a comment
+/* Trashes a comment
    Trashes the comment */
 "Trash" = "移至回收桶";
 
@@ -6203,9 +6173,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to create new invite links." = "無法新建邀請連結。";
 
-/* Text displayed in HUD if there was an error attempting to delete a media item. */
-"Unable to delete media item." = "無法刪除媒體項目。";
-
 /* An error message shown when there is an issue creating new invite links. */
 "Unable to disable invite links." = "無法停用邀請連結。";
 
@@ -6236,9 +6203,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
    Informing the user that a network request failed becuase the device wasn't able to establish a network connection. */
 "Unable to load this content right now." = "目前無法載入此內容。";
 
-/* Error shown when the app fails to load a video from the user's media library. */
-"Unable to load video." = "無法載入影片。";
-
 /* Dialog box title for when the user is canceling an upload. */
 "Unable to play video" = "無法播放影片";
 
@@ -6247,9 +6211,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* Title for the Jetpack Restore Failed message. */
 "Unable to restore your site" = "無法還原網站";
-
-/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
-"Unable to save media item." = "無法儲存媒體項目。";
 
 /* Message displayed when sharing a link to the downloadable backup fails. */
 "Unable to share link" = "無法分享連結";
@@ -6406,9 +6367,6 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* System notification displayed to the user when media files have failed to upload. */
 "Upload failed" = "上傳失敗";
 
-/* Label for the date a media asset (image / video) was uploaded */
-"Uploaded" = "已上傳";
-
 /* Local notification displayed to the user when a single draft post and multiple files have uploaded successfully. */
 "Uploaded 1 draft post, %ld files" = "已上傳 1 篇文章草稿、%ld 個檔案";
 
@@ -6450,6 +6408,9 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 
 /* The button title text for logging in with WP.com password instead of magic link. */
 "Use password to sign in" = "使用密碼登入";
+
+/* Option to enable theme styles in the block editor */
+"Use theme styles" = "使用佈景主題樣式";
 
 /* A placeholder for the twitter username
    Accessibility label for the username text field in the self-hosted login page.
@@ -6897,7 +6858,7 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Accessibility label for the Stats' world map. */
 "World map showing views by country." = "依國家顯示世界地圖的檢視次數。";
 
-/* Second line of Remove user/follower/viewer warning in confirmation dialog. */
+/* Second line of Remove user/viewer warning in confirmation dialog. */
 "Would you still like to remove this person?" = "仍要移除這位使用者嗎？";
 
 /* Button title. Opens the editor to write a new post.
@@ -7368,14 +7329,19 @@ translators: %s: Select control option value e.g: \"Auto, 25%\". */
 /* Description for the prompt to upgrade to Application Passwords. The first argument is the name of the feature that requires Application Passwords. */
 "applicationPasswordRequired.description" = "應用程式密碼可提供更安全的自助託管網站連結方式，還支援「%@」等功能。";
 
+/* Feature name for managing application passwords in the app */
+"applicationPasswordRequired.feature.applicationPasswords" = "應用程式密碼管理";
+
 /* Feature name for the block editor in application password required prompt */
 "applicationPasswordRequired.feature.blockEditor" = "區塊編輯器";
+
+/* Feature name for managing terms and taxonomies in the app */
+"applicationPasswordRequired.feature.customTaxonomies" = "分類法管理";
 
 /* Feature name for managing plugins in the app */
 "applicationPasswordRequired.feature.plugins" = "外掛程式管理";
 
-/* Feature name for managing application passwords in the app
-   Feature name for managing users in the app */
+/* Feature name for managing users in the app */
 "applicationPasswordRequired.feature.users" = "使用者管理";
 
 /* Title for the button to authenticate with Application Passwords */
@@ -7598,6 +7564,285 @@ Note that the word 'go' here should have a closer meaning to 'start' rather than
 
 /* Post Editor / Button in the 'More' menu */
 "classicEditor.moreMenu.saveDraft" = "儲存草稿";
+
+/* Button to add more screenshots */
+"com.jetpack.support.addMoreScreenshots" = "新增更多螢幕截圖";
+
+/* Button to add screenshots */
+"com.jetpack.support.addScreenshots" = "新增螢幕截圖";
+
+/* Header for application logs section */
+"com.jetpack.support.applicationLogs" = "應用程式記錄檔";
+
+/* Description explaining why including logs is helpful */
+"com.jetpack.support.applicationLogsDescription" = "若包含記錄，就能協助我們的團隊調查問題。 記錄檔可能包含最近的應用程式活動。";
+
+/* Navigation title for application logs screen */
+"com.jetpack.support.applicationLogsTitle" = "應用程式記錄檔";
+
+/* Format string for attachment identifier */
+"com.jetpack.support.attachment" = "附件 %@";
+
+/* Format string for attachment size limit. %1$@ is current size, %2$@ is maximum size */
+"com.jetpack.support.attachmentLimit" = "附件大小上限：%1$@\/%2$@";
+
+/* Bot greeting message. %1$@ is the user's name */
+"com.jetpack.support.botGreeting" = "%1$@，您好！";
+
+/* Bot introduction message explaining its purpose */
+"com.jetpack.support.botIntroduction" = "我是你的個人 AI 助理。 如果你有任何關於網站或帳號的問題，我都能提供協助。";
+
+/* Format string for cache file count and size. %1$d is the number of files, %2$@ is the formatted size. The system will pluralize 'files' based on the number – please specify it as the largest plural value */
+"com.jetpack.support.cacheFiles" = "%1$d 個快取檔案 (%2$@)";
+
+/* Message shown when cache has no files */
+"com.jetpack.support.cacheIsEmpty" = "快取沒有內容";
+
+/* Button to cancel current action */
+"com.jetpack.support.cancel" = "取消";
+
+/* Warning message that deleted logs cannot be recovered */
+"com.jetpack.support.cannotRecoverLogs" = "檔案一經刪除將無法恢復。";
+
+/* Button to clear all activity logs */
+"com.jetpack.support.clearAllActivityLogs" = "清除所有活動記錄";
+
+/* Button to clear disk cache */
+"com.jetpack.support.clearDiskCache" = "清除磁碟快取";
+
+/* Description explaining the purpose of clearing disk cache */
+"com.jetpack.support.clearDiskCacheDescription" = "移除暫存檔案，以騰出空間或解決問題。";
+
+/* Progress text while clearing cache */
+"com.jetpack.support.clearing" = "正在清除...";
+
+/* Message shown when cache clearing is complete */
+"com.jetpack.support.complete" = "完成";
+
+/* Confirmation message when canceling a draft */
+"com.jetpack.support.confirmCancelMessage" = "你確定要取消此訊息？ 您輸入的任何資料都會遺失";
+
+/* Title for alert confirming cancellation */
+"com.jetpack.support.confirmCancellation" = "確認取消";
+
+/* Confirmation dialog title when deleting all logs */
+"com.jetpack.support.confirmDeleteAllLogs" = "你確定要刪除所有記錄嗎？";
+
+/* Section title for contact information */
+"com.jetpack.support.contactInformation" = "聯絡資訊";
+
+/* Button to continue editing a message */
+"com.jetpack.support.continueWriting" = "繼續撰寫";
+
+/* Message shown at end of closed support conversation */
+"com.jetpack.support.conversationEnded" = "對談結束。 無法進一步回覆。";
+
+/* Navigation title for bot conversations list */
+"com.jetpack.support.conversations" = "對談";
+
+/* Button to delete all log files */
+"com.jetpack.support.deleteAllLogs" = "刪除所有記錄";
+
+/* Description text for diagnostics screen */
+"com.jetpack.support.diagnosticsDescription" = "執行一般維護和疑難排解工作項目。";
+
+/* Navigation title for diagnostics screen */
+"com.jetpack.support.diagnosticsTitle" = "診斷";
+
+/* Button to discard changes in a draft message */
+"com.jetpack.support.discardChanges" = "捨棄變更";
+
+/* Notice explaining where support will send email responses */
+"com.jetpack.support.emailNotice" = "我們會傳送電子郵件到這個地址。";
+
+/* Error title when logs fail to load */
+"com.jetpack.support.errorLoadingLogs" = "載入記錄檔時發生錯誤";
+
+/* Error message when support conversations fail to load */
+"com.jetpack.support.errorLoadingSupportConversations" = "載入支援對談時發生錯誤";
+
+/* Title for error alerts */
+"com.jetpack.support.errorTitle" = "錯誤";
+
+/* Option to export log as a file */
+"com.jetpack.support.exportAsFile" = "匯出為檔案";
+
+/* Button to dismiss alerts. */
+"com.jetpack.support.gotIt" = "收到";
+
+/* Text on the support form to refer to what area the user has problem with. */
+"com.jetpack.support.iNeedHelp" = "我需要協助處理";
+
+/* Toggle label to include application logs in the support request */
+"com.jetpack.support.includeApplicationLogs" = "包含應用程式記錄檔";
+
+/* Section title for issue details */
+"com.jetpack.support.issueDetails" = "問題詳細資料";
+
+/* Format string for when conversation was last updated */
+"com.jetpack.support.lastUpdated" = "最近更新：%@";
+
+/* Progress message while loading conversation messages */
+"com.jetpack.support.loadingBotConversationMessages" = "正在載入訊息";
+
+/* Progress message while loading bot conversations */
+"com.jetpack.support.loadingBotConversations" = "正在載入 Bot 對談";
+
+/* Progress text while loading support conversations */
+"com.jetpack.support.loadingConversations" = "正在載入對談";
+
+/* Progress message while loading disk usage information */
+"com.jetpack.support.loadingDiskUsage" = "正在載入磁碟使用量";
+
+/* Progress message while loading an image attachment */
+"com.jetpack.support.loadingImage" = "正在載入圖片";
+
+/* Progress message shown in overlay while refreshing content */
+"com.jetpack.support.loadingLatestContent" = "正在載入最新內容";
+
+/* Progress message while loading application log content */
+"com.jetpack.support.loadingLogContent" = "正在載入記錄檔內容...";
+
+/* Progress message while loading log files */
+"com.jetpack.support.loadingLogs" = "正在載入記錄檔...";
+
+/* Progress text while loading conversation messages */
+"com.jetpack.support.loadingMessages" = "正在載入訊息";
+
+/* Progress message while loading a video attachment */
+"com.jetpack.support.loadingVideo" = "正在載入影片";
+
+/* Section header for log files sorted by date */
+"com.jetpack.support.logFilesByDate" = "依建立日期排列記錄檔案";
+
+/* Text indicating which log files will be included in the support request */
+"com.jetpack.support.logFilesToUpload" = "將會上傳下列記錄檔：";
+
+/* Footer text explaining log retention policy */
+"com.jetpack.support.logRetentionNotice" = "可儲存最多七天的記錄。";
+
+/* Section header for message text input */
+"com.jetpack.support.message" = "訊息";
+
+/* Success message when reply is sent successfully */
+"com.jetpack.support.messageSent" = "已傳送的訊息";
+
+/* Format string for number of messages in conversation */
+"com.jetpack.support.messagesCount" = "%d 則訊息";
+
+/* The title of a new bot chat in the support area of the app */
+"com.jetpack.support.new-bot-chat" = "新的 Bot 對談";
+
+/* Option to create a new support ticket */
+"com.jetpack.support.newSupportTicket" = "新的客服支援單";
+
+/* Label shown when there are no bot conversations */
+"com.jetpack.support.noConversations" = "沒有對談";
+
+/* Description shown when no log files are available */
+"com.jetpack.support.noLogsAvailable" = "沒有可用的活動記錄";
+
+/* Label shown when no log files are available */
+"com.jetpack.support.noLogsFound" = "找不到記錄";
+
+/* Button to open a support ticket */
+"com.jetpack.support.openSupportTicket" = "開立客服支援單";
+
+/* Text indicating a field is optional */
+"com.jetpack.support.optional" = "(非必要)";
+
+/* Navigation title for replying to a support conversation */
+"com.jetpack.support.reply" = "回覆";
+
+/* Description for saving log as a file */
+"com.jetpack.support.saveAsFile" = "儲存為可分享或儲存的檔案";
+
+/* Label for screenshots section */
+"com.jetpack.support.screenshots" = "螢幕截圖";
+
+/* Description for screenshots section */
+"com.jetpack.support.screenshotsDescription" = "若新增螢幕截圖，就能協助我們迅速瞭解並加快問題解決速度。";
+
+/* Button to send a message or reply */
+"com.jetpack.support.send" = "傳送";
+
+/* Description for sending logs to support */
+"com.jetpack.support.sendLogsToSupport" = "將記錄直送支援團隊";
+
+/* Progress text while sending a message */
+"com.jetpack.support.sending" = "正在傳送";
+
+/* Progress message shown while sending a message */
+"com.jetpack.support.sendingMessage" = "傳送訊息";
+
+/* Button to share content */
+"com.jetpack.support.share" = "分享";
+
+/* Navigation title for sharing activity log */
+"com.jetpack.support.shareActivityLog" = "分享活動記錄";
+
+/* Message shown when sharing log with support */
+"com.jetpack.support.sharingWithSupport" = "與支援團隊分享！";
+
+/* Site Address title on the support form */
+"com.jetpack.support.siteAddress" = "網站位址";
+
+/* Description encouraging user to start a new conversation */
+"com.jetpack.support.startNewConversation" = "使用上方按鈕開始新的對談";
+
+/* Subject title on the support form */
+"com.jetpack.support.subject" = "主旨";
+
+/* Placeholder for subject field */
+"com.jetpack.support.subjectPlaceholder" = "問題的簡短摘要";
+
+/* Button title to submit a support request. */
+"com.jetpack.support.submitRequest" = "提交支援請求";
+
+/* Navigation title for the support conversations list */
+"com.jetpack.support.supportConversations" = "支援對談";
+
+/* Title for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSent" = "已傳送要求！";
+
+/* Message for the alert after the support request is created. */
+"com.jetpack.support.supportRequestSentMessage" = "已成功傳送你的支援申請。 會盡快透過電子郵件回覆你。";
+
+/* Progress message shown while bot is thinking */
+"com.jetpack.support.thinking" = "正在思考...";
+
+/* Title of the view for contacting support. */
+"com.jetpack.support.title" = "聯絡支援團隊";
+
+/* Button to retry a failed operation */
+"com.jetpack.support.tryAgain" = "請再試一次";
+
+/* Error title when log deletion fails */
+"com.jetpack.support.unableToDeleteLogs" = "無法刪除記錄檔";
+
+/* Error message when conversation cannot be displayed */
+"com.jetpack.support.unableToDisplayConversation" = "無法顯示對談";
+
+/* Error title when video cannot be loaded or played */
+"com.jetpack.support.unableToDisplayVideo" = "無法顯示影片";
+
+/* Error message when application logs cannot be loaded */
+"com.jetpack.support.unableToLoadApplicationLogs" = "無法載入應用程式記錄";
+
+/* Error title when bot conversations fail to load */
+"com.jetpack.support.unableToLoadConversations" = "無法載入對談";
+
+/* Error title when messages fail to load */
+"com.jetpack.support.unableToLoadMessages" = "無法載入訊息";
+
+/* Error title when message sending fails */
+"com.jetpack.support.unableToSendMessage" = "無法傳送訊息";
+
+/* Button to view an attachment */
+"com.jetpack.support.view" = "檢視";
+
+/* Progress message shown during cache clearing operation */
+"com.jetpack.support.working" = "處理中";
 
 /* Displayed in the confirmation alert when marking comment notifications as read. */
 "comment" = "留言";
@@ -7861,6 +8106,9 @@ Example: Reply to Pamela Nguyen */
 /* Weekly Roundup debug menu item */
 "debugMenu.weeklyRoundup" = "每週綜合整理";
 
+/* Title for selecting a default category for a post */
+"defaultCategory.title" = "預設分類";
+
 /* Error tilte */
 "discussionSettings.saveErrorTitle" = "無法儲存設定";
 
@@ -8000,10 +8248,10 @@ Example: Reply to Pamela Nguyen */
 "double-tap to change unit" = "點兩下即可變更單位";
 
 /* Message for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.message" = "你確定要刪除這個標籤嗎？";
+"edit.tag.delete.confirmation.message" = "你確定要刪除嗎？";
 
-/* Title for delete tag confirmation dialog */
-"edit.tag.delete.confirmation.title" = "刪除標籤";
+/* Title for delete a term confirmation dialog */
+"edit.tag.delete.confirmation.title" = "刪除";
 
 /* Placeholder text for tag description field */
 "edit.tag.description.placeholder" = "新增說明...";
@@ -8018,7 +8266,37 @@ Example: Reply to Pamela Nguyen */
 "edit.tag.section.description" = "說明";
 
 /* Section header for tag name in edit tag view */
-"edit.tag.section.tag" = "標籤";
+"edit.tag.section.tag" = "名稱";
+
+/* Context menu action to insert a block */
+"editor.blockInserter.insertBlock" = "插入區塊";
+
+/* Placeholder text for block search field */
+"editor.blockInserter.search" = "搜尋";
+
+/* Button title to collapse and show fewer blocks */
+"editor.blockInserter.showLess" = "顯示較少項目";
+
+/* Button title to expand and show more blocks */
+"editor.blockInserter.showMore" = "顯示更多項目";
+
+/* Error message when media insertion fails */
+"editor.media.failedToInsert" = "無法插入媒體檔";
+
+/* Category name for section showing all patterns */
+"editor.patterns.all" = "全部";
+
+/* Context menu action to insert a pattern */
+"editor.patterns.insertPattern" = "插入版面配置";
+
+/* Title shown when no patterns match the search */
+"editor.patterns.noPatternsFound" = "找不到版面配置";
+
+/* Navigation title for patterns view */
+"editor.patterns.title" = "版面配置";
+
+/* Category name for patterns without a category */
+"editor.patterns.uncategorized" = "未分類";
 
 /* Register Domain - Address information field Number placeholder */
 "eg. 1122334455" = "例如：1122334455";
@@ -8572,6 +8850,24 @@ Example: Reply to Pamela Nguyen */
 
 /* Write a blog prompt for the jetpack prologue */
 "jetpack.prologue.prompt.writeBlog" = "撰寫網誌";
+
+/* Description for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.description" = "任何人都可以檢視這篇文章";
+
+/* Title for post access level that allows everyone to view the post */
+"jetpackPostAccessLevel.everybody.title" = "所有人";
+
+/* Description for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.description" = "只有付費訂閱者才能檢視這篇文章";
+
+/* Title for post access level that allows only paid subscribers to view the post */
+"jetpackPostAccessLevel.paidSubscribers.title" = "付費訂閱者";
+
+/* Description for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.description" = "所有訂閱者 (包括免費讀者) 都看得到這篇文章";
+
+/* Title for post access level that allows only subscribers to view the post */
+"jetpackPostAccessLevel.subscribers.title" = "所有訂閱者";
 
 /* Message stating that the user is unable to use Stats and Notifications because their site is connected to a different WordPress.com account */
 "jetpackSite.connectToDefaultAccount" = "如需使用統計與通知，請以 %@ 登入。";
@@ -9162,6 +9458,12 @@ Example: Reply to Pamela Nguyen */
 /* Error message that informs likes from a private blog cannot be fetched. */
 "likesListViewController.likesList.privateBlogErrorMessage" = "你沒有檢視此私人網誌的權限。";
 
+/* Default empty state message format when there are no terms. %1$@ is the taxonomy name. */
+"localizedLabels.defaultNoTerms.format" = "沒有「%1$@」";
+
+/* Default search placeholder format. %1$@ is the taxonomy name. */
+"localizedLabels.defaultSearch.format" = "搜尋「%1$@」";
+
 /* Button to dismiss the re-authentication view */
 "login.appPasswordReAuth.cancelButton" = "取消";
 
@@ -9297,17 +9599,23 @@ Example: Reply to Pamela Nguyen */
 /* Message about buying storage add-on */
 "mediaLibrary.storageDetails.buyStorage.message" = "購買儲存空間附加元件";
 
-/* Message shown when all media items are attached */
-"mediaLibrary.storageDetails.cleanup.allAttached" = "已附加媒體庫中的所有項目。";
+/* Label for audio media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.audio" = "音訊";
 
-/* Message shown while loading unattached media count */
-"mediaLibrary.storageDetails.cleanup.loading" = "正在尋找是否有任何未附加的媒體項目…";
+/* Label for document media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.document" = "文件";
 
-/* Message about unattached media that can be cleaned up. %1$d is the count of unattached media. */
-"mediaLibrary.storageDetails.cleanup.message" = "%1$d 個未附加的項目。 移除這些項目以釋放儲存空間。";
+/* Label for image media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.image" = "圖片";
 
-/* Title for cleanup section */
-"mediaLibrary.storageDetails.cleanup.title" = "移除未使用的項目";
+/* Label for other/unknown media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.other" = "其他";
+
+/* Label for PowerPoint/presentation media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.powerpoint" = "簡報";
+
+/* Label for video media type in storage breakdown */
+"mediaLibrary.storageDetails.mediaType.video" = "影片";
 
 /* Success message shown after upgrading plan */
 "mediaLibrary.storageDetails.purchase.plan.success" = "你的網站方案已升級！";
@@ -9693,6 +10001,12 @@ Example: Reply to Pamela Nguyen */
 /* Menu option for filtering posts by me */
 "pagesList.pagesByMe" = "我的頁面";
 
+/* Text shown (to select no-category) in the parent-category-selection screen when creating a new category. */
+"parentCategory.noCategory" = "無類別";
+
+/* Title for selecting parent category of a category */
+"parentCategory.title" = "上層分類";
+
 /* Title for the parent page picker screen */
 "parentPagePicker.title" = "上層頁面";
 
@@ -9851,6 +10165,27 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the post author selection screen */
 "postAuthorPicker.title" = "作者";
+
+/* Title for selecting categories for a post or a page */
+"postCategories.title" = "分類";
+
+/* Toggle label for allowing comments on post */
+"postDiscussion.allowComments.label" = "允許留言";
+
+/* Toggle label for allowing pings/trackbacks on post */
+"postDiscussion.allowPings.label" = "允許引用通知";
+
+/* Footer text when comments are disabled */
+"postDiscussion.comments.disabled.footer" = "訪客無法新增新的留言或回覆。 現有留言維持可見。";
+
+/* Footer text when comments are enabled */
+"postDiscussion.comments.enabled.footer" = "訪客可以新增新的留言與回覆。";
+
+/* Link text for learning more about pingbacks and trackbacks */
+"postDiscussion.pingbacks.learnMore.text" = "深入了解引用通知和通告";
+
+/* Navigation title for post discussion settings */
+"postDiscussion.title" = "討論";
 
 /* Button in an alert confirming discaring changes */
 "postEditor.closeConfirmationAlert.discardChanges" = "捨棄變更";
@@ -10083,6 +10418,9 @@ Example: Reply to Pamela Nguyen */
 /* A default value for an post without a title */
 "postSaveErrorMessage.postUntitled" = "無標題";
 
+/* Section header for Access settings in Post Settings */
+"postSettings.access.header" = "存取";
+
 /* Label for the author field in Post Settings */
 "postSettings.author.label" = "作者";
 
@@ -10101,6 +10439,18 @@ Example: Reply to Pamela Nguyen */
 
 /* Title for the discard changes confirmation dialog */
 "postSettings.discardChanges.title" = "要捨棄變更嗎？";
+
+/* Status text when discussion (comments) is disabled */
+"postSettings.discussion.closed" = "已關閉";
+
+/* Label for the discussion settings field in Post Settings */
+"postSettings.discussion.label" = "討論";
+
+/* Status text when discussion (comments) is enabled */
+"postSettings.discussion.open" = "開啟";
+
+/* Label for the checkbox that lets you send a post to newsletter subscribers */
+"postSettings.emailToSubscribers.label" = "傳送電子郵件給訂閱者";
 
 /* Character count for excerpt. %1$d is the number of characters. */
 "postSettings.excerpt.characterCount" = "%1$d 個字元";
@@ -10201,6 +10551,21 @@ Example: Reply to Pamela Nguyen */
 /* Cell title for the Top Level option case */
 "postSettings.parentPage.topLevel" = "最上層";
 
+/* Accessibility label for hide password button */
+"postSettings.passwordEntry.hidePassword" = "隱藏密碼";
+
+/* Instructions for password entry */
+"postSettings.passwordEntry.instructions" = "輸入密碼保護這篇文章。 只有擁有密碼的使用者才能檢視。";
+
+/* Navigation title for password entry screen */
+"postSettings.passwordEntry.navigationTitle" = "輸入密碼";
+
+/* Placeholder for password field */
+"postSettings.passwordEntry.placeholder" = "輸入密碼";
+
+/* Accessibility label for show password button */
+"postSettings.passwordEntry.showPassword" = "顯示密碼";
+
 /* Label for the permalink field in Post Settings */
 "postSettings.permalink.label" = "永久連結";
 
@@ -10225,17 +10590,59 @@ Example: Reply to Pamela Nguyen */
 /* Section header for General settings in Post Settings */
 "postSettings.section.general" = "一般";
 
+/* Description text explaining what the slug editor does */
+"postSettings.slug.customizeDescription" = "自訂永久連結的最後一部分。";
+
 /* Hint text for the slug field. Should be the same as the text displayed if the user clicks the (i) in Slug in Calypso. */
 "postSettings.slug.hint" = "代稱是使 URL 更易讀好記的文章標題版本。";
 
 /* Label for the slug field. Should be the same as WP core. */
 "postSettings.slug.label" = "代稱";
 
+/* Button text to learn more about permalinks */
+"postSettings.slug.learnMore" = "深入了解";
+
+/* Label for the slug field. Should be the same as WP core. */
+"postSettings.slug.navigationTitle" = "代稱";
+
+/* Notice shown when the post doesn't have a remote and permalink template is missing */
+"postSettings.slug.permalinkDraftNotice" = "將草稿儲存於伺服器時，畫面會顯示建議的永久連結";
+
+/* Label for the permalink preview */
+"postSettings.slug.permalinkLabel" = "永久連結";
+
+/* Section title for the permalink preview */
+"postSettings.slug.permalinkSection" = "永久連結";
+
 /* Placeholder for the slug field */
 "postSettings.slug.placeholder" = "輸入代稱";
 
 /* Label for the preview button in Post Settings */
 "postSettings.socialSharing.header" = "社群分享";
+
+/* Label for the status field in Post Settings */
+"postSettings.status.label" = "狀態";
+
+/* Navigation title for status picker */
+"postSettings.statusPicker.navigationTitle" = "狀態及可見度";
+
+/* Label showing the current password */
+"postSettings.statusPicker.passwordLabel" = "密碼";
+
+/* Toggle label for password protection */
+"postSettings.statusPicker.passwordProtected" = "受密碼保護";
+
+/* Subtitle for password protected toggle */
+"postSettings.statusPicker.passwordProtectedSubtitle" = "只有知道密碼的人才看得到";
+
+/* Label for schedule date row */
+"postSettings.statusPicker.scheduleDate" = "日期";
+
+/* Toggle label for sticky posts */
+"postSettings.statusPicker.sticky" = "置頂";
+
+/* Subtitle for sticky toggle */
+"postSettings.statusPicker.stickySubtitle" = "將這則文章釘選至部落格頂端";
 
 /* Label for the sticky post toggle. Sticky posts are displayed at the top of the blog. */
 "postSettings.stickyPost.label" = "置頂";
@@ -10255,14 +10662,53 @@ Example: Reply to Pamela Nguyen */
 /* Navigation bar title of the Post Stats screen */
 "postStats.title" = "文章統計資料";
 
-/* Button to add a new tag. %1$@ is the tag name. */
-"postTags.addTag" = "新增標籤";
+/* Post status title */
+"postStatus.deleted.details" = "已永久刪除";
 
-/* Placeholder text for the tag search field */
-"postTags.searchOrAdd.placeholder" = "搜尋或新增標籤";
+/* Post status title */
+"postStatus.deleted.title" = "已刪除";
 
-/* Title for the tags screen */
-"postTags.title" = "標籤";
+/* Post status details */
+"postStatus.draft.details" = "還沒準備好發表";
+
+/* Post status title */
+"postStatus.draft.title" = "草稿";
+
+/* Post status details */
+"postStatus.pending.details" = "待發表審核";
+
+/* Post status title */
+"postStatus.pending.title" = "待確認";
+
+/* Post status title */
+"postStatus.private.title" = "私人";
+
+/* Post status details */
+"postStatus.published.details" = "所有人都能檢視";
+
+/* Post status title */
+"postStatus.published.title" = "已發表";
+
+/* Post status details */
+"postStatus.scheduled.details" = "在所選日期自動發表";
+
+/* Post status title */
+"postStatus.scheduled.title" = "已排程";
+
+/* Post status title */
+"postStatus.trash.details" = "已移至垃圾桶但尚未刪除";
+
+/* Post status title */
+"postStatus.trash.title" = "已移至垃圾桶";
+
+/* Button to add a new taxonomy term. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.addTag" = "新增「%1$@」";
+
+/* Placeholder text for the taxonomy search field. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.searchOrAdd.placeholder" = "搜尋或新增「%1$@」";
+
+/* Message shown when no taxonomy terms are selected. %1$@ is the taxonomy name (e.g., 'tags', 'categories'). */
+"postTags.selectionEmpty" = "未選取「%1$@」";
 
 /* Button cancel */
 "postVisibilityPicker.cancel" = "取消";
@@ -10338,9 +10784,6 @@ Example: Reply to Pamela Nguyen */
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.categories" = "類別";
-
-/* Voiceover accessibility label informing the user that this button dismiss the current view */
-"prepublishing.close" = "關閉";
 
 /* Button to confirm discarding changes */
 "prepublishing.discardChanges.button" = "捨棄變更";
@@ -10426,12 +10869,17 @@ Example: 27 social shares remaining in the next 30 days */
 /* a VoiceOver description for the warning icon to hint that the remaining shares are low. */
 "prepublishing.socialAccounts.footer.warningIcon.accessibilityHint" = "警告";
 
-/* The label displayed for a table row that displays the sharing message for the post.
-Tapping on this row allows the user to edit the sharing message. */
+/* Table section title */
 "prepublishing.socialAccounts.message.label" = "訊息";
+
+/* Placeholder text for the message field in Social Sharing */
+"prepublishing.socialAccounts.messagePlaceholder" = "撰寫簡短訊息，連同文章一併分享至社群媒體";
 
 /* The navigation title for the pre-publishing social accounts screen. */
 "prepublishing.socialAccounts.navigationTitle" = "社群";
+
+/* Table section title */
+"prepublishing.socialAccounts.servicesSectionTitle" = "服務";
 
 /* Label for a cell in the pre-publishing sheet */
 "prepublishing.tags" = "標籤";
@@ -11360,6 +11808,18 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Button to progress to the next step after selecting domain in Site Creation */
 "siteCreation.domains.buttons.selectDomain" = "選取網域";
 
+/* Default text for adding a new item when no label is provided */
+"siteCustomTaxonomies.defaultAddNew" = "新增";
+
+/* Description for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.description" = "可透過分類法，整理標準分類和標籤以外的內容。";
+
+/* Title for empty state when there are no custom taxonomies */
+"siteCustomTaxonomies.empty.title" = "無自訂的分類法";
+
+/* Navigation title for the custom taxonomies screen */
+"siteCustomTaxonomies.navigationTitle" = "分類法";
+
 /* Accessibility label for audio items in the media collection view. The parameter is the creation date of the audio. */
 "siteMedia.accessibilityLabelAudio" = "音訊，於 %@ 建立";
 
@@ -11378,8 +11838,77 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* Accessibility hint for actions when displaying media items. */
 "siteMedia.cellAccessibilityHint" = "選取媒體。";
 
+/* Label for the alt for a media asset (image) */
+"siteMedia.details.altText" = "替代文字";
+
+/* Verb. Button title. Tapping cancels an action. */
+"siteMedia.details.cancel" = "取消";
+
+/* Noun. Label for the caption for a media asset (image / video) */
+"siteMedia.details.caption" = "說明";
+
+/* Title for button that permanently deletes a media item (photo / video) */
+"siteMedia.details.delete" = "刪除";
+
+/* Message prompting the user to confirm that they want to permanently delete a media item. Should match Calypso. */
+"siteMedia.details.deleteConfirmation" = "你確定要永久刪除這個項目嗎？";
+
+/* Text displayed in HUD after successfully deleting a media item */
+"siteMedia.details.deleted" = "已刪除！";
+
+/* Text displayed in HUD while a media item is being deleted. */
+"siteMedia.details.deleting" = "正在刪除...";
+
+/* Label for the description for a media asset (image / video) */
+"siteMedia.details.description" = "說明";
+
+/* Label for the dimensions in pixels for a media asset (image / video) */
+"siteMedia.details.dimensions" = "尺寸";
+
+/* Label for the file name for a media asset (image / video) */
+"siteMedia.details.fileName" = "檔案名稱";
+
+/* Label for the file size for a media asset (image / video) */
+"siteMedia.details.fileSize" = "檔案大小";
+
+/* Label for the file type (.JPG, .PNG, etc) for a media asset (image / video) */
+"siteMedia.details.fileType" = "檔案類型";
+
+/* Message displayed in Media Library if the user attempts to edit a media asset (image / video) after it has been deleted. */
+"siteMedia.details.mediaDeleted" = "此媒體項目已刪除。";
+
+/* Noun. Label for the title of a media asset (image / video) */
+"siteMedia.details.title" = "標題";
+
+/* Accessibility label for trash buttons in nav bars */
+"siteMedia.details.trash" = "移至垃圾桶";
+
+/* Text displayed in HUD if there was an error attempting to delete a media item. */
+"siteMedia.details.unableToDeleteMedia" = "無法刪除媒體項目。";
+
+/* Error shown when the app fails to load a video from the user's media library. */
+"siteMedia.details.unableToLoadVideo" = "無法載入影片。";
+
+/* Text displayed in HUD when a media item's metadata (title, etc) couldn't be saved. */
+"siteMedia.details.unableToSaveMedia" = "無法儲存媒體項目。";
+
+/* Label for the date a media asset (image / video) was uploaded */
+"siteMedia.details.uploaded" = "已上傳";
+
 /* Title for the URL field */
 "siteMedia.details.url" = "URL";
+
+/* Hint for image alt on image settings. */
+"siteMedia.hints.imageAlt" = "圖片替代文字";
+
+/* Hint for image caption on image settings. */
+"siteMedia.hints.imageCaption" = "圖片說明";
+
+/* Hint for image description on image settings. */
+"siteMedia.hints.imageDescription" = "圖片內容說明";
+
+/* Hint for image title on image settings. */
+"siteMedia.hints.imageTitle" = "圖片標題";
 
 /* Accessibility hint for media item preview for user's viewing an item in their media library */
 "siteMediaItem.contentViewAccessibilityHint" = "點選即可在全螢幕中檢視媒體";
@@ -11477,6 +12006,9 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Title for screen to select the privacy options for a blog */
 "siteSettings.privacy.title" = "隱私權";
+
+/* Format string for adding a new taxonomy term. %1$@ is the taxonomy name. */
+"siteTaxonomy.addNew.format" = "新增「%1$@」";
 
 /* Hint for users when hidden privacy setting is set */
 "siteVisibility.hidden.hint" = "除非網站準備好供訪客瀏覽，否則訪客看不到網站，只看得到「即將推出」通知。";
@@ -12039,7 +12571,8 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 /* View title for Help & Support page. */
 "support.title" = "說明";
 
-/* Description for empty state when there are no tags */
+/* Description for empty state when there are no tags
+   Description for empty state when there are no tags. %1$@ is the taxonomy name. */
 "tags.empty.description" = "可運用標籤整理內容，方便讀者尋找相關文章。";
 
 /* Title for empty state when there are no tags */
@@ -12116,9 +12649,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* Displayed in the confirmation alert when marking unread notifications as read. */
 "unread" = "未讀";
-
-/* Site's Subscriber Profile. Displayed when the name is empty! */
-"user.details.title.subscriber" = "網站的訂閱者";
 
 /* Sites's User Profile. Displayed when the name is empty! */
 "user.details.title.user" = "網站的使用者";
@@ -12204,9 +12734,6 @@ Example: given a notice format "Following %@" and empty site name, this will be 
 
 /* The heading at the top of the user list */
 "userlist.title" = "使用者";
-
-/* Site Subscribers */
-"users.list.title.subscribers" = "訂閱者";
 
 /* Screen title */
 "users.title" = "使用者";

--- a/WordPress/WordPressDraftActionExtension/bg.lproj/InfoPlist.strings
+++ b/WordPress/WordPressDraftActionExtension/bg.lproj/InfoPlist.strings
@@ -2,5 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <!--Warning: Auto-generated file, do not edit.-->
 <plist version="1.0">
-  <dict/>
+  <dict>
+    <key>CFBundleDisplayName</key>
+    <string>Запазване като чернова</string>
+    <key>CFBundleName</key>
+    <string>Запазване като чернова</string>
+  </dict>
 </plist>

--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -499,6 +499,7 @@ end
 lane :lint_localizations do |options|
   ios_lint_localizations(
     input_dir: 'WordPress/Resources',
+    fail_on_strings_not_in_base_language: false,
     allow_retry: options.fetch(:allow_retry, true)
   )
 end


### PR DESCRIPTION
## Why

Last beta lane [failed on `ios_lint_localizations`](https://buildkite.com/automattic/wordpress-ios/builds/29988/steps/canvas?jid=019ac9ab-236c-4e85-b1ae-bb3a65cec80b#019ac9ab-236c-4e85-b1ae-bb3a65cec80b) because a string was removed from the codebase in the code-frozen `release/*` branch in https://github.com/wordpress-mobile/WordPress-iOS/pull/25022.

This caused the linter to complain about this for all locales:
```
`reader.blog.search.loading.title` was unexpected, as it is not present in the base locale.
```

## How

 - Added `fail_on_strings_not_in_base_language: false`  parameter to `ios_lint_translations`
 - Run the `download_localized_strings` lane, to ensure we download the latest translations from GlotPress, especially to get the changes on `postTags.addTag`, `postTags.searchOrAdd.placeholder` and `postTags.selectionEmpty` that apparently had a placeholder added in their English copy since initially introduced (which is quite dangerous as it can lead to crashes if not all locales are translated with the new copy in time, which is the main reason for the localization linting to be in place) and were otherwise (rightfully, this time) generating linter errors.

## Testing instructions

Run `bundle exec fastlane lint_localizations` from this branch and validate it does not error anymore about keys missing in the base locale.
