### PR TITLE
Fix Post Visibility discoverability

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -7,6 +7,7 @@
 * [*] Reader: Fix article view ignoring `use_excerpt` [#25108]
 * [*] Reader: Add translation support for posts [#25089]
 * [*] Reader: Collapse multiple spaces in site titles into one [#25094]
+* [*] Fix Post Visibility discoverability [#25127]
 * [*] Fix previewing posts on WordPress.com atomic sites [#25045]
 * [*] Stats: Rename "External Links" to "Clicks" to be consistent with the web [#25090]
 * [*] Stats: Fix locations data discrepancy with the web [#25105]

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -290,7 +290,7 @@ struct PostSettingsFormContentView: View {
         NavigationLink {
             PostStatusView(settings: $viewModel.settings, timeZone: viewModel.timeZone)
         } label: {
-            SettingsRow(Strings.status) {
+            SettingsRow(Strings.statusAndVisibility) {
                 HStack(alignment: .center, spacing: 2) {
                     ScaledImage(viewModel.settings.status.image, height: 23)
                     VStack(alignment: .leading, spacing: 2) {
@@ -712,9 +712,9 @@ private enum Strings {
         comment: "The title of the top section that shows the site your are publishing to. Default is 'Ready to Publish?'"
     )
 
-    static let status = NSLocalizedString(
-        "postSettings.status.label",
-        value: "Status",
+    static let statusAndVisibility = NSLocalizedString(
+        "postSettings.statusAndVisibility.label",
+        value: "Status & Visibility",
         comment: "Label for the status field in Post Settings"
     )
 }


### PR DESCRIPTION
Fixes [CMM-1092: Unable to Change Post Visibility for Existing Posts in Jetpack iOS App](https://linear.app/a8c/issue/CMM-1092/unable-to-change-post-visibility-for-existing-posts-in-jetpack-ios-app)

<img width="350" alt="Screenshot 2026-01-09 at 4 03 36 PM" src="https://github.com/user-attachments/assets/5f675204-8be4-48cc-8ccf-8af9a540ffee" />
