### PR TITLE
Fix CMM-1065: Find existing tag before creating a new one

### DIFF
--- a/WordPress/Classes/ViewRelated/Tags/TagsService.swift
+++ b/WordPress/Classes/ViewRelated/Tags/TagsService.swift
@@ -79,6 +79,11 @@ class TagsService: TaxonomyServiceProtocol {
             throw TagsServiceError.noRemoteService
         }
 
+        if let existing = try await searchTags(with: name)
+            .first(where: { $0.name.compare(name, options: .caseInsensitive) == .orderedSame }) {
+            return existing
+        }
+
         let tag = RemotePostTag()
         tag.name = name
         tag.tagDescription = description

--- a/WordPress/Classes/ViewRelated/Tags/TagsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Tags/TagsViewModel.swift
@@ -159,7 +159,14 @@ class TagsViewModel: ObservableObject {
         // Create a new tag in the background, which is consistent with the web editor.
         Task {
             do {
-                _ = try await tagsService.createTag(name: name, description: "")
+                let newTag = try await tagsService.createTag(name: name, description: "")
+                // The original input `name` was used as a temporary tag before sending the API request.
+                // Replace it with the actual tag returned by the API.
+                if newTag.name != name, let index = selectedTags.firstIndex(of: name) {
+                    selectedTagsSet.remove(lowercasedName)
+                    selectedTagsSet.insert(newTag.name.lowercased())
+                    selectedTags[index] = newTag.name
+                }
             } catch {
                 removeSelectedTag(name)
             }


### PR DESCRIPTION
## Description

Fixes https://linear.app/a8c/issue/CMM-1065.

The issue was introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/24955.

The API request sent by the `createTag` function returns an error if the `name` already exists as a tag.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
