### PR TITLE
Invert a boolean check of most recently used tags first

### DIFF
--- a/WordPress/Classes/ViewRelated/Tags/TagsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Tags/TagsViewModel.swift
@@ -90,7 +90,7 @@ class TagsViewModel: ObservableObject {
                 let page = pageIndex ?? 0
                 let remoteTags = try await self.tagsService.getTags(
                     page: page,
-                    recentlyUsed: self.isBrowseMode
+                    recentlyUsed: !self.isBrowseMode
                 )
 
                 let hasMore = remoteTags.count == 100


### PR DESCRIPTION
The issue was introduced in #24955. I missed a `!` in the refactor.
