### PR TITLE
Replace test-collector-swift with JUnit upload

### DIFF
--- a/.buildkite/commands/run-ui-tests.sh
+++ b/.buildkite/commands/run-ui-tests.sh
@@ -10,14 +10,6 @@ echo "Running UI tests on $DEVICE. The iOS version will be the latest available 
 
 xcrun simctl list --json devices available
 
-# Run this at the start to fail early if value not available
-echo '--- :test-analytics: Configuring Test Analytics'
-if [[ $DEVICE =~ ^iPhone ]]; then
-  export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPHONE
-else
-  export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPAD
-fi
-
 echo "--- 📦 Downloading Build Artifacts"
 download_artifact build-products-jetpack.tar
 tar -xf build-products-jetpack.tar
@@ -56,9 +48,9 @@ else
 fi
 
 if [[ $BUILDKITE_BRANCH == trunk ]] || [[ $BUILDKITE_BRANCH == release/* ]]; then
-    annotate_test_failures "build/results/JetpackUITests.xml" --slack "build-and-ship"
+    annotate_test_failures "build/results/report.junit" --slack "build-and-ship"
 else
-    annotate_test_failures "build/results/JetpackUITests.xml"
+    annotate_test_failures "build/results/report.junit"
 fi
 
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/commands/run-unit-tests-reader.sh
+++ b/.buildkite/commands/run-unit-tests-reader.sh
@@ -4,11 +4,6 @@ if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type validation; th
   exit 0
 fi
 
-# Run this at the start to fail early if value not available
-# TODO: We'll need to create a token for Reader
-# echo '--- :test-analytics: Configuring Test Analytics'
-# export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS
-
 "$(dirname "${BASH_SOURCE[0]}")/shared-set-up.sh"
 
 # For the moment, run code signing here just to show it works

--- a/.buildkite/commands/run-unit-tests.sh
+++ b/.buildkite/commands/run-unit-tests.sh
@@ -4,10 +4,6 @@ if "$(dirname "${BASH_SOURCE[0]}")/should-skip-job.sh" --job-type validation; th
   exit 0
 fi
 
-# Run this at the start to fail early if value not available
-echo '--- :test-analytics: Configuring Test Analytics'
-export BUILDKITE_ANALYTICS_TOKEN=$BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS
-
 echo "--- 📦 Downloading Build Artifacts"
 download_artifact build-products-wordpress.tar
 tar -xf build-products-wordpress.tar
@@ -40,9 +36,9 @@ else
 fi
 
 if [[ $BUILDKITE_BRANCH == trunk ]] || [[ $BUILDKITE_BRANCH == release/* ]]; then
-    annotate_test_failures "build/results/WordPress.xml" --slack "build-and-ship"
+    annotate_test_failures "build/results/report.junit" --slack "build-and-ship"
 else
-    annotate_test_failures "build/results/WordPress.xml"
+    annotate_test_failures "build/results/report.junit"
 fi
 
 exit $TESTS_EXIT_STATUS

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -61,7 +61,13 @@ steps:
       - label: "🔬 :wordpress: Unit Tests"
         command: ".buildkite/commands/run-unit-tests.sh"
         depends_on: "build_wordpress"
-        plugins: [$CI_TOOLKIT_PLUGIN]
+        plugins:
+          - $CI_TOOLKIT_PLUGIN
+          - ${TEST_COLLECTOR}:
+              files: build/results/report.junit
+              format: junit
+              missing-error: 0
+              api-token-env-name: BUILDKITE_ANALYTICS_TOKEN_UNIT_TESTS
         artifact_paths:
           - "build/results/*"
         notify:
@@ -102,7 +108,13 @@ steps:
       - label: "🔬 :jetpack: UI Tests (iPhone)"
         command: .buildkite/commands/run-ui-tests.sh 'iPhone 17'
         depends_on: "build_jetpack"
-        plugins: [$CI_TOOLKIT_PLUGIN]
+        plugins:
+          - $CI_TOOLKIT_PLUGIN
+          - ${TEST_COLLECTOR}:
+              files: build/results/report.junit
+              format: junit
+              missing-error: 0
+              api-token-env-name: BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPHONE
         artifact_paths:
           - "build/results/*"
           - "build/results/crashes/*"
@@ -114,7 +126,13 @@ steps:
       - label: "🔬 :jetpack: UI Tests (iPad)"
         command: .buildkite/commands/run-ui-tests.sh 'iPad (A16)'
         depends_on: "build_jetpack"
-        plugins: [$CI_TOOLKIT_PLUGIN]
+        plugins:
+          - $CI_TOOLKIT_PLUGIN
+          - ${TEST_COLLECTOR}:
+              files: build/results/report.junit
+              format: junit
+              missing-error: 0
+              api-token-env-name: BUILDKITE_ANALYTICS_TOKEN_UI_TESTS_IPAD
         artifact_paths:
           - "build/results/*"
           - "build/results/crashes/*"

--- a/.buildkite/shared-pipeline-vars
+++ b/.buildkite/shared-pipeline-vars
@@ -6,7 +6,9 @@
 # The ~> modifier is not currently used, but we check for it just in case
 XCODE_VERSION=$(sed -E 's/^~> ?//' .xcode-version)
 CI_TOOLKIT_PLUGIN_VERSION="5.3.1"
+TEST_COLLECTOR_PLUGIN_VERSION="1.11.0"
 
 export IMAGE_ID="xcode-$XCODE_VERSION"
 export CI_TOOLKIT_PLUGIN="automattic/a8c-ci-toolkit#$CI_TOOLKIT_PLUGIN_VERSION"
+export TEST_COLLECTOR="test-collector#v$TEST_COLLECTOR_PLUGIN_VERSION"
 export CLAUDE_PLUGIN="iangmaia/claude-summarize#iangmaia/add-build-log-mode"

--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -359,15 +359,6 @@
       }
     },
     {
-      "identity" : "test-collector-swift",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/buildkite/test-collector-swift",
-      "state" : {
-        "revision" : "631a2400dbe876141a3ef8c7400885907fec7f89",
-        "version" : "0.4.1"
-      }
-    },
-    {
       "identity" : "tocropviewcontroller",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/TimOliver/TOCropViewController",

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -36,7 +36,6 @@ let package = Package(
         .package(url: "https://github.com/Automattic/Gravatar-SDK-iOS", from: "3.4.0"),
         .package(url: "https://github.com/Automattic/Gridicons-iOS", branch: "develop"),
         .package(url: "https://github.com/Automattic/ScreenObject", from: "0.3.0"),
-        .package(url: "https://github.com/buildkite/test-collector-swift", from: "0.3.0"),
         .package(url: "https://github.com/ChartsOrg/Charts", from: "5.0.0"),
         .package(url: "https://github.com/CocoaLumberjack/CocoaLumberjack", from: "3.8.5"),
         .package(url: "https://github.com/daltoniam/Starscream", from: "4.0.8"),
@@ -405,7 +404,6 @@ enum XcodeSupport {
                 "WordPressUI",
                 .product(name: "Gravatar", package: "Gravatar-SDK-iOS"),
                 .product(name: "Nimble", package: "Nimble"),
-                .product(name: "BuildkiteTestCollector", package: "test-collector-swift"),
                 // Needed by WordPressData because of how linkage works...
                 //
                 "BuildSettingsKit",
@@ -486,7 +484,6 @@ enum XcodeSupport {
             ]),
             .xcodeTarget("XcodeTarget_UITests", dependencies: [
                 "UITestsFoundation",
-                .product(name: "BuildkiteTestCollector", package: "test-collector-swift"),
             ]),
             .xcodeTarget(
                 "XcodeTarget_WordPressData",

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/RemoteTestCase.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/RemoteTestCase.swift
@@ -1,4 +1,3 @@
-import BuildkiteTestCollector
 import Foundation
 import XCTest
 import OHHTTPStubs
@@ -176,9 +175,7 @@ extension RemoteTestCase {
     ///         https://github.com/AliSoftware/OHHTTPStubs/wiki/Usage-Examples#stack-multiple-stubs-and-remove-installed-stubs
     ///
     func stubAllNetworkRequestsWithNotConnectedError() {
-        // Stub all requests other than those to the Buildkite Test Analytics API,
-        // which we need them to go through for Test Analytics reporting.
-        stub(condition: !isHost(TestCollector.apiHost)) { response in
+        stub(condition: { _ in true }) { response in
             XCTFail("Unexpected network request was made to: \(response.url!.absoluteString)")
             let notConnectedError = NSError(domain: NSURLErrorDomain, code: Int(CFNetworkErrors.cfurlErrorNotConnectedToInternet.rawValue), userInfo: nil)
             return HTTPStubsResponse(error: notConnectedError)

--- a/Tests/WordPressKitTests/WordPressKitTests/Tests/TestCollector+Constants.swift
+++ b/Tests/WordPressKitTests/WordPressKitTests/Tests/TestCollector+Constants.swift
@@ -1,7 +1,0 @@
-import BuildkiteTestCollector
-import Foundation
-
-extension TestCollector {
-
-    static let apiHost = "analytics-api.buildkite.com"
-}

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -126,7 +126,6 @@ platform :ios do
       concurrent_workers: CONCURRENT_SIMULATORS,
       max_concurrent_simulators: CONCURRENT_SIMULATORS
     )
-
   end
 
   # Builds the WordPress app and uploads it to TestFlight, for beta-testing or final release

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -34,18 +34,6 @@ CONCURRENT_SIMULATORS = 2
 #   use the build number we set!
 COMMON_EXPORT_OPTIONS = { manageAppVersionAndBuildNumber: false }.freeze
 
-# https://buildkite.com/docs/test-analytics/ci-environments
-TEST_ANALYTICS_ENVIRONMENT = %w[
-  BUILDKITE_ANALYTICS_TOKEN
-  BUILDKITE_BUILD_ID
-  BUILDKITE_BUILD_NUMBER
-  BUILDKITE_JOB_ID
-  BUILDKITE_BRANCH
-  BUILDKITE_COMMIT
-  BUILDKITE_MESSAGE
-  BUILDKITE_BUILD_URL
-].freeze
-
 # Lanes related to Building and Testing the code
 #
 platform :ios do
@@ -108,7 +96,6 @@ platform :ios do
 
     UI.user_error!("Unable to find .xctestrun file at #{build_products_path}.") if xctestrun_path.nil? || !File.exist?(xctestrun_path)
 
-    inject_buildkite_analytics_environment(xctestrun_path: xctestrun_path) if buildkite_ci?
     # Our current configuration allows for either running the Jetpack UI tests or the WordPress unit tests.
     #
     # Their scheme and xctestrun name pairing are:
@@ -134,14 +121,13 @@ platform :ios do
       output_directory: File.join(PROJECT_ROOT_FOLDER, 'build', 'results'),
       reset_simulator: true,
       result_bundle: true,
-      output_types: '',
+      output_types: 'junit',
       fail_build: false,
       parallel_testing: parallel_testing_value,
       concurrent_workers: CONCURRENT_SIMULATORS,
       max_concurrent_simulators: CONCURRENT_SIMULATORS
     )
 
-    trainer(path: lane_context[SharedValues::SCAN_GENERATED_XCRESULT_PATH], fail_build: true)
   end
 
   # Builds the WordPress app and uploads it to TestFlight, for beta-testing or final release
@@ -409,28 +395,6 @@ platform :ios do
       build_version: build_number,
       app_identifier: app_identifier
     )
-  end
-
-  def inject_buildkite_analytics_environment(xctestrun_path:)
-    require 'plist'
-
-    xctestrun = Plist.parse_xml(xctestrun_path)
-    xctestrun['TestConfigurations'].each do |configuration|
-      configuration['TestTargets'].each do |target|
-        TEST_ANALYTICS_ENVIRONMENT.each do |key|
-          value = ENV.fetch(key)
-          next if value.nil?
-
-          target['EnvironmentVariables'][key] = value
-        end
-      end
-    end
-
-    File.write(xctestrun_path, Plist::Emit.dump(xctestrun))
-  end
-
-  def buildkite_ci?
-    ENV.fetch('BUILDKITE', false)
   end
 
   def upload_build_to_testflight(ipa_path:, whats_new_path:, distribution_groups:, beta_app_description_path:)

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -122,7 +122,6 @@ platform :ios do
       reset_simulator: true,
       result_bundle: true,
       output_types: 'junit',
-      fail_build: false,
       parallel_testing: parallel_testing_value,
       concurrent_workers: CONCURRENT_SIMULATORS,
       max_concurrent_simulators: CONCURRENT_SIMULATORS


### PR DESCRIPTION
## Summary

Replaces the `test-collector-swift` SPM package (runtime XCTest hook) with the `test-collector` Buildkite plugin that uploads JUnit XML files to Test Engine.

The SPM package hooks into XCTest at runtime, so Swift Testing tests are invisible to Test Engine.
The Buildkite plugin uploads JUnit XML files post-step, which works with any test framework.

The SPM dependency and all its supporting code (env injection, token exports, `trainer` calls) are removed.
The Buildkite plugin is added to the 3 test steps that have a Test Engine token.

Fixes AINFRA-1977

## Testing
- Let CI run on this PR
- Verify all test steps pass
- Check the Buildkite Test Analytics dashboard to confirm results are received

---

*Posted by Claude (Opus 4.6) on behalf of @mokagio with approval.*