### PR TITLE
Make syncing post types as part of syncing blog data

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -11,6 +11,7 @@
 * [*] Activity Logs: Minor visual improvements [#25220]
 * [*] Reader: The post tags are now displayed in the original order [#25229]
 * [*] Notifications: Fix notifications sometimes displaying wrong avatars [#25265]
+* [*] A new experimental feature: Custom Post Types. [#25267]
 
 
 26.6

--- a/WordPress/Classes/Login/ApplicationPasswordRequiredView.swift
+++ b/WordPress/Classes/Login/ApplicationPasswordRequiredView.swift
@@ -10,6 +10,7 @@ struct ApplicationPasswordRequiredView<Content: View>: View {
     private let localizedFeatureName: String
     @State private var site: WordPressSite?
     @State private var showLoading: Bool = true
+    @State private var isLoaded: Bool = false
     private let builder: (WordPressClient) -> Content
 
     weak var presentingViewController: UIViewController?
@@ -38,6 +39,11 @@ struct ApplicationPasswordRequiredView<Content: View>: View {
             }
         }
         .task {
+            // This code block should only execute once, like `viewDidLoad`.
+
+            guard !isLoaded else { return }
+            isLoaded = true
+
             showLoading = true
             defer { showLoading = false }
 

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -220,6 +220,11 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
         dispatch_group_leave(syncGroup);
     }];
 
+    dispatch_group_enter(syncGroup);
+    [self syncPostTypesFor:blog completion:^{
+        dispatch_group_leave(syncGroup);
+    }];
+
     // When everything has left the syncGroup (all calls have ended with success
     // or failure) perform the completionHandler
     dispatch_group_notify(syncGroup, dispatch_get_main_queue(),^{

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsTableViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsTableViewModel.swift
@@ -27,7 +27,7 @@ private struct Section {
 }
 
 @objc public final class BlogDetailsTableViewModel: NSObject {
-    private var blog: Blog
+    var blog: Blog
     private weak var tableView: UITableView?
     private weak var viewController: BlogDetailsViewController?
     private var sections: [Section] = []
@@ -593,12 +593,14 @@ private extension BlogDetailsTableViewModel {
         rows.append(Row.media(viewController: viewController))
         rows.append(Row.comments(viewController: viewController))
 
-        if FeatureFlag.customPostTypes.enabled && blog.supportsCoreRESTAPI && hasCustomPostTypes {
+        if FeatureFlag.customPostTypes.enabled && blog.supportsCoreRESTAPI {
             let pinned = SiteStorageAccess.pinnedPostTypes(for: TaggedManagedObjectID(blog))
             for type in pinned {
                 rows.append(Row.pinnedPostType(type, viewController: viewController))
             }
-            rows.append(Row.customPostTypes(viewController: viewController))
+            if !pinned.isEmpty || hasCustomPostTypes {
+                rows.append(Row.customPostTypes(viewController: viewController))
+            }
         }
 
         let title = isSplitViewDisplayed ? nil : Strings.contentSectionTitle

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsTableViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsTableViewModel.swift
@@ -54,6 +54,7 @@ private struct Section {
         }
     }
 
+    var hasCustomPostTypes = false
     var useSiteMenuStyle = false
 
     @objc public init(blog: Blog, viewController: BlogDetailsViewController) {
@@ -592,7 +593,7 @@ private extension BlogDetailsTableViewModel {
         rows.append(Row.media(viewController: viewController))
         rows.append(Row.comments(viewController: viewController))
 
-        if FeatureFlag.customPostTypes.enabled && blog.supportsCoreRESTAPI {
+        if FeatureFlag.customPostTypes.enabled && blog.supportsCoreRESTAPI && hasCustomPostTypes {
             let pinned = SiteStorageAccess.pinnedPostTypes(for: TaggedManagedObjectID(blog))
             for type in pinned {
                 rows.append(Row.pinnedPostType(type, viewController: viewController))
@@ -674,7 +675,7 @@ private extension BlogDetailsTableViewModel {
 
         rows.append(Row.comments(viewController: viewController))
 
-        if FeatureFlag.customPostTypes.enabled && blog.supportsCoreRESTAPI {
+        if FeatureFlag.customPostTypes.enabled && blog.supportsCoreRESTAPI && hasCustomPostTypes {
             let pinned = SiteStorageAccess.pinnedPostTypes(for: TaggedManagedObjectID(blog))
             for type in pinned {
                 rows.append(Row.pinnedPostType(type, viewController: viewController))

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
@@ -103,22 +103,6 @@ extension BlogDetailsViewController {
         presentationDelegate?.presentBlogDetailsViewController(controller)
     }
 
-    func syncPostTypes() {
-        guard let service = CustomPostTypeService(blog: blog) else { return }
-        Task { @MainActor [weak self] in
-            do {
-                try await service.refresh()
-
-                if let self {
-                    configureTableViewData()
-                    reloadTableViewPreservingSelection()
-                }
-            } catch {
-                DDLogError("Failed to sync post types: \(error)")
-            }
-        }
-    }
-
     func showPinnedPostType(_ postType: PinnedPostType) {
         guard let site = try? WordPressSite(blog: blog), case .selfHosted = site else { return }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.swift
@@ -11,7 +11,11 @@ public protocol BlogDetailsPresentationDelegate: AnyObject {
 
 public class BlogDetailsViewController: UIViewController {
 
-    public var blog: Blog
+    public var blog: Blog {
+        didSet {
+            tableViewModel?.blog = blog
+        }
+    }
     public private(set) var tableView: UITableView?
     public private(set) var tableViewModel: BlogDetailsTableViewModel?
     public var isScrollEnabled = false

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.swift
@@ -80,7 +80,6 @@ public class BlogDetailsViewController: UIViewController {
         observeManagedObjectContextObjectsDidChangeNotification()
         observeGravatarImageUpdate()
         downloadGravatarImage()
-        syncPostTypes()
 
         registerForTraitChanges([UITraitHorizontalSizeClass.self], action: #selector(handleTraitChanges))
     }
@@ -140,22 +139,29 @@ public class BlogDetailsViewController: UIViewController {
         tableViewModel?.showInitialDetailsForBlog()
     }
 
-    public func updateTableView(completion: (() -> Void)?) {
-        let completionBlock = completion ?? {}
-        blogService.syncBlogAndAllMetadata(blog) { [weak self] in
-            self?.configureTableViewData()
-            self?.reloadTableViewPreservingSelection()
-            completionBlock()
+    @MainActor
+    private func updateTableView() async {
+        await withCheckedContinuation { continuation in
+            blogService.syncBlogAndAllMetadata(blog) {
+                continuation.resume()
+            }
         }
+
+        if let service = CustomPostTypeService(blog: blog) {
+            tableViewModel?.hasCustomPostTypes = (try? await service.customTypes())?.isEmpty == false
+        } else {
+            tableViewModel?.hasCustomPostTypes = false
+        }
+
+        configureTableViewData()
+        reloadTableViewPreservingSelection()
     }
 
     public func pulledToRefresh(with refreshControl: UIRefreshControl, onCompletion completion: (() -> Void)?) {
-        let completionBlock = completion ?? {}
-        updateTableView { [weak refreshControl] in
-            DispatchQueue.main.async {
-                refreshControl?.endRefreshing()
-                completionBlock()
-            }
+        Task { @MainActor [weak refreshControl] in
+            await updateTableView()
+            refreshControl?.endRefreshing()
+            completion?()
         }
     }
 
@@ -188,9 +194,8 @@ public class BlogDetailsViewController: UIViewController {
     }
 
     public func preloadMetadata() {
-        blogService.syncBlogAndAllMetadata(blog) { [weak self] in
-            self?.configureTableViewData()
-            self?.reloadTableViewPreservingSelection()
+        Task {
+            await updateTableView()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
@@ -10,6 +10,7 @@ class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvid
         FeatureFlag.newStats,
         FeatureFlag.allowApplicationPasswords,
         RemoteFeatureFlag.newGutenberg,
+        FeatureFlag.customPostTypes,
         FeatureFlag.newSupport,
     ]
 


### PR DESCRIPTION
## Description

Do not show the "More" row if there are no custom post types on the site.

This PR also makes "Custom Post Types" an experimental feature.