### PR TITLE
Move finding existing tag code

### DIFF
--- a/WordPress/Classes/ViewRelated/Tags/TagsService.swift
+++ b/WordPress/Classes/ViewRelated/Tags/TagsService.swift
@@ -79,11 +79,6 @@ class TagsService: TaxonomyServiceProtocol {
             throw TagsServiceError.noRemoteService
         }
 
-        if let existing = try await searchTags(with: name)
-            .first(where: { $0.name.compare(name, options: .caseInsensitive) == .orderedSame }) {
-            return existing
-        }
-
         let tag = RemotePostTag()
         tag.name = name
         tag.tagDescription = description

--- a/WordPress/Classes/ViewRelated/Tags/TagsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Tags/TagsViewModel.swift
@@ -159,7 +159,14 @@ class TagsViewModel: ObservableObject {
         // Create a new tag in the background, which is consistent with the web editor.
         Task {
             do {
-                let newTag = try await tagsService.createTag(name: name, description: "")
+                let newTag: AnyTermWithViewContext
+                if let existing = try await tagsService.searchTags(with: name)
+                    .first(where: { $0.name.compare(name, options: .caseInsensitive) == .orderedSame }) {
+                    newTag = existing
+                } else {
+                    newTag = try await tagsService.createTag(name: name, description: "")
+                }
+
                 // The original input `name` was used as a temporary tag before sending the API request.
                 // Replace it with the actual tag returned by the API.
                 if newTag.name != name, let index = selectedTags.firstIndex(of: name) {


### PR DESCRIPTION
Moving the code to the view model, so that it can cover tags and custom taxonomy terms, which are two separate `TagsServiceProtocol` implementations.

The same issue fixed by https://github.com/wordpress-mobile/WordPress-iOS/pull/25061 exists in the custom taxonomy terms input screen, too.
