### PR TITLE
[Tooling] Redirect WireMock log to separate file

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -147,6 +147,7 @@ steps:
         artifact_paths:
           - "build/results/*"
           - "build/results/crashes/*"
+          - "build/logs/wiremock.txt"
         notify:
           - github_commit_status:
               context: "UI Tests (iPhone)"
@@ -158,6 +159,7 @@ steps:
         artifact_paths:
           - "build/results/*"
           - "build/results/crashes/*"
+          - "build/logs/wiremock.txt"
         notify:
           - github_commit_status:
               context: "UI Tests (iPad)"

--- a/API-Mocks/scripts/start.sh
+++ b/API-Mocks/scripts/start.sh
@@ -23,7 +23,7 @@ PORT="${1:-8282}"
 OUTPUT_REDIRECT="/dev/stdout"
 if [ -n "${BUILDKITE:-}" ]; then
     OUTPUT_REDIRECT="${BUILD_ARTIFACTS_DIR}/wiremock.txt"
-    mkdir -p "$(dirname "$OUTPUT_REDIRECT")"
+    mkdir -p "$BUILD_ARTIFACTS_DIR"
 fi
 java -jar "${WIREMOCK_JAR}" --root-dir "${SCRIPT_DIR}/../WordPressMocks/src/main/assets/mocks" \
                             --port "$PORT" \

--- a/API-Mocks/scripts/start.sh
+++ b/API-Mocks/scripts/start.sh
@@ -4,8 +4,9 @@ set -eu
 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 VENDOR_DIR="$(pwd)/vendor/wiremock"
+BUILD_ARTIFACTS_DIR="$(pwd)/build/logs"
 
-WIREMOCK_VERSION="2.35.0"
+WIREMOCK_VERSION="2.35.2"
 WIREMOCK_JAR="${VENDOR_DIR}/wiremock-jre8-standalone-${WIREMOCK_VERSION}.jar"
 
 if [ ! -f "$WIREMOCK_JAR" ]; then
@@ -18,6 +19,12 @@ fi
 PORT="${1:-8282}"
 
 # Start WireMock server. See http://wiremock.org/docs/running-standalone/
+# Redirect output to a log file on CI to reduce log noise
+OUTPUT_REDIRECT="/dev/stdout"
+if [ -n "${BUILDKITE:-}" ]; then
+    OUTPUT_REDIRECT="${BUILD_ARTIFACTS_DIR}/wiremock.txt"
+    mkdir -p "$(dirname "$OUTPUT_REDIRECT")"
+fi
 java -jar "${WIREMOCK_JAR}" --root-dir "${SCRIPT_DIR}/../WordPressMocks/src/main/assets/mocks" \
                             --port "$PORT" \
-                            --global-response-templating
+                            --global-response-templating > "$OUTPUT_REDIRECT" 2>&1


### PR DESCRIPTION
Fixes AINFRA-1728

## Description
WireMock logs are very verbose, and a large output is triggered whenever the app makes a HTTP call that doesn't have corresponding mocks. This can be valuable debug info, but it makes UI Test logs too long and hard to read.
I looked into its [documentation](https://wiremock.org/2.x/docs/standalone/java-jar/) but didn't find a way to have fine grained control over logging.

This PR redirects the WireMock output to a log file that is then published as a build artifact when running on CI. When running WireMock locally, console logging will work as usual.

## Testing instructions
- Make sure `build/logs/wiremock.txt` is being correctly generated for UI Test jobs
- Run `rake mocks` locally and make sure WireMock output is still being printed in the console