### PR TITLE
Minor visual changes in Stats

### DIFF
--- a/Modules/Sources/JetpackStats/Cards/ChartCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/ChartCard.swift
@@ -21,7 +21,7 @@ struct ChartCard: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            VStack(spacing: Constants.step0_5) {
+            VStack(spacing: Constants.step1) {
                 headerView(for: selectedMetric)
                     .unredacted()
                 contentView
@@ -78,7 +78,7 @@ struct ChartCard: View {
 
     @ViewBuilder
     private var contentView: some View {
-        VStack(spacing: 4) {
+        VStack(spacing: Constants.step1) {
             chartHeaderView
                 .padding(.trailing, -Constants.step0_5)
             chartContentView
@@ -171,9 +171,9 @@ struct ChartCard: View {
             moreMenuContent
         } label: {
             Image(systemName: "ellipsis")
-                .font(.system(size: 17))
+                .font(.system(size: 15))
                 .foregroundColor(.secondary)
-                .frame(width: 56, height: 50)
+                .frame(width: 50, height: 50)
         }
         .tint(Color.primary)
     }

--- a/Modules/Sources/JetpackStats/Cards/StandaloneChartCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/StandaloneChartCard.swift
@@ -189,9 +189,9 @@ struct StandaloneChartCard: View {
             }
         } label: {
             Image(systemName: "ellipsis")
-                .font(.body)
+                .font(.system(size: 15))
                 .foregroundColor(.secondary)
-                .frame(width: 56, height: 50)
+                .frame(width: 50, height: 50)
         }
         .tint(Color.primary)
     }

--- a/Modules/Sources/JetpackStats/Cards/TodayCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TodayCard.swift
@@ -203,9 +203,9 @@ struct TodayCard: View {
             moreMenuContent
         } label: {
             Image(systemName: "ellipsis")
-                .font(.system(size: 16))
+                .font(.system(size: 15))
                 .foregroundColor(.secondary)
-                .frame(width: 44, height: 44)
+                .frame(width: 50, height: 50)
         }
         .tint(Color.primary)
     }

--- a/Modules/Sources/JetpackStats/Cards/TopListCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListCard.swift
@@ -188,9 +188,9 @@ struct TopListCard: View {
             moreMenuContent
         } label: {
             Image(systemName: "ellipsis")
-                .font(.system(size: 17))
+                .font(.system(size: 15))
                 .foregroundColor(.secondary)
-                .frame(width: 56, height: 50)
+                .frame(width: 50, height: 50)
         }
         .tint(Color.primary)
     }

--- a/Modules/Sources/JetpackStats/Charts/BarChartView.swift
+++ b/Modules/Sources/JetpackStats/Charts/BarChartView.swift
@@ -74,7 +74,7 @@ struct BarChartView: View {
 
     private func lighten(_ color: Color) -> Color {
         if #available(iOS 18, *) {
-            color.mix(with: Color(.systemBackground), by: colorScheme == .light ? 0.5 : 0.25)
+            color.mix(with: Color(.systemBackground), by: colorScheme == .light ? 0.4 : 0.15)
         } else {
             color.opacity(0.5)
         }


### PR DESCRIPTION
## Changes

- Make "more" menus consistent and a notch smaller
- Fix vertical alignment for "more" menu in the "Today" card
- Add a bit more negative space in the "Chart" card
- Tone down the gradient in the "Chart" card bars

## Before / After

<img width="362" alt="stats-before" src="https://github.com/user-attachments/assets/737884d9-812e-42fc-abec-ce76d8d55161" />
<img width="340"  alt="stats-after" src="https://github.com/user-attachments/assets/fdbcfd66-3c55-4451-b8fc-3b6a00aea7e3" />
