### PR TITLE
Add agent instructions to CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,3 +121,12 @@ Document any process refinements discovered during execution.
 - **Exclude**: CI changes, code refactoring, dependency updates, internal technical changes
 - **Language**: Positive sentiment, avoid "fix" terminology, focus on improvements and enhancements
 - **Priority Order**: New features → Improvements → Performance → Other user-facing changes
+
+## Slow commands
+
+`swift`, `xcodebuild`, and `fastlane` commands can take several minutes.
+Account for this when setting `max_turns` on parallel subagents — 40 or higher is a safe default.
+
+## Opening Pull Requests
+
+Before opening a PR, read the `Dangerfile` and proactively satisfy its checks.


### PR DESCRIPTION
## Summary

Adds instructions for Claude Code agents to the existing `CLAUDE.md`:

- Slow command guidance (set higher `max_turns` for `swift`/`xcodebuild`/`fastlane`)
- PR checklist (read `Dangerfile` before opening PRs)

Extracted from #25237, decoupled from the `.claude/settings.json` permission changes.

Context: https://linear.app/a8c/issue/AINFRA-1965

## Test Plan

- [ ] CI passes