### PR TITLE
Stats: Add days/weeks/months/years picker for charts

### DIFF
--- a/Modules/Sources/JetpackStats/Analytics/StatsEvent.swift
+++ b/Modules/Sources/JetpackStats/Analytics/StatsEvent.swift
@@ -83,6 +83,12 @@ public enum StatsEvent {
     ///   - "to_type": New chart type
     case chartTypeChanged
 
+    /// Chart granularity changed
+    /// - Parameters:
+    ///   - "from": Previous granularity (e.g., "day", "week", "automatic")
+    ///   - "to": New granularity
+    case chartGranularityChanged
+
     /// Chart metric selected
     /// - Parameters:
     ///   - "metric": The metric selected (e.g., "visitors", "views", "likes")
@@ -197,6 +203,19 @@ extension SiteMetric {
         case .timeOnSite: "time_on_site"
         case .bounceRate: "bounce_rate"
         case .downloads: "downloads"
+        }
+    }
+}
+
+extension DateRangeGranularity {
+    /// Analytics tracking name for the granularity
+    var analyticsName: String {
+        switch self {
+        case .hour: "hour"
+        case .day: "day"
+        case .week: "week"
+        case .month: "month"
+        case .year: "year"
         }
     }
 }

--- a/Modules/Sources/JetpackStats/Cards/ChartCardViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/ChartCardViewModel.swift
@@ -183,11 +183,8 @@ final class ChartCardViewModel: ObservableObject, TrafficCardViewModel {
             // Map previous data to align with current period dates so they
             // are displayed on the same timeline on the charts.
             let mappedPreviousDataPoints = DataPoint.mapDataPoints(
-                previousDataPoints,
-                from: dateRange.effectiveComparisonInterval,
-                to: dateRange.dateInterval,
-                component: dateRange.component,
-                calendar: dateRange.calendar
+                currentData: dataPoints,
+                previousData: previousDataPoints
             )
 
             output[metric] = ChartData(

--- a/Modules/Sources/JetpackStats/Cards/ChartCardViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/ChartCardViewModel.swift
@@ -14,6 +14,7 @@ final class ChartCardViewModel: ObservableObject, TrafficCardViewModel {
 
     @Published var isEditing = false
     @Published var selectedMetric: SiteMetric
+
     @Published var selectedChartType: ChartType {
         didSet {
             // Update configuration when chart type changes
@@ -22,12 +23,27 @@ final class ChartCardViewModel: ObservableObject, TrafficCardViewModel {
         }
     }
 
+    @Published var selectedGranularity: DateRangeGranularity? {
+        didSet {
+            // Reload data with new granularity
+            loadData(for: dateRange)
+        }
+    }
+
     weak var configurationDelegate: CardConfigurationDelegate?
 
     var dateRange: StatsDateRange {
         didSet {
+            // Reset granularity to automatic when date period changes (but not for adjacent navigation)
+            if !dateRange.isAdjacent(to: oldValue) {
+                selectedGranularity = nil
+            }
             loadData(for: dateRange)
         }
+    }
+
+    var effectiveGranularity: DateRangeGranularity {
+        selectedGranularity ?? dateRange.dateInterval.preferredGranularity
     }
 
     private let service: any StatsServiceProtocol
@@ -147,7 +163,7 @@ final class ChartCardViewModel: ObservableObject, TrafficCardViewModel {
     private func getSiteStats(dateRange: StatsDateRange) async throws -> [SiteMetric: ChartData] {
         var output: [SiteMetric: ChartData] = [:]
 
-        let granularity = dateRange.dateInterval.preferredGranularity
+        let granularity = selectedGranularity ?? dateRange.dateInterval.preferredGranularity
 
         // Fetch both current and previous period data concurrently
         async let currentResponseTask = service.getSiteStats(

--- a/Modules/Sources/JetpackStats/Cards/StandaloneChartCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/StandaloneChartCard.swift
@@ -282,11 +282,8 @@ private func generateChartData(
 
     // Map previous data points to current period dates for overlay
     let mappedPreviousData = DataPoint.mapDataPoints(
-        previousPeriod.dataPoints,
-        from: previousDateInterval,
-        to: dateRange.dateInterval,
-        component: dateRange.component,
-        calendar: calendar
+        currentData: currentPeriod.dataPoints,
+        previousData: previousPeriod.dataPoints
     )
 
     return ChartData(

--- a/Modules/Sources/JetpackStats/Charts/BarChartView.swift
+++ b/Modules/Sources/JetpackStats/Charts/BarChartView.swift
@@ -195,7 +195,6 @@ struct BarChartView: View {
             if let date = value.as(Date.self) {
                 AxisValueLabel {
                     ChartAxisDateLabel(date: date, granularity: data.granularity)
-                        .offset(x: -2) // Align it better with bars
                 }
             }
         }

--- a/Modules/Sources/JetpackStats/Charts/BarChartView.swift
+++ b/Modules/Sources/JetpackStats/Charts/BarChartView.swift
@@ -55,7 +55,7 @@ struct BarChartView: View {
             BarMark(
                 x: .value("Date", point.date, unit: data.granularity.component, calendar: context.calendar),
                 y: .value("Value", point.value),
-                width: .automatic
+                width: barWidth
             )
             .foregroundStyle(
                 LinearGradient(
@@ -70,6 +70,10 @@ struct BarChartView: View {
             .cornerRadius(6)
             .opacity(getOpacityForCurrentPeriodBar(for: point))
         }
+    }
+
+    private var barWidth: MarkDimension {
+        data.currentData.count <= 3 ? .fixed(32) : .automatic
     }
 
     private func lighten(_ color: Color) -> Color {
@@ -102,7 +106,7 @@ struct BarChartView: View {
             BarMark(
                 x: .value("Date", point.date, unit: data.granularity.component, calendar: context.calendar),
                 y: .value("Value", point.value),
-                width: .automatic,
+                width: barWidth,
                 stacking: .unstacked
             )
             .foregroundStyle(Color.secondary)

--- a/Modules/Sources/JetpackStats/Charts/BarChartView.swift
+++ b/Modules/Sources/JetpackStats/Charts/BarChartView.swift
@@ -195,10 +195,21 @@ struct BarChartView: View {
     // MARK: - Axis Configuration
 
     private var xAxis: some AxisContent {
-        AxisMarks { value in
-            if let date = value.as(Date.self) {
-                AxisValueLabel {
-                    ChartAxisDateLabel(date: date, granularity: data.granularity)
+        if data.currentData.count == 1 {
+            // A quick workaround to make this look more acceptible
+            AxisMarks(values: .stride(by: data.granularity.component, count: 1, calendar: context.calendar)) { value in
+                if let date = value.as(Date.self) {
+                    AxisValueLabel {
+                        ChartAxisDateLabel(date: date, granularity: data.granularity)
+                    }
+                }
+            }
+        } else {
+            AxisMarks(values: .automatic) { value in
+                if let date = value.as(Date.self) {
+                    AxisValueLabel {
+                        ChartAxisDateLabel(date: date, granularity: data.granularity)
+                    }
                 }
             }
         }

--- a/Modules/Sources/JetpackStats/Services/Data/DataPoint.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/DataPoint.swift
@@ -12,27 +12,20 @@ struct DataPoint: Identifiable, Sendable {
 
 extension DataPoint {
     /// Maps previous period data points to align with current period dates.
+    /// Takes the dates from current data and replaces values with corresponding previous data values.
+    /// Arrays are aligned from the end - if lengths differ, the beginning of the longer array is skipped.
     /// - Parameters:
-    ///   - previousData: The data points from the previous period
-    ///   - from: The date interval of the previous period
-    ///   - to: The date interval of the current period
-    ///   - component: The calendar component to use for date calculations
-    ///   - calendar: The calendar to use for date calculations
-    /// - Returns: An array of data points with dates shifted to align with the current period
+    ///   - currentData: The data points from the current period (provides dates)
+    ///   - previousData: The data points from the previous period (provides values)
+    /// - Returns: An array of data points with current dates and previous values
     static func mapDataPoints(
-        _ dataPoits: [DataPoint],
-        from: DateInterval,
-        to: DateInterval,
-        component: Calendar.Component,
-        calendar: Calendar
+        currentData: [DataPoint],
+        previousData: [DataPoint]
     ) -> [DataPoint] {
-        let offset = calendar.dateComponents([component], from: from.start, to: to.start).value(for: component) ?? 0
-        return dataPoits.map { dataPoint in
-            DataPoint(
-                date: calendar.date(byAdding: component, value: offset, to: dataPoint.date) ?? dataPoint.date,
-                value: dataPoint.value
-            )
-        }
+        // reversing to align by the last item in case there is a mismatch in the number of items
+        zip(currentData.reversed(), previousData.reversed()).map { current, previous in
+            DataPoint(date: current.date, value: previous.value)
+        }.reversed()
     }
 
     static func getTotalValue(for dataPoints: [DataPoint], metric: SiteMetric) -> Int? {

--- a/Modules/Sources/JetpackStats/Strings.swift
+++ b/Modules/Sources/JetpackStats/Strings.swift
@@ -31,6 +31,15 @@ enum Strings {
         static let year = AppLocalizedString("jetpackStats.calendar.year", value: "Year", comment: "Year time period")
     }
 
+    enum Granularity {
+        static let automatic = AppLocalizedString("jetpackStats.granularity.automatic", value: "Automatic", comment: "Automatic granularity option")
+        static let hour = AppLocalizedString("jetpackStats.granularity.hours", value: "Hours", comment: "Hours granularity option")
+        static let day = AppLocalizedString("jetpackStats.granularity.days", value: "Days", comment: "Days granularity option")
+        static let week = AppLocalizedString("jetpackStats.granularity.weeks", value: "Weeks", comment: "Weeks granularity option")
+        static let month = AppLocalizedString("jetpackStats.granularity.months", value: "Months", comment: "Months granularity option")
+        static let year = AppLocalizedString("jetpackStats.granularity.years", value: "Years", comment: "Years granularity option")
+    }
+
     enum SiteMetrics {
         static let views = AppLocalizedString("jetpackStats.siteMetrics.views", value: "Views", comment: "Site views metric")
         static let visitors = AppLocalizedString("jetpackStats.siteMetrics.visitors", value: "Visitors", comment: "Site visitors metric")
@@ -113,6 +122,7 @@ enum Strings {
         static let incompleteData = AppLocalizedString("jetpackStats.chart.incompleteData", value: "Might show incomplete data", comment: "Shown when current period data might be incomplete")
         static let hourlyDataUnavailable = AppLocalizedString("jetpackStats.chart.hourlyDataNotAvailable", value: "Hourly data not available", comment: "Shown for metrics that don't support hourly data")
         static let empty = AppLocalizedString("jetpackStats.chart.dataEmpty", value: "No data for period", comment: "Shown for empty states")
+        static let granularity = AppLocalizedString("jetpackStats.chart.granularity", value: "Granularity", comment: "Granularity picker label")
     }
 
     enum TopListTitles {

--- a/Modules/Sources/JetpackStats/Utilities/DateRangeGranularity.swift
+++ b/Modules/Sources/JetpackStats/Utilities/DateRangeGranularity.swift
@@ -1,11 +1,13 @@
 import Foundation
 
-enum DateRangeGranularity: Comparable {
+enum DateRangeGranularity: Comparable, CaseIterable, Identifiable {
     case hour
     case day
     case week
     case month
     case year
+
+    var id: Self { self }
 }
 
 extension DateInterval {
@@ -21,7 +23,7 @@ extension DateInterval {
         if totalDays <= 1 {
             return .hour
         }
-        // For ranges 2-90 days: show daily data (2-90 points)
+        // For ranges 2-31 days: show daily data (2-90 points)
         else if totalDays <= 31 {
             return .day
         }
@@ -40,6 +42,16 @@ extension DateInterval {
 }
 
 extension DateRangeGranularity {
+    var localizedTitle: String {
+        switch self {
+        case .hour: Strings.Granularity.hour
+        case .day: Strings.Granularity.day
+        case .week: Strings.Granularity.week
+        case .month: Strings.Granularity.month
+        case .year: Strings.Granularity.year
+        }
+    }
+
     /// Components needed to aggregate data at this granularity
     var calendarComponents: Set<Calendar.Component> {
         switch self {

--- a/Modules/Sources/JetpackStats/Utilities/DateRangeGranularity.swift
+++ b/Modules/Sources/JetpackStats/Utilities/DateRangeGranularity.swift
@@ -23,7 +23,7 @@ extension DateInterval {
         if totalDays <= 1 {
             return .hour
         }
-        // For ranges 2-31 days: show daily data (2-90 points)
+        // For ranges 2-31 days: show daily data (2-31 points)
         else if totalDays <= 31 {
             return .day
         }

--- a/Modules/Tests/JetpackStatsTests/DataPointTests.swift
+++ b/Modules/Tests/JetpackStatsTests/DataPointTests.swift
@@ -4,18 +4,18 @@ import Foundation
 
 @Suite
 struct DataPointTests {
-    let calendar = Calendar.mock(timeZone: .eastern)
-
     @Test("Maps previous data to current period with simple day offset")
     func testMapPreviousDataToCurrentSimpleDayOffset() {
         // GIVEN
-        let previousStart = Date("2025-01-01T00:00:00-03:00")
-        let previousEnd = Date("2025-01-08T00:00:00-03:00")
-        let previousRange = DateInterval(start: previousStart, end: previousEnd)
-
-        let currentStart = Date("2025-01-08T00:00:00-03:00")
-        let currentEnd = Date("2025-01-15T00:00:00-03:00")
-        let currentRange = DateInterval(start: currentStart, end: currentEnd)
+        let currentData = [
+            DataPoint(date: Date("2025-01-08T00:00:00-03:00"), value: 0),
+            DataPoint(date: Date("2025-01-09T00:00:00-03:00"), value: 0),
+            DataPoint(date: Date("2025-01-10T00:00:00-03:00"), value: 0),
+            DataPoint(date: Date("2025-01-11T00:00:00-03:00"), value: 0),
+            DataPoint(date: Date("2025-01-12T00:00:00-03:00"), value: 0),
+            DataPoint(date: Date("2025-01-13T00:00:00-03:00"), value: 0),
+            DataPoint(date: Date("2025-01-14T00:00:00-03:00"), value: 0)
+        ]
 
         let previousData = [
             DataPoint(date: Date("2025-01-01T00:00:00-03:00"), value: 100),
@@ -29,11 +29,8 @@ struct DataPointTests {
 
         // WHEN
         let mappedData = DataPoint.mapDataPoints(
-            previousData,
-            from: previousRange,
-            to: currentRange,
-            component: .day,
-            calendar: calendar
+            currentData: currentData,
+            previousData: previousData
         )
 
         // THEN
@@ -49,13 +46,11 @@ struct DataPointTests {
     @Test("Maps previous month data to current month")
     func testMapPreviousMonthDataToCurrent() {
         // GIVEN
-        let previousStart = Date("2024-12-01T00:00:00-03:00")
-        let previousEnd = Date("2025-01-01T00:00:00-03:00")
-        let previousRange = DateInterval(start: previousStart, end: previousEnd)
-
-        let currentStart = Date("2025-01-01T00:00:00-03:00")
-        let currentEnd = Date("2025-02-01T00:00:00-03:00")
-        let currentRange = DateInterval(start: currentStart, end: currentEnd)
+        let currentData = [
+            DataPoint(date: Date("2025-01-01T00:00:00-03:00"), value: 0),
+            DataPoint(date: Date("2025-01-15T00:00:00-03:00"), value: 0),
+            DataPoint(date: Date("2025-01-31T00:00:00-03:00"), value: 0)
+        ]
 
         let previousData = [
             DataPoint(date: Date("2024-12-01T00:00:00-03:00"), value: 1000),
@@ -65,11 +60,8 @@ struct DataPointTests {
 
         // WHEN
         let mappedData = DataPoint.mapDataPoints(
-            previousData,
-            from: previousRange,
-            to: currentRange,
-            component: .month,
-            calendar: calendar
+            currentData: currentData,
+            previousData: previousData
         )
 
         // THEN
@@ -85,39 +77,67 @@ struct DataPointTests {
     @Test("Maps with empty previous data")
     func testMapEmptyPreviousData() {
         // GIVEN
-        let previousRange = DateInterval(
-            start: Date("2025-01-01T00:00:00-03:00"),
-            end: Date("2025-01-08T00:00:00-03:00")
-        )
-        let currentRange = DateInterval(
-            start: Date("2025-01-08T00:00:00-03:00"),
-            end: Date("2025-01-15T00:00:00-03:00")
-        )
+        let currentData = [
+            DataPoint(date: Date("2025-01-08T00:00:00-03:00"), value: 100),
+            DataPoint(date: Date("2025-01-09T00:00:00-03:00"), value: 200),
+            DataPoint(date: Date("2025-01-10T00:00:00-03:00"), value: 300)
+        ]
         let previousData: [DataPoint] = []
 
         // WHEN
         let mappedData = DataPoint.mapDataPoints(
-            previousData,
-            from: previousRange,
-            to: currentRange,
-            component: .day,
-            calendar: calendar
+            currentData: currentData,
+            previousData: previousData
         )
 
         // THEN
         #expect(mappedData.isEmpty)
     }
 
+    @Test("Maps with mismatched array lengths, aligned from the end")
+    func testMapMismatchedArrayLengths() {
+        // GIVEN - current has 6 items, previous has 5 items
+        let currentData = [
+            DataPoint(date: Date("2025-01-08T00:00:00-03:00"), value: 0),
+            DataPoint(date: Date("2025-01-09T00:00:00-03:00"), value: 0),
+            DataPoint(date: Date("2025-01-10T00:00:00-03:00"), value: 0),
+            DataPoint(date: Date("2025-01-11T00:00:00-03:00"), value: 0),
+            DataPoint(date: Date("2025-01-12T00:00:00-03:00"), value: 0),
+            DataPoint(date: Date("2025-01-13T00:00:00-03:00"), value: 0)
+        ]
+
+        let previousData = [
+            DataPoint(date: Date("2025-01-01T00:00:00-03:00"), value: 100),
+            DataPoint(date: Date("2025-01-02T00:00:00-03:00"), value: 200),
+            DataPoint(date: Date("2025-01-03T00:00:00-03:00"), value: 300),
+            DataPoint(date: Date("2025-01-04T00:00:00-03:00"), value: 400),
+            DataPoint(date: Date("2025-01-05T00:00:00-03:00"), value: 500)
+        ]
+
+        // WHEN
+        let mappedData = DataPoint.mapDataPoints(
+            currentData: currentData,
+            previousData: previousData
+        )
+
+        // THEN - should have 5 items (min count), aligned from the end
+        // current[1..5] paired with previous[0..4]
+        #expect(mappedData.count == 5)
+        #expect(mappedData[0].date == Date("2025-01-09T00:00:00-03:00"))
+        #expect(mappedData[0].value == 100)
+        #expect(mappedData[1].date == Date("2025-01-10T00:00:00-03:00"))
+        #expect(mappedData[1].value == 200)
+        #expect(mappedData[4].date == Date("2025-01-13T00:00:00-03:00"))
+        #expect(mappedData[4].value == 500)
+    }
+
     @Test("Maps year-over-year comparison")
     func testMapYearOverYearComparison() {
         // GIVEN
-        let previousStart = Date("2024-01-01T00:00:00-03:00")
-        let previousEnd = Date("2024-01-08T00:00:00-03:00")
-        let previousRange = DateInterval(start: previousStart, end: previousEnd)
-
-        let currentStart = Date("2025-01-01T00:00:00-03:00")
-        let currentEnd = Date("2025-01-08T00:00:00-03:00")
-        let currentRange = DateInterval(start: currentStart, end: currentEnd)
+        let currentData = [
+            DataPoint(date: Date("2025-01-01T00:00:00-03:00"), value: 0),
+            DataPoint(date: Date("2025-01-07T00:00:00-03:00"), value: 0)
+        ]
 
         let previousData = [
             DataPoint(date: Date("2024-01-01T00:00:00-03:00"), value: 1000),
@@ -126,11 +146,8 @@ struct DataPointTests {
 
         // WHEN
         let mappedData = DataPoint.mapDataPoints(
-            previousData,
-            from: previousRange,
-            to: currentRange,
-            component: .year,
-            calendar: calendar
+            currentData: currentData,
+            previousData: previousData
         )
 
         // THEN
@@ -139,5 +156,44 @@ struct DataPointTests {
         #expect(mappedData[0].value == 1000)
         #expect(mappedData[1].date == Date("2025-01-07T00:00:00-03:00"))
         #expect(mappedData[1].value == 2000)
+    }
+
+    @Test("Maps previous week data to current week")
+    func testMapPreviousWeekDataToCurrent() {
+        // GIVEN
+        let currentData = [
+            DataPoint(date: Date("2025-11-17T05:00:00+00:00"), value: 0),
+            DataPoint(date: Date("2025-11-24T05:00:00+00:00"), value: 0),
+            DataPoint(date: Date("2025-12-01T05:00:00+00:00"), value: 0),
+            DataPoint(date: Date("2025-12-08T05:00:00+00:00"), value: 0),
+            DataPoint(date: Date("2025-12-15T05:00:00+00:00"), value: 0)
+        ]
+
+        let previousData = [
+            DataPoint(date: Date("2025-10-20T04:00:00+00:00"), value: 3),
+            DataPoint(date: Date("2025-10-27T04:00:00+00:00"), value: 5),
+            DataPoint(date: Date("2025-11-03T05:00:00+00:00"), value: 0),
+            DataPoint(date: Date("2025-11-10T05:00:00+00:00"), value: 0),
+            DataPoint(date: Date("2025-11-17T05:00:00+00:00"), value: 1)
+        ]
+
+        // WHEN
+        let mappedData = DataPoint.mapDataPoints(
+            currentData: currentData,
+            previousData: previousData
+        )
+
+        // THEN
+        #expect(mappedData.count == 5)
+        #expect(mappedData[0].date == Date("2025-11-17T05:00:00+00:00"))
+        #expect(mappedData[0].value == 3)
+        #expect(mappedData[1].date == Date("2025-11-24T05:00:00+00:00"))
+        #expect(mappedData[1].value == 5)
+        #expect(mappedData[2].date == Date("2025-12-01T05:00:00+00:00"))
+        #expect(mappedData[2].value == 0)
+        #expect(mappedData[3].date == Date("2025-12-08T05:00:00+00:00"))
+        #expect(mappedData[3].value == 0)
+        #expect(mappedData[4].date == Date("2025-12-15T05:00:00+00:00"))
+        #expect(mappedData[4].value == 1)
     }
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,11 +16,9 @@
 * [*] Stats: Fix an issue where bar chart would prevent vertical scroll [#25133]
 * [*] Stats: Fix an issue with External Links (Clicks) sometimes displayed incorrectly [#25128]
 * [*] Stats: Fix locations data discrepancy with the web [#25105]
-* [*] Techical: Remove obsolete Core Data models to slightly reduce the app size (-6.4 MB) [#25124]
-
-
 * [*] Stats: Add days/weeks/months/years picker for bar and line charts [#25093]
 * [*] Stats: Fix an issue with weekly data for the comparison period sometimes not being shown correctly [#25093]
+* [*] Techical: Remove obsolete Core Data models to slightly reduce the app size (-6.4 MB) [#25124]
 
 26.5
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -19,6 +19,8 @@
 * [*] Techical: Remove obsolete Core Data models to slightly reduce the app size (-6.4 MB) [#25124]
 
 
+* [*] Stats: Add days/weeks/months/years picker for bar and line charts [#25093]
+* [*] Stats: Fix an issue with weekly data for the comparison period sometimes not being shown correctly [#25093]
 
 26.5
 -----

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent+JetpackStats.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent+JetpackStats.swift
@@ -22,6 +22,7 @@ extension StatsEvent {
         case .chartTypeChanged: .jetpackStatsChartTypeChanged
         case .chartMetricSelected: .jetpackStatsChartMetricSelected
         case .chartBarSelected: .jetpackStatsChartBarSelected
+        case .chartGranularityChanged: .jetpackStatsChartGranularityChanged
         case .todayCardTapped: .jetpackStatsTodayCardTapped
         case .topListItemTapped: .jetpackStatsTopListItemTapped
         case .statsTabSelected: .jetpackStatsTabSelected

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -657,6 +657,7 @@ import WordPressShared
     case jetpackStatsChartTypeChanged
     case jetpackStatsChartMetricSelected
     case jetpackStatsChartBarSelected
+    case jetpackStatsChartGranularityChanged
 
     // Today
     case jetpackStatsTodayCardTapped
@@ -1805,6 +1806,8 @@ import WordPressShared
             return "jetpack_stats_chart_metric_selected"
         case .jetpackStatsChartBarSelected:
             return "jetpack_stats_chart_bar_selected"
+        case .jetpackStatsChartGranularityChanged:
+            return "jetpack_stats_chart_granularity_changed"
 
         // Today
         case .jetpackStatsTodayCardTapped:


### PR DESCRIPTION
## Description
- Close [CMM-705: Add days/weeks/months/years granularity picker](https://linear.app/a8c/issue/CMM-705/add-daysweeksmonthsyears-granularity-picker).
- Fix an issue with mapping of data points from the previous to the current period (wasn't working correctly for weekly granularity)

**Note**: I decided not to limit the available combinations. You can pick "Last 10 years" and select "Days" granularity. It likely will not load, but you can just not do that and it's unclear where to set the boundaries otherwise.


## Testing instructions

https://github.com/user-attachments/assets/23d82cdf-4307-496a-8f00-d6eb107262bf

