### PR TITLE
Add WordAds Payment History

### DIFF
--- a/Modules/Sources/JetpackStats/Analytics/StatsEvent.swift
+++ b/Modules/Sources/JetpackStats/Analytics/StatsEvent.swift
@@ -29,6 +29,9 @@ public enum StatsEvent {
     /// Subscribers tab shown
     case subscribersTabShown
 
+    /// Ads tab shown
+    case adsTabShown
+
     /// Post details screen shown
     case postDetailsScreenShown
 

--- a/Modules/Sources/JetpackStats/Cards/WordAdsChartCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/WordAdsChartCard.swift
@@ -10,7 +10,7 @@ struct WordAdsChartCard: View {
         VStack(spacing: 0) {
             header
                 .padding(.horizontal, Constants.step3)
-                .padding(.top, Constants.step3)
+                .padding(.top, Constants.step2)
                 .padding(.bottom, Constants.step1)
 
             chartArea
@@ -18,7 +18,7 @@ struct WordAdsChartCard: View {
                 .padding(.horizontal, Constants.step2)
                 .padding(.vertical, Constants.step2)
                 .animation(.spring, value: viewModel.selectedMetric)
-                .animation(.easeInOut, value: viewModel.isFirstLoad)
+                .animation(.easeInOut, value: viewModel.isLoading)
 
             Divider()
 
@@ -74,6 +74,7 @@ struct WordAdsChartCard: View {
                 loadingErrorView(with: Strings.Chart.empty)
             } else {
                 chartView(data: data)
+                    .opacity(viewModel.isLoading ? 0.3 : 1.0)
                     .transition(.opacity.combined(with: .scale(scale: 0.97)))
             }
         } else {
@@ -82,21 +83,21 @@ struct WordAdsChartCard: View {
     }
 
     private var loadingView: some View {
-        SimpleBarChartView(
-            data: SimpleChartData.mock(
-                metric: viewModel.selectedMetric,
-                granularity: viewModel.selectedGranularity,
-                dataPointCount: viewModel.selectedGranularity.preferredQuantity
-            ),
-            selectedDate: nil,
-            onBarTapped: { _ in }
-        )
-        .redacted(reason: .placeholder)
-        .opacity(0.2)
-        .pulsating()
+        mockChartView
+            .opacity(0.2)
+            .pulsating()
     }
 
     private func loadingErrorView(with message: String) -> some View {
+        mockChartView
+            .grayscale(1)
+            .opacity(0.1)
+            .overlay {
+                SimpleErrorView(message: message)
+            }
+    }
+
+    private var mockChartView: some View {
         SimpleBarChartView(
             data: SimpleChartData.mock(
                 metric: viewModel.selectedMetric,
@@ -107,11 +108,6 @@ struct WordAdsChartCard: View {
             onBarTapped: { _ in }
         )
         .redacted(reason: .placeholder)
-        .grayscale(1)
-        .opacity(0.1)
-        .overlay {
-            SimpleErrorView(message: message)
-        }
     }
 
     private func chartView(data: SimpleChartData) -> some View {
@@ -128,13 +124,15 @@ struct WordAdsChartCard: View {
 
     private var footer: some View {
         MetricsOverviewTabView(
-            data: viewModel.tabViewData,
+            data: viewModel.isFirstLoad ? viewModel.placeholderTabViewData : viewModel.tabViewData,
             selectedMetric: $viewModel.selectedMetric,
             onMetricSelected: { metric in
                 viewModel.onMetricSelected(metric)
             },
             showTrend: false
         )
+        .redacted(reason: viewModel.isLoading ? .placeholder : [])
+        .pulsating(viewModel.isLoading)
         .background(
             CardGradientBackground(metric: viewModel.selectedMetric)
         )

--- a/Modules/Sources/JetpackStats/Cards/WordAdsChartCardViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/WordAdsChartCardViewModel.swift
@@ -7,6 +7,7 @@ final class WordAdsChartCardViewModel: ObservableObject {
 
     @Published private(set) var chartData: [WordAdsMetric: SimpleChartData] = [:]
     @Published private(set) var isFirstLoad = true
+    @Published private(set) var isLoading = false
     @Published private(set) var loadingError: Error?
 
     @Published var selectedMetric: WordAdsMetric = .impressions
@@ -56,6 +57,12 @@ final class WordAdsChartCardViewModel: ObservableObject {
         chartData[selectedMetric]
     }
 
+    var placeholderTabViewData: [MetricsOverviewTabView<WordAdsMetric>.MetricData] {
+        WordAdsMetric.allMetrics.map { metric in
+            .init(metric: metric, value: 12345, previousValue: nil)
+        }
+    }
+
     // MARK: - Initialization
 
     init(service: any StatsServiceProtocol) {
@@ -95,10 +102,13 @@ final class WordAdsChartCardViewModel: ObservableObject {
         // Cancel any existing load task
         loadTask?.cancel()
 
+        withAnimation {
+            isLoading = true
+            loadingError = nil
+        }
+
         loadTask = Task { [weak self] in
             guard let self else { return }
-
-            self.loadingError = nil
 
             do {
                 let response = try await service.getWordAdsStats(
@@ -126,8 +136,11 @@ final class WordAdsChartCardViewModel: ObservableObject {
                     }
                 }
 
-                self.chartData = newChartData
-                self.isFirstLoad = false
+                withAnimation {
+                    self.chartData = newChartData
+                    self.isFirstLoad = false
+                    self.isLoading = false
+                }
 
                 // Automatically select the latest period if no selection exists
                 if self.selectedBarDate == nil, let latestDate = newChartData[self.selectedMetric]?.currentData.last?.date {
@@ -135,8 +148,11 @@ final class WordAdsChartCardViewModel: ObservableObject {
                 }
             } catch {
                 guard !Task.isCancelled else { return }
-                self.loadingError = error
-                self.isFirstLoad = false
+                withAnimation {
+                    self.loadingError = error
+                    self.isFirstLoad = false
+                    self.isLoading = false
+                }
             }
         }
     }

--- a/Modules/Sources/JetpackStats/Cards/WordAdsEarningsTotalsCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/WordAdsEarningsTotalsCard.swift
@@ -55,11 +55,7 @@ struct WordAdsEarningsTotalsCard: View {
 
     private var totalEarningsValue: String {
         guard let value = metricsData?.totalEarnings else { return "–" }
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .currency
-        formatter.currencyCode = "USD"
-        formatter.maximumFractionDigits = 2
-        return formatter.string(from: value as NSDecimalNumber) ?? "$0.00"
+        return value.formatted(.currency(code: "USD"))
     }
 
     private var metricsData: EarningsMetricsData? {
@@ -100,11 +96,7 @@ private struct SecondaryMetricView: View {
 
     private var displayValue: String {
         guard let value else { return "–" }
-        let formatter = NumberFormatter()
-        formatter.numberStyle = .currency
-        formatter.currencyCode = "USD"
-        formatter.maximumFractionDigits = 2
-        return formatter.string(from: value as NSDecimalNumber) ?? "$0.00"
+        return value.formatted(.currency(code: "USD"))
     }
 }
 

--- a/Modules/Sources/JetpackStats/Cards/WordAdsEarningsTotalsCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/WordAdsEarningsTotalsCard.swift
@@ -1,0 +1,129 @@
+import SwiftUI
+import WordPressKit
+
+struct WordAdsEarningsTotalsCard: View {
+    @ObservedObject var viewModel: WordAdsEarningsViewModel
+
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Constants.step2) {
+            StatsCardTitleView(title: Strings.WordAds.totalEarnings)
+
+            EarningsMetricsStrip(data: metricsData)
+                .redacted(reason: viewModel.isFirstLoad ? .placeholder : [])
+        }
+        .padding(Constants.step2)
+        .cardStyle()
+        .overlay(alignment: .topTrailing) {
+            moreMenu
+        }
+    }
+
+    private var moreMenu: some View {
+        Menu {
+            Link(destination: URL(string: "https://wordpress.com/support/wordads-and-earn/track-your-ads/")!) {
+                Label(Strings.WordAds.learnMore, systemImage: "info.circle")
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.system(size: 15))
+                .foregroundColor(.secondary)
+                .frame(width: 50, height: 50)
+        }
+        .tint(Color.primary)
+    }
+
+    private var metricsData: EarningsMetricsData? {
+        if let earnings = viewModel.earnings {
+            return EarningsMetricsData(
+                totalEarnings: earnings.totalEarnings,
+                paid: earnings.totalEarnings - earnings.totalAmountOwed,
+                outstanding: earnings.totalAmountOwed
+            )
+        } else if viewModel.isFirstLoad {
+            return .mockData
+        } else {
+            return nil
+        }
+    }
+}
+
+// MARK: - Earnings Metrics Strip
+
+private struct EarningsMetricsStrip: View {
+    let data: EarningsMetricsData?
+
+    var body: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: Constants.step3) {
+                MetricView(
+                    title: Strings.WordAds.earnings,
+                    value: data?.totalEarnings
+                )
+                MetricView(
+                    title: Strings.WordAds.paid,
+                    value: data?.paid
+                )
+                MetricView(
+                    title: Strings.WordAds.outstanding,
+                    value: data?.outstanding
+                )
+            }
+        }
+    }
+
+    struct MetricView: View {
+        let title: String
+        let value: Decimal?
+
+        var body: some View {
+            VStack(alignment: .leading, spacing: 0) {
+                Text(title.uppercased())
+                    .font(.caption.weight(.medium))
+                    .foregroundColor(.secondary)
+
+                Text(displayValue)
+                    .contentTransition(.numericText())
+                    .font(Font.make(.recoleta, textStyle: .title, weight: .medium))
+                    .foregroundColor(.primary)
+                    .animation(.spring, value: displayValue)
+            }
+            .lineLimit(1)
+            .frame(minWidth: 78, alignment: .leading)
+        }
+
+        private var displayValue: String {
+            guard let value else { return "–" }
+            let formatter = NumberFormatter()
+            formatter.numberStyle = .currency
+            formatter.currencyCode = "USD"
+            formatter.maximumFractionDigits = 2
+            return formatter.string(from: value as NSDecimalNumber) ?? "$0.00"
+        }
+    }
+}
+
+// MARK: - Data Models
+
+private struct EarningsMetricsData {
+    let totalEarnings: Decimal
+    let paid: Decimal
+    let outstanding: Decimal
+
+    /// Mock data used for loading state placeholders
+    static let mockData = EarningsMetricsData(
+        totalEarnings: 42.67,
+        paid: 4.27,
+        outstanding: 38.40
+    )
+}
+
+#Preview {
+    @Previewable @StateObject var viewModel = WordAdsEarningsViewModel(service: MockStatsService())
+
+    return VStack {
+        WordAdsEarningsTotalsCard(viewModel: viewModel)
+    }
+    .padding()
+}

--- a/Modules/Sources/JetpackStats/Cards/WordAdsEarningsTotalsCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/WordAdsEarningsTotalsCard.swift
@@ -7,12 +7,31 @@ struct WordAdsEarningsTotalsCard: View {
     @Environment(\.openURL) private var openURL
 
     var body: some View {
-        VStack(alignment: .leading, spacing: Constants.step2) {
+        VStack(alignment: .leading, spacing: 0) {
             StatsCardTitleView(title: Strings.WordAds.totalEarnings)
 
-            EarningsMetricsStrip(data: metricsData)
-                .redacted(reason: viewModel.isFirstLoad ? .placeholder : [])
+            VStack(alignment: .leading, spacing: Constants.step1) {
+                Text(totalEarningsValue)
+                    .contentTransition(.numericText())
+                    .font(Font.make(.recoleta, textStyle: .largeTitle, weight: .medium))
+                    .foregroundColor(.primary)
+                    .animation(.spring, value: totalEarningsValue)
+
+                HStack(spacing: Constants.step4) {
+                    SecondaryMetricView(
+                        title: Strings.WordAds.paid,
+                        value: metricsData?.paid
+                    )
+
+                    SecondaryMetricView(
+                        title: Strings.WordAds.outstanding,
+                        value: metricsData?.outstanding
+                    )
+                }
+            }
+            .redacted(reason: viewModel.isFirstLoad ? .placeholder : [])
         }
+        .frame(maxWidth: .infinity, alignment: .leading)
         .padding(Constants.step2)
         .cardStyle()
         .overlay(alignment: .topTrailing) {
@@ -34,6 +53,15 @@ struct WordAdsEarningsTotalsCard: View {
         .tint(Color.primary)
     }
 
+    private var totalEarningsValue: String {
+        guard let value = metricsData?.totalEarnings else { return "–" }
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = "USD"
+        formatter.maximumFractionDigits = 2
+        return formatter.string(from: value as NSDecimalNumber) ?? "$0.00"
+    }
+
     private var metricsData: EarningsMetricsData? {
         if let earnings = viewModel.earnings {
             return EarningsMetricsData(
@@ -49,58 +77,34 @@ struct WordAdsEarningsTotalsCard: View {
     }
 }
 
-// MARK: - Earnings Metrics Strip
+// MARK: - Secondary Metric View
 
-private struct EarningsMetricsStrip: View {
-    let data: EarningsMetricsData?
+private struct SecondaryMetricView: View {
+    let title: String
+    let value: Decimal?
 
     var body: some View {
-        ScrollView(.horizontal, showsIndicators: false) {
-            HStack(spacing: Constants.step3) {
-                MetricView(
-                    title: Strings.WordAds.earnings,
-                    value: data?.totalEarnings
-                )
-                MetricView(
-                    title: Strings.WordAds.paid,
-                    value: data?.paid
-                )
-                MetricView(
-                    title: Strings.WordAds.outstanding,
-                    value: data?.outstanding
-                )
-            }
+        VStack(alignment: .leading, spacing: 2) {
+            Text(title)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+
+            Text(displayValue)
+                .contentTransition(.numericText())
+                .font(.subheadline.weight(.medium))
+                .foregroundColor(.primary)
+                .animation(.spring, value: displayValue)
         }
+        .lineLimit(1)
     }
 
-    struct MetricView: View {
-        let title: String
-        let value: Decimal?
-
-        var body: some View {
-            VStack(alignment: .leading, spacing: 0) {
-                Text(title.uppercased())
-                    .font(.caption.weight(.medium))
-                    .foregroundColor(.secondary)
-
-                Text(displayValue)
-                    .contentTransition(.numericText())
-                    .font(Font.make(.recoleta, textStyle: .title, weight: .medium))
-                    .foregroundColor(.primary)
-                    .animation(.spring, value: displayValue)
-            }
-            .lineLimit(1)
-            .frame(minWidth: 78, alignment: .leading)
-        }
-
-        private var displayValue: String {
-            guard let value else { return "–" }
-            let formatter = NumberFormatter()
-            formatter.numberStyle = .currency
-            formatter.currencyCode = "USD"
-            formatter.maximumFractionDigits = 2
-            return formatter.string(from: value as NSDecimalNumber) ?? "$0.00"
-        }
+    private var displayValue: String {
+        guard let value else { return "–" }
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .currency
+        formatter.currencyCode = "USD"
+        formatter.maximumFractionDigits = 2
+        return formatter.string(from: value as NSDecimalNumber) ?? "$0.00"
     }
 }
 

--- a/Modules/Sources/JetpackStats/Cards/WordAdsEarningsViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/WordAdsEarningsViewModel.swift
@@ -21,29 +21,17 @@ final class WordAdsEarningsViewModel: ObservableObject {
         self.service = service
     }
 
-    // MARK: - Public Methods
-
-    func onAppear() {
-        guard earnings == nil && loadingError == nil else { return }
-        loadData()
-    }
-
-    // MARK: - Private Methods
-
-    private func loadData() {
-        loadTask?.cancel()
-        loadTask = Task {
-            do {
-                let response = try await service.getWordAdsEarnings()
-                guard !Task.isCancelled else { return }
-                self.earnings = response
-                self.loadingError = nil
-                self.isFirstLoad = false
-            } catch {
-                guard !Task.isCancelled else { return }
-                self.loadingError = error
-                self.isFirstLoad = false
-            }
+    func refresh() async {
+        do {
+            let response = try await service.getWordAdsEarnings()
+            guard !Task.isCancelled else { return }
+            self.earnings = response
+            self.loadingError = nil
+            self.isFirstLoad = false
+        } catch {
+            guard !Task.isCancelled else { return }
+            self.loadingError = error
+            self.isFirstLoad = false
         }
     }
 }

--- a/Modules/Sources/JetpackStats/Cards/WordAdsEarningsViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/WordAdsEarningsViewModel.swift
@@ -13,7 +13,6 @@ final class WordAdsEarningsViewModel: ObservableObject {
     // MARK: - Dependencies
 
     private let service: any StatsServiceProtocol
-    private var loadTask: Task<Void, Never>?
 
     // MARK: - Initialization
 

--- a/Modules/Sources/JetpackStats/Cards/WordAdsEarningsViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/WordAdsEarningsViewModel.swift
@@ -1,0 +1,49 @@
+import Foundation
+@preconcurrency import WordPressKit
+
+/// ViewModel managing state for WordAds earnings data.
+@MainActor
+final class WordAdsEarningsViewModel: ObservableObject {
+    // MARK: - Published Properties
+
+    @Published private(set) var earnings: StatsWordAdsEarningsResponse?
+    @Published private(set) var isFirstLoad = true
+    @Published private(set) var loadingError: Error?
+
+    // MARK: - Dependencies
+
+    private let service: any StatsServiceProtocol
+    private var loadTask: Task<Void, Never>?
+
+    // MARK: - Initialization
+
+    init(service: any StatsServiceProtocol) {
+        self.service = service
+    }
+
+    // MARK: - Public Methods
+
+    func onAppear() {
+        guard earnings == nil && loadingError == nil else { return }
+        loadData()
+    }
+
+    // MARK: - Private Methods
+
+    private func loadData() {
+        loadTask?.cancel()
+        loadTask = Task {
+            do {
+                let response = try await service.getWordAdsEarnings()
+                guard !Task.isCancelled else { return }
+                self.earnings = response
+                self.loadingError = nil
+                self.isFirstLoad = false
+            } catch {
+                guard !Task.isCancelled else { return }
+                self.loadingError = error
+                self.isFirstLoad = false
+            }
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Cards/WordAdsPaymentHistoryCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/WordAdsPaymentHistoryCard.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+@preconcurrency import WordPressKit
+
+struct WordAdsPaymentHistoryCard: View {
+    @ObservedObject var viewModel: WordAdsEarningsViewModel
+
+    @Environment(\.router) private var router
+    @Environment(\.context) private var context
+
+    private let itemLimit = 6
+
+    private var mockViewModels: [WordAdsPaymentHistoryRowViewModel] {
+        (0..<5).map { index in
+            WordAdsPaymentHistoryRowViewModel(
+                earning: StatsWordAdsEarningsResponse.MonthlyEarning(
+                    period: StatsWordAdsEarningsResponse.Period(year: 2025, month: 12 - index),
+                    data: StatsWordAdsEarningsResponse.MonthlyEarningData(
+                        amount: 15.25,
+                        status: .outstanding,
+                        pageviews: "3420"
+                    )
+                )
+            )
+        }
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            StatsCardTitleView(title: Strings.WordAds.paymentsHistory)
+                .padding(.horizontal, Constants.step3)
+                .padding(.bottom, Constants.step1)
+
+            if viewModel.isFirstLoad {
+                loadingView
+            } else if let earnings = viewModel.earnings, !earnings.wordAdsEarnings.isEmpty {
+                let rowViewModels = earnings.wordAdsEarnings.prefix(itemLimit).map {
+                    WordAdsPaymentHistoryRowViewModel(earning: $0)
+                }
+                contentView(viewModels: Array(rowViewModels), hasMore: earnings.wordAdsEarnings.count > itemLimit)
+            } else if let loadingError = viewModel.loadingError {
+                errorView(error: loadingError)
+            } else {
+                emptyView
+            }
+        }
+        .padding(.vertical, Constants.step2)
+        .cardStyle()
+    }
+
+    private var loadingView: some View {
+        contentView(viewModels: mockViewModels, hasMore: false)
+            .redacted(reason: .placeholder)
+            .pulsating()
+    }
+
+    private var emptyView: some View {
+        Text(Strings.WordAds.noPaymentsYet)
+            .font(.subheadline)
+            .foregroundColor(.secondary)
+            .frame(maxWidth: .infinity, alignment: .center)
+            .padding(.vertical, Constants.step3)
+    }
+
+    private func errorView(error: Error) -> some View {
+        contentView(viewModels: mockViewModels, hasMore: false)
+            .redacted(reason: .placeholder)
+            .grayscale(1)
+            .opacity(0.1)
+            .overlay {
+                SimpleErrorView(error: error)
+            }
+    }
+
+    private func contentView(viewModels: [WordAdsPaymentHistoryRowViewModel], hasMore: Bool) -> some View {
+        VStack(spacing: 0) {
+            ForEach(Array(viewModels.enumerated()), id: \.offset) { index, viewModel in
+                WordAdsPaymentHistoryRowView(viewModel: viewModel)
+                    .padding(.horizontal, Constants.step3)
+                    .padding(.vertical, 8)
+
+                if index < viewModels.count - 1 {
+                    Divider()
+                        .padding(.leading, Constants.step3)
+                }
+            }
+
+            if hasMore {
+                showMoreButton
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, Constants.step3)
+            }
+        }
+    }
+
+    private var showMoreButton: some View {
+        Button {
+            navigateToPaymentHistory()
+        } label: {
+            HStack(spacing: 4) {
+                Text(Strings.Buttons.showAll)
+                    .padding(.trailing, 4)
+                    .font(.callout)
+                    .foregroundColor(.primary)
+                Image(systemName: "chevron.right")
+                    .font(.caption.weight(.semibold))
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding(.top, 16)
+        .tint(Color.secondary.opacity(0.8))
+        .dynamicTypeSize(...DynamicTypeSize.xLarge)
+    }
+
+    private func navigateToPaymentHistory() {
+        guard let earnings = viewModel.earnings else { return }
+
+        router.navigate(
+            to: WordAdsPaymentHistoryView(earnings: earnings),
+            title: Strings.WordAds.paymentsHistory
+        )
+    }
+}
+
+#Preview {
+    @Previewable @StateObject var viewModel = WordAdsEarningsViewModel(service: MockStatsService())
+
+    return VStack {
+        WordAdsPaymentHistoryCard(viewModel: viewModel)
+    }
+    .padding()
+}

--- a/Modules/Sources/JetpackStats/Cards/WordAdsPaymentHistoryCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/WordAdsPaymentHistoryCard.swift
@@ -76,7 +76,7 @@ struct WordAdsPaymentHistoryCard: View {
             ForEach(Array(viewModels.enumerated()), id: \.offset) { index, viewModel in
                 WordAdsPaymentHistoryRowView(viewModel: viewModel)
                     .padding(.horizontal, Constants.step3)
-                    .padding(.vertical, 8)
+                    .padding(.vertical, 9)
 
                 if index < viewModels.count - 1 {
                     Divider()

--- a/Modules/Sources/JetpackStats/Screens/AdsTabView.swift
+++ b/Modules/Sources/JetpackStats/Screens/AdsTabView.swift
@@ -36,6 +36,9 @@ public struct AdsTabView: View {
         .background(Constants.Colors.background)
         .environment(\.context, context)
         .environment(\.router, router)
+        .onAppear {
+            context.tracker?.send(.adsTabShown)
+        }
         .task {
             await earningsViewModel.refresh()
         }

--- a/Modules/Sources/JetpackStats/Screens/AdsTabView.swift
+++ b/Modules/Sources/JetpackStats/Screens/AdsTabView.swift
@@ -7,9 +7,13 @@ public struct AdsTabView: View {
     @StateObject private var earningsViewModel: WordAdsEarningsViewModel
 
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
-    @Environment(\.context) private var context
+
+    private let context: StatsContext
+    private let router: StatsRouter
 
     public init(context: StatsContext, router: StatsRouter) {
+        self.context = context
+        self.router = router
         _chartViewModel = StateObject(
             wrappedValue: WordAdsChartCardViewModel(service: context.service)
         )
@@ -30,6 +34,8 @@ public struct AdsTabView: View {
             .padding(.top, Constants.step0_5)
         }
         .background(Constants.Colors.background)
+        .environment(\.context, context)
+        .environment(\.router, router)
         .onAppear {
             earningsViewModel.onAppear()
         }
@@ -45,6 +51,5 @@ public struct AdsTabView: View {
                 factory: MockStatsRouterScreenFactory()
             )
         )
-        .environment(\.context, .demo)
     }
 }

--- a/Modules/Sources/JetpackStats/Screens/AdsTabView.swift
+++ b/Modules/Sources/JetpackStats/Screens/AdsTabView.swift
@@ -36,8 +36,8 @@ public struct AdsTabView: View {
         .background(Constants.Colors.background)
         .environment(\.context, context)
         .environment(\.router, router)
-        .onAppear {
-            earningsViewModel.onAppear()
+        .task {
+            await earningsViewModel.refresh()
         }
     }
 }

--- a/Modules/Sources/JetpackStats/Screens/AdsTabView.swift
+++ b/Modules/Sources/JetpackStats/Screens/AdsTabView.swift
@@ -1,25 +1,38 @@
 import SwiftUI
+import WordPressKit
+import WordPressUI
 
 public struct AdsTabView: View {
-    @StateObject private var viewModel: WordAdsChartCardViewModel
+    @StateObject private var chartViewModel: WordAdsChartCardViewModel
+    @StateObject private var earningsViewModel: WordAdsEarningsViewModel
+
     @Environment(\.horizontalSizeClass) var horizontalSizeClass
+    @Environment(\.context) private var context
 
     public init(context: StatsContext, router: StatsRouter) {
-        _viewModel = StateObject(
+        _chartViewModel = StateObject(
             wrappedValue: WordAdsChartCardViewModel(service: context.service)
+        )
+        _earningsViewModel = StateObject(
+            wrappedValue: WordAdsEarningsViewModel(service: context.service)
         )
     }
 
     public var body: some View {
         ScrollView {
             VStack(spacing: Constants.step3) {
-                WordAdsChartCard(viewModel: viewModel)
+                WordAdsEarningsTotalsCard(viewModel: earningsViewModel)
+                WordAdsChartCard(viewModel: chartViewModel)
+                WordAdsPaymentHistoryCard(viewModel: earningsViewModel)
             }
             .padding(.vertical, Constants.step2)
             .padding(.horizontal, Constants.cardHorizontalInset(for: horizontalSizeClass))
             .padding(.top, Constants.step0_5)
         }
         .background(Constants.Colors.background)
+        .onAppear {
+            earningsViewModel.onAppear()
+        }
     }
 }
 

--- a/Modules/Sources/JetpackStats/Screens/WordAdsPaymentHistoryView.swift
+++ b/Modules/Sources/JetpackStats/Screens/WordAdsPaymentHistoryView.swift
@@ -12,6 +12,7 @@ struct WordAdsPaymentHistoryView: View {
                 Section(header: Text(String(group.year))) {
                     ForEach(group.earnings, id: \.period) { earning in
                         WordAdsPaymentHistoryRowView(viewModel: WordAdsPaymentHistoryRowViewModel(earning: earning))
+                            .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
                     }
                 }
             }

--- a/Modules/Sources/JetpackStats/Screens/WordAdsPaymentHistoryView.swift
+++ b/Modules/Sources/JetpackStats/Screens/WordAdsPaymentHistoryView.swift
@@ -12,7 +12,7 @@ struct WordAdsPaymentHistoryView: View {
                 Section(header: Text(String(group.year))) {
                     ForEach(group.earnings, id: \.period) { earning in
                         WordAdsPaymentHistoryRowView(viewModel: WordAdsPaymentHistoryRowViewModel(earning: earning))
-                            .listRowInsets(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+                            .listRowInsets(EdgeInsets(top: 8, leading: 16, bottom: 8, trailing: 16))
                     }
                 }
             }

--- a/Modules/Sources/JetpackStats/Screens/WordAdsPaymentHistoryView.swift
+++ b/Modules/Sources/JetpackStats/Screens/WordAdsPaymentHistoryView.swift
@@ -1,0 +1,66 @@
+import SwiftUI
+@preconcurrency import WordPressKit
+
+struct WordAdsPaymentHistoryView: View {
+    let earnings: StatsWordAdsEarningsResponse
+
+    @Environment(\.context) private var context
+
+    var body: some View {
+        List {
+            ForEach(groupedEarningsByYear, id: \.year) { group in
+                Section(header: Text(String(group.year))) {
+                    ForEach(group.earnings, id: \.period) { earning in
+                        WordAdsPaymentHistoryRowView(viewModel: WordAdsPaymentHistoryRowViewModel(earning: earning))
+                    }
+                }
+            }
+        }
+        .listStyle(.plain)
+    }
+
+    private var groupedEarningsByYear: [YearGroup] {
+        let grouped = Dictionary(grouping: earnings.wordAdsEarnings) { $0.period.year }
+        return grouped.map { YearGroup(year: $0.key, earnings: $0.value) }
+            .sorted { $0.year > $1.year }
+    }
+
+    private struct YearGroup {
+        let year: Int
+        let earnings: [StatsWordAdsEarningsResponse.MonthlyEarning]
+    }
+}
+
+#Preview {
+    let json = """
+    {
+        "ID": 123456,
+        "name": "Test Site",
+        "URL": "https://test.com",
+        "earnings": {
+            "total_earnings": "150.00",
+            "total_amount_owed": "120.00",
+            "wordads": {
+                "2025-12": {"amount": 25.50, "status": "0", "pageviews": "4500"},
+                "2025-11": {"amount": 20.30, "status": "0", "pageviews": "3800"},
+                "2025-10": {"amount": 18.75, "status": "1", "pageviews": "3200"},
+                "2025-09": {"amount": 15.20, "status": "1", "pageviews": "2900"},
+                "2025-08": {"amount": 12.80, "status": "1", "pageviews": "2500"},
+                "2025-07": {"amount": 11.50, "status": "1", "pageviews": "2300"},
+                "2024-12": {"amount": 10.20, "status": "1", "pageviews": "2100"},
+                "2024-11": {"amount": 9.80, "status": "1", "pageviews": "1900"},
+                "2024-10": {"amount": 8.50, "status": "1", "pageviews": "1700"},
+                "2024-09": {"amount": 7.20, "status": "1", "pageviews": "1500"}
+            }
+        }
+    }
+    """
+    let earnings = try! JSONDecoder().decode(StatsWordAdsEarningsResponse.self, from: json.data(using: .utf8)!)
+
+    return NavigationStack {
+        WordAdsPaymentHistoryView(earnings: earnings)
+            .navigationTitle(Strings.WordAds.paymentsHistory)
+            .navigationBarTitleDisplayMode(.inline)
+    }
+    .environment(\.context, .demo)
+}

--- a/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
@@ -413,6 +413,7 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
 
         var wordadsDict: [String: [String: Any]] = [:]
         var totalEarnings: Double = 0
+        var totalAmountOwed: Double = 0
 
         // Generate earnings for last 12 months
         for monthsAgo in 0..<12 {
@@ -429,6 +430,14 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
 
             totalEarnings += amount
 
+            // Months older than 2 months are paid, recent months are outstanding
+            let isPaid = monthsAgo > 2
+            let status = isPaid ? "1" : "0"
+
+            if !isPaid {
+                totalAmountOwed += amount
+            }
+
             // Generate realistic pageviews
             let basePageviews = Int.random(in: 50...500)
             let pageviewsGrowth = 1.0 + (Double(12 - monthsAgo) * 0.1)
@@ -436,7 +445,7 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
 
             wordadsDict[period] = [
                 "amount": amount,
-                "status": "0",
+                "status": status,
                 "pageviews": String(pageviews)
             ]
         }
@@ -447,7 +456,7 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
             "URL": "https://mocksite.wordpress.com",
             "earnings": [
                 "total_earnings": String(format: "%.2f", totalEarnings),
-                "total_amount_owed": String(format: "%.2f", totalEarnings * 0.1), // 10% of total
+                "total_amount_owed": String(format: "%.2f", totalAmountOwed),
                 "wordads": wordadsDict,
                 "sponsored": [],
                 "adjustment": []

--- a/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
@@ -399,6 +399,67 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
         )
     }
 
+    func getWordAdsEarnings() async throws -> WordPressKit.StatsWordAdsEarningsResponse {
+        // Simulate network delay
+        if !delaysDisabled {
+            try? await Task.sleep(for: .milliseconds(Int.random(in: 200...500)))
+        }
+
+        // Generate mock earnings data for the last 12 months
+        let now = Date()
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM"
+        dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+
+        var wordadsDict: [String: [String: Any]] = [:]
+        var totalEarnings: Double = 0
+
+        // Generate earnings for last 12 months
+        for monthsAgo in 0..<12 {
+            guard let monthDate = calendar.date(byAdding: .month, value: -monthsAgo, to: now) else {
+                continue
+            }
+
+            let period = dateFormatter.string(from: monthDate)
+
+            // Generate realistic earnings that increase over time
+            let baseAmount = Double.random(in: 0.01...2.0)
+            let growthFactor = 1.0 + (Double(12 - monthsAgo) * 0.05) // More recent months earn more
+            let amount = baseAmount * growthFactor
+
+            totalEarnings += amount
+
+            // Generate realistic pageviews
+            let basePageviews = Int.random(in: 50...500)
+            let pageviewsGrowth = 1.0 + (Double(12 - monthsAgo) * 0.1)
+            let pageviews = Int(Double(basePageviews) * pageviewsGrowth)
+
+            wordadsDict[period] = [
+                "amount": amount,
+                "status": "0",
+                "pageviews": String(pageviews)
+            ]
+        }
+
+        let jsonDictionary: [String: Any] = [
+            "ID": 238291108,
+            "name": "Mock Site",
+            "URL": "https://mocksite.wordpress.com",
+            "earnings": [
+                "total_earnings": String(format: "%.2f", totalEarnings),
+                "total_amount_owed": String(format: "%.2f", totalEarnings * 0.9), // 90% of total
+                "wordads": wordadsDict,
+                "sponsored": [],
+                "adjustment": []
+            ]
+        ]
+
+        let jsonData = try JSONSerialization.data(withJSONObject: jsonDictionary)
+        let response = try JSONDecoder().decode(WordPressKit.StatsWordAdsEarningsResponse.self, from: jsonData)
+
+        return response
+    }
+
     // MARK: - Data Loading
 
     /// Loads historical items from JSON files based on the data type

--- a/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
@@ -423,8 +423,8 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
             let period = dateFormatter.string(from: monthDate)
 
             // Generate realistic earnings that increase over time
-            let baseAmount = Double.random(in: 0.01...2.0)
-            let growthFactor = 1.0 + (Double(12 - monthsAgo) * 0.05) // More recent months earn more
+            let baseAmount = Double.random(in: 2000...5000)
+            let growthFactor = 1.0 + (Double(12 - monthsAgo) * 0.08) // More recent months earn more
             let amount = baseAmount * growthFactor
 
             totalEarnings += amount
@@ -447,7 +447,7 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
             "URL": "https://mocksite.wordpress.com",
             "earnings": [
                 "total_earnings": String(format: "%.2f", totalEarnings),
-                "total_amount_owed": String(format: "%.2f", totalEarnings * 0.9), // 90% of total
+                "total_amount_owed": String(format: "%.2f", totalEarnings * 0.1), // 10% of total
                 "wordads": wordadsDict,
                 "sponsored": [],
                 "adjustment": []

--- a/Modules/Sources/JetpackStats/Services/StatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/StatsService.swift
@@ -118,6 +118,10 @@ actor StatsService: StatsServiceProtocol {
         return data
     }
 
+    func getWordAdsEarnings() async throws -> WordPressKit.StatsWordAdsEarningsResponse {
+        try await service.getWordAdsEarnings()
+    }
+
     private func fetchWordAdsStats(date: Date, granularity: DateRangeGranularity) async throws -> WordAdsMetricsResponse {
         let localDate = convertDateSiteToLocal(date)
 

--- a/Modules/Sources/JetpackStats/Services/StatsServiceProtocol.swift
+++ b/Modules/Sources/JetpackStats/Services/StatsServiceProtocol.swift
@@ -9,6 +9,7 @@ protocol StatsServiceProtocol: AnyObject, Sendable {
 
     func getSiteStats(interval: DateInterval, granularity: DateRangeGranularity) async throws -> SiteMetricsResponse
     func getWordAdsStats(date: Date, granularity: DateRangeGranularity) async throws -> WordAdsMetricsResponse
+    func getWordAdsEarnings() async throws -> WordPressKit.StatsWordAdsEarningsResponse
     func getTopListData(_ item: TopListItemType, metric: SiteMetric, interval: DateInterval, granularity: DateRangeGranularity, limit: Int?, locationLevel: LocationLevel?) async throws -> TopListResponse
     func getRealtimeTopListData(_ item: TopListItemType) async throws -> TopListResponse
     func getPostDetails(for postID: Int) async throws -> StatsPostDetails

--- a/Modules/Sources/JetpackStats/Strings.swift
+++ b/Modules/Sources/JetpackStats/Strings.swift
@@ -59,6 +59,22 @@ enum Strings {
         static let revenue = AppLocalizedString("jetpackStats.wordAdsMetrics.revenue", value: "Revenue", comment: "Revenue from ads")
     }
 
+    enum WordAds {
+        static let totalEarnings = AppLocalizedString("jetpackStats.wordAds.totalEarnings", value: "Total Earnings", comment: "Title for WordAds total earnings card")
+        static let earnings = AppLocalizedString("jetpackStats.wordAds.earnings", value: "Earnings", comment: "Total earnings from WordAds")
+        static let paid = AppLocalizedString("jetpackStats.wordAds.paid", value: "Paid", comment: "Amount paid out from WordAds earnings")
+        static let outstanding = AppLocalizedString("jetpackStats.wordAds.outstanding", value: "Outstanding", comment: "Outstanding amount owed from WordAds")
+        static let learnMore = AppLocalizedString("jetpackStats.wordAds.learnMore", value: "Learn More", comment: "Button to learn more about WordAds earnings")
+        static let paymentsHistory = AppLocalizedString("jetpackStats.wordAds.paymentsHistory", value: "Payments History", comment: "Title for payment history card and screen")
+        static let noPaymentsYet = AppLocalizedString("jetpackStats.wordAds.noPaymentsYet", value: "No payments yet", comment: "Message shown when there are no payment records")
+        static func adsServed(_ count: String) -> String {
+            String.localizedStringWithFormat(
+                AppLocalizedString("jetpackStats.wordAds.adsServed.count", value: "%@ ads served", comment: "Number of ads served. %@ is the ads count."),
+                count
+            )
+        }
+    }
+
     enum SiteDataTypes {
         static let postsAndPages = AppLocalizedString("jetpackStats.siteDataTypes.postsAndPages", value: "Posts & Pages", comment: "Posts and pages data type")
         static let archive = AppLocalizedString("jetpackStats.siteDataTypes.archive", value: "Archive", comment: "Archive data type")

--- a/Modules/Sources/JetpackStats/Views/WordAds/WordAdsPaymentHistoryRowView.swift
+++ b/Modules/Sources/JetpackStats/Views/WordAds/WordAdsPaymentHistoryRowView.swift
@@ -1,0 +1,71 @@
+import SwiftUI
+@preconcurrency import WordPressKit
+
+struct WordAdsPaymentHistoryRowView: View {
+    let viewModel: WordAdsPaymentHistoryRowViewModel
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 0) {
+            // Period and Status
+            VStack(alignment: .leading, spacing: 2) {
+                Text(viewModel.formattedPeriod)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundColor(.primary)
+
+                statusBadge
+            }
+
+            Spacer(minLength: 6)
+
+            // Metrics
+            VStack(alignment: .trailing, spacing: 2) {
+                Text(viewModel.formattedAmount)
+                    .font(.subheadline.weight(.semibold))
+                    .foregroundColor(.primary)
+
+                Text(viewModel.formattedAdsServed)
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+    }
+
+    private var statusBadge: some View {
+        HStack(spacing: 4) {
+            Text(viewModel.statusText)
+                .font(.caption2.weight(.medium))
+        }
+        .foregroundColor(.secondary)
+    }
+}
+
+#Preview {
+    List {
+        WordAdsPaymentHistoryRowView(
+            viewModel: WordAdsPaymentHistoryRowViewModel(
+                earning: StatsWordAdsEarningsResponse.MonthlyEarning(
+                    period: StatsWordAdsEarningsResponse.Period(year: 2025, month: 12),
+                    data: StatsWordAdsEarningsResponse.MonthlyEarningData(
+                        amount: 15.25,
+                        status: .outstanding,
+                        pageviews: "3420"
+                    )
+                )
+            )
+        )
+
+        WordAdsPaymentHistoryRowView(
+            viewModel: WordAdsPaymentHistoryRowViewModel(
+                earning: StatsWordAdsEarningsResponse.MonthlyEarning(
+                    period: StatsWordAdsEarningsResponse.Period(year: 2025, month: 8),
+                    data: StatsWordAdsEarningsResponse.MonthlyEarningData(
+                        amount: 5.50,
+                        status: .paid,
+                        pageviews: "1200"
+                    )
+                )
+            )
+        )
+    }
+    .listStyle(.plain)
+}

--- a/Modules/Sources/JetpackStats/Views/WordAds/WordAdsPaymentHistoryRowView.swift
+++ b/Modules/Sources/JetpackStats/Views/WordAds/WordAdsPaymentHistoryRowView.swift
@@ -20,7 +20,7 @@ struct WordAdsPaymentHistoryRowView: View {
             // Metrics
             VStack(alignment: .trailing, spacing: 2) {
                 Text(viewModel.formattedAmount)
-                    .font(.subheadline.weight(.semibold))
+                    .font(.subheadline.weight(.medium))
                     .foregroundColor(.primary)
 
                 Text(viewModel.formattedAdsServed)

--- a/Modules/Sources/JetpackStats/Views/WordAds/WordAdsPaymentHistoryRowViewModel.swift
+++ b/Modules/Sources/JetpackStats/Views/WordAds/WordAdsPaymentHistoryRowViewModel.swift
@@ -1,0 +1,31 @@
+import Foundation
+@preconcurrency import WordPressKit
+
+struct WordAdsPaymentHistoryRowViewModel {
+    let earning: StatsWordAdsEarningsResponse.MonthlyEarning
+
+    var formattedPeriod: String {
+        var components = DateComponents()
+        components.year = earning.period.year
+        components.month = earning.period.month
+        components.day = 1
+
+        guard let date = Calendar.current.date(from: components) else {
+            return earning.period.string
+        }
+
+        return date.formatted(.dateTime.month(.abbreviated).year())
+    }
+
+    var formattedAmount: String {
+        earning.amount.formatted(.currency(code: "USD"))
+    }
+
+    var formattedAdsServed: String {
+        Strings.WordAds.adsServed(earning.pageviews)
+    }
+
+    var statusText: String {
+        earning.status == .paid ? Strings.WordAds.paid : Strings.WordAds.outstanding
+    }
+}

--- a/Modules/Sources/WordPressKit/StatsServiceRemoteV2.swift
+++ b/Modules/Sources/WordPressKit/StatsServiceRemoteV2.swift
@@ -395,6 +395,16 @@ public extension StatsServiceRemoteV2 {
     }
 }
 
+// MARK: - WordAds Earnings
+
+public extension StatsServiceRemoteV2 {
+    func getWordAdsEarnings() async throws -> StatsWordAdsEarningsResponse {
+        let path = self.path(forEndpoint: "sites/\(siteID)/wordads/earnings", withVersion: ._1_1)
+        let result = await wordPressComRestApi.perform(.get, URLString: path, parameters: [:], type: StatsWordAdsEarningsResponse.self)
+        return try result.get().body
+    }
+}
+
 // This serves both as a way to get the query properties in a "nice" way,
 // but also as a way to narrow down the generic type in `getInsight(completion:)` method.
 public protocol StatsInsightData {

--- a/Modules/Sources/WordPressKit/StatsWordAdsEarningsResponse.swift
+++ b/Modules/Sources/WordPressKit/StatsWordAdsEarningsResponse.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+public struct StatsWordAdsEarningsResponse: Decodable {
+    public let totalEarnings: Decimal
+    public let totalAmountOwed: Decimal
+    public let wordAdsEarnings: [MonthlyEarning]
+
+    private enum CodingKeys: String, CodingKey {
+        case earnings
+    }
+
+    private struct EarningsContainer: Decodable {
+        let totalEarnings: FlexibleDecimal
+        let totalAmountOwed: FlexibleDecimal
+        let wordads: [String: MonthlyEarningData]
+
+        private enum CodingKeys: String, CodingKey {
+            case totalEarnings = "total_earnings"
+            case totalAmountOwed = "total_amount_owed"
+            case wordads
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let earningsContainer = try container.decode(EarningsContainer.self, forKey: .earnings)
+        totalEarnings = earningsContainer.totalEarnings.value
+        totalAmountOwed = earningsContainer.totalAmountOwed.value
+
+        // Convert dictionary to sorted array
+        var earnings = earningsContainer.wordads.compactMap { (period, data) -> MonthlyEarning? in
+            guard let parsedPeriod = Period(string: period) else { return nil }
+            return MonthlyEarning(period: parsedPeriod, data: data)
+        }
+        earnings.sort { $0.period > $1.period }
+        wordAdsEarnings = earnings
+    }
+
+    public struct MonthlyEarning {
+        public let period: Period
+        public let amount: Decimal
+        public let status: PaymentStatus
+        public let pageviews: String
+
+        public init(period: Period, data: MonthlyEarningData) {
+            self.period = period
+            self.amount = data.amount
+            self.status = data.status
+            self.pageviews = data.pageviews
+        }
+    }
+
+    public struct MonthlyEarningData: Decodable {
+        private let _amount: FlexibleDecimal
+        private let _status: FlexiblePaymentStatus
+
+        public let pageviews: String
+
+        public var amount: Decimal { _amount.value }
+        public var status: PaymentStatus { _status.value }
+
+        public init(amount: Decimal, status: PaymentStatus, pageviews: String) {
+            self._amount = FlexibleDecimal(value: amount)
+            self._status = FlexiblePaymentStatus(value: status)
+            self.pageviews = pageviews
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case _amount = "amount"
+            case _status = "status"
+            case pageviews
+        }
+    }
+
+    public enum PaymentStatus: Equatable {
+        case paid
+        case outstanding
+    }
+
+    public struct Period: Equatable, Comparable, Hashable {
+        public let year: Int
+        public let month: Int
+
+        public init(year: Int, month: Int) {
+            self.year = year
+            self.month = month
+        }
+
+        init?(string: String) {
+            let components = string.split(separator: "-")
+            guard components.count == 2,
+                  let year = Int(components[0]),
+                  let month = Int(components[1]),
+                  (1...12).contains(month) else {
+                return nil
+            }
+            self.year = year
+            self.month = month
+        }
+
+        public var string: String {
+            String(format: "%04d-%02d", year, month)
+        }
+
+        public static func < (lhs: Period, rhs: Period) -> Bool {
+            if lhs.year != rhs.year {
+                return lhs.year < rhs.year
+            }
+            return lhs.month < rhs.month
+        }
+    }
+}
+
+// MARK: - Decoding Helpers
+
+private struct FlexibleDecimal: Decodable {
+    let value: Decimal
+
+    init(value: Decimal) {
+        self.value = value
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let stringValue = try? container.decode(String.self), let decimal = Decimal(string: stringValue) {
+            value = decimal
+        } else if let doubleValue = try? container.decode(Double.self) {
+            value = Decimal(doubleValue)
+        } else if let intValue = try? container.decode(Int.self) {
+            value = Decimal(intValue)
+        } else {
+            throw DecodingError.typeMismatch(Decimal.self, DecodingError.Context(
+                codingPath: container.codingPath,
+                debugDescription: "Expected string or number"
+            ))
+        }
+    }
+}
+
+private struct FlexiblePaymentStatus: Decodable {
+    let value: StatsWordAdsEarningsResponse.PaymentStatus
+
+    init(value: StatsWordAdsEarningsResponse.PaymentStatus) {
+        self.value = value
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let stringValue = try? container.decode(String.self) {
+            value = stringValue == "1" ? .paid : .outstanding
+        } else if let intValue = try? container.decode(Int.self) {
+            value = intValue == 1 ? .paid : .outstanding
+        } else {
+            throw DecodingError.typeMismatch(StatsWordAdsEarningsResponse.PaymentStatus.self, DecodingError.Context(
+                codingPath: container.codingPath,
+                debugDescription: "Expected string or int"
+            ))
+        }
+    }
+}

--- a/Modules/Sources/WordPressKit/StatsWordAdsEarningsResponse.swift
+++ b/Modules/Sources/WordPressKit/StatsWordAdsEarningsResponse.swift
@@ -104,10 +104,7 @@ public struct StatsWordAdsEarningsResponse: Decodable {
         }
 
         public static func < (lhs: Period, rhs: Period) -> Bool {
-            if lhs.year != rhs.year {
-                return lhs.year < rhs.year
-            }
-            return lhs.month < rhs.month
+            (lhs.year, lhs.month) < (rhs.year, rhs.month)
         }
     }
 }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,6 @@
 26.7
 -----
-* [**] Stats: Add new "Adds" tab to show WordAdds statistics [#25165]
+* [**] Stats: Add new "Adds" tab to show WordAdds earnings and stats [#25165]
 
 26.6
 -----

--- a/Tests/WordPressKitTests/WordPressKitTests/Mock Data/stats-wordads-earnings.json
+++ b/Tests/WordPressKitTests/WordPressKitTests/Mock Data/stats-wordads-earnings.json
@@ -1,0 +1,38 @@
+{
+    "ID": 456123789,
+    "name": "Example",
+    "URL": "https://example.wordpress.com",
+    "earnings": {
+        "total_earnings": "42.67",
+        "total_amount_owed": "38.40",
+        "wordads": {
+            "2025-12": {
+                "amount": 15.25,
+                "status": "0",
+                "pageviews": "3420"
+            },
+            "2025-11": {
+                "amount": 12.80,
+                "status": "0",
+                "pageviews": "2890"
+            },
+            "2025-10": {
+                "amount": 8.45,
+                "status": "0",
+                "pageviews": "1950"
+            },
+            "2025-09": {
+                "amount": 6.17,
+                "status": "0",
+                "pageviews": "1420"
+            },
+            "2025-08": {
+                "amount": 5.50,
+                "status": "1",
+                "pageviews": "1200"
+            }
+        },
+        "sponsored": [],
+        "adjustment": []
+    }
+}

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/StatsRemoteV2Tests.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/StatsRemoteV2Tests.swift
@@ -29,6 +29,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
     let getArchivesDataFilename = "stats-archives-data.json"
     let getEmailOpensFilename = "stats-email-opens.json"
     let getWordAdsMonthMockFilename = "stats-wordads-month.json"
+    let getWordAdsEarningsFilename = "stats-wordads-earnings.json"
 
     // MARK: - Properties
 
@@ -48,6 +49,7 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
     var siteArchivesDataEndpoint: String { return "sites/\(siteID)/stats/archives" }
     var siteEmailOpensEndpoint: String { return "sites/\(siteID)/stats/opens/emails/231/rate" }
     var siteWordAdsEndpoint: String { return "sites/\(siteID)/wordads/stats" }
+    var siteWordAdsEarningsEndpoint: String { return "sites/\(siteID)/wordads/earnings" }
 
     func toggleSpamStateEndpoint(for referrerDomain: String, markAsSpam: Bool) -> String {
         let action = markAsSpam ? "new" : "delete"
@@ -907,7 +909,67 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
         XCTAssertEqual(data[2][.impressions], 174.0)
         XCTAssertEqual(data[2][.revenue], 0.01)
         XCTAssertEqual(data[2][.cpm], 0.06)
+    }
 
+    func testWordAdsEarnings() async throws {
+        stubRemoteResponse(siteWordAdsEarningsEndpoint, filename: getWordAdsEarningsFilename, contentType: .ApplicationJSON)
 
+        let response = try await remote.getWordAdsEarnings()
+
+        // Test total earnings
+        XCTAssertEqual(response.totalEarnings, Decimal(string: "42.67"))
+        XCTAssertEqual(response.totalAmountOwed, Decimal(string: "38.40"))
+
+        // Test monthly earnings count
+        XCTAssertEqual(response.wordAdsEarnings.count, 5)
+
+        // Test monthly earnings are sorted by period descending (most recent first)
+        XCTAssertEqual(response.wordAdsEarnings[0].period, StatsWordAdsEarningsResponse.Period(year: 2025, month: 12))
+        XCTAssertEqual(response.wordAdsEarnings[1].period, StatsWordAdsEarningsResponse.Period(year: 2025, month: 11))
+        XCTAssertEqual(response.wordAdsEarnings[2].period, StatsWordAdsEarningsResponse.Period(year: 2025, month: 10))
+        XCTAssertEqual(response.wordAdsEarnings[3].period, StatsWordAdsEarningsResponse.Period(year: 2025, month: 9))
+
+        // Test first month (December 2025)
+        let decEarnings = response.wordAdsEarnings[0]
+        XCTAssertEqual(decEarnings.period.year, 2025)
+        XCTAssertEqual(decEarnings.period.month, 12)
+        XCTAssertEqual(decEarnings.amount, Decimal(string: "15.25"))
+        XCTAssertEqual(decEarnings.status, .outstanding)
+        XCTAssertEqual(decEarnings.pageviews, "3420")
+
+        // Test second month (November 2025)
+        let novEarnings = response.wordAdsEarnings[1]
+        XCTAssertEqual(novEarnings.period.year, 2025)
+        XCTAssertEqual(novEarnings.period.month, 11)
+        XCTAssertEqual(novEarnings.amount, Decimal(string: "12.80"))
+        XCTAssertEqual(novEarnings.status, .outstanding)
+        XCTAssertEqual(novEarnings.pageviews, "2890")
+
+        // Test third month (October 2025)
+        let octEarnings = response.wordAdsEarnings[2]
+        XCTAssertEqual(octEarnings.period.year, 2025)
+        XCTAssertEqual(octEarnings.period.month, 10)
+        XCTAssertEqual(octEarnings.amount, Decimal(string: "8.45"))
+        XCTAssertEqual(octEarnings.status, .outstanding)
+        XCTAssertEqual(octEarnings.pageviews, "1950")
+
+        // Test fourth month (September 2025)
+        let sepEarnings = response.wordAdsEarnings[3]
+        XCTAssertEqual(sepEarnings.period.year, 2025)
+        XCTAssertEqual(sepEarnings.period.month, 9)
+        XCTAssertEqual(sepEarnings.amount, Decimal(string: "6.17"))
+        XCTAssertEqual(sepEarnings.status, .outstanding)
+        XCTAssertEqual(sepEarnings.pageviews, "1420")
+
+        // Test fifth month (August 2025) - with paid status
+        let augEarnings = response.wordAdsEarnings[4]
+        XCTAssertEqual(augEarnings.period.year, 2025)
+        XCTAssertEqual(augEarnings.period.month, 8)
+        XCTAssertEqual(augEarnings.amount, Decimal(string: "5.50"))
+        XCTAssertEqual(augEarnings.status, .paid)
+        XCTAssertEqual(augEarnings.pageviews, "1200")
+
+        // Test Period string conversion
+        XCTAssertEqual(decEarnings.period.string, "2025-12")
     }
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent+JetpackStats.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent+JetpackStats.swift
@@ -9,6 +9,7 @@ extension StatsEvent {
         case .trafficTabShown: .jetpackStatsTrafficTabShown
         case .realtimeTabShown: .jetpackStatsRealtimeTabShown
         case .subscribersTabShown: .jetpackStatsSubscribersTabShown
+        case .adsTabShown: .jetpackStatsAdsTabShown
         case .postDetailsScreenShown: .jetpackStatsPostDetailsScreenShown
         case .authorStatsScreenShown: .jetpackStatsAuthorStatsScreenShown
         case .archiveStatsScreenShown: .jetpackStatsArchiveStatsScreenShown

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -641,6 +641,7 @@ import WordPressShared
     case jetpackStatsTrafficTabShown
     case jetpackStatsRealtimeTabShown
     case jetpackStatsSubscribersTabShown
+    case jetpackStatsAdsTabShown
     case jetpackStatsPostDetailsScreenShown
     case jetpackStatsAuthorStatsScreenShown
     case jetpackStatsArchiveStatsScreenShown
@@ -1789,6 +1790,8 @@ import WordPressShared
             return "jetpack_stats_realtime_tab_shown"
         case .jetpackStatsSubscribersTabShown:
             return "jetpack_stats_subscribers_tab_shown"
+        case .jetpackStatsAdsTabShown:
+            return "jetpack_stats_ads_tab_shown"
         case .jetpackStatsPostDetailsScreenShown:
             return "jetpack_stats_post_details_screen_shown"
         case .jetpackStatsAuthorStatsScreenShown:

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -30,7 +30,7 @@
     [super viewDidLoad];
 
     self.view.backgroundColor = [UIColor systemGroupedBackgroundColor];
-    self.navigationItem.title = NSLocalizedString(@"Stats", @"Stats window title");
+    [self updateNavigationTitle];
 
     self.siteStatsDashboardVC = [[SiteStatsDashboardViewController alloc] init];
 
@@ -54,6 +54,8 @@
 
     [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(reachabilityChanged:) name:kTMReachabilityChangedNotification object:ReachabilityUtils.internetReachability];
 
+    [self registerForTraitChanges:@[UITraitHorizontalSizeClass.class] withAction:@selector(updateNavigationTitle)];
+
     [self initStats];
 }
 
@@ -62,6 +64,15 @@
     [super viewDidAppear:animated];
 
     [ObjCBridge incrementSignificantEvent];
+}
+
+- (void)updateNavigationTitle
+{
+    if (self.traitCollection.horizontalSizeClass == UIUserInterfaceSizeClassCompact) {
+        self.navigationItem.title = NSLocalizedString(@"Stats", @"Stats window title");
+    } else {
+        self.navigationItem.title = nil;
+    }
 }
 
 - (void)setBlog:(Blog *)blog


### PR DESCRIPTION
Closes [CMM-1132: Add WordAds revenue stats to Jetpack app](https://linear.app/a8c/issue/CMM-1132/add-wordads-revenue-stats-to-jetpack-app).

This PR adds "Total Payment" and "Payment History" cards.

<img width="450"  alt="Screenshot 2026-01-27 at 10 43 24 AM" src="https://github.com/user-attachments/assets/c106db7d-96dc-4a78-9229-a92fcb5ecf84" />

