### PR TITLE
Rename `PostService` to `MenuPostService`

### DIFF
--- a/Sources/WordPressData/Objective-C/PostHelper.m
+++ b/Sources/WordPressData/Objective-C/PostHelper.m
@@ -7,6 +7,10 @@
 @import WordPressShared;
 @import NSObject_SafeExpectations;
 
+PostServiceType const PostServiceTypePost = @"post";
+PostServiceType const PostServiceTypePage = @"page";
+PostServiceType const PostServiceTypeAny = @"any";
+
 @implementation PostHelper
 
 + (void)updatePost:(AbstractPost *)post withRemotePost:(RemotePost *)remotePost inContext:(NSManagedObjectContext *)managedObjectContext {

--- a/Sources/WordPressData/Objective-C/include/PostHelper.h
+++ b/Sources/WordPressData/Objective-C/include/PostHelper.h
@@ -1,8 +1,12 @@
 #import <Foundation/Foundation.h>
 #import <CoreData/CoreData.h>
-#import <WordPressData/PostService.h>
 
-@class AbstractPost, RemotePost;
+@class AbstractPost, RemotePost, Post, Blog;
+
+typedef NSString * PostServiceType NS_TYPED_ENUM;
+extern PostServiceType const PostServiceTypePost;
+extern PostServiceType const PostServiceTypePage;
+extern PostServiceType const PostServiceTypeAny;
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/Sources/WordPressData/WordPressData.h
+++ b/Sources/WordPressData/WordPressData.h
@@ -15,8 +15,6 @@ FOUNDATION_EXPORT const unsigned char WordPressDataVersionString[];
 #import <WordPressData/LocalCoreDataService.h>
 #import <WordPressData/Media.h>
 #import <WordPressData/PostHelper.h>
-#import <WordPressData/PostService.h>
-#import <WordPressData/PostServiceOptions.h>
 #import <WordPressData/ReaderPost.h>
 #import <WordPressData/WPAccount.h>
 

--- a/Tests/KeystoneTests/Tests/Reader/ReaderReblogActionTests.swift
+++ b/Tests/KeystoneTests/Tests/Reader/ReaderReblogActionTests.swift
@@ -12,16 +12,13 @@ class MockReblogPresenter: ReaderReblogPresenter {
 
 class ReblogTestCase: CoreDataTestCase {
     var readerPost: ReaderPost?
-    var postService: PostService?
 
     override func setUp() {
         readerPost = ReaderPost(context: self.mainContext)
-        postService = PostService(managedObjectContext: self.mainContext)
     }
 
     override func tearDown() {
         readerPost = nil
-        postService = nil
     }
 }
 
@@ -29,7 +26,7 @@ class ReaderReblogActionTests: ReblogTestCase {
 
     func testExecuteAction() {
         // Given
-        let presenter = MockReblogPresenter(postService: postService!)
+        let presenter = MockReblogPresenter()
         presenter.presentReblogExpectation = expectation(description: "presentBlog was called")
         let action = ReaderReblogAction(coreDataStack: contextManager, presenter: presenter)
         let controller = UIViewController()
@@ -53,7 +50,7 @@ class ReblogPresenterTests: ReblogTestCase {
         let draftPosts = NSFetchRequest<Post>(entityName: "Post")
         draftPosts.predicate = NSPredicate(format: "status = %@", Post.Status.draft.rawValue)
         try XCTAssertEqual(mainContext.count(for: draftPosts), 0)
-        let presenter = ReaderReblogPresenter(postService: postService!)
+        let presenter = ReaderReblogPresenter()
         // When
         presenter.presentReblog(coreDataStack: contextManager, readerPost: readerPost!, origin: UIViewController())
         // Then
@@ -65,7 +62,7 @@ class ReblogPresenterTests: ReblogTestCase {
         for _ in 1...2 {
             BlogBuilder(contextManager.mainContext).isHostedAtWPcom().withAnAccount().build()
         }
-        let presenter = ReaderReblogPresenter(postService: postService!)
+        let presenter = ReaderReblogPresenter()
         let origin = MockViewController()
         origin.presentExpectation = expectation(description: "blog selector is presented")
         // When

--- a/WordPress/Classes/Services/PostService+Likes.swift
+++ b/WordPress/Classes/Services/PostService+Likes.swift
@@ -1,6 +1,16 @@
 import WordPressData
 import WordPressKit
 
+final class PostService {
+    let managedObjectContext: NSManagedObjectContext
+    let postServiceRemoteFactory: PostServiceRemoteFactory
+
+    init(managedObjectContext: NSManagedObjectContext, postServiceRemoteFactory: PostServiceRemoteFactory = PostServiceRemoteFactory()) {
+        self.managedObjectContext = managedObjectContext
+        self.postServiceRemoteFactory = postServiceRemoteFactory
+    }
+}
+
 extension PostService {
 
     /**

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemAbstractPostsViewController.h
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemAbstractPostsViewController.h
@@ -6,11 +6,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@class PostServiceSyncOptions;
+@class MenuPostServiceSyncOptions;
 
 @protocol MenuItemSourcePostAbstractViewSubclass <NSObject>
 - (Class)entityClass;
-- (PostServiceSyncOptions *)syncOptions;
+- (MenuPostServiceSyncOptions *)syncOptions;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemAbstractPostsViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemAbstractPostsViewController.m
@@ -1,5 +1,6 @@
 #import "MenuItemAbstractPostsViewController.h"
-@import WordPressData;
+#import "MenuPostService.h"
+#import "MenuPostServiceOptions.h"
 @import WordPressKit;
 
 @interface MenuItemAbstractPostsViewController () <MenuItemSourcePostAbstractViewSubclass>
@@ -54,8 +55,8 @@
     [self showLoadingSourcesIndicatorIfEmpty];
     self.additionalPostsAvailableForSync = YES;
 
-    PostService *service = [[PostService alloc] initWithManagedObjectContext:[self managedObjectContext]];
-    PostServiceSyncOptions *options = [self syncOptions];
+    MenuPostService *service = [[MenuPostService alloc] initWithManagedObjectContext:[self managedObjectContext]];
+    MenuPostServiceSyncOptions *options = [self syncOptions];
     [service syncPostsOfType:[self sourceItemType]
                  withOptions:options
                      forBlog:[self blog]
@@ -110,15 +111,15 @@
     return nil;
 }
 
-- (PostServiceSyncOptions *)syncOptions
+- (MenuPostServiceSyncOptions *)syncOptions
 {
-    PostServiceSyncOptions *options = [[PostServiceSyncOptions alloc] init];
+    MenuPostServiceSyncOptions *options = [[MenuPostServiceSyncOptions alloc] init];
     options.statuses = @[PostStatusPublish, PostStatusPrivate];
     options.number = @(PostServiceDefaultNumberToSync);
     return options;
 }
 
-- (void)didFinishSyncingPosts:(NSArray *)posts options:(PostServiceSyncOptions *)options
+- (void)didFinishSyncingPosts:(NSArray *)posts options:(MenuPostServiceSyncOptions *)options
 {
     self.isSyncing = NO;
     if (posts) {
@@ -143,8 +144,8 @@
     self.isSyncingAdditionalPosts = YES;
     [self showLoadingSourcesIndicator];
 
-    PostService *service = [[PostService alloc] initWithManagedObjectContext:[self managedObjectContext]];
-    PostServiceSyncOptions *options = [self syncOptions];
+    MenuPostService *service = [[MenuPostService alloc] initWithManagedObjectContext:[self managedObjectContext]];
+    MenuPostServiceSyncOptions *options = [self syncOptions];
     options.offset = @(self.resultsController.fetchedObjects.count);
     [service syncPostsOfType:[self sourceItemType]
                  withOptions:options
@@ -202,8 +203,8 @@
     };
 
     DDLogDebug(@"MenuItemSourcePostView: Searching posts via PostService");
-    PostService *service = [[PostService alloc] initWithManagedObjectContext:[self managedObjectContext]];
-    PostServiceSyncOptions *options = [self syncOptions];
+    MenuPostService *service = [[MenuPostService alloc] initWithManagedObjectContext:[self managedObjectContext]];
+    MenuPostServiceSyncOptions *options = [self syncOptions];
     options.search = searchText;
     [service syncPostsOfType:[self sourceItemType]
                  withOptions:options

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemPagesViewController.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuItemPagesViewController.m
@@ -1,6 +1,6 @@
 #import "MenuItemPagesViewController.h"
 #import "WordPress-Swift.h"
-@import WordPressData;
+#import "MenuPostServiceOptions.h"
 
 @interface MenuItemAbstractPostsViewController () <MenuItemSourcePostAbstractViewSubclass>
 @end
@@ -31,9 +31,9 @@
     return [Page class];
 }
 
-- (PostServiceSyncOptions *)syncOptions
+- (MenuPostServiceSyncOptions *)syncOptions
 {
-    PostServiceSyncOptions *options = [super syncOptions];
+    MenuPostServiceSyncOptions *options = [super syncOptions];
     options.order = PostServiceResultsOrderAscending;
     options.orderBy = PostServiceResultsOrderingByTitle;
     return options;

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuPostService.h
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuPostService.h
@@ -18,7 +18,6 @@ typedef void(^PostServiceSyncFailure)(NSError * _Nullable error);
 
 extern const NSUInteger PostServiceDefaultNumberToSync;
 
-
 @interface MenuPostService : LocalCoreDataService
 
 // This is public so it can be accessed from Swift extensions.

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuPostService.h
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuPostService.h
@@ -1,5 +1,6 @@
 #import <Foundation/Foundation.h>
-#import <WordPressData/LocalCoreDataService.h>
+
+@import WordPressData;
 
 @class AbstractPost;
 @class Blog;
@@ -8,21 +9,17 @@
 @class RemotePost;
 @class RemoteUser;
 @class PostServiceRemoteFactory;
-@class PostServiceSyncOptions;
+@class MenuPostServiceSyncOptions;
 
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void(^PostServiceSyncSuccess)(NSArray<AbstractPost *> * _Nullable posts);
 typedef void(^PostServiceSyncFailure)(NSError * _Nullable error);
 
-typedef NSString * PostServiceType NS_TYPED_ENUM;
-extern PostServiceType const PostServiceTypePost;
-extern PostServiceType const PostServiceTypePage;
-extern PostServiceType const PostServiceTypeAny;
 extern const NSUInteger PostServiceDefaultNumberToSync;
 
 
-@interface PostService : LocalCoreDataService
+@interface MenuPostService : LocalCoreDataService
 
 // This is public so it can be accessed from Swift extensions.
 @property (nonnull, strong, nonatomic) PostServiceRemoteFactory *postServiceRemoteFactory;
@@ -59,7 +56,7 @@ extern const NSUInteger PostServiceDefaultNumberToSync;
  @param failure A failure block
  */
 - (void)syncPostsOfType:(PostServiceType)postType
-            withOptions:(PostServiceSyncOptions *)options
+            withOptions:(MenuPostServiceSyncOptions *)options
                 forBlog:(Blog *)blog
                 success:(PostServiceSyncSuccess)success
                 failure:(PostServiceSyncFailure)failure;

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuPostService.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuPostService.m
@@ -1,24 +1,16 @@
 #import "Blog.h"
-#import "PostService.h"
-#import "PostServiceOptions.h"
-#import "Media.h"
-#import "WordPressData-Swift.h"
+#import "MenuPostService.h"
+#import "MenuPostServiceOptions.h"
 #import "PostHelper.h"
 @import WordPressKit;
 @import WordPressShared;
+@import WordPressData;
 
-PostServiceType const PostServiceTypePost = @"post";
-PostServiceType const PostServiceTypePage = @"page";
-PostServiceType const PostServiceTypeAny = @"any";
 NSString * const PostServiceErrorDomain = @"PostServiceErrorDomain";
 
 const NSUInteger PostServiceDefaultNumberToSync = 40;
 
-@interface PostService ()
-
-@end
-
-@implementation PostService
+@implementation MenuPostService
 
 - (instancetype)initWithManagedObjectContext:(NSManagedObjectContext *)context {
     return [self initWithManagedObjectContext:context
@@ -46,7 +38,7 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
 }
 
 - (void)syncPostsOfType:(PostServiceType)postType
-            withOptions:(PostServiceSyncOptions *)options
+            withOptions:(MenuPostServiceSyncOptions *)options
                 forBlog:(Blog *)blog
                 success:(PostServiceSyncSuccess)success
                 failure:(PostServiceSyncFailure)failure
@@ -61,7 +53,7 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
 }
 
 - (void)syncPostsOfType:(PostServiceType)postType
-            withOptions:(PostServiceSyncOptions *)options
+            withOptions:(MenuPostServiceSyncOptions *)options
                 forBlog:(Blog *)blog
             loadedPosts:(NSMutableArray <RemotePost *>*)loadedPosts
                 syncAll:(BOOL)syncAll
@@ -128,7 +120,7 @@ const NSUInteger PostServiceDefaultNumberToSync = 40;
 #pragma mark - Helpers
 
 - (NSDictionary *)remoteSyncParametersDictionaryForRemote:(nonnull id <PostServiceRemote>)remote
-                                              withOptions:(nonnull PostServiceSyncOptions *)options
+                                              withOptions:(nonnull MenuPostServiceSyncOptions *)options
 {
     return [remote dictionaryWithRemoteOptions:options];
 }

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuPostServiceOptions.h
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuPostServiceOptions.h
@@ -1,13 +1,13 @@
 @import WordPressKitObjC;
 
 /**
- @class PostServiceSyncOptions
+ @class MenuPostServiceSyncOptions
  @brief An object of options and paramters for specific filtering and syncing of posts.
  See each remote API parameters for specifics regarding default values and limits.
  WP.com/REST Jetpack: https://developer.wordpress.com/docs/api/1.1/get/sites/%24site/posts/
  XML-RPC: https://codex.wordpress.org/XML-RPC_WordPress_API/Posts
  */
-@interface PostServiceSyncOptions : NSObject <PostServiceRemoteOptions>
+@interface MenuPostServiceSyncOptions : NSObject <PostServiceRemoteOptions>
 
 /**
  When set to true previously synced AbstractPosts matching statuses and authorID will be purged while updating.

--- a/WordPress/Classes/ViewRelated/Menus/Controllers/MenuPostServiceOptions.m
+++ b/WordPress/Classes/ViewRelated/Menus/Controllers/MenuPostServiceOptions.m
@@ -1,6 +1,6 @@
-#import "PostServiceOptions.h"
+#import "MenuPostServiceOptions.h"
 
-@implementation PostServiceSyncOptions
+@implementation MenuPostServiceSyncOptions
 
 - (instancetype)init
 {

--- a/WordPress/Classes/ViewRelated/Post/Controllers/AbstractPostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Controllers/AbstractPostListViewController.swift
@@ -508,7 +508,7 @@ class AbstractPostListViewController: UIViewController,
     }
 
     @objc func numberOfPostsPerSync() -> UInt {
-        return PostServiceDefaultNumberToSync
+        return 40
     }
 
     // MARK: - WPContentSyncHelperDelegate

--- a/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderReblogPresenter.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Controllers/ReaderPostActions/ReaderReblogPresenter.swift
@@ -4,7 +4,6 @@ import WordPressUI
 
 /// Presents the appropriate reblog scene, depending on the number of available sites
 class ReaderReblogPresenter {
-    private let postService: PostService
 
     private struct NoSitesConfiguration {
         static let noSitesTitle = NSLocalizedString(
@@ -24,16 +23,6 @@ class ReaderReblogPresenter {
         )
         static let backButtonTitle = NSLocalizedString("Back",
                                                        comment: "Back button title.")
-    }
-
-    init(postService: PostService? = nil) {
-
-        // fallback for self.postService
-        func makePostService() -> PostService {
-            let context = ContextManager.shared.mainContext
-            return PostService(managedObjectContext: context)
-        }
-        self.postService = postService ?? makePostService()
     }
 
     /// Presents the reblog screen(s)

--- a/WordPress/WordPress.xcodeproj/project.pbxproj
+++ b/WordPress/WordPress.xcodeproj/project.pbxproj
@@ -1178,8 +1178,6 @@
 				"Objective-C/include/LocalCoreDataService.h",
 				"Objective-C/include/Media.h",
 				"Objective-C/include/PostHelper.h",
-				"Objective-C/include/PostService.h",
-				"Objective-C/include/PostServiceOptions.h",
 				"Objective-C/include/ReaderPost.h",
 				"Objective-C/include/WPAccount.h",
 				WordPressData.h,


### PR DESCRIPTION
## Description

The "sync" functions in `PostService` are only used in the Menu feature. This PR renames the `PostService` type to `MenuPostService` to avoid the sync function being used in other features. The sync functions fetch every single page when used to fetch pages, and fetch paginated posts when used to fetch posts, which I think is not something we'd normally want.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
