### PR TITLE
Prioritize value over trend in Top List

### DIFF
--- a/Modules/Sources/JetpackStats/Views/TopList/TopListMetricsView.swift
+++ b/Modules/Sources/JetpackStats/Views/TopList/TopListMetricsView.swift
@@ -8,28 +8,37 @@ struct TopListMetricsView: View {
     var device: TopListItem.Device?
 
     var body: some View {
-        VStack(alignment: .trailing, spacing: 2) {
+        VStack(alignment: .trailing, spacing: 1) {
             HStack(spacing: 3) {
                 Text(formattedValue)
-                    .font(.system(.subheadline, design: .rounded, weight: .medium)).tracking(-0.1)
+                    .font(.system(.callout, design: .rounded, weight: .medium)).tracking(-0.1)
                     .foregroundColor(.primary)
                     .contentTransition(.numericText())
-
                 if showChevron {
-                    Image(systemName: "chevron.forward")
-                        .font(.caption2.weight(.bold))
-                        .foregroundStyle(Color(.tertiaryLabel))
-                        .padding(.trailing, -2)
+                    chevron
                 }
             }
             if let trend {
-                Text(trend.formattedTrendShort)
-                    .foregroundColor(trend.sentiment.foregroundColor)
-                    .contentTransition(.numericText())
-                    .font(.system(.caption, design: .rounded, weight: .medium)).tracking(-0.33)
+                HStack(spacing: 3) {
+                    Text("\(trend.iconSign) \(trend.formattedPercentage)")
+                        .font(.system(.caption2, design: .rounded, weight: .semibold)).tracking(-0.25)
+                        .foregroundColor(trend.sentiment.foregroundColor)
+                        .contentTransition(.numericText())
+                        .font(.system(.caption, design: .rounded, weight: .medium)).tracking(-0.33)
+                    if showChevron {
+                        chevron.opacity(0) // Just to allocate space
+                    }
+                }
             }
         }
         .animation(.spring, value: trend)
+    }
+
+    private var chevron: some View {
+        Image(systemName: "chevron.forward")
+            .font(.caption2.weight(.bold))
+            .foregroundStyle(Color(.tertiaryLabel))
+            .padding(.trailing, -2)
     }
 
     // TEMPORARY WORKAROUND (CMM-1168):

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -4,6 +4,7 @@
 * [**] Stats: Add "Devices" view to the "Traffic" tab [#25176]
 * [**] Stats: Add "UTM" view to the "Traffic" tab [#25178]
 * [*] Stats: Fix a few issues with charts (x axis labels alignment, occasionally incorrect displayed date period, and more) [#25185]
+* [*] Stats: Minor design improvements and simplifcations [#25215], [#25214]
 
 26.6
 -----


### PR DESCRIPTION
## Description

We overdid it with showing period-over-period comparison in lists. Let's town it down. In the future PR, I ensure you can still see this if you open the details page.

## Screenshots

Before / After
<img width="364" alt="Screenshot 2026-02-03 at 4 39 56 PM" src="https://github.com/user-attachments/assets/1c59402b-5558-46c4-8aa1-e25fc7c8a5ec" />  <img width="346" alt="Screenshot 2026-02-03 at 4 49 48 PM" src="https://github.com/user-attachments/assets/57cb10e8-f4b3-480a-a553-4a942486b8ec" />

