### PR TITLE
Use standard Dotcom secondary color for excerpts in Reader

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -136,7 +136,7 @@ private final class ReaderPostCellView: UIView {
         titleLabel.maximumContentSizeCategory = .accessibilityExtraLarge
 
         detailsLabel.font = .preferredFont(forTextStyle: .subheadline)
-        detailsLabel.textColor = .secondaryLabel
+        detailsLabel.textColor = UIAppColor.secondary
         detailsLabel.adjustsFontForContentSizeCategory = true
         detailsLabel.maximumContentSizeCategory = .accessibilityExtraLarge
 


### PR DESCRIPTION
Just a notch darker secondary color for text in excerpts – there've been some feedback about it being too hard to read. The new color is a standard dotcom secondary color.

<img width="340"  alt="Screenshot 2026-01-21 at 10 05 25 AM" src="https://github.com/user-attachments/assets/e4cac968-adb6-4565-b255-3ee11112ae24" /> <img width="340"  alt="Screenshot 2026-01-21 at 10 07 13 AM" src="https://github.com/user-attachments/assets/fba02176-8e5f-474a-8a26-ff2dbd02fe6c" />


