### PR TITLE
feat: Implement editorRequestsLatestContent for WebView recovery

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "d71372b06363bccb6807fa8297bc0a5e78787c06823b49c154a38c8ea038d79b",
+  "originHash" : "efe11d92062675e3ed9aa36c6f5a0cd63ed114a4728409661e96e0cf50890910",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "4506f77222058c712ef6f586fc2887a9a539a580"
+        "revision" : "add768fa0a4ac40573c18f47cd52b5668349392e"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5701fed54f4c40bda6a3dbfb4173e65a063cd60485bd358c446a85d9f857d369",
+  "originHash" : "024ca0929c05dc22af0ce33abb347be2db737ddaa09348ee3a09c1181b56a628",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,7 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "ba98f11399c285289efa1b46b9d590626be1ce3c"
+        "revision" : "8addad7fd018985dd3f8b15cfcc0d028cdc189b3",
+        "version" : "0.13.0"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5faa58b0998f4c70b768e99e1526177ab7aaf4fae1215fbf764f4f2f7df1282f",
+  "originHash" : "120d2e7f3f979eae9796da49eae286ecc4bfcfd1d2154d5e2273a3c40d2430cc",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "d37eee059a60d70c47f6b045d475d1eb31551bb3"
+        "revision" : "9925a4312a9727c718aa9247d78966b58373226d"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "70be48d0eb082238f9389749632f80f30c4c499b77ac89d84c8acab08c45509a",
+  "originHash" : "d71372b06363bccb6807fa8297bc0a5e78787c06823b49c154a38c8ea038d79b",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,8 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "45e9ed3c77c989f4970731ef2657e658bdc87d2e",
-        "version" : "0.12.1"
+        "revision" : "4506f77222058c712ef6f586fc2887a9a539a580"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "120d2e7f3f979eae9796da49eae286ecc4bfcfd1d2154d5e2273a3c40d2430cc",
+  "originHash" : "5701fed54f4c40bda6a3dbfb4173e65a063cd60485bd358c446a85d9f857d369",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "9925a4312a9727c718aa9247d78966b58373226d"
+        "revision" : "ba98f11399c285289efa1b46b9d590626be1ce3c"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "efe11d92062675e3ed9aa36c6f5a0cd63ed114a4728409661e96e0cf50890910",
+  "originHash" : "5faa58b0998f4c70b768e99e1526177ab7aaf4fae1215fbf764f4f2f7df1282f",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,7 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "add768fa0a4ac40573c18f47cd52b5668349392e"
+        "revision" : "d37eee059a60d70c47f6b045d475d1eb31551bb3"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/wpxmlrpc", from: "0.9.0"),
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "9925a4312a9727c718aa9247d78966b58373226d"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "ba98f11399c285289efa1b46b9d590626be1ce3c"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20260114"),
         .package(

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/wpxmlrpc", from: "0.9.0"),
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.12.1"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "4506f77222058c712ef6f586fc2887a9a539a580"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20260114"),
         .package(

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/wpxmlrpc", from: "0.9.0"),
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "add768fa0a4ac40573c18f47cd52b5668349392e"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "d37eee059a60d70c47f6b045d475d1eb31551bb3"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20260114"),
         .package(

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/wpxmlrpc", from: "0.9.0"),
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "4506f77222058c712ef6f586fc2887a9a539a580"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "add768fa0a4ac40573c18f47cd52b5668349392e"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20260114"),
         .package(

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/wpxmlrpc", from: "0.9.0"),
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "ba98f11399c285289efa1b46b9d590626be1ce3c"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.13.0"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20260114"),
         .package(

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/wpxmlrpc", from: "0.9.0"),
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "d37eee059a60d70c47f6b045d475d1eb31551bb3"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "9925a4312a9727c718aa9247d78966b58373226d"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20260114"),
         .package(

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/Editor/CommentGutenbergEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/Editor/CommentGutenbergEditorViewController.swift
@@ -83,7 +83,7 @@ extension CommentGutenbergEditorViewController: GutenbergKit.EditorViewControlle
         // Do nothing
     }
 
-    func editorRequestsLatestContent(_ controller: GutenbergKit.EditorViewController) -> (title: String, content: String)? {
+    func editorDidRequestLatestContent(_ controller: GutenbergKit.EditorViewController) -> (title: String, content: String)? {
         return nil
     }
 

--- a/WordPress/Classes/ViewRelated/Comments/Controllers/Editor/CommentGutenbergEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/Editor/CommentGutenbergEditorViewController.swift
@@ -83,6 +83,10 @@ extension CommentGutenbergEditorViewController: GutenbergKit.EditorViewControlle
         // Do nothing
     }
 
+    func editorRequestsLatestContent(_ controller: GutenbergKit.EditorViewController) -> (title: String, content: String)? {
+        return nil
+    }
+
     func editor(_ viewController: GutenbergKit.EditorViewController, didUpdateContentWithState state: GutenbergKit.EditorState) {
         editorDidUpdate.send(())
     }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -471,7 +471,7 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
         setNavigationItemsEnabled(true)
     }
 
-    func editorRequestsLatestContent(_ controller: GutenbergKit.EditorViewController) -> (title: String, content: String)? {
+    func editorDidRequestLatestContent(_ controller: GutenbergKit.EditorViewController) -> (title: String, content: String)? {
         // Return the current post title and content from Core Data.
         // This is the authoritative source, updated via autosave.
         return (post.postTitle ?? "", post.content ?? "")

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -132,10 +132,12 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
 
         // Create configuration with post content
         let postType = post is Page ? "page" : "post"
+        let postStatus = post.status?.rawValue ?? "draft"
         let editorConfiguration = EditorConfiguration(blog: post.blog, postType: postType)
             .toBuilder()
             .setTitle(post.postTitle ?? "")
             .setContent(post.content ?? "")
+            .setStatus(postStatus)
             .setNativeInserterEnabled(FeatureFlag.nativeBlockInserter.enabled)
             .build()
 

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -468,6 +468,12 @@ extension NewGutenbergViewController: GutenbergKit.EditorViewControllerDelegate 
         setNavigationItemsEnabled(true)
     }
 
+    func editorRequestsLatestContent(_ controller: GutenbergKit.EditorViewController) -> (title: String, content: String)? {
+        // Return the current post title and content from Core Data.
+        // This is the authoritative source, updated via autosave.
+        return (post.postTitle ?? "", post.content ?? "")
+    }
+
     private func convertMediaInfoArrayToJSONString(_ mediaInfoArray: [MediaInfo]) -> String? {
         do {
             let jsonData = try JSONEncoder().encode(mediaInfoArray)

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -137,6 +137,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
             .toBuilder()
             .setTitle(post.postTitle ?? "")
             .setContent(post.content ?? "")
+            .setPostID(post.postID?.intValue)
             .setStatus(postStatus)
             .setNativeInserterEnabled(FeatureFlag.nativeBlockInserter.enabled)
             .build()

--- a/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/NewGutenbergViewController.swift
@@ -138,7 +138,7 @@ class NewGutenbergViewController: UIViewController, PostEditor, PublishingEditor
             .setTitle(post.postTitle ?? "")
             .setContent(post.content ?? "")
             .setPostID(post.postID?.intValue)
-            .setStatus(postStatus)
+            .setPostStatus(postStatus)
             .setNativeInserterEnabled(FeatureFlag.nativeBlockInserter.enabled)
             .build()
 


### PR DESCRIPTION
## Description
Ref CMM-1123. 

Implements the `editorRequestsLatestContent` delegate method for GutenbergKit's pull-based content recovery mechanism.

When the WebView reinitializes (due to OS memory pressure or page refresh), the editor now requests the latest content from the app rather than using stale content from the initial WebView load. This ensures users don't lose their work during WebView recovery.

**Changes:**
- Added `editorRequestsLatestContent(_:)` delegate method to `NewGutenbergViewController`
- Returns the current post title and content from Core Data (the authoritative source updated via autosave)
-  Properly set overlooked post status and ID to avoid unexpectedly [emptying post titles](https://github.com/WordPress/gutenberg/blob/75d608f96d813261faa22d0ef280a824f019269c/packages/core-data/src/actions.js#L96-L105). 

**Related PRs:**
- GutenbergKit: https://github.com/wordpress-mobile/GutenbergKit/pull/283
- WordPress-Android: https://github.com/wordpress-mobile/WordPress-Android/pull/22493

## Testing instructions
1. Open a post with existing content in the GutenbergKit editor
2. Make edits to the content (wait 2+ seconds for autosave to persist)
3. Trigger a WebView refresh:
   - **Safari DevTools**: <kbd>Cmd</kbd>+<kbd>R</kbd> while WebView is inspected via the [Safari Inspector](https://developer.apple.com/documentation/safari-developer-tools/inspecting-ios)
   - **iOS Simulator**: Open Activity Monitor, force quit "com.apple.WebKit.WebContent"
4. Verify the editor recovers with the edited content, not the original

🤖 Generated with [Claude Code](https://claude.com/claude-code)