### PR TITLE
Rename `AbstractPost.original()`

### DIFF
--- a/Sources/WordPressData/Swift/AbstractPost.swift
+++ b/Sources/WordPressData/Swift/AbstractPost.swift
@@ -5,8 +5,8 @@ import WordPressShared
 public extension AbstractPost {
     /// Returns the original post by navigating the entire list of revisions
     /// until it reaches the head.
-    func rootOriginal() -> AbstractPost {
-        original?.rootOriginal() ?? self
+    func getOriginal() -> AbstractPost {
+        original?.getOriginal() ?? self
     }
 
     /// Returns `true` if the post was never uploaded to the remote and has
@@ -127,7 +127,7 @@ public extension AbstractPost {
         [
             "post_type": analyticsPostType ?? "",
             "status": status?.rawValue ?? "",
-            "original_status": rootOriginal().status?.rawValue ?? "unknown",
+            "original_status": getOriginal().status?.rawValue ?? "unknown",
             "password_protected": PostVisibility(post: self) == .protected
         ]
     }
@@ -226,7 +226,7 @@ public extension AbstractPost {
         guard let previous = revision.original else {
             return wpAssertionFailure("missing original")
         }
-        let original = revision.rootOriginal()
+        let original = revision.getOriginal()
         previous.deleteRevision()
         if previous == original, !previous.hasRemote() {
             context.delete(original)

--- a/Sources/WordPressData/Swift/AbstractPost.swift
+++ b/Sources/WordPressData/Swift/AbstractPost.swift
@@ -5,8 +5,8 @@ import WordPressShared
 public extension AbstractPost {
     /// Returns the original post by navigating the entire list of revisions
     /// until it reaches the head.
-    func original() -> AbstractPost {
-        original?.original() ?? self
+    func rootOriginal() -> AbstractPost {
+        original?.rootOriginal() ?? self
     }
 
     /// Returns `true` if the post was never uploaded to the remote and has
@@ -127,7 +127,7 @@ public extension AbstractPost {
         [
             "post_type": analyticsPostType ?? "",
             "status": status?.rawValue ?? "",
-            "original_status": original().status?.rawValue ?? "unknown",
+            "original_status": rootOriginal().status?.rawValue ?? "unknown",
             "password_protected": PostVisibility(post: self) == .protected
         ]
     }
@@ -226,7 +226,7 @@ public extension AbstractPost {
         guard let previous = revision.original else {
             return wpAssertionFailure("missing original")
         }
-        let original = revision.original()
+        let original = revision.rootOriginal()
         previous.deleteRevision()
         if previous == original, !previous.hasRemote() {
             context.delete(original)

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -89,7 +89,7 @@ class MediaCoordinator: NSObject {
         }
 
         // Use the original post so we don't create new coordinators for post revisions
-        let original = post.original()
+        let original = post.rootOriginal()
 
         let coordinator = MediaProgressCoordinator()
         coordinator.delegate = self
@@ -105,7 +105,7 @@ class MediaCoordinator: NSObject {
     ///            if one does not exist.
     private func cachedCoordinator(for post: AbstractPost) -> MediaProgressCoordinator? {
         // Use the original post so we don't create new coordinators for post revisions
-        let original = post.original()
+        let original = post.rootOriginal()
 
         return progressCoordinatorQueue.sync {
             return postMediaProgressCoordinators[original]
@@ -557,7 +557,7 @@ class MediaCoordinator: NSObject {
     func addObserver(_ onUpdate: @escaping ObserverBlock, forMediaFor post: AbstractPost) -> UUID {
         let uuid = UUID()
 
-        let original = post.original()
+        let original = post.rootOriginal()
         let observer = MediaObserver(subject: .post(id: original.objectID), onUpdate: onUpdate)
 
         queue.async {
@@ -692,7 +692,7 @@ class MediaCoordinator: NSObject {
                 guard let post = object as? AbstractPost else {
                     return nil
                 }
-                return post.original().objectID
+                return post.rootOriginal().objectID
             } ?? []
         }
 

--- a/WordPress/Classes/Services/MediaCoordinator.swift
+++ b/WordPress/Classes/Services/MediaCoordinator.swift
@@ -89,7 +89,7 @@ class MediaCoordinator: NSObject {
         }
 
         // Use the original post so we don't create new coordinators for post revisions
-        let original = post.rootOriginal()
+        let original = post.getOriginal()
 
         let coordinator = MediaProgressCoordinator()
         coordinator.delegate = self
@@ -105,7 +105,7 @@ class MediaCoordinator: NSObject {
     ///            if one does not exist.
     private func cachedCoordinator(for post: AbstractPost) -> MediaProgressCoordinator? {
         // Use the original post so we don't create new coordinators for post revisions
-        let original = post.rootOriginal()
+        let original = post.getOriginal()
 
         return progressCoordinatorQueue.sync {
             return postMediaProgressCoordinators[original]
@@ -557,7 +557,7 @@ class MediaCoordinator: NSObject {
     func addObserver(_ onUpdate: @escaping ObserverBlock, forMediaFor post: AbstractPost) -> UUID {
         let uuid = UUID()
 
-        let original = post.rootOriginal()
+        let original = post.getOriginal()
         let observer = MediaObserver(subject: .post(id: original.objectID), onUpdate: onUpdate)
 
         queue.async {
@@ -692,7 +692,7 @@ class MediaCoordinator: NSObject {
                 guard let post = object as? AbstractPost else {
                     return nil
                 }
-                return post.rootOriginal().objectID
+                return post.getOriginal().objectID
             } ?? []
         }
 

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -103,7 +103,7 @@ class PostCoordinator: NSObject {
     /// Uploads the changes made to the post to the server.
     @discardableResult @MainActor
     func save(_ post: AbstractPost, changes: RemotePostUpdateParameters? = nil) async throws -> AbstractPost {
-        let post = post.rootOriginal()
+        let post = post.getOriginal()
 
         await pauseSyncing(for: post)
         defer { resumeSyncing(for: post) }
@@ -150,7 +150,7 @@ class PostCoordinator: NSObject {
     private func update(_ post: AbstractPost, changes: RemotePostUpdateParameters) async throws {
         wpAssert(post.isOriginal())
 
-        let post = post.rootOriginal()
+        let post = post.getOriginal()
         do {
             try await PostRepository(coreDataStack: coreDataStack).update(post, changes: changes)
         } catch {
@@ -244,7 +244,7 @@ class PostCoordinator: NSObject {
     /// Sets the post state to "updating" and performs the given changes.
     private func performChanges(_ changes: RemotePostUpdateParameters, for post: AbstractPost) {
         Task { @MainActor in
-            let post = post.rootOriginal()
+            let post = post.getOriginal()
             setUpdating(true, for: post)
             defer { setUpdating(false, for: post) }
 
@@ -261,7 +261,7 @@ class PostCoordinator: NSObject {
 
     /// Returns `true` if post has any revisions that need to be synced.
     func isSyncNeeded(for post: AbstractPost) -> Bool {
-        post.rootOriginal().getLatestRevisionNeedingSync() != nil
+        post.getOriginal().getLatestRevisionNeedingSync() != nil
     }
 
     /// Sets a flag to sync the given revision and schedules the next sync.
@@ -269,14 +269,14 @@ class PostCoordinator: NSObject {
     /// - warning: Should only be used for draft posts.
     func setNeedsSync(for revision: AbstractPost) {
         wpAssert(revision.isRevision(), "Must be used only on revisions")
-        wpAssert(isSyncAllowed(for: revision.rootOriginal()), "Sync is not supported for this post")
+        wpAssert(isSyncAllowed(for: revision.getOriginal()), "Sync is not supported for this post")
 
         if !revision.isSyncNeeded {
             revision.remoteStatus = .syncNeeded
             revision.confirmedChangesTimestamp = Date()
             ContextManager.shared.saveContextAndWait(coreDataStack.mainContext)
         }
-        startSync(for: revision.rootOriginal())
+        startSync(for: revision.getOriginal())
     }
 
     func retrySync(for post: AbstractPost) {
@@ -300,7 +300,7 @@ class PostCoordinator: NSObject {
         request.predicate = NSPredicate(format: "remoteStatusNumber == %i", AbstractPostRemoteStatus.syncNeeded.rawValue)
         do {
             let revisions = try coreDataStack.mainContext.fetch(request)
-            let originals = Set(revisions.map { $0.rootOriginal() })
+            let originals = Set(revisions.map { $0.getOriginal() })
             for post in originals {
                 startSync(for: post)
             }
@@ -862,12 +862,12 @@ class PostCoordinator: NSObject {
     // MARK: - State
 
     func isUpdating(_ post: AbstractPost) -> Bool {
-        pendingPostIDs.contains(post.rootOriginal().objectID)
+        pendingPostIDs.contains(post.getOriginal().objectID)
     }
 
     @MainActor
     private func setUpdating(_ isUpdating: Bool, for post: AbstractPost) {
-        let post = post.rootOriginal()
+        let post = post.getOriginal()
         if isUpdating {
             pendingPostIDs.insert(post.objectID)
         } else {

--- a/WordPress/Classes/Services/PostCoordinator.swift
+++ b/WordPress/Classes/Services/PostCoordinator.swift
@@ -103,7 +103,7 @@ class PostCoordinator: NSObject {
     /// Uploads the changes made to the post to the server.
     @discardableResult @MainActor
     func save(_ post: AbstractPost, changes: RemotePostUpdateParameters? = nil) async throws -> AbstractPost {
-        let post = post.original()
+        let post = post.rootOriginal()
 
         await pauseSyncing(for: post)
         defer { resumeSyncing(for: post) }
@@ -150,7 +150,7 @@ class PostCoordinator: NSObject {
     private func update(_ post: AbstractPost, changes: RemotePostUpdateParameters) async throws {
         wpAssert(post.isOriginal())
 
-        let post = post.original()
+        let post = post.rootOriginal()
         do {
             try await PostRepository(coreDataStack: coreDataStack).update(post, changes: changes)
         } catch {
@@ -244,7 +244,7 @@ class PostCoordinator: NSObject {
     /// Sets the post state to "updating" and performs the given changes.
     private func performChanges(_ changes: RemotePostUpdateParameters, for post: AbstractPost) {
         Task { @MainActor in
-            let post = post.original()
+            let post = post.rootOriginal()
             setUpdating(true, for: post)
             defer { setUpdating(false, for: post) }
 
@@ -261,7 +261,7 @@ class PostCoordinator: NSObject {
 
     /// Returns `true` if post has any revisions that need to be synced.
     func isSyncNeeded(for post: AbstractPost) -> Bool {
-        post.original().getLatestRevisionNeedingSync() != nil
+        post.rootOriginal().getLatestRevisionNeedingSync() != nil
     }
 
     /// Sets a flag to sync the given revision and schedules the next sync.
@@ -269,14 +269,14 @@ class PostCoordinator: NSObject {
     /// - warning: Should only be used for draft posts.
     func setNeedsSync(for revision: AbstractPost) {
         wpAssert(revision.isRevision(), "Must be used only on revisions")
-        wpAssert(isSyncAllowed(for: revision.original()), "Sync is not supported for this post")
+        wpAssert(isSyncAllowed(for: revision.rootOriginal()), "Sync is not supported for this post")
 
         if !revision.isSyncNeeded {
             revision.remoteStatus = .syncNeeded
             revision.confirmedChangesTimestamp = Date()
             ContextManager.shared.saveContextAndWait(coreDataStack.mainContext)
         }
-        startSync(for: revision.original())
+        startSync(for: revision.rootOriginal())
     }
 
     func retrySync(for post: AbstractPost) {
@@ -300,7 +300,7 @@ class PostCoordinator: NSObject {
         request.predicate = NSPredicate(format: "remoteStatusNumber == %i", AbstractPostRemoteStatus.syncNeeded.rawValue)
         do {
             let revisions = try coreDataStack.mainContext.fetch(request)
-            let originals = Set(revisions.map { $0.original() })
+            let originals = Set(revisions.map { $0.rootOriginal() })
             for post in originals {
                 startSync(for: post)
             }
@@ -862,12 +862,12 @@ class PostCoordinator: NSObject {
     // MARK: - State
 
     func isUpdating(_ post: AbstractPost) -> Bool {
-        pendingPostIDs.contains(post.original().objectID)
+        pendingPostIDs.contains(post.rootOriginal().objectID)
     }
 
     @MainActor
     private func setUpdating(_ isUpdating: Bool, for post: AbstractPost) {
-        let post = post.original()
+        let post = post.rootOriginal()
         if isUpdating {
             pendingPostIDs.insert(post.objectID)
         } else {

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -134,7 +134,7 @@ final class PostRepository {
         overwrite: Bool = false
     ) async throws {
         wpAssert(post.isOriginal())
-        let post = post.original() // Defensive code
+        let post = post.rootOriginal() // Defensive code
         let context = coreDataStack.mainContext
 
         let remotePost: RemotePost
@@ -231,7 +231,7 @@ final class PostRepository {
     private func _patch(_ post: AbstractPost, postID: Int, changes: RemotePostUpdateParameters, overwrite: Bool) async throws -> RemotePost {
         WPAnalytics.track(.postRepositoryPatchStarted)
         let service = try getRemoteService(for: post.blog)
-        let original = post.original()
+        let original = post.rootOriginal()
         var changes = changes
 
         // Make sure the app never overwrites the content without the user approval.

--- a/WordPress/Classes/Services/PostRepository.swift
+++ b/WordPress/Classes/Services/PostRepository.swift
@@ -134,7 +134,7 @@ final class PostRepository {
         overwrite: Bool = false
     ) async throws {
         wpAssert(post.isOriginal())
-        let post = post.rootOriginal() // Defensive code
+        let post = post.getOriginal() // Defensive code
         let context = coreDataStack.mainContext
 
         let remotePost: RemotePost
@@ -231,7 +231,7 @@ final class PostRepository {
     private func _patch(_ post: AbstractPost, postID: Int, changes: RemotePostUpdateParameters, overwrite: Bool) async throws -> RemotePost {
         WPAnalytics.track(.postRepositoryPatchStarted)
         let service = try getRemoteService(for: post.blog)
-        let original = post.rootOriginal()
+        let original = post.getOriginal()
         var changes = changes
 
         // Make sure the app never overwrites the content without the user approval.

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1143,7 +1143,7 @@ private extension AztecPostViewController {
             alert.title = textCounterTitle
         }
 
-        if post.original().isStatus(in: [.draft, .pending]) && editorHasChanges {
+        if post.rootOriginal().isStatus(in: [.draft, .pending]) && editorHasChanges {
             alert.addDefaultActionWithTitle(MoreSheetAlert.saveDraft) { _ in
                 self.buttonSaveDraftTapped()
             }

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecPostViewController.swift
@@ -1143,7 +1143,7 @@ private extension AztecPostViewController {
             alert.title = textCounterTitle
         }
 
-        if post.rootOriginal().isStatus(in: [.draft, .pending]) && editorHasChanges {
+        if post.getOriginal().isStatus(in: [.draft, .pending]) && editorHasChanges {
             alert.addDefaultActionWithTitle(MoreSheetAlert.saveDraft) { _ in
                 self.buttonSaveDraftTapped()
             }

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -42,7 +42,7 @@ extension GutenbergViewController {
 
     private func makeMoreMenuSecondaryActions() -> [UIAction] {
         var actions: [UIAction] = []
-        if post.original().isStatus(in: [.draft, .pending]) {
+        if post.rootOriginal().isStatus(in: [.draft, .pending]) {
             actions.append(UIAction(title: Strings.saveDraft, image: UIImage(systemName: "doc"), attributes: (editorHasChanges && editorHasContent) ? [] : [.disabled]) { [weak self] _ in
                 self?.buttonSaveDraftTapped()
             })

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController+MoreActions.swift
@@ -42,7 +42,7 @@ extension GutenbergViewController {
 
     private func makeMoreMenuSecondaryActions() -> [UIAction] {
         var actions: [UIAction] = []
-        if post.rootOriginal().isStatus(in: [.draft, .pending]) {
+        if post.getOriginal().isStatus(in: [.draft, .pending]) {
             actions.append(UIAction(title: Strings.saveDraft, image: UIImage(systemName: "doc"), attributes: (editorHasChanges && editorHasContent) ? [] : [.disabled]) { [weak self] _ in
                 self?.buttonSaveDraftTapped()
             })

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -853,7 +853,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
             focusTitleIfNeeded()
             mediaInserterHelper.refreshMediaStatus()
 
-            let original = post.original()
+            let original = post.rootOriginal()
             if let content = original.voiceContent {
                 original.voiceContent = nil
                 gutenberg.onContentUpdate(content: content)

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -853,7 +853,7 @@ extension GutenbergViewController: GutenbergBridgeDelegate {
             focusTitleIfNeeded()
             mediaInserterHelper.refreshMediaStatus()
 
-            let original = post.rootOriginal()
+            let original = post.getOriginal()
             if let content = original.voiceContent {
                 original.voiceContent = nil
                 gutenberg.onContentUpdate(content: content)

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -994,7 +994,7 @@ extension NewGutenbergViewController {
 
     private func makeMoreMenuSecondaryActions() -> [UIAction] {
         var actions: [UIAction] = []
-        if post.original().isStatus(in: [.draft, .pending]) {
+        if post.rootOriginal().isStatus(in: [.draft, .pending]) {
             actions.append(UIAction(title: Strings.saveDraft, image: UIImage(systemName: "doc"), attributes: (editorHasChanges && editorHasContent) ? [] : [.disabled]) { [weak self] _ in
                 self?.buttonSaveDraftTapped()
             })

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -994,7 +994,7 @@ extension NewGutenbergViewController {
 
     private func makeMoreMenuSecondaryActions() -> [UIAction] {
         var actions: [UIAction] = []
-        if post.rootOriginal().isStatus(in: [.draft, .pending]) {
+        if post.getOriginal().isStatus(in: [.draft, .pending]) {
             actions.append(UIAction(title: Strings.saveDraft, image: UIImage(systemName: "doc"), attributes: (editorHasChanges && editorHasContent) ? [] : [.disabled]) { [weak self] _ in
                 self?.buttonSaveDraftTapped()
             })

--- a/WordPress/Classes/ViewRelated/Pages/PageEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageEditorPresenter.swift
@@ -15,10 +15,10 @@ struct PageEditorPresenter {
         }
 
         // No editing posts until the conflict has been resolved.
-        if let error = PostCoordinator.shared.syncError(for: page.rootOriginal()),
+        if let error = PostCoordinator.shared.syncError(for: page.getOriginal()),
            let saveError = error as? PostRepository.PostSaveError,
            case .conflict(let latest) = saveError {
-            let page = page.rootOriginal()
+            let page = page.getOriginal()
             PostCoordinator.shared.showResolveConflictView(post: page, remoteRevision: latest, source: .pageList)
             return false
         }

--- a/WordPress/Classes/ViewRelated/Pages/PageEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Pages/PageEditorPresenter.swift
@@ -15,10 +15,10 @@ struct PageEditorPresenter {
         }
 
         // No editing posts until the conflict has been resolved.
-        if let error = PostCoordinator.shared.syncError(for: page.original()),
+        if let error = PostCoordinator.shared.syncError(for: page.rootOriginal()),
            let saveError = error as? PostRepository.PostSaveError,
            case .conflict(let latest) = saveError {
-            let page = page.original()
+            let page = page.rootOriginal()
             PostCoordinator.shared.showResolveConflictView(post: page, remoteRevision: latest, source: .pageList)
             return false
         }

--- a/WordPress/Classes/ViewRelated/Post/Controllers/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Controllers/AbstractPostListViewController.swift
@@ -233,7 +233,7 @@ class AbstractPostListViewController: UIViewController,
             guard let post = cell?.post else {
                 return false
             }
-            return updatedObjects.contains(post) || updatedObjects.contains(post.rootOriginal())
+            return updatedObjects.contains(post) || updatedObjects.contains(post.getOriginal())
         }
         if !updatedIndexPaths.isEmpty {
             tableView.beginUpdates()
@@ -689,7 +689,7 @@ class AbstractPostListViewController: UIViewController,
     func trash(_ post: AbstractPost, completion: @escaping () -> Void) {
         WPAnalytics.track(.postListTrashAction, withProperties: propertiesForAnalytics())
 
-        let post = post.rootOriginal()
+        let post = post.getOriginal()
 
         func performAction() {
             Task {
@@ -715,7 +715,7 @@ class AbstractPostListViewController: UIViewController,
     func delete(_ post: AbstractPost, completion: @escaping () -> Void) {
         WPAnalytics.track(.postListDeleteAction, properties: propertiesForAnalytics())
 
-        let post = post.rootOriginal()
+        let post = post.getOriginal()
 
         let alert = UIAlertController(title: Strings.Delete.actionTitle, message: Strings.Delete.message(for: post.latest()), preferredStyle: .alert)
         alert.addCancelActionWithTitle(Strings.cancelText) { _ in
@@ -732,7 +732,7 @@ class AbstractPostListViewController: UIViewController,
 
     func retry(_ post: AbstractPost) {
         WPAnalytics.track(.postListRetryAction, properties: propertiesForAnalytics())
-        PostCoordinator.shared.retrySync(for: post.rootOriginal())
+        PostCoordinator.shared.retrySync(for: post.getOriginal())
     }
 
     func stats(for post: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Post/Controllers/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Controllers/AbstractPostListViewController.swift
@@ -233,7 +233,7 @@ class AbstractPostListViewController: UIViewController,
             guard let post = cell?.post else {
                 return false
             }
-            return updatedObjects.contains(post) || updatedObjects.contains(post.original())
+            return updatedObjects.contains(post) || updatedObjects.contains(post.rootOriginal())
         }
         if !updatedIndexPaths.isEmpty {
             tableView.beginUpdates()
@@ -689,7 +689,7 @@ class AbstractPostListViewController: UIViewController,
     func trash(_ post: AbstractPost, completion: @escaping () -> Void) {
         WPAnalytics.track(.postListTrashAction, withProperties: propertiesForAnalytics())
 
-        let post = post.original()
+        let post = post.rootOriginal()
 
         func performAction() {
             Task {
@@ -715,7 +715,7 @@ class AbstractPostListViewController: UIViewController,
     func delete(_ post: AbstractPost, completion: @escaping () -> Void) {
         WPAnalytics.track(.postListDeleteAction, properties: propertiesForAnalytics())
 
-        let post = post.original()
+        let post = post.rootOriginal()
 
         let alert = UIAlertController(title: Strings.Delete.actionTitle, message: Strings.Delete.message(for: post.latest()), preferredStyle: .alert)
         alert.addCancelActionWithTitle(Strings.cancelText) { _ in
@@ -732,7 +732,7 @@ class AbstractPostListViewController: UIViewController,
 
     func retry(_ post: AbstractPost) {
         WPAnalytics.track(.postListRetryAction, properties: propertiesForAnalytics())
-        PostCoordinator.shared.retrySync(for: post.original())
+        PostCoordinator.shared.retrySync(for: post.rootOriginal())
     }
 
     func stats(for post: AbstractPost) {

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -240,7 +240,7 @@ class EditPostViewController: UIViewController {
                 return
             }
             self.afterDismiss?()
-            guard let post = self.post?.rootOriginal(),
+            guard let post = self.post?.getOriginal(),
                   post.isPublished(),
                   !self.editingExistingPost,
                   let controller = presentingController else {
@@ -294,7 +294,7 @@ extension EditPostViewController {
         if let restorationDate, Date().timeIntervalSince(restorationDate) < 0.5 {
             return // Appears to be crashing repeatedly
         }
-        let postURL = post.rootOriginal().objectID.uriRepresentation().absoluteString
+        let postURL = post.getOriginal().objectID.uriRepresentation().absoluteString
         UserDefaults.standard.set(postURL, forKey: restorationBlogURLKey)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/EditPostViewController.swift
@@ -240,7 +240,7 @@ class EditPostViewController: UIViewController {
                 return
             }
             self.afterDismiss?()
-            guard let post = self.post?.original(),
+            guard let post = self.post?.rootOriginal(),
                   post.isPublished(),
                   !self.editingExistingPost,
                   let controller = presentingController else {
@@ -294,7 +294,7 @@ extension EditPostViewController {
         if let restorationDate, Date().timeIntervalSince(restorationDate) < 0.5 {
             return // Appears to be crashing repeatedly
         }
-        let postURL = post.original().objectID.uriRepresentation().absoluteString
+        let postURL = post.rootOriginal().objectID.uriRepresentation().absoluteString
         UserDefaults.standard.set(postURL, forKey: restorationBlogURLKey)
     }
 

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -31,7 +31,7 @@ extension PostEditor {
     }
 
     private func savePostBeforePreview(completion: @escaping ((String?, Error?) -> Void)) {
-        guard !post.changes.isEmpty || post.original().isNewDraft else {
+        guard !post.changes.isEmpty || post.rootOriginal().isNewDraft else {
             completion(nil, nil)
             return
         }
@@ -43,7 +43,7 @@ extension PostEditor {
                     SVProgressHUD.setDefaultMaskType(.clear)
                     SVProgressHUD.show(withStatus: Strings.savingDraft)
 
-                    let original = post.original()
+                    let original = post.rootOriginal()
                     try await coordinator.save(original)
                     self.post = original
                     self.createRevisionOfPost()

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+MoreOptions.swift
@@ -31,7 +31,7 @@ extension PostEditor {
     }
 
     private func savePostBeforePreview(completion: @escaping ((String?, Error?) -> Void)) {
-        guard !post.changes.isEmpty || post.rootOriginal().isNewDraft else {
+        guard !post.changes.isEmpty || post.getOriginal().isNewDraft else {
             completion(nil, nil)
             return
         }
@@ -43,7 +43,7 @@ extension PostEditor {
                     SVProgressHUD.setDefaultMaskType(.clear)
                     SVProgressHUD.show(withStatus: Strings.savingDraft)
 
-                    let original = post.rootOriginal()
+                    let original = post.getOriginal()
                     try await coordinator.save(original)
                     self.post = original
                     self.createRevisionOfPost()

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -196,7 +196,7 @@ extension PublishingEditor {
             return discardAndDismiss()
         }
 
-        if post.rootOriginal().isStatus(in: [.draft, .pending]) {
+        if post.getOriginal().isStatus(in: [.draft, .pending]) {
             // The "Discard Changes" behavior is problematic due to the way
             // the editor and `PostCoordinator` often update the content
             // in the background without the user interaction.
@@ -246,7 +246,7 @@ extension PublishingEditor {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         alert.view.accessibilityIdentifier = "post-has-changes-alert"
         alert.addCancelActionWithTitle(Strings.closeConfirmationAlertCancel)
-        let discardTitle = post.rootOriginal().isNewDraft ? Strings.closeConfirmationAlertDelete : Strings.closeConfirmationAlertDiscardChanges
+        let discardTitle = post.getOriginal().isNewDraft ? Strings.closeConfirmationAlertDelete : Strings.closeConfirmationAlertDiscardChanges
         alert.addDestructiveActionWithTitle(discardTitle) { _ in
             self.discardAndDismiss()
         }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor+Publish.swift
@@ -196,7 +196,7 @@ extension PublishingEditor {
             return discardAndDismiss()
         }
 
-        if post.original().isStatus(in: [.draft, .pending]) {
+        if post.rootOriginal().isStatus(in: [.draft, .pending]) {
             // The "Discard Changes" behavior is problematic due to the way
             // the editor and `PostCoordinator` often update the content
             // in the background without the user interaction.
@@ -246,7 +246,7 @@ extension PublishingEditor {
         let alert = UIAlertController(title: nil, message: nil, preferredStyle: .actionSheet)
         alert.view.accessibilityIdentifier = "post-has-changes-alert"
         alert.addCancelActionWithTitle(Strings.closeConfirmationAlertCancel)
-        let discardTitle = post.original().isNewDraft ? Strings.closeConfirmationAlertDelete : Strings.closeConfirmationAlertDiscardChanges
+        let discardTitle = post.rootOriginal().isNewDraft ? Strings.closeConfirmationAlertDelete : Strings.closeConfirmationAlertDiscardChanges
         alert.addDestructiveActionWithTitle(discardTitle) { _ in
             self.discardAndDismiss()
         }

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -96,7 +96,7 @@ extension PostEditor {
 
 extension PostEditor where Self: UIViewController {
     func onViewDidLoad() {
-        if post.original().status == .trash {
+        if post.rootOriginal().status == .trash {
             showPostTrashedOverlay()
         } else {
             showAutosaveAvailableAlertIfNeeded()
@@ -117,7 +117,7 @@ extension PostEditor where Self: UIViewController {
                 self?.postConflictResolved(notification)
             }.store(in: &cancellables)
 
-        let originalPostID = post.original().objectID
+        let originalPostID = post.rootOriginal().objectID
         NotificationCenter.default
             .publisher(for: NSManagedObjectContext.didChangeObjectsNotification, object: post.managedObjectContext)
             .sink { [weak self] in self?.didChangeObjects($0, originalPostID: originalPostID) }
@@ -159,8 +159,8 @@ extension PostEditor where Self: UIViewController {
         // Defensive code to make sure that in rare scenarios where the user changes
         // status from post settings but doesn't save, and the app gets terminated,
         // the app doesn't end up saving posts with uncommited status changes.
-        if post.status != post.original().status {
-            post.status = post.original().status
+        if post.status != post.rootOriginal().status {
+            post.status = post.rootOriginal().status
         }
         if !editorHasChanges {
             AbstractPost.deleteLatestRevision(post, in: context)

--- a/WordPress/Classes/ViewRelated/Post/PostEditor.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditor.swift
@@ -96,7 +96,7 @@ extension PostEditor {
 
 extension PostEditor where Self: UIViewController {
     func onViewDidLoad() {
-        if post.rootOriginal().status == .trash {
+        if post.getOriginal().status == .trash {
             showPostTrashedOverlay()
         } else {
             showAutosaveAvailableAlertIfNeeded()
@@ -117,7 +117,7 @@ extension PostEditor where Self: UIViewController {
                 self?.postConflictResolved(notification)
             }.store(in: &cancellables)
 
-        let originalPostID = post.rootOriginal().objectID
+        let originalPostID = post.getOriginal().objectID
         NotificationCenter.default
             .publisher(for: NSManagedObjectContext.didChangeObjectsNotification, object: post.managedObjectContext)
             .sink { [weak self] in self?.didChangeObjects($0, originalPostID: originalPostID) }
@@ -159,8 +159,8 @@ extension PostEditor where Self: UIViewController {
         // Defensive code to make sure that in rare scenarios where the user changes
         // status from post settings but doesn't save, and the app gets terminated,
         // the app doesn't end up saving posts with uncommited status changes.
-        if post.status != post.rootOriginal().status {
-            post.status = post.rootOriginal().status
+        if post.status != post.getOriginal().status {
+            post.status = post.getOriginal().status
         }
         if !editorHasChanges {
             AbstractPost.deleteLatestRevision(post, in: context)

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -100,7 +100,7 @@ public class PostEditorStateContext {
                      action: PostEditorAction? = nil) {
         var originalPostStatus: BasePost.Status? = nil
 
-        let originalPost = post.rootOriginal()
+        let originalPost = post.getOriginal()
         if let postStatus = originalPost.status, originalPost.hasRemote() {
             originalPostStatus = postStatus
         }

--- a/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostEditorState.swift
@@ -100,7 +100,7 @@ public class PostEditorStateContext {
                      action: PostEditorAction? = nil) {
         var originalPostStatus: BasePost.Status? = nil
 
-        let originalPost = post.original()
+        let originalPost = post.rootOriginal()
         if let postStatus = originalPost.status, originalPost.hasRemote() {
             originalPostStatus = postStatus
         }

--- a/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
@@ -22,10 +22,10 @@ struct PostListEditorPresenter {
         }
 
         // No editing posts until the conflict has been resolved.
-        if let error = PostCoordinator.shared.syncError(for: post.rootOriginal()),
+        if let error = PostCoordinator.shared.syncError(for: post.getOriginal()),
            let saveError = error as? PostRepository.PostSaveError,
            case .conflict(let latest) = saveError {
-            let post = post.rootOriginal()
+            let post = post.getOriginal()
             PostCoordinator.shared.showResolveConflictView(post: post, remoteRevision: latest, source: .postList)
             return
         }

--- a/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostListEditorPresenter.swift
@@ -22,10 +22,10 @@ struct PostListEditorPresenter {
         }
 
         // No editing posts until the conflict has been resolved.
-        if let error = PostCoordinator.shared.syncError(for: post.original()),
+        if let error = PostCoordinator.shared.syncError(for: post.rootOriginal()),
            let saveError = error as? PostRepository.PostSaveError,
            case .conflict(let latest) = saveError {
-            let post = post.original()
+            let post = post.rootOriginal()
             PostCoordinator.shared.showResolveConflictView(post: post, remoteRevision: latest, source: .postList)
             return
         }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -92,7 +92,7 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
     }
 
     var isDraftOrPending: Bool {
-        post.rootOriginal().isStatus(in: [.draft, .pending])
+        post.getOriginal().isStatus(in: [.draft, .pending])
     }
 
     var isPost: Bool {
@@ -352,7 +352,7 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
             do {
                 let coordinator = PostCoordinator.shared
                 let changes = settings.makeUpdateParameters(from: post)
-                try await coordinator.publish(post.rootOriginal(), parameters: changes)
+                try await coordinator.publish(post.getOriginal(), parameters: changes)
                 onPostPublished?()
             } catch {
                 isSaving = false
@@ -370,7 +370,7 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
 
         switch selection.type {
         case .public, .protected:
-            if post.rootOriginal().status == .scheduled {
+            if post.getOriginal().status == .scheduled {
                 // Keep it scheduled
             } else {
                 settings.status = .publish

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -92,7 +92,7 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
     }
 
     var isDraftOrPending: Bool {
-        post.original().isStatus(in: [.draft, .pending])
+        post.rootOriginal().isStatus(in: [.draft, .pending])
     }
 
     var isPost: Bool {
@@ -352,7 +352,7 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
             do {
                 let coordinator = PostCoordinator.shared
                 let changes = settings.makeUpdateParameters(from: post)
-                try await coordinator.publish(post.original(), parameters: changes)
+                try await coordinator.publish(post.rootOriginal(), parameters: changes)
                 onPostPublished?()
             } catch {
                 isSaving = false
@@ -370,7 +370,7 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
 
         switch selection.type {
         case .public, .protected:
-            if post.original().status == .scheduled {
+            if post.rootOriginal().status == .scheduled {
                 // Keep it scheduled
             } else {
                 settings.status = .publish

--- a/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
@@ -74,7 +74,7 @@ private extension RevisionsTableViewController {
         refreshControl.addTarget(self, action: #selector(refreshRevisions), for: .valueChanged)
         self.refreshControl = refreshControl
 
-        if post?.rootOriginal().isStatus(in: [.draft, .pending]) == false {
+        if post?.getOriginal().isStatus(in: [.draft, .pending]) == false {
             tableView.tableFooterView = tableViewFooter
         }
 

--- a/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Revisions/RevisionsTableViewController.swift
@@ -74,7 +74,7 @@ private extension RevisionsTableViewController {
         refreshControl.addTarget(self, action: #selector(refreshRevisions), for: .valueChanged)
         self.refreshControl = refreshControl
 
-        if post?.original().isStatus(in: [.draft, .pending]) == false {
+        if post?.rootOriginal().isStatus(in: [.draft, .pending]) == false {
             tableView.tableFooterView = tableViewFooter
         }
 

--- a/WordPress/Classes/ViewRelated/Post/Views/PageMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PageMenuViewModel.swift
@@ -112,12 +112,12 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
             return AbstractPostButtonSection(buttons: [])
         }
 
-        let action: AbstractPostButton = page.rootOriginal().status == .trash ? .delete : .trash
+        let action: AbstractPostButton = page.getOriginal().status == .trash ? .delete : .trash
         return AbstractPostButtonSection(buttons: [action])
     }
 
     private func createUploadStatusSection() -> AbstractPostButtonSection {
-        guard let error = PostCoordinator.shared.syncError(for: page.rootOriginal()) else {
+        guard let error = PostCoordinator.shared.syncError(for: page.getOriginal()) else {
             return AbstractPostButtonSection(buttons: [])
         }
         return AbstractPostButtonSection(title: error.localizedDescription, buttons: [.retry])

--- a/WordPress/Classes/ViewRelated/Post/Views/PageMenuViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PageMenuViewModel.swift
@@ -112,12 +112,12 @@ final class PageMenuViewModel: AbstractPostMenuViewModel {
             return AbstractPostButtonSection(buttons: [])
         }
 
-        let action: AbstractPostButton = page.original().status == .trash ? .delete : .trash
+        let action: AbstractPostButton = page.rootOriginal().status == .trash ? .delete : .trash
         return AbstractPostButtonSection(buttons: [action])
     }
 
     private func createUploadStatusSection() -> AbstractPostButtonSection {
-        guard let error = PostCoordinator.shared.syncError(for: page.original()) else {
+        guard let error = PostCoordinator.shared.syncError(for: page.rootOriginal()) else {
             return AbstractPostButtonSection(buttons: [])
         }
         return AbstractPostButtonSection(title: error.localizedDescription, buttons: [.retry])

--- a/WordPress/Classes/ViewRelated/Post/Views/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PostCardStatusViewModel.swift
@@ -102,12 +102,12 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
     }
 
     private func createTrashSection() -> AbstractPostButtonSection {
-        let action: AbstractPostButton = post.original().status == .trash ? .delete : .trash
+        let action: AbstractPostButton = post.rootOriginal().status == .trash ? .delete : .trash
         return AbstractPostButtonSection(buttons: [action])
     }
 
     private func createUploadStatusSection() -> AbstractPostButtonSection {
-        guard let error = PostCoordinator.shared.syncError(for: post.original()) else {
+        guard let error = PostCoordinator.shared.syncError(for: post.rootOriginal()) else {
             return AbstractPostButtonSection(buttons: [])
         }
         return AbstractPostButtonSection(title: error.localizedDescription, buttons: [.retry])

--- a/WordPress/Classes/ViewRelated/Post/Views/PostCardStatusViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PostCardStatusViewModel.swift
@@ -102,12 +102,12 @@ class PostCardStatusViewModel: NSObject, AbstractPostMenuViewModel {
     }
 
     private func createTrashSection() -> AbstractPostButtonSection {
-        let action: AbstractPostButton = post.rootOriginal().status == .trash ? .delete : .trash
+        let action: AbstractPostButton = post.getOriginal().status == .trash ? .delete : .trash
         return AbstractPostButtonSection(buttons: [action])
     }
 
     private func createUploadStatusSection() -> AbstractPostButtonSection {
-        guard let error = PostCoordinator.shared.syncError(for: post.rootOriginal()) else {
+        guard let error = PostCoordinator.shared.syncError(for: post.getOriginal()) else {
             return AbstractPostButtonSection(buttons: [])
         }
         return AbstractPostButtonSection(title: error.localizedDescription, buttons: [.retry])

--- a/WordPress/Classes/ViewRelated/Post/Views/PostSyncStateViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PostSyncStateViewModel.swift
@@ -23,7 +23,7 @@ final class PostSyncStateViewModel {
         if PostCoordinator.shared.isUpdating(post) {
             return .uploading
         }
-        if let error = PostCoordinator.shared.syncError(for: post.rootOriginal()) {
+        if let error = PostCoordinator.shared.syncError(for: post.getOriginal()) {
             if let urlError = (error as NSError).underlyingErrors.first as? URLError,
                urlError.code == .notConnectedToInternet || urlError.code == .networkConnectionLost {
                 return .offlineChanges // A better indicator on what's going on

--- a/WordPress/Classes/ViewRelated/Post/Views/PostSyncStateViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/Views/PostSyncStateViewModel.swift
@@ -23,7 +23,7 @@ final class PostSyncStateViewModel {
         if PostCoordinator.shared.isUpdating(post) {
             return .uploading
         }
-        if let error = PostCoordinator.shared.syncError(for: post.original()) {
+        if let error = PostCoordinator.shared.syncError(for: post.rootOriginal()) {
             if let urlError = (error as NSError).underlyingErrors.first as? URLError,
                urlError.code == .notConnectedToInternet || urlError.code == .networkConnectionLost {
                 return .offlineChanges // A better indicator on what's going on


### PR DESCRIPTION
## Description

The `original()` function will conflict with the `original` property once `AbstractPost` is translated to Swift. I renamed it to `rootOriginal()`. Any suggestions for alternative names are welcome!
