### PR TITLE
fix: Enable GutenbergKit theme styles by default

### DIFF
--- a/Modules/Sources/WordPressShared/Utility/KeyValueDatabase.swift
+++ b/Modules/Sources/WordPressShared/Utility/KeyValueDatabase.swift
@@ -31,7 +31,7 @@ public extension KeyValueDatabase {
 
 extension UserDefaults: KeyValueDatabase {
     public func hasEntry(forKey key: String) -> Bool {
-        self.object(forKey: key) == nil
+        self.object(forKey: key) != nil
     }
 }
 


### PR DESCRIPTION
## Description

Fix CMM-1224. 

Enable theme styles for the editor, unless the user specifically
disabled them. This matches Gutenberg web and Gutenberg Mobile.

This was not working because the `hasEntry` method was incorrectly
returning `true` when the key did NOT exist (when object was nil),
instead of returning `true` when the key exists. This caused
`isThemeStylesEnabled` to default to `false` instead of `true` for sites
that support theme styles.

## Testing instructions

> [!important] 
> This does not address a race condition between fetching site capabilities and preloading. Hence, step number seven below. We should address that separately to avoid heavily modifying the pending release. 

1. Install a fresh app install. 
1. Enable the experimental editor feature. 
2. Use a site with the Gutenberg plugin activated. 
3. Navigate to My Site → Site Settings. 
4. **Verify** the Use theme styles toggle is enabled. 
5. Navigate to My Site. 
6. Perform a pull-to-refresh gesture. 
7. Open the editor. 
8. **Verify** the theme styles are applied to the editor. 