### PR TITLE
Fix a crash when double-tap the Skip button in the site creation flow

### DIFF
--- a/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Design Selection/SiteDesignContentCollectionViewController.swift
@@ -180,6 +180,14 @@ class SiteDesignContentCollectionViewController: CollapsableHeaderViewController
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
         fetchSiteDesigns()
+
+        // Disable the button temporarily during the transition animation.
+        navigationItem.rightBarButtonItem?.isEnabled = false
+    }
+
+    override func viewDidAppear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        navigationItem.rightBarButtonItem?.isEnabled = true
     }
 
     private func fetchSiteDesigns() {


### PR DESCRIPTION
## Description

The crash happens because the first screen and the second screen both have a `rightBarButtonItem`, whose action calls the same function (eventually). When double-tapping the "Skip" button, the first tap is handled by the first screen `SiteIntentViewController`, and the second tap is handled by the second screen `SiteDesignContentCollectionViewController`. Both bar button items trigger the same code: `WizardNavigation.nextStep`. The internal step of `WizardNavigation` is not updated because the view controllers are still transitioning.

This PR fixes the issue by disabling the second Skip button during the push animation.

## Testing instructions

Enter the WordPress.com site creation flow, and double-tap the Skip button.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
