### PR TITLE
Add tint color for hide button

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Cards/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -2,6 +2,7 @@ import UIKit
 import WordPressReader
 import WordPressShared
 import WordPressKit
+import WordPressUI
 
 enum ReaderTopicCollectionViewState {
     case collapsed
@@ -192,6 +193,7 @@ extension ReaderTopicCollectionViewCoordinator: UICollectionViewDelegateFlowLayo
 
         cell.label.backgroundColor = .clear
         cell.label.accessibilityHint = layout.isExpanded ? Strings.collapseButtonAccessbilityHint : Strings.expandButtonAccessbilityHint
+        cell.label.textColor = layout.isExpanded ? UIAppColor.primary : (displaySetting?.color.foreground ?? .label)
 
         let tapGestureRecognizer = UITapGestureRecognizer(target: self, action: #selector(toggleExpanded))
         cell.addGestureRecognizer(tapGestureRecognizer)


### PR DESCRIPTION
Fixes [CMM-1212: "Hide" looks like a tag in Reader](https://linear.app/a8c/issue/CMM-1212/hide-looks-like-a-tag-in-reader).

I just added tint color. Probably, no the best solution, but it's fine.

<img width="456" height="972" alt="Screenshot 2026-02-10 at 1 19 11 PM" src="https://github.com/user-attachments/assets/b2d9eed5-301c-49d1-8736-704129160e93" />
