### PR TITLE
Fix a crash where a Swift enum is used as a event property value

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -1934,6 +1934,11 @@ extension WPAnalytics {
     /// - Parameter properties: a `Hash` that represents the properties
     ///
     static func track(_ event: WPAnalyticsEvent, properties: [AnyHashable: Any]) {
+        // Try to catch issues during development where an invalid JSON object is used as event properties.
+        #if DEBUG
+        precondition(JSONSerialization.isValidJSONObject(properties))
+        #endif
+
         var mergedProperties: [AnyHashable: Any] = event.defaultProperties ?? [:]
         mergedProperties.merge(properties) { (_, new) in new }
 

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostSettingsFeaturedImageRow.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostSettingsFeaturedImageRow.swift
@@ -180,7 +180,7 @@ public final class PostSettingsFeaturedImageViewModel: ObservableObject {
     }
 
     func setFeaturedImage(selection: MediaPickerSelection) {
-        WPAnalytics.track(.editorPostFeaturedImageChanged, properties: ["via": "settings", "action": "added", "source": selection.source])
+        WPAnalytics.track(.editorPostFeaturedImageChanged, properties: ["via": "settings", "action": "added", "source": selection.source.rawValue])
 
         guard let item = selection.items.first else {
             return wpAssertionFailure("selection is empty")


### PR DESCRIPTION
## Description

Fix https://linear.app/a8c/issue/CMM-1050.

## Testing instructions

You can use the Test Flight build to reproduce the crash by setting a featured image to a post, and the app crashes after a few seconds.


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
