### PR TITLE
Add feature gating for new advanced features in Stats

### DIFF
--- a/Modules/Sources/JetpackStats/Analytics/StatsEvent.swift
+++ b/Modules/Sources/JetpackStats/Analytics/StatsEvent.swift
@@ -179,6 +179,14 @@ public enum StatsEvent {
     ///   - "error_code": Specific error code if available
     ///   - "screen": Where the error occurred
     case errorEncountered
+
+    // MARK: - Feature Gate Events
+
+    /// Feature gate "Explore Plans" button tapped
+    /// - Parameters:
+    ///   - "feature": The gated feature (e.g., "utm_stats", "device_stats", "location_regions")
+    ///   - "source": Where the button was tapped (e.g., "card", "detail_view")
+    case featureGateExplorePlansTapped
 }
 
 // MARK: - StatsTracker Protocol

--- a/Modules/Sources/JetpackStats/Cards/TopListCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListCard.swift
@@ -320,7 +320,10 @@ struct TopListCard: View {
                 } else {
                     topListItemsView(data: data)
                 }
+            } else if let error = viewModel.loadingError as? StatsFeatureGateError {
+                makeFeatureGateView(error: error)
             } else {
+                // Show generic error view for other errors
                 makeEmptyStateView(message: viewModel.loadingError?.localizedDescription ?? Strings.Errors.generic)
             }
         }
@@ -396,6 +399,16 @@ struct TopListCard: View {
             .overlay {
                 SimpleErrorView(message: message)
                     .offset(y: -18)
+            }
+    }
+
+    private func makeFeatureGateView(error: StatsFeatureGateError) -> some View {
+        topListItemsView(data: mockData)
+            .allowsHitTesting(false)
+            .redacted(reason: .placeholder)
+            .opacity(0.2)
+            .overlay {
+                FeatureGateBannerView(error: error)
             }
     }
 

--- a/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
@@ -201,6 +201,7 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
             loadingError = error
             data = nil
             countriesMapData = nil
+            staleTimer?.cancel()
             tracker?.trackError(error, screen: "top_list_card")
         }
 

--- a/Modules/Sources/JetpackStats/Services/StatsFeatureGateError.swift
+++ b/Modules/Sources/JetpackStats/Services/StatsFeatureGateError.swift
@@ -1,0 +1,43 @@
+import Foundation
+@preconcurrency import WordPressKit
+
+/// Error indicating a stats feature is gated behind a paid plan
+struct StatsFeatureGateError: LocalizedError, Sendable {
+    let message: String
+    let itemType: TopListItemType
+
+    var errorDescription: String? {
+        message
+    }
+
+    /// Analytics-friendly feature name
+    var featureName: String {
+        switch itemType {
+        case .utm:
+            return "utm_stats"
+        case .devices:
+            return "device_stats"
+        case .locations:
+            return "location_breakdown"
+        default:
+            return itemType.rawValue
+        }
+    }
+
+    /// Creates a feature gate error from an API error response
+    /// - Parameters:
+    ///   - apiError: The error from the API
+    ///   - itemType: The item type that was requested when the error occurred
+    /// - Returns: A StatsFeatureGateError if the error indicates a gated feature, nil otherwise
+    static func from(apiError: Error, itemType: TopListItemType) -> StatsFeatureGateError? {
+        guard let wpError = apiError as? WordPressAPIError<WordPressComRestApiEndpointError>,
+              case .endpointError(let endpointError) = wpError else {
+            return nil
+        }
+        guard endpointError.apiErrorCode == "unauthorized",
+              let message = endpointError.apiErrorMessage else {
+            return nil
+        }
+        return StatsFeatureGateError(message: message, itemType: itemType)
+    }
+}

--- a/Modules/Sources/JetpackStats/Services/StatsService.swift
+++ b/Modules/Sources/JetpackStats/Services/StatsService.swift
@@ -195,6 +195,9 @@ actor StatsService: StatsServiceProtocol {
 
             return data
         } catch {
+            if let error = StatsFeatureGateError.from(apiError: error, itemType: item) {
+                throw error
+            }
             // A workaround for an issue where `/stats` return `"summary": null`
             // when there are no recoreded periods (happens when the entire requested
             // period is _before_ the site creation).

--- a/Modules/Sources/JetpackStats/StatsContext.swift
+++ b/Modules/Sources/JetpackStats/StatsContext.swift
@@ -13,6 +13,8 @@ public struct StatsContext: Sendable {
     public var preprocessAvatar: (@Sendable (URL, CGFloat) -> URL)?
     /// Analytics tracker for monitoring user interactions
     public var tracker: (any StatsTracker)?
+    /// URL to upgrade the site's plan
+    public var upgradeURL: URL?
 
     public init(timeZone: TimeZone, siteID: Int, api: WordPressComRestApi) {
         self.init(timeZone: timeZone, siteID: siteID, service: StatsService(siteID: siteID, api: api, timeZone: timeZone))
@@ -31,12 +33,14 @@ public struct StatsContext: Sendable {
         self.formatters = StatsFormatters(timeZone: timeZone)
         self.preprocessAvatar = nil
         self.tracker = nil
+        self.upgradeURL = nil
     }
 
     public static let demo: StatsContext = {
         var context = StatsContext(timeZone: .current, siteID: 1, service: MockStatsService())
 #if DEBUG
         context.tracker = MockStatsTracker.shared
+        context.upgradeURL = URL(string: "https://wordpress.com/pricing/")
 #endif
         return context
     }()

--- a/Modules/Sources/JetpackStats/Strings.swift
+++ b/Modules/Sources/JetpackStats/Strings.swift
@@ -410,4 +410,9 @@ enum Strings {
         static let date = AppLocalizedString("jetpackStats.chartData.date", value: "DATE", comment: "Column header for date")
         static let value = AppLocalizedString("jetpackStats.chartData.value", value: "VALUE", comment: "Column header for value")
     }
+
+    enum FeatureGate {
+        static let message = AppLocalizedString("jetpackStats.featureGate.message", value: "Upgrade your plan to get access to advanced analytics", comment: "Message shown when a stats feature is gated behind a paid plan")
+        static let explorePlans = AppLocalizedString("jetpackStats.featureGate.explorePlans", value: "Explore Plans", comment: "Button to explore plans when a feature is gated")
+    }
 }

--- a/Modules/Sources/JetpackStats/Views/FeatureGateBannerView.swift
+++ b/Modules/Sources/JetpackStats/Views/FeatureGateBannerView.swift
@@ -1,0 +1,54 @@
+import SwiftUI
+
+/// Banner shown when a stats feature is gated behind a paid plan
+struct FeatureGateBannerView: View {
+    let error: StatsFeatureGateError
+
+    @Environment(\.context) private var context
+    @Environment(\.openURL) private var openURL
+
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: "lock.fill")
+                .font(.system(size: 40))
+                .foregroundStyle(.secondary)
+                .accessibilityHidden(true)
+
+            Text(Strings.FeatureGate.message)
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+                .frame(maxWidth: 240)
+
+            if let upgradeURL = context.upgradeURL {
+                Button(Strings.FeatureGate.explorePlans) {
+                    handleExplorePlansTapped(upgradeURL: upgradeURL)
+                }
+                .buttonStyle(.borderedProminent)
+                .buttonBorderShape(.capsule)
+                .padding(.top, 16)
+            }
+        }
+        .padding(Constants.step2)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private func handleExplorePlansTapped(upgradeURL: URL) {
+        context.tracker?.send(.featureGateExplorePlansTapped, properties: [
+            "feature": error.featureName,
+            "source": "card"
+        ])
+        openURL(upgradeURL)
+    }
+}
+
+#Preview("Feature Gate on Card") {
+    FeatureGateBannerView(error: StatsFeatureGateError(
+        message: "The plan for this site does not allow fetching Device stats",
+        itemType: .devices
+    ))
+    .environment(\.context, .demo)
+    .padding()
+    .background(Color(uiColor: .secondarySystemBackground))
+}

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent+JetpackStats.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent+JetpackStats.swift
@@ -36,6 +36,7 @@ extension StatsEvent {
         case .utmParamGroupingChanged: .jetpackStatsUtmParamGroupingChanged
         case .statsTabSelected: .jetpackStatsTabSelected
         case .errorEncountered: .jetpackStatsErrorEncountered
+        case .featureGateExplorePlansTapped: .jetpackStatsFeatureGateExplorePlansTapped
         }
     }
 }

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -684,6 +684,9 @@ import WordPressShared
     // Error Events
     case jetpackStatsErrorEncountered
 
+    // Feature Gate Events
+    case jetpackStatsFeatureGateExplorePlansTapped
+
     // Jetpack Connection Flow
     case jetpackConnectStarted
     case jetpackConnectLogin
@@ -1863,6 +1866,10 @@ import WordPressShared
         // Error Events
         case .jetpackStatsErrorEncountered:
             return "jetpack_stats_error_encountered"
+
+        // Feature Gate Events
+        case .jetpackStatsFeatureGateExplorePlansTapped:
+            return "jetpack_stats_feature_gate_explore_plans_tapped"
 
         // Jetpack Connection Flow
         case .jetpackConnectStarted:

--- a/WordPress/Classes/ViewRelated/Stats/StatsHostingViewController.swift
+++ b/WordPress/Classes/ViewRelated/Stats/StatsHostingViewController.swift
@@ -80,8 +80,17 @@ extension StatsContext {
             return avatarURL.replacing(options: options)?.url ?? url
         }
 
-        // Configure analytics tracker
         self.tracker = WPAnalyticsStatsTracker()
+
+        self.upgradeURL = Self.makeUpgradeURL(for: blog)
+    }
+
+    private static func makeUpgradeURL(for blog: Blog) -> URL {
+        if blog.isHostedAtWPcom {
+            return URL(string: "https://wordpress.com/pricing/")!
+        } else {
+            return URL(string: "https://cloud.jetpack.com/pricing")!
+        }
     }
 }
 


### PR DESCRIPTION
## Description
Closes [CMM-1152](https://linear.app/a8c/issue/CMM-1152/add-feature-gating) by adding a simple banner for new advanced features in Stats.

The implementation relies on the feature gate implemented on the individual API layer. It returns the following:

```
"body": {
	"error": "unauthorized",
	"message": "The plan for <your-site-id> does not allow fetching Device stats"
}
```

## Testing instructions

New advanced features: UTM, Devices, and Location by Region and City.

- **Verify** that new features are available for "Premium" and higher plans
- **Verify** that the banner is shown for free plans
- **Verify** that "Explore Plans" opens Dotcom pricing for Dotcom sites and Jetpack pricing for Jetpack sites

## Screenshots

<img width="456" height="972" alt="Screenshot 2026-01-30 at 5 13 16 PM" src="https://github.com/user-attachments/assets/51e78cdb-6f47-42a1-8dcc-57e55f004519" />
