### PR TITLE
Use Buildkite's storage for tests build products

### DIFF
--- a/.buildkite/commands/build-for-testing.sh
+++ b/.buildkite/commands/build-for-testing.sh
@@ -30,4 +30,4 @@ bundle exec fastlane build_${APP}_for_testing
 
 echo "--- :arrow_up: Upload Build Products"
 tar -cf build-products-${APP}.tar DerivedData/Build/Products/
-upload_artifact build-products-${APP}.tar
+buildkite-agent artifact upload build-products-${APP}.tar

--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -19,7 +19,7 @@ else
 fi
 
 echo "--- 📦 Downloading Build Artifacts"
-download_artifact build-products-jetpack.tar
+buildkite-agent artifact download build-products-jetpack.tar .
 tar -xf build-products-jetpack.tar
 
 # Only the gems are needed here, given we run the tests on a pre-built binary

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -9,7 +9,7 @@ echo '--- :test-analytics: Configuring Test Analytics'
 export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS
 
 echo "--- 📦 Downloading Build Artifacts"
-download_artifact build-products-wordpress.tar
+buildkite-agent artifact download build-products-wordpress.tar .
 tar -xf build-products-wordpress.tar
 
 # Only the gems are needed here, given we run the tests on a pre-built binary


### PR DESCRIPTION
Test PR to compare the transfer performance of the Buildkite implementation after year of using ours.

---

Unfortunately, the difference (ours left, Buildkite right) is still significant:

<img width="2917" height="273" alt="image" src="https://github.com/user-attachments/assets/2c404285-c429-4f9a-ad1c-bba5e504df49" />
