### PR TITLE
Stats: Fix locations data discrepancy with the web

### DIFF
--- a/Modules/Sources/WordPressKit/StatsTopCountryTimeIntervalData.swift
+++ b/Modules/Sources/WordPressKit/StatsTopCountryTimeIntervalData.swift
@@ -37,7 +37,7 @@ public struct StatsCountry {
 
 extension StatsTopCountryTimeIntervalData: StatsTimeIntervalData {
     public static var pathComponent: String {
-        return "stats/country-views"
+        "stats/location-views/country"
     }
 
     public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * [**] Intelligence: Expand AI-based features to more locales [#25034]
 * [*] Fix previewing posts on WordPress.com atomic sites [#25045]
 * [*] Stats: Rename "External Links" to "Clicks" to be consistent with the web [#25090]
+* [*] Stats: Fix locations data discrepancy with the web [#25105]
 
 
 26.5

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/StatsRemoteV2Tests.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/StatsRemoteV2Tests.swift
@@ -35,7 +35,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
     var siteSearchDataEndpoint: String { return "sites/\(siteID)/stats/search-terms/" }
     var siteAuthorsDataEndpoint: String { return "sites/\(siteID)/stats/top-authors/" }
     var siteVideosDataEndpoint: String { return "sites/\(siteID)/stats/video-plays/" }
-    var siteCountriesDataEndpoint: String { return "sites/\(siteID)/stats/country-views/" }
+    var siteCountriesDataEndpoint: String { return "sites/\(siteID)/stats/location-views/country/" }
     var siteClicksDataEndpoint: String { return "sites/\(siteID)/stats/clicks/" }
     var siteReferrerDataEndpoint: String { return "sites/\(siteID)/stats/referrers/" }
     var siteVisitsDataEndpoint: String { return "sites/\(siteID)/stats/visits/" }


### PR DESCRIPTION
Fixes [CMM-1039: Jetpack iOS App Traffic Locations Don't Match Website View](https://linear.app/a8c/issue/CMM-1039/jetpack-ios-app-traffic-locations-dont-match-website-view)

<img width="1375" height="845" alt="Screenshot 2026-01-05 at 2 26 37 PM" src="https://github.com/user-attachments/assets/ae10693b-29b0-46c1-acda-a6fa058756b5" />
