### PR TITLE
Improve gesture recognizers in Bar Chart view

### DIFF
--- a/Modules/Sources/JetpackStats/Charts/BarChartView.swift
+++ b/Modules/Sources/JetpackStats/Charts/BarChartView.swift
@@ -247,24 +247,20 @@ struct BarChartView: View {
 
     private func makeGesturesOverlayView(proxy: ChartProxy) -> some View {
         GeometryReader { geometry in
-            Rectangle()
-                .fill(.clear)
-                .contentShape(Rectangle())
-                .onTapGesture { location in
+            ChartGestureOverlay(
+                onTap: { location in
                     handleTapGesture(at: location, proxy: proxy, geometry: geometry)
+                },
+                onInteractionUpdate: { location in
+                    isDragging = true
+                    selectedDataPoints = getSelectedDataPoints(at: location, proxy: proxy, geometry: geometry)
+                },
+                onInteractionEnd: {
+                    isDragging = false
+                    selectedDataPoints = nil
+                    tappedDataPoint = nil
                 }
-                .simultaneousGesture(
-                    DragGesture(minimumDistance: 16)
-                        .onChanged { value in
-                            isDragging = true
-                            selectedDataPoints = getSelectedDataPoints(at: value.location, proxy: proxy, geometry: geometry)
-                        }
-                        .onEnded { _ in
-                            isDragging = false
-                            selectedDataPoints = nil
-                            tappedDataPoint = nil
-                        }
-                )
+            )
         }
     }
 
@@ -287,7 +283,6 @@ struct BarChartView: View {
     }
 
     private func getSelectedDataPoints(at location: CGPoint, proxy: ChartProxy, geometry: GeometryProxy) -> SelectedDataPoints? {
-
         guard let frame = proxy.plotFrame else {
             return nil
         }

--- a/Modules/Sources/JetpackStats/Charts/ChartGestureOverlay.swift
+++ b/Modules/Sources/JetpackStats/Charts/ChartGestureOverlay.swift
@@ -1,0 +1,119 @@
+import SwiftUI
+
+/// A UIKit-based gesture overlay that handles tap, long-press, and horizontal pan gestures.
+///
+/// UIKit is used instead of SwiftUI gestures because:
+/// - `UILongPressGestureRecognizer` properly fires after the minimum duration even without movement,
+///   while SwiftUI's `DragGesture` requires actual dragging to trigger.
+/// - `gestureRecognizerShouldBegin` allows immediate rejection of vertical pans based on velocity,
+///   preventing interference with vertical scrolling.
+struct ChartGestureOverlay: UIViewRepresentable {
+    let onTap: (CGPoint) -> Void
+    let onInteractionUpdate: (CGPoint) -> Void
+    let onInteractionEnd: () -> Void
+
+    func makeUIView(context: Context) -> UIView {
+        let view = UIView()
+        view.backgroundColor = .clear
+
+        let tapGesture = UITapGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleTap(_:)))
+        let longPressGesture = UILongPressGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handleLongPress(_:)))
+        let panGesture = UIPanGestureRecognizer(target: context.coordinator, action: #selector(Coordinator.handlePan(_:)))
+
+        longPressGesture.minimumPressDuration = 0.33
+        panGesture.delegate = context.coordinator
+
+        view.addGestureRecognizer(tapGesture)
+        view.addGestureRecognizer(longPressGesture)
+        view.addGestureRecognizer(panGesture)
+
+        return view
+    }
+
+    func updateUIView(_ uiView: UIView, context: Context) {
+        context.coordinator.onTap = onTap
+        context.coordinator.onInteractionUpdate = onInteractionUpdate
+        context.coordinator.onInteractionEnd = onInteractionEnd
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(
+            onTap: onTap,
+            onInteractionUpdate: onInteractionUpdate,
+            onInteractionEnd: onInteractionEnd
+        )
+    }
+
+    class Coordinator: NSObject, UIGestureRecognizerDelegate {
+        var onTap: (CGPoint) -> Void
+        var onInteractionUpdate: (CGPoint) -> Void
+        var onInteractionEnd: () -> Void
+
+        private var isInteracting = false
+
+        init(
+            onTap: @escaping (CGPoint) -> Void,
+            onInteractionUpdate: @escaping (CGPoint) -> Void,
+            onInteractionEnd: @escaping () -> Void
+        ) {
+            self.onTap = onTap
+            self.onInteractionUpdate = onInteractionUpdate
+            self.onInteractionEnd = onInteractionEnd
+        }
+
+        @objc func handleTap(_ gesture: UITapGestureRecognizer) {
+            guard !isInteracting else { return }
+            let location = gesture.location(in: gesture.view)
+            onTap(location)
+        }
+
+        @objc func handleLongPress(_ gesture: UILongPressGestureRecognizer) {
+            let location = gesture.location(in: gesture.view)
+
+            switch gesture.state {
+            case .began, .changed:
+                isInteracting = true
+                onInteractionUpdate(location)
+            case .ended, .cancelled:
+                isInteracting = false
+                onInteractionEnd()
+            default:
+                break
+            }
+        }
+
+        @objc func handlePan(_ gesture: UIPanGestureRecognizer) {
+            let location = gesture.location(in: gesture.view)
+
+            switch gesture.state {
+            case .began, .changed:
+                isInteracting = true
+                onInteractionUpdate(location)
+            case .ended, .cancelled:
+                isInteracting = false
+                onInteractionEnd()
+            default:
+                break
+            }
+        }
+
+        // UIGestureRecognizerDelegate - Allow pan to fail on vertical scrolls
+        func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+            guard let panGesture = gestureRecognizer as? UIPanGestureRecognizer else {
+                return true
+            }
+
+            let velocity = panGesture.velocity(in: gestureRecognizer.view)
+            let isHorizontal = abs(velocity.x) > abs(velocity.y)
+            return isHorizontal
+        }
+
+        // Allow all gestures to be recognized simultaneously
+        func gestureRecognizer(
+            _ gestureRecognizer: UIGestureRecognizer,
+            shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer
+        ) -> Bool {
+            return false
+        }
+    }
+}

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -12,6 +12,8 @@
 * [*] Fix previewing posts on WordPress.com atomic sites [#25045]
 * [**] Stats: Add Country/Region/City picker to the Locations card [#25125]
 * [*] Stats: Rename "External Links" to "Clicks" to be consistent with the web [#25090]
+* [*] Stats: Add long-press support for bars in a "Bar Chart" view [#25133]
+* [*] Stats: Fix an issue where bar chart would prevent vertical scroll [#25133]
 * [*] Stats: Fix an issue with External Links (Clicks) sometimes displayed incorrectly [#25128]
 * [*] Stats: Fix locations data discrepancy with the web [#25105]
 * [*] Techical: Remove obsolete Core Data models to slightly reduce the app size (-6.4 MB) [#25124]


### PR DESCRIPTION
## Changes

- Fix [CMM-1104: Long-press on a chart should show the details panel](https://linear.app/a8c/issue/CMM-1104/long-press-on-a-chart-should-show-the-details-panel). When you long-press on a bar, it will now show the details.
- Fix an issue where bar chart would prevent vertical scroll

## Testing Instructions

- Enable "Bar Chart" view
- **Verify** that when you start vertical scroll from a location in a chart, it immediately recognizes as a vertical scroll. In the previous version, Bar Chart would "eat" these gestures.
- **Verify** that a single tap opens data for the selected period
- **Verify** that a long-tap shows a popup with details for the selected period. Previously, it was not supported. You had to start panning horizontally.