### PR TITLE
Add Devices item to Top List

### DIFF
--- a/Modules/Sources/JetpackStats/Analytics/StatsEvent.swift
+++ b/Modules/Sources/JetpackStats/Analytics/StatsEvent.swift
@@ -148,6 +148,12 @@ public enum StatsEvent {
     ///   - "to_level": New level
     case locationLevelChanged
 
+    /// Device breakdown changed in device drill-down
+    /// - Parameters:
+    ///   - "from_breakdown": Previous breakdown ("screensize", "platform", or "browser")
+    ///   - "to_breakdown": New breakdown
+    case deviceBreakdownChanged
+
     // MARK: - Navigation Events
 
     /// Stats tab selected
@@ -217,6 +223,7 @@ extension TopListItemType {
         case .authors: "authors"
         case .referrers: "referrers"
         case .locations: "locations"
+        case .devices: "devices"
         case .videos: "videos"
         case .externalLinks: "external_links"
         case .searchTerms: "search_terms"

--- a/Modules/Sources/JetpackStats/Cards/TopListCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListCard.swift
@@ -35,6 +35,12 @@ struct TopListCard: View {
                     .padding(.horizontal, Constants.step2)
             }
 
+            if viewModel.selection.item == .devices {
+                pieChartView
+                    .padding(.vertical, Constants.step1)
+                    .padding(.horizontal, Constants.step3)
+            }
+
             listHeaderView
                 .padding(.horizontal, Constants.step3)
                 .dynamicTypeSize(...DynamicTypeSize.xxLarge)
@@ -93,14 +99,37 @@ struct TopListCard: View {
         )
     }
 
+    private var pieChartView: some View {
+        let mockPieData = PieChartData(items: mockData.items, metric: viewModel.selection.metric)
+        let isShowingMockData = viewModel.isFirstLoad || viewModel.pieChartData == nil
+        let data = viewModel.pieChartData ?? mockPieData
+
+        return PieChartView(data: data)
+            .frame(height: 200)
+            .allowsHitTesting(!isShowingMockData)
+            .redacted(reason: isShowingMockData ? .placeholder : [])
+            .opacity(isShowingMockData ? 0.2 : 1.0)
+            .pulsating(isShowingMockData && viewModel.isFirstLoad)
+    }
+
     private var listHeaderView: some View {
         HStack {
-            // Left side: Location level for locations, otherwise item type
+            // Left side: Location level for locations, device breakdown for devices, otherwise item type
             if viewModel.selection.item == .locations {
                 Menu {
                     locationLevelPicker
                 } label: {
-                    InlineValuePickerTitle(title: viewModel.selection.locationLevel.localizedTitle)
+                    InlineValuePickerTitle(title: viewModel.selection.options.locationLevel.localizedTitle)
+                        .foregroundStyle(Color.secondary)
+                        .padding(.top, 6)
+                        .padding(.vertical, Constants.step0_5)
+                }
+                .fixedSize()
+            } else if viewModel.selection.item == .devices {
+                Menu {
+                    deviceBreakdownPicker
+                } label: {
+                    InlineValuePickerTitle(title: viewModel.selection.options.deviceBreakdown.localizedTitle)
                         .foregroundStyle(Color.secondary)
                         .padding(.top, 6)
                         .padding(.vertical, Constants.step0_5)
@@ -148,7 +177,6 @@ struct TopListCard: View {
                     Button {
                         var selection = viewModel.selection
                         selection.item = item
-
                         let supportedMetric = getSupportedMetrics(for: item)
                         if !supportedMetric.contains(selection.metric),
                            let metric = supportedMetric.first {
@@ -206,8 +234,8 @@ struct TopListCard: View {
     private var locationLevelPicker: some View {
         ForEach(LocationLevel.allCases) { level in
             Button {
-                let previousLevel = viewModel.selection.locationLevel
-                viewModel.selection.locationLevel = level
+                let previousLevel = viewModel.selection.options.locationLevel
+                viewModel.selection.options.locationLevel = level
 
                 // Track location level change
                 viewModel.tracker?.send(.locationLevelChanged, properties: [
@@ -216,6 +244,24 @@ struct TopListCard: View {
                 ])
             } label: {
                 Label(level.localizedTitle, systemImage: level.systemImage)
+            }
+        }
+        .tint(Color.primary)
+    }
+
+    private var deviceBreakdownPicker: some View {
+        ForEach(DeviceBreakdown.allCases) { breakdown in
+            Button {
+                let previousBreakdown = viewModel.selection.options.deviceBreakdown
+                viewModel.selection.options.deviceBreakdown = breakdown
+
+                // Track device breakdown change
+                viewModel.tracker?.send(.deviceBreakdownChanged, properties: [
+                    "from_breakdown": previousBreakdown.analyticsName,
+                    "to_breakdown": breakdown.analyticsName
+                ])
+            } label: {
+                Label(breakdown.localizedTitle, systemImage: breakdown.systemImage)
             }
         }
         .tint(Color.primary)
@@ -326,6 +372,7 @@ struct TopListCard: View {
 #Preview {
     ScrollView {
         VStack {
+            TopListCardPreview(item: .devices)
             TopListCardPreview(item: .authors)
             TopListCardPreview(item: .locations)
         }

--- a/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
@@ -28,6 +28,7 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
     @Published private(set) var loadingError: Error?
     @Published private(set) var isStale = false
     @Published private(set) var countriesMapData: CountriesMapData?
+    @Published private(set) var pieChartData: PieChartData?
 
     @Published var isEditing = false
 
@@ -50,7 +51,7 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
     struct Selection: Equatable, Sendable {
         var item: TopListItemType
         var metric: SiteMetric
-        var locationLevel: LocationLevel = .countries
+        var options = TopListItemOptions()
     }
 
     enum Filter: Equatable {
@@ -164,16 +165,22 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
             // Fetch country-level data for map if viewing regions or cities
             var mapData: CountriesMapData?
             if selection.item == .locations {
-                if selection.locationLevel == .countries {
+                if selection.options.locationLevel == .countries {
                     // Use the main data for countries
                     mapData = createCountriesMapData(from: data)
                 } else {
                     // Fetch separate country-level data for regions/cities
                     var countriesSelection = selection
-                    countriesSelection.locationLevel = .countries
+                    countriesSelection.options.locationLevel = .countries
                     let countriesData = try await getTopListData(for: countriesSelection, dateRange: dateRange)
                     mapData = createCountriesMapData(from: countriesData)
                 }
+            }
+
+            // Create pie chart data for devices
+            var pieData: PieChartData?
+            if selection.item == .devices {
+                pieData = PieChartData(items: data.items, metric: selection.metric)
             }
 
             // Check for cancellation before updating the state
@@ -182,8 +189,10 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
             // Cancel stale timer and reset stale flag when data is successfully loaded
             staleTimer?.cancel()
             isStale = false
+
             self.data = data
             self.countriesMapData = mapData
+            self.pieChartData = pieData
         } catch is CancellationError {
             return
         } catch {
@@ -216,7 +225,7 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
             interval: dateRange.dateInterval,
             granularity: granularity,
             limit: fetchLimit,
-            locationLevel: selection.locationLevel
+            options: selection.options
         )
 
         // Fetch previous data only for items that support it
@@ -230,7 +239,7 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
                 interval: dateRange.effectiveComparisonInterval,
                 granularity: granularity,
                 limit: fetchLimit,
-                locationLevel: selection.locationLevel
+                options: selection.options
             )
         }()
 

--- a/Modules/Sources/JetpackStats/Charts/Helpers/PieChartData.swift
+++ b/Modules/Sources/JetpackStats/Charts/Helpers/PieChartData.swift
@@ -1,0 +1,98 @@
+import Foundation
+import WordPressShared
+
+struct PieChartData: Identifiable, Sendable {
+    let id = UUID()
+    let metric: SiteMetric
+    let segments: [Segment]
+    let totalValue: Int
+
+    struct Segment: Identifiable, Sendable {
+        let id: String
+        let name: String
+        let value: Int
+        let percentage: Double
+        let isOther: Bool
+    }
+
+    init(items: [any TopListItemProtocol], metric: SiteMetric) {
+        self.metric = metric
+
+        // Calculate total value for the metric
+        let total = items.reduce(0) { sum, item in
+            sum + (item.metrics[metric] ?? 0)
+        }
+        self.totalValue = total
+
+        // Create segments with percentages, sorted by value descending
+        let sortedItems = items.sorted { ($0.metrics[metric] ?? 0) > ($1.metrics[metric] ?? 0) }
+
+        let allSegments = sortedItems.compactMap { item -> Segment? in
+            guard let value = item.metrics[metric], value > 0 else { return nil }
+
+            let percentage = total > 0 ? Double(value) / Double(total) * 100.0 : 0.0
+
+            return Segment(
+                id: item.id.id,
+                name: item.displayName,
+                value: value,
+                percentage: percentage,
+                isOther: false
+            )
+        }
+
+        // Smart Adaptive Algorithm:
+        // - Show 3-6 segments based on data distribution
+        // - Always show top 3 (if available)
+        // - Never show more than 6 total segments
+        // - Only show segments >= 2% (unless needed to reach minimum)
+
+        let minSegments = 3
+        let maxSegments = 6
+        let minPercentage = 2.0
+
+        if allSegments.count <= minSegments {
+            // Show all segments if we have 3 or fewer
+            self.segments = allSegments
+        } else {
+            // Determine which segments to show
+            var selectedSegments: [Segment] = []
+            var remainingSegments: [Segment] = []
+
+            for (index, segment) in allSegments.enumerated() {
+                if index < minSegments {
+                    // Always include top 3
+                    selectedSegments.append(segment)
+                } else if selectedSegments.count < maxSegments && segment.percentage >= minPercentage {
+                    // Include segments above threshold, up to max
+                    selectedSegments.append(segment)
+                } else {
+                    // Aggregate the rest
+                    remainingSegments.append(segment)
+                }
+            }
+
+            // Create "Other" segment if we have remaining items
+            if !remainingSegments.isEmpty {
+                let otherValue = remainingSegments.reduce(0) { $0 + $1.value }
+                let otherPercentage = total > 0 ? Double(otherValue) / Double(total) * 100.0 : 0.0
+
+                // Create unique ID for "Other" segment based on aggregated item IDs
+                let aggregatedIDs = remainingSegments.map { $0.id }.sorted().joined(separator: "-")
+                let otherID = "pie-chart-other-\(aggregatedIDs.hashValue)"
+
+                let otherSegment = Segment(
+                    id: otherID,
+                    name: Strings.Chart.other,
+                    value: otherValue,
+                    percentage: otherPercentage,
+                    isOther: true
+                )
+
+                self.segments = selectedSegments + [otherSegment]
+            } else {
+                self.segments = selectedSegments
+            }
+        }
+    }
+}

--- a/Modules/Sources/JetpackStats/Charts/PieChartView.swift
+++ b/Modules/Sources/JetpackStats/Charts/PieChartView.swift
@@ -1,0 +1,97 @@
+import SwiftUI
+import Charts
+
+struct PieChartView: View {
+    let data: PieChartData
+
+    @Environment(\.colorScheme) var colorScheme
+
+    private var valueFormatter: StatsValueFormatter {
+        StatsValueFormatter(metric: data.metric)
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Chart(data.segments) { segment in
+                SectorMark(
+                    angle: .value("Value", segment.value),
+                    innerRadius: .ratio(0.5),
+                    angularInset: 1.5
+                )
+                .foregroundStyle(color(for: segment))
+                .cornerRadius(5)
+                .annotation(position: .overlay) {
+                    if shouldShowAnnotation(for: segment) {
+                        Text("\(segment.name.capitalized) \((segment.percentage / 100).formatted(.percent.precision(.fractionLength(1))))")
+                            .font(.caption2)
+                            .fontWeight(.medium)
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 3)
+                            .background(
+                                Capsule()
+                                    .fill(Color.black.opacity(0.7))
+                            )
+                            .dynamicTypeSize(...DynamicTypeSize.large)
+                    }
+                }
+            }
+            .chartLegend(.hidden)
+        }
+    }
+
+    private func color(for segment: PieChartData.Segment) -> Color {
+        // Use light secondary color for "Other" segment
+        if segment.isOther {
+            return Color.secondary.opacity(0.2)
+        }
+
+        guard let index = data.segments.firstIndex(where: { $0.id == segment.id }) else {
+            return data.metric.primaryColor
+        }
+
+        let baseColor = data.metric.primaryColor
+        let variations: [Double] = [0.0, 0.2, 0.4, 0.6, 0.8, 0.9]
+        let adjustmentIndex = index % variations.count
+        let adjustment = variations[adjustmentIndex]
+
+        if colorScheme == .light {
+            return baseColor.opacity(1.0 - adjustment)
+        } else {
+            // In dark mode, mix with white to create lighter variants
+            if #available(iOS 18, *) {
+                return baseColor.mix(with: .white, by: adjustment)
+            } else {
+                return baseColor.opacity(1.0 - (adjustment * 0.5))
+            }
+        }
+    }
+
+    private func shouldShowAnnotation(for segment: PieChartData.Segment) -> Bool {
+        // Never show annotation for "Other" segment
+        guard !segment.isOther else { return false }
+
+        // Show annotation for top 3 segments
+        guard let index = data.segments.firstIndex(where: { $0.id == segment.id }) else {
+            return false
+        }
+
+        return index < 3 && segment.percentage > 5.0
+    }
+}
+
+#Preview {
+    let mockItems: [TopListItem.Device] = [
+        TopListItem.Device(name: "mobile", breakdown: .screensize, metrics: SiteMetricsSet(views: 738)),
+        TopListItem.Device(name: "desktop", breakdown: .screensize, metrics: SiteMetricsSet(views: 258)),
+        TopListItem.Device(name: "tablet", breakdown: .screensize, metrics: SiteMetricsSet(views: 4))
+    ]
+
+    let pieChartData = PieChartData(items: mockItems, metric: .views)
+
+    return VStack {
+        PieChartView(data: pieChartData)
+            .frame(height: 200)
+            .padding()
+    }
+}

--- a/Modules/Sources/JetpackStats/Resources/Mocks/HistoricalData/historical-devices.json
+++ b/Modules/Sources/JetpackStats/Resources/Mocks/HistoricalData/historical-devices.json
@@ -1,0 +1,114 @@
+[
+  {
+    "name": "mobile",
+    "breakdown": "screensize",
+    "metrics": {
+      "views": 6980
+    }
+  },
+  {
+    "name": "desktop",
+    "breakdown": "screensize",
+    "metrics": {
+      "views": 2580
+    }
+  },
+  {
+    "name": "tablet",
+    "breakdown": "screensize",
+    "metrics": {
+      "views": 4400
+    }
+  },
+  {
+    "name": "android",
+    "breakdown": "platform",
+    "metrics": {
+      "views": 805
+    }
+  },
+  {
+    "name": "linux",
+    "breakdown": "platform",
+    "metrics": {
+      "views": 217
+    }
+  },
+  {
+    "name": "windows",
+    "breakdown": "platform",
+    "metrics": {
+      "views": 41
+    }
+  },
+  {
+    "name": "mac",
+    "breakdown": "platform",
+    "metrics": {
+      "views": 25
+    }
+  },
+  {
+    "name": "iphone",
+    "breakdown": "platform",
+    "metrics": {
+      "views": 10
+    }
+  },
+  {
+    "name": "android_tablet",
+    "breakdown": "platform",
+    "metrics": {
+      "views": 3
+    }
+  },
+  {
+    "name": "ipad",
+    "breakdown": "platform",
+    "metrics": {
+      "views": 1
+    }
+  },
+  {
+    "name": "chrome",
+    "breakdown": "browser",
+    "metrics": {
+      "views": 1063
+    }
+  },
+  {
+    "name": "safari",
+    "breakdown": "browser",
+    "metrics": {
+      "views": 15
+    }
+  },
+  {
+    "name": "miui",
+    "breakdown": "browser",
+    "metrics": {
+      "views": 10
+    }
+  },
+  {
+    "name": "edge",
+    "breakdown": "browser",
+    "metrics": {
+      "views": 9
+    }
+  },
+  {
+    "name": "firefox",
+    "breakdown": "browser",
+    "metrics": {
+      "views": 1
+    }
+  },
+  {
+    "name": "opera",
+    "breakdown": "browser",
+    "metrics": {
+      "views": 1
+    }
+  }
+]

--- a/Modules/Sources/JetpackStats/Services/Data/DeviceBreakdown.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/DeviceBreakdown.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+enum DeviceBreakdown: String, Identifiable, CaseIterable, Sendable, Codable {
+    case screensize
+    case browser
+    case platform
+
+    var id: DeviceBreakdown { self }
+
+    var localizedTitle: String {
+        switch self {
+        case .screensize: Strings.DeviceBreakdowns.screensize
+        case .browser: Strings.DeviceBreakdowns.browser
+        case .platform: Strings.DeviceBreakdowns.platform
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .screensize: "laptopcomputer.and.iphone"
+        case .browser: "safari"
+        case .platform: "square.stack.3d.up"
+        }
+    }
+
+    var analyticsName: String {
+        rawValue
+    }
+}

--- a/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListData.swift
@@ -98,6 +98,7 @@ extension TopListData {
         case .postsAndPages: mockPosts(metric: metric)
         case .referrers: mockReferrers(metric: metric)
         case .locations: mockLocations(metric: metric)
+        case .devices: mockDevices(metric: metric)
         case .authors: mockAuthors(metric: metric)
         case .externalLinks: mockExternalLinks(metric: metric)
         case .fileDownloads: mockFileDownloads(metric: metric)
@@ -203,6 +204,53 @@ extension TopListData {
                 metrics: metrics
             )
         }
+    }
+
+    private static func mockDevices(metric: SiteMetric) -> [TopListItem.Device] {
+        let devices = [
+            ("mobile", 7380),
+            ("desktop", 2580),
+            ("tablet", 400),
+            ("android", 8050),
+            ("ios", 1200),
+            ("windows", 4100),
+            ("mac", 3500),
+            ("linux", 2170),
+            ("chrome", 10630),
+            ("safari", 2150),
+            ("firefox", 1100),
+            ("edge", 450)
+        ]
+
+        return devices
+            .sorted { $0.1 > $1.1 } // Sort by value descending
+            .map { data in
+                let baseValue = data.1
+                let metrics = createMetrics(baseValue: baseValue, metric: metric)
+                let breakdown = inferDeviceBreakdown(from: data.0)
+                return TopListItem.Device(
+                    name: data.0,
+                    breakdown: breakdown,
+                    metrics: metrics
+                )
+            }
+    }
+
+    private static func inferDeviceBreakdown(from deviceName: String) -> DeviceBreakdown {
+        let lowercasedName = deviceName.lowercased()
+
+        // Screen size devices
+        if ["mobile", "desktop", "tablet"].contains(lowercasedName) {
+            return .screensize
+        }
+
+        // Browser devices
+        if ["chrome", "safari", "firefox", "edge", "opera", "miui"].contains(lowercasedName) {
+            return .browser
+        }
+
+        // Platform devices (default)
+        return .platform
     }
 
     private static func mockAuthors(metric: SiteMetric) -> [TopListItem.Author] {

--- a/Modules/Sources/JetpackStats/Services/Data/TopListItem+WordPressKit.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListItem+WordPressKit.swift
@@ -66,6 +66,16 @@ extension TopListItem.Location {
     }
 }
 
+extension TopListItem.Device {
+    init(_ item: WordPressKit.StatsDeviceItem, breakdown: DeviceBreakdown) {
+        self.init(
+            name: item.name,
+            breakdown: breakdown,
+            metrics: SiteMetricsSet(views: Int(item.value))
+        )
+    }
+}
+
 extension TopListItem.Author {
     init(_ author: WordPressKit.StatsTopAuthor, dateFormatter: DateFormatter) {
         self.init(

--- a/Modules/Sources/JetpackStats/Services/Data/TopListItem.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListItem.swift
@@ -73,6 +73,20 @@ extension TopListItem {
         }
     }
 
+    struct Device: Codable, TopListItemProtocol {
+        let name: String
+        let breakdown: DeviceBreakdown
+        var metrics: SiteMetricsSet
+
+        var id: TopListItemID {
+            TopListItemID(type: .devices, id: name)
+        }
+
+        var displayName: String {
+            name.capitalized
+        }
+    }
+
     struct Author: Codable, TopListItemProtocol {
         let name: String
         let userId: String

--- a/Modules/Sources/JetpackStats/Services/Data/TopListItemOptions.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListItemOptions.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Options specific to certain top list item types.
+///
+/// Different item types use different options:
+/// - `.locations`: Uses `locationLevel` to determine granularity (countries, regions, cities)
+/// - `.devices`: Uses `deviceBreakdown` to determine breakdown type (screensize, platform, browser)
+/// - Other item types: These options are ignored
+struct TopListItemOptions: Equatable, Sendable, Codable, Hashable {
+    /// The granularity level for location data.
+    /// Only applies to `.locations` item type.
+    var locationLevel: LocationLevel
+
+    /// The breakdown type for device data.
+    /// Only applies to `.devices` item type.
+    var deviceBreakdown: DeviceBreakdown
+
+    init(
+        locationLevel: LocationLevel = .countries,
+        deviceBreakdown: DeviceBreakdown = .screensize
+    ) {
+        self.locationLevel = locationLevel
+        self.deviceBreakdown = deviceBreakdown
+    }
+}

--- a/Modules/Sources/JetpackStats/Services/Data/TopListItemType.swift
+++ b/Modules/Sources/JetpackStats/Services/Data/TopListItemType.swift
@@ -5,6 +5,7 @@ enum TopListItemType: String, Identifiable, CaseIterable, Sendable, Codable {
     case authors
     case referrers
     case locations
+    case devices
     case videos
     case externalLinks
     case searchTerms
@@ -19,6 +20,7 @@ enum TopListItemType: String, Identifiable, CaseIterable, Sendable, Codable {
         case .authors: Strings.SiteDataTypes.authors
         case .referrers: Strings.SiteDataTypes.referrers
         case .locations: Strings.SiteDataTypes.locations
+        case .devices: Strings.SiteDataTypes.devices
         case .externalLinks: Strings.SiteDataTypes.clicks
         case .fileDownloads: Strings.SiteDataTypes.fileDownloads
         case .searchTerms: Strings.SiteDataTypes.searchTerms
@@ -32,6 +34,7 @@ enum TopListItemType: String, Identifiable, CaseIterable, Sendable, Codable {
         case .postsAndPages: "text.page"
         case .referrers: "link"
         case .locations: "map"
+        case .devices: "laptopcomputer.and.iphone"
         case .authors: "person"
         case .externalLinks: "cursorarrow.click"
         case .fileDownloads: "arrow.down.circle"
@@ -47,6 +50,7 @@ enum TopListItemType: String, Identifiable, CaseIterable, Sendable, Codable {
         case .authors: Strings.TopListTitles.authors
         case .referrers: Strings.TopListTitles.referrers
         case .locations: Strings.TopListTitles.locations
+        case .devices: Strings.TopListTitles.devices
         case .externalLinks: Strings.TopListTitles.clicks
         case .fileDownloads: Strings.TopListTitles.fileDownloads
         case .searchTerms: Strings.TopListTitles.searchTerms
@@ -56,7 +60,7 @@ enum TopListItemType: String, Identifiable, CaseIterable, Sendable, Codable {
     }
 
     static let secondaryItems: Set<TopListItemType> = [
-        .externalLinks, .fileDownloads, .searchTerms, .archive
+        .externalLinks, .videos, .fileDownloads, .searchTerms, .archive
     ]
 
     var documentationURL: URL? {
@@ -77,7 +81,7 @@ enum TopListItemType: String, Identifiable, CaseIterable, Sendable, Codable {
             "https://wordpress.com/support/stats/analyze-content-performance/#track-file-downloads"
         case .externalLinks:
             "https://wordpress.com/support/stats/analyze-content-performance/#analyze-clicks"
-        case .locations:
+        case .locations, .devices:
             "https://wordpress.com/support/stats/audience-insights/"
         case .videos:
             "https://wordpress.com/support/stats/analyze-content-performance/#see-video-traffic"

--- a/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/Mocks/MockStatsService.swift
@@ -3,9 +3,14 @@ import SwiftUI
 @preconcurrency import WordPressKit
 
 actor MockStatsService: ObservableObject, StatsServiceProtocol {
+    private struct TopListCacheKey: Hashable {
+        let itemType: TopListItemType
+        let options: TopListItemOptions
+    }
+
     private var hourlyData: [SiteMetric: [DataPoint]] = [:]
     private var wordAdsHourlyData: [WordAdsMetric: [DataPoint]] = [:]
-    private var dailyTopListData: [TopListItemType: [Date: [any TopListItemProtocol]]] = [:]
+    private var dailyTopListData: [TopListCacheKey: [Date: [any TopListItemProtocol]]] = [:]
     private let calendar: Calendar
 
     let supportedMetrics = SiteMetric.allCases.filter {
@@ -21,6 +26,7 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
         case .archive: [.views]
         case .referrers: [.views, .visitors]
         case .locations: [.views, .visitors]
+        case .devices: [.views]
         case .authors: [.views, .comments, .likes]
         case .externalLinks: [.views, .visitors]
         case .fileDownloads: [.downloads]
@@ -133,11 +139,20 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
         return WordAdsMetricsResponse(total: total, metrics: output)
     }
 
-    func getTopListData(_ item: TopListItemType, metric: SiteMetric, interval: DateInterval, granularity: DateRangeGranularity, limit: Int?, locationLevel: LocationLevel?) async throws -> TopListResponse {
+    func getTopListData(_ item: TopListItemType, metric: SiteMetric, interval: DateInterval, granularity: DateRangeGranularity, limit: Int?, options: TopListItemOptions) async throws -> TopListResponse {
         await generateDataIfNeeded()
 
-        guard let typeData = dailyTopListData[item] else {
-            fatalError("data not configured for data type: \(item)")
+        if item == .devices && options.deviceBreakdown == .screensize {
+            return TopListResponse(items: [
+                TopListItem.Device(name: "mobile", breakdown: .screensize, metrics: .init(views: 6980)),
+                TopListItem.Device(name: "desktop", breakdown: .screensize, metrics: .init(views: 2580)),
+                TopListItem.Device(name: "tablet", breakdown: .screensize, metrics: .init(views: 440))
+            ])
+        }
+
+        let cacheKey = TopListCacheKey(itemType: item, options: options)
+        guard let typeData = dailyTopListData[cacheKey] else {
+            return TopListResponse(items: [])
         }
 
         // Filter data within the date range
@@ -253,6 +268,8 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
             fileName = "referrers"
         case .locations:
             fileName = "locations"
+        case .devices:
+            fileName = "devices"
         case .authors:
             fileName = "authors"
         case .externalLinks:
@@ -284,6 +301,9 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
             case .locations:
                 let locations = try decoder.decode([TopListItem.Location].self, from: data)
                 return locations
+            case .devices:
+                let devices = try decoder.decode([TopListItem.Device].self, from: data)
+                return devices
             case .authors:
                 let authors = try decoder.decode([TopListItem.Author].self, from: data)
                 return authors.map {
@@ -472,7 +492,26 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
     // MARK: - Data Loading
 
     /// Loads historical items from JSON files based on the data type
-    private func loadHistoricalItems(for dataType: TopListItemType) -> [any TopListItemProtocol] {
+    /// Returns all relevant option combinations for a given item type
+    private func getOptionSets(for itemType: TopListItemType) -> [TopListItemOptions] {
+        switch itemType {
+        case .locations:
+            // Generate options for all location levels
+            return LocationLevel.allCases.map { level in
+                TopListItemOptions(locationLevel: level, deviceBreakdown: .screensize)
+            }
+        case .devices:
+            // Generate options for all device breakdowns
+            return DeviceBreakdown.allCases.map { breakdown in
+                TopListItemOptions(locationLevel: .countries, deviceBreakdown: breakdown)
+            }
+        default:
+            // For other types, use default options
+            return [TopListItemOptions()]
+        }
+    }
+
+    private func loadHistoricalItems(for dataType: TopListItemType, options: TopListItemOptions) -> [any TopListItemProtocol] {
         let fileName: String
         switch dataType {
         case .postsAndPages:
@@ -483,6 +522,8 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
             fileName = "historical-referrers"
         case .locations:
             fileName = "historical-locations"
+        case .devices:
+            fileName = "historical-devices"
         case .authors:
             fileName = "historical-authors"
         case .externalLinks:
@@ -513,7 +554,12 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
                 return referrers
             case .locations:
                 let locations = try decoder.decode([TopListItem.Location].self, from: data)
+                // For now, use same data for all location levels
+                // Could be extended to generate synthetic regions/cities data
                 return locations
+            case .devices:
+                let devices = try decoder.decode([TopListItem.Device].self, from: data)
+                return devices.filter { $0.breakdown == options.deviceBreakdown }
             case .authors:
                 let authors = try decoder.decode([TopListItem.Author].self, from: data)
                 return authors.map {
@@ -759,18 +805,23 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
 
         let startDate = calendar.date(from: dateComponents)!
 
-        // Generate daily data for each type
+        // Generate daily data for each type and option combination
         for dataType in TopListItemType.allCases {
-            var typeData: [Date: [any TopListItemProtocol]] = [:]
+            // Generate data for all relevant option combinations
+            let optionSets = getOptionSets(for: dataType)
 
-            // Load base items from JSON files
-            let baseItems = loadHistoricalItems(for: dataType)
+            for options in optionSets {
+                var typeData: [Date: [any TopListItemProtocol]] = [:]
 
-            // Skip if no items to process
-            if baseItems.isEmpty {
-                dailyTopListData[dataType] = typeData
-                continue
-            }
+                // Load base items from JSON files, filtered by options
+                let baseItems = loadHistoricalItems(for: dataType, options: options)
+
+                // Skip if no items to process
+                if baseItems.isEmpty {
+                    let cacheKey = TopListCacheKey(itemType: dataType, options: options)
+                    dailyTopListData[cacheKey] = typeData
+                    continue
+                }
 
             var currentDate = startDate
             let nowDate = Date()
@@ -828,7 +879,9 @@ actor MockStatsService: ObservableObject, StatsServiceProtocol {
                 currentDate = calendar.date(byAdding: .day, value: 1, to: currentDate)!
             }
 
-            dailyTopListData[dataType] = typeData
+                let cacheKey = TopListCacheKey(itemType: dataType, options: options)
+                dailyTopListData[cacheKey] = typeData
+            }
         }
     }
 

--- a/Modules/Sources/JetpackStats/Services/StatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/StatsService.swift
@@ -26,7 +26,7 @@ actor StatsService: StatsServiceProtocol {
     ]
 
     let supportedItems: [TopListItemType] = [
-        .postsAndPages, .authors, .referrers, .locations,
+        .postsAndPages, .authors, .referrers, .locations, .devices,
         .externalLinks, .fileDownloads, .searchTerms, .videos, .archive
     ]
 
@@ -36,6 +36,7 @@ actor StatsService: StatsServiceProtocol {
         case .archive: [.views]
         case .referrers: [.views]
         case .locations: [.views]
+        case .devices: [.views]
         case .authors: [.views]
         case .externalLinks: [.views]
         case .fileDownloads: [.downloads]
@@ -175,16 +176,16 @@ actor StatsService: StatsServiceProtocol {
         return WordAdsMetricsResponse(total: total, metrics: metrics)
     }
 
-    func getTopListData(_ item: TopListItemType, metric: SiteMetric, interval: DateInterval, granularity: DateRangeGranularity, limit: Int?, locationLevel: LocationLevel?) async throws -> TopListResponse {
+    func getTopListData(_ item: TopListItemType, metric: SiteMetric, interval: DateInterval, granularity: DateRangeGranularity, limit: Int?, options: TopListItemOptions) async throws -> TopListResponse {
         // Check cache first
-        let cacheKey = TopListCacheKey(item: item, metric: metric, locationLevel: locationLevel, interval: interval, granularity: granularity, limit: limit)
+        let cacheKey = TopListCacheKey(item: item, metric: metric, options: options, interval: interval, granularity: granularity, limit: limit)
         if let cached = topListCache[cacheKey], !cached.isExpired {
             return cached.data
         }
 
         // Fetch fresh data
         do {
-            let data = try await _getTopListData(item, metric: metric, interval: interval, granularity: granularity, limit: limit, locationLevel: locationLevel)
+            let data = try await _getTopListData(item, metric: metric, interval: interval, granularity: granularity, limit: limit, options: options)
 
             // Cache the result
             // Historical data never expires (ttl = nil), current period data expires after 30 seconds
@@ -204,7 +205,7 @@ actor StatsService: StatsServiceProtocol {
         }
     }
 
-    private func _getTopListData(_ item: TopListItemType, metric: SiteMetric, interval: DateInterval, granularity: DateRangeGranularity, limit: Int?, locationLevel: LocationLevel?) async throws -> TopListResponse {
+    private func _getTopListData(_ item: TopListItemType, metric: SiteMetric, interval: DateInterval, granularity: DateRangeGranularity, limit: Int?, options: TopListItemOptions) async throws -> TopListResponse {
 
         func getData<T: WordPressKit.StatsTimeIntervalData>(
             _ type: T.Type,
@@ -244,8 +245,7 @@ actor StatsService: StatsServiceProtocol {
             return TopListResponse(items: sortItems(items))
 
         case .locations:
-            let level = locationLevel ?? .cities
-            switch level {
+            switch options.locationLevel {
             case .countries:
                 let data = try await getData(StatsTopCountryTimeIntervalData.self)
                 let items = data.countries.map(TopListItem.Location.init)
@@ -259,6 +259,40 @@ actor StatsService: StatsServiceProtocol {
                 let items = data.cities.map(TopListItem.Location.init)
                 return TopListResponse(items: sortItems(items))
             }
+
+        case .devices:
+            let breakdown: WordPressKit.StatsServiceRemoteV2.DeviceBreakdown
+            let deviceBreakdown = options.deviceBreakdown
+            switch deviceBreakdown {
+            case .screensize: breakdown = .screensize
+            case .platform: breakdown = .platform
+            case .browser: breakdown = .browser
+            }
+
+            let convertedInterval = convertDateIntervalSiteToLocal(interval)
+            let data = try await service.getDeviceStats(breakdown: breakdown, startDate: convertedInterval.start, endDate: convertedInterval.end)
+
+            // TEMPORARY WORKAROUND (CMM-1168):
+            // The screensize breakdown returns percentages (e.g., 73.8 for 73.8%), but SiteMetricsSet
+            // only supports Int values. We multiply by 100 to convert percentages to integers (73.8 → 7380)
+            // while preserving precision. This allows us to display the data correctly until proper
+            // percentage metric support is implemented.
+            let items = data.items.map { item in
+                let value: Int
+                if deviceBreakdown == .screensize {
+                    // Convert percentage to integer by multiplying by 100
+                    value = Int(item.value * 100)
+                } else {
+                    // Platform and browser breakdowns return counts, not percentages
+                    value = Int(item.value)
+                }
+                return TopListItem.Device(
+                    name: item.name,
+                    breakdown: deviceBreakdown,
+                    metrics: SiteMetricsSet(views: value)
+                )
+            }
+            return TopListResponse(items: sortItems(items))
 
         case .authors:
             let data = try await getData(StatsTopAuthorsTimeIntervalData.self)
@@ -483,6 +517,7 @@ actor StatsService: StatsServiceProtocol {
 enum StatsServiceError: LocalizedError {
     case unknown
     case unavailable
+    case invalidServiceType
 
     var errorDescription: String? {
         Strings.Errors.generic
@@ -517,7 +552,7 @@ private struct CachedEntity<T> {
 private struct TopListCacheKey: Hashable {
     let item: TopListItemType
     let metric: SiteMetric
-    let locationLevel: LocationLevel?
+    let options: TopListItemOptions
     let interval: DateInterval
     let granularity: DateRangeGranularity
     let limit: Int?

--- a/Modules/Sources/JetpackStats/Services/StatsServiceProtocol.swift
+++ b/Modules/Sources/JetpackStats/Services/StatsServiceProtocol.swift
@@ -10,7 +10,7 @@ protocol StatsServiceProtocol: AnyObject, Sendable {
     func getSiteStats(interval: DateInterval, granularity: DateRangeGranularity) async throws -> SiteMetricsResponse
     func getWordAdsStats(date: Date, granularity: DateRangeGranularity) async throws -> WordAdsMetricsResponse
     func getWordAdsEarnings() async throws -> WordPressKit.StatsWordAdsEarningsResponse
-    func getTopListData(_ item: TopListItemType, metric: SiteMetric, interval: DateInterval, granularity: DateRangeGranularity, limit: Int?, locationLevel: LocationLevel?) async throws -> TopListResponse
+    func getTopListData(_ item: TopListItemType, metric: SiteMetric, interval: DateInterval, granularity: DateRangeGranularity, limit: Int?, options: TopListItemOptions) async throws -> TopListResponse
     func getRealtimeTopListData(_ item: TopListItemType) async throws -> TopListResponse
     func getPostDetails(for postID: Int) async throws -> StatsPostDetails
     func getPostLikes(for postID: Int, count: Int) async throws -> PostLikesData

--- a/Modules/Sources/JetpackStats/Strings.swift
+++ b/Modules/Sources/JetpackStats/Strings.swift
@@ -81,6 +81,7 @@ enum Strings {
         static let authors = AppLocalizedString("jetpackStats.siteDataTypes.authors", value: "Authors", comment: "Authors data type")
         static let referrers = AppLocalizedString("jetpackStats.siteDataTypes.referrers", value: "Referrers", comment: "Referrers data type")
         static let locations = AppLocalizedString("jetpackStats.siteDataTypes.locations", value: "Locations", comment: "Locations data type")
+        static let devices = AppLocalizedString("jetpackStats.siteDataTypes.devices", value: "Devices", comment: "Devices data type")
         static let clicks = AppLocalizedString("jetpackStats.siteDataTypes.clicks", value: "Clicks", comment: "Clicks data type (external links)")
         static let fileDownloads = AppLocalizedString("jetpackStats.siteDataTypes.fileDownloads", value: "File Downloads", comment: "File downloads data type")
         static let searchTerms = AppLocalizedString("jetpackStats.siteDataTypes.searchTerms", value: "Search Terms", comment: "Search terms data type")
@@ -95,6 +96,12 @@ enum Strings {
         static let countries = AppLocalizedString("jetpackStats.locationLevels.countries", value: "Countries", comment: "Location level selector for countries")
         static let regions = AppLocalizedString("jetpackStats.locationLevels.regions", value: "Regions", comment: "Location level selector for regions")
         static let cities = AppLocalizedString("jetpackStats.locationLevels.cities", value: "Cities", comment: "Location level selector for cities")
+    }
+
+    enum DeviceBreakdowns {
+        static let screensize = AppLocalizedString("jetpackStats.deviceBreakdowns.screensize", value: "Screen Size", comment: "Device breakdown by screen size")
+        static let platform = AppLocalizedString("jetpackStats.deviceBreakdowns.operatingSystem", value: "Operating System", comment: "Device breakdown by platform/OS")
+        static let browser = AppLocalizedString("jetpackStats.deviceBreakdowns.browser", value: "Browser", comment: "Device breakdown by browser")
     }
 
     enum Buttons {
@@ -147,6 +154,7 @@ enum Strings {
         static let hourlyDataUnavailable = AppLocalizedString("jetpackStats.chart.hourlyDataNotAvailable", value: "Hourly data not available", comment: "Shown for metrics that don't support hourly data")
         static let empty = AppLocalizedString("jetpackStats.chart.dataEmpty", value: "No data for period", comment: "Shown for empty states")
         static let granularity = AppLocalizedString("jetpackStats.chart.granularity", value: "Granularity", comment: "Granularity picker label")
+        static let other = AppLocalizedString("jetpackStats.chart.other", value: "Other", comment: "Label for aggregated 'Other' segment in pie charts")
     }
 
     enum TopListTitles {
@@ -155,6 +163,7 @@ enum Strings {
         static let authors = AppLocalizedString("jetpackStats.topListColumnTitle.authors", value: "Author", comment: "Table column title for Top List card")
         static let referrers = AppLocalizedString("jetpackStats.topListColumnTitle.referrers", value: "Referrer", comment: "Table column title for Top List card")
         static let locations = AppLocalizedString("jetpackStats.topListColumnTitle.locations", value: "Location", comment: "Table column title for Top List card")
+        static let devices = AppLocalizedString("jetpackStats.topListColumnTitle.devices", value: "Device", comment: "Table column title for Devices Top List card")
         static let clicks = AppLocalizedString("jetpackStats.topListColumnTitle.clicks", value: "External Link", comment: "Table column title for Top List card")
         static let fileDownloads = AppLocalizedString("jetpackStats.topListColumnTitle.fileDownloads", value: "File", comment: "Table column title for Top List card")
         static let searchTerms = AppLocalizedString("jetpackStats.topListColumnTitle.searchTerms", value: "Term", comment: "Table column title for Top List card")

--- a/Modules/Sources/JetpackStats/Utilities/Modifiers/PulseAnimationModifier.swift
+++ b/Modules/Sources/JetpackStats/Utilities/Modifiers/PulseAnimationModifier.swift
@@ -4,28 +4,29 @@ struct PulseAnimationModifier: ViewModifier {
     let isEnabled: Bool
 
     func body(content: Content) -> some View {
-        content
-            .overlay {
-                if isEnabled {
-                    PulsingOverlay()
-                        .padding(-8) // Temporary workaround to cover charts properly
+        if isEnabled {
+            content
+                .mask {
+                    PulsingMask()
                 }
-            }
+        } else {
+            content
+        }
     }
 }
 
-private struct PulsingOverlay: View {
-    @State private var opacity: Double = 0.1
+private struct PulsingMask: View {
+    @State private var opacity: Double = 0.3
 
     var body: some View {
-        Constants.Colors.secondaryBackground
+        Rectangle()
+            .fill(.white)
             .opacity(opacity)
             .onAppear {
-                withAnimation(.easeInOut(duration: 1.5) .repeatForever(autoreverses: true)) {
-                    opacity = 0.6
+                withAnimation(.easeInOut(duration: 1.5).repeatForever(autoreverses: true)) {
+                    opacity = 1.0
                 }
             }
-            .allowsHitTesting(false)
     }
 }
 

--- a/Modules/Sources/JetpackStats/Views/TopList/Rows/TopListDeviceRowView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/Rows/TopListDeviceRowView.swift
@@ -1,0 +1,26 @@
+import SwiftUI
+
+struct TopListDeviceRowView: View {
+    let item: TopListItem.Device
+    let totalValue: Int
+
+    private var percentage: Double {
+        guard totalValue > 0, let itemValue = item.metrics.views else { return 0.0 }
+        return Double(itemValue) / Double(totalValue) * 100.0
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 1) {
+            Text(item.displayName)
+                .font(.callout)
+                .foregroundColor(.primary)
+            // For screensize breakdown, percentage is shown in TopListMetricsView instead
+            if item.breakdown != .screensize {
+                Text((percentage / 100).formatted(.percent.precision(.fractionLength(1))))
+                    .font(.footnote)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .lineLimit(1)
+    }
+}

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemView+ContextMenu.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemView+ContextMenu.swift
@@ -17,6 +17,8 @@ extension TopListItemView {
                 referrerActions(referrer)
             case let location as TopListItem.Location:
                 locationActions(location)
+            case let device as TopListItem.Device:
+                deviceActions(device)
             case let link as TopListItem.ExternalLink:
                 externalLinkActions(link)
             case let download as TopListItem.FileDownload:
@@ -100,6 +102,17 @@ extension TopListItemView {
             UIPasteboard.general.string = location.name
         } label: {
             Label(Strings.ContextMenuActions.copyCountryName, systemImage: "doc.on.doc")
+        }
+    }
+
+    // MARK: - Device Actions
+
+    @ViewBuilder
+    func deviceActions(_ device: TopListItem.Device) -> some View {
+        Button {
+            UIPasteboard.general.string = device.name
+        } label: {
+            Label(Strings.ContextMenuActions.copyName, systemImage: "doc.on.doc")
         }
     }
 

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemView.swift
@@ -10,6 +10,7 @@ struct TopListItemView: View {
     let metric: SiteMetric
     let maxValue: Int
     let dateRange: StatsDateRange
+    var totalValue: Int?
 
     @State private var isTapped = false
 
@@ -72,6 +73,8 @@ struct TopListItemView: View {
                 TopListReferrerRowView(item: referrer)
             case let location as TopListItem.Location:
                 TopListLocationRowView(item: location)
+            case let device as TopListItem.Device:
+                TopListDeviceRowView(item: device, totalValue: totalValue ?? 0)
             case let link as TopListItem.ExternalLink:
                 TopListExternalLinkRowView(item: link)
             case let download as TopListItem.FileDownload:
@@ -96,7 +99,8 @@ struct TopListItemView: View {
                 currentValue: item.metrics[metric] ?? 0,
                 previousValue: previousValue,
                 metric: metric,
-                showChevron: hasDetails
+                showChevron: hasDetails,
+                device: item as? TopListItem.Device
             )
             .frame(minWidth: previousValue == nil ? 20 : minTrailingWidth, alignment: .trailing)
             .padding(.trailing, -3)
@@ -298,6 +302,48 @@ private func makePreviewItems() -> some View {
                 flag: "🇬🇧",
                 countryCode: "GB",
                 metrics: SiteMetricsSet(views: 15600)
+            ),
+            previousValue: nil
+        )
+    }
+
+    // Devices (screensize - shows percentage)
+    VStack(spacing: 8) {
+        makePreviewItem(
+            TopListItem.Device(
+                name: "mobile",
+                breakdown: .screensize,
+                metrics: SiteMetricsSet(views: 7380) // 73.8%
+            ),
+            previousValue: 7500
+        )
+
+        makePreviewItem(
+            TopListItem.Device(
+                name: "desktop",
+                breakdown: .screensize,
+                metrics: SiteMetricsSet(views: 2580) // 25.8%
+            ),
+            previousValue: nil
+        )
+    }
+
+    // Devices (platform - shows count)
+    VStack(spacing: 8) {
+        makePreviewItem(
+            TopListItem.Device(
+                name: "android",
+                breakdown: .platform,
+                metrics: SiteMetricsSet(views: 805)
+            ),
+            previousValue: 750
+        )
+
+        makePreviewItem(
+            TopListItem.Device(
+                name: "linux",
+                breakdown: .platform,
+                metrics: SiteMetricsSet(views: 217)
             ),
             previousValue: nil
         )

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListItemsView.swift
@@ -33,7 +33,8 @@ struct TopListItemsView: View {
             previousValue: data.previousItem(for: item)?.metrics[data.metric],
             metric: data.metric,
             maxValue: data.metrics.maxValue,
-            dateRange: dateRange
+            dateRange: dateRange,
+            totalValue: data.metrics.total
         )
         .frame(height: cellHeight)
     }

--- a/Modules/Sources/JetpackStats/Views/TopList/TopListMetricsView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListMetricsView.swift
@@ -5,11 +5,12 @@ struct TopListMetricsView: View {
     let previousValue: Int?
     let metric: SiteMetric
     var showChevron = false
+    var device: TopListItem.Device?
 
     var body: some View {
         VStack(alignment: .trailing, spacing: 2) {
             HStack(spacing: 3) {
-                Text(StatsValueFormatter.formatNumber(currentValue, onlyLarge: true))
+                Text(formattedValue)
                     .font(.system(.subheadline, design: .rounded, weight: .medium)).tracking(-0.1)
                     .foregroundColor(.primary)
                     .contentTransition(.numericText())
@@ -29,6 +30,18 @@ struct TopListMetricsView: View {
             }
         }
         .animation(.spring, value: trend)
+    }
+
+    // TEMPORARY WORKAROUND (CMM-1168):
+    // For screensize breakdown, display as percentage since the values are percentages * 100
+    // (e.g., 7380 represents 73.8%). For other breakdowns, display as regular numbers.
+    private var formattedValue: String {
+        if let device, device.breakdown == .screensize {
+            let percentage = Double(currentValue) / 100.0
+            return (percentage / 100).formatted(.percent.precision(.fractionLength(1)))
+        } else {
+            return StatsValueFormatter.formatNumber(currentValue, onlyLarge: true)
+        }
     }
 
     private var trend: TrendViewModel? {

--- a/Modules/Sources/WordPressKit/StatsDeviceTimeIntervalData.swift
+++ b/Modules/Sources/WordPressKit/StatsDeviceTimeIntervalData.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public struct StatsDeviceItem: Decodable {
+    public let name: String
+    public let value: Double
+
+    public init(name: String, value: Double) {
+        self.name = name
+        self.value = value
+    }
+}
+
+public struct StatsDeviceTimeIntervalData: Decodable {
+    public let items: [StatsDeviceItem]
+
+    enum CodingKeys: String, CodingKey {
+        case topValues = "top_values"
+    }
+
+    public init(items: [StatsDeviceItem]) {
+        self.items = items
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        // Decode top_values dictionary (Double handles both percentages and integer counts)
+        let topValues = try container.decode([String: Double].self, forKey: .topValues)
+
+        // Convert dictionary to array of items, sorted by value descending
+        self.items = topValues.map { key, value in
+            StatsDeviceItem(name: key, value: value)
+        }.sorted { $0.value > $1.value }
+    }
+}

--- a/Modules/Sources/WordPressKit/StatsServiceRemoteV2.swift
+++ b/Modules/Sources/WordPressKit/StatsServiceRemoteV2.swift
@@ -547,3 +547,37 @@ public extension StatsInsightData where Self: Codable {
         }
     }
 }
+
+// MARK: - Device Stats
+
+extension StatsServiceRemoteV2 {
+    public enum DeviceBreakdown: String {
+        case screensize
+        case platform
+        case browser
+    }
+
+    /// Fetches device stats for a specific breakdown type
+    /// - Parameters:
+    ///   - breakdown: The type of device breakdown (screensize, platform, or browser)
+    ///   - startDate: The start date for the stats query
+    ///   - endDate: The end date for the stats query
+    /// - Returns: Device stats data
+    public func getDeviceStats(
+        breakdown: DeviceBreakdown,
+        startDate: Date,
+        endDate: Date
+    ) async throws -> StatsDeviceTimeIntervalData {
+        let pathComponent = "stats/devices/\(breakdown.rawValue)"
+        let path = self.path(forEndpoint: "sites/\(siteID)/\(pathComponent)/", withVersion: ._1_1)
+
+        let dateFormatter = periodDataQueryDateFormatter
+        let parameters: [String: String] = [
+            "start_date": dateFormatter.string(from: startDate),
+            "date": dateFormatter.string(from: endDate)
+        ]
+
+        let result = await wordPressComRestApi.perform(.get, URLString: path, parameters: parameters, type: StatsDeviceTimeIntervalData.self)
+        return try result.get().body
+    }
+}

--- a/Modules/Tests/JetpackStatsTests/MockStatsServiceTests.swift
+++ b/Modules/Tests/JetpackStatsTests/MockStatsServiceTests.swift
@@ -20,7 +20,7 @@ struct MockStatsServiceTests {
             interval: dateInterval,
             granularity: dateInterval.preferredGranularity,
             limit: nil,
-            locationLevel: nil
+            options: TopListItemOptions()
         )
         print("elapsed: \((CFAbsoluteTimeGetCurrent() - startTime) * 1000) ms")
 

--- a/Modules/Tests/JetpackStatsTests/PieChartDataTests.swift
+++ b/Modules/Tests/JetpackStatsTests/PieChartDataTests.swift
@@ -1,0 +1,297 @@
+import Testing
+@testable import JetpackStats
+
+@Suite("PieChartData Tests")
+struct PieChartDataTests {
+
+    // MARK: - Helper Methods
+
+    private func makeDevice(name: String, views: Int, breakdown: DeviceBreakdown = .screensize) -> TopListItem.Device {
+        TopListItem.Device(
+            name: name,
+            breakdown: breakdown,
+            metrics: SiteMetricsSet(views: views)
+        )
+    }
+
+    // MARK: - Basic Functionality Tests
+
+    @Test("Calculates total value correctly")
+    func testTotalValue() {
+        let items = [
+            makeDevice(name: "Mobile", views: 100),
+            makeDevice(name: "Desktop", views: 50),
+            makeDevice(name: "Tablet", views: 25)
+        ]
+
+        let data = PieChartData(items: items, metric: .views)
+
+        #expect(data.totalValue == 175)
+    }
+
+    @Test("Calculates percentages correctly")
+    func testPercentages() {
+        let items = [
+            makeDevice(name: "Mobile", views: 60),
+            makeDevice(name: "Desktop", views: 40)
+        ]
+
+        let data = PieChartData(items: items, metric: .views)
+
+        #expect(data.segments.count == 2)
+        #expect(data.segments[0].percentage == 60.0)
+        #expect(data.segments[1].percentage == 40.0)
+    }
+
+    @Test("Sorts segments by value descending")
+    func testSorting() {
+        let items = [
+            makeDevice(name: "Tablet", views: 10),
+            makeDevice(name: "Desktop", views: 50),
+            makeDevice(name: "Mobile", views: 100)
+        ]
+
+        let data = PieChartData(items: items, metric: .views)
+
+        #expect(data.segments[0].name == "Mobile")
+        #expect(data.segments[1].name == "Desktop")
+        #expect(data.segments[2].name == "Tablet")
+    }
+
+    // MARK: - Smart Adaptive Algorithm Tests
+
+    @Test("Shows all segments when count is 3 or less")
+    func testShowAllWhenThreeOrFewer() {
+        let items = [
+            makeDevice(name: "Mobile", views: 100),
+            makeDevice(name: "Desktop", views: 50),
+            makeDevice(name: "Tablet", views: 25)
+        ]
+
+        let data = PieChartData(items: items, metric: .views)
+
+        #expect(data.segments.count == 3)
+        #expect(data.segments.allSatisfy { !$0.isOther })
+    }
+
+    @Test("Always shows top 3 segments")
+    func testAlwaysShowsTopThree() {
+        let items = [
+            makeDevice(name: "Mobile", views: 100),
+            makeDevice(name: "Desktop", views: 50),
+            makeDevice(name: "Tablet", views: 25),
+            makeDevice(name: "Chrome", views: 1), // Below 2% threshold
+            makeDevice(name: "Safari", views: 1)  // Below 2% threshold
+        ]
+
+        let data = PieChartData(items: items, metric: .views)
+
+        // Should show top 3 + "Other"
+        #expect(data.segments.count == 4)
+        #expect(data.segments[0].name == "Mobile")
+        #expect(data.segments[1].name == "Desktop")
+        #expect(data.segments[2].name == "Tablet")
+        #expect(data.segments[3].isOther == true)
+    }
+
+    @Test("Respects 2% threshold for segments beyond top 3")
+    func testPercentageThreshold() {
+        // Total = 1000
+        let items = [
+            makeDevice(name: "Mobile", views: 400),    // 40%
+            makeDevice(name: "Desktop", views: 300),   // 30%
+            makeDevice(name: "Tablet", views: 200),    // 20%
+            makeDevice(name: "Chrome", views: 50),     // 5% (above 2% threshold)
+            makeDevice(name: "Safari", views: 30),     // 3% (above 2% threshold)
+            makeDevice(name: "Firefox", views: 10),    // 1% (below threshold)
+            makeDevice(name: "Edge", views: 10)        // 1% (below threshold)
+        ]
+
+        let data = PieChartData(items: items, metric: .views)
+
+        // Should show: Mobile, Desktop, Tablet, Chrome, Safari + "Other"
+        #expect(data.segments.count == 6)
+        #expect(data.segments[0].name == "Mobile")
+        #expect(data.segments[1].name == "Desktop")
+        #expect(data.segments[2].name == "Tablet")
+        #expect(data.segments[3].name == "Chrome")
+        #expect(data.segments[4].name == "Safari")
+        #expect(data.segments[5].isOther == true)
+        #expect(data.segments[5].percentage == 2.0) // Firefox + Edge
+    }
+
+    @Test("Never shows more than 6 total segments")
+    func testMaximumSegmentLimit() {
+        // Create 10 items where first 6 are above 2% threshold
+        // Total = 1000, so 2% threshold = 20
+        let items = [
+            makeDevice(name: "Item1", views: 200),  // 20%
+            makeDevice(name: "Item2", views: 180),  // 18%
+            makeDevice(name: "Item3", views: 160),  // 16%
+            makeDevice(name: "Item4", views: 140),  // 14%
+            makeDevice(name: "Item5", views: 120),  // 12%
+            makeDevice(name: "Item6", views: 100),  // 10%
+            makeDevice(name: "Item7", views: 50),   // 5%
+            makeDevice(name: "Item8", views: 30),   // 3%
+            makeDevice(name: "Item9", views: 10),   // 1%
+            makeDevice(name: "Item10", views: 10)   // 1%
+        ]
+
+        let data = PieChartData(items: items, metric: .views)
+
+        // Should show top 5 + "Other" (max 6 total)
+        // Items 1-5 are always shown, Item6 is shown (10% > 2%), Items 7-10 aggregated
+        #expect(data.segments.count == 6)
+        #expect(data.segments[5].isOther == true)
+        #expect(data.segments[5].value == 100) // Items 7-10
+    }
+
+    @Test("Does not create 'Other' when all items fit within limits")
+    func testNoOtherWhenNotNeeded() {
+        let items = [
+            makeDevice(name: "Mobile", views: 400),
+            makeDevice(name: "Desktop", views: 300),
+            makeDevice(name: "Tablet", views: 200),
+            makeDevice(name: "Chrome", views: 100)
+        ]
+
+        let data = PieChartData(items: items, metric: .views)
+
+        #expect(data.segments.count == 4)
+        #expect(data.segments.allSatisfy { !$0.isOther })
+    }
+
+    // MARK: - Edge Cases
+
+    @Test("Handles empty items array")
+    func testEmptyItems() {
+        let items: [TopListItem.Device] = []
+        let data = PieChartData(items: items, metric: .views)
+
+        #expect(data.segments.isEmpty)
+        #expect(data.totalValue == 0)
+    }
+
+    @Test("Handles single item")
+    func testSingleItem() {
+        let items = [makeDevice(name: "Mobile", views: 100)]
+        let data = PieChartData(items: items, metric: .views)
+
+        #expect(data.segments.count == 1)
+        #expect(data.segments[0].percentage == 100.0)
+        #expect(data.segments[0].isOther == false)
+    }
+
+    @Test("Filters out items with zero values")
+    func testFiltersZeroValues() {
+        let items = [
+            makeDevice(name: "Mobile", views: 100),
+            makeDevice(name: "Desktop", views: 0),
+            makeDevice(name: "Tablet", views: 50)
+        ]
+
+        let data = PieChartData(items: items, metric: .views)
+
+        #expect(data.segments.count == 2)
+        #expect(data.segments.contains { $0.name == "Desktop" } == false)
+    }
+
+    @Test("Handles all items below threshold except top 3")
+    func testAllItemsBelowThreshold() {
+        // Total = 103
+        let items = [
+            makeDevice(name: "Mobile", views: 50),     // ~48.5%
+            makeDevice(name: "Desktop", views: 30),    // ~29.1%
+            makeDevice(name: "Tablet", views: 20),     // ~19.4%
+            makeDevice(name: "Chrome", views: 1),      // ~0.97% (below threshold)
+            makeDevice(name: "Safari", views: 1),      // ~0.97% (below threshold)
+            makeDevice(name: "Firefox", views: 1)      // ~0.97% (below threshold)
+        ]
+
+        let data = PieChartData(items: items, metric: .views)
+
+        // Should show top 3 + "Other"
+        #expect(data.segments.count == 4)
+        #expect(data.segments[3].isOther == true)
+        #expect(data.segments[3].value == 3)
+    }
+
+    // MARK: - Other Segment Tests
+
+    @Test("Other segment has unique ID")
+    func testOtherSegmentUniqueID() {
+        let items = [
+            makeDevice(name: "Mobile", views: 100),
+            makeDevice(name: "Desktop", views: 50),
+            makeDevice(name: "Tablet", views: 25),
+            makeDevice(name: "Chrome", views: 1),
+            makeDevice(name: "Safari", views: 1)
+        ]
+
+        let data = PieChartData(items: items, metric: .views)
+        let otherSegment = data.segments.first { $0.isOther }
+
+        #expect(otherSegment != nil)
+        #expect(otherSegment?.id.hasPrefix("pie-chart-other-") == true)
+    }
+
+    @Test("Other segment aggregates values correctly")
+    func testOtherSegmentAggregation() {
+        // Total = 1000, so 2% = 20
+        let items = [
+            makeDevice(name: "Mobile", views: 500),     // 50%
+            makeDevice(name: "Desktop", views: 300),    // 30%
+            makeDevice(name: "Tablet", views: 100),     // 10%
+            makeDevice(name: "Chrome", views: 50),      // 5%
+            makeDevice(name: "Safari", views: 30),      // 3%
+            makeDevice(name: "Firefox", views: 10),     // 1% (below threshold)
+            makeDevice(name: "Edge", views: 10)         // 1% (below threshold)
+        ]
+
+        let data = PieChartData(items: items, metric: .views)
+        let otherSegment = data.segments.first { $0.isOther }
+
+        #expect(otherSegment != nil)
+        #expect(otherSegment?.value == 20) // Firefox + Edge
+        #expect(otherSegment?.percentage == 2.0)
+    }
+
+    // MARK: - Real-World Scenarios
+
+    @Test("Handles typical device distribution")
+    func testTypicalDeviceDistribution() {
+        let items = [
+            makeDevice(name: "mobile", views: 738),
+            makeDevice(name: "desktop", views: 258),
+            makeDevice(name: "tablet", views: 4)
+        ]
+
+        let data = PieChartData(items: items, metric: .views)
+
+        #expect(data.segments.count == 3)
+        #expect(data.totalValue == 1000)
+        #expect(data.segments[0].percentage == 73.8)
+        #expect(data.segments[1].percentage == 25.8)
+        #expect(data.segments[2].percentage == 0.4)
+    }
+
+    @Test("Handles browser distribution with many items")
+    func testBrowserDistribution() {
+        let items = [
+            makeDevice(name: "chrome", views: 1063),
+            makeDevice(name: "safari", views: 15),
+            makeDevice(name: "miui", views: 10),
+            makeDevice(name: "edge", views: 9),
+            makeDevice(name: "other", views: 5),
+            makeDevice(name: "firefox", views: 1),
+            makeDevice(name: "opera", views: 1)
+        ]
+
+        let data = PieChartData(items: items, metric: .views)
+
+        // Chrome is ~96%, others are small
+        // Should show Chrome, Safari, Miui, Edge + "Other" (firefox, opera, other)
+        #expect(data.segments.count <= 6)
+        #expect(data.segments[0].name == "Chrome") // displayName capitalizes it
+    }
+}

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 26.7
 -----
 * [**] Stats: Add new "Adds" tab to show WordAdds earnings and stats [#25165]
+* [**] Stats: Add "Devices" view to the "Traffic" tab [#25176]
 
 26.6
 -----

--- a/Tests/WordPressKitTests/WordPressKitTests/Mock Data/stats-devices-browser.json
+++ b/Tests/WordPressKitTests/WordPressKitTests/Mock Data/stats-devices-browser.json
@@ -1,0 +1,11 @@
+{
+  "top_values": {
+    "chrome": 1063,
+    "safari": 15,
+    "miui": 10,
+    "edge": 9,
+    "other": 5,
+    "firefox": 1,
+    "opera": 1
+  }
+}

--- a/Tests/WordPressKitTests/WordPressKitTests/Mock Data/stats-devices-platform.json
+++ b/Tests/WordPressKitTests/WordPressKitTests/Mock Data/stats-devices-platform.json
@@ -1,0 +1,12 @@
+{
+  "top_values": {
+    "android": 805,
+    "linux": 217,
+    "windows": 41,
+    "mac": 25,
+    "iphone": 10,
+    "android_tablet": 3,
+    "ipad": 1,
+    "other": 1
+  }
+}

--- a/Tests/WordPressKitTests/WordPressKitTests/Mock Data/stats-devices-screensize.json
+++ b/Tests/WordPressKitTests/WordPressKitTests/Mock Data/stats-devices-screensize.json
@@ -1,0 +1,7 @@
+{
+  "top_values": {
+    "mobile": 73.8,
+    "desktop": 25.8,
+    "tablet": 0.4
+  }
+}

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/StatsRemoteV2Tests.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/StatsRemoteV2Tests.swift
@@ -30,6 +30,9 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
     let getEmailOpensFilename = "stats-email-opens.json"
     let getWordAdsMonthMockFilename = "stats-wordads-month.json"
     let getWordAdsEarningsFilename = "stats-wordads-earnings.json"
+    let getDeviceScreensizeFilename = "stats-devices-screensize.json"
+    let getDevicePlatformFilename = "stats-devices-platform.json"
+    let getDeviceBrowserFilename = "stats-devices-browser.json"
 
     // MARK: - Properties
 
@@ -50,6 +53,9 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
     var siteEmailOpensEndpoint: String { return "sites/\(siteID)/stats/opens/emails/231/rate" }
     var siteWordAdsEndpoint: String { return "sites/\(siteID)/wordads/stats" }
     var siteWordAdsEarningsEndpoint: String { return "sites/\(siteID)/wordads/earnings" }
+    var siteDeviceScreensizeEndpoint: String { return "sites/\(siteID)/stats/devices/screensize/" }
+    var siteDevicePlatformEndpoint: String { return "sites/\(siteID)/stats/devices/platform/" }
+    var siteDeviceBrowserEndpoint: String { return "sites/\(siteID)/stats/devices/browser/" }
 
     func toggleSpamStateEndpoint(for referrerDomain: String, markAsSpam: Bool) -> String {
         let action = markAsSpam ? "new" : "delete"
@@ -971,5 +977,35 @@ class StatsRemoteV2Tests: RemoteTestCase, RESTTestable {
 
         // Test Period string conversion
         XCTAssertEqual(decEarnings.period.string, "2025-12")
+    }
+
+    func testFetchDeviceScreensize() async throws {
+        stubRemoteResponse(siteDeviceScreensizeEndpoint, filename: getDeviceScreensizeFilename, contentType: .ApplicationJSON)
+
+        let devicesData = try await remote.getDeviceStats(breakdown: .screensize, startDate: Date(), endDate: Date())
+
+        XCTAssertEqual(devicesData.items.count, 3)
+        XCTAssertEqual(devicesData.items.first?.name, "mobile")
+        XCTAssertEqual(devicesData.items.first?.value, 73.8)
+    }
+
+    func testFetchDevicePlatform() async throws {
+        stubRemoteResponse(siteDevicePlatformEndpoint, filename: getDevicePlatformFilename, contentType: .ApplicationJSON)
+
+        let platformData = try await remote.getDeviceStats(breakdown: .platform, startDate: Date(), endDate: Date())
+
+        XCTAssertEqual(platformData.items.count, 8)
+        XCTAssertEqual(platformData.items.first?.name, "android")
+        XCTAssertEqual(platformData.items.first?.value, 805.0)
+    }
+
+    func testFetchDeviceBrowser() async throws {
+        stubRemoteResponse(siteDeviceBrowserEndpoint, filename: getDeviceBrowserFilename, contentType: .ApplicationJSON)
+
+        let browserData = try await remote.getDeviceStats(breakdown: .browser, startDate: Date(), endDate: Date())
+
+        XCTAssertEqual(browserData.items.count, 7)
+        XCTAssertEqual(browserData.items.first?.name, "chrome")
+        XCTAssertEqual(browserData.items.first?.value, 1063.0)
     }
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent+JetpackStats.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent+JetpackStats.swift
@@ -31,6 +31,7 @@ extension StatsEvent {
         case .todayCardTapped: .jetpackStatsTodayCardTapped
         case .topListItemTapped: .jetpackStatsTopListItemTapped
         case .locationLevelChanged: .jetpackStatsLocationLevelChanged
+        case .deviceBreakdownChanged: .jetpackStatsDeviceBreakdownChanged
         case .statsTabSelected: .jetpackStatsTabSelected
         case .errorEncountered: .jetpackStatsErrorEncountered
         }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -674,6 +674,7 @@ import WordPressShared
     // List Events
     case jetpackStatsTopListItemTapped
     case jetpackStatsLocationLevelChanged
+    case jetpackStatsDeviceBreakdownChanged
 
     // Navigation Events
     case jetpackStatsTabSelected
@@ -1846,6 +1847,8 @@ import WordPressShared
             return "jetpack_stats_top_list_item_tapped"
         case .jetpackStatsLocationLevelChanged:
             return "jetpack_stats_location_level_changed"
+        case .jetpackStatsDeviceBreakdownChanged:
+            return "jetpack_stats_device_breakdown_changed"
 
         // Navigation Events
         case .jetpackStatsTabSelected:


### PR DESCRIPTION
Closes [CMM-599: Add Devices breakdown (Premium+)](https://linear.app/a8c/issue/CMM-599/add-devices-breakdown-premium).

The feature and the implementation are pretty straightforward. It simply uses the existing infrastructure to add new TopListItemType, parse data using `StatsTimeIntervalData`, use SwiftUI Charts to render a pie chart – nothing fancy.

One issue I encounter was a limitation of how data measurements are models in JetpackStats. I documented it in code and in [CMM-1168: Switch to Double to represent data points](https://linear.app/a8c/issue/CMM-1168/switch-to-double-to-represent-data-points). I plan to address it separately.

##Screenshots

I used the existing `TopListCard` design and structure to represent "Screen Time". It's different form the web, but I think it works. I didn't want to add an ad-hoc card just for this one use-case just yet.

<img width="1349" height="677" alt="Screenshot 2026-01-28 at 11 43 31 AM" src="https://github.com/user-attachments/assets/5ca3fc22-357c-48ad-99aa-a242783f8b9d" />

<img width="1209" height="622" alt="Screenshot 2026-01-28 at 11 43 23 AM" src="https://github.com/user-attachments/assets/10ec0da9-20fe-4bd3-b26b-039586917000" />

<img width="1231" height="609" alt="Screenshot 2026-01-28 at 11 43 13 AM" src="https://github.com/user-attachments/assets/6eaea1a0-5b81-412e-8b5a-981ebbfbdc08" />
