### PR TITLE
Reader: Improve inline comments

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -8,6 +8,8 @@
 * [*] Reader: Fix article view ignoring `use_excerpt` [#25108]
 * [*] Reader: Add translation support for posts [#25089]
 * [*] Reader: Collapse multiple spaces in site titles into one [#25094]
+* [*] Reader: Add a "Leave Comment" button to directly to the "Comments" under the article (one less tap to leave a comment) [#25155]
+* [*] Reader: You can now reply and like the comments directly under the artile and see more of them [#25155]
 * [*] Post Settings: Fix post Visibility discoverability [#25127]
 * [*] Post Settings: Fix an issue with button "Done" sometimes disappearing when you entering password for post when publishing [#25138]
 * [*] Post Settings: Show the selected value for the "Access" field [#25138]

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -103,6 +103,7 @@ import WordPressShared
     case readerPostReported
     case readerPostAuthorReported
     case readerArticleDetailMoreTapped
+    case readerArticleLeaveCommentTapped
     case readerSharedItem
     case readerSuggestedSiteVisited
     case readerSuggestedSiteToggleFollow
@@ -870,6 +871,8 @@ import WordPressShared
             return "reader_post_author_reported"
         case .readerArticleDetailMoreTapped:
             return "reader_article_detail_more_tapped"
+        case .readerArticleLeaveCommentTapped:
+            return "reader_article_leave_comment_tapped"
         case .readerSharedItem:
             return "reader_shared_item"
         case .readerSuggestedSiteVisited:

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -190,8 +190,6 @@ final class CommentContentTableViewCell: UITableViewCell, NibReusable {
     func configureForPostDetails(with comment: Comment, helper: ReaderCommentsHelper, onContentLoaded: ((CGFloat) -> Void)?) {
         configure(viewModel: CommentCellViewModel(comment: comment), helper: helper, onContentLoaded: onContentLoaded)
 
-        hideActions()
-
         containerStackLeadingConstraint.constant = 0
         containerStackTrailingConstraint.constant = 0
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Views/CommentLargeButton.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/CommentLargeButton.swift
@@ -3,16 +3,13 @@ import WordPressUI
 import WordPressShared
 
 final class CommentLargeButton: UIView {
-    private let iconView = MyProfileIconView(hidesWhenEmpty: true)
-    private var containerView = CommentLargeButtonContainerView()
-    private let placeholderLabel = UILabel()
+    private let leaveCommentView = LeaveCommentView()
     private let button = UIButton()
     private let commentsClosedView = makeCommentsClosedView()
-    private var contentStackView: UIStackView?
 
     @objc var isCommentingClosed = false {
         didSet {
-            contentStackView?.isHidden = isCommentingClosed
+            leaveCommentView.isHidden = isCommentingClosed
             commentsClosedView.isHidden = !isCommentingClosed
             isUserInteractionEnabled = !isCommentingClosed
         }
@@ -31,8 +28,8 @@ final class CommentLargeButton: UIView {
     }
 
     var placeholder: String? {
-        set { placeholderLabel.text = newValue }
-        get { placeholderLabel.text }
+        set { leaveCommentView.placeholder = newValue }
+        get { leaveCommentView.placeholder }
     }
 
     private func setupView() {
@@ -41,17 +38,8 @@ final class CommentLargeButton: UIView {
 
         backgroundColor = .systemBackground
 
-        placeholderLabel.textColor = .tertiaryLabel
-
-        placeholderLabel.text = CommentCreateViewModel.leaveCommentLocalizedPlaceholder
-
-        containerView.addSubview(placeholderLabel)
-        placeholderLabel.pinEdges(insets: UIEdgeInsets(horizontal: 14, vertical: 10))
-
-        let stackView = UIStackView(alignment: .center, spacing: 8, [iconView, containerView])
-        addSubview(stackView)
-        stackView.pinEdges(to: safeAreaLayoutGuide, insets: UIEdgeInsets.init(top: 14, left: 20, bottom: 8, right: 20))
-        self.contentStackView = stackView
+        addSubview(leaveCommentView)
+        leaveCommentView.pinEdges(to: safeAreaLayoutGuide, insets: UIEdgeInsets.init(top: 14, left: 20, bottom: 8, right: 20))
 
         let divider = SeparatorView.horizontal()
         addSubview(divider)
@@ -62,12 +50,45 @@ final class CommentLargeButton: UIView {
         button.pinEdges() // Make sure it covers everything
 
         addSubview(commentsClosedView)
-        commentsClosedView.pinCenter(to: stackView)
+        commentsClosedView.pinCenter(to: leaveCommentView)
         commentsClosedView.isHidden = true
     }
 
     @objc private func buttonTapped() {
         onTap?()
+    }
+}
+
+final class LeaveCommentView: UIView {
+    private let iconView = MyProfileIconView(hidesWhenEmpty: true)
+    private let containerView = CommentLargeButtonContainerView()
+    private let placeholderLabel = UILabel()
+
+    var placeholder: String? {
+        set { placeholderLabel.text = newValue }
+        get { placeholderLabel.text }
+    }
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        super.init(coder: coder)
+        setupView()
+    }
+
+    private func setupView() {
+        placeholderLabel.textColor = .tertiaryLabel
+        placeholderLabel.text = CommentCreateViewModel.leaveCommentLocalizedPlaceholder
+
+        containerView.addSubview(placeholderLabel)
+        placeholderLabel.pinEdges(insets: UIEdgeInsets(horizontal: 14, vertical: 10))
+
+        let stackView = UIStackView(alignment: .center, spacing: 8, [iconView, containerView])
+        addSubview(stackView)
+        stackView.pinEdges()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -75,7 +75,7 @@ class ReaderDetailCoordinator {
 
     /// Comment Service
     private let commentService: CommentService
-    private let commentsDisplayed: UInt = 1
+    private let commentsDisplayed: UInt = 2
 
     /// Post Sharing Controller
     private let sharingController: PostSharingController

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -487,6 +487,9 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         // Set the delegate here so the table isn't shown until fetching is complete.
         commentsTableView.delegate = commentsTableViewDelegate
         commentsTableView.dataSource = commentsTableViewDelegate
+        commentsTableViewDelegate.addCommentButtonTappedClosure = { [weak self] in
+            self?.handleAddCommentButtonTapped()
+        }
         commentsTableViewDelegate.updateWith(post: post,
                                              comments: approvedComments,
                                              totalComments: totalComments,
@@ -1460,6 +1463,18 @@ extension ReaderDetailViewController: BorderedButtonTableViewCellDelegate {
             post: post,
             origin: self,
             source: .postDetailsComments
+        )
+    }
+
+    func handleAddCommentButtonTapped() {
+        guard let post else {
+            return
+        }
+
+        ReaderCommentAction().execute(
+            post: post,
+            origin: self,
+            source: .postDetails
         )
     }
 }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -490,11 +490,13 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         commentsTableViewDelegate.addCommentButtonTappedClosure = { [weak self] in
             self?.handleAddCommentButtonTapped()
         }
-        commentsTableViewDelegate.updateWith(post: post,
-                                             comments: approvedComments,
-                                             totalComments: totalComments,
-                                             presentingViewController: self,
-                                             buttonDelegate: self)
+        commentsTableViewDelegate.configure(
+            post: post,
+            comments: approvedComments,
+            totalComments: totalComments,
+            presentingViewController: self,
+            buttonDelegate: self
+        )
 
         commentsTableView.reloadData()
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -1470,14 +1470,12 @@ extension ReaderDetailViewController: BorderedButtonTableViewCellDelegate {
 
     func handleAddCommentButtonTapped() {
         guard let post else {
-            return
+            return wpAssertionFailure("post missing")
         }
-
-        ReaderCommentAction().execute(
-            post: post,
-            origin: self,
-            source: .postDetails
-        )
+        let viewModel = CommentCreateViewModel(post: post)
+        let composerVC = CommentCreateViewController(viewModel: viewModel)
+        let navigationVC = UINavigationController(rootViewController: composerVC)
+        present(navigationVC, animated: true)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -487,8 +487,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
         // Set the delegate here so the table isn't shown until fetching is complete.
         commentsTableView.delegate = commentsTableViewDelegate
         commentsTableView.dataSource = commentsTableViewDelegate
-        commentsTableViewDelegate.addCommentButtonTappedClosure = { [weak self] in
-            self?.handleAddCommentButtonTapped()
+        commentsTableViewDelegate.buttonLeaveCommentTapped = { [weak self] in
+            self?.buttonLeaveCommentTapped(replyingTo: $0)
         }
         commentsTableViewDelegate.configure(
             post: post,
@@ -1468,11 +1468,11 @@ extension ReaderDetailViewController: BorderedButtonTableViewCellDelegate {
         )
     }
 
-    func handleAddCommentButtonTapped() {
+    func buttonLeaveCommentTapped(replyingTo comment: Comment?) {
         guard let post else {
             return wpAssertionFailure("post missing")
         }
-        let viewModel = CommentCreateViewModel(post: post)
+        let viewModel = CommentCreateViewModel(post: post, replyingTo: comment)
         let composerVC = CommentCreateViewController(viewModel: viewModel)
         let navigationVC = UINavigationController(rootViewController: composerVC)
         present(navigationVC, animated: true)

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -83,9 +83,9 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
         case .addCommentButton:
             return makeAddCommentButtonCell()
         case .comment(let comment):
-            return makeCommentCell(for: comment, tableView: tableView)
+            return makeCommentCell(for: comment, in: tableView)
         case .emptyState(let title):
-            return makeEmptyStateCell(title: title)
+            return makeEmptyStateCell(title: title, in: tableView)
         case .viewAllButton:
             return makeViewAllButtonCell()
         }
@@ -155,12 +155,12 @@ private extension ReaderDetailCommentsTableViewDelegate {
         leaveCommentView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(leaveCommentCellTapped)))
 
         cell.contentView.addSubview(leaveCommentView)
-        leaveCommentView.pinEdges(insets: UIEdgeInsets(.vertical, 8))
+        leaveCommentView.pinEdges(insets: UIEdgeInset(top: 16, left: 0, bottom: 8, right: 0))
 
         return cell
     }
 
-    func makeCommentCell(for comment: Comment, tableView: UITableView) -> UITableViewCell {
+    func makeCommentCell(for comment: Comment, in tableView: UITableView) -> UITableViewCell {
         guard let cell = tableView.dequeueReusableCell(withIdentifier: CommentContentTableViewCell.defaultReuseID) as? CommentContentTableViewCell else {
             return UITableViewCell()
         }
@@ -182,8 +182,10 @@ private extension ReaderDetailCommentsTableViewDelegate {
         return cell
     }
 
-    func makeEmptyStateCell(title: String) -> UITableViewCell {
-        let cell = ReaderDetailNoCommentCell()
+    func makeEmptyStateCell(title: String, in tableView: UITableView) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: ReaderDetailNoCommentCell.defaultReuseID) as? ReaderDetailNoCommentCell else {
+            return UITableViewCell()
+        }
 
         cell.titleLabel.text = title
         cell.backgroundColor = .clear
@@ -193,7 +195,6 @@ private extension ReaderDetailCommentsTableViewDelegate {
             cell.titleLabel.font = displaySetting.font(with: .body)
             cell.titleLabel.textColor = displaySetting.color.secondaryForeground
         }
-
         return cell
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -18,40 +18,15 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
     var followButtonTappedClosure: (() ->Void)?
     var addCommentButtonTappedClosure: (() -> Void)?
 
-    private var totalRows = 0
-    private var hideButton = true
-    private var showAddCommentButton = false
-
     var displaySetting: ReaderDisplaySettings
 
-    private var comments: [Comment] = [] {
-        didSet {
-            totalRows = {
-                var rows = 0
+    private var items: [Item] = []
 
-                // Add row for CommentLargeButton if comments are enabled
-                if showAddCommentButton {
-                    rows += 1
-                }
-
-                // If there are no comments and commenting is closed, 1 empty cell.
-                if hideButton {
-                    return rows + 1
-                }
-
-                // If there are no comments, 1 empty cell + 1 button.
-                if comments.count == 0 {
-                    return rows + 2
-                }
-
-                // Otherwise add 1 for the button.
-                return rows + comments.count + 1
-            }()
-        }
-    }
-
-    private var commentsEnabled: Bool {
-        return post?.commentsOpen ?? false
+    private enum Item {
+        case addCommentButton
+        case comment(Comment)
+        case emptyState(title: String)
+        case viewAllButton
     }
 
     // MARK: - Public Methods
@@ -60,18 +35,32 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
         self.displaySetting = displaySetting
     }
 
-    func updateWith(post: ReaderPost,
-                    comments: [Comment] = [],
-                    totalComments: Int = 0,
-                    presentingViewController: UIViewController,
-                    buttonDelegate: BorderedButtonTableViewCellDelegate? = nil) {
+    func configure(
+        post: ReaderPost,
+        comments: [Comment] = [],
+        totalComments: Int = 0,
+        presentingViewController: UIViewController,
+        buttonDelegate: BorderedButtonTableViewCellDelegate? = nil
+    ) {
         self.post = post
-        hideButton = (comments.count == 0 && !commentsEnabled)
-        showAddCommentButton = commentsEnabled
-        self.comments = comments
         self.totalComments = totalComments
         self.presentingViewController = presentingViewController
         self.buttonDelegate = buttonDelegate
+
+        var items: [Item] = []
+        if post.commentsOpen {
+            items.append(.addCommentButton)
+        }
+        if comments.isEmpty {
+            let title = post.commentsOpen ? Constants.noComments : Constants.closedComments
+            items.append(.emptyState(title: title))
+        } else {
+            items.append(contentsOf: comments.map { .comment($0) })
+        }
+        if !comments.isEmpty || post.commentsOpen {
+            items.append(.viewAllButton)
+        }
+        self.items = items
     }
 
     func updateFollowButtonState(post: ReaderPost) {
@@ -86,59 +75,20 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
     }
 
     func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return totalRows
+        return items.count
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
-        // Show CommentLargeButton as first cell if comments are enabled
-        if showAddCommentButton && indexPath.row == 0 {
-            return commentLargeButtonCell()
+        switch items[indexPath.row] {
+        case .addCommentButton:
+            return makeAddCommentButtonCell()
+        case .comment(let comment):
+            return makeCommentCell(for: comment, tableView: tableView)
+        case .emptyState(let title):
+            return makeEmptyStateCell(title: title)
+        case .viewAllButton:
+            return makeViewAllButtonCell()
         }
-
-        // Show "View all comments" button at the last row
-        if indexPath.row == (totalRows - 1) && !hideButton {
-            return showCommentsButtonCell()
-        }
-
-        // Adjust index for accessing comments array
-        let commentIndex = showAddCommentButton ? indexPath.row - 1 : indexPath.row
-
-        if let comment = comments[safe: commentIndex] {
-            guard let cell = tableView.dequeueReusableCell(withIdentifier: CommentContentTableViewCell.defaultReuseID) as? CommentContentTableViewCell else {
-                return UITableViewCell()
-            }
-
-            cell.displaySetting = displaySetting
-            cell.configureForPostDetails(with: comment, helper: helper) { _ in
-                do {
-                    try WPException.objcTry {
-                        tableView.performBatchUpdates({})
-                    }
-                } catch {
-                    WordPressAppDelegate.crashLogging?.logError(error)
-                }
-            }
-
-            cell.backgroundColor = .clear
-            cell.contentView.backgroundColor = .clear
-
-            return cell
-        }
-
-        guard let cell = tableView.dequeueReusableCell(withIdentifier: ReaderDetailNoCommentCell.defaultReuseID) as? ReaderDetailNoCommentCell else {
-            return UITableViewCell()
-        }
-
-        cell.titleLabel.text = commentsEnabled ? Constants.noComments : Constants.closedComments
-        cell.backgroundColor = .clear
-        cell.contentView.backgroundColor = .clear
-
-        if ReaderDisplaySettings.customizationEnabled {
-            cell.titleLabel.font = displaySetting.font(with: .body)
-            cell.titleLabel.textColor = displaySetting.color.secondaryForeground
-        }
-
-        return cell
     }
 
     func tableView(_ tableView: UITableView, viewForHeaderInSection section: Int) -> UIView? {
@@ -195,7 +145,7 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
 
 private extension ReaderDetailCommentsTableViewDelegate {
 
-    func commentLargeButtonCell() -> UITableViewCell {
+    func makeAddCommentButtonCell() -> UITableViewCell {
         let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
         cell.selectionStyle = .none
         cell.backgroundColor = .clear
@@ -210,11 +160,44 @@ private extension ReaderDetailCommentsTableViewDelegate {
         return cell
     }
 
-    @objc private func leaveCommentCellTapped() {
-        addCommentButtonTappedClosure?()
+    func makeCommentCell(for comment: Comment, tableView: UITableView) -> UITableViewCell {
+        guard let cell = tableView.dequeueReusableCell(withIdentifier: CommentContentTableViewCell.defaultReuseID) as? CommentContentTableViewCell else {
+            return UITableViewCell()
+        }
+
+        cell.displaySetting = displaySetting
+        cell.configureForPostDetails(with: comment, helper: helper) { _ in
+            do {
+                try WPException.objcTry {
+                    tableView.performBatchUpdates({})
+                }
+            } catch {
+                WordPressAppDelegate.crashLogging?.logError(error)
+            }
+        }
+
+        cell.backgroundColor = .clear
+        cell.contentView.backgroundColor = .clear
+
+        return cell
     }
 
-    func showCommentsButtonCell() -> BorderedButtonTableViewCell {
+    func makeEmptyStateCell(title: String) -> UITableViewCell {
+        let cell = ReaderDetailNoCommentCell()
+
+        cell.titleLabel.text = title
+        cell.backgroundColor = .clear
+        cell.contentView.backgroundColor = .clear
+
+        if ReaderDisplaySettings.customizationEnabled {
+            cell.titleLabel.font = displaySetting.font(with: .body)
+            cell.titleLabel.textColor = displaySetting.color.secondaryForeground
+        }
+
+        return cell
+    }
+
+    func makeViewAllButtonCell() -> BorderedButtonTableViewCell {
         let cell = BorderedButtonTableViewCell()
         let title = totalComments == 0 ? Constants.leaveCommentButtonTitle : Constants.viewAllButtonTitle
 
@@ -232,6 +215,10 @@ private extension ReaderDetailCommentsTableViewDelegate {
         cell.backgroundColor = .clear
         cell.contentView.backgroundColor = .clear
         return cell
+    }
+
+    @objc private func leaveCommentCellTapped() {
+        addCommentButtonTappedClosure?()
     }
 
     @objc func jetpackButtonTapped() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -16,7 +16,7 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
     private(set) var headerView: ReaderDetailCommentsHeader?
     private let helper = ReaderCommentsHelper()
     var followButtonTappedClosure: (() ->Void)?
-    var addCommentButtonTappedClosure: (() -> Void)?
+    var buttonLeaveCommentTapped: ((Comment?) -> Void)?
 
     var displaySetting: ReaderDisplaySettings
 
@@ -175,6 +175,13 @@ private extension ReaderDetailCommentsTableViewDelegate {
             }
         }
 
+        cell.accessoryButtonAction = { [weak self] sourceView in
+            self?.shareComment(comment, sourceView: sourceView)
+        }
+        cell.replyButtonAction = { [weak self] in
+            self?.buttonLeaveCommentTapped?(comment)
+        }
+
         cell.backgroundColor = .clear
         cell.contentView.backgroundColor = .clear
 
@@ -203,18 +210,18 @@ private extension ReaderDetailCommentsTableViewDelegate {
         cell.backgroundColor = .clear
 
         var configuration = UIButton.Configuration.bordered()
-//        configuration.buttonSize = .large
         configuration.title = Constants.viewAllButtonTitle.localizedCapitalized + "   \(totalComments)"
         configuration.image = UIImage(systemName: "chevron.right")
         configuration.imagePlacement = .trailing
         configuration.titleTextAttributesTransformer = .init {
             var container = $0
-            container.font = UIFont.preferredFont(forTextStyle: .headline)
+            container.font = UIFont.preferredFont(forTextStyle: .headline).withWeight(.medium)
             return container
         }
         configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(paletteColors: [.tertiaryLabel])
             .applying(UIImage.SymbolConfiguration(font: UIFont.preferredFont(forTextStyle: .caption2).withWeight(.bold)))
         configuration.imagePadding = 4
+        configuration.contentInsets = .init(top: 8, leading: 8, bottom: 8, trailing: 8)
 
         let button = UIButton(configuration: configuration, primaryAction: .init { [weak self] _ in
             self?.buttonDelegate?.buttonTapped()
@@ -228,8 +235,21 @@ private extension ReaderDetailCommentsTableViewDelegate {
         return cell
     }
 
+    // MARK: - Actions
+
+    private func shareComment(_ comment: Comment, sourceView: UIView?) {
+        guard let commentURL = comment.commentURL() else {
+            return
+        }
+        WPAnalytics.track(.readerArticleCommentShared)
+
+        let activityViewController = UIActivityViewController(activityItems: [commentURL as Any], applicationActivities: nil)
+        activityViewController.popoverPresentationController?.sourceView = sourceView
+        UIViewController.topViewController?.present(activityViewController, animated: true, completion: nil)
+    }
+
     @objc private func leaveCommentCellTapped() {
-        addCommentButtonTappedClosure?()
+        buttonLeaveCommentTapped?()
     }
 
     @objc func jetpackButtonTapped() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -249,6 +249,7 @@ private extension ReaderDetailCommentsTableViewDelegate {
     }
 
     @objc private func leaveCommentCellTapped() {
+        WPAnalytics.track(.readerArticleLeaveCommentTapped)
         buttonLeaveCommentTapped?(nil)
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -221,7 +221,7 @@ private extension ReaderDetailCommentsTableViewDelegate {
         configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(paletteColors: [.tertiaryLabel])
             .applying(UIImage.SymbolConfiguration(font: UIFont.preferredFont(forTextStyle: .caption2).withWeight(.bold)))
         configuration.imagePadding = 4
-        configuration.contentInsets = .init(top: 8, leading: 8, bottom: 8, trailing: 8)
+        configuration.contentInsets = .init(top: 9, leading: 12, bottom: 9, trailing: 12)
 
         let button = UIButton(configuration: configuration, primaryAction: .init { [weak self] _ in
             self?.buttonDelegate?.buttonTapped()
@@ -249,7 +249,7 @@ private extension ReaderDetailCommentsTableViewDelegate {
     }
 
     @objc private func leaveCommentCellTapped() {
-        buttonLeaveCommentTapped?()
+        buttonLeaveCommentTapped?(nil)
     }
 
     @objc func jetpackButtonTapped() {

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -149,13 +149,12 @@ private extension ReaderDetailCommentsTableViewDelegate {
         let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
         cell.selectionStyle = .none
         cell.backgroundColor = .clear
-        cell.contentView.backgroundColor = .clear
 
         let leaveCommentView = LeaveCommentView()
         leaveCommentView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(leaveCommentCellTapped)))
 
         cell.contentView.addSubview(leaveCommentView)
-        leaveCommentView.pinEdges(insets: UIEdgeInset(top: 16, left: 0, bottom: 8, right: 0))
+        leaveCommentView.pinEdges(insets: UIEdgeInsets(top: 16, left: 0, bottom: 8, right: 0))
 
         return cell
     }
@@ -198,23 +197,34 @@ private extension ReaderDetailCommentsTableViewDelegate {
         return cell
     }
 
-    func makeViewAllButtonCell() -> BorderedButtonTableViewCell {
-        let cell = BorderedButtonTableViewCell()
-        let title = totalComments == 0 ? Constants.leaveCommentButtonTitle : Constants.viewAllButtonTitle
-
-        cell.configure(
-            buttonTitle: title,
-            titleFont: displaySetting.font(with: .body, weight: .semibold),
-            normalColor: displaySetting.color.foreground,
-            highlightedColor: displaySetting.color.background,
-            borderColor: displaySetting.color.border,
-            buttonInsets: UIEdgeInsets(.vertical, 16),
-            backgroundColor: .clear
-        )
-
-        cell.delegate = buttonDelegate
+    func makeViewAllButtonCell() -> UITableViewCell {
+        let cell = UITableViewCell()
+        cell.selectionStyle = .none
         cell.backgroundColor = .clear
-        cell.contentView.backgroundColor = .clear
+
+        var configuration = UIButton.Configuration.bordered()
+        configuration.buttonSize = .large
+        configuration.title = Constants.viewAllButtonTitle.localizedCapitalized + "   \(totalComments)"
+        configuration.image = UIImage(systemName: "chevron.right")
+        configuration.imagePlacement = .trailing
+        configuration.titleTextAttributesTransformer = .init {
+            var container = $0
+            container.font = UIFont.preferredFont(forTextStyle: .headline)
+            return container
+        }
+        configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(paletteColors: [.tertiaryLabel])
+            .applying(UIImage.SymbolConfiguration(font: UIFont.preferredFont(forTextStyle: .caption2).withWeight(.bold)))
+        configuration.imagePadding = 4
+
+        let button = UIButton(configuration: configuration, primaryAction: .init { [weak self] _ in
+            self?.buttonDelegate?.buttonTapped()
+        })
+
+        cell.contentView.addSubview(button)
+
+        button.pinEdges([.leading, .vertical], insets: UIEdgeInsets(horizontal: 0, vertical: 12))
+        button.pinEdges(.trailing, relation: .lessThanOrEqual)
+
         return cell
     }
 
@@ -234,6 +244,7 @@ private extension ReaderDetailCommentsTableViewDelegate {
         static let noComments = NSLocalizedString("No comments yet", comment: "Displayed on the post details page when there are no post comments.")
         static let closedComments = NSLocalizedString("Comments are closed", comment: "Displayed on the post details page when there are no post comments and commenting is closed.")
         static let viewAllButtonTitle = NSLocalizedString("View all comments", comment: "Title for button on the post details page to show all comments when tapped.")
+        // TODO: use as emty title?
         static let leaveCommentButtonTitle = NSLocalizedString("Be the first to comment", comment: "Title for button on the post details page when there are no comments.")
         static let jetpackBadgeBottomPadding: CGFloat = 10
     }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -16,27 +16,36 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
     private(set) var headerView: ReaderDetailCommentsHeader?
     private let helper = ReaderCommentsHelper()
     var followButtonTappedClosure: (() ->Void)?
+    var addCommentButtonTappedClosure: (() -> Void)?
 
     private var totalRows = 0
     private var hideButton = true
+    private var showAddCommentButton = false
 
     var displaySetting: ReaderDisplaySettings
 
     private var comments: [Comment] = [] {
         didSet {
             totalRows = {
+                var rows = 0
+
+                // Add row for CommentLargeButton if comments are enabled
+                if showAddCommentButton {
+                    rows += 1
+                }
+
                 // If there are no comments and commenting is closed, 1 empty cell.
                 if hideButton {
-                    return 1
+                    return rows + 1
                 }
 
                 // If there are no comments, 1 empty cell + 1 button.
                 if comments.count == 0 {
-                    return 2
+                    return rows + 2
                 }
 
                 // Otherwise add 1 for the button.
-                return comments.count + 1
+                return rows + comments.count + 1
             }()
         }
     }
@@ -58,6 +67,7 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
                     buttonDelegate: BorderedButtonTableViewCellDelegate? = nil) {
         self.post = post
         hideButton = (comments.count == 0 && !commentsEnabled)
+        showAddCommentButton = commentsEnabled
         self.comments = comments
         self.totalComments = totalComments
         self.presentingViewController = presentingViewController
@@ -80,11 +90,20 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
     }
 
     func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        // Show CommentLargeButton as first cell if comments are enabled
+        if showAddCommentButton && indexPath.row == 0 {
+            return commentLargeButtonCell()
+        }
+
+        // Show "View all comments" button at the last row
         if indexPath.row == (totalRows - 1) && !hideButton {
             return showCommentsButtonCell()
         }
 
-        if let comment = comments[safe: indexPath.row] {
+        // Adjust index for accessing comments array
+        let commentIndex = showAddCommentButton ? indexPath.row - 1 : indexPath.row
+
+        if let comment = comments[safe: commentIndex] {
             guard let cell = tableView.dequeueReusableCell(withIdentifier: CommentContentTableViewCell.defaultReuseID) as? CommentContentTableViewCell else {
                 return UITableViewCell()
             }
@@ -175,6 +194,25 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
 }
 
 private extension ReaderDetailCommentsTableViewDelegate {
+
+    func commentLargeButtonCell() -> UITableViewCell {
+        let cell = UITableViewCell(style: .default, reuseIdentifier: nil)
+        cell.selectionStyle = .none
+        cell.backgroundColor = .clear
+        cell.contentView.backgroundColor = .clear
+
+        let leaveCommentView = LeaveCommentView()
+        leaveCommentView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(leaveCommentCellTapped)))
+
+        cell.contentView.addSubview(leaveCommentView)
+        leaveCommentView.pinEdges(insets: UIEdgeInsets(.vertical, 8))
+
+        return cell
+    }
+
+    @objc private func leaveCommentCellTapped() {
+        addCommentButtonTappedClosure?()
+    }
 
     func showCommentsButtonCell() -> BorderedButtonTableViewCell {
         let cell = BorderedButtonTableViewCell()

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -52,12 +52,12 @@ class ReaderDetailCommentsTableViewDelegate: NSObject, UITableViewDataSource, UI
             items.append(.addCommentButton)
         }
         if comments.isEmpty {
-            let title = post.commentsOpen ? Constants.noComments : Constants.closedComments
+            let title = post.commentsOpen ? Constants.emptyStateTitle : Constants.closedComments
             items.append(.emptyState(title: title))
         } else {
             items.append(contentsOf: comments.map { .comment($0) })
         }
-        if !comments.isEmpty || post.commentsOpen {
+        if !comments.isEmpty {
             items.append(.viewAllButton)
         }
         self.items = items
@@ -203,7 +203,7 @@ private extension ReaderDetailCommentsTableViewDelegate {
         cell.backgroundColor = .clear
 
         var configuration = UIButton.Configuration.bordered()
-        configuration.buttonSize = .large
+//        configuration.buttonSize = .large
         configuration.title = Constants.viewAllButtonTitle.localizedCapitalized + "   \(totalComments)"
         configuration.image = UIImage(systemName: "chevron.right")
         configuration.imagePlacement = .trailing
@@ -222,7 +222,7 @@ private extension ReaderDetailCommentsTableViewDelegate {
 
         cell.contentView.addSubview(button)
 
-        button.pinEdges([.leading, .vertical], insets: UIEdgeInsets(horizontal: 0, vertical: 12))
+        button.pinEdges([.leading, .vertical], insets: UIEdgeInsets(horizontal: 0, vertical: 16))
         button.pinEdges(.trailing, relation: .lessThanOrEqual)
 
         return cell
@@ -241,11 +241,9 @@ private extension ReaderDetailCommentsTableViewDelegate {
     }
 
     struct Constants {
-        static let noComments = NSLocalizedString("No comments yet", comment: "Displayed on the post details page when there are no post comments.")
         static let closedComments = NSLocalizedString("Comments are closed", comment: "Displayed on the post details page when there are no post comments and commenting is closed.")
         static let viewAllButtonTitle = NSLocalizedString("View all comments", comment: "Title for button on the post details page to show all comments when tapped.")
-        // TODO: use as emty title?
-        static let leaveCommentButtonTitle = NSLocalizedString("Be the first to comment", comment: "Title for button on the post details page when there are no comments.")
+        static let emptyStateTitle = NSLocalizedString("Be the first to comment", comment: "Title for button on the post details page when there are no comments.")
         static let jetpackBadgeBottomPadding: CGFloat = 10
     }
 }


### PR DESCRIPTION
## Changes

- Add a "Leave Comment" button to the "Comments" section (one less tap to leave a comment)
- Add support for replying and liking inline comments
- Show more inline comments (two instead of just one)
- Update the design of the "Show All Comment" button to make it stand out more
- Refactor `ReaderDetailCommentsTableViewDelegate`

## Testing Instructions

- **Verify** that you can leave comments to articles directly from the "Article" screen
- **Verify** that like, reply, and "more" actions work for inline comments
- **Verify** that liking and replying still works from the dedicated "Comments" screen

**Known Issues**: 
- [CMM-1161: Reader details screen does not updated after leaving a comment](https://linear.app/a8c/issue/CMM-1161/reader-details-screen-does-not-updated-after-leaving-a-comment) (same happens in production when you leave a comment from the "Comments" screen)
- [CMM-1162: Reader: inline comments show no indications when a comment have threaded reply](https://linear.app/a8c/issue/CMM-1162/reader-inline-comments-show-no-indications-when-a-comment-have)

## Screenshots

A more engaging "Comments" section (before / after):

<img width="320" alt="Screenshot 2026-01-21 at 2 19 27 PM" src="https://github.com/user-attachments/assets/f6c92311-ca6a-437a-b7f3-5f478b7677b5" /> <img width="320" alt="Screenshot 2026-01-21 at 2 16 09 PM" src="https://github.com/user-attachments/assets/7971ca22-fd82-4a10-8960-f110d06ddc5e" />


An improved empty state with a button that directly opens the composer. The previous "Be the first to leave a comment" button – that doesn't look like a button and has a non-button-ish title – would open an empty "Comments" screen instead. Before / After:

<img width="320"  alt="Screenshot 2026-01-21 at 2 24 34 PM" src="https://github.com/user-attachments/assets/649d2c6b-75b4-4618-b7b4-a7aa5db77a46" /> <img width="320" alt="Screenshot 2026-01-21 at 2 16 17 PM" src="https://github.com/user-attachments/assets/b9607620-badc-4511-935f-68a70783f6e9" />

With custom rendering preferences and background:

<img width="320" alt="Screenshot 2026-01-21 at 2 32 46 PM" src="https://github.com/user-attachments/assets/81db65d2-b293-4f6a-9bba-cda6853240c0" />

