### PR TITLE
Add a clear button to the site address text field

### DIFF
--- a/WordPress/Classes/Login/LoginWithUrlView.swift
+++ b/WordPress/Classes/Login/LoginWithUrlView.swift
@@ -73,8 +73,19 @@ struct LoginWithUrlView: View {
     }
 
     private func siteAdddressTextField() -> some View {
-        TextField(text: $urlField) {
-            Text("example.com")
+        HStack {
+            TextField(text: $urlField) {
+                Text("example.com")
+            }
+
+            if !urlField.isEmpty {
+                Button {
+                    urlField = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.gray)
+                }
+            }
         }
         .padding(.top)
         .padding(.bottom, 8)
@@ -84,6 +95,7 @@ struct LoginWithUrlView: View {
         .textContentType(.URL)
         .keyboardType(.URL)
         .textInputAutocapitalization(.never)
+        .autocorrectionDisabled()
         .onSubmit { self.loginTrigger += 1 }
         .disabled(isLoading)
     }


### PR DESCRIPTION
## Description

Not sure if there is an easier or more straightforward way to do it than using an `HStack`.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
