### PR TITLE
Redirect to WP.com login during self-hosted sites login

### DIFF
--- a/Sources/WordPressAuthenticator/Helpers/Authenticator/WordPressAuthenticator.swift
+++ b/Sources/WordPressAuthenticator/Helpers/Authenticator/WordPressAuthenticator.swift
@@ -479,7 +479,7 @@ import WordPressKit
     ///
     /// - Returns: The base URL or an empty string.
     ///
-    class func baseSiteURL(string: String) -> String {
+    public class func baseSiteURL(string: String) -> String {
 
         guard !string.isEmpty,
               let siteURL = NSURL(string: NSURL.idnEncodedURL(string)),

--- a/WordPress/Classes/Login/LoginWithUrlView.swift
+++ b/WordPress/Classes/Login/LoginWithUrlView.swift
@@ -31,7 +31,7 @@ struct LoginWithUrlView: View {
                 .padding(24)
                 .frame(maxWidth: .infinity, alignment: .center)
 
-            Text(Self.enterSiteAddress)
+            Text(Strings.enterSiteAddress)
 
             siteAdddressTextField()
 
@@ -51,7 +51,7 @@ struct LoginWithUrlView: View {
             .disabled(isContinueButtonDisabled)
         }
         .padding()
-        .navigationTitle(Self.title)
+        .navigationTitle(Strings.title)
         .navigationBarTitleDisplayMode(.inline)
     }
 
@@ -94,6 +94,7 @@ struct LoginWithUrlView: View {
                     // We need to chain the dismissing and presenting,
                     // which is not supported by SwiftUI's `dismiss` variable.
                     presenter.dismiss(animated: true) {
+                        Notice(title: Strings.wpcomSiteRedirect).post()
                         presentDotComLogin()
                     }
                 } else {
@@ -133,9 +134,24 @@ struct LoginWithUrlView: View {
     }
 }
 
-private extension LoginWithUrlView {
-    static var title: String { NSLocalizedString("addSite.selfHosted.title", value: "Add Self-Hosted Site", comment: "Title of the page to add a self-hosted site") }
-    static var enterSiteAddress: String { NSLocalizedString("addSite.selfHosted.enterSiteAddress", value: "Enter the address of the WordPress site you'd like to connect.", comment: "A message to inform users to type the site address in the text field.") }
+private enum Strings {
+    static let title = NSLocalizedString(
+        "addSite.selfHosted.title",
+        value: "Add Self-Hosted Site",
+        comment: "Title of the page to add a self-hosted site"
+    )
+
+    static let enterSiteAddress = NSLocalizedString(
+        "addSite.selfHosted.enterSiteAddress",
+        value: "Enter the address of the WordPress site you'd like to connect.",
+        comment: "A message to inform users to type the site address in the text field."
+    )
+
+    static let wpcomSiteRedirect = NSLocalizedString(
+        "addSite.selfHosted.wpcomSiteRedirect",
+        value: "This site is hosted on WordPress.com. Please log in with your WordPress.com account.",
+        comment: "Notice message shown when a user tries to add a WordPress.com site as self-hosted"
+    )
 }
 
 private extension AutoDiscoveryAttemptFailure {

--- a/WordPress/Classes/Login/LoginWithUrlView.swift
+++ b/WordPress/Classes/Login/LoginWithUrlView.swift
@@ -10,6 +10,7 @@ struct LoginWithUrlView: View {
 
     weak var presenter: UIViewController?
     let loginCompleted: (TaggedManagedObjectID<Blog>) -> Void
+    let presentDotComLogin: () -> Void
 
     @State fileprivate var errorMessage: String?
     @State private var urlField: String = ""
@@ -89,7 +90,15 @@ struct LoginWithUrlView: View {
                 dismiss()
                 self.loginCompleted(blog)
             } catch {
-                errorMessage = error.localizedDescription
+                if await shouldRedirectToDotComLogin(error: error) {
+                    // We need to chain the dismissing and presenting,
+                    // which is not supported by SwiftUI's `dismiss` variable.
+                    presenter.dismiss(animated: true) {
+                        presentDotComLogin()
+                    }
+                } else {
+                    errorMessage = error.localizedDescription
+                }
             }
 
             isLoading = false
@@ -98,6 +107,37 @@ struct LoginWithUrlView: View {
         Task { @MainActor in
             await login()
         }
+    }
+
+    // If the error is "API root (wp-json) not found", it's possible that the user typed
+    // a WP.com simple site address. We should redirect to WP.com login if that's
+    // the case.
+    private func shouldRedirectToDotComLogin(
+        error: SelfHostedSiteAuthenticator.SignInError
+    ) async -> Bool {
+        guard case let .authentication(error) = error,
+              let error = error as? AutoDiscoveryAttemptFailure,
+              case .FindApiRoot = error else { return false}
+
+        let client = WPComApiClient(
+            delegate: .init(
+                authProvider: .none(),
+                requestExecutor: WpRequestExecutor(urlSession: .shared),
+                middlewarePipeline: .default,
+                appNotifier: EmptyAppNotifier()
+            )
+        )
+
+        let siteInfo: SiteInfoResponse
+        do {
+            let url = WordPressAuthenticator.baseSiteURL(string: urlField)
+            siteInfo = try await client.siteInfo.fetch(params: .init(url: url)).data
+        } catch {
+            DDLogError("Failed to fetch site info: \(error)")
+            return false
+        }
+
+        return siteInfo.isWordPressDotCom
     }
 }
 
@@ -109,5 +149,9 @@ private extension LoginWithUrlView {
 // MARK: - SwiftUI Preview
 
 #Preview {
-    LoginWithUrlView(presenter: nil) { _ in }
+    LoginWithUrlView(
+        presenter: nil,
+        loginCompleted: { _ in },
+        presentDotComLogin: { }
+    )
 }

--- a/WordPress/Classes/Login/LoginWithUrlView.swift
+++ b/WordPress/Classes/Login/LoginWithUrlView.swift
@@ -117,33 +117,36 @@ struct LoginWithUrlView: View {
     ) async -> Bool {
         guard case let .authentication(error) = error,
               let error = error as? AutoDiscoveryAttemptFailure,
-              case .FindApiRoot = error else { return false}
+              error.shouldAttemptDotComLogin else { return false}
 
-        let client = WPComApiClient(
-            delegate: .init(
-                authProvider: .none(),
-                requestExecutor: WpRequestExecutor(urlSession: .shared),
-                middlewarePipeline: .default,
-                appNotifier: EmptyAppNotifier()
-            )
-        )
-
-        let siteInfo: SiteInfoResponse
-        do {
-            let url = WordPressAuthenticator.baseSiteURL(string: urlField)
-            siteInfo = try await client.siteInfo.fetch(params: .init(url: url)).data
-        } catch {
-            DDLogError("Failed to fetch site info: \(error)")
-            return false
+        let api = WordPressComRestApi.anonymousApi(userAgent: WPUserAgent.defaultUserAgent())
+        let remote = BlogServiceRemoteREST(wordPressComRestApi: api, siteID: 0)
+        let url = WordPressAuthenticator.baseSiteURL(string: urlField)
+        let response: [AnyHashable: Any]? = await withCheckedContinuation { continuation in
+            remote.fetchUnauthenticatedSiteInfo(forAddress: url) {
+                continuation.resume(returning: $0)
+            } failure: { _ in
+                continuation.resume(returning: nil)
+            }
         }
-
-        return siteInfo.isWordPressDotCom
+        return (response?["isWordPressDotCom"] as? Bool) == true
     }
 }
 
 private extension LoginWithUrlView {
     static var title: String { NSLocalizedString("addSite.selfHosted.title", value: "Add Self-Hosted Site", comment: "Title of the page to add a self-hosted site") }
     static var enterSiteAddress: String { NSLocalizedString("addSite.selfHosted.enterSiteAddress", value: "Enter the address of the WordPress site you'd like to connect.", comment: "A message to inform users to type the site address in the text field.") }
+}
+
+private extension AutoDiscoveryAttemptFailure {
+    var shouldAttemptDotComLogin: Bool {
+        switch self {
+        case .ParseSiteUrl:
+            false
+        case .FindApiRoot, .FetchAndParseApiRoot:
+            true
+        }
+    }
 }
 
 // MARK: - SwiftUI Preview

--- a/WordPress/Classes/Networking/WordPressDotComClient.swift
+++ b/WordPress/Classes/Networking/WordPressDotComClient.swift
@@ -151,12 +151,6 @@ final class WpComNotifier: WpAppNotifier {
     }
 }
 
-final class EmptyAppNotifier: WpAppNotifier {
-    func requestedWithInvalidAuthentication(requestUrl: String) async {
-        // Do nothing
-    }
-}
-
 final class WpComTrafficDebugger: Middleware {
     func process(
         requestExecutor: any WordPressAPIInternal.RequestExecutor,

--- a/WordPress/Classes/Networking/WordPressDotComClient.swift
+++ b/WordPress/Classes/Networking/WordPressDotComClient.swift
@@ -151,6 +151,12 @@ final class WpComNotifier: WpAppNotifier {
     }
 }
 
+final class EmptyAppNotifier: WpAppNotifier {
+    func requestedWithInvalidAuthentication(requestUrl: String) async {
+        // Do nothing
+    }
+}
+
 final class WpComTrafficDebugger: Middleware {
     func process(
         requestExecutor: any WordPressAPIInternal.RequestExecutor,


### PR DESCRIPTION
## Description

When the user types WP.com simple sites into the self-hosted site login flow, we need to redirect the user to the WordPress.com sign in flow. This feature already exists in the WordPressAuthenticator. This PR ports it to the application password authentication flow.

## Testing instructions

Turn on the application password feature flag, sign in with a simple site URL.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
