### PR TITLE
Fix compilation issues

### DIFF
--- a/.buildkite/commands/run-unit-tests-for-scheme.sh
+++ b/.buildkite/commands/run-unit-tests-for-scheme.sh
@@ -2,7 +2,6 @@
 
 SCHEME="${1:?Usage $0 SCHEME}"
 DEVICE="iPhone 17"
-OS_VERSION="26.0"
 
 if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type validation; then
   exit 0
@@ -12,6 +11,6 @@ $(dirname "${BASH_SOURCE[0]}")/shared-set-up.sh
 
 xcodebuild \
   -scheme "${SCHEME}" \
-  -destination "platform=iOS Simulator,OS=${OS_VERSION},name=${DEVICE}" \
+  -destination "platform=iOS Simulator,name=${DEVICE}" \
   test \
   | xcbeautify

--- a/Modules/Sources/JetpackStats/Charts/BarChartView.swift
+++ b/Modules/Sources/JetpackStats/Charts/BarChartView.swift
@@ -316,6 +316,7 @@ struct BarChartView: View {
 }
 
 // MARK: - Preview
+#if DEBUG
 
 #Preview {
     ScrollView {
@@ -357,3 +358,5 @@ private func previewCard<Content: View>(
             .stroke(Color(.separator), lineWidth: 0.5)
     )
 }
+
+#endif

--- a/Modules/Sources/JetpackStats/Charts/LineChartView.swift
+++ b/Modules/Sources/JetpackStats/Charts/LineChartView.swift
@@ -246,6 +246,7 @@ struct LineChartView: View {
 }
 
 // MARK: - Preview
+#if DEBUG
 
 #Preview {
     ScrollView {
@@ -287,3 +288,5 @@ private func previewCard<Content: View>(
             .stroke(Color(.separator), lineWidth: 0.5)
     )
 }
+
+#endif


### PR DESCRIPTION
## Description

Fix prototype build failures on CI

```
[18:52:59]: ▸ ❌ /opt/ci/builds/builder/automattic/wordpress-ios/Modules/Sources/JetpackStats/Charts/BarChartView.swift:328:31: type 'ChartData' has no member 'previewExamples'
[18:52:59]: ▸             ForEach(ChartData.previewExamples) { example in
[18:52:59]: ▸                     ~~~~~~~~~ ^~~~~~~~~~~~~~~
[18:52:59]: ▸ ❌ /opt/ci/builds/builder/automattic/wordpress-ios/Modules/Sources/JetpackStats/Charts/BarChartView.swift:329:37: cannot convert value of type 'Binding<Subject>' to expected argument type 'String'
[18:52:59]: ▸                 previewCard(example.title) {
[18:52:59]: ▸                                     ^
[18:52:59]: ▸ ❌ /opt/ci/builds/builder/automattic/wordpress-ios/Modules/Sources/JetpackStats/Charts/BarChartView.swift:330:48: cannot convert value of type 'Binding<Subject>' to expected argument type 'ChartData'
[18:52:59]: ▸                     BarChartView(data: example.data)
[18:52:59]: ▸                                                ^
[18:52:59]: ▸ ❌ /opt/ci/builds/builder/automattic/wordpress-ios/Modules/Sources/JetpackStats/Charts/BarChartView.swift:331:64: cannot convert value of type 'Binding<Subject>' to expected argument type 'Bool'
[18:52:59]: ▸                         .environment(\.showComparison, example.showComparison)
[18:52:59]: ▸                                                                ^
[18:52:59]: ▸ ❌ /opt/ci/builds/builder/automattic/wordpress-ios/Modules/Sources/JetpackStats/Charts/BarChartView.swift:328:13: generic parameter 'C' could not be inferred
[18:52:59]: ▸             ForEach(ChartData.previewExamples) { example in
[18:52:59]: ▸             ^
[18:52:59]: ▸ ❌ /opt/ci/builds/builder/automattic/wordpress-ios/Modules/Sources/JetpackStats/Charts/LineChartView.swift:258:31: type 'ChartData' has no member 'previewExamples'
[18:52:59]: ▸             ForEach(ChartData.previewExamples) { example in
[18:52:59]: ▸                     ~~~~~~~~~ ^~~~~~~~~~~~~~~
[18:52:59]: ▸ ❌ /opt/ci/builds/builder/automattic/wordpress-ios/Modules/Sources/JetpackStats/Charts/LineChartView.swift:259:37: cannot convert value of type 'Binding<Subject>' to expected argument type 'String'
[18:52:59]: ▸                 previewCard(example.title) {
[18:52:59]: ▸                                     ^
[18:52:59]: ▸ ❌ /opt/ci/builds/builder/automattic/wordpress-ios/Modules/Sources/JetpackStats/Charts/LineChartView.swift:260:49: cannot convert value of type 'Binding<Subject>' to expected argument type 'ChartData'
[18:52:59]: ▸                     LineChartView(data: example.data)
[18:52:59]: ▸                                                 ^
[18:52:59]: ▸ ❌ /opt/ci/builds/builder/automattic/wordpress-ios/Modules/Sources/JetpackStats/Charts/LineChartView.swift:261:64: cannot convert value of type 'Binding<Subject>' to expected argument type 'Bool'
[18:52:59]: ▸                         .environment(\.showComparison, example.showComparison)
[18:52:59]: ▸                                                                ^
[18:52:59]: ▸ ❌ /opt/ci/builds/builder/automattic/wordpress-ios/Modules/Sources/JetpackStats/Charts/LineChartView.swift:258:13: generic parameter 'C' could not be inferred
[18:52:59]: ▸             ForEach(ChartData.previewExamples) { example in
[18:52:59]: ▸             ^
```