### PR TITLE
Use application password login in "Add Site"

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -23,6 +23,7 @@
 * [*] Stats: Fix ordering of Top List items with the same metrics – sort by name [#25135]
 * [*] Techical: Remove obsolete Core Data models to slightly reduce the app size (-6.4 MB) [#25124]
 * [*] Update some illustrations, app shortcut icons, and more to better match the system [#25141], [#25115], [#25140], [#25122]
+* [*] Site Picker -> Add self-hosted sites now uses Application Password authentication [#25148]
 
 
 26.5

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/AddSiteController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/AddSiteController.swift
@@ -33,14 +33,6 @@ struct AddSiteController {
     }
 
     func showSelfHostedSiteLoginScreen() {
-        guard FeatureFlag.allowApplicationPasswords.enabled else {
-            WordPressAuthenticator.showLoginForSelfHostedSite(viewController)
-            return
-        }
-        showApplicationPasswordAuthenticationForSelfHostedSite()
-    }
-
-    private func showApplicationPasswordAuthenticationForSelfHostedSite() {
         let loginCompleted: (TaggedManagedObjectID<Blog>) -> Void = { [weak viewController] _ in
             // The `LoginWithUrlView` view is dismissed when this closure is called.
             // We also need to dismiss the `viewController` if it's presented as a modal.


### PR DESCRIPTION
## Description

This comes out of a discussion with Jeremy: we'll start rolling out the application password login, starting from the "Add Site" button in the site picker.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
