### PR TITLE
Update Activity Logs to match the web 

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [*] Stats: Fix a few issues with charts (x axis labels alignment, occasionally incorrect displayed date period, and more) [#25185]
 * [*] Stats: the "Post Stats" screen will now automatically show "Last 7 days" instead of attempting to show unavailable hourly data when "Today" or other "day" period is selected [#25210]
 * [*] Stats: Minor design improvements and simplifcations [#25215], [#25214]
+* [*] Activity Logs: Minor visual improvements [#25220]
 
 26.6
 -----

--- a/WordPress/Classes/ViewRelated/Activity/Extensions/Activity+Extensions.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Extensions/Activity+Extensions.swift
@@ -26,7 +26,7 @@ extension Activity {
         case ActivityStatus.error:
             return UIAppColor.error
         case ActivityStatus.success:
-            return UIAppColor.success
+            return UIAppColor.neutral(.shade20)
         case ActivityStatus.warning:
             return UIAppColor.warning
         default:

--- a/WordPress/Classes/ViewRelated/Activity/Extensions/ActivityActorAvatarView.swift
+++ b/WordPress/Classes/ViewRelated/Activity/Extensions/ActivityActorAvatarView.swift
@@ -49,12 +49,26 @@ struct ActivityActorAvatarView: View {
             )
     }
 
+    @ViewBuilder
     private var applicationAvatar: some View {
-        ZStack {
-            Circle()
-                .fill(AppColor.primary)
-            Image(uiImage: .gridicon(.plugins, size: CGSize(width: iconSize, height: iconSize)))
-                .foregroundColor(.white)
+        switch actor?.displayName {
+        case "Jetpack":
+            Image("jetpack-install-logo")
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+        case "WordPress":
+            Image("social-wordpress")
+                .renderingMode(.template)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+                .foregroundStyle(Color.primary)
+        default:
+            ZStack {
+                Circle()
+                    .fill(AppColor.primary)
+                Image(uiImage: .gridicon(.plugins, size: CGSize(width: iconSize, height: iconSize)))
+                    .foregroundColor(.white)
+            }
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Activity/List/ActivityLogRowView.swift
+++ b/WordPress/Classes/ViewRelated/Activity/List/ActivityLogRowView.swift
@@ -6,44 +6,53 @@ struct ActivityLogRowView: View {
     let viewModel: ActivityLogRowViewModel
 
     var body: some View {
-        HStack(alignment: .center, spacing: 12) {
+        HStack(alignment: .top, spacing: 12) {
             icon
+                .offset(y: -2)
 
             VStack(alignment: .leading, spacing: 4) {
-                HStack {
-                    Text(viewModel.subtitle)
-                        .font(.caption)
+                HStack(alignment: .firstTextBaseline, spacing: 0) {
+                    Text(viewModel.title)
+                        .font(.callout)
                         .fontWeight(.medium)
-                        .foregroundStyle(.secondary)
-                    Spacer()
+                        .foregroundStyle(.primary)
+                    Spacer(minLength: 9)
                     Text(viewModel.time)
-                        .font(.caption2)
+                        .font(.caption)
                         .foregroundColor(.secondary)
                 }
 
-                Text(viewModel.title.isEmpty ? "—" : viewModel.title)
-                    .font(.subheadline)
-                    .lineLimit(2)
-                    .foregroundColor(viewModel.title.isEmpty ? .secondary : .primary)
+                // Details text
+                if !viewModel.subtitle.isEmpty {
+                    Text(viewModel.subtitle)
+                        .font(.subheadline)
+                        .lineLimit(2)
+                        .foregroundColor(.secondary)
+                }
 
-                if let actor = viewModel.activity.actor {
-                    HStack(spacing: 6) {
-                        ActivityActorAvatarView(actor: actor, diameter: 16)
-                        HStack(spacing: 4) {
-                            Text(actor.displayName.isEmpty ? Activity.Strings.unknownUser : actor.displayName)
-                                .font(.footnote)
-                                .foregroundColor(.secondary)
-                            if let subtitle = viewModel.actorSubtitle {
-                                Text("·")
-                                    .font(.footnote)
-                                    .foregroundColor(.secondary)
-                                Text(subtitle)
-                                    .font(.footnote)
-                                    .foregroundColor(.secondary)
-                            }
-                        }
-                    }
+                metadata
                     .padding(.top, 4)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var metadata: some View {
+        if let actor = viewModel.activity.actor {
+            HStack(alignment: .center, spacing: 0) {
+                HStack(spacing: 6) {
+                    ActivityActorAvatarView(actor: actor, diameter: 16)
+                    Text(actor.displayName.isEmpty ? Activity.Strings.unknownUser : actor.displayName)
+                        .font(.footnote)
+                        .foregroundColor(.secondary)
+                    if let subtitle = viewModel.actorSubtitle {
+                        Text("·")
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                        Text(subtitle)
+                            .font(.footnote)
+                            .foregroundColor(.secondary)
+                    }
                 }
             }
         }
@@ -53,14 +62,14 @@ struct ActivityLogRowView: View {
         ZStack {
             RoundedRectangle(cornerRadius: 10)
                 .fill(viewModel.tintColor.opacity(0.15))
-                .frame(width: 36, height: 36)
+                .frame(width: 32, height: 32)
 
             if let iconImage = viewModel.icon {
                 Image(uiImage: iconImage)
                     .renderingMode(.template)
                     .resizable()
                     .aspectRatio(contentMode: .fit)
-                    .frame(width: 20, height: 20)
+                    .frame(width: 18, height: 18)
                     .foregroundColor(viewModel.tintColor)
             }
         }

--- a/WordPress/Classes/ViewRelated/Activity/List/ActivityLogRowViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Activity/List/ActivityLogRowViewModel.swift
@@ -26,8 +26,8 @@ struct ActivityLogRowViewModel: Identifiable {
         }
         self.date = activity.published
         self.time = activity.published.formatted(date: .omitted, time: .shortened)
-        self.title = activity.text
-        self.subtitle = activity.summary.localizedCapitalized
+        self.title = activity.summary.localizedCapitalized
+        self.subtitle = activity.text
 
         self.icon = activity.icon
         self.tintColor = Color(activity.statusColor)


### PR DESCRIPTION
## Description

- Change the visual hierarchy – `title` first
- Use larger font for title (same we use in other areas like "Site List")
- Hardcode icons for Jetpack and WordPress "Application" actors
- Use neutral gray color for most types of activities (only warnings and errors now use separate type). Previously, almost everything was green, which was not helpful.

## Screenshots

Before / After

<img width="340"  alt="Screenshot 2026-02-04 at 12 22 28 PM" src="https://github.com/user-attachments/assets/b42006b9-5f7e-4845-8678-22b7ef8f1fff" />
<img width="340" alt="Screenshot 2026-02-04 at 3 07 38 PM" src="https://github.com/user-attachments/assets/ebec061e-a974-49c7-9793-1c2500934d84" />

Here's the same screen on the web:

<img width="1445" height="643" alt="Screenshot 2026-02-04 at 3 11 29 PM" src="https://github.com/user-attachments/assets/d0936896-852e-410a-be9f-2e00958c4936" />
