### PR TITLE
Fix ordering of top list items

### DIFF
--- a/Modules/Sources/JetpackStats/Services/Data/TopListItem.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListItem.swift
@@ -20,6 +20,7 @@ struct TopListItemID: Hashable {
 protocol TopListItemProtocol: Codable, Sendable, Identifiable {
     var metrics: SiteMetricsSet { get set }
     var id: TopListItemID { get }
+    var displayName: String { get }
 }
 
 extension TopListItem {
@@ -35,6 +36,10 @@ extension TopListItem {
         var id: TopListItemID {
             TopListItemID(type: .postsAndPages, id: postID ?? title)
         }
+
+        var displayName: String {
+            title
+        }
     }
 
     struct Referrer: Codable, TopListItemProtocol {
@@ -47,6 +52,10 @@ extension TopListItem {
         var id: TopListItemID {
             TopListItemID(type: .referrers, id: (domain ?? "–") + name)
         }
+
+        var displayName: String {
+            name
+        }
     }
 
     struct Location: Codable, TopListItemProtocol {
@@ -57,6 +66,10 @@ extension TopListItem {
 
         var id: TopListItemID {
             TopListItemID(type: .locations, id: name)
+        }
+
+        var displayName: String {
+            name
         }
     }
 
@@ -71,6 +84,10 @@ extension TopListItem {
         var id: TopListItemID {
             TopListItemID(type: .authors, id: userId)
         }
+
+        var displayName: String {
+            name
+        }
     }
 
     struct ExternalLink: Codable, TopListItemProtocol {
@@ -82,6 +99,10 @@ extension TopListItem {
         var id: TopListItemID {
             TopListItemID(type: .externalLinks, id: url + (title ?? ""))
         }
+
+        var displayName: String {
+            title ?? url
+        }
     }
 
     struct FileDownload: Codable, TopListItemProtocol {
@@ -92,6 +113,10 @@ extension TopListItem {
         var id: TopListItemID {
             TopListItemID(type: .fileDownloads, id: filePath ?? fileName)
         }
+
+        var displayName: String {
+            fileName
+        }
     }
 
     struct SearchTerm: Codable, TopListItemProtocol {
@@ -100,6 +125,10 @@ extension TopListItem {
 
         var id: TopListItemID {
             TopListItemID(type: .searchTerms, id: term)
+        }
+
+        var displayName: String {
+            term
         }
     }
 
@@ -112,6 +141,10 @@ extension TopListItem {
         var id: TopListItemID {
             TopListItemID(type: .videos, id: postId)
         }
+
+        var displayName: String {
+            title
+        }
     }
 
     struct ArchiveItem: Codable, TopListItemProtocol {
@@ -121,6 +154,10 @@ extension TopListItem {
 
         var id: TopListItemID {
             TopListItemID(type: .archive, id: href)
+        }
+
+        var displayName: String {
+            value
         }
     }
 

--- a/Modules/Sources/JetpackStats/Services/StatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/StatsService.swift
@@ -139,24 +139,11 @@ actor StatsService: StatsServiceProtocol {
 
         // Helper function to sort items by metric value (descending), then by displayName, and then by itemID for stable ordering
         func sortItems(_ items: [any TopListItemProtocol]) -> [any TopListItemProtocol] {
-            items.sorted { lhs, rhs in
-                let lhsValue = lhs.metrics[metric] ?? 0
-                let rhsValue = rhs.metrics[metric] ?? 0
-
-                // First sort by metric value (descending)
-                if lhsValue != rhsValue {
-                    return lhsValue > rhsValue
-                }
-
-                // If values are equal, sort by displayName (ascending)
-                let displayNameComparison = lhs.displayName.localizedStandardCompare(rhs.displayName)
-                if displayNameComparison != .orderedSame {
-                    return displayNameComparison == .orderedAscending
-                }
-
-                // If displayNames are equal, sort by itemID for stable ordering
-                return lhs.id.id < rhs.id.id
-            }
+            items.sorted(using: [
+                KeyPathComparator(\.metrics[metric], order: .reverse),
+                KeyPathComparator(\.displayName, comparator: .localizedStandard),
+                KeyPathComparator(\.id.id)
+            ])
         }
 
         switch item {

--- a/Modules/Sources/JetpackStats/Services/StatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/StatsService.swift
@@ -137,7 +137,7 @@ actor StatsService: StatsServiceProtocol {
             return try await service.getData(interval: interval, unit: .day, summarize: true, limit: limit ?? 0, parameters: parameters)
         }
 
-        // Helper function to sort items by metric value (descending) and then by itemID for stable ordering
+        // Helper function to sort items by metric value (descending), then by displayName, and then by itemID for stable ordering
         func sortItems(_ items: [any TopListItemProtocol]) -> [any TopListItemProtocol] {
             items.sorted { lhs, rhs in
                 let lhsValue = lhs.metrics[metric] ?? 0
@@ -148,7 +148,13 @@ actor StatsService: StatsServiceProtocol {
                     return lhsValue > rhsValue
                 }
 
-                // If values are equal, sort by itemID for stable ordering
+                // If values are equal, sort by displayName (ascending)
+                let displayNameComparison = lhs.displayName.localizedStandardCompare(rhs.displayName)
+                if displayNameComparison != .orderedSame {
+                    return displayNameComparison == .orderedAscending
+                }
+
+                // If displayNames are equal, sort by itemID for stable ordering
                 return lhs.id.id < rhs.id.id
             }
         }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -18,6 +18,7 @@
 * [*] Stats: Fix locations data discrepancy with the web [#25105]
 * [*] Stats: Add days/weeks/months/years picker for bar and line charts [#25093]
 * [*] Stats: Fix an issue with weekly data for the comparison period sometimes not being shown correctly [#25093]
+* [*] Stats: Fix ordering of Top List items with the same metrics – sort by name [#25135]
 * [*] Techical: Remove obsolete Core Data models to slightly reduce the app size (-6.4 MB) [#25124]
 
 26.5


### PR DESCRIPTION
Fixes [CMM-965: Sort Top List items by display name (after count)](https://linear.app/a8c/issue/CMM-965/sort-top-list-items-by-display-name-after-count).