### PR TITLE
Clear the tag input field after tapping the Enter key

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostTagsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostTagsView.swift
@@ -328,6 +328,8 @@ private struct AddTagsTextField: UIViewRepresentable {
 
         func textFieldShouldReturn(_ textField: UITextField) -> Bool {
             view.onSubmit()
+            self.view.text = ""
+            textField.text = ""
             return false
         }
     }


### PR DESCRIPTION
We already have code that clears the text field in the `addTag` function. However, during testing, I noticed it does not always work. The new change here makes sure the `UITextField` is cleared, because we are calling the UIKit directly, instead of relying on SwiftUI to pass the `text` changes to UIKit.
