### PR TITLE
Minor visual changes to post list to make it more accessible

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/ReaderPostCell.swift
@@ -136,7 +136,7 @@ private final class ReaderPostCellView: UIView {
         titleLabel.maximumContentSizeCategory = .accessibilityExtraLarge
 
         detailsLabel.font = .preferredFont(forTextStyle: .subheadline)
-        detailsLabel.textColor = .secondaryLabel
+        detailsLabel.textColor = UIAppColor.secondary
         detailsLabel.adjustsFontForContentSizeCategory = true
         detailsLabel.maximumContentSizeCategory = .accessibilityExtraLarge
 
@@ -200,7 +200,7 @@ private final class ReaderPostCellView: UIView {
 
     private func configureLayout(isCompact: Bool) {
         titleLabel.numberOfLines = 3
-        detailsLabel.numberOfLines = isCompact ? 3 : 5
+        detailsLabel.numberOfLines = isCompact ? 2 : 4
 
         postPreview.axis = isCompact ? .vertical : .horizontal
         postPreview.spacing = isCompact ? 12 : 20
@@ -389,7 +389,7 @@ private final class ReaderPostCellView: UIView {
 
     private static let authorAttributes = AttributeContainer([
         .font: WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .medium),
-        .foregroundColor: UIColor.label
+        .foregroundColor: UIColor.secondaryLabel
     ])
 
     private static let toolbarAttributes = AttributeContainer([


### PR DESCRIPTION
Based on the design feedback:

- Darker except
- More focus on titles with experts now limited to 2 lines
- Secondary color for all metadata, including site name for better visual hierarchy

<img width="340"  alt="before" src="https://github.com/user-attachments/assets/b577c751-d20d-4ed5-8b16-c67b664fdd24" /> <img width="340" alt="Screenshot 2026-02-16 at 1 43 58 PM" src="https://github.com/user-attachments/assets/f0bb03f7-197a-4b4a-8993-fea527154a40" />
