### PR TITLE
Exclude sensitive headers from Pulse logs

### DIFF
--- a/WordPress/Classes/Networking/PulseNetworkLogger.swift
+++ b/WordPress/Classes/Networking/PulseNetworkLogger.swift
@@ -4,8 +4,21 @@ import Support
 
 public final class PulseNetworkLogger: NSObject, URLSessionTaskDelegate, URLSessionDataDelegate {
 
+    private let _logger: NetworkLogger
     private var logger: NetworkLogger? {
-        ExtensiveLogging.enabled ? NetworkLogger.shared : nil
+        ExtensiveLogging.enabled ? _logger : nil
+    }
+
+    override public init() {
+        var configuration = NetworkLogger.Configuration()
+        configuration.sensitiveHeaders = [
+            "Authorization",
+            "Cookie",
+            "Set-Cookie",
+            "X-WP-Nonce"
+        ]
+        _logger = NetworkLogger(configuration: configuration)
+        super.init()
     }
 
     public func urlSession(_ session: URLSession, didCreateTask task: URLSessionTask) {


### PR DESCRIPTION
## Description

The Authorization header is now shown as `<private>`.

<img width="400" src="https://github.com/user-attachments/assets/270154a9-ea95-4101-a07f-b99343d347f8" />


## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
