### PR TITLE
Fix an issue where cancelling login does not abort the login flow

### DIFF
--- a/WordPress/Classes/Login/SelfHostedSiteAuthenticator.swift
+++ b/WordPress/Classes/Login/SelfHostedSiteAuthenticator.swift
@@ -126,6 +126,11 @@ struct SelfHostedSiteAuthenticator {
             throw .authentication(error)
         }
 
+        // We need to manually check for cancellation, because `WordPressLoginClient` does not support Swift cancellation.
+        if Task.isCancelled {
+            throw .cancelled
+        }
+
         return try await signIn(details: details, from: viewController, context: context)
     }
 

--- a/WordPress/Classes/System/Root View/WordPressAuthenticatorProtocol.swift
+++ b/WordPress/Classes/System/Root View/WordPressAuthenticatorProtocol.swift
@@ -55,22 +55,16 @@ extension WordPressAuthenticator: WordPressAuthenticatorProtocol {
             _ = Self.continueWithDotCom(viewController)
         }
 
-        let view = LoginWithUrlView(
+        let view = NavigationStack {
+            LoginWithUrlView(
                 presenter: viewController,
                 loginCompleted: loginCompleted,
                 presentDotComLogin: presentDotComLogin
             )
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(SharedStrings.Button.cancel) { [weak viewController] in
-                        viewController?.dismiss(animated: true)
-                    }
-                }
-            }
+        }
         let hostVC = UIHostingController(rootView: view)
-        let navigationVC = UINavigationController(rootViewController: hostVC)
-        navigationVC.modalPresentationStyle = .formSheet
-        viewController.present(navigationVC, animated: true)
+        hostVC.modalPresentationStyle = .formSheet
+        viewController.present(hostVC, animated: true)
         return true
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/AddSiteController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/AddSiteController.swift
@@ -53,22 +53,16 @@ struct AddSiteController {
             }
         }
 
-        let view = LoginWithUrlView(
+        let view = NavigationStack {
+            LoginWithUrlView(
                 presenter: viewController,
                 loginCompleted: loginCompleted,
                 presentDotComLogin: presentDotComLogin
             )
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(SharedStrings.Button.cancel) { [weak viewController] in
-                        viewController?.dismiss(animated: true)
-                    }
-                }
-            }
+        }
         let hostVC = UIHostingController(rootView: view)
-        let navigationVC = UINavigationController(rootViewController: hostVC)
-        navigationVC.modalPresentationStyle = .formSheet
-        viewController.present(navigationVC, animated: true)
+        hostVC.modalPresentationStyle = .formSheet
+        viewController.present(hostVC, animated: true)
     }
 }
 


### PR DESCRIPTION
> [!Note]
> [Hiding whitespace](https://github.com/wordpress-mobile/WordPress-iOS/pull/25132/changes?w=1) shows a cleaner diff.

## Description

To reproduce the cancellation issue:
1. Go to the application password login flow.
2. Type a valid self-hosted site address.
3. Tap the "Cancel" immediately after the login process begins.
  This is pretty easy to do in a simulator: press the Enter key on your Mac's keyboard, then immediately click the "Cancel" button with your Mac's mouse.

Expected behaviour: the view dismisses, and no login prompt is shown.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
