### PR TITLE
Set 60 seconds UI test timeout

### DIFF
--- a/WordPress/UITests/JetpackUITests.xctestplan
+++ b/WordPress/UITests/JetpackUITests.xctestplan
@@ -11,12 +11,14 @@
   ],
   "defaultOptions" : {
     "codeCoverage" : false,
+    "defaultTestExecutionTimeAllowance" : 60,
     "targetForVariableExpansion" : {
       "containerPath" : "container:WordPress.xcodeproj",
       "identifier" : "FABB1F8F2602FC2C00C8785C",
       "name" : "Jetpack"
     },
     "testRepetitionMode" : "retryOnFailure",
+    "testTimeoutsEnabled" : true
   },
   "testTargets" : [
     {


### PR DESCRIPTION
Almost all successful tests complete within 30 seconds.
