### PR TITLE
Rename External Links to Clicks

### DIFF
--- a/Modules/Sources/JetpackStats/Services/Data/TopListItemType.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListItemType.swift
@@ -19,7 +19,7 @@ enum TopListItemType: String, Identifiable, CaseIterable, Sendable, Codable {
         case .authors: Strings.SiteDataTypes.authors
         case .referrers: Strings.SiteDataTypes.referrers
         case .locations: Strings.SiteDataTypes.locations
-        case .externalLinks: Strings.SiteDataTypes.externalLinks
+        case .externalLinks: Strings.SiteDataTypes.clicks
         case .fileDownloads: Strings.SiteDataTypes.fileDownloads
         case .searchTerms: Strings.SiteDataTypes.searchTerms
         case .videos: Strings.SiteDataTypes.videos

--- a/Modules/Sources/JetpackStats/Strings.swift
+++ b/Modules/Sources/JetpackStats/Strings.swift
@@ -49,7 +49,7 @@ enum Strings {
         static let authors = AppLocalizedString("jetpackStats.siteDataTypes.authors", value: "Authors", comment: "Authors data type")
         static let referrers = AppLocalizedString("jetpackStats.siteDataTypes.referrers", value: "Referrers", comment: "Referrers data type")
         static let locations = AppLocalizedString("jetpackStats.siteDataTypes.locations", value: "Locations", comment: "Locations data type")
-        static let externalLinks = AppLocalizedString("jetpackStats.siteDataTypes.externalLinks", value: "External Links", comment: "External links data type")
+        static let clicks = AppLocalizedString("jetpackStats.siteDataTypes.clicks", value: "Clicks", comment: "Clicks data type (external links)")
         static let fileDownloads = AppLocalizedString("jetpackStats.siteDataTypes.fileDownloads", value: "File Downloads", comment: "File downloads data type")
         static let searchTerms = AppLocalizedString("jetpackStats.siteDataTypes.searchTerms", value: "Search Terms", comment: "Search terms data type")
         static let videos = AppLocalizedString("jetpackStats.siteDataTypes.videos", value: "Videos", comment: "Videos data type")

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,8 @@
 -----
 * [**] [Intelligence] Expand AI-based features to more locales [#25034]
 * [*] Fix previewing posts on WordPress.com atomic sites [#25045]
+* [*] Stats: Rename "External Links" to "Clicks" to be consistent with the web [#25090]
+
 
 26.5
 -----


### PR DESCRIPTION
## Description
Fixes https://linear.app/a8c/issue/CMM-1089/jetpack-ios-clicks-section-missing-from-new-stats-experience.

<img width="456" height="972" alt="Screenshot 2025-12-22 at 5 52 34 PM" src="https://github.com/user-attachments/assets/656e04de-b4b6-4f9a-9474-887309bf7fd3" />
