### PR TITLE
Fix an issue with button "Done" sometimes disappearing when you entering password for post when publishing

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,8 @@
 * [*] Reader: Add translation support for posts [#25089]
 * [*] Reader: Collapse multiple spaces in site titles into one [#25094]
 * [*] Post Settings: Fix post Visibility discoverability [#25127]
+* [*] Post Settings: Fix an issue with button "Done" sometimes disappearing when you entering password for post when publishing [#25138]
+* [*] Post Settings: Show the selected value for the "Access" field [#25138]
 * [*] Fix previewing posts on WordPress.com atomic sites [#25045]
 * [**] Stats: Add Country/Region/City picker to the Locations card [#25125]
 * [*] Stats: Rename "External Links" to "Clicks" to be consistent with the web [#25090]

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,7 +8,7 @@
 * [*] Reader: Fix article view ignoring `use_excerpt` [#25108]
 * [*] Reader: Add translation support for posts [#25089]
 * [*] Reader: Collapse multiple spaces in site titles into one [#25094]
-* [*] Fix Post Visibility discoverability [#25127]
+* [*] Post Settings: Fix post Visibility discoverability [#25127]
 * [*] Fix previewing posts on WordPress.com atomic sites [#25045]
 * [**] Stats: Add Country/Region/City picker to the Locations card [#25125]
 * [*] Stats: Rename "External Links" to "Clicks" to be consistent with the web [#25090]

--- a/WordPress/Classes/ViewRelated/Blog/Settings/SettingsPicker.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Settings/SettingsPicker.swift
@@ -51,7 +51,12 @@ struct SettingsPickerListView<T: Hashable>: View {
             guard selection != value.id else { return }
             selection = value.id
         }) {
-            HStack {
+            HStack(spacing: 10) {
+                Image(systemName: "checkmark")
+                    .font(.headline)
+                    .foregroundColor(.accentColor)
+                    .opacity(value.id == selection ? 1 : 0)
+
                 VStack(alignment: .leading, spacing: 2) {
                     Text(value.title)
                     if let details = value.details {
@@ -61,12 +66,6 @@ struct SettingsPickerListView<T: Hashable>: View {
                     }
                 }
                 Spacer()
-                if value.id == selection {
-                    Image(systemName: "checkmark")
-                        .font(.headline)
-                        .foregroundColor(.accentColor)
-
-                }
             }
             .contentShape(Rectangle())
         }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
@@ -28,7 +28,6 @@ struct PostSettings: Hashable {
     var postFormat: String?
     var isStickyPost = false
     var sharing: PostSocialSharingSettings?
-    var accessLevel: JetpackPostAccessLevel?
     var allowComments = true
     var allowPings = true
 
@@ -67,7 +66,6 @@ struct PostSettings: Hashable {
                 $0.categoryID.intValue
             })
             sharing = PostSocialSharingSettings.make(for: post)
-            accessLevel = metadata.accessLevel ?? .everybody
             allowComments = post.allowComments
             allowPings = post.allowPings
         case let page as Page:

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -344,13 +344,9 @@ struct PostSettingsFormContentView: View {
 
     private var visibilityRow: some View {
         NavigationLink {
-            PostVisibilityPicker(
-                selection: PostVisibilityPicker.Selection(post: viewModel.post),
-                dismissOnSelection: true,
-                onSubmit: { selection in
-                    viewModel.updateVisibility(selection)
-                }
-            )
+            PostVisibilityPicker(selection: PostVisibilityPicker.Selection(settings: viewModel.settings)) {
+                viewModel.updateVisibility($0)
+            }
         } label: {
             SettingsRow(Strings.visibilityLabel, value: viewModel.visibilityText)
         }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -334,7 +334,7 @@ struct PostSettingsFormContentView: View {
                     )
                     .navigationTitle(Strings.accessHeader)
                 } label: {
-                    SettingsRow(Strings.accessHeader, value: viewModel.settings.metadata.accessLevel?.localizedTitle ?? "—")
+                    SettingsRow(Strings.accessHeader, value: (viewModel.settings.metadata.accessLevel ?? .everybody).localizedTitle)
                 }
             } header: {
                 SectionHeader(Strings.accessHeader)

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -321,17 +321,21 @@ struct PostSettingsFormContentView: View {
     private var accessSection: some View {
         if viewModel.shouldShow(.jetpackAccessLevel) {
             Section {
-                SettingsPicker(
-                    title: Strings.accessHeader,
-                    selection: $viewModel.settings.metadata.accessLevel,
-                    values: JetpackPostAccessLevel.allCases.map { level in
-                        SettingsPickerValue(
-                            title: level.localizedTitle,
-                            details: level.localizedDescription,
-                            id: level
-                        )
-                    }
-                )
+                NavigationLink {
+                    SettingsPickerListView(
+                        selection: $viewModel.settings.metadata.accessLevel,
+                        values: JetpackPostAccessLevel.allCases.map { level in
+                            SettingsPickerValue(
+                                title: level.localizedTitle,
+                                details: level.localizedDescription,
+                                id: level
+                            )
+                        }
+                    )
+                    .navigationTitle(Strings.accessHeader)
+                } label: {
+                    SettingsRow(Strings.accessHeader, value: viewModel.settings.metadata.accessLevel?.localizedTitle ?? "—")
+                }
             } header: {
                 SectionHeader(Strings.accessHeader)
             }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -323,7 +323,7 @@ struct PostSettingsFormContentView: View {
             Section {
                 NavigationLink {
                     SettingsPickerListView(
-                        selection: $viewModel.settings.metadata.accessLevel,
+                        selection: $viewModel.accessLevel,
                         values: JetpackPostAccessLevel.allCases.map { level in
                             SettingsPickerValue(
                                 title: level.localizedTitle,
@@ -334,7 +334,7 @@ struct PostSettingsFormContentView: View {
                     )
                     .navigationTitle(Strings.accessHeader)
                 } label: {
-                    SettingsRow(Strings.accessHeader, value: (viewModel.settings.metadata.accessLevel ?? .everybody).localizedTitle)
+                    SettingsRow(Strings.accessHeader, value: (viewModel.accessLevel).localizedTitle)
                 }
             } header: {
                 SectionHeader(Strings.accessHeader)

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -58,6 +58,11 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
         set { settings.metadata.isJetpackNewsletterEmailDisabled = !newValue }
     }
 
+    var accessLevel: JetpackPostAccessLevel {
+        get { settings.metadata.accessLevel ?? .everybody }
+        set { settings.metadata.accessLevel = newValue }
+    }
+
     var publishDateText: String? {
         guard let date = settings.publishDate else {
             return nil

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostStatusView.swift
@@ -99,11 +99,11 @@ struct PostStatusView: View {
                     }
                 }
             }
-            if !(settings.password ?? "").isEmpty {
+            if let password = settings.password, !password.isEmpty {
                 Button {
                     isShowingPasswordEntry = true
                 } label: {
-                    PostSettingsPasswordRow(password: settings.password ?? "")
+                    PostSettingsPasswordRow(password: password)
                 }
                 .buttonStyle(.plain)
             }
@@ -212,14 +212,9 @@ struct PostSettingsPasswordRow: View {
         HStack {
             Text(Strings.passwordLabel)
             Spacer()
-            if !password.isEmpty {
-                Text("••••••••••••")
-                    .font(.footnote.monospaced())
-                    .foregroundStyle(.secondary)
-            } else {
-                Text(Strings.passwordPlaceholder)
-                    .foregroundStyle(.tertiary)
-            }
+            Text("••••••••••••")
+                .font(.footnote.monospaced())
+                .foregroundStyle(.secondary)
             Image(systemName: "chevron.forward")
                 .font(.subheadline.weight(.medium))
                 .foregroundStyle(.secondary.opacity(0.5))
@@ -238,7 +233,6 @@ private enum Strings {
     static let stickySubtitle = NSLocalizedString("postSettings.statusPicker.stickySubtitle", value: "Pin this post to the top of the blog", comment: "Subtitle for sticky toggle")
 
     static let passwordLabel = NSLocalizedString("postSettings.statusPicker.passwordLabel", value: "Password", comment: "Label showing the current password")
-    static let passwordPlaceholder = NSLocalizedString("postSettings.statusPicker.passwordPlaceholder", value: "Not set", comment: "Placeholder text when password is not set")
 
     static let scheduleDate = NSLocalizedString("postSettings.statusPicker.scheduleDate", value: "Date", comment: "Label for schedule date row")
 }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostStatusView.swift
@@ -103,17 +103,7 @@ struct PostStatusView: View {
                 Button {
                     isShowingPasswordEntry = true
                 } label: {
-                    HStack {
-                        Text(Strings.passwordLabel)
-                        Spacer()
-                        Text("••••••••••••")
-                            .font(.footnote.monospaced())
-                            .foregroundStyle(.secondary)
-                        Image(systemName: "chevron.forward")
-                            .font(.subheadline.weight(.medium))
-                            .foregroundStyle(.secondary.opacity(0.5))
-                    }
-                    .contentShape(Rectangle())
+                    PostSettingsPasswordRow(password: settings.password ?? "")
                 }
                 .buttonStyle(.plain)
             }
@@ -215,6 +205,29 @@ private struct PostStatusRow: View {
     }
 }
 
+struct PostSettingsPasswordRow: View {
+    let password: String
+
+    var body: some View {
+        HStack {
+            Text(Strings.passwordLabel)
+            Spacer()
+            if !password.isEmpty {
+                Text("••••••••••••")
+                    .font(.footnote.monospaced())
+                    .foregroundStyle(.secondary)
+            } else {
+                Text(Strings.passwordPlaceholder)
+                    .foregroundStyle(.tertiary)
+            }
+            Image(systemName: "chevron.forward")
+                .font(.subheadline.weight(.medium))
+                .foregroundStyle(.secondary.opacity(0.5))
+        }
+        .contentShape(Rectangle())
+    }
+}
+
 private enum Strings {
     static let title = NSLocalizedString("postSettings.statusPicker.navigationTitle", value: "Status & Visibility", comment: "Navigation title for status picker")
 
@@ -225,6 +238,7 @@ private enum Strings {
     static let stickySubtitle = NSLocalizedString("postSettings.statusPicker.stickySubtitle", value: "Pin this post to the top of the blog", comment: "Subtitle for sticky toggle")
 
     static let passwordLabel = NSLocalizedString("postSettings.statusPicker.passwordLabel", value: "Password", comment: "Label showing the current password")
+    static let passwordPlaceholder = NSLocalizedString("postSettings.statusPicker.passwordPlaceholder", value: "Not set", comment: "Placeholder text when password is not set")
 
     static let scheduleDate = NSLocalizedString("postSettings.statusPicker.scheduleDate", value: "Date", comment: "Label for schedule date row")
 }


### PR DESCRIPTION
## Description

Fixes [CMM-809: Button "Done" disappears when you enter a password for post](https://linear.app/a8c/issue/CMM-809/button-done-disappears-when-you-enter-a-password-for-post).

I previously attempted it in https://github.com/wordpress-mobile/WordPress-iOS/pull/24950, but it turned out to be too complicated. Instead of replacing "Visibility" with "Status", I now simply updated the "Enter Password" flow so it's now consistent across "Post Settings" and "Publishing" screen.

The "Visibility" row works the same as one the web, so I don't think we should touch it unless web (Gutenberg) changes it.

In addition, I fixed an issue with the new "Access" field not showing the selected value.

## Recording

https://github.com/user-attachments/assets/ece99be3-b1ed-426f-a66f-c693cb915b29

