### PR TITLE
Move XMLRPC availability check to the blog syncing call

### DIFF
--- a/Sources/WordPressData/Swift/Blog+Jetpack.swift
+++ b/Sources/WordPressData/Swift/Blog+Jetpack.swift
@@ -80,4 +80,9 @@ public extension Blog {
 
         return !(activeJetpackPlugins.isEmpty || activeJetpackPlugins.contains("jetpack"))
     }
+
+    @objc var isXMLRPCDisabled: Bool {
+        get { getOption(name: "__app_xmlrpc_disabled") ?? false }
+        set { setValue(NSNumber(value: newValue), forOption: "__app_xmlrpc_disabled") }
+    }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsTableViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsTableViewModel.swift
@@ -108,7 +108,7 @@ private struct Section {
             newSections.append(Section(rows: [], category: .extensiveLogging))
         }
 
-        if blog.isSelfHosted, viewController.showXMLRPCDisabled {
+        if blog.isSelfHosted, blog.isXMLRPCDisabled {
             newSections.append(Section(rows: [], category: .xmlrpcDisabled))
         }
 


### PR DESCRIPTION
## Description

I realized that we can move the XMLPRC availability check to the existing "blog syncing" call. It's probably a better place for the check than a separate check initiated from the view controller.

## Testing instructions

The "XMLRPC disabled" card appears and disappears appropriately after going to a site, or pull to refresh.
