### PR TITLE
Update GutenbergKit

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "b04dbf1cacec1d24bb12d82340416ae4d2a5c7058ff23620edfc73d3f4fcb6d8",
+  "originHash" : "7c1d70acb5444b6fbf2a4b40b27372d2b56e7afaaa4cbb72a178af5595bd7725",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -149,7 +149,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "c60333ebf4bd37eafc8981cfc8387b71bdfa5dcc"
+        "branch" : "v0.14.0-alpha.0",
+        "revision" : "361cf9a591cdbed8c02dfee8bfae90e96c0d34ec"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -56,7 +56,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/wpxmlrpc", from: "0.9.0"),
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "c60333ebf4bd37eafc8981cfc8387b71bdfa5dcc"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", revision: "v0.14.0-alpha.0"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20260210"),
         .package(


### PR DESCRIPTION
Following up https://github.com/wordpress-mobile/WordPress-iOS/pull/25208#discussion_r2760171566. I have published the GBK release on my mac.