### PR TITLE
Remove details label from the Discover header view

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Headers/ReaderDiscoverHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Headers/ReaderDiscoverHeaderView.swift
@@ -6,7 +6,7 @@ protocol ReaderDiscoverHeaderViewDelegate: AnyObject {
     func readerDiscoverHeaderView(_ view: ReaderDiscoverHeaderView, didChangeSelection selection: ReaderDiscoverChannel)
 }
 
-final class ReaderDiscoverHeaderView: ReaderBaseHeaderView, UITextViewDelegate {
+final class ReaderDiscoverHeaderView: ReaderBaseHeaderView {
     private let titleView = ReaderTitleView()
     private let channelsStackView = UIStackView(spacing: 8, [])
     private let scrollView = UIScrollView()
@@ -33,24 +33,14 @@ final class ReaderDiscoverHeaderView: ReaderBaseHeaderView, UITextViewDelegate {
 
         NSLayoutConstraint.activate([
             titleView.topAnchor.constraint(equalTo: contentView.topAnchor),
-            scrollView.topAnchor.constraint(equalTo: titleView.bottomAnchor, constant: 8),
+            scrollView.topAnchor.constraint(equalTo: titleView.bottomAnchor),
             scrollView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
         ])
         titleView.pinEdges(.horizontal)
         scrollView.pinEdges(.horizontal)
 
         titleView.titleLabel.text = SharedStrings.Reader.discover
-        titleView.detailsTextView.attributedText = {
-            guard let details = try? NSMutableAttributedString(markdown: Strings.details) else {
-                return nil
-            }
-            details.addAttributes([
-                .font: UIFont.preferredFont(forTextStyle: .subheadline),
-                .foregroundColor: UIColor.secondaryLabel,
-            ], range: NSRange(location: 0, length: details.length))
-            return details
-        }()
-        titleView.detailsTextView.delegate = self
+        titleView.detailsTextView.isHidden = true
     }
 
     required init?(coder: NSCoder) {
@@ -115,21 +105,6 @@ final class ReaderDiscoverHeaderView: ReaderBaseHeaderView, UITextViewDelegate {
         for view in channelViews {
             view.isSelected = view.channel == selectedChannel
         }
-    }
-
-    // MARK: UITextViewDelegate
-
-    func textView(_ textView: UITextView, shouldInteractWith URL: URL, in characterRange: NSRange) -> Bool {
-        WPAnalytics.track(.readerDiscoverEditInterestsTapped)
-
-        let tagsVC = ReaderTagsTableViewController(style: .plain)
-        tagsVC.title = Strings.editInterests
-        tagsVC.navigationItem.rightBarButtonItem = UIBarButtonItem(title: SharedStrings.Button.done, primaryAction: UIAction { [weak tagsVC] _ in
-            tagsVC?.presentingViewController?.dismiss(animated: true)
-        })
-        let navVC = UINavigationController(rootViewController: tagsVC)
-        UIViewController.topViewController?.present(navVC, animated: true)
-        return false
     }
 }
 
@@ -243,11 +218,6 @@ enum ReaderDiscoverChannel: Hashable {
         case .tag: "tag"
         }
     }
-}
-
-private enum Strings {
-    static let details = NSLocalizedString("reader.discover.header.title", value: "Explore popular blogs that inspire, educate, and entertain based on your [interests](/interests).", comment: "Reader Discover header view details label. The text has a Markdown URL: [interests](/interests). Only the text in the square brackets needs to be translated: [<translate_this>](/interests).")
-    static let editInterests = NSLocalizedString("reader.editInterests.title", value: "Edit Interests", comment: "Screen title")
 }
 
 #Preview {


### PR DESCRIPTION
Fixes [CMM-1018: When a user subscribes to a tag, show that tag immediately afterward](https://linear.app/a8c/issue/CMM-1018/when-a-user-subscribes-to-a-tag-show-that-tag-immediately-afterward) and [CMM-1019: Discover section description doesn't update as you change pills](https://linear.app/a8c/issue/CMM-1019/discover-section-description-doesnt-update-as-you-change-pills). Less is more.

The "Edit Interests" button does not exist on the web, so we are consistent. It feels like false advertising when you have this prominent view and it doesn't really impact the algorithms. This will likely be reworked entirely soon.

<img width="456" height="972" alt="Screenshot 2026-01-22 at 4 04 36 PM" src="https://github.com/user-attachments/assets/7878b07c-04d6-4dce-a581-17d7e8a6c274" />

