### PR TITLE
Fix wrong avatar in notifications

### DIFF
--- a/Modules/Sources/AsyncImageKit/Views/CachedAsyncImage.swift
+++ b/Modules/Sources/AsyncImageKit/Views/CachedAsyncImage.swift
@@ -137,6 +137,7 @@ public struct CachedAsyncImage<Content>: View where Content: View {
             if let image = imageDownloader.cachedImage(for: url) {
                 phase = .success(Image(uiImage: image))
             } else {
+                phase = .empty
                 let image = try await imageDownloader.image(for: request)
                 phase = .success(Image(uiImage: image))
             }

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -10,6 +10,7 @@
 * [*] Insights: Fix empty posting activity [#25219]
 * [*] Activity Logs: Minor visual improvements [#25220]
 * [*] Reader: The post tags are now displayed in the original order [#25229]
+* [*] Notifications: Fix notifications sometimes displaying wrong avatars [#25265]
 
 
 26.6

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockHeaderTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockHeaderTableViewCell.swift
@@ -91,6 +91,14 @@ class NoteBlockHeaderTableViewCell: NoteBlockTableViewCell {
     }
 
     // MARK: - Overriden Methods
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        authorAvatarURL = nil
+        authorAvatarImageView.cancelImageDownload()
+        authorAvatarImageView.image = nil
+    }
+
     override func refreshSeparators() {
         separatorsView.bottomVisible = true
         separatorsView.bottomInsets = UIEdgeInsets.zero

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockUserTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockUserTableViewCell.swift
@@ -62,6 +62,14 @@ class NoteBlockUserTableViewCell: NoteBlockTableViewCell {
     }
 
     // MARK: - View Methods
+
+    override func prepareForReuse() {
+        super.prepareForReuse()
+        gravatarURL = nil
+        gravatarImageView.cancelImageDownload()
+        gravatarImageView.image = nil
+    }
+
     override func awakeFromNib() {
         super.awakeFromNib()
 


### PR DESCRIPTION
Fixes [CMM-1182: Gravatars in Jetpack iOS notifications show wrong avatars](https://linear.app/a8c/issue/CMM-1182/gravatars-in-jetpack-ios-notifications-show-wrong-avatars).

It's hard to reproduce, but I identified and addressed three potential issues. It should work fine one.

