### PR TITLE
Add WordAdsChartView

### DIFF
--- a/Modules/Sources/JetpackStats/Analytics/StatsEvent.swift
+++ b/Modules/Sources/JetpackStats/Analytics/StatsEvent.swift
@@ -29,6 +29,9 @@ public enum StatsEvent {
     /// Subscribers tab shown
     case subscribersTabShown
 
+    /// Ads tab shown
+    case adsTabShown
+
     /// Post details screen shown
     case postDetailsScreenShown
 

--- a/Modules/Sources/JetpackStats/Cards/ChartCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/ChartCard.swift
@@ -69,7 +69,7 @@ struct ChartCard: View {
 
     private func headerView(for metric: SiteMetric) -> some View {
         HStack(alignment: .center) {
-            StatsCardTitleView(title: metric.localizedTitle, showChevron: false)
+            StatsCardTitleView(title: metric.localizedTitle)
             Spacer(minLength: 0)
         }
         .accessibilityElement(children: .combine)
@@ -101,7 +101,7 @@ struct ChartCard: View {
                 )
             } else if viewModel.isFirstLoad {
                 ChartValuesSummaryView(
-                    trend: .init(currentValue: 100, previousValue: 10, metric: .views),
+                    trend: .init(currentValue: 100, previousValue: 10, metric: SiteMetric.views),
                     style: .compact
                 )
                 .redacted(reason: .placeholder)

--- a/Modules/Sources/JetpackStats/Cards/ChartCardViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/ChartCardViewModel.swift
@@ -201,7 +201,7 @@ final class ChartCardViewModel: ObservableObject, TrafficCardViewModel {
         return output
     }
 
-    var tabViewData: [MetricsOverviewTabView.MetricData] {
+    var tabViewData: [MetricsOverviewTabView<SiteMetric>.MetricData] {
         metrics.map { metric in
             if let chartData = chartData[metric] {
                 return .init(
@@ -215,7 +215,7 @@ final class ChartCardViewModel: ObservableObject, TrafficCardViewModel {
         }
     }
 
-    var placeholderTabViewData: [MetricsOverviewTabView.MetricData] {
+    var placeholderTabViewData: [MetricsOverviewTabView<SiteMetric>.MetricData] {
         metrics.map { metric in
             .init(metric: metric, value: 12345, previousValue: 11234)
         }

--- a/Modules/Sources/JetpackStats/Cards/StandaloneChartCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/StandaloneChartCard.swift
@@ -88,7 +88,7 @@ struct StandaloneChartCard: View {
                 )
             } else {
                 ChartValuesSummaryView(
-                    trend: .init(currentValue: 100, previousValue: 10, metric: .views),
+                    trend: .init(currentValue: 100, previousValue: 10, metric: SiteMetric.views),
                     style: .compact
                 )
                 .redacted(reason: .placeholder)
@@ -229,7 +229,7 @@ struct StandaloneChartCard: View {
     }
 
     @ViewBuilder
-    private func navigationButton(direction: Calendar.NavigationDirection) -> some View {
+    private func navigationButton(direction: NavigationDirection) -> some View {
         Button {
             dateRange = dateRange.navigate(direction)
         } label: {

--- a/Modules/Sources/JetpackStats/Cards/WordAdsChartCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/WordAdsChartCard.swift
@@ -10,7 +10,7 @@ struct WordAdsChartCard: View {
         VStack(spacing: 0) {
             header
                 .padding(.horizontal, Constants.step3)
-                .padding(.top, Constants.step3)
+                .padding(.top, Constants.step2)
                 .padding(.bottom, Constants.step1)
 
             chartArea
@@ -18,7 +18,7 @@ struct WordAdsChartCard: View {
                 .padding(.horizontal, Constants.step2)
                 .padding(.vertical, Constants.step2)
                 .animation(.spring, value: viewModel.selectedMetric)
-                .animation(.easeInOut, value: viewModel.isFirstLoad)
+                .animation(.easeInOut, value: viewModel.isLoading)
 
             Divider()
 
@@ -74,6 +74,7 @@ struct WordAdsChartCard: View {
                 loadingErrorView(with: Strings.Chart.empty)
             } else {
                 chartView(data: data)
+                    .opacity(viewModel.isLoading ? 0.3 : 1.0)
                     .transition(.opacity.combined(with: .scale(scale: 0.97)))
             }
         } else {
@@ -82,21 +83,21 @@ struct WordAdsChartCard: View {
     }
 
     private var loadingView: some View {
-        SimpleBarChartView(
-            data: SimpleChartData.mock(
-                metric: viewModel.selectedMetric,
-                granularity: viewModel.selectedGranularity,
-                dataPointCount: viewModel.selectedGranularity.preferredQuantity
-            ),
-            selectedDate: nil,
-            onBarTapped: { _ in }
-        )
-        .redacted(reason: .placeholder)
-        .opacity(0.2)
-        .pulsating()
+        mockChartView
+            .opacity(0.2)
+            .pulsating()
     }
 
     private func loadingErrorView(with message: String) -> some View {
+        mockChartView
+            .grayscale(1)
+            .opacity(0.1)
+            .overlay {
+                SimpleErrorView(message: message)
+            }
+    }
+
+    private var mockChartView: some View {
         SimpleBarChartView(
             data: SimpleChartData.mock(
                 metric: viewModel.selectedMetric,
@@ -107,11 +108,6 @@ struct WordAdsChartCard: View {
             onBarTapped: { _ in }
         )
         .redacted(reason: .placeholder)
-        .grayscale(1)
-        .opacity(0.1)
-        .overlay {
-            SimpleErrorView(message: message)
-        }
     }
 
     private func chartView(data: SimpleChartData) -> some View {
@@ -128,13 +124,15 @@ struct WordAdsChartCard: View {
 
     private var footer: some View {
         MetricsOverviewTabView(
-            data: viewModel.tabViewData,
+            data: viewModel.isFirstLoad ? viewModel.placeholderTabViewData : viewModel.tabViewData,
             selectedMetric: $viewModel.selectedMetric,
             onMetricSelected: { metric in
                 viewModel.onMetricSelected(metric)
             },
             showTrend: false
         )
+        .redacted(reason: viewModel.isLoading ? .placeholder : [])
+        .pulsating(viewModel.isLoading)
         .background(
             CardGradientBackground(metric: viewModel.selectedMetric)
         )

--- a/Modules/Sources/JetpackStats/Cards/WordAdsChartCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/WordAdsChartCard.swift
@@ -133,7 +133,7 @@ struct WordAdsChartCard: View {
             onMetricSelected: { metric in
                 viewModel.onMetricSelected(metric)
             },
-            showTrends: false
+            showTrend: false
         )
         .background(
             CardGradientBackground(metric: viewModel.selectedMetric)

--- a/Modules/Sources/JetpackStats/Cards/WordAdsChartCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/WordAdsChartCard.swift
@@ -1,0 +1,172 @@
+import SwiftUI
+
+/// A chart card for displaying WordAds metrics with granularity selection and period navigation.
+struct WordAdsChartCard: View {
+    @ObservedObject var viewModel: WordAdsChartCardViewModel
+
+    @ScaledMetric(relativeTo: .body) private var chartHeight: CGFloat = 180
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+                .padding(.horizontal, Constants.step3)
+                .padding(.top, Constants.step3)
+                .padding(.bottom, Constants.step1)
+
+            chartArea
+                .frame(height: chartHeight)
+                .padding(.horizontal, Constants.step2)
+                .padding(.vertical, Constants.step2)
+                .animation(.spring, value: viewModel.selectedMetric)
+                .animation(.easeInOut, value: viewModel.isFirstLoad)
+
+            Divider()
+
+            footer
+        }
+        .onAppear {
+            viewModel.onAppear()
+        }
+        .cardStyle()
+    }
+
+    // MARK: - Header
+
+    private var header: some View {
+        HStack(spacing: 0) {
+            StatsCardTitleView(title: viewModel.formattedCurrentDate)
+
+            Spacer(minLength: 8)
+
+            granularityMenu
+        }
+    }
+
+    private var granularityMenu: some View {
+        Menu {
+            ForEach(DateRangeGranularity.allCases.filter { $0 != .hour }) { granularity in
+                Button {
+                    viewModel.onGranularityChanged(granularity)
+                } label: {
+                    Text(granularity.localizedTitle)
+                }
+            }
+        } label: {
+            HStack(spacing: 4) {
+                Text(viewModel.selectedGranularity.localizedTitle)
+                    .font(.subheadline.weight(.medium))
+                Image(systemName: "chevron.up.chevron.down")
+                    .font(.caption2.weight(.semibold))
+            }
+            .foregroundStyle(Color.primary)
+        }
+        .accessibilityLabel(Strings.Chart.granularity)
+    }
+
+    // MARK: - Chart Area
+
+    @ViewBuilder
+    private var chartArea: some View {
+        if viewModel.isFirstLoad {
+            loadingView
+        } else if let data = viewModel.currentChartData {
+            if data.isEmpty {
+                loadingErrorView(with: Strings.Chart.empty)
+            } else {
+                chartView(data: data)
+                    .transition(.opacity.combined(with: .scale(scale: 0.97)))
+            }
+        } else {
+            loadingErrorView(with: viewModel.loadingError?.localizedDescription ?? Strings.Errors.generic)
+        }
+    }
+
+    private var loadingView: some View {
+        SimpleBarChartView(
+            data: SimpleChartData.mock(
+                metric: viewModel.selectedMetric,
+                granularity: viewModel.selectedGranularity,
+                dataPointCount: viewModel.selectedGranularity.preferredQuantity
+            ),
+            selectedDate: nil,
+            onBarTapped: { _ in }
+        )
+        .redacted(reason: .placeholder)
+        .opacity(0.2)
+        .pulsating()
+    }
+
+    private func loadingErrorView(with message: String) -> some View {
+        SimpleBarChartView(
+            data: SimpleChartData.mock(
+                metric: viewModel.selectedMetric,
+                granularity: viewModel.selectedGranularity,
+                dataPointCount: viewModel.selectedGranularity.preferredQuantity
+            ),
+            selectedDate: nil,
+            onBarTapped: { _ in }
+        )
+        .redacted(reason: .placeholder)
+        .grayscale(1)
+        .opacity(0.1)
+        .overlay {
+            SimpleErrorView(message: message)
+        }
+    }
+
+    private func chartView(data: SimpleChartData) -> some View {
+        SimpleBarChartView(
+            data: data,
+            selectedDate: viewModel.selectedBarDate,
+            onBarTapped: { date in
+                viewModel.onBarTapped(date)
+            }
+        )
+    }
+
+    // MARK: - Footer
+
+    private var footer: some View {
+        MetricsOverviewTabView(
+            data: viewModel.tabViewData,
+            selectedMetric: $viewModel.selectedMetric,
+            onMetricSelected: { metric in
+                viewModel.onMetricSelected(metric)
+            },
+            showTrends: false
+        )
+        .background(
+            CardGradientBackground(metric: viewModel.selectedMetric)
+        )
+        .animation(.easeInOut, value: viewModel.selectedMetric)
+    }
+}
+
+// MARK: - Supporting Views
+
+private struct CardGradientBackground: View {
+    let metric: WordAdsMetric
+
+    @Environment(\.colorScheme) var colorScheme
+
+    var body: some View {
+        LinearGradient(
+            colors: [
+                metric.primaryColor.opacity(colorScheme == .light ? 0.03 : 0.04),
+                Constants.Colors.secondaryBackground
+            ],
+            startPoint: .top,
+            endPoint: .center
+        )
+    }
+}
+
+// MARK: - Preview
+
+#Preview {
+    WordAdsChartCard(
+        viewModel: WordAdsChartCardViewModel(service: MockStatsService())
+    )
+    .padding()
+    .background(Constants.Colors.background)
+}

--- a/Modules/Sources/JetpackStats/Cards/WordAdsChartCardViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/WordAdsChartCardViewModel.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+
+/// ViewModel managing state and interactions for the WordAds chart card.
+@MainActor
+final class WordAdsChartCardViewModel: ObservableObject {
+    // MARK: - Published Properties
+
+    @Published private(set) var chartData: [WordAdsMetric: SimpleChartData] = [:]
+    @Published private(set) var isFirstLoad = true
+    @Published private(set) var loadingError: Error?
+
+    @Published var selectedMetric: WordAdsMetric = .impressions
+    @Published var selectedGranularity: DateRangeGranularity = .day
+    @Published var currentDate = Date()
+    @Published var selectedBarDate: Date?
+
+    // MARK: - Dependencies
+
+    private let service: any StatsServiceProtocol
+    private var loadTask: Task<Void, Never>?
+
+    // MARK: - Computed Properties
+
+    var tabViewData: [MetricsOverviewTabView<WordAdsMetric>.MetricData] {
+        WordAdsMetric.allMetrics.map { metric in
+            let data = chartData[metric]
+            let value: Int? = {
+                guard let selectedBarDate else {
+                    return data?.currentTotal
+                }
+                // Find the data point matching the selected date
+                return data?.currentData.first { dataPoint in
+                    Calendar.current.isDate(
+                        dataPoint.date,
+                        equalTo: selectedBarDate,
+                        toGranularity: selectedGranularity.component
+                    )
+                }?.value
+            }()
+
+            return MetricsOverviewTabView.MetricData(
+                metric: metric,
+                value: value,
+                previousValue: nil // No comparison for legacy chart
+            )
+        }
+    }
+
+    var formattedCurrentDate: String {
+        let formatter = StatsDateFormatter()
+        let dateToFormat = selectedBarDate ?? currentDate
+        return formatter.formatDate(dateToFormat, granularity: selectedGranularity, context: .regular)
+    }
+
+    var currentChartData: SimpleChartData? {
+        chartData[selectedMetric]
+    }
+
+    // MARK: - Initialization
+
+    init(service: any StatsServiceProtocol) {
+        self.service = service
+    }
+
+    // MARK: - Public Methods
+
+    func onAppear() {
+        guard chartData.isEmpty else { return }
+        loadData()
+    }
+
+    func onGranularityChanged(_ newGranularity: DateRangeGranularity) {
+        selectedGranularity = newGranularity
+        currentDate = Date() // Reset to current date
+        selectedBarDate = nil
+        loadData()
+    }
+
+    func onBarTapped(_ date: Date) {
+        selectedBarDate = date
+    }
+
+    func onMetricSelected(_ metric: WordAdsMetric) {
+        selectedMetric = metric
+        // Chart data already loaded, no need to reload
+        // Select the latest period for the new metric
+        if let latestDate = chartData[metric]?.currentData.last?.date {
+            selectedBarDate = latestDate
+        }
+    }
+
+    // MARK: - Private Methods
+
+    func loadData() {
+        // Cancel any existing load task
+        loadTask?.cancel()
+
+        loadTask = Task { [weak self] in
+            guard let self else { return }
+
+            self.loadingError = nil
+
+            do {
+                let response = try await service.getWordAdsStats(
+                    date: currentDate,
+                    granularity: selectedGranularity
+                )
+
+                guard !Task.isCancelled else { return }
+
+                // Transform response into chart data for each metric
+                var newChartData: [WordAdsMetric: SimpleChartData] = [:]
+                for metric in WordAdsMetric.allMetrics {
+                    if let dataPoints = response.metrics[metric] {
+                        let total = DataPoint.getTotalValue(
+                            for: dataPoints,
+                            metric: metric
+                        ) ?? 0
+
+                        newChartData[metric] = SimpleChartData(
+                            metric: metric,
+                            granularity: selectedGranularity,
+                            currentTotal: total,
+                            currentData: dataPoints
+                        )
+                    }
+                }
+
+                self.chartData = newChartData
+                self.isFirstLoad = false
+
+                // Automatically select the latest period if no selection exists
+                if self.selectedBarDate == nil, let latestDate = newChartData[self.selectedMetric]?.currentData.last?.date {
+                    self.selectedBarDate = latestDate
+                }
+            } catch {
+                guard !Task.isCancelled else { return }
+                self.loadingError = error
+                self.isFirstLoad = false
+            }
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Cards/WordAdsChartCardViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/WordAdsChartCardViewModel.swift
@@ -7,6 +7,7 @@ final class WordAdsChartCardViewModel: ObservableObject {
 
     @Published private(set) var chartData: [WordAdsMetric: SimpleChartData] = [:]
     @Published private(set) var isFirstLoad = true
+    @Published private(set) var isLoading = false
     @Published private(set) var loadingError: Error?
 
     @Published var selectedMetric: WordAdsMetric = .impressions
@@ -56,6 +57,12 @@ final class WordAdsChartCardViewModel: ObservableObject {
         chartData[selectedMetric]
     }
 
+    var placeholderTabViewData: [MetricsOverviewTabView<WordAdsMetric>.MetricData] {
+        WordAdsMetric.allMetrics.map { metric in
+            .init(metric: metric, value: 12345, previousValue: nil)
+        }
+    }
+
     // MARK: - Initialization
 
     init(service: any StatsServiceProtocol) {
@@ -95,10 +102,13 @@ final class WordAdsChartCardViewModel: ObservableObject {
         // Cancel any existing load task
         loadTask?.cancel()
 
+        withAnimation {
+            isLoading = true
+            loadingError = nil
+        }
+
         loadTask = Task { [weak self] in
             guard let self else { return }
-
-            self.loadingError = nil
 
             do {
                 let response = try await service.getWordAdsStats(
@@ -126,8 +136,11 @@ final class WordAdsChartCardViewModel: ObservableObject {
                     }
                 }
 
-                self.chartData = newChartData
-                self.isFirstLoad = false
+                withAnimation {
+                    self.chartData = newChartData
+                    self.isFirstLoad = false
+                    self.isLoading = false
+                }
 
                 // Automatically select the latest period if no selection exists
                 if self.selectedBarDate == nil, let latestDate = newChartData[self.selectedMetric]?.currentData.last?.date {
@@ -135,8 +148,11 @@ final class WordAdsChartCardViewModel: ObservableObject {
                 }
             } catch {
                 guard !Task.isCancelled else { return }
-                self.loadingError = error
-                self.isFirstLoad = false
+                withAnimation {
+                    self.loadingError = error
+                    self.isFirstLoad = false
+                    self.isLoading = false
+                }
             }
         }
     }

--- a/Modules/Sources/JetpackStats/Cards/WordAdsEarningsTotalsCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/WordAdsEarningsTotalsCard.swift
@@ -1,0 +1,125 @@
+import SwiftUI
+import WordPressKit
+
+struct WordAdsEarningsTotalsCard: View {
+    @ObservedObject var viewModel: WordAdsEarningsViewModel
+
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            StatsCardTitleView(title: Strings.WordAds.totalEarnings)
+
+            VStack(alignment: .leading, spacing: Constants.step1) {
+                Text(totalEarningsValue)
+                    .contentTransition(.numericText())
+                    .font(Font.make(.recoleta, textStyle: .largeTitle, weight: .medium))
+                    .foregroundColor(.primary)
+                    .animation(.spring, value: totalEarningsValue)
+
+                HStack(spacing: Constants.step4) {
+                    SecondaryMetricView(
+                        title: Strings.WordAds.paid,
+                        value: metricsData?.paid
+                    )
+
+                    SecondaryMetricView(
+                        title: Strings.WordAds.outstanding,
+                        value: metricsData?.outstanding
+                    )
+                }
+            }
+            .redacted(reason: viewModel.isFirstLoad ? .placeholder : [])
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(Constants.step2)
+        .cardStyle()
+        .overlay(alignment: .topTrailing) {
+            moreMenu
+        }
+    }
+
+    private var moreMenu: some View {
+        Menu {
+            Link(destination: URL(string: "https://wordpress.com/support/wordads-and-earn/track-your-ads/")!) {
+                Label(Strings.WordAds.learnMore, systemImage: "info.circle")
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 15))
+                .foregroundColor(.secondary)
+                .frame(width: 50, height: 50)
+        }
+        .tint(Color.primary)
+    }
+
+    private var totalEarningsValue: String {
+        guard let value = metricsData?.totalEarnings else { return "–" }
+        return value.formatted(.currency(code: "USD"))
+    }
+
+    private var metricsData: EarningsMetricsData? {
+        if let earnings = viewModel.earnings {
+            return EarningsMetricsData(
+                totalEarnings: earnings.totalEarnings,
+                paid: earnings.totalEarnings - earnings.totalAmountOwed,
+                outstanding: earnings.totalAmountOwed
+            )
+        } else if viewModel.isFirstLoad {
+            return .mockData
+        } else {
+            return nil
+        }
+    }
+}
+
+// MARK: - Secondary Metric View
+
+private struct SecondaryMetricView: View {
+    let title: String
+    let value: Decimal?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+
+            Text(displayValue)
+                .contentTransition(.numericText())
+                .font(.subheadline.weight(.medium))
+                .foregroundColor(.primary)
+                .animation(.spring, value: displayValue)
+        }
+        .lineLimit(1)
+    }
+
+    private var displayValue: String {
+        guard let value else { return "–" }
+        return value.formatted(.currency(code: "USD"))
+    }
+}
+
+// MARK: - Data Models
+
+private struct EarningsMetricsData {
+    let totalEarnings: Decimal
+    let paid: Decimal
+    let outstanding: Decimal
+
+    /// Mock data used for loading state placeholders
+    static let mockData = EarningsMetricsData(
+        totalEarnings: 42.67,
+        paid: 4.27,
+        outstanding: 38.40
+    )
+}
+
+#Preview {
+    @Previewable @StateObject var viewModel = WordAdsEarningsViewModel(service: MockStatsService())
+
+    return VStack {
+        WordAdsEarningsTotalsCard(viewModel: viewModel)
+    }
+    .padding()
+}

--- a/Modules/Sources/JetpackStats/Cards/WordAdsEarningsViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/WordAdsEarningsViewModel.swift
@@ -1,0 +1,36 @@
+import Foundation
+@preconcurrency import WordPressKit
+
+/// ViewModel managing state for WordAds earnings data.
+@MainActor
+final class WordAdsEarningsViewModel: ObservableObject {
+    // MARK: - Published Properties
+
+    @Published private(set) var earnings: StatsWordAdsEarningsResponse?
+    @Published private(set) var isFirstLoad = true
+    @Published private(set) var loadingError: Error?
+
+    // MARK: - Dependencies
+
+    private let service: any StatsServiceProtocol
+
+    // MARK: - Initialization
+
+    init(service: any StatsServiceProtocol) {
+        self.service = service
+    }
+
+    func refresh() async {
+        do {
+            let response = try await service.getWordAdsEarnings()
+            guard !Task.isCancelled else { return }
+            self.earnings = response
+            self.loadingError = nil
+            self.isFirstLoad = false
+        } catch {
+            guard !Task.isCancelled else { return }
+            self.loadingError = error
+            self.isFirstLoad = false
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Cards/WordAdsPaymentHistoryCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/WordAdsPaymentHistoryCard.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+@preconcurrency import WordPressKit
+
+struct WordAdsPaymentHistoryCard: View {
+    @ObservedObject var viewModel: WordAdsEarningsViewModel
+
+    @Environment(\.router) private var router
+    @Environment(\.context) private var context
+
+    private let itemLimit = 6
+
+    private var mockViewModels: [WordAdsPaymentHistoryRowViewModel] {
+        (0..<5).map { index in
+            WordAdsPaymentHistoryRowViewModel(
+                earning: StatsWordAdsEarningsResponse.MonthlyEarning(
+                    period: StatsWordAdsEarningsResponse.Period(year: 2025, month: 12 - index),
+                    data: StatsWordAdsEarningsResponse.MonthlyEarningData(
+                        amount: 15.25,
+                        status: .outstanding,
+                        pageviews: "3420"
+                    )
+                )
+            )
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            StatsCardTitleView(title: Strings.WordAds.paymentsHistory)
+                .padding(.horizontal, Constants.step3)
+                .padding(.bottom, Constants.step1)
+
+            if viewModel.isFirstLoad {
+                loadingView
+            } else if let earnings = viewModel.earnings, !earnings.wordAdsEarnings.isEmpty {
+                let rowViewModels = earnings.wordAdsEarnings.prefix(itemLimit).map {
+                    WordAdsPaymentHistoryRowViewModel(earning: $0)
+                }
+                contentView(viewModels: Array(rowViewModels), hasMore: earnings.wordAdsEarnings.count > itemLimit)
+            } else if let loadingError = viewModel.loadingError {
+                errorView(error: loadingError)
+            } else {
+                emptyView
+            }
+        }
+        .padding(.vertical, Constants.step2)
+        .cardStyle()
+    }
+
+    private var loadingView: some View {
+        contentView(viewModels: mockViewModels, hasMore: false)
+            .redacted(reason: .placeholder)
+            .pulsating()
+    }
+
+    private var emptyView: some View {
+        Text(Strings.WordAds.noPaymentsYet)
+            .font(.subheadline)
+            .foregroundColor(.secondary)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, Constants.step3)
+    }
+
+    private func errorView(error: Error) -> some View {
+        contentView(viewModels: mockViewModels, hasMore: false)
+            .redacted(reason: .placeholder)
+            .grayscale(1)
+            .opacity(0.1)
+            .overlay {
+                SimpleErrorView(error: error)
+            }
+    }
+
+    private func contentView(viewModels: [WordAdsPaymentHistoryRowViewModel], hasMore: Bool) -> some View {
+        VStack(spacing: 0) {
+            ForEach(Array(viewModels.enumerated()), id: \.offset) { index, viewModel in
+                WordAdsPaymentHistoryRowView(viewModel: viewModel)
+                    .padding(.horizontal, Constants.step3)
+                    .padding(.vertical, 9)
+
+                if index < viewModels.count - 1 {
+                    Divider()
+                        .padding(.leading, Constants.step3)
+                }
+            }
+
+            if hasMore {
+                showMoreButton
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, Constants.step3)
+            }
+        }
+    }
+
+    private var showMoreButton: some View {
+        Button {
+            navigateToPaymentHistory()
+        } label: {
+            HStack(spacing: 4) {
+                Text(Strings.Buttons.showAll)
+                    .padding(.trailing, 4)
+                    .font(.callout)
+                    .foregroundColor(.primary)
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(.top, 16)
+        .tint(Color.secondary.opacity(0.8))
+        .dynamicTypeSize(...DynamicTypeSize.xLarge)
+    }
+
+    private func navigateToPaymentHistory() {
+        guard let earnings = viewModel.earnings else { return }
+
+        router.navigate(
+            to: WordAdsPaymentHistoryView(earnings: earnings),
+            title: Strings.WordAds.paymentsHistory
+        )
+    }
+}
+
+#Preview {
+    @Previewable @StateObject var viewModel = WordAdsEarningsViewModel(service: MockStatsService())
+
+    return VStack {
+        WordAdsPaymentHistoryCard(viewModel: viewModel)
+    }
+    .padding()
+}

--- a/Modules/Sources/JetpackStats/Charts/Helpers/ChartAverageAnnotation.swift
+++ b/Modules/Sources/JetpackStats/Charts/Helpers/ChartAverageAnnotation.swift
@@ -2,7 +2,7 @@ import SwiftUI
 
 struct ChartAverageAnnotation: View {
     let value: Int
-    let formatter: StatsValueFormatter
+    let formatter: any ValueFormatterProtocol
 
     @Environment(\.colorScheme) private var colorScheme
 

--- a/Modules/Sources/JetpackStats/Charts/Helpers/SimpleChartData.swift
+++ b/Modules/Sources/JetpackStats/Charts/Helpers/SimpleChartData.swift
@@ -1,0 +1,56 @@
+import SwiftUI
+
+/// Simplified chart data structure for metrics without comparison period support.
+final class SimpleChartData: Sendable {
+    let metric: any MetricType
+    let granularity: DateRangeGranularity
+    let currentTotal: Int
+    let currentData: [DataPoint]
+    let maxValue: Int
+    var isEmpty: Bool {
+        currentData.isEmpty || currentData.allSatisfy { $0.value == 0 }
+    }
+
+    init(
+        metric: any MetricType,
+        granularity: DateRangeGranularity,
+        currentTotal: Int,
+        currentData: [DataPoint]
+    ) {
+        self.metric = metric
+        self.granularity = granularity
+        self.currentTotal = currentTotal
+        self.currentData = currentData
+        self.maxValue = currentData.map(\.value).max() ?? 0
+    }
+
+    /// Creates mock chart data for preview and testing purposes.
+    static func mock(
+        metric: any MetricType,
+        granularity: DateRangeGranularity = .day,
+        dataPointCount: Int = 7
+    ) -> SimpleChartData {
+        let calendar = Calendar.current
+        let now = Date()
+
+        var mockData: [DataPoint] = []
+        for i in 0..<dataPointCount {
+            guard let date = calendar.date(byAdding: granularity.component, value: -dataPointCount + i + 1, to: now) else {
+                continue
+            }
+
+            // Generate random values - generic approach
+            let value = Int.random(in: 100...1000)
+            mockData.append(DataPoint(date: date, value: value))
+        }
+
+        let total = DataPoint.getTotalValue(for: mockData, metric: metric) ?? 0
+
+        return SimpleChartData(
+            metric: metric,
+            granularity: granularity,
+            currentTotal: total,
+            currentData: mockData
+        )
+    }
+}

--- a/Modules/Sources/JetpackStats/Charts/SimpleBarChartView.swift
+++ b/Modules/Sources/JetpackStats/Charts/SimpleBarChartView.swift
@@ -1,0 +1,300 @@
+import SwiftUI
+import Charts
+
+/// Simplified bar chart for metrics without tooltips or comparison bars.
+struct SimpleBarChartView: View {
+    let data: SimpleChartData
+    let selectedDate: Date?
+    let onBarTapped: (Date) -> Void
+
+    @State private var hoveredDate: Date?
+    @State private var isInteracting = false
+
+    @Environment(\.context) var context
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var valueFormatter: any ValueFormatterProtocol {
+        data.metric.makeValueFormatter()
+    }
+
+    private var currentAverage: Double {
+        guard !data.currentData.isEmpty else { return 0 }
+        return Double(data.currentTotal) / Double(data.currentData.count)
+    }
+
+    var body: some View {
+        Chart {
+            currentPeriodBars
+            averageLine
+            peakAnnotation
+            selectionIndicator
+        }
+        .chartXAxis { xAxis }
+        .chartYAxis { yAxis }
+        .chartYScale(domain: yAxisDomain)
+        .chartLegend(.hidden)
+        .animation(.spring, value: ObjectIdentifier(data))
+        .chartOverlay { proxy in
+            makeOverlayView(proxy: proxy)
+        }
+        .dynamicTypeSize(...DynamicTypeSize.xxxLarge)
+    }
+
+    // MARK: - Chart Marks
+
+    @ChartContentBuilder
+    private var currentPeriodBars: some ChartContent {
+        ForEach(data.currentData) { point in
+            BarMark(
+                x: .value("Date", point.date, unit: data.granularity.component),
+                y: .value("Value", point.value),
+                width: barWidth
+            )
+            .foregroundStyle(
+                LinearGradient(
+                    colors: [
+                        data.metric.primaryColor,
+                        lighten(data.metric.primaryColor)
+                    ],
+                    startPoint: .top,
+                    endPoint: .bottom
+                )
+            )
+            .cornerRadius(6)
+            .opacity(getBarOpacity(for: point))
+        }
+    }
+
+    private var barWidth: MarkDimension {
+        data.currentData.count <= 3 ? .fixed(32) : .automatic
+    }
+
+    private func lighten(_ color: Color) -> Color {
+        if #available(iOS 18, *) {
+            color.mix(with: Color(.systemBackground), by: colorScheme == .light ? 0.4 : 0.15)
+        } else {
+            color.opacity(0.5)
+        }
+    }
+
+    private func getBarOpacity(for point: DataPoint) -> CGFloat {
+        let dateToMatch = isInteracting ? hoveredDate : selectedDate
+        guard let dateToMatch else { return 1.0 }
+
+        return context.calendar.isDate(
+            point.date,
+            equalTo: dateToMatch,
+            toGranularity: data.granularity.component
+        ) ? 1.0 : 0.5
+    }
+
+    @ChartContentBuilder
+    private var averageLine: some ChartContent {
+        if currentAverage > 0 {
+            RuleMark(y: .value("Average", currentAverage))
+                .foregroundStyle(Color.secondary.opacity(0.33))
+                .lineStyle(StrokeStyle(lineWidth: 1, dash: [6, 6]))
+                .annotation(position: .trailing, alignment: .trailing) {
+                    ChartAverageAnnotation(value: Int(currentAverage), formatter: valueFormatter)
+                }
+        }
+    }
+
+    @ChartContentBuilder
+    private var peakAnnotation: some ChartContent {
+        if let maxPoint = data.currentData.max(by: { $0.value < $1.value }), data.currentData.count > 0 {
+            PointMark(
+                x: .value("Date", maxPoint.date, unit: data.granularity.component),
+                y: .value("Value", maxPoint.value)
+            )
+            .opacity(0)
+            .annotation(position: .top, spacing: 8) {
+                PeakValueAnnotation(value: maxPoint.value, metric: data.metric)
+                    // Hide when interacting to avoid clutter
+                    .opacity(isInteracting ? 0 : 1)
+            }
+        }
+    }
+
+    @ChartContentBuilder
+    private var selectionIndicator: some ChartContent {
+        let dateToMatch = isInteracting ? hoveredDate : selectedDate
+        if let dateToMatch,
+           let selectedPoint = data.currentData.first(where: { point in
+               context.calendar.isDate(
+                   point.date,
+                   equalTo: dateToMatch,
+                   toGranularity: data.granularity.component
+               )
+           }) {
+            // Subtle vertical background fill for entire bar area
+            RectangleMark(
+                x: .value("Date", selectedPoint.date, unit: data.granularity.component),
+                yStart: .value("Bottom", 0),
+                yEnd: .value("Top", yAxisDomain.upperBound),
+                width: barWidth
+            )
+            .foregroundStyle(data.metric.primaryColor.opacity(colorScheme == .light ? 0.08 : 0.12))
+            .zIndex(-1)
+        }
+    }
+
+    // MARK: - Axis Configuration
+
+    private var xAxis: some AxisContent {
+        if data.currentData.count == 1 {
+            AxisMarks(values: .stride(by: data.granularity.component, count: 1)) { value in
+                if let date = value.as(Date.self) {
+                    AxisValueLabel {
+                        ChartAxisDateLabel(date: date, granularity: data.granularity)
+                    }
+                }
+            }
+        } else {
+            AxisMarks(values: .automatic) { value in
+                if let date = value.as(Date.self) {
+                    AxisValueLabel {
+                        ChartAxisDateLabel(date: date, granularity: data.granularity)
+                    }
+                }
+            }
+        }
+    }
+
+    private var yAxis: some AxisContent {
+        AxisMarks(values: .automatic) { value in
+            if let value = value.as(Int.self) {
+                AxisGridLine()
+                    .foregroundStyle(Color.secondary.opacity(0.33))
+                AxisValueLabel {
+                    if value > 0 {
+                        Text(valueFormatter.format(value: value, context: .compact))
+                            .font(.caption2.weight(.medium))
+                            .foregroundColor(.secondary)
+                    }
+                }
+            }
+        }
+    }
+
+    private var yAxisDomain: ClosedRange<Int> {
+        // If all values are zero, show a reasonable range
+        if data.maxValue == 0 {
+            return 0...100
+        }
+        guard data.maxValue > 0 else {
+            return data.maxValue...0
+        }
+        // Add some padding above the max value
+        let padding = max(Int(Double(data.maxValue) * 0.33), 1)
+        return 0...(data.maxValue + padding)
+    }
+
+    // MARK: - Gesture Handling
+
+    private func makeOverlayView(proxy: ChartProxy) -> some View {
+        GeometryReader { geometry in
+            ChartGestureOverlay(
+                onTap: { location in
+                    handleTap(at: location, proxy: proxy, geometry: geometry)
+                },
+                onInteractionUpdate: { location in
+                    isInteracting = true
+                    if let date = getDate(at: location, proxy: proxy, geometry: geometry) {
+                        hoveredDate = date
+                        onBarTapped(date)
+                    }
+                },
+                onInteractionEnd: {
+                    isInteracting = false
+                    hoveredDate = nil
+                }
+            )
+        }
+    }
+
+    private func handleTap(at location: CGPoint, proxy: ChartProxy, geometry: GeometryProxy) {
+        guard !isInteracting,
+              let date = getDate(at: location, proxy: proxy, geometry: geometry) else {
+            return
+        }
+        onBarTapped(date)
+    }
+
+    private func getDate(at location: CGPoint, proxy: ChartProxy, geometry: GeometryProxy) -> Date? {
+        guard let frame = proxy.plotFrame else { return nil }
+
+        let origin = geometry[frame].origin
+        let adjustedX = location.x - origin.x
+
+        return proxy.value(atX: adjustedX)
+    }
+}
+
+// MARK: - Supporting Views
+
+private struct PeakValueAnnotation: View {
+    let value: Int
+    let metric: any MetricType
+    let valueFormatter: any ValueFormatterProtocol
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    init(value: Int, metric: any MetricType) {
+        self.value = value
+        self.metric = metric
+        self.valueFormatter = metric.makeValueFormatter()
+    }
+
+    var body: some View {
+        Text(valueFormatter.format(value: value, context: .compact))
+            .fixedSize()
+            .font(.system(.caption, design: .rounded, weight: .semibold))
+            .foregroundColor(metric.primaryColor)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background {
+                ZStack {
+                    Capsule()
+                        .fill(Color(.systemBackground).opacity(0.75))
+                    Capsule()
+                        .fill(metric.primaryColor.opacity(colorScheme == .light ? 0.1 : 0.25))
+                }
+            }
+    }
+}
+
+// MARK: - Preview
+
+#Preview("Days") {
+    SimpleBarChartView(
+        data: SimpleChartData.mock(metric: WordAdsMetric.impressions, granularity: .day, dataPointCount: 7),
+        selectedDate: nil,
+        onBarTapped: { _ in }
+    )
+    .frame(height: 180)
+    .padding()
+    .background(Constants.Colors.background)
+}
+
+#Preview("With Selection") {
+    SimpleBarChartView(
+        data: SimpleChartData.mock(metric: WordAdsMetric.revenue, granularity: .day, dataPointCount: 7),
+        selectedDate: Date(),
+        onBarTapped: { _ in }
+    )
+    .frame(height: 180)
+    .padding()
+    .background(Constants.Colors.background)
+}
+
+#Preview("Months") {
+    SimpleBarChartView(
+        data: SimpleChartData.mock(metric: WordAdsMetric.cpm, granularity: .month, dataPointCount: 12),
+        selectedDate: nil,
+        onBarTapped: { _ in }
+    )
+    .frame(height: 180)
+    .padding()
+    .background(Constants.Colors.background)
+}

--- a/Modules/Sources/JetpackStats/Extensions/Calendar+Navigation.swift
+++ b/Modules/Sources/JetpackStats/Extensions/Calendar+Navigation.swift
@@ -1,18 +1,25 @@
 import Foundation
 
-extension Calendar {
-    enum NavigationDirection {
-        case backward
-        case forward
+enum NavigationDirection {
+    case backward
+    case forward
 
-        var systemImage: String {
-            switch self {
-            case .backward: "chevron.backward"
-            case .forward: "chevron.forward"
-            }
+    var systemImage: String {
+        switch self {
+        case .backward: "chevron.backward"
+        case .forward: "chevron.forward"
         }
     }
 
+    var accessibilityLabel: String {
+        switch self {
+        case .forward: Strings.Accessibility.nextPeriod
+        case .backward: Strings.Accessibility.previousPeriod
+        }
+    }
+}
+
+extension Calendar {
     /// Navigates to the next or previous period from the given date interval.
     ///
     /// This method navigates by the length of the period for the given component.

--- a/Modules/Sources/JetpackStats/Screens/AdsTabView.swift
+++ b/Modules/Sources/JetpackStats/Screens/AdsTabView.swift
@@ -1,28 +1,36 @@
 import SwiftUI
 
 public struct AdsTabView: View {
+    @StateObject private var viewModel: WordAdsChartCardViewModel
 
-    public init() {}
+    public init(context: StatsContext, router: StatsRouter) {
+        _viewModel = StateObject(
+            wrappedValue: WordAdsChartCardViewModel(service: context.service)
+        )
+    }
 
     public var body: some View {
         ScrollView {
-            VStack(spacing: 16) {
-                Text("Ads")
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
-                    .padding(.top, 20)
-
-                Text("Coming Soon")
-                    .font(.headline)
-                    .foregroundColor(.secondary)
-
-                Spacer(minLength: 100)
+            VStack(spacing: Constants.step3) {
+                WordAdsChartCard(viewModel: viewModel)
             }
-            .padding()
+            .padding(.vertical, Constants.step2)
+            .padding(.horizontal, Constants.step1)
+            .padding(.top, Constants.step0_5)
         }
+        .background(Constants.Colors.background)
     }
 }
 
 #Preview {
-    AdsTabView()
+    NavigationStack {
+        AdsTabView(
+            context: .demo,
+            router: StatsRouter(
+                viewController: UINavigationController(),
+                factory: MockStatsRouterScreenFactory()
+            )
+        )
+        .environment(\.context, .demo)
+    }
 }

--- a/Modules/Sources/JetpackStats/Screens/AdsTabView.swift
+++ b/Modules/Sources/JetpackStats/Screens/AdsTabView.swift
@@ -2,6 +2,7 @@ import SwiftUI
 
 public struct AdsTabView: View {
     @StateObject private var viewModel: WordAdsChartCardViewModel
+    @Environment(\.horizontalSizeClass) var horizontalSizeClass
 
     public init(context: StatsContext, router: StatsRouter) {
         _viewModel = StateObject(
@@ -15,7 +16,7 @@ public struct AdsTabView: View {
                 WordAdsChartCard(viewModel: viewModel)
             }
             .padding(.vertical, Constants.step2)
-            .padding(.horizontal, Constants.step1)
+            .padding(.horizontal, Constants.cardHorizontalInset(for: horizontalSizeClass))
             .padding(.top, Constants.step0_5)
         }
         .background(Constants.Colors.background)

--- a/Modules/Sources/JetpackStats/Screens/AdsTabView.swift
+++ b/Modules/Sources/JetpackStats/Screens/AdsTabView.swift
@@ -1,25 +1,47 @@
 import SwiftUI
+import WordPressKit
+import WordPressUI
 
 public struct AdsTabView: View {
-    @StateObject private var viewModel: WordAdsChartCardViewModel
+    @StateObject private var chartViewModel: WordAdsChartCardViewModel
+    @StateObject private var earningsViewModel: WordAdsEarningsViewModel
+
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
 
+    private let context: StatsContext
+    private let router: StatsRouter
+
     public init(context: StatsContext, router: StatsRouter) {
-        _viewModel = StateObject(
+        self.context = context
+        self.router = router
+        _chartViewModel = StateObject(
             wrappedValue: WordAdsChartCardViewModel(service: context.service)
+        )
+        _earningsViewModel = StateObject(
+            wrappedValue: WordAdsEarningsViewModel(service: context.service)
         )
     }
 
     public var body: some View {
         ScrollView {
             VStack(spacing: Constants.step3) {
-                WordAdsChartCard(viewModel: viewModel)
+                WordAdsEarningsTotalsCard(viewModel: earningsViewModel)
+                WordAdsChartCard(viewModel: chartViewModel)
+                WordAdsPaymentHistoryCard(viewModel: earningsViewModel)
             }
             .padding(.vertical, Constants.step2)
             .padding(.horizontal, Constants.cardHorizontalInset(for: horizontalSizeClass))
             .padding(.top, Constants.step0_5)
         }
         .background(Constants.Colors.background)
+        .environment(\.context, context)
+        .environment(\.router, router)
+        .onAppear {
+            context.tracker?.send(.adsTabShown)
+        }
+        .task {
+            await earningsViewModel.refresh()
+        }
     }
 }
 
@@ -32,6 +54,5 @@ public struct AdsTabView: View {
                 factory: MockStatsRouterScreenFactory()
             )
         )
-        .environment(\.context, .demo)
     }
 }

--- a/Modules/Sources/JetpackStats/Screens/AuthorStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/AuthorStatsView.swift
@@ -138,7 +138,7 @@ struct AuthorStatsView: View {
                     let trend = TrendViewModel(
                         currentValue: current,
                         previousValue: previous,
-                        metric: .views
+                        metric: SiteMetric.views
                     )
 
                     HStack(spacing: 4) {

--- a/Modules/Sources/JetpackStats/Screens/StatsMainView.swift
+++ b/Modules/Sources/JetpackStats/Screens/StatsMainView.swift
@@ -67,7 +67,7 @@ public struct StatsMainView: View {
                     context.tracker?.send(.subscribersTabShown)
                 }
         case .ads:
-            AdsTabView()
+            AdsTabView(context: context, router: router)
         }
     }
 

--- a/Modules/Sources/JetpackStats/Screens/WordAdsPaymentHistoryView.swift
+++ b/Modules/Sources/JetpackStats/Screens/WordAdsPaymentHistoryView.swift
@@ -1,0 +1,67 @@
+import SwiftUI
+@preconcurrency import WordPressKit
+
+struct WordAdsPaymentHistoryView: View {
+    let earnings: StatsWordAdsEarningsResponse
+
+    @Environment(\.context) private var context
+
+    var body: some View {
+        List {
+            ForEach(groupedEarningsByYear, id: \.year) { group in
+                Section(header: Text(String(group.year))) {
+                    ForEach(group.earnings, id: \.period) { earning in
+                        WordAdsPaymentHistoryRowView(viewModel: WordAdsPaymentHistoryRowViewModel(earning: earning))
+                            .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
+                    }
+                }
+            }
+        }
+        .listStyle(.plain)
+    }
+
+    private var groupedEarningsByYear: [YearGroup] {
+        let grouped = Dictionary(grouping: earnings.wordAdsEarnings) { $0.period.year }
+        return grouped.map { YearGroup(year: $0.key, earnings: $0.value) }
+            .sorted { $0.year > $1.year }
+    }
+
+    private struct YearGroup {
+        let year: Int
+        let earnings: [StatsWordAdsEarningsResponse.MonthlyEarning]
+    }
+}
+
+#Preview {
+    let json = """
+    {
+        "ID": 123456,
+        "name": "Test Site",
+        "URL": "https://test.com",
+        "earnings": {
+            "total_earnings": "150.00",
+            "total_amount_owed": "120.00",
+            "wordads": {
+                "2025-12": {"amount": 25.50, "status": "0", "pageviews": "4500"},
+                "2025-11": {"amount": 20.30, "status": "0", "pageviews": "3800"},
+                "2025-10": {"amount": 18.75, "status": "1", "pageviews": "3200"},
+                "2025-09": {"amount": 15.20, "status": "1", "pageviews": "2900"},
+                "2025-08": {"amount": 12.80, "status": "1", "pageviews": "2500"},
+                "2025-07": {"amount": 11.50, "status": "1", "pageviews": "2300"},
+                "2024-12": {"amount": 10.20, "status": "1", "pageviews": "2100"},
+                "2024-11": {"amount": 9.80, "status": "1", "pageviews": "1900"},
+                "2024-10": {"amount": 8.50, "status": "1", "pageviews": "1700"},
+                "2024-09": {"amount": 7.20, "status": "1", "pageviews": "1500"}
+            }
+        }
+    }
+    """
+    let earnings = try! JSONDecoder().decode(StatsWordAdsEarningsResponse.self, from: json.data(using: .utf8)!)
+
+    return NavigationStack {
+        WordAdsPaymentHistoryView(earnings: earnings)
+            .navigationTitle(Strings.WordAds.paymentsHistory)
+            .navigationBarTitleDisplayMode(.inline)
+    }
+    .environment(\.context, .demo)
+}

--- a/Modules/Sources/JetpackStats/Services/Data/MetricType.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/MetricType.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 
 /// Protocol defining the requirements for a metric type that can be displayed in stats views.
-protocol MetricType: Identifiable, Hashable, Equatable {
+protocol MetricType: Identifiable, Hashable, Equatable, Sendable {
     var localizedTitle: String { get }
     var systemImage: String { get }
     var primaryColor: Color { get }

--- a/Modules/Sources/JetpackStats/Services/Data/WordAdsMetric.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/WordAdsMetric.swift
@@ -54,7 +54,7 @@ struct WordAdsMetric: Identifiable, Sendable, Hashable, MetricType {
         id: "cpm",
         localizedTitle: Strings.WordAdsMetrics.averageCPM,
         systemImage: "chart.bar",
-        primaryColor: Constants.Colors.green,
+        primaryColor: Constants.Colors.celadon,
         aggregationStrategy: .average
     )
 

--- a/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
@@ -399,6 +399,76 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
         )
     }
 
+    func getWordAdsEarnings() async throws -> WordPressKit.StatsWordAdsEarningsResponse {
+        // Simulate network delay
+        if !delaysDisabled {
+            try? await Task.sleep(for: .milliseconds(Int.random(in: 200...500)))
+        }
+
+        // Generate mock earnings data for the last 12 months
+        let now = Date()
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+
+        var wordadsDict: [String: [String: Any]] = [:]
+        var totalEarnings: Double = 0
+        var totalAmountOwed: Double = 0
+
+        // Generate earnings for last 12 months
+        for monthsAgo in 0..<12 {
+            guard let monthDate = calendar.date(byAdding: .month, value: -monthsAgo, to: now) else {
+                continue
+            }
+
+            let period = dateFormatter.string(from: monthDate)
+
+            // Generate realistic earnings that increase over time
+            let baseAmount = Double.random(in: 2000...5000)
+            let growthFactor = 1.0 + (Double(12 - monthsAgo) * 0.08) // More recent months earn more
+            let amount = baseAmount * growthFactor
+
+            totalEarnings += amount
+
+            // Months older than 2 months are paid, recent months are outstanding
+            let isPaid = monthsAgo > 2
+            let status = isPaid ? "1" : "0"
+
+            if !isPaid {
+                totalAmountOwed += amount
+            }
+
+            // Generate realistic pageviews
+            let basePageviews = Int.random(in: 50...500)
+            let pageviewsGrowth = 1.0 + (Double(12 - monthsAgo) * 0.1)
+            let pageviews = Int(Double(basePageviews) * pageviewsGrowth)
+
+            wordadsDict[period] = [
+                "amount": amount,
+                "status": status,
+                "pageviews": String(pageviews)
+            ]
+        }
+
+        let jsonDictionary: [String: Any] = [
+            "ID": 238291108,
+            "name": "Mock Site",
+            "URL": "https://mocksite.wordpress.com",
+            "earnings": [
+                "total_earnings": String(format: "%.2f", totalEarnings),
+                "total_amount_owed": String(format: "%.2f", totalAmountOwed),
+                "wordads": wordadsDict,
+                "sponsored": [],
+                "adjustment": []
+            ]
+        ]
+
+        let jsonData = try JSONSerialization.data(withJSONObject: jsonDictionary)
+        let response = try JSONDecoder().decode(WordPressKit.StatsWordAdsEarningsResponse.self, from: jsonData)
+
+        return response
+    }
+
     // MARK: - Data Loading
 
     /// Loads historical items from JSON files based on the data type

--- a/Modules/Sources/JetpackStats/Services/StatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/StatsService.swift
@@ -118,6 +118,10 @@ actor StatsService: StatsServiceProtocol {
         return data
     }
 
+    func getWordAdsEarnings() async throws -> WordPressKit.StatsWordAdsEarningsResponse {
+        try await service.getWordAdsEarnings()
+    }
+
     private func fetchWordAdsStats(date: Date, granularity: DateRangeGranularity) async throws -> WordAdsMetricsResponse {
         let localDate = convertDateSiteToLocal(date)
 

--- a/Modules/Sources/JetpackStats/Services/StatsServiceProtocol.swift
+++ b/Modules/Sources/JetpackStats/Services/StatsServiceProtocol.swift
@@ -9,6 +9,7 @@ protocol StatsServiceProtocol: AnyObject, Sendable {
 
     func getSiteStats(interval: DateInterval, granularity: DateRangeGranularity) async throws -> SiteMetricsResponse
     func getWordAdsStats(date: Date, granularity: DateRangeGranularity) async throws -> WordAdsMetricsResponse
+    func getWordAdsEarnings() async throws -> WordPressKit.StatsWordAdsEarningsResponse
     func getTopListData(_ item: TopListItemType, metric: SiteMetric, interval: DateInterval, granularity: DateRangeGranularity, limit: Int?, locationLevel: LocationLevel?) async throws -> TopListResponse
     func getRealtimeTopListData(_ item: TopListItemType) async throws -> TopListResponse
     func getPostDetails(for postID: Int) async throws -> StatsPostDetails

--- a/Modules/Sources/JetpackStats/Strings.swift
+++ b/Modules/Sources/JetpackStats/Strings.swift
@@ -59,6 +59,22 @@ enum Strings {
         static let revenue = AppLocalizedString("jetpackStats.wordAdsMetrics.revenue", value: "Revenue", comment: "Revenue from ads")
     }
 
+    enum WordAds {
+        static let totalEarnings = AppLocalizedString("jetpackStats.wordAds.totalEarnings", value: "Total Earnings", comment: "Title for WordAds total earnings card")
+        static let earnings = AppLocalizedString("jetpackStats.wordAds.earnings", value: "Earnings", comment: "Total earnings from WordAds")
+        static let paid = AppLocalizedString("jetpackStats.wordAds.paid", value: "Paid", comment: "Amount paid out from WordAds earnings")
+        static let outstanding = AppLocalizedString("jetpackStats.wordAds.outstanding", value: "Outstanding", comment: "Outstanding amount owed from WordAds")
+        static let learnMore = AppLocalizedString("jetpackStats.wordAds.learnMore", value: "Learn More", comment: "Button to learn more about WordAds earnings")
+        static let paymentsHistory = AppLocalizedString("jetpackStats.wordAds.paymentsHistory", value: "Payments History", comment: "Title for payment history card and screen")
+        static let noPaymentsYet = AppLocalizedString("jetpackStats.wordAds.noPaymentsYet", value: "No payments yet", comment: "Message shown when there are no payment records")
+        static func adsServed(_ count: String) -> String {
+            String.localizedStringWithFormat(
+                AppLocalizedString("jetpackStats.wordAds.adsServed.count", value: "%@ ads served", comment: "Number of ads served. %@ is the ads count."),
+                count
+            )
+        }
+    }
+
     enum SiteDataTypes {
         static let postsAndPages = AppLocalizedString("jetpackStats.siteDataTypes.postsAndPages", value: "Posts & Pages", comment: "Posts and pages data type")
         static let archive = AppLocalizedString("jetpackStats.siteDataTypes.archive", value: "Archive", comment: "Archive data type")

--- a/Modules/Sources/JetpackStats/Utilities/DateRangeGranularity.swift
+++ b/Modules/Sources/JetpackStats/Utilities/DateRangeGranularity.swift
@@ -78,11 +78,11 @@ extension DateRangeGranularity {
     /// Used by legacy APIs that accept a date and quantity instead of date periods.
     var preferredQuantity: Int {
         switch self {
-        case .hour: 48
-        case .day: 30
+        case .hour: 24
+        case .day: 14
         case .week: 12
         case .month: 12
-        case .year: 10
+        case .year: 6
         }
     }
 }

--- a/Modules/Sources/JetpackStats/Utilities/StatsDateRange.swift
+++ b/Modules/Sources/JetpackStats/Utilities/StatsDateRange.swift
@@ -66,7 +66,7 @@ struct StatsDateRange: Equatable, Sendable {
     // MARK: - Navigation
 
     /// Navigates to the specified direction (previous or next period).
-    func navigate(_ direction: Calendar.NavigationDirection) -> StatsDateRange {
+    func navigate(_ direction: NavigationDirection) -> StatsDateRange {
         // Use the component if available, otherwise determine it from the interval
         let newInterval = calendar.navigate(dateInterval, direction: direction, component: component)
         // When navigating, we lose the preset since it's no longer a standard preset
@@ -74,7 +74,7 @@ struct StatsDateRange: Equatable, Sendable {
     }
 
     /// Returns true if can navigate in the specified direction.
-    func canNavigate(in direction: Calendar.NavigationDirection, now: Date = .now) -> Bool {
+    func canNavigate(in direction: NavigationDirection, now: Date = .now) -> Bool {
         calendar.canNavigate(dateInterval, direction: direction, now: now)
     }
 
@@ -84,7 +84,7 @@ struct StatsDateRange: Equatable, Sendable {
     ///   - maxCount: Maximum number of periods to generate (default: 10)
     ///   - now: The reference date for determining navigation bounds (default: .now)
     /// - Returns: Array of AdjacentPeriod structs
-    func availableAdjacentPeriods(in direction: Calendar.NavigationDirection, maxCount: Int = 10, now: Date = .now) -> [AdjacentPeriod] {
+    func availableAdjacentPeriods(in direction: NavigationDirection, maxCount: Int = 10, now: Date = .now) -> [AdjacentPeriod] {
         var periods: [AdjacentPeriod] = []
         var currentRange = self
         let formatter = StatsDateRangeFormatter(timeZone: calendar.timeZone, now: { now })

--- a/Modules/Sources/JetpackStats/Utilities/TrendViewModel.swift
+++ b/Modules/Sources/JetpackStats/Utilities/TrendViewModel.swift
@@ -3,11 +3,18 @@ import SwiftUI
 
 /// Represents a change from the current to the previous value and determines
 /// a trend: is it a positive change, what's the percentage, etc.
-struct TrendViewModel: Hashable {
+struct TrendViewModel: Equatable {
     let currentValue: Int
     let previousValue: Int
-    let metric: SiteMetric
+    let metric: any MetricType
     var context: StatsValueFormatter.Context = .compact
+
+    static func == (lhs: TrendViewModel, rhs: TrendViewModel) -> Bool {
+        lhs.currentValue == rhs.currentValue &&
+        lhs.previousValue == rhs.previousValue &&
+        lhs.context == rhs.context &&
+        String(describing: type(of: lhs.metric)) == String(describing: type(of: rhs.metric))
+    }
 
     /// The sign prefix for the change value.
     var sign: String {
@@ -75,7 +82,7 @@ struct TrendViewModel: Hashable {
     }
 
     private func formattedValue(_ value: Int) -> String {
-        StatsValueFormatter(metric: metric)
+        metric.makeValueFormatter()
             .format(value: value, context: context)
     }
 

--- a/Modules/Sources/JetpackStats/Views/BadgeTrendIndicator.swift
+++ b/Modules/Sources/JetpackStats/Views/BadgeTrendIndicator.swift
@@ -28,19 +28,19 @@ struct BadgeTrendIndicator: View {
     VStack(spacing: 20) {
         Text("Examples").font(.headline)
         // 15% increase in views - positive sentiment
-        BadgeTrendIndicator(trend: TrendViewModel(currentValue: 115, previousValue: 100, metric: .views))
+        BadgeTrendIndicator(trend: TrendViewModel(currentValue: 115, previousValue: 100, metric: SiteMetric.views))
         // 15% decrease in views - negative sentiment
-        BadgeTrendIndicator(trend: TrendViewModel(currentValue: 85, previousValue: 100, metric: .views))
+        BadgeTrendIndicator(trend: TrendViewModel(currentValue: 85, previousValue: 100, metric: SiteMetric.views))
         // 0.1% increase in views - negative sentiment
-        BadgeTrendIndicator(trend: TrendViewModel(currentValue: 1001, previousValue: 1000, metric: .views))
+        BadgeTrendIndicator(trend: TrendViewModel(currentValue: 1001, previousValue: 1000, metric: SiteMetric.views))
 
         Text("Edge Cases").font(.headline).padding(.top)
         // No change
-        BadgeTrendIndicator(trend: TrendViewModel(currentValue: 100, previousValue: 100, metric: .views))
+        BadgeTrendIndicator(trend: TrendViewModel(currentValue: 100, previousValue: 100, metric: SiteMetric.views))
         // Division by zero (from 0 to 100)
-        BadgeTrendIndicator(trend: TrendViewModel(currentValue: 100, previousValue: 0, metric: .views))
+        BadgeTrendIndicator(trend: TrendViewModel(currentValue: 100, previousValue: 0, metric: SiteMetric.views))
         // Large change
-        BadgeTrendIndicator(trend: TrendViewModel(currentValue: 400, previousValue: 100, metric: .views))
+        BadgeTrendIndicator(trend: TrendViewModel(currentValue: 400, previousValue: 100, metric: SiteMetric.views))
     }
     .padding()
 }

--- a/Modules/Sources/JetpackStats/Views/ChartValuesSummaryView.swift
+++ b/Modules/Sources/JetpackStats/Views/ChartValuesSummaryView.swift
@@ -50,11 +50,11 @@ struct ChartValuesSummaryView: View {
 #Preview {
     VStack(spacing: 20) {
         ForEach(ChartValuesSummaryView.SummaryStyle.allCases, id: \.self) { style in
-            ChartValuesSummaryView(trend: .init(currentValue: 1000, previousValue: 500, metric: .views), style: style)
-            ChartValuesSummaryView(trend: .init(currentValue: 500, previousValue: 1000, metric: .views), style: style)
-            ChartValuesSummaryView(trend: .init(currentValue: 100, previousValue: 100, metric: .views), style: style)
-            ChartValuesSummaryView(trend: .init(currentValue: 56, previousValue: 60, metric: .bounceRate), style: style)
-            ChartValuesSummaryView(trend: .init(currentValue: 42, previousValue: 0, metric: .views), style: style)
+            ChartValuesSummaryView(trend: .init(currentValue: 1000, previousValue: 500, metric: SiteMetric.views), style: style)
+            ChartValuesSummaryView(trend: .init(currentValue: 500, previousValue: 1000, metric: SiteMetric.views), style: style)
+            ChartValuesSummaryView(trend: .init(currentValue: 100, previousValue: 100, metric: SiteMetric.views), style: style)
+            ChartValuesSummaryView(trend: .init(currentValue: 56, previousValue: 60, metric: SiteMetric.bounceRate), style: style)
+            ChartValuesSummaryView(trend: .init(currentValue: 42, previousValue: 0, metric: SiteMetric.views), style: style)
             Divider()
         }
     }

--- a/Modules/Sources/JetpackStats/Views/CountryMap/CountryTooltip.swift
+++ b/Modules/Sources/JetpackStats/Views/CountryMap/CountryTooltip.swift
@@ -39,7 +39,7 @@ struct CountryTooltip: View {
         return TrendViewModel(
             currentValue: currentViews,
             previousValue: previousViews,
-            metric: .views
+            metric: SiteMetric.views
         )
     }
 

--- a/Modules/Sources/JetpackStats/Views/LegacyFloatingDateControl.swift
+++ b/Modules/Sources/JetpackStats/Views/LegacyFloatingDateControl.swift
@@ -91,7 +91,7 @@ struct LegacyFloatingDateControl: View {
         .floatingStyle()
     }
 
-    private func makeNavigationButton(direction: Calendar.NavigationDirection) -> some View {
+    private func makeNavigationButton(direction: NavigationDirection) -> some View {
         let isDisabled = !dateRange.canNavigate(in: direction)
         return Menu {
             ForEach(dateRange.availableAdjacentPeriods(in: direction)) { period in

--- a/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
+++ b/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
@@ -15,7 +15,7 @@ struct MetricsOverviewTabView<Metric: MetricType>: View {
     let data: [MetricData]
     @Binding var selectedMetric: Metric
     var onMetricSelected: ((Metric) -> Void)?
-    var showTrends: Bool = true
+    var showTrend: Bool = true
 
     @ScaledMetric(relativeTo: .title) private var minTabWidth: CGFloat = 100
 
@@ -36,7 +36,7 @@ struct MetricsOverviewTabView<Metric: MetricType>: View {
     }
 
     private func makeItemView(for item: MetricData, onTap: @escaping () -> Void) -> some View {
-        MetricItemView(data: item, isSelected: selectedMetric == item.metric, showTrend: showTrends, onTap: onTap)
+        MetricItemView(data: item, isSelected: selectedMetric == item.metric, showTrend: showTrend, onTap: onTap)
             .frame(minWidth: minTabWidth)
             .id(item.metric)
     }
@@ -99,9 +99,11 @@ private struct MetricItemView<Metric: MetricType>: View {
 
     private var headerView: some View {
         HStack(spacing: 2) {
-            Image(systemName: data.metric.systemImage)
-                .font(.caption2.weight(.medium))
-                .scaleEffect(x: 0.9, y: 0.9)
+            if showTrend {
+                Image(systemName: data.metric.systemImage)
+                    .font(.caption2.weight(.medium))
+                    .scaleEffect(x: 0.9, y: 0.9)
+            }
             Text(data.metric.localizedTitle.uppercased())
                 .font(.caption.weight(.medium))
         }

--- a/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
+++ b/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
@@ -4,17 +4,18 @@ import WordPressUI
 /// A horizontal scrollable tab view displaying metric summaries with values and trends.
 ///
 /// Each tab shows a metric's current value, percentage change, and visual selection indicator.
-struct MetricsOverviewTabView: View {
+struct MetricsOverviewTabView<Metric: MetricType>: View {
     /// Data for a single metric tab
     struct MetricData {
-        let metric: SiteMetric
+        let metric: Metric
         let value: Int?
         let previousValue: Int?
     }
 
     let data: [MetricData]
-    @Binding var selectedMetric: SiteMetric
-    var onMetricSelected: ((SiteMetric) -> Void)?
+    @Binding var selectedMetric: Metric
+    var onMetricSelected: ((Metric) -> Void)?
+    var showTrends: Bool = true
 
     @ScaledMetric(relativeTo: .title) private var minTabWidth: CGFloat = 100
 
@@ -35,12 +36,12 @@ struct MetricsOverviewTabView: View {
     }
 
     private func makeItemView(for item: MetricData, onTap: @escaping () -> Void) -> some View {
-        MetricItemView(data: item, isSelected: selectedMetric == item.metric, onTap: onTap)
+        MetricItemView(data: item, isSelected: selectedMetric == item.metric, showTrend: showTrends, onTap: onTap)
             .frame(minWidth: minTabWidth)
             .id(item.metric)
     }
 
-    private func selectDataType(_ type: SiteMetric, proxy: ScrollViewProxy) {
+    private func selectDataType(_ type: Metric, proxy: ScrollViewProxy) {
         withAnimation(.spring) {
             selectedMetric = type
             proxy.scrollTo(type, anchor: .center)
@@ -50,13 +51,14 @@ struct MetricsOverviewTabView: View {
     }
 }
 
-private struct MetricItemView: View {
-    let data: MetricsOverviewTabView.MetricData
+private struct MetricItemView<Metric: MetricType>: View {
+    let data: MetricsOverviewTabView<Metric>.MetricData
     let isSelected: Bool
+    let showTrend: Bool
     let onTap: () -> Void
 
-    private var valueFormatter: StatsValueFormatter {
-        StatsValueFormatter(metric: data.metric)
+    private var valueFormatter: any ValueFormatterProtocol {
+        data.metric.makeValueFormatter()
     }
 
     private var formattedValue: String {
@@ -117,15 +119,17 @@ private struct MetricItemView: View {
                 .lineLimit(1)
                 .animation(.spring, value: formattedValue)
 
-            if let trend {
-                BadgeTrendIndicator(trend: trend)
-            } else {
-                // Placeholder for loading state
-                BadgeTrendIndicator(
-                    trend: TrendViewModel(currentValue: 125, previousValue: 100, metric: data.metric)
-                )
-                .grayscale(1)
-                .redacted(reason: .placeholder)
+            if showTrend {
+                if let trend {
+                    BadgeTrendIndicator(trend: trend)
+                } else {
+                    // Placeholder for loading state
+                    BadgeTrendIndicator(
+                        trend: TrendViewModel(currentValue: 125, previousValue: 100, metric: data.metric)
+                    )
+                    .grayscale(1)
+                    .redacted(reason: .placeholder)
+                }
             }
         }
         .padding(.trailing, 8)
@@ -147,7 +151,7 @@ private struct MetricItemView: View {
 #if DEBUG
 
 #Preview {
-    let mockData: [MetricsOverviewTabView.MetricData] = [
+    let mockData: [MetricsOverviewTabView<SiteMetric>.MetricData] = [
         .init(metric: .views, value: 128400, previousValue: 142600),
         .init(metric: .visitors, value: 49800, previousValue: 54200),
         .init(metric: .likes, value: nil, previousValue: nil),

--- a/Modules/Sources/JetpackStats/Views/StatsDateRangeButtons.swift
+++ b/Modules/Sources/JetpackStats/Views/StatsDateRangeButtons.swift
@@ -51,7 +51,7 @@ struct StatsDatePickerToolbarItem: View {
 
 struct StatsNavigationButton: View {
     @Binding var dateRange: StatsDateRange
-    let direction: Calendar.NavigationDirection
+    let direction: NavigationDirection
 
     @Environment(\.context) var context
 

--- a/Modules/Sources/JetpackStats/Views/WordAds/WordAdsPaymentHistoryRowView.swift
+++ b/Modules/Sources/JetpackStats/Views/WordAds/WordAdsPaymentHistoryRowView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+@preconcurrency import WordPressKit
+
+struct WordAdsPaymentHistoryRowView: View {
+    let viewModel: WordAdsPaymentHistoryRowViewModel
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 0) {
+            // Period and Status
+            VStack(alignment: .leading, spacing: 2) {
+                Text(viewModel.formattedPeriod)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundColor(.primary)
+
+                statusBadge
+            }
+
+            Spacer(minLength: 6)
+
+            // Metrics
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(viewModel.formattedAmount)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundColor(.primary)
+
+                Text(viewModel.formattedAdsServed)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    private var statusBadge: some View {
+        HStack(spacing: 4) {
+            Text(viewModel.statusText)
+                .font(.caption2.weight(.medium))
+        }
+        .foregroundColor(.secondary)
+    }
+}
+
+#Preview {
+    List {
+        WordAdsPaymentHistoryRowView(
+            viewModel: WordAdsPaymentHistoryRowViewModel(
+                earning: StatsWordAdsEarningsResponse.MonthlyEarning(
+                    period: StatsWordAdsEarningsResponse.Period(year: 2025, month: 12),
+                    data: StatsWordAdsEarningsResponse.MonthlyEarningData(
+                        amount: 15.25,
+                        status: .outstanding,
+                        pageviews: "3420"
+                    )
+                )
+            )
+        )
+
+        WordAdsPaymentHistoryRowView(
+            viewModel: WordAdsPaymentHistoryRowViewModel(
+                earning: StatsWordAdsEarningsResponse.MonthlyEarning(
+                    period: StatsWordAdsEarningsResponse.Period(year: 2025, month: 8),
+                    data: StatsWordAdsEarningsResponse.MonthlyEarningData(
+                        amount: 5.50,
+                        status: .paid,
+                        pageviews: "1200"
+                    )
+                )
+            )
+        )
+    }
+    .listStyle(.plain)
+}

--- a/Modules/Sources/JetpackStats/Views/WordAds/WordAdsPaymentHistoryRowViewModel.swift
+++ b/Modules/Sources/JetpackStats/Views/WordAds/WordAdsPaymentHistoryRowViewModel.swift
@@ -1,0 +1,31 @@
+import Foundation
+@preconcurrency import WordPressKit
+
+struct WordAdsPaymentHistoryRowViewModel {
+    let earning: StatsWordAdsEarningsResponse.MonthlyEarning
+
+    var formattedPeriod: String {
+        var components = DateComponents()
+        components.year = earning.period.year
+        components.month = earning.period.month
+        components.day = 1
+
+        guard let date = Calendar.current.date(from: components) else {
+            return earning.period.string
+        }
+
+        return date.formatted(.dateTime.month(.abbreviated).year())
+    }
+
+    var formattedAmount: String {
+        earning.amount.formatted(.currency(code: "USD"))
+    }
+
+    var formattedAdsServed: String {
+        Strings.WordAds.adsServed(earning.pageviews)
+    }
+
+    var statusText: String {
+        earning.status == .paid ? Strings.WordAds.paid : Strings.WordAds.outstanding
+    }
+}

--- a/Modules/Sources/WordPressKit/StatsServiceRemoteV2.swift
+++ b/Modules/Sources/WordPressKit/StatsServiceRemoteV2.swift
@@ -395,6 +395,16 @@ public extension StatsServiceRemoteV2 {
     }
 }
 
+// MARK: - WordAds Earnings
+
+public extension StatsServiceRemoteV2 {
+    func getWordAdsEarnings() async throws -> StatsWordAdsEarningsResponse {
+        let path = self.path(forEndpoint: "sites/\(siteID)/wordads/earnings", withVersion: ._1_1)
+        let result = await wordPressComRestApi.perform(.get, URLString: path, parameters: [:], type: StatsWordAdsEarningsResponse.self)
+        return try result.get().body
+    }
+}
+
 // This serves both as a way to get the query properties in a "nice" way,
 // but also as a way to narrow down the generic type in `getInsight(completion:)` method.
 public protocol StatsInsightData {

--- a/Modules/Sources/WordPressKit/StatsWordAdsEarningsResponse.swift
+++ b/Modules/Sources/WordPressKit/StatsWordAdsEarningsResponse.swift
@@ -1,0 +1,158 @@
+import Foundation
+
+public struct StatsWordAdsEarningsResponse: Decodable {
+    public let totalEarnings: Decimal
+    public let totalAmountOwed: Decimal
+    public let wordAdsEarnings: [MonthlyEarning]
+
+    private enum CodingKeys: String, CodingKey {
+        case earnings
+    }
+
+    private struct EarningsContainer: Decodable {
+        let totalEarnings: FlexibleDecimal
+        let totalAmountOwed: FlexibleDecimal
+        let wordads: [String: MonthlyEarningData]
+
+        private enum CodingKeys: String, CodingKey {
+            case totalEarnings = "total_earnings"
+            case totalAmountOwed = "total_amount_owed"
+            case wordads
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let earningsContainer = try container.decode(EarningsContainer.self, forKey: .earnings)
+        totalEarnings = earningsContainer.totalEarnings.value
+        totalAmountOwed = earningsContainer.totalAmountOwed.value
+
+        // Convert dictionary to sorted array
+        var earnings = earningsContainer.wordads.compactMap { (period, data) -> MonthlyEarning? in
+            guard let parsedPeriod = Period(string: period) else { return nil }
+            return MonthlyEarning(period: parsedPeriod, data: data)
+        }
+        earnings.sort { $0.period > $1.period }
+        wordAdsEarnings = earnings
+    }
+
+    public struct MonthlyEarning {
+        public let period: Period
+        public let amount: Decimal
+        public let status: PaymentStatus
+        public let pageviews: String
+
+        public init(period: Period, data: MonthlyEarningData) {
+            self.period = period
+            self.amount = data.amount
+            self.status = data.status
+            self.pageviews = data.pageviews
+        }
+    }
+
+    public struct MonthlyEarningData: Decodable {
+        private let _amount: FlexibleDecimal
+        private let _status: FlexiblePaymentStatus
+
+        public let pageviews: String
+
+        public var amount: Decimal { _amount.value }
+        public var status: PaymentStatus { _status.value }
+
+        public init(amount: Decimal, status: PaymentStatus, pageviews: String) {
+            self._amount = FlexibleDecimal(value: amount)
+            self._status = FlexiblePaymentStatus(value: status)
+            self.pageviews = pageviews
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case _amount = "amount"
+            case _status = "status"
+            case pageviews
+        }
+    }
+
+    public enum PaymentStatus: Equatable {
+        case paid
+        case outstanding
+    }
+
+    public struct Period: Equatable, Comparable, Hashable {
+        public let year: Int
+        public let month: Int
+
+        public init(year: Int, month: Int) {
+            self.year = year
+            self.month = month
+        }
+
+        init?(string: String) {
+            let components = string.split(separator: "-")
+            guard components.count == 2,
+                  let year = Int(components[0]),
+                  let month = Int(components[1]),
+                  (1...12).contains(month) else {
+                return nil
+            }
+            self.year = year
+            self.month = month
+        }
+
+        public var string: String {
+            String(format: "%04d-%02d", year, month)
+        }
+
+        public static func < (lhs: Period, rhs: Period) -> Bool {
+            (lhs.year, lhs.month) < (rhs.year, rhs.month)
+        }
+    }
+}
+
+// MARK: - Decoding Helpers
+
+private struct FlexibleDecimal: Decodable {
+    let value: Decimal
+
+    init(value: Decimal) {
+        self.value = value
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let stringValue = try? container.decode(String.self), let decimal = Decimal(string: stringValue) {
+            value = decimal
+        } else if let doubleValue = try? container.decode(Double.self) {
+            value = Decimal(doubleValue)
+        } else if let intValue = try? container.decode(Int.self) {
+            value = Decimal(intValue)
+        } else {
+            throw DecodingError.typeMismatch(Decimal.self, DecodingError.Context(
+                codingPath: container.codingPath,
+                debugDescription: "Expected string or number"
+            ))
+        }
+    }
+}
+
+private struct FlexiblePaymentStatus: Decodable {
+    let value: StatsWordAdsEarningsResponse.PaymentStatus
+
+    init(value: StatsWordAdsEarningsResponse.PaymentStatus) {
+        self.value = value
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let stringValue = try? container.decode(String.self) {
+            value = stringValue == "1" ? .paid : .outstanding
+        } else if let intValue = try? container.decode(Int.self) {
+            value = intValue == 1 ? .paid : .outstanding
+        } else {
+            throw DecodingError.typeMismatch(StatsWordAdsEarningsResponse.PaymentStatus.self, DecodingError.Context(
+                codingPath: container.codingPath,
+                debugDescription: "Expected string or int"
+            ))
+        }
+    }
+}

--- a/Modules/Sources/WordPressKit/StatsWordAdsResponse.swift
+++ b/Modules/Sources/WordPressKit/StatsWordAdsResponse.swift
@@ -107,8 +107,7 @@ private func makeDateFormatter(for unit: StatsPeriodUnit) -> DateFormatter {
     formatter.dateFormat = {
         switch unit {
         case .hour: "yyyy-MM-dd HH:mm:ss"
-        case .week: "yyyy'W'MM'W'dd"
-        case .day, .month, .year: "yyyy-MM-dd"
+        case .day, .week, .month, .year: "yyyy-MM-dd"
         }
     }()
     return formatter

--- a/Modules/Sources/WordPressUI/Views/AdaptiveTabBarController.swift
+++ b/Modules/Sources/WordPressUI/Views/AdaptiveTabBarController.swift
@@ -86,7 +86,13 @@ public final class AdaptiveTabBarController<Item: AdaptiveTabBarItem> {
 
         if viewController.traitCollection.horizontalSizeClass == .regular {
             filterBarContainer.removeFromSuperview()
-            (navigationItem ?? viewController.navigationItem).leftBarButtonItem = UIBarButtonItem(customView: segmentedControl)
+            (navigationItem ?? viewController.navigationItem).leftBarButtonItem = {
+                let button = UIBarButtonItem(customView: segmentedControl)
+                if #available(iOS 26.0, *) {
+                    button.hidesSharedBackground = true
+                }
+                return button
+            }()
             viewController.additionalSafeAreaInsets = .zero
         } else {
             viewController.navigationItem.titleView = nil

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 26.7
 -----
-* [**] Stats: Add new "Adds" tab to show WordAdds statistics [#25165]
+* [**] Stats: Add new "Adds" tab to show WordAdds earnings and stats [#25165]
 
 26.6
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 26.7
 -----
-
+* [**] Stats: Add new "Adds" tab to show WordAdds statistics [#25165]
 
 26.6
 -----

--- a/Tests/WordPressKitTests/WordPressKitTests/Mock Data/stats-wordads-earnings.json
+++ b/Tests/WordPressKitTests/WordPressKitTests/Mock Data/stats-wordads-earnings.json
@@ -1,0 +1,38 @@
+{
+    "ID": 456123789,
+    "name": "Example",
+    "URL": "https://example.wordpress.com",
+    "earnings": {
+        "total_earnings": "42.67",
+        "total_amount_owed": "38.40",
+        "wordads": {
+            "2025-12": {
+                "amount": 15.25,
+                "status": "0",
+                "pageviews": "3420"
+            },
+            "2025-11": {
+                "amount": 12.80,
+                "status": "0",
+                "pageviews": "2890"
+            },
+            "2025-10": {
+                "amount": 8.45,
+                "status": "0",
+                "pageviews": "1950"
+            },
+            "2025-09": {
+                "amount": 6.17,
+                "status": "0",
+                "pageviews": "1420"
+            },
+            "2025-08": {
+                "amount": 5.50,
+                "status": "1",
+                "pageviews": "1200"
+            }
+        },
+        "sponsored": [],
+        "adjustment": []
+    }
+}

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/StatsRemoteV2Tests.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/StatsRemoteV2Tests.swift
@@ -29,6 +29,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
     let getArchivesDataFilename = "stats-archives-data.json"
     let getEmailOpensFilename = "stats-email-opens.json"
     let getWordAdsMonthMockFilename = "stats-wordads-month.json"
+    let getWordAdsEarningsFilename = "stats-wordads-earnings.json"
 
     // MARK: - Properties
 
@@ -48,6 +49,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
     var siteArchivesDataEndpoint: String { return "sites/\(siteID)/stats/archives" }
     var siteEmailOpensEndpoint: String { return "sites/\(siteID)/stats/opens/emails/231/rate" }
     var siteWordAdsEndpoint: String { return "sites/\(siteID)/wordads/stats" }
+    var siteWordAdsEarningsEndpoint: String { return "sites/\(siteID)/wordads/earnings" }
 
     func toggleSpamStateEndpoint(for referrerDomain: String, markAsSpam: Bool) -> String {
         let action = markAsSpam ? "new" : "delete"
@@ -907,7 +909,67 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
         XCTAssertEqual(data[2][.impressions], 174.0)
         XCTAssertEqual(data[2][.revenue], 0.01)
         XCTAssertEqual(data[2][.cpm], 0.06)
+    }
 
+    func testWordAdsEarnings() async throws {
+        stubRemoteResponse(siteWordAdsEarningsEndpoint, filename: getWordAdsEarningsFilename, contentType: .ApplicationJSON)
 
+        let response = try await remote.getWordAdsEarnings()
+
+        // Test total earnings
+        XCTAssertEqual(response.totalEarnings, Decimal(string: "42.67"))
+        XCTAssertEqual(response.totalAmountOwed, Decimal(string: "38.40"))
+
+        // Test monthly earnings count
+        XCTAssertEqual(response.wordAdsEarnings.count, 5)
+
+        // Test monthly earnings are sorted by period descending (most recent first)
+        XCTAssertEqual(response.wordAdsEarnings[0].period, StatsWordAdsEarningsResponse.Period(year: 2025, month: 12))
+        XCTAssertEqual(response.wordAdsEarnings[1].period, StatsWordAdsEarningsResponse.Period(year: 2025, month: 11))
+        XCTAssertEqual(response.wordAdsEarnings[2].period, StatsWordAdsEarningsResponse.Period(year: 2025, month: 10))
+        XCTAssertEqual(response.wordAdsEarnings[3].period, StatsWordAdsEarningsResponse.Period(year: 2025, month: 9))
+
+        // Test first month (December 2025)
+        let decEarnings = response.wordAdsEarnings[0]
+        XCTAssertEqual(decEarnings.period.year, 2025)
+        XCTAssertEqual(decEarnings.period.month, 12)
+        XCTAssertEqual(decEarnings.amount, Decimal(string: "15.25"))
+        XCTAssertEqual(decEarnings.status, .outstanding)
+        XCTAssertEqual(decEarnings.pageviews, "3420")
+
+        // Test second month (November 2025)
+        let novEarnings = response.wordAdsEarnings[1]
+        XCTAssertEqual(novEarnings.period.year, 2025)
+        XCTAssertEqual(novEarnings.period.month, 11)
+        XCTAssertEqual(novEarnings.amount, Decimal(string: "12.80"))
+        XCTAssertEqual(novEarnings.status, .outstanding)
+        XCTAssertEqual(novEarnings.pageviews, "2890")
+
+        // Test third month (October 2025)
+        let octEarnings = response.wordAdsEarnings[2]
+        XCTAssertEqual(octEarnings.period.year, 2025)
+        XCTAssertEqual(octEarnings.period.month, 10)
+        XCTAssertEqual(octEarnings.amount, Decimal(string: "8.45"))
+        XCTAssertEqual(octEarnings.status, .outstanding)
+        XCTAssertEqual(octEarnings.pageviews, "1950")
+
+        // Test fourth month (September 2025)
+        let sepEarnings = response.wordAdsEarnings[3]
+        XCTAssertEqual(sepEarnings.period.year, 2025)
+        XCTAssertEqual(sepEarnings.period.month, 9)
+        XCTAssertEqual(sepEarnings.amount, Decimal(string: "6.17"))
+        XCTAssertEqual(sepEarnings.status, .outstanding)
+        XCTAssertEqual(sepEarnings.pageviews, "1420")
+
+        // Test fifth month (August 2025) - with paid status
+        let augEarnings = response.wordAdsEarnings[4]
+        XCTAssertEqual(augEarnings.period.year, 2025)
+        XCTAssertEqual(augEarnings.period.month, 8)
+        XCTAssertEqual(augEarnings.amount, Decimal(string: "5.50"))
+        XCTAssertEqual(augEarnings.status, .paid)
+        XCTAssertEqual(augEarnings.pageviews, "1200")
+
+        // Test Period string conversion
+        XCTAssertEqual(decEarnings.period.string, "2025-12")
     }
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent+JetpackStats.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent+JetpackStats.swift
@@ -9,6 +9,7 @@ extension StatsEvent {
         case .trafficTabShown: .jetpackStatsTrafficTabShown
         case .realtimeTabShown: .jetpackStatsRealtimeTabShown
         case .subscribersTabShown: .jetpackStatsSubscribersTabShown
+        case .adsTabShown: .jetpackStatsAdsTabShown
         case .postDetailsScreenShown: .jetpackStatsPostDetailsScreenShown
         case .authorStatsScreenShown: .jetpackStatsAuthorStatsScreenShown
         case .archiveStatsScreenShown: .jetpackStatsArchiveStatsScreenShown

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -641,6 +641,7 @@ import WordPressShared
     case jetpackStatsTrafficTabShown
     case jetpackStatsRealtimeTabShown
     case jetpackStatsSubscribersTabShown
+    case jetpackStatsAdsTabShown
     case jetpackStatsPostDetailsScreenShown
     case jetpackStatsAuthorStatsScreenShown
     case jetpackStatsArchiveStatsScreenShown
@@ -1789,6 +1790,8 @@ import WordPressShared
             return "jetpack_stats_realtime_tab_shown"
         case .jetpackStatsSubscribersTabShown:
             return "jetpack_stats_subscribers_tab_shown"
+        case .jetpackStatsAdsTabShown:
+            return "jetpack_stats_ads_tab_shown"
         case .jetpackStatsPostDetailsScreenShown:
             return "jetpack_stats_post_details_screen_shown"
         case .jetpackStatsAuthorStatsScreenShown:

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -192,7 +192,9 @@ public class SiteStatsDashboardViewController: UIViewController {
 
         switch currentSelectedTab {
         case .insights:
-            parent?.navigationItem.rightBarButtonItem = manageInsightsButton
+            parent?.navigationItem.trailingItemGroups = [
+                UIBarButtonItemGroup.fixedGroup(items: [manageInsightsButton])
+            ]
         case .traffic:
             // Always show the menu for switching between stats experiences
             statsMenuButton.menu = createStatsMenu()
@@ -212,9 +214,9 @@ public class SiteStatsDashboardViewController: UIViewController {
                 }
             }
         case .ads:
-            parent?.navigationItem.rightBarButtonItem = nil
+            parent?.navigationItem.trailingItemGroups = []
         default:
-            parent?.navigationItem.rightBarButtonItem = nil
+            parent?.navigationItem.trailingItemGroups = []
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/SiteStatsDashboardViewController.swift
@@ -147,11 +147,11 @@ public class SiteStatsDashboardViewController: UIViewController {
         return StatsSubscribersViewController(viewModel: viewModel)
     }()
 
-    private lazy var adsViewController: UIViewController = {
-        let adsView = AdsTabView()
-        let hostingController = UIHostingController(rootView: adsView)
-        hostingController.view.backgroundColor = .systemBackground
-        return hostingController
+    private lazy var adsViewController: UIViewController? = {
+        guard let blog = Self.currentBlog() else {
+            return nil
+        }
+        return StatsHostingViewController.makeAdsViewController(blog: blog, parentViewController: self)
     }()
 
     // MARK: - View
@@ -461,7 +461,9 @@ private extension SiteStatsDashboardViewController {
             }
         case .ads:
             if oldSelectedTab != .ads || containerIsEmpty {
-                showChildViewController(adsViewController)
+                if let adsViewController {
+                    showChildViewController(adsViewController)
+                }
             }
         }
     }

--- a/WordPress/Classes/ViewRelated/Stats/StatsHostingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/StatsHostingViewController.swift
@@ -41,6 +41,20 @@ class StatsHostingViewController: UIViewController {
         statsVC.navigationItem.largeTitleDisplayMode = .never
         return statsVC
     }
+
+    static func makeAdsViewController(blog: Blog, parentViewController: UIViewController) -> UIViewController? {
+        guard let context = StatsContext(blog: blog) else {
+            return nil
+        }
+
+        let adsView = AdsTabView(
+            context: context,
+            router: StatsRouter(viewController: parentViewController)
+        )
+        let hostingController = UIHostingController(rootView: adsView)
+        hostingController.view.backgroundColor = .systemBackground
+        return hostingController
+    }
 }
 
 extension StatsContext {

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -30,7 +30,7 @@
     [super viewDidLoad];
 
     self.view.backgroundColor = [UIColor systemGroupedBackgroundColor];
-    self.navigationItem.title = NSLocalizedString(@"Stats", @"Stats window title");
+    [self updateNavigationTitle];
 
     self.siteStatsDashboardVC = [[SiteStatsDashboardViewController alloc] init];
 
@@ -54,6 +54,8 @@
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(reachabilityChanged:) name:kTMReachabilityChangedNotification object:ReachabilityUtils.internetReachability];
 
+    [self registerForTraitChanges:@[UITraitHorizontalSizeClass.class] withAction:@selector(updateNavigationTitle)];
+
     [self initStats];
 }
 
@@ -62,6 +64,15 @@
     [super viewDidAppear:animated];
 
     [ObjCBridge incrementSignificantEvent];
+}
+
+- (void)updateNavigationTitle
+{
+    if (self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact) {
+        self.navigationItem.title = NSLocalizedString(@"Stats", @"Stats window title");
+    } else {
+        self.navigationItem.title = nil;
+    }
 }
 
 - (void)setBlog:(Blog *)blog


### PR DESCRIPTION
## Description

Closes [CMM-1132: Add WordAds revenue stats to Jetpack app](https://linear.app/a8c/issue/CMM-1132/add-wordads-revenue-stats-to-jetpack-app).

This PR adds the main bar chart view for the WordAds tab. Since the WordAds API doesn't support custom date periods, it uses a simplified version of the chart (`SimpleBarChartView`). Unlike the production version of `BarChartView`, I made it use the new `MetricType` protocol, so it's fully generalized.

## Testing instructions

I used one of the production accounts and made sure the data matches for all the available date periods and granularity options.

## Screenshots & Recording

<img width="456" height="972" alt="Screenshot 2026-01-23 at 4 20 50 PM" src="https://github.com/user-attachments/assets/59d8a740-02dc-4260-91a2-0f40eb9622e1" />

https://github.com/user-attachments/assets/02eaac09-2602-4ac5-8d76-e73543006268

