### PR TITLE
Experiment: Use GutenbergKit distributed via binary target

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -57,7 +57,7 @@ let package = Package(
         // To test https://github.com/wordpress-mobile/GutenbergKit/pull/241
         .package(
             url: "https://github.com/wordpress-mobile/GutenbergKit",
-            revision: "a3276998e2f474f89cd26e196961387b48c94207"
+            revision: "b9f5ca522ac1fd0af43dbbea782a562fe1860ef1"
         ),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20251101"),

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -54,7 +54,11 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/wpxmlrpc", from: "0.9.0"),
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.10.1"),
+        // To test https://github.com/wordpress-mobile/GutenbergKit/pull/241
+        .package(
+            url: "https://github.com/wordpress-mobile/GutenbergKit",
+            revision: "a3276998e2f474f89cd26e196961387b48c94207"
+        ),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20251101"),
         .package(


### PR DESCRIPTION
<!-- red -->
> [!CAUTION]
> The ZIP archive used here no longer exists in S3. I deleted it as part of AINFRA-1608. Do not expect the code to compile.

---

Uses the GutenbergKit build from the experimental branch https://github.com/wordpress-mobile/GutenbergKit/pull/241.

_I tried uploading a recording of the prototype build from this branch but it timed out twice. Available internally at paaHJt-9ds-p2#comment-10938._