### PR TITLE
Lazy render logs to increase performance

### DIFF
--- a/WordPress/Classes/ViewRelated/Me/Help & Support/SupportActivityDetailsView.swift
+++ b/WordPress/Classes/ViewRelated/Me/Help & Support/SupportActivityDetailsView.swift
@@ -13,10 +13,7 @@ struct SupportActivityDetailsView: View {
     var body: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 0) {
-                ForEach(Array(viewModel.logLines.enumerated()), id: \.offset) { _, line in
-                    Text(line)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                }
+                logLinesContent
             }
             .font(.subheadline)
             .padding()
@@ -31,6 +28,14 @@ struct SupportActivityDetailsView: View {
                     Image(systemName: "square.and.arrow.up")
                 }
             }
+        }
+    }
+
+    @ViewBuilder
+    private var logLinesContent: some View {
+        ForEach(Array(viewModel.logLines.enumerated()), id: \.offset) { _, line in
+            Text(line)
+                .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Me/Help & Support/SupportActivityDetailsView.swift
+++ b/WordPress/Classes/ViewRelated/Me/Help & Support/SupportActivityDetailsView.swift
@@ -12,10 +12,14 @@ struct SupportActivityDetailsView: View {
 
     var body: some View {
         ScrollView {
-            Text(viewModel.logText)
-                .font(.subheadline)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding()
+            LazyVStack(alignment: .leading, spacing: 0) {
+                ForEach(Array(viewModel.logLines.enumerated()), id: \.offset) { _, line in
+                    Text(line)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .font(.subheadline)
+            .padding()
         }
         .navigationTitle(viewModel.logDate)
         .navigationBarTitleDisplayMode(.inline)
@@ -32,7 +36,7 @@ struct SupportActivityDetailsView: View {
 }
 
 private final class SupportActivityDetailsViewModel: ObservableObject {
-    let logText: String
+    let logLines: [String]
     let logDate: String
 
     init(logFile: DDLogFileInfo) {
@@ -45,15 +49,17 @@ private final class SupportActivityDetailsViewModel: ObservableObject {
 
         guard let logData = try? Data(contentsOf: URL(fileURLWithPath: logFile.filePath)),
               let logText = String(data: logData, encoding: .utf8) else {
-            self.logText = ""
+            self.logLines = []
             return
         }
-        self.logText = logText
+        self.logLines = logText
+            .split(separator: "\n", omittingEmptySubsequences: false)
+            .map(String.init)
     }
 
     func buttonShareTapped() {
         let activityVC = UIActivityViewController(
-            activityItems: [logText],
+            activityItems: [logLines.joined(separator: "\n")],
             applicationActivities: nil
         )
 


### PR DESCRIPTION
## Description

Instead of rendering one potentially massive `Text` view, lazy load it via array of strings. Logs on my device were large enough to crash the app due to the main thread watchdog.

https://github.com/user-attachments/assets/78dba592-c557-4bb0-9289-87633d735776

## Testing instructions

### Legacy support view

_Ensure new support experience feature is disabled._

1. Me -> Help & Support -> Logs -> Tap on an Activity Log
  - Expect the log to load immediately and you should be able to scroll + read the log in its entirety.
2. Tap the Share icon while viewing a log
  - Expect the same options to be available as before and that sharing works (saving, copying, etc.).

### New support view

_Ensure new support experience feature is enabled._

1. Me -> Application Logs -> Tap a log
  - Expect the log to load immediately and you should be able to scroll + read the log in its entirety.
  - Memory usage shouldn't inflate to gigabytes.
 2. Tap the Share icon while viewing a log
  - Expect the same options to be available as before and that sharing works (new support ticket, exporting as a file, etc.).