### PR TITLE
Increase timeout to fix flaky unit tests

### DIFF
--- a/Tests/KeystoneTests/Tests/CoreData/ContextManagerTests.swift
+++ b/Tests/KeystoneTests/Tests/CoreData/ContextManagerTests.swift
@@ -254,7 +254,7 @@ class ContextManagerTests: XCTestCase {
                 expectation.fulfill()
             }
         }
-        wait(for: allCompleted, timeout: 1)
+        wait(for: allCompleted, timeout: 3)
 
         let request = WPAccount.fetchRequest()
         request.predicate = NSPredicate(format: "username = %@", username)


### PR DESCRIPTION
The increased timeout does not affect the test run time.