### PR TITLE
CMM-1067: fix support UI glitches

### DIFF
--- a/WordPress/Classes/ViewRelated/NewSupport/RootSupportView.swift
+++ b/WordPress/Classes/ViewRelated/NewSupport/RootSupportView.swift
@@ -96,7 +96,7 @@ struct RootSupportView: View {
         } label: {
             SupportAreaRow(
                 imageName: "bubble.left.and.text.bubble.right",
-                title: "Ask the bots",
+                title: "Ask the Bots",
                 detail: "Get quick answers to common questions."
             )
         }

--- a/WordPress/Classes/ViewRelated/NewSupport/RootSupportView.swift
+++ b/WordPress/Classes/ViewRelated/NewSupport/RootSupportView.swift
@@ -179,9 +179,9 @@ struct SupportAreaRow: View {
     let detail: String
 
     var body: some View {
-        HStack(spacing: 12) {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
             Image(systemName: imageName)
-                .frame(width: 24, height: 24)
+                .frame(width: 24)
                 .foregroundColor(.accentColor)
             VStack(alignment: .leading, spacing: 2) {
                 Text(title)


### PR DESCRIPTION
## Description

  - Fixes inconsistent title casing in the Support screen ("Ask the bots" → "Ask the Bots") to match other items like "Help Center" and "Ask the Happiness Engineers"
  - Fixes icon alignment in support rows by using .firstTextBaseline alignment, ensuring icons align with the title text rather than being centered between title and description


## Testing instructions

  - Open the Support screen
  -  [ ] Verify "Ask the Bots" uses Title Case consistent with other items
  - [ ] Verify all row icons are aligned with their respective titles


<img width="448" height="915" alt="Screenshot 2025-12-16 at 11 02 55" src="https://github.com/user-attachments/assets/cc74c535-4469-4362-9f05-f6fc7639b99c" />


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
