### PR TITLE
fix: Add Authorization header to WordPressOrgRestApi for self-hosted sites

### DIFF
--- a/Modules/Sources/WordPressKit/WordPressOrgRestApi.swift
+++ b/Modules/Sources/WordPressKit/WordPressOrgRestApi.swift
@@ -25,18 +25,11 @@ public struct WordPressOrgRestApiError: LocalizedError, Decodable, HTTPURLRespon
 
 @objc
 public final class WordPressOrgRestApi: NSObject {
-    public struct SelfHostedSiteCredential {
-        public let loginURL: URL
-        public let username: String
-        public let password: Secret<String>
-        public let adminURL: URL
-
-        public init(loginURL: URL, username: String, password: String, adminURL: URL) {
-            self.loginURL = loginURL
-            self.username = username
-            self.password = .init(password)
-            self.adminURL = adminURL
-        }
+    public enum SelfHostedSiteCredential {
+        /// Cookie + nonce authentication via wp-admin login.
+        case accountPassword(loginURL: URL, username: String, password: Secret<String>, adminURL: URL)
+        /// Application password authentication via Basic auth header.
+        case applicationPassword(username: String, password: Secret<String>)
     }
 
     enum Site {
@@ -53,15 +46,15 @@ public final class WordPressOrgRestApi: NSObject {
         self.init(site: .dotCom(siteID: dotComSiteID, bearerToken: bearerToken, apiURL: apiURL), userAgent: userAgent)
     }
 
-    public convenience init(selfHostedSiteWPJSONURL apiURL: URL, credential: SelfHostedSiteCredential, userAgent: String? = nil, authorizationHeader: String? = nil) {
+    public convenience init(selfHostedSiteWPJSONURL apiURL: URL, credential: SelfHostedSiteCredential, userAgent: String? = nil) {
         assert(apiURL.host != "public-api.wordpress.com", "Not a self-hosted site: \(apiURL)")
         // Potential improvement(?): discover API URL instead. See https://developer.wordpress.org/rest-api/using-the-rest-api/discovery/
         assert(apiURL.lastPathComponent == "wp-json", "Not a REST API URL: \(apiURL)")
 
-        self.init(site: .selfHosted(apiURL: apiURL, credential: credential), userAgent: userAgent, authorizationHeader: authorizationHeader)
+        self.init(site: .selfHosted(apiURL: apiURL, credential: credential), userAgent: userAgent)
     }
 
-    init(site: Site, userAgent: String? = nil, authorizationHeader: String? = nil) {
+    init(site: Site, userAgent: String? = nil) {
         self.site = site
 
         var additionalHeaders = [String: String]()
@@ -70,8 +63,10 @@ public final class WordPressOrgRestApi: NSObject {
         }
         if case let Site.dotCom(_, token, _) = site {
             additionalHeaders["Authorization"] = "Bearer \(token)"
-        } else if let authorizationHeader {
-            additionalHeaders["Authorization"] = authorizationHeader
+        } else if case let .selfHosted(_, credential) = site,
+                  case let .applicationPassword(username, password) = credential {
+            let data = "\(username):\(password.secretValue)".data(using: .utf8)!
+            additionalHeaders["Authorization"] = "Basic \(data.base64EncodedString())"
         }
 
         let configuration = URLSessionConfiguration.default
@@ -174,14 +169,17 @@ public final class WordPressOrgRestApi: NSObject {
     func perform(builder originalBuilder: HTTPRequestBuilder) async -> WordPressAPIResult<HTTPAPIResponse<Data>, WordPressOrgRestApiError> {
         var builder = originalBuilder
 
-        if case .selfHosted = site, let nonce = selfHostedSiteNonce {
+        if case let .selfHosted(_, credential) = site,
+           case .accountPassword = credential,
+           let nonce = selfHostedSiteNonce {
             builder = originalBuilder.header(name: "X-WP-Nonce", value: nonce)
         }
 
         var result = await urlSession.perform(request: builder, errorType: WordPressOrgRestApiError.self)
 
-        // When a self hosted site request fails with 401, authenticate and retry the request.
-        if case .selfHosted = site,
+        // When a self hosted site using account password auth fails with 401, refresh the nonce and retry.
+        if case let .selfHosted(_, credential) = site,
+            case .accountPassword = credential,
             case let .failure(.unacceptableStatusCode(response, _)) = result,
             response.statusCode == 401,
             await refreshNonce(),
@@ -223,7 +221,8 @@ private extension WordPressOrgRestApi {
     ///
     /// - Returns true if the nonce is fetched and it's different than the cached one.
     func refreshNonce() async -> Bool {
-        guard case let .selfHosted(_, credential) = site else {
+        guard case let .selfHosted(_, credential) = site,
+              case let .accountPassword(loginURL, username, password, adminURL) = credential else {
             return false
         }
 
@@ -232,10 +231,10 @@ private extension WordPressOrgRestApi {
         let methods: [NonceRetrievalMethod] = [.ajaxNonceRequest, .newPostScrap]
         for method in methods {
             guard let nonce = await method.retrieveNonce(
-                username: credential.username,
-                password: credential.password,
-                loginURL: credential.loginURL,
-                adminURL: credential.adminURL,
+                username: username,
+                password: password,
+                loginURL: loginURL,
+                adminURL: adminURL,
                 using: urlSession
             ) else {
                 continue

--- a/Modules/Sources/WordPressKit/WordPressOrgRestApi.swift
+++ b/Modules/Sources/WordPressKit/WordPressOrgRestApi.swift
@@ -53,15 +53,15 @@ public final class WordPressOrgRestApi: NSObject {
         self.init(site: .dotCom(siteID: dotComSiteID, bearerToken: bearerToken, apiURL: apiURL), userAgent: userAgent)
     }
 
-    public convenience init(selfHostedSiteWPJSONURL apiURL: URL, credential: SelfHostedSiteCredential, userAgent: String? = nil) {
+    public convenience init(selfHostedSiteWPJSONURL apiURL: URL, credential: SelfHostedSiteCredential, userAgent: String? = nil, authorizationHeader: String? = nil) {
         assert(apiURL.host != "public-api.wordpress.com", "Not a self-hosted site: \(apiURL)")
         // Potential improvement(?): discover API URL instead. See https://developer.wordpress.org/rest-api/using-the-rest-api/discovery/
         assert(apiURL.lastPathComponent == "wp-json", "Not a REST API URL: \(apiURL)")
 
-        self.init(site: .selfHosted(apiURL: apiURL, credential: credential), userAgent: userAgent)
+        self.init(site: .selfHosted(apiURL: apiURL, credential: credential), userAgent: userAgent, authorizationHeader: authorizationHeader)
     }
 
-    init(site: Site, userAgent: String? = nil) {
+    init(site: Site, userAgent: String? = nil, authorizationHeader: String? = nil) {
         self.site = site
 
         var additionalHeaders = [String: String]()
@@ -70,6 +70,8 @@ public final class WordPressOrgRestApi: NSObject {
         }
         if case let Site.dotCom(_, token, _) = site {
             additionalHeaders["Authorization"] = "Bearer \(token)"
+        } else if let authorizationHeader {
+            additionalHeaders["Authorization"] = authorizationHeader
         }
 
         let configuration = URLSessionConfiguration.default

--- a/Sources/WordPressData/Swift/WordPressOrgRestApi+WordPress.swift
+++ b/Sources/WordPressData/Swift/WordPressOrgRestApi+WordPress.swift
@@ -44,6 +44,11 @@ extension WordPressOrgRestApi {
                   let adminURL = URL(string: blog.adminUrl(withPath: "")),
                   let username = blog.username,
                   let password = blog.password {
+            var authorizationHeader: String?
+            if let appPassword = try? blog.getApplicationToken(),
+               let credentialsData = "\(username):\(appPassword)".data(using: .utf8) {
+                authorizationHeader = "Basic \(credentialsData.base64EncodedString())"
+            }
             self.init(
                 selfHostedSiteWPJSONURL: apiBase,
                 credential: .init(
@@ -52,7 +57,8 @@ extension WordPressOrgRestApi {
                     password: password,
                     adminURL: adminURL
                 ),
-                userAgent: userAgent
+                userAgent: userAgent,
+                authorizationHeader: authorizationHeader
             )
         } else {
             return nil

--- a/Sources/WordPressData/Swift/WordPressOrgRestApi+WordPress.swift
+++ b/Sources/WordPressData/Swift/WordPressOrgRestApi+WordPress.swift
@@ -40,25 +40,21 @@ extension WordPressOrgRestApi {
                 apiURL: wordPressComApiURL
             )
         } else if let apiBase = apiBase(blog: blog),
-                  let loginURL = URL(string: blog.loginUrl()),
-                  let adminURL = URL(string: blog.adminUrl(withPath: "")),
-                  let username = blog.username,
-                  let password = blog.password {
-            var authorizationHeader: String?
-            if let appPassword = try? blog.getApplicationToken(),
-               let credentialsData = "\(username):\(appPassword)".data(using: .utf8) {
-                authorizationHeader = "Basic \(credentialsData.base64EncodedString())"
+                  let username = blog.username {
+            let credential: WordPressOrgRestApi.SelfHostedSiteCredential
+            if let appPassword = try? blog.getApplicationToken() {
+                credential = .applicationPassword(username: username, password: .init(appPassword))
+            } else if let loginURL = URL(string: blog.loginUrl()),
+                      let adminURL = URL(string: blog.adminUrl(withPath: "")),
+                      let password = blog.password {
+                credential = .accountPassword(loginURL: loginURL, username: username, password: .init(password), adminURL: adminURL)
+            } else {
+                return nil
             }
             self.init(
                 selfHostedSiteWPJSONURL: apiBase,
-                credential: .init(
-                    loginURL: loginURL,
-                    username: username,
-                    password: password,
-                    adminURL: adminURL
-                ),
-                userAgent: userAgent,
-                authorizationHeader: authorizationHeader
+                credential: credential,
+                userAgent: userAgent
             )
         } else {
             return nil

--- a/Tests/KeystoneTests/Tests/Services/BlockEditorSettingsServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Services/BlockEditorSettingsServiceTests.swift
@@ -270,7 +270,7 @@ class BlockEditorSettingsServiceTests: CoreDataTestCase {
             return HTTPStubsResponse(jsonObject: mockedResponse, statusCode: 200, headers: nil)
         }
 
-        let remoteAPI = WordPressOrgRestApi(selfHostedSiteWPJSONURL: URL(string: "https://w.org/wp-json")!, credential: .init(loginURL: URL(string: "https://not-used.org")!, username: "user", password: "pass", adminURL: URL(string: "https://not-used.org")!))
+        let remoteAPI = WordPressOrgRestApi(selfHostedSiteWPJSONURL: URL(string: "https://w.org/wp-json")!, credential: .accountPassword(loginURL: URL(string: "https://not-used.org")!, username: "user", password: .init("pass"), adminURL: URL(string: "https://not-used.org")!))
         service = BlockEditorSettingsService(blog: blog, remoteAPI: remoteAPI, coreDataStack: contextManager)
 
         let waitExpectation = expectation(description: "Theme should be successfully fetched")
@@ -287,7 +287,7 @@ class BlockEditorSettingsServiceTests: CoreDataTestCase {
             HTTPStubsResponse(jsonObject: mockedResponse, statusCode: 200, headers: nil)
         }
 
-        let remoteAPI = WordPressOrgRestApi(selfHostedSiteWPJSONURL: URL(string: "https://w.org/wp-json")!, credential: .init(loginURL: URL(string: "https://not-used.org")!, username: "user", password: "pass", adminURL: URL(string: "https://not-used.org")!))
+        let remoteAPI = WordPressOrgRestApi(selfHostedSiteWPJSONURL: URL(string: "https://w.org/wp-json")!, credential: .accountPassword(loginURL: URL(string: "https://not-used.org")!, username: "user", password: .init("pass"), adminURL: URL(string: "https://not-used.org")!))
         service = BlockEditorSettingsService(blog: blog, remoteAPI: remoteAPI, coreDataStack: contextManager)
 
         let waitExpectation = expectation(description: "Theme should be successfully fetched")

--- a/Tests/WordPressKitTests/CoreAPITests/WordPressOrgAPITests.swift
+++ b/Tests/WordPressKitTests/CoreAPITests/WordPressOrgAPITests.swift
@@ -6,10 +6,10 @@ import OHHTTPStubsSwift
 
 class WordPressOrgAPITests: XCTestCase {
 
-    let fakeCredential = WordPressOrgRestApi.SelfHostedSiteCredential(
+    let fakeCredential: WordPressOrgRestApi.SelfHostedSiteCredential = .accountPassword(
         loginURL: URL(string: "https://wordpress.org/wp-login.php")!,
         username: "test-user",
-        password: "test-password",
+        password: .init("test-password"),
         adminURL: URL(string: "https://wordpress.org/wp-admin/")!
     )
 

--- a/Tests/WordPressKitTests/CoreAPITests/WordPressOrgRestApiTests.swift
+++ b/Tests/WordPressKitTests/CoreAPITests/WordPressOrgRestApiTests.swift
@@ -117,7 +117,7 @@ class WordPressOrgRestApiTests: XCTestCase {
         XCTAssertEqual(request?.url?.absoluteString, "http://localhost:8000/wp/v2/sites/1001/hello")
     }
 
-    func testSelfHostedWithAuthorizationHeaderSendsHeader() async throws {
+    func testSelfHostedWithApplicationPasswordSendsAuthorizationHeader() async throws {
         var request: URLRequest?
         stub(condition: isHost("wordpress.org")) {
             request = $0
@@ -126,16 +126,16 @@ class WordPressOrgRestApiTests: XCTestCase {
 
         let api = WordPressOrgRestApi(
             selfHostedSiteWPJSONURL: apiBase,
-            credential: .init(loginURL: URL(string: "https://not-used.com")!, username: "user", password: "pass", adminURL: URL(string: "https://not-used.com")!),
-            authorizationHeader: "Basic fake-token-for-testing"
+            credential: .applicationPassword(username: "user", password: .init("app-pass"))
         )
         let _ = await api.get(path: "/wp/v2/posts", type: AnyResponse.self)
 
         let captured = try XCTUnwrap(request)
-        XCTAssertEqual(captured.value(forHTTPHeaderField: "Authorization"), "Basic fake-token-for-testing")
+        let expectedData = "user:app-pass".data(using: .utf8)!
+        XCTAssertEqual(captured.value(forHTTPHeaderField: "Authorization"), "Basic \(expectedData.base64EncodedString())")
     }
 
-    func testSelfHostedWithoutAuthorizationHeaderSendsNoHeader() async throws {
+    func testSelfHostedWithAccountPasswordSendsNoAuthorizationHeader() async throws {
         var request: URLRequest?
         stub(condition: isHost("wordpress.org")) {
             request = $0
@@ -178,7 +178,7 @@ extension WordPressOrgRestApi {
     convenience init(apiBase: URL) {
         self.init(
             selfHostedSiteWPJSONURL: apiBase,
-            credential: .init(loginURL: URL(string: "https://not-used.com")!, username: "user", password: "pass", adminURL: URL(string: "https://not-used.com")!)
+            credential: .accountPassword(loginURL: URL(string: "https://not-used.com")!, username: "user", password: .init("pass"), adminURL: URL(string: "https://not-used.com")!)
         )
     }
 }

--- a/Tests/WordPressKitTests/CoreAPITests/WordPressOrgRestApiTests.swift
+++ b/Tests/WordPressKitTests/CoreAPITests/WordPressOrgRestApiTests.swift
@@ -117,6 +117,38 @@ class WordPressOrgRestApiTests: XCTestCase {
         XCTAssertEqual(request?.url?.absoluteString, "http://localhost:8000/wp/v2/sites/1001/hello")
     }
 
+    func testSelfHostedWithAuthorizationHeaderSendsHeader() async throws {
+        var request: URLRequest?
+        stub(condition: isHost("wordpress.org")) {
+            request = $0
+            return HTTPStubsResponse(error: URLError(.notConnectedToInternet))
+        }
+
+        let api = WordPressOrgRestApi(
+            selfHostedSiteWPJSONURL: apiBase,
+            credential: .init(loginURL: URL(string: "https://not-used.com")!, username: "user", password: "pass", adminURL: URL(string: "https://not-used.com")!),
+            authorizationHeader: "Basic fake-token-for-testing"
+        )
+        let _ = await api.get(path: "/wp/v2/posts", type: AnyResponse.self)
+
+        let captured = try XCTUnwrap(request)
+        XCTAssertEqual(captured.value(forHTTPHeaderField: "Authorization"), "Basic fake-token-for-testing")
+    }
+
+    func testSelfHostedWithoutAuthorizationHeaderSendsNoHeader() async throws {
+        var request: URLRequest?
+        stub(condition: isHost("wordpress.org")) {
+            request = $0
+            return HTTPStubsResponse(error: URLError(.notConnectedToInternet))
+        }
+
+        let api = WordPressOrgRestApi(apiBase: apiBase)
+        let _ = await api.get(path: "/wp/v2/posts", type: AnyResponse.self)
+
+        let captured = try XCTUnwrap(request)
+        XCTAssertNil(captured.value(forHTTPHeaderField: "Authorization"))
+    }
+
     // Gutenberg Editor in the WordPress app may call `WordPressOrgRestApi` with a 'path' parameter that contain path
     // and query. This unit test ensures WordPressKit doesn't break that feature.
     func testPathWithQuery() async {


### PR DESCRIPTION
## Description

Closes: CMM-1255

Self-hosted sites added with application passwords fail when using Gutenberg Mobile because REST API requests from the editor lack an `Authorization` header. The existing authentication for self-hosted sites in `WordPressOrgRestApi` relies on a cookie+nonce flow (login to wp-admin, scrape a nonce, send `X-WP-Nonce`). This does not work for application-password-only sites because application passwords cannot be used to log into wp-admin to retrieve the cookie and nonce.

GutenbergKit (the new editor) already works correctly because it constructs a `Basic` auth header from the application password directly (`EditorConfiguration+Blog.swift`). This fix replicates that pattern in `WordPressOrgRestApi`.

### Changes

1. **`WordPressOrgRestApi.swift`** — Added an optional `authorizationHeader` parameter to the self-hosted and internal initializers. When provided, sets the `Authorization` header on the `URLSession` configuration.
2. **`WordPressOrgRestApi+WordPress.swift`** — In the self-hosted branch of `init?(blog:...)`, checks for an application password via `blog.getApplicationToken()`. When found, constructs a `Basic` auth header and passes it through to the initializer.
3. **`WordPressOrgRestApiTests.swift`** — Added two tests verifying the `Authorization` header is sent when `authorizationHeader` is provided, and absent when it is not.

## Testing instructions

### 1. Verify self-hosted site authentication with app passwords succeeds
1. Add a self-hosted WordPress site with an **application password**
2. Use a site with a **block theme**
3. Open the Gutenberg Mobile editor to create or edit a post
4. Verify the block theme's styles are applied to the editor (previously they were not, because the `GET /wp-block-editor/v1/settings` request failed without auth)
5. Add an image block, upload an image, and save/publish — verify media GET requests (e.g., `GET /wp/v2/media/<id>`) succeed and the full flow works without errors

### 2. Verify self-hosted site authentication with cookie auth succeeds
1. Log out of all sites in the app. 
2. Add a self-hosted site using traditional cookie auth, not app passwords. 
3. Repeat steps 2-5 of the first test case. 

### 3. Verify test WP.com authentication 
1. Log in with a WP.com account. 
3. Repeat steps 2-5 of the first test case with a WP.com account. 
