### PR TITLE
Add Conditional editor theme styles

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8664a4514f442229cd644649cd67990fb3cdf4a7566cb24cfed52a90eec46a99",
+  "originHash" : "a4bb4eeeafdac8f1de8c6594484158bd7c58df998d8d72d75cd71fd171eaa503",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -390,8 +390,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/wordpress-rs",
       "state" : {
-        "branch" : "alpha-20260116",
-        "revision" : "8cb908517e0673b11a5e5d93d16861f67bf4e195"
+        "branch" : "alpha-20260122v2",
+        "revision" : "6a34b2b745022debb9b7ab8487068fe1eb7f58aa"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "8690afb109ff1805aab7c0ddaa3fef90ec45706b52252dbe4da3f8f926054ca5",
+  "originHash" : "8664a4514f442229cd644649cd67990fb3cdf4a7566cb24cfed52a90eec46a99",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -390,8 +390,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Automattic/wordpress-rs",
       "state" : {
-        "branch" : "alpha-20260114",
-        "revision" : "4895b1bf67136eeeca5eb792418749c23ec5726d"
+        "branch" : "alpha-20260116",
+        "revision" : "8cb908517e0673b11a5e5d93d16861f67bf4e195"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -58,7 +58,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.13.2"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
-        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20260114"),
+        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20260116"),
         .package(
             url: "https://github.com/Automattic/color-studio",
             revision: "bf141adc75e2769eb469a3e095bdc93dc30be8de"

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -58,7 +58,7 @@ let package = Package(
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
         .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.13.2"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
-        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20260116"),
+        .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20260122v2"),
         .package(
             url: "https://github.com/Automattic/color-studio",
             revision: "bf141adc75e2769eb469a3e095bdc93dc30be8de"

--- a/Modules/Sources/WordPressCore/WordPressClient.swift
+++ b/Modules/Sources/WordPressCore/WordPressClient.swift
@@ -54,21 +54,25 @@ public actor WordPressClient {
     public let api: any WordPressClientAPI
     public let rootUrl: String
 
-    private var loadSiteInfoTask: Task<(WpApiDetails, UserWithEditContext, ThemeWithEditContext?), Error>
+    private var loadSiteInfoTask: Task<WpApiDetails, Error>
+    private var loadCurrentUserTask: Task<UserWithEditContext, Error>
+    private var loadActiveThemeTask: Task<ThemeWithEditContext?, Error>
 
     public init(api: any WordPressClientAPI, rootUrl: ParsedUrl) {
         self.api = api
         self.rootUrl = rootUrl.url()
 
-        self.loadSiteInfoTask = Task { [api] in
-            async let apiRootTask = try await api.apiRoot.get().data
-            async let currentUserTask = try await api.users.retrieveMeWithEditContext().data
-            async let activeThemeTask = try await api.themes.listWithEditContext(
-                params: ThemeListParams(status: .active)
-            ).data.first(where: { $0.status == .active })
+        // These tasks need to be manually restated here because we can't use the task constructors
+        self.loadSiteInfoTask = Task { try await api.apiRoot.get().data }
+        self.loadCurrentUserTask = Task { try await api.users.retrieveMeWithEditContext().data }
+        self.loadActiveThemeTask = Task { try await api.themes.listWithEditContext(params: ThemeListParams(status: .active)).data.first }
+    }
 
-            return try await (apiRootTask, currentUserTask, activeThemeTask)
-        }
+    /// Invalidates all cached data and triggers a fresh fetch from the server.
+    public func refresh() {
+        loadSiteInfoTask = self.newSiteInfoTask()
+        loadCurrentUserTask = self.newCurrentUserTask()
+        loadActiveThemeTask = self.newActiveThemeTask()
     }
 
     public func supports(_ feature: Feature, forSiteId siteId: Int? = nil) async throws -> Bool {
@@ -101,12 +105,47 @@ public actor WordPressClient {
     }
 
     private func fetchApiRoot() async throws -> WpApiDetails {
-        // Wait for the `loadSiteInfoTask` to finish the initial load then use that value
-        return try await loadSiteInfoTask.value.0
+        switch await self.loadSiteInfoTask.result {
+        case .success(let details): return details
+        case .failure(let error):
+            self.loadSiteInfoTask = newSiteInfoTask()
+            throw error
+        }
     }
 
     private func fetchActiveTheme() async throws -> ThemeWithEditContext? {
-        // Wait for the `loadSiteInfoTask` to finish the initial load then use that value
-        return try await loadSiteInfoTask.value.2
+        switch await self.loadActiveThemeTask.result {
+        case .success(let theme): return theme
+        case .failure(let error):
+            self.loadActiveThemeTask = newActiveThemeTask()
+            throw error
+        }
+    }
+
+    private func fetchCurrentUser() async throws -> UserWithEditContext {
+        switch await self.loadCurrentUserTask.result {
+        case .success(let user): return user
+        case .failure(let error):
+            self.loadCurrentUserTask = newCurrentUserTask()
+            throw error
+        }
+    }
+
+    private nonisolated func newSiteInfoTask() -> Task<WpApiDetails, Error> {
+        Task {
+            try await api.apiRoot.get().data
+        }
+    }
+
+    private nonisolated func newCurrentUserTask() -> Task<UserWithEditContext, Error> {
+        Task {
+            try await api.users.retrieveMeWithEditContext().data
+        }
+    }
+
+    private nonisolated func newActiveThemeTask() -> Task<ThemeWithEditContext?, Error> {
+        Task {
+            try await api.themes.listWithEditContext(params: ThemeListParams(status: .active)).data.first
+        }
     }
 }

--- a/Modules/Sources/WordPressCore/WordPressClient.swift
+++ b/Modules/Sources/WordPressCore/WordPressClient.swift
@@ -1,13 +1,88 @@
 import Foundation
 import WordPressAPI
+import WordPressAPIInternal
 
 public actor WordPressClient {
+
+    public enum Feature {
+        /// A block theme is required to style the editor.
+        case blockTheme
+
+        /// The block editor settings API is required to style the editor.
+        case blockEditorSettings
+
+        /// Application Password Extras grants additional capabilities using Application Passwords.
+        case applicationPasswordExtras
+
+        /// WordPress.com sites don't all support plugins.
+        case plugins
+
+        public var stringValue: String {
+            switch self {
+            case .blockTheme: "is-block-theme"
+            case .blockEditorSettings: "block-editor-settings"
+            case .applicationPasswordExtras: "application-password-extras"
+            case .plugins: "plugins"
+            }
+        }
+    }
 
     public let api: WordPressAPI
     public let rootUrl: String
 
+    private var loadSiteInfoTask: Task<(WpApiDetails, UserWithEditContext, ThemeWithEditContext?), Error>
+
     public init(api: WordPressAPI, rootUrl: ParsedUrl) {
         self.api = api
         self.rootUrl = rootUrl.url()
+
+        self.loadSiteInfoTask = Task { [api] in
+            async let apiRootTask = try await api.apiRoot.get().data
+            async let currentUserTask = try await api.users.retrieveMeWithEditContext().data
+            async let activeThemeTask = try await api.themes.listWithEditContext(
+                params: ThemeListParams(status: .active)
+            ).data.first(where: { $0.status == .active })
+
+            return try await (apiRootTask, currentUserTask, activeThemeTask)
+        }
+    }
+
+    public func supports(_ feature: Feature, forSiteId siteId: Int? = nil) async throws -> Bool {
+        let apiRoot = try await fetchApiRoot()
+        let isBlockTheme: Bool = try await fetchActiveTheme()?.isBlockTheme ?? false
+
+        if let siteId {
+            return switch feature {
+            case .blockEditorSettings: apiRoot.hasRoute(route: "/wp-block-editor/v1/sites/\(siteId)/settings")
+            case .blockTheme: isBlockTheme
+            case .plugins: apiRoot.hasRoute(route: "/wp/v2/plugins")
+            case .applicationPasswordExtras: apiRoot.hasRoute(route: "/application-password-extras/v1/admin-ajax")
+            }
+        }
+
+        return switch feature {
+        case .blockEditorSettings: apiRoot.hasRoute(route: "/wp-block-editor/v1/settings")
+        case .blockTheme: isBlockTheme
+        case .plugins: apiRoot.hasRoute(route: "/wp/v2/plugins")
+        case .applicationPasswordExtras: apiRoot.hasRoute(route: "/application-password-extras/v1/admin-ajax")
+        }
+    }
+
+    /// Asynchronously read the site's API details. This value is cached internally.
+    ///
+    private var apiRoot: WpApiDetails {
+        get async throws {
+            try await self.fetchApiRoot()
+        }
+    }
+
+    private func fetchApiRoot() async throws -> WpApiDetails {
+        // Wait for the `loadSiteInfoTask` to finish the initial load then use that value
+        return try await loadSiteInfoTask.value.0
+    }
+
+    private func fetchActiveTheme() async throws -> ThemeWithEditContext? {
+        // Wait for the `loadSiteInfoTask` to finish the initial load then use that value
+        return try await loadSiteInfoTask.value.2
     }
 }

--- a/Modules/Sources/WordPressCore/WordPressClient.swift
+++ b/Modules/Sources/WordPressCore/WordPressClient.swift
@@ -2,6 +2,30 @@ import Foundation
 import WordPressAPI
 import WordPressAPIInternal
 
+/// Protocol defining the WordPress API methods that WordPressClient needs.
+/// This abstraction allows for mocking in tests using the `NoHandle` constructors
+/// available on the executor classes.
+public protocol WordPressClientAPI: Sendable {
+    var apiRoot: ApiRootRequestExecutor { get }
+    var users: UsersRequestExecutor { get }
+    var themes: ThemesRequestExecutor { get }
+    var plugins: PluginsRequestExecutor { get }
+    var comments: CommentsRequestExecutor { get }
+    var media: MediaRequestExecutor { get }
+    var taxonomies: TaxonomiesRequestExecutor { get }
+    var terms: TermsRequestExecutor { get }
+    var applicationPasswords: ApplicationPasswordsRequestExecutor { get }
+
+    func uploadMedia(
+        params: MediaCreateParams,
+        fulfilling progress: Progress
+    ) async throws -> MediaRequestCreateResponse
+}
+
+/// WordPressAPI already has these properties with the correct types,
+/// so conformance is automatic.
+extension WordPressAPI: WordPressClientAPI {}
+
 public actor WordPressClient {
 
     public enum Feature {
@@ -27,12 +51,12 @@ public actor WordPressClient {
         }
     }
 
-    public let api: WordPressAPI
+    public let api: any WordPressClientAPI
     public let rootUrl: String
 
     private var loadSiteInfoTask: Task<(WpApiDetails, UserWithEditContext, ThemeWithEditContext?), Error>
 
-    public init(api: WordPressAPI, rootUrl: ParsedUrl) {
+    public init(api: any WordPressClientAPI, rootUrl: ParsedUrl) {
         self.api = api
         self.rootUrl = rootUrl.url()
 

--- a/Modules/Sources/WordPressCore/WordPressClient.swift
+++ b/Modules/Sources/WordPressCore/WordPressClient.swift
@@ -26,8 +26,17 @@ public protocol WordPressClientAPI: Sendable {
 /// so conformance is automatic.
 extension WordPressAPI: WordPressClientAPI {}
 
+/// A client for interacting with the WordPress REST API.
+///
+/// `WordPressClient` provides a high-level interface for making WordPress API requests with
+/// built-in caching of commonly-accessed data like site info, current user, and active theme.
+/// It is implemented as an actor to ensure thread-safe access to its internal cache state.
 public actor WordPressClient {
 
+    /// Features that a WordPress site may or may not support.
+    ///
+    /// Use these values with ``supports(_:forSiteId:)`` to check if a site
+    /// has the necessary capabilities for specific functionality.
     public enum Feature {
         /// A block theme is required to style the editor.
         case blockTheme
@@ -41,6 +50,7 @@ public actor WordPressClient {
         /// WordPress.com sites don't all support plugins.
         case plugins
 
+        /// A string representation of the feature for use in API queries or logging.
         public var stringValue: String {
             switch self {
             case .blockTheme: "is-block-theme"
@@ -51,13 +61,39 @@ public actor WordPressClient {
         }
     }
 
+    /// Errors that can occur when accessing cached client data.
+    public enum ClientCacheError: Swift.Error {
+        /// No active theme was found for the site.
+        ///
+        /// This typically indicates an unexpected server state, as WordPress sites
+        /// should always have exactly one active theme.
+        case noActiveTheme
+    }
+
+    /// The underlying API executor used for making network requests.
     public let api: any WordPressClientAPI
+
+    /// The root URL of the WordPress site this client is connected to.
     public let rootUrl: String
 
+    /// The cached task for fetching site API details.
     private var loadSiteInfoTask: Task<WpApiDetails, Error>
-    private var loadCurrentUserTask: Task<UserWithEditContext, Error>
-    private var loadActiveThemeTask: Task<ThemeWithEditContext?, Error>
 
+    /// The cached task for fetching the current authenticated user.
+    private var loadCurrentUserTask: Task<UserWithEditContext, Error>
+
+    /// The cached task for fetching the site's active theme.
+    private var loadActiveThemeTask: Task<ThemeWithEditContext, Error>
+
+    /// Creates a new WordPress client for the specified site.
+    ///
+    /// Upon initialization, the client automatically begins fetching and caching site info,
+    /// the current user, and the active theme in parallel. These cached values are used
+    /// by subsequent API calls to avoid redundant network requests.
+    ///
+    /// - Parameters:
+    ///   - api: The API executor to use for network requests.
+    ///   - rootUrl: The parsed root URL of the WordPress site.
     public init(api: any WordPressClientAPI, rootUrl: ParsedUrl) {
         self.api = api
         self.rootUrl = rootUrl.url()
@@ -65,19 +101,43 @@ public actor WordPressClient {
         // These tasks need to be manually restated here because we can't use the task constructors
         self.loadSiteInfoTask = Task { try await api.apiRoot.get().data }
         self.loadCurrentUserTask = Task { try await api.users.retrieveMeWithEditContext().data }
-        self.loadActiveThemeTask = Task { try await api.themes.listWithEditContext(params: ThemeListParams(status: .active)).data.first }
+        self.loadActiveThemeTask = Task {
+            let query = ThemeListParams(status: .active)
+
+            guard let activeTheme = try await api.themes.listWithEditContext(params: query).data.first else {
+                throw ClientCacheError.noActiveTheme
+            }
+
+            return activeTheme
+        }
     }
 
     /// Invalidates all cached data and triggers a fresh fetch from the server.
+    ///
+    /// Call this method when you need to ensure the client has the latest data from the server,
+    /// such as after the user makes changes that affect site settings, theme, or user profile.
+    /// This clears the cached site info, current user, and active theme, then initiates new
+    /// background fetches for each.
     public func refresh() {
         loadSiteInfoTask = self.newSiteInfoTask()
         loadCurrentUserTask = self.newCurrentUserTask()
         loadActiveThemeTask = self.newActiveThemeTask()
     }
 
+    /// Checks whether the WordPress site supports a given feature.
+    ///
+    /// This method queries the site's API root to determine if specific REST API routes
+    /// are available, and checks theme capabilities where relevant.
+    ///
+    /// - Parameters:
+    ///   - feature: The feature to check support for.
+    ///   - siteId: An optional site ID for WordPress.com multi-site configurations.
+    ///             When provided, uses site-specific API routes for feature detection.
+    /// - Returns: `true` if the feature is supported, `false` otherwise.
+    /// - Throws: An error if the API root or active theme cannot be fetched.
     public func supports(_ feature: Feature, forSiteId siteId: Int? = nil) async throws -> Bool {
         let apiRoot = try await fetchApiRoot()
-        let isBlockTheme: Bool = try await fetchActiveTheme()?.isBlockTheme ?? false
+        let isBlockTheme = try await fetchActiveTheme().isBlockTheme
 
         if let siteId {
             return switch feature {
@@ -96,56 +156,81 @@ public actor WordPressClient {
         }
     }
 
-    /// Asynchronously read the site's API details. This value is cached internally.
+    /// Fetches the site's API root details, using the cached value if available.
     ///
-    private var apiRoot: WpApiDetails {
-        get async throws {
-            try await self.fetchApiRoot()
-        }
-    }
-
+    /// If the cached task has failed, creates a new task and retries the fetch.
+    /// This ensures transient network failures don't permanently block API access.
+    ///
+    /// - Returns: The site's API details including available routes and namespaces.
     private func fetchApiRoot() async throws -> WpApiDetails {
         switch await self.loadSiteInfoTask.result {
         case .success(let details): return details
-        case .failure(let error):
+        case .failure:
             self.loadSiteInfoTask = newSiteInfoTask()
-            throw error
+            return try await self.loadSiteInfoTask.value
         }
     }
 
-    private func fetchActiveTheme() async throws -> ThemeWithEditContext? {
+    /// Fetches the site's active theme, using the cached value if available.
+    ///
+    /// If the cached task has failed, creates a new task and retries the fetch.
+    ///
+    /// - Returns: The currently active theme with edit context.
+    private func fetchActiveTheme() async throws -> ThemeWithEditContext {
         switch await self.loadActiveThemeTask.result {
         case .success(let theme): return theme
-        case .failure(let error):
+        case .failure:
             self.loadActiveThemeTask = newActiveThemeTask()
-            throw error
+            return try await self.loadActiveThemeTask.value
         }
     }
 
+    /// Fetches the current authenticated user, using the cached value if available.
+    ///
+    /// If the cached task has failed, creates a new task and retries the fetch.
+    ///
+    /// - Returns: The current user with edit context.
     private func fetchCurrentUser() async throws -> UserWithEditContext {
         switch await self.loadCurrentUserTask.result {
         case .success(let user): return user
-        case .failure(let error):
+        case .failure:
             self.loadCurrentUserTask = newCurrentUserTask()
-            throw error
+            return try await self.loadCurrentUserTask.value
         }
     }
 
-    private nonisolated func newSiteInfoTask() -> Task<WpApiDetails, Error> {
+    /// Creates a new task to fetch the site's API root details from the server.
+    ///
+    /// - Returns: A task that resolves to the site's API details.
+    private func newSiteInfoTask() -> Task<WpApiDetails, Error> {
         Task {
             try await api.apiRoot.get().data
         }
     }
 
-    private nonisolated func newCurrentUserTask() -> Task<UserWithEditContext, Error> {
+    /// Creates a new task to fetch the current authenticated user from the server.
+    ///
+    /// - Returns: A task that resolves to the current user with edit context.
+    private func newCurrentUserTask() -> Task<UserWithEditContext, Error> {
         Task {
             try await api.users.retrieveMeWithEditContext().data
         }
     }
 
-    private nonisolated func newActiveThemeTask() -> Task<ThemeWithEditContext?, Error> {
+    /// Creates a new task to fetch the site's active theme from the server.
+    ///
+    /// - Returns: A task that resolves to the active theme with edit context.
+    /// - Throws: ``ClientCacheError/noActiveTheme`` if no active theme is found.
+    private func newActiveThemeTask() -> Task<ThemeWithEditContext, Error> {
         Task {
-            try await api.themes.listWithEditContext(params: ThemeListParams(status: .active)).data.first
+            let params = ThemeListParams(status: .active)
+
+            // There should only ever be one active theme for a site
+            guard let theme = try await api.themes.listWithEditContext(params: params).data.first else {
+                throw ClientCacheError.noActiveTheme
+            }
+
+            return theme
         }
     }
 }

--- a/Modules/Sources/WordPressShared/Utility/KeyValueDatabase.swift
+++ b/Modules/Sources/WordPressShared/Utility/KeyValueDatabase.swift
@@ -9,6 +9,7 @@ public protocol KeyValueDatabase {
     func object(forKey defaultName: String) -> Any?
     func set(_ value: Any?, forKey defaultName: String)
     func removeObject(forKey defaultName: String)
+    func hasEntry(forKey key: String) -> Bool
 }
 
 public extension KeyValueDatabase {
@@ -28,7 +29,11 @@ public extension KeyValueDatabase {
 
 // MARK: - Storage implementations
 
-extension UserDefaults: KeyValueDatabase {}
+extension UserDefaults: KeyValueDatabase {
+    public func hasEntry(forKey key: String) -> Bool {
+        self.object(forKey: key) == nil
+    }
+}
 
 /// `EphemeralKeyValueDatabase` stores values in a dictionary in memory, and is
 /// never persisted between app launches.
@@ -47,5 +52,9 @@ open class EphemeralKeyValueDatabase: KeyValueDatabase {
 
     open func removeObject(forKey defaultName: String) {
         memory[defaultName] = nil
+    }
+
+    open func hasEntry(forKey key: String) -> Bool {
+        self.memory.keys.contains(key)
     }
 }

--- a/Modules/Tests/WordPressCoreTests/MockWordPressClientAPI.swift
+++ b/Modules/Tests/WordPressCoreTests/MockWordPressClientAPI.swift
@@ -1,0 +1,180 @@
+import Foundation
+import WordPressAPI
+import WordPressAPIInternal
+@testable import WordPressCore
+
+/// Tracks call counts for API methods to verify caching behavior.
+final class MockWordPressClientAPI: WordPressClientAPI, @unchecked Sendable {
+    private let lock = NSLock()
+
+    private var _apiRootCallCount = 0
+    private var _usersCallCount = 0
+    private var _themesCallCount = 0
+
+    var apiRootCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _apiRootCallCount
+    }
+
+    var usersCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _usersCallCount
+    }
+
+    var themesCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _themesCallCount
+    }
+
+    var mockRoutes: Set<String> = []
+    var mockIsBlockTheme: Bool = false
+
+    var apiRoot: ApiRootRequestExecutor {
+        lock.lock()
+        _apiRootCallCount += 1
+        lock.unlock()
+        return MockApiRootRequestExecutor(routes: mockRoutes)
+    }
+
+    var users: UsersRequestExecutor {
+        lock.lock()
+        _usersCallCount += 1
+        lock.unlock()
+        return MockUsersRequestExecutor(noHandle: UsersRequestExecutor.NoHandle())
+    }
+
+    var themes: ThemesRequestExecutor {
+        lock.lock()
+        _themesCallCount += 1
+        lock.unlock()
+        return MockThemesRequestExecutor(isBlockTheme: mockIsBlockTheme)
+    }
+
+    // Unused in WordPressClient.supports() - provide minimal implementations
+    var plugins: PluginsRequestExecutor { fatalError("Not implemented") }
+    var comments: CommentsRequestExecutor { fatalError("Not implemented") }
+    var media: MediaRequestExecutor { fatalError("Not implemented") }
+    var taxonomies: TaxonomiesRequestExecutor { fatalError("Not implemented") }
+    var terms: TermsRequestExecutor { fatalError("Not implemented") }
+    var applicationPasswords: ApplicationPasswordsRequestExecutor { fatalError("Not implemented") }
+
+    func uploadMedia(params: MediaCreateParams, fulfilling progress: Progress) async throws -> MediaRequestCreateResponse {
+        fatalError("Not implemented")
+    }
+}
+
+// MARK: - Mock Executors
+
+final class MockApiRootRequestExecutor: ApiRootRequestExecutor {
+    private var routes: Set<String>
+
+    init(routes: Set<String>) {
+        self.routes = routes
+        super.init(noHandle: ApiRootRequestExecutor.NoHandle())
+    }
+
+    required init(unsafeFromHandle handle: UInt64) {
+        self.routes = []
+        super.init(unsafeFromHandle: handle)
+    }
+
+    override func getCancellation(context: RequestContext?) async throws -> ApiRootRequestGetResponse {
+        let mockApiDetails = MockWpApiDetails(routes: routes)
+        let mockHeaderMap = WpNetworkHeaderMap(noHandle: WpNetworkHeaderMap.NoHandle())
+        return ApiRootRequestGetResponse(data: mockApiDetails, headerMap: mockHeaderMap)
+    }
+}
+
+final class MockUsersRequestExecutor: UsersRequestExecutor {
+    override init(noHandle: UsersRequestExecutor.NoHandle) {
+        super.init(noHandle: noHandle)
+    }
+
+    required init(unsafeFromHandle handle: UInt64) {
+        super.init(unsafeFromHandle: handle)
+    }
+
+    override func retrieveMeWithEditContextCancellation(context: RequestContext?) async throws -> UsersRequestRetrieveMeWithEditContextResponse {
+        let mockUser = UserWithEditContext(
+            id: UserId(1),
+            username: "testuser",
+            name: "Test User",
+            firstName: "Test",
+            lastName: "User",
+            email: "test@example.com",
+            url: "",
+            description: "",
+            link: "https://example.com/author/testuser",
+            locale: "en_US",
+            nickname: "testuser",
+            slug: "testuser",
+            registeredDate: "2024-01-01T00:00:00",
+            roles: [],
+            capabilities: [:],
+            extraCapabilities: [:],
+            avatarUrls: nil
+        )
+        let mockHeaderMap = WpNetworkHeaderMap(noHandle: WpNetworkHeaderMap.NoHandle())
+        return UsersRequestRetrieveMeWithEditContextResponse(data: mockUser, headerMap: mockHeaderMap)
+    }
+}
+
+final class MockThemesRequestExecutor: ThemesRequestExecutor {
+    private var isBlockTheme: Bool
+
+    init(isBlockTheme: Bool) {
+        self.isBlockTheme = isBlockTheme
+        super.init(noHandle: ThemesRequestExecutor.NoHandle())
+    }
+
+    required init(unsafeFromHandle handle: UInt64) {
+        self.isBlockTheme = false
+        super.init(unsafeFromHandle: handle)
+    }
+
+    override func listWithEditContextCancellation(params: ThemeListParams, context: RequestContext?) async throws -> ThemesRequestListWithEditContextResponse {
+        let mockTheme = ThemeWithEditContext(
+            stylesheet: ThemeStylesheet(value: "twentytwentyfour"),
+            template: "twentytwentyfour",
+            requiresPhp: "7.0",
+            requiresWp: "6.4",
+            textdomain: "twentytwentyfour",
+            version: "1.0",
+            screenshot: "",
+            author: ThemeAuthor(raw: "WordPress", rendered: "WordPress"),
+            authorUri: ThemeAuthorUri(raw: "", rendered: ""),
+            description: ThemeDescription(raw: "", rendered: ""),
+            name: ThemeName(raw: "Twenty Twenty-Four", rendered: "Twenty Twenty-Four"),
+            tags: ThemeTags(raw: [], rendered: ""),
+            themeUri: ThemeUri(raw: "", rendered: ""),
+            status: .active,
+            isBlockTheme: isBlockTheme,
+            stylesheetUri: "",
+            templateUri: "",
+            themeSupports: nil
+        )
+        let mockHeaderMap = WpNetworkHeaderMap(noHandle: WpNetworkHeaderMap.NoHandle())
+        return ThemesRequestListWithEditContextResponse(data: [mockTheme], headerMap: mockHeaderMap)
+    }
+}
+
+final class MockWpApiDetails: WpApiDetails {
+    private var routes: Set<String>
+
+    init(routes: Set<String>) {
+        self.routes = routes
+        super.init(noHandle: WpApiDetails.NoHandle())
+    }
+
+    required init(unsafeFromHandle handle: UInt64) {
+        self.routes = []
+        super.init(unsafeFromHandle: handle)
+    }
+
+    override func hasRoute(route: String) -> Bool {
+        routes.contains(route)
+    }
+}

--- a/Modules/Tests/WordPressCoreTests/WordPressClientFeatureTests.swift
+++ b/Modules/Tests/WordPressCoreTests/WordPressClientFeatureTests.swift
@@ -1,0 +1,104 @@
+import Foundation
+import Testing
+import WordPressAPI
+import WordPressAPIInternal
+@testable import WordPressCore
+
+@Suite
+struct WordPressClientFeatureTests {
+
+    @Test
+    func featureStringValues() {
+        // These should never change – doing so will cause settings data to be lost
+        #expect(WordPressClient.Feature.blockTheme.stringValue == "is-block-theme")
+        #expect(WordPressClient.Feature.blockEditorSettings.stringValue == "block-editor-settings")
+        #expect(WordPressClient.Feature.applicationPasswordExtras.stringValue == "application-password-extras")
+        #expect(WordPressClient.Feature.plugins.stringValue == "plugins")
+    }
+}
+
+@Suite("API Caching Behavior")
+struct WordPressClientCachingTests {
+
+    @Test
+    func supports_cachesAPIResponses_doesNotRefetch() async throws {
+        let mockAPI = MockWordPressClientAPI()
+        mockAPI.mockRoutes = ["/wp-block-editor/v1/settings"]
+        mockAPI.mockIsBlockTheme = true
+
+        let client = try WordPressClient(api: mockAPI, rootUrl: .parse(input: "https://example.com"))
+
+        // First call - should trigger API fetches
+        let result1 = try await client.supports(.blockEditorSettings)
+        #expect(result1 == true)
+
+        // Verify API was called once
+        #expect(mockAPI.apiRootCallCount == 1)
+        #expect(mockAPI.usersCallCount == 1)
+        #expect(mockAPI.themesCallCount == 1)
+
+        // Second call - should use cached Task, not refetch
+        let result2 = try await client.supports(.blockTheme)
+        #expect(result2 == true)
+
+        // Verify API was NOT called again
+        #expect(mockAPI.apiRootCallCount == 1)
+        #expect(mockAPI.usersCallCount == 1)
+        #expect(mockAPI.themesCallCount == 1)
+
+        // Third call with different feature - still uses cache
+        let result3 = try await client.supports(.plugins)
+        #expect(result3 == false) // Route not in mockRoutes
+
+        // Still no additional API calls
+        #expect(mockAPI.apiRootCallCount == 1)
+        #expect(mockAPI.usersCallCount == 1)
+        #expect(mockAPI.themesCallCount == 1)
+    }
+
+    @Test
+    func supports_withSiteId_usesCachedData() async throws {
+        let mockAPI = MockWordPressClientAPI()
+        mockAPI.mockRoutes = ["/wp-block-editor/v1/sites/12345/settings"]
+
+        let client = try WordPressClient(api: mockAPI, rootUrl: .parse(input: "https://example.com"))
+
+        // Call with siteId
+        let result = try await client.supports(.blockEditorSettings, forSiteId: 12345)
+        #expect(result == true)
+
+        // Second call with different siteId - uses same cached data
+        let result2 = try await client.supports(.blockEditorSettings, forSiteId: 99999)
+        #expect(result2 == false) // Different siteId, route not found
+
+        // API was only called once total
+        #expect(mockAPI.apiRootCallCount == 1)
+    }
+
+    @Test
+    func supports_concurrentCalls_onlyFetchesOnce() async throws {
+        let mockAPI = MockWordPressClientAPI()
+        mockAPI.mockRoutes = ["/wp-block-editor/v1/settings", "/wp/v2/plugins"]
+        mockAPI.mockIsBlockTheme = true
+
+        let client = try WordPressClient(api: mockAPI, rootUrl: .parse(input: "https://example.com"))
+
+        // Make multiple concurrent calls
+        async let result1 = client.supports(.blockEditorSettings)
+        async let result2 = client.supports(.blockTheme)
+        async let result3 = client.supports(.plugins)
+        async let result4 = client.supports(.applicationPasswordExtras)
+
+        let results = try await [result1, result2, result3, result4]
+
+        #expect(results[0] == true)  // blockEditorSettings
+        #expect(results[1] == true)  // blockTheme
+        #expect(results[2] == true)  // plugins
+        #expect(results[3] == false) // applicationPasswordExtras (not in routes)
+
+        // Despite 4 concurrent calls, API should only be called once
+        #expect(mockAPI.apiRootCallCount == 1)
+        #expect(mockAPI.usersCallCount == 1)
+        #expect(mockAPI.themesCallCount == 1)
+    }
+}

--- a/Tests/KeystoneTests/Helpers/InMemoryUserDefaults.swift
+++ b/Tests/KeystoneTests/Helpers/InMemoryUserDefaults.swift
@@ -76,4 +76,8 @@ class InMemoryUserDefaults: UserPersistentRepository {
     func object(forKey defaultName: String) -> Any? {
         return dictionary[defaultName] as Any?
     }
+
+    func hasEntry(forKey key: String) -> Bool {
+        dictionary.keys.contains(key)
+    }
 }

--- a/Tests/KeystoneTests/Tests/Services/UserListViewModelTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/UserListViewModelTests.swift
@@ -16,7 +16,8 @@ class UserListViewModelTests: XCTestCase {
     override func setUp() async throws {
         try await super.setUp()
 
-        let client = try WordPressClient(api: .init(urlSession: .shared, apiRootUrl: .parse(input: "https://example.com/wp-json"), authentication: .none), rootUrl: .parse(input: "https://example.com"))
+        let api = try WordPressAPI(urlSession: .shared, apiRootUrl: .parse(input: "https://example.com/wp-json"), authentication: .none)
+        let client = try WordPressClient(api: api, rootUrl: .parse(input: "https://example.com"))
         service = UserService(client: client)
         viewModel = await UserListViewModel(userService: service, currentUserId: 0)
     }

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -2,6 +2,8 @@ import Foundation
 import WordPressData
 import WordPressShared
 
+import WordPressCore
+
 /// Takes care of storing and accessing Gutenberg settings.
 ///
 class GutenbergSettings {
@@ -226,15 +228,7 @@ class GutenbergSettings {
     /// - Parameter blog: The blog to check theme styles setting for
     /// - Returns: true if theme styles are enabled (default: true), false if explicitly disabled
     func isThemeStylesEnabled(for blog: Blog) -> Bool {
-        let key = Key.themeStylesEnabled(forBlogURL: blog.url)
-
-        // If the preference has been explicitly set, return its value
-        if database.object(forKey: key) != nil {
-            return database.bool(forKey: key)
-        }
-
-        // Default to enabled for sites that haven't set a preference
-        return true
+        return getSupports(.blockEditorSettings, for: blog)
     }
 
     /// Sets whether theme styles should be enabled for the given blog.
@@ -244,6 +238,32 @@ class GutenbergSettings {
     ///   - blog: The blog to set theme styles setting for
     func setThemeStylesEnabled(_ isEnabled: Bool, for blog: Blog) {
         database.set(isEnabled, forKey: Key.themeStylesEnabled(forBlogURL: blog.url))
+    }
+
+    /// Sets whether the given API feature is available for the given blog
+    ///
+    /// - Parameters:
+    ///   - isEnabled: Whether to enable theme styles
+    ///   - blog: The blog to set theme styles setting for
+    @discardableResult
+    func setSupports(_ feature: WordPressClient.Feature, _ newValue: Bool, for blog: Blog) -> Self {
+        let key = "org.wordpress.gutenberg-supports-" + feature.stringValue + "-" + blog.locallyUniqueId
+        database.set(newValue, forKey: key)
+        return self
+    }
+
+    /// Returns whether the given API feature is available for the given blog.
+    ///
+    /// - Parameter blog: The blog to check the given API feature for
+    /// - Returns: true if the feature is available, false if the server hasn't been queried for support yet, or if the server doesn't support it.
+    func getSupports(_ feature: WordPressClient.Feature, for blog: Blog) -> Bool {
+        let key = "org.wordpress.gutenberg-supports-" + feature.stringValue + "-" + blog.locallyUniqueId
+
+        if database.object(forKey: key) != nil {
+            return database.bool(forKey: key)
+        }
+
+        return false
     }
 }
 
@@ -272,6 +292,12 @@ public class GutenbergSettingsBridge: NSObject {
     @objc(setThemeStylesEnabled:forBlog:)
     public static func setThemeStylesEnabled(_ isEnabled: Bool, for blog: Blog) {
         GutenbergSettings().setThemeStylesEnabled(isEnabled, for: blog)
+    }
+
+    @objc(isThemeStylesSupportedForBlog:)
+    public static func canEnableThemeStyleSetting(for blog: Blog) -> Bool {
+        let settings = GutenbergSettings()
+        return settings.getSupports(.blockEditorSettings, for: blog) && settings.getSupports(.blockTheme, for: blog)
     }
 }
 

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -232,6 +232,11 @@ class GutenbergSettings {
             return false
         }
 
+        // Default to `true` if the user hasn't specifically set a preference
+        guard database.hasEntry(forKey: Key.themeStylesEnabled(forBlogURL: blog.url)) else {
+            return true
+        }
+
         return database.bool(forKey: Key.themeStylesEnabled(forBlogURL: blog.url))
     }
 

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -228,7 +228,11 @@ class GutenbergSettings {
     /// - Parameter blog: The blog to check theme styles setting for
     /// - Returns: true if theme styles are enabled (default: true), false if explicitly disabled
     func isThemeStylesEnabled(for blog: Blog) -> Bool {
-        return getSupports(.blockEditorSettings, for: blog)
+        if !getSupports(.blockEditorSettings, for: blog) {
+            return false
+        }
+
+        return database.bool(forKey: Key.themeStylesEnabled(forBlogURL: blog.url))
     }
 
     /// Sets whether theme styles should be enabled for the given blog.
@@ -240,7 +244,7 @@ class GutenbergSettings {
         database.set(isEnabled, forKey: Key.themeStylesEnabled(forBlogURL: blog.url))
     }
 
-    /// Sets whether the given API feature is available for the given blog
+    /// Sets whether the given API feature is available for the given blog. This is unrelated to whether it's *enabled* for that blog.
     ///
     /// - Parameters:
     ///   - isEnabled: Whether to enable theme styles
@@ -252,7 +256,7 @@ class GutenbergSettings {
         return self
     }
 
-    /// Returns whether the given API feature is available for the given blog.
+    /// Returns whether the given API feature is available for the given blog. This is unrelated to whether it's *enabled* for that blog.
     ///
     /// - Parameter blog: The blog to check the given API feature for
     /// - Returns: true if the feature is available, false if the server hasn't been queried for support yet, or if the server doesn't support it.
@@ -297,7 +301,17 @@ public class GutenbergSettingsBridge: NSObject {
     @objc(isThemeStylesSupportedForBlog:)
     public static func canEnableThemeStyleSetting(for blog: Blog) -> Bool {
         let settings = GutenbergSettings()
-        return settings.getSupports(.blockEditorSettings, for: blog) && settings.getSupports(.blockTheme, for: blog)
+
+        // It's possible for a theme to publish editor styles while not being a block theme.
+        // We'll leave it up to the user to decide if they want to use styles or not, and will enable them by default.
+        return settings.getSupports(.blockEditorSettings, for: blog)
+    }
+
+    @objc(siteIsUsingBlockTheme:)
+    public static func siteIsUsingBlockTheme(for blog: Blog) -> Bool {
+        let settings = GutenbergSettings()
+
+        return settings.getSupports(.blockTheme, for: blog)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -380,8 +380,6 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         }
 
         if RemoteFeatureFlag.newGutenberg.enabled() {
-            warmUpEditorIfNeeded(for: blog)
-
             // Refresh editor capabilities
             EditorDependencyManager.shared.fetchEditorCapabilities(for: blog)
         }

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -409,7 +409,9 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         }
 
         // Refresh editor capabilities
-        EditorDependencyManager.shared.fetchEditorCapabilities(for: blog)
+        if RemoteFeatureFlag.newGutenberg.enabled() {
+            EditorDependencyManager.shared.fetchEditorCapabilities(for: blog)
+        }
 
         switch currentSection {
         case .siteMenu:

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -379,6 +379,12 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
             showDashboard(for: blog)
         }
 
+        if RemoteFeatureFlag.newGutenberg.enabled() {
+            warmUpEditorIfNeeded(for: blog)
+
+            // Refresh editor capabilities
+            EditorDependencyManager.shared.fetchEditorCapabilities(for: blog)
+        }
     }
 
     @objc
@@ -403,6 +409,10 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
         guard let blog else {
             return
         }
+
+        // Refresh editor capabilities
+        EditorDependencyManager.shared.fetchEditorCapabilities(for: blog)
+
         switch currentSection {
         case .siteMenu:
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -75,6 +75,11 @@ extension SiteSettingsViewController {
         self.navigationController?.pushViewController(viewController, animated: true)
     }
 
+    @objc public func swiftRefreshSettings() {
+        // Refresh editor capabilities
+        EditorDependencyManager.shared.fetchEditorCapabilities(for: self.blog)
+    }
+
     // MARK: - Timezone
 
     func formattedTimezoneValue() -> String? {
@@ -200,7 +205,15 @@ extension SiteSettingsViewController {
     @objc(getThemeStylesSectionFooterView)
     public func themeStylesSectionFooterView() -> UIView {
         let footer = makeFooterView()
-        footer.textLabel?.text = NSLocalizedString("Make the block editor look like your theme.", comment: "Explanation for the option to enable theme styles")
+        let settings = GutenbergSettings()
+        if !settings.getSupports(.blockTheme, for: self.blog) {
+            footer.textLabel?.text = Strings.themeStylesFooterBlockThemeRequired
+        } else if !settings.getSupports(.blockEditorSettings, for: self.blog) {
+            footer.textLabel?.text = Strings.themeStylesFooterGutenbergRequired
+        } else {
+            footer.textLabel?.text = Strings.themeStylesFooterEnabled
+        }
+
         return footer
     }
 
@@ -445,6 +458,24 @@ extension SiteSettingsViewController {
 private extension SiteSettingsViewController {
     enum Strings {
         static let privacyTitle = NSLocalizedString("siteSettings.privacy.title", value: "Privacy", comment: "Title for screen to select the privacy options for a blog")
+
+        static let themeStylesFooterBlockThemeRequired = NSLocalizedString(
+            "siteSettings.themeStyles.footer.blockThemeRequired",
+            value: "Switch to a theme that supports blocks to use theme styles.",
+            comment: "Explanation for why the 'Use theme styles' toggle is disabled when the site doesn't have a block theme"
+        )
+
+        static let themeStylesFooterGutenbergRequired = NSLocalizedString(
+            "siteSettings.themeStyles.footer.gutenbergRequired",
+            value: "Install the Gutenberg Plugin on your site to activate theme style support.",
+            comment: "Explanation for why the 'Use theme styles' toggle is disabled when the site doesn't have the Gutenberg plugin"
+        )
+
+        static let themeStylesFooterEnabled = NSLocalizedString(
+            "siteSettings.themeStyles.footer.enabled",
+            value: "Make the block editor look like your theme.",
+            comment: "Explanation for the option to enable theme styles when the feature is available"
+        )
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -207,7 +207,7 @@ extension SiteSettingsViewController {
         let footer = makeFooterView()
         let settings = GutenbergSettings()
         if !settings.getSupports(.blockTheme, for: self.blog) {
-            footer.textLabel?.text = Strings.themeStylesFooterBlockThemeRequired
+            footer.textLabel?.text = Strings.themeStylesFooterBlockThemeSuggested
         } else if !settings.getSupports(.blockEditorSettings, for: self.blog) {
             footer.textLabel?.text = Strings.themeStylesFooterGutenbergRequired
         } else {
@@ -459,9 +459,9 @@ private extension SiteSettingsViewController {
     enum Strings {
         static let privacyTitle = NSLocalizedString("siteSettings.privacy.title", value: "Privacy", comment: "Title for screen to select the privacy options for a blog")
 
-        static let themeStylesFooterBlockThemeRequired = NSLocalizedString(
-            "siteSettings.themeStyles.footer.blockThemeRequired",
-            value: "Switch to a theme that supports blocks to use theme styles.",
+        static let themeStylesFooterBlockThemeSuggested = NSLocalizedString(
+            "siteSettings.themeStyles.footer.blockThemeSuggested",
+            value: "Your site isn't using a Block Theme, so the editor might not match your content correctly. If things aren't looking right, you can disable editor styles.",
             comment: "Explanation for why the 'Use theme styles' toggle is disabled when the site doesn't have a block theme"
         )
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController+Swift.swift
@@ -77,6 +77,10 @@ extension SiteSettingsViewController {
 
     @objc public func swiftRefreshSettings() {
         // Refresh editor capabilities
+        guard RemoteFeatureFlag.newGutenberg.enabled() else {
+            return
+        }
+
         EditorDependencyManager.shared.fetchEditorCapabilities(for: self.blog)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -362,6 +362,11 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
         _themeStylesSelectorCell.onChange = ^(BOOL value){
             [GutenbergSettings setThemeStylesEnabled:value forBlog:blog];
         };
+
+        // Default to greyed-out, only make the control interactive if theme styles are supported
+        _themeStylesSelectorCell.flipSwitch.enabled = false;
+        _themeStylesSelectorCell.textLabel.textColor = UIColor.lightGrayColor;
+        [self.themeStylesSelectorCell setOn:false];
     }
     return _themeStylesSelectorCell;
 }
@@ -529,7 +534,11 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
 
 - (void)configureThemeStylesSelectorCell
 {
-    [self.themeStylesSelectorCell setOn:[GutenbergSettings isThemeStylesEnabledForBlog:self.blog]];
+    if([GutenbergSettings isThemeStylesSupportedForBlog: self.blog]){
+        _themeStylesSelectorCell.flipSwitch.enabled = true;
+        _themeStylesSelectorCell.textLabel.textColor = UIColor.labelColor;
+        [self.themeStylesSelectorCell setOn:[GutenbergSettings isThemeStylesEnabledForBlog:self.blog]];
+    }
 }
 
 - (void)configureDefaultCategoryCell
@@ -1025,6 +1034,7 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
         [weakSelf.refreshControl endRefreshing];
     }];
 
+    [self swiftRefreshSettings];
 }
 
 #pragma mark - Authentication methods
@@ -1224,3 +1234,4 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
 }
 
 @end
+

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -534,7 +534,7 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
 
 - (void)configureThemeStylesSelectorCell
 {
-    if([GutenbergSettings isThemeStylesSupportedForBlog: self.blog]){
+    if ([GutenbergSettings isThemeStylesSupportedForBlog: self.blog]){
         _themeStylesSelectorCell.flipSwitch.enabled = true;
         _themeStylesSelectorCell.textLabel.textColor = UIColor.labelColor;
         [self.themeStylesSelectorCell setOn:[GutenbergSettings isThemeStylesEnabledForBlog:self.blog]];


### PR DESCRIPTION
## Summary                                                        

Fix CMM-1163.                                                                                                                                             
                                                                                                                                                                                                                
  - Use API to determine theme style support by querying the WordPress REST API for editor capabilities                                                                                                         
  - Add some initial tests for `WordPressClient` feature detection and caching behaviour – there's more to do here, but that'll be a future PR.
                                                                                                                                                                                                                                                                                                                                                                                                                                
  ## Changes                                                                                                                                                                                                    
                                                                                                                                                                                                                
  ### `WordPressClient` Feature Detection                                                                                                                                                                       
  - Added `WordPressClientAPI` protocol to abstract WordPress API access for testing                                                                                                                            
  - Added `supports(_:forSiteId:)` method to check API route availability for features
  - Results are cached internally using a single `Task` to avoid redundant API calls. In the future, we'll want a way to invalidate this, but we'll do that later.
                                                                                                                                                                                                                
  ### Editor Capability Fetching                                                                                                                                                                                
  - `EditorDependencyManager` now fetches and caches editor capabilities on My Site load                                                                                                                        
  - `GutenbergSettings` stores feature support per-blog using `WordPressClient.Feature.stringValue` as stable keys                                                                                              
  - Theme styles toggle visibility is now determined by API capability rather than hardcoded logic                                                                                                              
                                                                                                                                                                                                                
  ### Testing Instructions
                                                                                                                                                                                    
  - [ ] Ensure CI passes                                                                                                                                                    
  - [ ] Add `cpt.wpmt.co` to the app. Ensure the editor loads as expected. Ensure that theme styles toggle cannot be activated in Site Settings.   
  - [ ] Add `jetpack.wpmt.co` to the app. Ensure the editor loads. Ensure that theme styles toggle can be activated.
  - [ ] Add a WP.com simple site to the app. Ensure the editor loads. Ensure that theme styles toggle can be activated.
                                                                                                                                                                                                               