### PR TITLE
[Tooling] Disable branch protection bypass when creating the release branch

### DIFF
--- a/fastlane/lanes/release.rb
+++ b/fastlane/lanes/release.rb
@@ -91,11 +91,17 @@ platform :ios do
 
     push_to_git_remote(tags: false)
 
-    # Protect release/* branch
+    # Copy the branch protection settings from the default branch to the new release branch
     copy_branch_protection(
       repository: GITHUB_REPO,
       from_branch: DEFAULT_BRANCH,
       to_branch: release_branch_name
+    )
+    # But allow admins to bypass restrictions, so that wpmobilebot can push to the release branch directly
+    set_branch_protection(
+      repository: GITHUB_REPO,
+      branch: release_branch_name,
+      enforce_admins: false
     )
 
     begin


### PR DESCRIPTION
Fixes AINFRA-1808
Android counterpart: https://github.com/wordpress-mobile/WordPress-Android/pull/22517

## Summary
During the code freeze, after copying branch protection settings from `trunk` to a new release branch, explicitly disable admin enforcement. This allows wpmobilebot to push directly to release branches.

Once this PR is merged, we'll change the repo's settings enabling the setting "**Do not allow bypassing the above settings**" on `trunk`.

## Test plan
- Will be verified during the next release code freeze process