### PR TITLE
CMM-1058: Show the mobile support page when opening the Help Center

### DIFF
--- a/WordPress/Classes/ViewRelated/NewSupport/RootSupportView.swift
+++ b/WordPress/Classes/ViewRelated/NewSupport/RootSupportView.swift
@@ -77,7 +77,7 @@ struct RootSupportView: View {
     @ViewBuilder
     private var communitySupportLink: some View {
         NavigationLink {
-            let url = URL(string: "https://apps.wordpress.com/support/")!
+            let url = URL(string: "https://apps.wordpress.com/support/mobile/")!
             WebKitView(configuration: WebViewControllerConfiguration(url: url))
         } label: {
             SupportAreaRow(


### PR DESCRIPTION
## Description

Updates the Help Center URL in the support screen to point to the mobile-specific support page


## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

1. Open the app and navigate to Me → Help & Support
2.  Tap on "Help Center"
- [ ]  Verify it loads https://apps.wordpress.com/support/mobile/

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
