### PR TITLE
fix: Hide Gutenberg image lightbox expand button in Reader

### DIFF
--- a/WordPress/Misc/Reader/reader.css
+++ b/WordPress/Misc/Reader/reader.css
@@ -43,6 +43,9 @@ div.feedflare { display: none; }
 
 .sharedaddy, .jp-relatedposts, .mc4wp-form, .wpcnt, .OUTBRAIN, .adsbygoogle { display: none; }
 
+/* Hide Gutenberg image lightbox expand button - iOS has its own image zoom handling */
+button.lightbox-trigger { display: none; }
+
 img {
     opacity: 0;
 }


### PR DESCRIPTION
## Description

Hides the Gutenberg image lightbox expand button that appears on images in Reader posts. These buttons are disruptive to the reading experience and non-functional in the Reader context since iOS has its own image zoom handling.

Fix CMM-1205

<details><summary>Screenshot of disruptive button</summary>
<p>

![jetpack-ios-reader-gallery-button](https://github.com/user-attachments/assets/cf6d6d3c-0044-4fb6-8ab9-d5705e77a985)


</p>
</details> 

## Testing instructions

1. Open the Reader tab
2. Navigate to a post that contains images with Gutenberg's lightbox feature enabled (e.g., a photo gallery post)
3. Verify that the small expand buttons no longer appear at the bottom corners of images
4. Confirm that the native iOS image zoom functionality still works as expected