### PR TITLE
Fix an issue where the app fails to remove tags from posts

### DIFF
--- a/Modules/Sources/WordPressKit/RemotePostParameters.swift
+++ b/Modules/Sources/WordPressKit/RemotePostParameters.swift
@@ -350,10 +350,10 @@ struct RemotePostUpdateParametersWordPressComEncoder: Encodable {
 
         // Terms (including tags)
         var terms = [String: [String]]()
-        if let tags = parameters.tags, !tags.isEmpty {
+        if let tags = parameters.tags {
             terms[RemotePostWordPressComCodingKeys.postTags] = tags
         }
-        if let otherTerms = parameters.otherTerms, !otherTerms.isEmpty {
+        if let otherTerms = parameters.otherTerms {
             terms.merge(otherTerms) { old, _ in old }
         }
         if !terms.isEmpty {
@@ -476,10 +476,10 @@ struct RemotePostUpdateParametersXMLRPCEncoder: Encodable {
 
         // Terms (including tags)
         var terms = [String: [String]]()
-        if let tags = parameters.tags, !tags.isEmpty {
+        if let tags = parameters.tags {
             terms[RemotePostXMLRPCCodingKeys.taxonomyTag] = tags
         }
-        if let otherTerms = parameters.otherTerms, !otherTerms.isEmpty {
+        if let otherTerms = parameters.otherTerms {
             terms.merge(otherTerms) { old, _ in old }
         }
         if !terms.isEmpty {


### PR DESCRIPTION
To reproduce the issue: remove all tags in an existing post and save the post. The app shows an "invalid input" error.

This is a regression introduced in #24964. We should not check if values are an empty list in the "update" parameter types.