### PR TITLE
fix: Invalidate editor cache when plugins feature flag changes

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "dc6a09055cd83c98ea9491f1049daa2890dfd7ada78f143c12a9e2274d443cdb",
+  "originHash" : "ab0556fecab7b57b8b994011f8d8349c6aa75d7a0e65d4c94bbc33045ebece90",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,7 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "6c3a438dc9a6e5dbe118810d9b98052086261a0b"
+        "revision" : "58f3d0cafa3e2d35fabf3609a9946b71fa6c70a7",
+        "version" : "0.13.1"
       }
     },
     {

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "024ca0929c05dc22af0ce33abb347be2db737ddaa09348ee3a09c1181b56a628",
+  "originHash" : "dc6a09055cd83c98ea9491f1049daa2890dfd7ada78f143c12a9e2274d443cdb",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,8 +149,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "8addad7fd018985dd3f8b15cfcc0d028cdc189b3",
-        "version" : "0.13.0"
+        "revision" : "6c3a438dc9a6e5dbe118810d9b98052086261a0b"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/wpxmlrpc", from: "0.9.0"),
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "6c3a438dc9a6e5dbe118810d9b98052086261a0b"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.13.1"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20260114"),
         .package(

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/wpxmlrpc", from: "0.9.0"),
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.13.0"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "6c3a438dc9a6e5dbe118810d9b98052086261a0b"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20260114"),
         .package(

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -128,7 +128,9 @@ final class BlogDashboardViewModel {
     }
 
     func viewWillAppear() {
-        EditorDependencyManager.shared.prefetchDependencies(for: self.blog)
+        if RemoteFeatureFlag.newGutenberg.enabled() {
+            EditorDependencyManager.shared.prefetchDependencies(for: self.blog)
+        }
         quickActionsViewModel.viewWillAppear()
     }
 
@@ -146,7 +148,9 @@ final class BlogDashboardViewModel {
         self.loadCardsFromCache()
         self.loadCards()
 
-        EditorDependencyManager.shared.prefetchDependencies(for: blog)
+        if RemoteFeatureFlag.newGutenberg.enabled() {
+            EditorDependencyManager.shared.prefetchDependencies(for: blog)
+        }
     }
 
     func clearEditorCache(_ completion: @escaping () -> Void) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -189,26 +189,27 @@ final class BlogDashboardViewModel {
 
 private extension BlogDashboardViewModel {
 
-    /// Warms up the editor for the given blog if it hasn't been warmed up already.
-    /// This avoids duplicative warmups when the site hasn't changed.
+    /// Warms up the editor for the given blog.
+    ///
+    /// This performs two operations:
+    /// 1. WebKit warmup (once per blog) - pre-compiles HTML/JS
+    /// 2. Data prefetch (always called) - fetches settings, assets, preload list
+    ///
+    /// The prefetch is always called because `EditorDependencyManager` handles its own
+    /// caching and needs to detect when the plugins feature flag changes.
     func warmUpEditorIfNeeded(for blog: Blog) {
         guard RemoteFeatureFlag.newGutenberg.enabled() else {
             return
         }
 
-        guard blog.objectID != Self.lastWarmedUpBlogID else {
-            // Editor already warmed up for this blog
-            return
+        // WebKit warmup - only needed once per blog (shaves ~100-200ms)
+        if blog.objectID != Self.lastWarmedUpBlogID {
+            Self.lastWarmedUpBlogID = blog.objectID
+            let configuration = EditorConfiguration(blog: blog)
+            GutenbergKit.EditorViewController.warmup(configuration: configuration)
         }
 
-        Self.lastWarmedUpBlogID = blog.objectID
-
-        let configuration = EditorConfiguration(blog: blog)
-
-        // WebKit warmup - pre-compile HTML/JS (shaves ~100-200ms)
-        GutenbergKit.EditorViewController.warmup(configuration: configuration)
-
-        // Data prefetch - pre-fetch settings, assets, preload list
+        // Data prefetch - always call to allow EditorDependencyManager to detect flag changes
         EditorDependencyManager.shared.prefetchDependencies(for: blog)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/ViewModel/BlogDashboardViewModel.swift
@@ -1,6 +1,7 @@
 import Foundation
 import UIKit
 import CoreData
+import GutenbergKit
 import WordPressData
 import WordPressKit
 import WordPressCore
@@ -29,6 +30,9 @@ final class BlogDashboardViewModel {
     private let managedObjectContext: NSManagedObjectContext
 
     private var blog: Blog
+
+    /// Tracks the last blog for which the editor was warmed up to avoid redundant warmups.
+    private static var lastWarmedUpBlogID: NSManagedObjectID?
 
     private var error: Error?
 
@@ -128,9 +132,7 @@ final class BlogDashboardViewModel {
     }
 
     func viewWillAppear() {
-        if RemoteFeatureFlag.newGutenberg.enabled() {
-            EditorDependencyManager.shared.prefetchDependencies(for: self.blog)
-        }
+        warmUpEditorIfNeeded(for: self.blog)
         quickActionsViewModel.viewWillAppear()
     }
 
@@ -148,9 +150,7 @@ final class BlogDashboardViewModel {
         self.loadCardsFromCache()
         self.loadCards()
 
-        if RemoteFeatureFlag.newGutenberg.enabled() {
-            EditorDependencyManager.shared.prefetchDependencies(for: blog)
-        }
+        warmUpEditorIfNeeded(for: blog)
     }
 
     func clearEditorCache(_ completion: @escaping () -> Void) {
@@ -188,6 +188,29 @@ final class BlogDashboardViewModel {
 // MARK: - Private methods
 
 private extension BlogDashboardViewModel {
+
+    /// Warms up the editor for the given blog if it hasn't been warmed up already.
+    /// This avoids duplicative warmups when the site hasn't changed.
+    func warmUpEditorIfNeeded(for blog: Blog) {
+        guard RemoteFeatureFlag.newGutenberg.enabled() else {
+            return
+        }
+
+        guard blog.objectID != Self.lastWarmedUpBlogID else {
+            // Editor already warmed up for this blog
+            return
+        }
+
+        Self.lastWarmedUpBlogID = blog.objectID
+
+        let configuration = EditorConfiguration(blog: blog)
+
+        // WebKit warmup - pre-compile HTML/JS (shaves ~100-200ms)
+        GutenbergKit.EditorViewController.warmup(configuration: configuration)
+
+        // Data prefetch - pre-fetch settings, assets, preload list
+        EditorDependencyManager.shared.prefetchDependencies(for: blog)
+    }
 
     func registerNotifications() {
         NotificationCenter.default.addObserver(self, selector: #selector(showDraftsCardIfNeeded), name: .newPostCreated, object: nil)

--- a/WordPress/Classes/ViewRelated/Post/Controllers/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Controllers/PostListViewController.swift
@@ -40,7 +40,7 @@ final class PostListViewController: AbstractPostListViewController, InteractiveP
             self?.handleRefreshNoResultsViewController($0)
         }
 
-        if let blog = self.blog {
+        if let blog = self.blog, RemoteFeatureFlag.newGutenberg.enabled() {
             EditorDependencyManager.shared.prefetchDependencies(for: blog)
         }
     }

--- a/WordPress/Classes/ViewRelated/Post/Controllers/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Controllers/PostListViewController.swift
@@ -39,6 +39,10 @@ final class PostListViewController: AbstractPostListViewController, InteractiveP
         refreshNoResultsViewController = { [weak self] in
             self?.handleRefreshNoResultsViewController($0)
         }
+
+        if let blog = self.blog, RemoteFeatureFlag.newGutenberg.enabled() {
+            EditorDependencyManager.shared.prefetchDependencies(for: blog)
+        }
     }
 
     private lazy var createButtonCoordinator: CreateButtonCoordinator = {

--- a/WordPress/Classes/ViewRelated/Post/Controllers/PostListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Controllers/PostListViewController.swift
@@ -39,10 +39,6 @@ final class PostListViewController: AbstractPostListViewController, InteractiveP
         refreshNoResultsViewController = { [weak self] in
             self?.handleRefreshNoResultsViewController($0)
         }
-
-        if let blog = self.blog, RemoteFeatureFlag.newGutenberg.enabled() {
-            EditorDependencyManager.shared.prefetchDependencies(for: blog)
-        }
     }
 
     private lazy var createButtonCoordinator: CreateButtonCoordinator = {


### PR DESCRIPTION
## Description

Fix CMM-1174. 

This PR fixes an issue where block editor plugins fail to load on fresh app install when the `gutenberg_kit_plugins` feature flag is toggled after the editor dependencies have been prefetched.

**Root cause:** When the app launches, `EditorDependencyManager` prefetches editor dependencies including asset bundles. If the plugins flag is disabled at that time, an empty asset bundle is cached. When the user later enables the flag and opens the editor, the stale cached empty bundle is used, causing the "Loading plugins failed" notice.

**Solution:** 
1. Track the `newGutenbergPlugins` flag value when caching dependencies
2. On each prefetch call, check if the flag value has changed since the last cache
3. If changed, invalidate all cached entries and re-prefetch with the current flag state

Additionally, this PR consolidates editor warmup logic:
- Moved `warmUpEditorIfNeeded` from `MySiteViewController` to `BlogDashboardViewModel`
- Removed redundant prefetch call from `PostListViewController`
- Ensured `prefetchDependencies` is always called (not guarded by blog change) so flag changes can be detected

## Testing instructions

1. Fresh install the app
2. Enable the Experimental Block Editor feature flag 
3. Ensure `gutenberg_kit_plugins` feature flag is **disabled** via the debug menu
4. Navigate to My Site (this triggers the prefetch with empty bundle)
5. Enable the `gutenberg_kit_plugins` feature flag via debug menu
6. Navigate away from and back to My Site (this triggers the prefetch with a populated bundle) 
7. Open the block editor
8. **Expected:** Plugins load successfully (no "Loading plugins failed" notice)
9. **Previous behavior:** "Loading plugins failed" notice appeared