### PR TITLE
Fix CI error: no `sentry_upload_dsym` action found

### DIFF
--- a/WordPress/Classes/System/main.swift
+++ b/WordPress/Classes/System/main.swift
@@ -5,7 +5,7 @@ import UIKit
 let isRunningTests = NSClassFromString("XCTestCase") != nil
 let appDelegateClass = isRunningTests ? NSStringFromClass(TestingAppDelegate.self) : NSStringFromClass(WordPressAppDelegate.self)
 
-// The secrets _must_ be configured before the app launches.
+// The secrets MUST be configured before the app launches.
 //
 // This is because `BuildSettings` are not propagated through the app via chain injection but accessed via a `static` `current` property for convenience.
 // Also for convenience, we assume the secrets not to be nil at runtime, to avoid unwrapping values that we know must be there.

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -182,11 +182,11 @@ platform :ios do
       beta_app_description_path: WORDPRESS_BETA_APP_DESCRIPTION_PATH
     )
 
-    sentry_upload_dsym(
+    sentry_debug_files_upload(
       auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
       org_slug: SENTRY_ORG_SLUG,
       project_slug: SENTRY_PROJECT_SLUG_WORDPRESS,
-      dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH]
+      path: lane_context[SharedValues::DSYM_OUTPUT_PATH]
     )
 
     upload_gutenberg_sourcemaps(
@@ -251,11 +251,11 @@ platform :ios do
       beta_app_description_path: JETPACK_BETA_APP_DESCRIPTION_PATH
     )
 
-    sentry_upload_dsym(
+    sentry_debug_files_upload(
       auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
       org_slug: SENTRY_ORG_SLUG,
       project_slug: SENTRY_PROJECT_SLUG_JETPACK,
-      dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH]
+      path: lane_context[SharedValues::DSYM_OUTPUT_PATH]
     )
 
     release_version = release_version_current
@@ -396,11 +396,11 @@ platform :ios do
     )
 
     # Upload dSYMs to Sentry
-    sentry_upload_dsym(
+    sentry_debug_files_upload(
       auth_token: get_required_env('SENTRY_AUTH_TOKEN'),
       org_slug: SENTRY_ORG_SLUG,
       project_slug: sentry_project_slug,
-      dsym_path: lane_context[SharedValues::DSYM_OUTPUT_PATH]
+      path: lane_context[SharedValues::DSYM_OUTPUT_PATH]
     )
 
     upload_gutenberg_sourcemaps(


### PR DESCRIPTION
`sentry_upload_dsym` was deprecated and removed after the plugin update in https://github.com/wordpress-mobile/WordPress-iOS/pull/25232