### PR TITLE
[Tooling] Adjust tasks retry reason

### DIFF
--- a/.buildkite/release-pipelines/code-freeze.yml
+++ b/.buildkite/release-pipelines/code-freeze.yml
@@ -26,4 +26,5 @@ steps:
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
+        reason: If release jobs fail, you should always re-trigger the task from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-pipelines/code-freeze.yml
+++ b/.buildkite/release-pipelines/code-freeze.yml
@@ -25,6 +25,6 @@ steps:
       bundle exec fastlane code_freeze version:"${RELEASE_VERSION}" skip_confirm:true
     retry:
       manual:
-        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
-        reason: If release jobs fail, you should always re-trigger the task from ReleaseV2 rather than retrying the individual job from Buildkite
+        # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite
+        reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -16,4 +16,5 @@ steps:
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
+        reason: If release jobs fail, you should always re-trigger the task from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-pipelines/complete-code-freeze.yml
+++ b/.buildkite/release-pipelines/complete-code-freeze.yml
@@ -15,6 +15,6 @@ steps:
     command: .buildkite/commands/complete-code-freeze.sh "$RELEASE_VERSION"
     retry:
       manual:
-        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
-        reason: If release jobs fail, you should always re-trigger the task from ReleaseV2 rather than retrying the individual job from Buildkite
+        # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite
+        reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-pipelines/finalize-hotfix.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix.yml
@@ -15,6 +15,6 @@ steps:
     command: .buildkite/commands/finalize-hotfix.sh $VERSION
     retry:
       manual:
-        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
-        reason: If release jobs fail, you should always re-trigger the task from ReleaseV2 rather than retrying the individual job from Buildkite
+        # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite
+        reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-pipelines/finalize-hotfix.yml
+++ b/.buildkite/release-pipelines/finalize-hotfix.yml
@@ -16,4 +16,5 @@ steps:
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
+        reason: If release jobs fail, you should always re-trigger the task from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -15,6 +15,6 @@ steps:
     command: .buildkite/commands/finalize-release.sh "$RELEASE_VERSION"
     retry:
       manual:
-        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
-        reason: If release jobs fail, you should always re-trigger the task from ReleaseV2 rather than retrying the individual job from Buildkite
+        # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite
+        reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-pipelines/finalize-release.yml
+++ b/.buildkite/release-pipelines/finalize-release.yml
@@ -16,4 +16,5 @@ steps:
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
+        reason: If release jobs fail, you should always re-trigger the task from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -27,4 +27,5 @@ steps:
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
+        reason: If release jobs fail, you should always re-trigger the task from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-pipelines/new-beta-release.yml
+++ b/.buildkite/release-pipelines/new-beta-release.yml
@@ -26,6 +26,6 @@ steps:
       bundle exec fastlane new_beta_release skip_confirm:true
     retry:
       manual:
-        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
-        reason: If release jobs fail, you should always re-trigger the task from ReleaseV2 rather than retrying the individual job from Buildkite
+        # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite
+        reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-pipelines/new-hotfix.yml
+++ b/.buildkite/release-pipelines/new-hotfix.yml
@@ -26,6 +26,6 @@ steps:
       bundle exec fastlane new_hotfix_release skip_confirm:true version:"$VERSION"
     retry:
       manual:
-        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
-        reason: If release jobs fail, you should always re-trigger the task from ReleaseV2 rather than retrying the individual job from Buildkite
+        # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite
+        reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-pipelines/new-hotfix.yml
+++ b/.buildkite/release-pipelines/new-hotfix.yml
@@ -27,4 +27,5 @@ steps:
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
+        reason: If release jobs fail, you should always re-trigger the task from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -26,6 +26,6 @@ steps:
       bundle exec fastlane publish_release skip_confirm:true
     retry:
       manual:
-        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
-        reason: If release jobs fail, you should always re-trigger the task from ReleaseV2 rather than retrying the individual job from Buildkite
+        # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite
+        reason: If release jobs fail, you should always re-trigger the task from Releases V2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-pipelines/publish-release.yml
+++ b/.buildkite/release-pipelines/publish-release.yml
@@ -27,4 +27,5 @@ steps:
     retry:
       manual:
         # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
+        reason: If release jobs fail, you should always re-trigger the task from ReleaseV2 rather than retrying the individual job from Buildkite
         allowed: false

--- a/.buildkite/release-pipelines/update-app-store-strings.yml
+++ b/.buildkite/release-pipelines/update-app-store-strings.yml
@@ -25,5 +25,5 @@ steps:
       bundle exec fastlane update_appstore_strings skip_confirm:true
     retry:
       manual:
-        # If those jobs fail, one should always prefer re-triggering a new build from ReleaseV2 rather than retrying the individual job from Buildkite
+        # If those jobs fail, one should always prefer re-triggering a new build from Releases V2 rather than retrying the individual job from Buildkite
         allowed: false


### PR DESCRIPTION
Fixes AINFRA-23

This PR adds the `reason` field to release pipeline steps that have `retry: allowed: false`, providing a clear message to users that release jobs should be re-triggered from ReleaseV2 rather than retrying individual Buildkite jobs.