### PR TITLE
Add Claude Code tool permissions and feedback loop instructions

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -10,7 +10,12 @@
       "Bash(tail:*)",
       "Bash(wc:*)",
       "Bash(tree:*)",
-      "Bash(git:log,status,diff,branch)"
+      "Bash(git:log,status,diff,branch)",
+      "Bash(rake *)",
+      "Bash(xcodebuild *)",
+      "Bash(xcrun simctl *)",
+      "Bash(bundle exec *)",
+      "Bash(swift package:*)"
     ],
     "deny": []
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,6 +122,11 @@ Document any process refinements discovered during execution.
 - **Language**: Positive sentiment, avoid "fix" terminology, focus on improvements and enhancements
 - **Priority Order**: New features → Improvements → Performance → Other user-facing changes
 
+## Slow commands
+
+`swift`, `xcodebuild`, and `fastlane` commands can take several minutes.
+Account for this when setting `max_turns` on parallel subagents — 40 or higher is a safe default.
+
 ## Opening Pull Requests
 
 Before opening a PR, read the `Dangerfile` and proactively satisfy its checks.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,3 +121,7 @@ Document any process refinements discovered during execution.
 - **Exclude**: CI changes, code refactoring, dependency updates, internal technical changes
 - **Language**: Positive sentiment, avoid "fix" terminology, focus on improvements and enhancements
 - **Priority Order**: New features → Improvements → Performance → Other user-facing changes
+
+## Opening Pull Requests
+
+Before opening a PR, read the `Dangerfile` and proactively satisfy its checks.


### PR DESCRIPTION
## Summary

Adds `rake`, `xcodebuild`, `xcrun simctl`, `bundle exec`, and `swift package` to the Claude Code team-level allow list so agents can lint, build, test, and resolve packages without manual approval.

Context: https://linear.app/a8c/issue/AINFRA-1965/add-first-round-of-permissions-allow-lists-to-apple-projects

## Test Plan

- [ ] CI passes