### PR TITLE
task: Add scripts for toggling local GutenbergKit development

### DIFF
--- a/Scripts/gutenbergkit-local.sh
+++ b/Scripts/gutenbergkit-local.sh
@@ -10,8 +10,26 @@ REPO_ROOT="$(dirname "$SCRIPT_DIR")"
 PACKAGE_SWIFT="$REPO_ROOT/Modules/Package.swift"
 JETPACK_SCHEME="$REPO_ROOT/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Jetpack.xcscheme"
 
+# Check if already using local path
+if grep -q '\.package(path: "../../GutenbergKit")' "$PACKAGE_SWIFT"; then
+    echo "Already using local GutenbergKit path"
+    exit 0
+fi
+
+# Verify remote URL exists before replacing
+if ! grep -q 'github.com/wordpress-mobile/GutenbergKit' "$PACKAGE_SWIFT"; then
+    echo "Error: Could not find GutenbergKit dependency in Package.swift" >&2
+    exit 1
+fi
+
 # Replace GutenbergKit dependency with local path
 sed -i '' 's|\.package(url: "https://github.com/wordpress-mobile/GutenbergKit",[^)]*)|.package(path: "../../GutenbergKit")|' "$PACKAGE_SWIFT"
+
+# Verify the change was applied
+if ! grep -q '\.package(path: "../../GutenbergKit")' "$PACKAGE_SWIFT"; then
+    echo "Error: Failed to update Package.swift" >&2
+    exit 1
+fi
 
 # Enable GUTENBERG_EDITOR_URL environment variable in Jetpack scheme
 sed -i '' '

--- a/Scripts/gutenbergkit-local.sh
+++ b/Scripts/gutenbergkit-local.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+#
+# Enable local GutenbergKit development by switching Package.swift to use a local path.
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+PACKAGE_SWIFT="$REPO_ROOT/Modules/Package.swift"
+JETPACK_SCHEME="$REPO_ROOT/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Jetpack.xcscheme"
+
+# Replace GutenbergKit dependency with local path
+sed -i '' 's|\.package(url: "https://github.com/wordpress-mobile/GutenbergKit",[^)]*)|.package(path: "../../GutenbergKit")|' "$PACKAGE_SWIFT"
+
+# Enable GUTENBERG_EDITOR_URL environment variable in Jetpack scheme
+sed -i '' '
+    /key = "GUTENBERG_EDITOR_URL"/{
+        n
+        n
+        s/isEnabled = "NO"/isEnabled = "YES"/
+    }
+' "$JETPACK_SCHEME"
+
+echo "Switched to local GutenbergKit path"
+echo "Enabled GUTENBERG_EDITOR_URL in Jetpack scheme"
+echo "Resolving package dependencies..."
+
+xcodebuild -resolvePackageDependencies -project "$REPO_ROOT/WordPress/WordPress.xcodeproj" -quiet
+
+echo "Done"

--- a/Scripts/gutenbergkit-local.sh
+++ b/Scripts/gutenbergkit-local.sh
@@ -42,7 +42,7 @@ sed -i '' '
 
 echo "Switched to local GutenbergKit path"
 echo "Enabled GUTENBERG_EDITOR_URL in Jetpack scheme"
-echo "Resolving package dependencies..."
+echo "Resolving package dependencies (this may take a while)..."
 
 xcodebuild -resolvePackageDependencies -project "$REPO_ROOT/WordPress/WordPress.xcodeproj" -quiet
 

--- a/Scripts/gutenbergkit-remote.sh
+++ b/Scripts/gutenbergkit-remote.sh
@@ -16,7 +16,7 @@ VERSION=$(git show trunk:Modules/Package.swift \
     | sed -n 's/.*from: "\([^"]*\)".*/\1/p')
 
 if [ -z "$VERSION" ]; then
-    echo "Error: Could not find GutenbergKit version in git history" >&2
+    echo "Error: Could not find GutenbergKit version in trunk" >&2
     exit 1
 fi
 

--- a/Scripts/gutenbergkit-remote.sh
+++ b/Scripts/gutenbergkit-remote.sh
@@ -52,7 +52,7 @@ sed -i '' '
 
 echo "Switched to remote GutenbergKit ($VERSION)"
 echo "Disabled GUTENBERG_EDITOR_URL in Jetpack scheme"
-echo "Resolving package dependencies..."
+echo "Resolving package dependencies (this may take a while)..."
 
 xcodebuild -resolvePackageDependencies -project "$REPO_ROOT/WordPress/WordPress.xcodeproj" -quiet
 

--- a/Scripts/gutenbergkit-remote.sh
+++ b/Scripts/gutenbergkit-remote.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Disable local GutenbergKit development by switching Package.swift back to remote.
+#
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(dirname "$SCRIPT_DIR")"
+PACKAGE_SWIFT="$REPO_ROOT/Modules/Package.swift"
+JETPACK_SCHEME="$REPO_ROOT/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/Jetpack.xcscheme"
+
+# Extract the GutenbergKit version from trunk
+VERSION=$(git show trunk:Modules/Package.swift \
+    | grep 'wordpress-mobile/GutenbergKit' \
+    | sed -n 's/.*from: "\([^"]*\)".*/\1/p')
+
+if [ -z "$VERSION" ]; then
+    echo "Error: Could not find GutenbergKit version in git history" >&2
+    exit 1
+fi
+
+# Replace local path with remote URL
+sed -i '' "s|\.package(path: \"../../GutenbergKit\")|.package(url: \"https://github.com/wordpress-mobile/GutenbergKit\", from: \"$VERSION\")|" "$PACKAGE_SWIFT"
+
+# Disable GUTENBERG_EDITOR_URL environment variable in Jetpack scheme
+sed -i '' '
+    /key = "GUTENBERG_EDITOR_URL"/{
+        n
+        n
+        s/isEnabled = "YES"/isEnabled = "NO"/
+    }
+' "$JETPACK_SCHEME"
+
+echo "Switched to remote GutenbergKit ($VERSION)"
+echo "Disabled GUTENBERG_EDITOR_URL in Jetpack scheme"
+echo "Resolving package dependencies..."
+
+xcodebuild -resolvePackageDependencies -project "$REPO_ROOT/WordPress/WordPress.xcodeproj" -quiet
+
+echo "Done"

--- a/Scripts/gutenbergkit-remote.sh
+++ b/Scripts/gutenbergkit-remote.sh
@@ -20,8 +20,26 @@ if [ -z "$VERSION" ]; then
     exit 1
 fi
 
+# Check if already using remote URL
+if grep -q 'github.com/wordpress-mobile/GutenbergKit' "$PACKAGE_SWIFT"; then
+    echo "Already using remote GutenbergKit"
+    exit 0
+fi
+
+# Verify local path exists before replacing
+if ! grep -q '\.package(path: "../../GutenbergKit")' "$PACKAGE_SWIFT"; then
+    echo "Error: Could not find local GutenbergKit dependency in Package.swift" >&2
+    exit 1
+fi
+
 # Replace local path with remote URL
 sed -i '' "s|\.package(path: \"../../GutenbergKit\")|.package(url: \"https://github.com/wordpress-mobile/GutenbergKit\", from: \"$VERSION\")|" "$PACKAGE_SWIFT"
+
+# Verify the change was applied
+if ! grep -q 'github.com/wordpress-mobile/GutenbergKit' "$PACKAGE_SWIFT"; then
+    echo "Error: Failed to update Package.swift" >&2
+    exit 1
+fi
 
 # Disable GUTENBERG_EDITOR_URL environment variable in Jetpack scheme
 sed -i '' '


### PR DESCRIPTION
## Description
Add two shell scripts to simplify switching between local and remote GutenbergKit development:

- `Scripts/gutenbergkit-local.sh`: Switches Package.swift to use a local path (`../../GutenbergKit`) and enables `GUTENBERG_EDITOR_URL` in the Jetpack scheme
- `Scripts/gutenbergkit-remote.sh`: Restores the remote GitHub URL (version pulled from trunk) and disables `GUTENBERG_EDITOR_URL`

These scripts aren't completely necessary, it's just something I do very frequently. If others do not feel this is worthwhile, we can discard these changes. 

## Testing instructions
1. Run `./Scripts/gutenbergkit-local.sh` and verify:
   - Package.swift uses `.package(path: "../../GutenbergKit")`
   - Jetpack scheme has `GUTENBERG_EDITOR_URL` with `isEnabled = "YES"`
2. Run `./Scripts/gutenbergkit-remote.sh` and verify:
   - Package.swift uses `.package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "X.Y.Z")`
   - Jetpack scheme has `GUTENBERG_EDITOR_URL` with `isEnabled = "NO"`