### PR TITLE
Fix ID collisions in TopListItem.ExternalLink

### DIFF
--- a/Modules/Sources/JetpackStats/Services/Data/TopListItem.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListItem.swift
@@ -80,7 +80,7 @@ extension TopListItem {
         var metrics: SiteMetricsSet
 
         var id: TopListItemID {
-            TopListItemID(type: .externalLinks, id: url)
+            TopListItemID(type: .externalLinks, id: url + (title ?? ""))
         }
     }
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,7 +9,9 @@
 * [*] Reader: Collapse multiple spaces in site titles into one [#25094]
 * [*] Fix previewing posts on WordPress.com atomic sites [#25045]
 * [*] Stats: Rename "External Links" to "Clicks" to be consistent with the web [#25090]
+* [*] Stats: Fix an issue with External Links (Clicks) sometimes displayed incorrectly [#25128]
 * [*] Stats: Fix locations data discrepancy with the web [#25105]
+
 
 26.5
 -----


### PR DESCRIPTION
In some cases, `url` is empty. The collisions would lead to the list displayed incorrectly.

<img width="445" height="333" alt="Screenshot 2026-01-09 at 4 12 53 PM" src="https://github.com/user-attachments/assets/27ced3a3-4162-4220-acd7-b568af83debd" />
