### PR TITLE
Add country/region/city picker to the Locations card

### DIFF
--- a/Modules/Sources/JetpackStats/Cards/RealtimeTopListCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/RealtimeTopListCard.swift
@@ -27,7 +27,7 @@ struct RealtimeTopListCard: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 16) {
             HStack {
-                StatsCardTitleView(title: selectedItem.getTitle(for: .views))
+                StatsCardTitleView(title: selectedItem.localizedTitle)
                     .unredacted()
                 Spacer()
             }

--- a/Modules/Sources/JetpackStats/Cards/TopListCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListCard.swift
@@ -88,7 +88,7 @@ struct TopListCard: View {
 
     private var mapView: some View {
         CountriesMapView(
-            data: viewModel.cachedCountriesMapData ?? .init(metric: viewModel.selection.metric, locations: []),
+            data: viewModel.countriesMapData ?? .init(metric: viewModel.selection.metric, locations: []),
             primaryColor: Constants.Colors.uiColorBlue
         )
     }

--- a/Modules/Sources/JetpackStats/Cards/TopListCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListCard.swift
@@ -75,11 +75,15 @@ struct TopListCard: View {
 
     private var cardHeaderView: some View {
         HStack {
-            StatsCardTitleView(title: viewModel.selection.item == .locations ? "Countries" : viewModel.title)
+            Menu {
+                itemTypePicker
+            } label: {
+                StatsCardTitleView(title: viewModel.selection.item.localizedTitle, showChevron: true)
+            }
             Spacer(minLength: 44)
         }
         .accessibilityElement(children: .combine)
-        .accessibilityLabel(Strings.Accessibility.cardTitle(viewModel.selection.item == .locations ? "Countries" : viewModel.title))
+        .accessibilityLabel(Strings.Accessibility.cardTitle(viewModel.title))
     }
 
     private var mapView: some View {
@@ -91,43 +95,35 @@ struct TopListCard: View {
 
     private var listHeaderView: some View {
         HStack {
-            if viewModel.items.count > 1 {
+            // Left side: Location level for locations, otherwise item type
+            if viewModel.selection.item == .locations {
                 Menu {
-                    itemTypePicker
+                    locationLevelPicker
                 } label: {
-                    InlineValuePickerTitle(title: viewModel.selection.item.localizedTitle)
-                        .padding(.top, 6)
-                        .padding(.vertical, Constants.step0_5) // Increase tap area
-                }
-                .fixedSize()
-            } else {
-                Text(viewModel.selection.item.localizedTitle)
-                    .padding(.top, 6)
-                    .padding(.vertical, Constants.step0_5)
-                    .font(.subheadline)
-                    .fontWeight(.medium)
-            }
-
-            Spacer()
-
-            let metrics = getSupportedMetrics(for: viewModel.selection.item)
-            if metrics.count > 1 {
-                Menu {
-                    makeMetricPicker(with: metrics)
-                } label: {
-                    InlineValuePickerTitle(title: viewModel.selection.metric.localizedTitle)
+                    InlineValuePickerTitle(title: viewModel.selection.locationLevel.localizedTitle)
+                        .foregroundStyle(Color.secondary)
                         .padding(.top, 6)
                         .padding(.vertical, Constants.step0_5)
                 }
                 .fixedSize()
             } else {
-                Text(viewModel.selection.metric.localizedTitle)
-                    .padding(.top, 6)
-                    .padding(.vertical, Constants.step0_5)
-                    .font(.subheadline)
-                    .fontWeight(.medium)
+                makeColumnTitle(viewModel.selection.item.localizedColumnName)
             }
+
+            Spacer()
+
+            // Right side: selected metric
+            makeColumnTitle(viewModel.selection.metric.localizedTitle)
         }
+    }
+
+    private func makeColumnTitle(_ title: String) -> some View {
+        Text(title)
+            .foregroundStyle(Color.secondary)
+            .padding(.top, 6)
+            .padding(.vertical, Constants.step0_5)
+            .font(.subheadline)
+            .fontWeight(.medium)
     }
 
     private func navigateToTopListScreen() {
@@ -205,6 +201,17 @@ struct TopListCard: View {
             }
         }
         EditCardMenuContent(cardViewModel: viewModel)
+    }
+
+    private var locationLevelPicker: some View {
+        ForEach(LocationLevel.allCases) { level in
+            Button {
+                viewModel.selection.locationLevel = level
+            } label: {
+                Label(level.localizedTitle, systemImage: level.systemImage)
+            }
+        }
+        .tint(Color.primary)
     }
 
     @ViewBuilder
@@ -310,7 +317,15 @@ struct TopListCard: View {
 }
 
 #Preview {
-    TopListCardPreview(item: .authors)
+    ScrollView {
+        VStack {
+            TopListCardPreview(item: .authors)
+            TopListCardPreview(item: .locations)
+        }
+        .padding(.horizontal, 8)
+    }
+    .scrollContentBackground(.hidden)
+    .background(Constants.Colors.background)
 }
 
 private struct TopListCardPreview: View {

--- a/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
@@ -27,7 +27,7 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
     @Published private(set) var isLoading = true
     @Published private(set) var loadingError: Error?
     @Published private(set) var isStale = false
-    @Published private(set) var cachedCountriesMapData: CountriesMapData?
+    @Published private(set) var countriesMapData: CountriesMapData?
 
     @Published var isEditing = false
 
@@ -106,22 +106,12 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
         isFirstAppear = false
 
         // Track card shown event
-        var properties: [String: String] = [
+        tracker?.send(.cardShown, properties: [
             "card_type": CardType.topList.rawValue,
+            "configuration": "\(selection.item.analyticsName)_\(selection.metric.analyticsName)",
             "item_type": selection.item.analyticsName,
             "metric": selection.metric.analyticsName
-        ]
-
-        // Add location level if applicable
-        if selection.item == .locations {
-            let level = selection.locationLevel
-            properties["location_level"] = level.analyticsName
-            properties["configuration"] = "\(selection.item.analyticsName)_\(level.analyticsName)_\(selection.metric.analyticsName)"
-        } else {
-            properties["configuration"] = "\(selection.item.analyticsName)_\(selection.metric.analyticsName)"
-        }
-
-        tracker?.send(.cardShown, properties: properties)
+        ])
 
         loadData()
     }
@@ -171,22 +161,35 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
             // Check for cancellation before updating the state
             try Task.checkCancellation()
 
+            // Fetch country-level data for map if viewing regions or cities
+            var mapData: CountriesMapData?
+            if selection.item == .locations {
+                if selection.locationLevel == .countries {
+                    // Use the main data for countries
+                    mapData = createCountriesMapData(from: data)
+                } else {
+                    // Fetch separate country-level data for regions/cities
+                    var countriesSelection = selection
+                    countriesSelection.locationLevel = .countries
+                    let countriesData = try await getTopListData(for: countriesSelection, dateRange: dateRange)
+                    mapData = createCountriesMapData(from: countriesData)
+                }
+            }
+
+            // Check for cancellation before updating the state
+            try Task.checkCancellation()
+
             // Cancel stale timer and reset stale flag when data is successfully loaded
             staleTimer?.cancel()
             isStale = false
             self.data = data
-
-            // Update cached CountriesMapData if locations are selected
-            if selection.item == .locations {
-                updateCountriesMapDataCache(from: data)
-            } else {
-                cachedCountriesMapData = nil
-            }
+            self.countriesMapData = mapData
         } catch is CancellationError {
             return
         } catch {
             loadingError = error
             data = nil
+            countriesMapData = nil
             tracker?.trackError(error, screen: "top_list_card")
         }
 
@@ -266,11 +269,11 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
         }
     }
 
-    private func updateCountriesMapDataCache(from data: TopListData) {
+    private func createCountriesMapData(from data: TopListData) -> CountriesMapData {
         let locations = data.items.compactMap { $0 as? TopListItem.Location }
         let previousLocations = data.previousItems.compactMapValues { $0 as? TopListItem.Location }
 
-        cachedCountriesMapData = CountriesMapData(
+        return CountriesMapData(
             metric: selection.metric,
             locations: locations,
             previousLocations: previousLocations

--- a/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
@@ -8,7 +8,7 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
     let groupedItems: [[TopListItemType]]
 
     var title: String {
-        selection.item.getTitle(for: selection.metric)
+        selection.item.localizedTitle
     }
 
     @Published private(set) var configuration: TopListCardConfiguration {
@@ -50,6 +50,7 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
     struct Selection: Equatable, Sendable {
         var item: TopListItemType
         var metric: SiteMetric
+        var locationLevel: LocationLevel = .countries
     }
 
     enum Filter: Equatable {
@@ -105,12 +106,22 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
         isFirstAppear = false
 
         // Track card shown event
-        tracker?.send(.cardShown, properties: [
+        var properties: [String: String] = [
             "card_type": CardType.topList.rawValue,
-            "configuration": "\(selection.item.analyticsName)_\(selection.metric.analyticsName)",
             "item_type": selection.item.analyticsName,
             "metric": selection.metric.analyticsName
-        ])
+        ]
+
+        // Add location level if applicable
+        if selection.item == .locations {
+            let level = selection.locationLevel
+            properties["location_level"] = level.analyticsName
+            properties["configuration"] = "\(selection.item.analyticsName)_\(level.analyticsName)_\(selection.metric.analyticsName)"
+        } else {
+            properties["configuration"] = "\(selection.item.analyticsName)_\(selection.metric.analyticsName)"
+        }
+
+        tracker?.send(.cardShown, properties: properties)
 
         loadData()
     }
@@ -201,7 +212,8 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
             metric: selection.metric,
             interval: dateRange.dateInterval,
             granularity: granularity,
-            limit: fetchLimit
+            limit: fetchLimit,
+            locationLevel: selection.locationLevel
         )
 
         // Fetch previous data only for items that support it
@@ -212,7 +224,8 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
                 metric: selection.metric,
                 interval: dateRange.effectiveComparisonInterval,
                 granularity: granularity,
-                limit: fetchLimit
+                limit: fetchLimit,
+                locationLevel: selection.locationLevel
             )
         }()
 

--- a/Modules/Sources/JetpackStats/Resources/Mocks/HistoricalData/historical-locations.json
+++ b/Modules/Sources/JetpackStats/Resources/Mocks/HistoricalData/historical-locations.json
@@ -1,6 +1,6 @@
 [
   {
-    "country": "United States",
+    "name": "United States",
     "countryCode": "US",
     "flag": "🇺🇸",
     "metrics": {
@@ -13,7 +13,7 @@
     }
   },
   {
-    "country": "United Kingdom",
+    "name": "United Kingdom",
     "countryCode": "GB",
     "flag": "🇬🇧",
     "metrics": {
@@ -26,7 +26,7 @@
     }
   },
   {
-    "country": "Canada",
+    "name": "Canada",
     "countryCode": "CA",
     "flag": "🇨🇦",
     "metrics": {
@@ -39,7 +39,7 @@
     }
   },
   {
-    "country": "Germany",
+    "name": "Germany",
     "countryCode": "DE",
     "flag": "🇩🇪",
     "metrics": {
@@ -52,7 +52,7 @@
     }
   },
   {
-    "country": "Japan",
+    "name": "Japan",
     "countryCode": "JP",
     "flag": "🇯🇵",
     "metrics": {
@@ -65,7 +65,7 @@
     }
   },
   {
-    "country": "Australia",
+    "name": "Australia",
     "countryCode": "AU",
     "flag": "🇦🇺",
     "metrics": {
@@ -78,7 +78,7 @@
     }
   },
   {
-    "country": "France",
+    "name": "France",
     "countryCode": "FR",
     "flag": "🇫🇷",
     "metrics": {
@@ -91,7 +91,7 @@
     }
   },
   {
-    "country": "India",
+    "name": "India",
     "countryCode": "IN",
     "flag": "🇮🇳",
     "metrics": {
@@ -104,7 +104,7 @@
     }
   },
   {
-    "country": "Netherlands",
+    "name": "Netherlands",
     "countryCode": "NL",
     "flag": "🇳🇱",
     "metrics": {
@@ -117,7 +117,7 @@
     }
   },
   {
-    "country": "Sweden",
+    "name": "Sweden",
     "countryCode": "SE",
     "flag": "🇸🇪",
     "metrics": {
@@ -130,7 +130,7 @@
     }
   },
   {
-    "country": "Italy",
+    "name": "Italy",
     "countryCode": "IT",
     "flag": "🇮🇹",
     "metrics": {
@@ -143,7 +143,7 @@
     }
   },
   {
-    "country": "South Korea",
+    "name": "South Korea",
     "countryCode": "KR",
     "flag": "🇰🇷",
     "metrics": {
@@ -156,7 +156,7 @@
     }
   },
   {
-    "country": "Spain",
+    "name": "Spain",
     "countryCode": "ES",
     "flag": "🇪🇸",
     "metrics": {
@@ -169,7 +169,7 @@
     }
   },
   {
-    "country": "Brazil",
+    "name": "Brazil",
     "countryCode": "BR",
     "flag": "🇧🇷",
     "metrics": {
@@ -182,7 +182,7 @@
     }
   },
   {
-    "country": "Switzerland",
+    "name": "Switzerland",
     "countryCode": "CH",
     "flag": "🇨🇭",
     "metrics": {
@@ -195,7 +195,7 @@
     }
   },
   {
-    "country": "Norway",
+    "name": "Norway",
     "countryCode": "NO",
     "flag": "🇳🇴",
     "metrics": {
@@ -208,7 +208,7 @@
     }
   },
   {
-    "country": "Denmark",
+    "name": "Denmark",
     "countryCode": "DK",
     "flag": "🇩🇰",
     "metrics": {
@@ -221,7 +221,7 @@
     }
   },
   {
-    "country": "Belgium",
+    "name": "Belgium",
     "countryCode": "BE",
     "flag": "🇧🇪",
     "metrics": {
@@ -234,7 +234,7 @@
     }
   },
   {
-    "country": "Poland",
+    "name": "Poland",
     "countryCode": "PL",
     "flag": "🇵🇱",
     "metrics": {
@@ -247,7 +247,7 @@
     }
   },
   {
-    "country": "Finland",
+    "name": "Finland",
     "countryCode": "FI",
     "flag": "🇫🇮",
     "metrics": {
@@ -260,7 +260,7 @@
     }
   },
   {
-    "country": "Austria",
+    "name": "Austria",
     "countryCode": "AT",
     "flag": "🇦🇹",
     "metrics": {
@@ -273,7 +273,7 @@
     }
   },
   {
-    "country": "Singapore",
+    "name": "Singapore",
     "countryCode": "SG",
     "flag": "🇸🇬",
     "metrics": {
@@ -286,7 +286,7 @@
     }
   },
   {
-    "country": "Ireland",
+    "name": "Ireland",
     "countryCode": "IE",
     "flag": "🇮🇪",
     "metrics": {
@@ -299,7 +299,7 @@
     }
   },
   {
-    "country": "New Zealand",
+    "name": "New Zealand",
     "countryCode": "NZ",
     "flag": "🇳🇿",
     "metrics": {
@@ -312,7 +312,7 @@
     }
   },
   {
-    "country": "Hong Kong",
+    "name": "Hong Kong",
     "countryCode": "HK",
     "flag": "🇭🇰",
     "metrics": {
@@ -325,7 +325,7 @@
     }
   },
   {
-    "country": "Israel",
+    "name": "Israel",
     "countryCode": "IL",
     "flag": "🇮🇱",
     "metrics": {
@@ -338,7 +338,7 @@
     }
   },
   {
-    "country": "Mexico",
+    "name": "Mexico",
     "countryCode": "MX",
     "flag": "🇲🇽",
     "metrics": {
@@ -351,7 +351,7 @@
     }
   },
   {
-    "country": "Czech Republic",
+    "name": "Czech Republic",
     "countryCode": "CZ",
     "flag": "🇨🇿",
     "metrics": {
@@ -364,7 +364,7 @@
     }
   },
   {
-    "country": "Portugal",
+    "name": "Portugal",
     "countryCode": "PT",
     "flag": "🇵🇹",
     "metrics": {
@@ -377,7 +377,7 @@
     }
   },
   {
-    "country": "Taiwan",
+    "name": "Taiwan",
     "countryCode": "TW",
     "flag": "🇹🇼",
     "metrics": {

--- a/Modules/Sources/JetpackStats/Resources/Mocks/RealtimeData/realtime-locations.json
+++ b/Modules/Sources/JetpackStats/Resources/Mocks/RealtimeData/realtime-locations.json
@@ -1,6 +1,6 @@
 [
   {
-    "country": "United States",
+    "name": "United States",
     "countryCode": "US",
     "flag": "🇺🇸",
     "metrics": {
@@ -8,7 +8,7 @@
     }
   },
   {
-    "country": "United Kingdom",
+    "name": "United Kingdom",
     "countryCode": "GB",
     "flag": "🇬🇧",
     "metrics": {
@@ -16,7 +16,7 @@
     }
   },
   {
-    "country": "Canada",
+    "name": "Canada",
     "countryCode": "CA",
     "flag": "🇨🇦",
     "metrics": {
@@ -24,7 +24,7 @@
     }
   },
   {
-    "country": "Germany",
+    "name": "Germany",
     "countryCode": "DE",
     "flag": "🇩🇪",
     "metrics": {
@@ -32,7 +32,7 @@
     }
   },
   {
-    "country": "Australia",
+    "name": "Australia",
     "countryCode": "AU",
     "flag": "🇦🇺",
     "metrics": {
@@ -40,7 +40,7 @@
     }
   },
   {
-    "country": "France",
+    "name": "France",
     "countryCode": "FR",
     "flag": "🇫🇷",
     "metrics": {
@@ -48,7 +48,7 @@
     }
   },
   {
-    "country": "Japan",
+    "name": "Japan",
     "countryCode": "JP",
     "flag": "🇯🇵",
     "metrics": {
@@ -56,7 +56,7 @@
     }
   },
   {
-    "country": "Netherlands",
+    "name": "Netherlands",
     "countryCode": "NL",
     "flag": "🇳🇱",
     "metrics": {

--- a/Modules/Sources/JetpackStats/Services/Data/CSVExportable.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/CSVExportable.swift
@@ -51,7 +51,7 @@ extension TopListItem.Location: CSVExportable {
 
     var csvValues: [String] {
         [
-            country,
+            name,
             countryCode ?? ""
         ]
     }

--- a/Modules/Sources/JetpackStats/Services/Data/LocationLevel.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/LocationLevel.swift
@@ -1,0 +1,37 @@
+import Foundation
+
+enum LocationLevel: String, Identifiable, CaseIterable, Sendable, Codable {
+    case countries
+    case regions
+    case cities
+
+    var id: LocationLevel { self }
+
+    var localizedTitle: String {
+        switch self {
+        case .countries: Strings.LocationLevels.countries
+        case .regions: Strings.LocationLevels.regions
+        case .cities: Strings.LocationLevels.cities
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .countries: "flag"
+        case .regions: "map"
+        case .cities: "building.2"
+        }
+    }
+
+    var analyticsName: String {
+        rawValue
+    }
+
+    var pathComponent: String {
+        switch self {
+        case .countries: "stats/location-views/country"
+        case .regions: "stats/location-views/region"
+        case .cities: "stats/location-views/city"
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Services/Data/LocationLevel.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/LocationLevel.swift
@@ -26,12 +26,4 @@ enum LocationLevel: String, Identifiable, CaseIterable, Sendable, Codable {
     var analyticsName: String {
         rawValue
     }
-
-    var pathComponent: String {
-        switch self {
-        case .countries: "stats/location-views/country"
-        case .regions: "stats/location-views/region"
-        case .cities: "stats/location-views/city"
-        }
-    }
 }

--- a/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
@@ -197,7 +197,7 @@ extension TopListData {
             let baseValue = data.3
             let metrics = createMetrics(baseValue: baseValue, metric: metric)
             return TopListItem.Location(
-                country: data.0,
+                name: data.0,
                 flag: data.2,
                 countryCode: data.1,
                 metrics: metrics

--- a/Modules/Sources/JetpackStats/Services/Data/TopListItem+WordPressKit.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListItem+WordPressKit.swift
@@ -37,6 +37,28 @@ extension TopListItem.Location {
         )
     }
 
+    init(_ region: WordPressKit.StatsRegion) {
+        self.init(
+            name: region.name,
+            code: region.code,
+            flag: nil,
+            parentName: nil,
+            parentCode: region.countryCode,
+            metrics: SiteMetricsSet(views: region.viewsCount)
+        )
+    }
+
+    init(_ city: WordPressKit.StatsCity) {
+        self.init(
+            name: city.name,
+            code: city.code,
+            flag: nil,
+            parentName: city.regionName,
+            parentCode: city.countryCode,
+            metrics: SiteMetricsSet(views: city.viewsCount)
+        )
+    }
+
     private static func countryCodeToEmoji(_ code: String) -> String? {
         let base: UInt32 = 127397
         var scalarView = String.UnicodeScalarView()

--- a/Modules/Sources/JetpackStats/Services/Data/TopListItem+WordPressKit.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListItem+WordPressKit.swift
@@ -30,31 +30,27 @@ extension TopListItem.Referrer {
 extension TopListItem.Location {
     init(_ country: WordPressKit.StatsCountry) {
         self.init(
-            country: country.name,
+            name: country.name,
             flag: Self.countryCodeToEmoji(country.code),
             countryCode: country.code,
             metrics: SiteMetricsSet(views: country.viewsCount)
         )
     }
 
-    init(_ region: WordPressKit.StatsRegion) {
+    init(_ region: WordPressKit.StatsTopRegionTimeIntervalData.Region) {
         self.init(
             name: region.name,
-            code: region.code,
-            flag: nil,
-            parentName: nil,
-            parentCode: region.countryCode,
+            flag: Self.countryCodeToEmoji(region.countryCode),
+            countryCode: region.countryCode,
             metrics: SiteMetricsSet(views: region.viewsCount)
         )
     }
 
-    init(_ city: WordPressKit.StatsCity) {
+    init(_ city: WordPressKit.StatsTopCityTimeIntervalData.City) {
         self.init(
             name: city.name,
-            code: city.code,
-            flag: nil,
-            parentName: city.regionName,
-            parentCode: city.countryCode,
+            flag: Self.countryCodeToEmoji(city.countryCode),
+            countryCode: city.countryCode,
             metrics: SiteMetricsSet(views: city.viewsCount)
         )
     }

--- a/Modules/Sources/JetpackStats/Services/Data/TopListItem.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListItem.swift
@@ -50,13 +50,48 @@ extension TopListItem {
     }
 
     struct Location: Codable, TopListItemProtocol {
-        let country: String
+        let name: String
+        let code: String?
         let flag: String?
-        let countryCode: String?
+        let parentName: String?
+        let parentCode: String?
         var metrics: SiteMetricsSet
 
         var id: TopListItemID {
-            TopListItemID(type: .locations, id: countryCode ?? country)
+            TopListItemID(type: .locations, id: code ?? name)
+        }
+
+        // Backwards compatibility
+        var country: String { name }
+        var countryCode: String? { code }
+
+        // Custom coding keys for backwards compatibility with JSON files
+        enum CodingKeys: String, CodingKey {
+            case name = "country"
+            case code = "countryCode"
+            case flag
+            case parentName
+            case parentCode
+            case metrics
+        }
+
+        init(name: String, code: String?, flag: String?, parentName: String? = nil, parentCode: String? = nil, metrics: SiteMetricsSet) {
+            self.name = name
+            self.code = code
+            self.flag = flag
+            self.parentName = parentName
+            self.parentCode = parentCode
+            self.metrics = metrics
+        }
+
+        // Backwards compatibility initializer
+        init(country: String, flag: String?, countryCode: String?, metrics: SiteMetricsSet) {
+            self.name = country
+            self.code = countryCode
+            self.flag = flag
+            self.parentName = nil
+            self.parentCode = nil
+            self.metrics = metrics
         }
     }
 

--- a/Modules/Sources/JetpackStats/Services/Data/TopListItem.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListItem.swift
@@ -51,47 +51,12 @@ extension TopListItem {
 
     struct Location: Codable, TopListItemProtocol {
         let name: String
-        let code: String?
         let flag: String?
-        let parentName: String?
-        let parentCode: String?
+        let countryCode: String?
         var metrics: SiteMetricsSet
 
         var id: TopListItemID {
-            TopListItemID(type: .locations, id: code ?? name)
-        }
-
-        // Backwards compatibility
-        var country: String { name }
-        var countryCode: String? { code }
-
-        // Custom coding keys for backwards compatibility with JSON files
-        enum CodingKeys: String, CodingKey {
-            case name = "country"
-            case code = "countryCode"
-            case flag
-            case parentName
-            case parentCode
-            case metrics
-        }
-
-        init(name: String, code: String?, flag: String?, parentName: String? = nil, parentCode: String? = nil, metrics: SiteMetricsSet) {
-            self.name = name
-            self.code = code
-            self.flag = flag
-            self.parentName = parentName
-            self.parentCode = parentCode
-            self.metrics = metrics
-        }
-
-        // Backwards compatibility initializer
-        init(country: String, flag: String?, countryCode: String?, metrics: SiteMetricsSet) {
-            self.name = country
-            self.code = countryCode
-            self.flag = flag
-            self.parentName = nil
-            self.parentCode = nil
-            self.metrics = metrics
+            TopListItemID(type: .locations, id: name)
         }
     }
 

--- a/Modules/Sources/JetpackStats/Services/Data/TopListItemType.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListItemType.swift
@@ -41,16 +41,17 @@ enum TopListItemType: String, Identifiable, CaseIterable, Sendable, Codable {
         }
     }
 
-    func getTitle(for metric: SiteMetric) -> String {
-        switch metric {
-        case .views: Strings.TopListTitles.mostViewed
-        case .visitors: Strings.TopListTitles.mostVisitors
-        case .comments: Strings.TopListTitles.mostCommented
-        case .likes: Strings.TopListTitles.mostLiked
-        case .posts: Strings.TopListTitles.mostPosts
-        case .bounceRate: Strings.TopListTitles.highestBounceRate
-        case .timeOnSite: Strings.TopListTitles.longestTimeOnSite
-        case .downloads: Strings.TopListTitles.mostDownloadeded
+    var localizedColumnName: String {
+        switch self {
+        case .postsAndPages: Strings.TopListTitles.postsAndPages
+        case .authors: Strings.TopListTitles.authors
+        case .referrers: Strings.TopListTitles.referrers
+        case .locations: Strings.TopListTitles.locations
+        case .externalLinks: Strings.TopListTitles.clicks
+        case .fileDownloads: Strings.TopListTitles.fileDownloads
+        case .searchTerms: Strings.TopListTitles.searchTerms
+        case .videos: Strings.TopListTitles.videos
+        case .archive: Strings.TopListTitles.archive
         }
     }
 

--- a/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
@@ -79,7 +79,7 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
         return SiteMetricsResponse(total: total, metrics: output)
     }
 
-    func getTopListData(_ item: TopListItemType, metric: SiteMetric, interval: DateInterval, granularity: DateRangeGranularity, limit: Int?) async throws -> TopListResponse {
+    func getTopListData(_ item: TopListItemType, metric: SiteMetric, interval: DateInterval, granularity: DateRangeGranularity, limit: Int?, locationLevel: LocationLevel?) async throws -> TopListResponse {
         await generateDataIfNeeded()
 
         guard let typeData = dailyTopListData[item] else {

--- a/Modules/Sources/JetpackStats/Services/StatsServiceProtocol.swift
+++ b/Modules/Sources/JetpackStats/Services/StatsServiceProtocol.swift
@@ -8,7 +8,7 @@ protocol StatsServiceProtocol: AnyObject, Sendable {
     func getSupportedMetrics(for item: TopListItemType) -> [SiteMetric]
 
     func getSiteStats(interval: DateInterval, granularity: DateRangeGranularity) async throws -> SiteMetricsResponse
-    func getTopListData(_ item: TopListItemType, metric: SiteMetric, interval: DateInterval, granularity: DateRangeGranularity, limit: Int?) async throws -> TopListResponse
+    func getTopListData(_ item: TopListItemType, metric: SiteMetric, interval: DateInterval, granularity: DateRangeGranularity, limit: Int?, locationLevel: LocationLevel?) async throws -> TopListResponse
     func getRealtimeTopListData(_ item: TopListItemType) async throws -> TopListResponse
     func getPostDetails(for postID: Int) async throws -> StatsPostDetails
     func getPostLikes(for postID: Int, count: Int) async throws -> PostLikesData

--- a/Modules/Sources/JetpackStats/Strings.swift
+++ b/Modules/Sources/JetpackStats/Strings.swift
@@ -56,11 +56,13 @@ enum Strings {
     }
 
     enum Countries {
-        static let noViews = AppLocalizedString(
-            "jetpackStats.countries.noViews",
-            value: "No views",
-            comment: "Message shown when a country has no views"
-        )
+        static let noViews = AppLocalizedString("jetpackStats.countries.noViews", value: "No views", comment: "Message shown when a country has no views")
+    }
+
+    enum LocationLevels {
+        static let countries = AppLocalizedString("jetpackStats.locationLevels.countries", value: "Countries", comment: "Location level selector for countries")
+        static let regions = AppLocalizedString("jetpackStats.locationLevels.regions", value: "Regions", comment: "Location level selector for regions")
+        static let cities = AppLocalizedString("jetpackStats.locationLevels.cities", value: "Cities", comment: "Location level selector for cities")
     }
 
     enum Buttons {
@@ -114,14 +116,15 @@ enum Strings {
     }
 
     enum TopListTitles {
-        static let mostViewed = AppLocalizedString("jetpackStats.topList.mostViewed", value: "Most Viewed", comment: "Title for most viewed items")
-        static let mostVisitors = AppLocalizedString("jetpackStats.topList.mostVisitors", value: "Most Visitors", comment: "Title for items with most visitors")
-        static let mostCommented = AppLocalizedString("jetpackStats.topList.mostCommented", value: "Most Commented", comment: "Title for most commented items")
-        static let mostLiked = AppLocalizedString("jetpackStats.topList.mostLiked", value: "Most Liked", comment: "Title for most liked items")
-        static let mostPosts = AppLocalizedString("jetpackStats.topList.mostPosts", value: "Most Posts", comment: "Title for most posts (per author)")
-        static let highestBounceRate = AppLocalizedString("jetpackStats.topList.highestBounceRate", value: "Highest Bounce Rate", comment: "Title for items with highest bounce rate")
-        static let longestTimeOnSite = AppLocalizedString("jetpackStats.topList.longestTimeOnSite", value: "Longest Time on Site", comment: "Title for items with longest time on site")
-        static let mostDownloadeded = AppLocalizedString("jetpackStats.topList.mostDownloads", value: "Most Downloaded", comment: "Title for chart")
+        static let postsAndPages = AppLocalizedString("jetpackStats.topListColumnTitle.postsAndPages", value: "Title", comment: "Table column title for Top List card")
+        static let archive = AppLocalizedString("jetpackStats.topListColumnTitle.archive", value: "Title", comment: "Table column title for Top List card")
+        static let authors = AppLocalizedString("jetpackStats.topListColumnTitle.authors", value: "Author", comment: "Table column title for Top List card")
+        static let referrers = AppLocalizedString("jetpackStats.topListColumnTitle.referrers", value: "Referrer", comment: "Table column title for Top List card")
+        static let locations = AppLocalizedString("jetpackStats.topListColumnTitle.locations", value: "Location", comment: "Table column title for Top List card")
+        static let clicks = AppLocalizedString("jetpackStats.topListColumnTitle.clicks", value: "External Link", comment: "Table column title for Top List card")
+        static let fileDownloads = AppLocalizedString("jetpackStats.topListColumnTitle.fileDownloads", value: "File", comment: "Table column title for Top List card")
+        static let searchTerms = AppLocalizedString("jetpackStats.topListColumnTitle.searchTerms", value: "Term", comment: "Table column title for Top List card")
+        static let videos = AppLocalizedString("jetpackStats.topListColumnTitle.videos", value: "Video", comment: "Table column title for Top List card")
         static let top10 = AppLocalizedString("jetpackStats.postDetails.top10", value: "Top 10", comment: "Section title")
         static let top50 = AppLocalizedString("jetpackStats.postDetails.top50", value: "Top 50", comment: "Section title")
     }

--- a/Modules/Sources/JetpackStats/Views/CountryMap/CountriesMapView.swift
+++ b/Modules/Sources/JetpackStats/Views/CountryMap/CountriesMapView.swift
@@ -67,49 +67,49 @@ struct CountriesMapView: View {
     CountriesMapView(
         data: CountriesMapData(metric: .views, locations: [
             TopListItem.Location(
-                country: "United States",
+                name: "United States",
                 flag: "🇺🇸",
                 countryCode: "US",
                 metrics: SiteMetricsSet(views: 10000)
             ),
             TopListItem.Location(
-                country: "United Kingdom",
+                name: "United Kingdom",
                 flag: "🇬🇧",
                 countryCode: "GB",
                 metrics: SiteMetricsSet(views: 4000)
             ),
             TopListItem.Location(
-                country: "Canada",
+                name: "Canada",
                 flag: "🇨🇦",
                 countryCode: "CA",
                 metrics: SiteMetricsSet(views: 2800)
             ),
             TopListItem.Location(
-                country: "Germany",
+                name: "Germany",
                 flag: "🇩🇪",
                 countryCode: "DE",
                 metrics: SiteMetricsSet(views: 2000)
             ),
             TopListItem.Location(
-                country: "Australia",
+                name: "Australia",
                 flag: "🇦🇺",
                 countryCode: "AU",
                 metrics: SiteMetricsSet(views: 1600)
             ),
             TopListItem.Location(
-                country: "France",
+                name: "France",
                 flag: "🇫🇷",
                 countryCode: "FR",
                 metrics: SiteMetricsSet(views: 1400)
             ),
             TopListItem.Location(
-                country: "Japan",
+                name: "Japan",
                 flag: "🇯🇵",
                 countryCode: "JP",
                 metrics: SiteMetricsSet(views: 1100)
             ),
             TopListItem.Location(
-                country: "Netherlands",
+                name: "Netherlands",
                 flag: "🇳🇱",
                 countryCode: "NL",
                 metrics: SiteMetricsSet(views: 800)

--- a/Modules/Sources/JetpackStats/Views/CountryMap/CountryTooltip.swift
+++ b/Modules/Sources/JetpackStats/Views/CountryMap/CountryTooltip.swift
@@ -8,7 +8,7 @@ struct CountryTooltip: View {
 
     private var countryName: String {
         if let location {
-            return location.country
+            return location.name
         } else {
             // Use native API to get country name from code
             let locale = Locale.current
@@ -125,13 +125,13 @@ private struct CountryTooltipRow: View {
         CountryTooltip(
             countryCode: "US",
             location: TopListItem.Location(
-                country: "United States",
+                name: "United States",
                 flag: "🇺🇸",
                 countryCode: "US",
                 metrics: SiteMetricsSet(views: 15000)
             ),
             previousLocation: TopListItem.Location(
-                country: "United States",
+                name: "United States",
                 flag: "🇺🇸",
                 countryCode: "US",
                 metrics: SiteMetricsSet(views: 12000)

--- a/Modules/Sources/JetpackStats/Views/StatsCardTitleView.swift
+++ b/Modules/Sources/JetpackStats/Views/StatsCardTitleView.swift
@@ -27,7 +27,7 @@ struct StatsCardTitleView: View {
             // Note: had to do that to fix the animation issuse with Menu
             // hiding the image.
             title + Text(" ") + Text(Image(systemName: "chevron.up.chevron.down"))
-                .font(.footnote.weight(.semibold))
+                .font(.caption2.weight(.semibold))
                 .foregroundColor(.secondary)
                 .baselineOffset(1)
         } else {
@@ -60,7 +60,7 @@ struct InlineValuePickerTitle: View {
         // Note: had to do that to fix the animation issuse with Menu
         // hiding the image.
         title + Text(" ") + Text(Image(systemName: "chevron.up.chevron.down"))
-            .font(.footnote.weight(.semibold))
+            .font(.caption2.weight(.semibold))
             .foregroundColor(.secondary)
             .baselineOffset(1)
     }

--- a/Modules/Sources/JetpackStats/Views/TopList/Rows/TopListLocationRowView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/Rows/TopListLocationRowView.swift
@@ -13,7 +13,7 @@ struct TopListLocationRowView: View {
                     .font(.body)
                     .foregroundStyle(.secondary)
             }
-            Text(item.country)
+            Text(item.name)
                 .font(.body)
                 .foregroundColor(.primary)
         }

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemView+ContextMenu.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemView+ContextMenu.swift
@@ -97,7 +97,7 @@ extension TopListItemView {
     @ViewBuilder
     func locationActions(_ location: TopListItem.Location) -> some View {
         Button {
-            UIPasteboard.general.string = location.country
+            UIPasteboard.general.string = location.name
         } label: {
             Label(Strings.ContextMenuActions.copyCountryName, systemImage: "doc.on.doc")
         }

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemView.swift
@@ -284,7 +284,7 @@ private func makePreviewItems() -> some View {
     VStack(spacing: 8) {
         makePreviewItem(
             TopListItem.Location(
-                country: "United States",
+                name: "United States",
                 flag: "🇺🇸",
                 countryCode: "US",
                 metrics: SiteMetricsSet(views: 50000)
@@ -294,7 +294,7 @@ private func makePreviewItems() -> some View {
 
         makePreviewItem(
             TopListItem.Location(
-                country: "United Kingdom",
+                name: "United Kingdom",
                 flag: "🇬🇧",
                 countryCode: "GB",
                 metrics: SiteMetricsSet(views: 15600)

--- a/Modules/Sources/WordPressKit/StatsTopCityTimeIntervalData.swift
+++ b/Modules/Sources/WordPressKit/StatsTopCityTimeIntervalData.swift
@@ -7,11 +7,11 @@ public struct StatsTopCityTimeIntervalData {
     public let totalViewsCount: Int
     public let otherViewsCount: Int
 
-    public let cities: [StatsCity]
+    public let cities: [City]
 
     public init(period: StatsPeriodUnit,
                 periodEndDate: Date,
-                cities: [StatsCity],
+                cities: [City],
                 totalViewsCount: Int,
                 otherViewsCount: Int) {
         self.period = period
@@ -20,25 +20,32 @@ public struct StatsTopCityTimeIntervalData {
         self.totalViewsCount = totalViewsCount
         self.otherViewsCount = otherViewsCount
     }
-}
 
-public struct StatsCity {
-    public let name: String
-    public let code: String?
-    public let countryCode: String
-    public let regionName: String?
-    public let viewsCount: Int
+    public struct City {
+        public let name: String
+        public let countryCode: String
+        public let coordinates: Coordinates?
+        public let viewsCount: Int
 
-    public init(name: String,
-                code: String?,
-                countryCode: String,
-                regionName: String?,
-                viewsCount: Int) {
-        self.name = name
-        self.code = code
-        self.countryCode = countryCode
-        self.regionName = regionName
-        self.viewsCount = viewsCount
+        public init(name: String,
+                    countryCode: String,
+                    coordinates: Coordinates?,
+                    viewsCount: Int) {
+            self.name = name
+            self.countryCode = countryCode
+            self.coordinates = coordinates
+            self.viewsCount = viewsCount
+        }
+
+        public struct Coordinates {
+            public let latitude: String
+            public let longitude: String
+
+            public init(latitude: String, longitude: String) {
+                self.latitude = latitude
+                self.longitude = longitude
+            }
+        }
     }
 }
 
@@ -49,55 +56,46 @@ extension StatsTopCityTimeIntervalData: StatsTimeIntervalData {
 
     public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
         guard
-            let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
-            let citiesViews = Bamboozled.parseArray(unwrappedDays["views"])
+            let summary = jsonDictionary["summary"] as? [String: AnyObject],
+            let citiesViews = Bamboozled.parseArray(summary["views"])
         else {
             return nil
         }
 
-        let cityInfo = jsonDictionary["city-info"] as? [String: AnyObject] ?? [:]
-        let totalViews = unwrappedDays["total_views"] as? Int ?? 0
-        let otherViews = unwrappedDays["other_views"] as? Int ?? 0
+        let totalViews = summary["total_views"] as? Int ?? 0
+        let otherViews = summary["other_views"] as? Int ?? 0
 
         self.periodEndDate = date
         self.period = period
 
         self.totalViewsCount = totalViews
         self.otherViewsCount = otherViews
-        self.cities = citiesViews.compactMap { StatsCity(jsonDictionary: $0, cityInfo: cityInfo) }
+        self.cities = citiesViews.compactMap { City(jsonDictionary: $0) }
     }
 }
 
-extension StatsCity {
-    init?(jsonDictionary: [String: AnyObject], cityInfo: [String: AnyObject]) {
+extension StatsTopCityTimeIntervalData.City {
+    init?(jsonDictionary: [String: AnyObject]) {
         guard
+            let location = jsonDictionary["location"] as? String,
             let viewsCount = jsonDictionary["views"] as? Int,
             let countryCode = jsonDictionary["country_code"] as? String
         else {
             return nil
         }
 
-        let cityCode = jsonDictionary["city_code"] as? String
-        let regionName = jsonDictionary["region"] as? String
-
-        let name: String
-
-        if let code = cityCode,
-           let cityDict = cityInfo[code] as? [String: AnyObject],
-           let cityName = cityDict["city_full"] as? String {
-            name = cityName
-        } else if let cityName = jsonDictionary["city"] as? String {
-            name = cityName
-        } else if let code = cityCode {
-            name = code
+        let coordinates: Coordinates?
+        if let coordinatesDict = jsonDictionary["coordinates"] as? [String: AnyObject],
+           let latitude = coordinatesDict["latitude"] as? String,
+           let longitude = coordinatesDict["longitude"] as? String {
+            coordinates = Coordinates(latitude: latitude, longitude: longitude)
         } else {
-            return nil
+            coordinates = nil
         }
 
-        self.viewsCount = viewsCount
-        self.code = cityCode
+        self.name = location
         self.countryCode = countryCode
-        self.regionName = regionName
-        self.name = name
+        self.coordinates = coordinates
+        self.viewsCount = viewsCount
     }
 }

--- a/Modules/Sources/WordPressKit/StatsTopCityTimeIntervalData.swift
+++ b/Modules/Sources/WordPressKit/StatsTopCityTimeIntervalData.swift
@@ -1,0 +1,103 @@
+import Foundation
+
+public struct StatsTopCityTimeIntervalData {
+    public let period: StatsPeriodUnit
+    public let periodEndDate: Date
+
+    public let totalViewsCount: Int
+    public let otherViewsCount: Int
+
+    public let cities: [StatsCity]
+
+    public init(period: StatsPeriodUnit,
+                periodEndDate: Date,
+                cities: [StatsCity],
+                totalViewsCount: Int,
+                otherViewsCount: Int) {
+        self.period = period
+        self.periodEndDate = periodEndDate
+        self.cities = cities
+        self.totalViewsCount = totalViewsCount
+        self.otherViewsCount = otherViewsCount
+    }
+}
+
+public struct StatsCity {
+    public let name: String
+    public let code: String?
+    public let countryCode: String
+    public let regionName: String?
+    public let viewsCount: Int
+
+    public init(name: String,
+                code: String?,
+                countryCode: String,
+                regionName: String?,
+                viewsCount: Int) {
+        self.name = name
+        self.code = code
+        self.countryCode = countryCode
+        self.regionName = regionName
+        self.viewsCount = viewsCount
+    }
+}
+
+extension StatsTopCityTimeIntervalData: StatsTimeIntervalData {
+    public static var pathComponent: String {
+        "stats/location-views/city"
+    }
+
+    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
+        guard
+            let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
+            let citiesViews = Bamboozled.parseArray(unwrappedDays["views"])
+        else {
+            return nil
+        }
+
+        let cityInfo = jsonDictionary["city-info"] as? [String: AnyObject] ?? [:]
+        let totalViews = unwrappedDays["total_views"] as? Int ?? 0
+        let otherViews = unwrappedDays["other_views"] as? Int ?? 0
+
+        self.periodEndDate = date
+        self.period = period
+
+        self.totalViewsCount = totalViews
+        self.otherViewsCount = otherViews
+        self.cities = citiesViews.compactMap { StatsCity(jsonDictionary: $0, cityInfo: cityInfo) }
+    }
+}
+
+extension StatsCity {
+    init?(jsonDictionary: [String: AnyObject], cityInfo: [String: AnyObject]) {
+        guard
+            let viewsCount = jsonDictionary["views"] as? Int,
+            let countryCode = jsonDictionary["country_code"] as? String
+        else {
+            return nil
+        }
+
+        let cityCode = jsonDictionary["city_code"] as? String
+        let regionName = jsonDictionary["region"] as? String
+
+        let name: String
+
+        if let code = cityCode,
+           let cityDict = cityInfo[code] as? [String: AnyObject],
+           let cityName = cityDict["city_full"] as? String {
+            name = cityName
+        } else if let cityName = jsonDictionary["city"] as? String {
+            name = cityName
+        } else if let code = cityCode {
+            name = code
+        } else {
+            return nil
+        }
+
+        self.viewsCount = viewsCount
+        self.code = cityCode
+        self.countryCode = countryCode
+        self.regionName = regionName
+        self.name = name
+    }
+}

--- a/Modules/Sources/WordPressKit/StatsTopRegionTimeIntervalData.swift
+++ b/Modules/Sources/WordPressKit/StatsTopRegionTimeIntervalData.swift
@@ -1,0 +1,92 @@
+import Foundation
+
+public struct StatsTopRegionTimeIntervalData {
+    public let period: StatsPeriodUnit
+    public let periodEndDate: Date
+
+    public let totalViewsCount: Int
+    public let otherViewsCount: Int
+
+    public let regions: [StatsRegion]
+
+    public init(period: StatsPeriodUnit,
+                periodEndDate: Date,
+                regions: [StatsRegion],
+                totalViewsCount: Int,
+                otherViewsCount: Int) {
+        self.period = period
+        self.periodEndDate = periodEndDate
+        self.regions = regions
+        self.totalViewsCount = totalViewsCount
+        self.otherViewsCount = otherViewsCount
+    }
+}
+
+public struct StatsRegion {
+    public let name: String
+    public let code: String
+    public let countryCode: String
+    public let viewsCount: Int
+
+    public init(name: String,
+                code: String,
+                countryCode: String,
+                viewsCount: Int) {
+        self.name = name
+        self.code = code
+        self.countryCode = countryCode
+        self.viewsCount = viewsCount
+    }
+}
+
+extension StatsTopRegionTimeIntervalData: StatsTimeIntervalData {
+    public static var pathComponent: String {
+        "stats/location-views/region"
+    }
+
+    public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
+        guard
+            let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
+            let regionsViews = Bamboozled.parseArray(unwrappedDays["views"])
+        else {
+            return nil
+        }
+
+        let regionInfo = jsonDictionary["region-info"] as? [String: AnyObject] ?? [:]
+        let totalViews = unwrappedDays["total_views"] as? Int ?? 0
+        let otherViews = unwrappedDays["other_views"] as? Int ?? 0
+
+        self.periodEndDate = date
+        self.period = period
+
+        self.totalViewsCount = totalViews
+        self.otherViewsCount = otherViews
+        self.regions = regionsViews.compactMap { StatsRegion(jsonDictionary: $0, regionInfo: regionInfo) }
+    }
+}
+
+extension StatsRegion {
+    init?(jsonDictionary: [String: AnyObject], regionInfo: [String: AnyObject]) {
+        guard
+            let viewsCount = jsonDictionary["views"] as? Int,
+            let regionCode = jsonDictionary["region_code"] as? String,
+            let countryCode = jsonDictionary["country_code"] as? String
+        else {
+            return nil
+        }
+
+        let name: String
+
+        if let regionDict = regionInfo[regionCode] as? [String: AnyObject],
+           let regionName = regionDict["region_full"] as? String {
+            name = regionName
+        } else {
+            name = regionCode
+        }
+
+        self.viewsCount = viewsCount
+        self.code = regionCode
+        self.countryCode = countryCode
+        self.name = name
+    }
+}

--- a/Modules/Sources/WordPressKit/StatsTopRegionTimeIntervalData.swift
+++ b/Modules/Sources/WordPressKit/StatsTopRegionTimeIntervalData.swift
@@ -7,11 +7,11 @@ public struct StatsTopRegionTimeIntervalData {
     public let totalViewsCount: Int
     public let otherViewsCount: Int
 
-    public let regions: [StatsRegion]
+    public let regions: [Region]
 
     public init(period: StatsPeriodUnit,
                 periodEndDate: Date,
-                regions: [StatsRegion],
+                regions: [Region],
                 totalViewsCount: Int,
                 otherViewsCount: Int) {
         self.period = period
@@ -20,22 +20,19 @@ public struct StatsTopRegionTimeIntervalData {
         self.totalViewsCount = totalViewsCount
         self.otherViewsCount = otherViewsCount
     }
-}
 
-public struct StatsRegion {
-    public let name: String
-    public let code: String
-    public let countryCode: String
-    public let viewsCount: Int
+    public struct Region {
+        public let name: String
+        public let countryCode: String
+        public let viewsCount: Int
 
-    public init(name: String,
-                code: String,
-                countryCode: String,
-                viewsCount: Int) {
-        self.name = name
-        self.code = code
-        self.countryCode = countryCode
-        self.viewsCount = viewsCount
+        public init(name: String,
+                    countryCode: String,
+                    viewsCount: Int) {
+            self.name = name
+            self.countryCode = countryCode
+            self.viewsCount = viewsCount
+        }
     }
 }
 
@@ -46,47 +43,36 @@ extension StatsTopRegionTimeIntervalData: StatsTimeIntervalData {
 
     public init?(date: Date, period: StatsPeriodUnit, jsonDictionary: [String: AnyObject]) {
         guard
-            let unwrappedDays = type(of: self).unwrapDaysDictionary(jsonDictionary: jsonDictionary),
-            let regionsViews = Bamboozled.parseArray(unwrappedDays["views"])
+            let summary = jsonDictionary["summary"] as? [String: AnyObject],
+            let regionsViews = Bamboozled.parseArray(summary["views"])
         else {
             return nil
         }
 
-        let regionInfo = jsonDictionary["region-info"] as? [String: AnyObject] ?? [:]
-        let totalViews = unwrappedDays["total_views"] as? Int ?? 0
-        let otherViews = unwrappedDays["other_views"] as? Int ?? 0
+        let totalViews = summary["total_views"] as? Int ?? 0
+        let otherViews = summary["other_views"] as? Int ?? 0
 
         self.periodEndDate = date
         self.period = period
 
         self.totalViewsCount = totalViews
         self.otherViewsCount = otherViews
-        self.regions = regionsViews.compactMap { StatsRegion(jsonDictionary: $0, regionInfo: regionInfo) }
+        self.regions = regionsViews.compactMap { Region(jsonDictionary: $0) }
     }
 }
 
-extension StatsRegion {
-    init?(jsonDictionary: [String: AnyObject], regionInfo: [String: AnyObject]) {
+extension StatsTopRegionTimeIntervalData.Region {
+    init?(jsonDictionary: [String: AnyObject]) {
         guard
+            let location = jsonDictionary["location"] as? String,
             let viewsCount = jsonDictionary["views"] as? Int,
-            let regionCode = jsonDictionary["region_code"] as? String,
             let countryCode = jsonDictionary["country_code"] as? String
         else {
             return nil
         }
 
-        let name: String
-
-        if let regionDict = regionInfo[regionCode] as? [String: AnyObject],
-           let regionName = regionDict["region_full"] as? String {
-            name = regionName
-        } else {
-            name = regionCode
-        }
-
-        self.viewsCount = viewsCount
-        self.code = regionCode
+        self.name = location
         self.countryCode = countryCode
-        self.name = name
+        self.viewsCount = viewsCount
     }
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,8 +8,10 @@
 * [*] Reader: Add translation support for posts [#25089]
 * [*] Reader: Collapse multiple spaces in site titles into one [#25094]
 * [*] Fix previewing posts on WordPress.com atomic sites [#25045]
+* [**] Stats: Add Country/Region/City picker to the Locations card [#25125]
 * [*] Stats: Rename "External Links" to "Clicks" to be consistent with the web [#25090]
 * [*] Stats: Fix locations data discrepancy with the web [#25105]
+
 
 26.5
 -----


### PR DESCRIPTION
## Description

Closes [CMM-1101: Jetpack Mobile Stats: add region and city breakdown](https://linear.app/a8c/issue/CMM-1101/jetpack-mobile-stats-add-region-and-city-breakdown). 

This PR introduces the first (existing) Stats premium feature to the mobile app: more detailed location information. 

## Changes

This PR also changes how you switch between item types in the "Top List" card. You now do that via the card title itself. There are multiple advantages to this:
- It's more clear what card is about
- The titles are consistent with the web
- The column names could offer more context
- Switching between item types is easier

Before / After

<img width="340"  alt="Screenshot 2026-01-09 at 1 00 52 PM" src="https://github.com/user-attachments/assets/e571cad3-3782-473c-966a-03dd54ddbe36" />
<img width="357"  alt="Screenshot 2026-01-09 at 1 00 05 PM" src="https://github.com/user-attachments/assets/f026c6a4-0991-4b16-a05f-9181110acabc" />


Also, by moving the picker to the card title, we free the column names to be used for different purpose. For "Locations", it is now used to switch between the location level:

Before / After

<img width="340" alt="Screenshot 2026-01-09 at 1 01 02 PM" src="https://github.com/user-attachments/assets/6926da99-595d-429c-8b8a-b0e5789cf310" />
<img width="320" alt="Screenshot 2026-01-09 at 1 13 04 PM" src="https://github.com/user-attachments/assets/f17178c3-288a-486a-9e05-f78684998649" />

Cities (with production data)

<img width="340" alt="Screenshot 2026-01-09 at 2 25 28 PM" src="https://github.com/user-attachments/assets/190400a7-95ed-4316-8f4e-812beb7b06af" />




## Future Changes

The app currently doesn't provide the optimal experience when you don't have a require plan. I'm discussing how to address it. I plan to do that in separate PRs.

<img width="320" alt="Screenshot 2026-01-09 at 10 06 44 AM" src="https://github.com/user-attachments/assets/d031ee51-8133-465a-811e-c20de520489f" />


