### PR TITLE
Switch to Sans in Stats

### DIFF
--- a/Modules/Sources/JetpackStats/Cards/RealtimeMetricsCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/RealtimeMetricsCard.swift
@@ -84,7 +84,8 @@ struct RealtimeMetricsCard: View {
             Text(value)
                 .contentTransition(.numericText())
                 .animation(.spring, value: value)
-                .font(Font.make(.recoleta, textStyle: .title, weight: .medium))
+                .font(Constants.Typography.mediumDisplayFont)
+                .kerning(Constants.Typography.largeDisplayKerning)
                 .foregroundColor(.primary)
         }
         .frame(maxWidth: .infinity, alignment: .leading)

--- a/Modules/Sources/JetpackStats/Cards/TodayCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TodayCard.swift
@@ -71,7 +71,7 @@ struct TodayCard: View {
                 .font(.caption.weight(.medium))
         }
         .foregroundStyle(Color.secondary)
-        .offset(y: 7) // Get it close to the value
+        .offset(y: 3) // Get it close to the value
         .dynamicTypeSize(...DynamicTypeSize.large)
     }
 
@@ -118,7 +118,7 @@ struct TodayCard: View {
             ForEach(viewModel.configuration.metrics) { metric in
                 if metric == .views {
                     TodayCardProminentMetricView(value: metrics[metric], metric: metric)
-                        .offset(y: 6.5) // Compensate for the larger line height
+                        .offset(y: 2.5) // Compensate for the larger line height
                 } else {
                     TodayCardMetricView(metric: metric, value: metrics[metric])
                 }
@@ -319,7 +319,8 @@ private struct TodayCardProminentMetricView: View {
     var body: some View {
         Text(formattedValue)
             .contentTransition(.numericText())
-            .font(Font.make(.recoleta, textStyle: .title, weight: .medium))
+            .font(Font.system(.title, design: .rounded, weight: .medium))
+            .kerning(-1.0)
             .foregroundColor(.primary)
             .lineLimit(1)
             .animation(.spring, value: value)

--- a/Modules/Sources/JetpackStats/Cards/WordAdsEarningsTotalsCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/WordAdsEarningsTotalsCard.swift
@@ -13,7 +13,8 @@ struct WordAdsEarningsTotalsCard: View {
             VStack(alignment: .leading, spacing: Constants.step1) {
                 Text(totalEarningsValue)
                     .contentTransition(.numericText())
-                    .font(Font.make(.recoleta, textStyle: .largeTitle, weight: .medium))
+                    .font(Constants.Typography.largeDisplayFont)
+                    .kerning(Constants.Typography.largeDisplayKerning)
                     .foregroundColor(.primary)
                     .animation(.spring, value: totalEarningsValue)
 

--- a/Modules/Sources/JetpackStats/Constants.swift
+++ b/Modules/Sources/JetpackStats/Constants.swift
@@ -92,6 +92,20 @@ public enum Constants {
             return baseColor.opacity(colorScheme == .light ? 0.38 : 0.60)
         }
     }
+
+    enum Typography {
+        /// Large display font (used for prominent metrics)
+        static let largeDisplayFont = Font.system(.largeTitle, design: .rounded, weight: .medium)
+
+        /// Medium display font (used for main metrics)
+        static let mediumDisplayFont = Font.system(.title, design: .rounded, weight: .medium)
+
+        /// Small display font (used for secondary metrics)
+        static let smallDisplayFont = Font.system(.title2, design: .rounded, weight: .medium)
+
+        /// Kerning for large display fonts to improve readability
+        static let largeDisplayKerning: CGFloat = -1.0
+    }
 }
 
 private extension Color {

--- a/Modules/Sources/JetpackStats/Screens/AuthorStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/AuthorStatsView.swift
@@ -128,9 +128,9 @@ struct AuthorStatsView: View {
                     .textCase(.uppercase)
             }
 
-            HStack(spacing: Constants.step2) {
+            HStack(alignment: .center, spacing: Constants.step1) {
                 Text(StatsValueFormatter.formatNumber(current, onlyLarge: true))
-                    .font(Font.make(.recoleta, textStyle: .title2, weight: .medium))
+                    .font(Constants.Typography.smallDisplayFont)
                     .foregroundColor(.primary)
                     .contentTransition(.numericText())
 

--- a/Modules/Sources/JetpackStats/Screens/PostStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/PostStatsView.swift
@@ -412,7 +412,8 @@ private struct PostStatsMetricsStripView: View {
                     Text(formattedValue)
                         .contentTransition(.numericText())
                         .animation(.spring, value: value)
-                        .font(Font.make(.recoleta, textStyle: .title, weight: .medium))
+                        .font(Constants.Typography.mediumDisplayFont)
+                        .kerning(Constants.Typography.largeDisplayKerning)
                         .foregroundColor(.primary)
                 }
             }
@@ -516,7 +517,8 @@ private struct PostStatsEmailMetricsView: View {
                 HStack {
                     Text(formattedValue)
                         .contentTransition(.numericText())
-                        .font(Font.make(.recoleta, textStyle: .title, weight: .medium))
+                        .font(Constants.Typography.mediumDisplayFont)
+                        .kerning(Constants.Typography.largeDisplayKerning)
                         .foregroundColor(.primary)
                 }
             }

--- a/Modules/Sources/JetpackStats/Screens/TopListScreenView.swift
+++ b/Modules/Sources/JetpackStats/Screens/TopListScreenView.swift
@@ -132,6 +132,7 @@ struct TopListScreenView: View {
                 .redacted(reason: viewModel.isFirstLoad ? .placeholder : [])
                 .pulsating(viewModel.isFirstLoad)
                 .animation(.smooth, value: viewModel.isFirstLoad)
+                .offset(y: -1)
         }
         .padding(.vertical, Constants.step2)
         .padding(.horizontal, Constants.step3)
@@ -150,7 +151,8 @@ struct TopListScreenView: View {
         VStack(alignment: .trailing, spacing: 0) {
             Text(formattedValue)
                 .contentTransition(.numericText())
-                .font(Font.make(.recoleta, textStyle: .title, weight: .medium))
+                .font(Constants.Typography.mediumDisplayFont)
+                .kerning(Constants.Typography.largeDisplayKerning)
                 .foregroundColor(.primary)
                 .lineLimit(1)
                 .animation(.spring, value: formattedValue)
@@ -158,7 +160,6 @@ struct TopListScreenView: View {
             Text(trend.formattedTrend)
                 .font(.system(.subheadline, design: .rounded, weight: .medium)).tracking(-0.2)
                 .foregroundStyle(trend.sentiment.foregroundColor)
-                .padding(.top, -4)
         }
     }
 

--- a/Modules/Sources/JetpackStats/Screens/UTMMetricStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/UTMMetricStatsView.swift
@@ -81,14 +81,6 @@ struct UTMMetricStatsView: View {
     private var headerView: some View {
         VStack(spacing: Constants.step3) {
             HStack(spacing: Constants.step3) {
-                // UTM Icon
-                Image(systemName: "chart.line.uptrend.xyaxis")
-                    .font(.system(size: 40))
-                    .foregroundColor(.secondary)
-                    .frame(width: 60, height: 60)
-                    .background(Color.secondary.opacity(0.1))
-                    .clipShape(Circle())
-
                 // Label and metrics
                 VStack(alignment: .leading, spacing: Constants.step1) {
                     Text(utmMetric.label)
@@ -127,7 +119,7 @@ struct UTMMetricStatsView: View {
 
             HStack(spacing: Constants.step2) {
                 Text(StatsValueFormatter.formatNumber(current, onlyLarge: true))
-                    .font(Font.make(.recoleta, textStyle: .title2, weight: .medium))
+                    .font(Constants.Typography.smallDisplayFont)
                     .foregroundColor(.primary)
                     .contentTransition(.numericText())
 

--- a/Modules/Sources/JetpackStats/Views/BadgeTrendIndicator.swift
+++ b/Modules/Sources/JetpackStats/Views/BadgeTrendIndicator.swift
@@ -16,8 +16,8 @@ struct BadgeTrendIndicator: View {
                 .font(.system(.caption, design: .rounded, weight: .semibold)).tracking(-0.25)
         }
         .foregroundColor(trend.sentiment.foregroundColor)
-        .padding(.horizontal, 7)
-        .padding(.vertical, 6)
+        .padding(.horizontal, 6)
+        .padding(.vertical, 5)
         .background(trend.sentiment.backgroundColor)
         .cornerRadius(6)
         .animation(.spring, value: trend.percentage)

--- a/Modules/Sources/JetpackStats/Views/ChartValuesSummaryView.swift
+++ b/Modules/Sources/JetpackStats/Views/ChartValuesSummaryView.swift
@@ -22,7 +22,8 @@ struct ChartValuesSummaryView: View {
     private var standard: some View {
         HStack(alignment: .center, spacing: 16) {
             Text(trend.formattedCurrentValue)
-                .font(Font.make(.recoleta, textStyle: .title, weight: .medium))
+                .font(Constants.Typography.mediumDisplayFont)
+                .kerning(Constants.Typography.largeDisplayKerning)
                 .foregroundColor(.primary)
                 .contentTransition(.numericText())
 

--- a/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
+++ b/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
@@ -116,7 +116,8 @@ private struct MetricItemView<Metric: MetricType>: View {
         VStack(alignment: .leading, spacing: 2) {
             Text(formattedValue)
                 .contentTransition(.numericText())
-                .font(Font.make(.recoleta, textStyle: .title, weight: .medium))
+                .font(Font.system(.title, design: .rounded, weight: .medium))
+                .kerning(-1.0)
                 .foregroundColor(.primary)
                 .lineLimit(1)
                 .animation(.spring, value: formattedValue)

--- a/Modules/Sources/JetpackStats/Views/StandaloneMetricView.swift
+++ b/Modules/Sources/JetpackStats/Views/StandaloneMetricView.swift
@@ -18,7 +18,7 @@ struct StandaloneMetricView: View {
                     .textCase(.uppercase)
             }
             Text(StatsValueFormatter.formatNumber(value, onlyLarge: true))
-                .font(Font.make(.recoleta, textStyle: .title2, weight: .medium))
+                .font(Constants.Typography.smallDisplayFont)
                 .foregroundColor(.primary)
                 .contentTransition(.numericText())
         }


### PR DESCRIPTION
## Description
Closes [CMM-1211: Stats Fonts Inconsistent in Jetpack iOS App](https://linear.app/a8c/issue/CMM-1211/stats-fonts-inconsistent-in-jetpack-ios-app).

## Screenshots
<img width="555" height="1024" alt="Screenshot 2026-02-03 at 5 00 17 PM" src="https://github.com/user-attachments/assets/c58910cc-c43d-4328-866a-a66adb11f0cd" />

<img width="340" alt="Screenshot 2026-02-03 at 3 56 12 PM" src="https://github.com/user-attachments/assets/21137843-b9be-4441-af56-5bf0314c6650" />
<img width="340" alt="Screenshot 2026-02-03 at 3 58 38 PM" src="https://github.com/user-attachments/assets/3f866497-b915-404e-8e54-57c980447dad" />
