### PR TITLE
Rewrite parts of WPAccount in Swift

### DIFF
--- a/Sources/WordPressData/Objective-C/WPAccount.m
+++ b/Sources/WordPressData/Objective-C/WPAccount.m
@@ -1,13 +1,6 @@
-@import SFHFKeychainUtils;
 #import "WPAccount.h"
 #import "WordPressData-Swift.h"
 @import WordPressKit;
-
-@interface WPAccount ()
-
-@property (nonatomic, strong, readwrite) NSString *cachedToken;
-
-@end
 
 @implementation WPAccount
 
@@ -75,49 +68,6 @@
     }
 }
 
-- (NSString *)authToken
-{
-    if (self.cachedToken != nil) {
-        return self.cachedToken;
-    }
-
-    NSString *token = [WPAccount tokenForUsername:self.username];
-    self.cachedToken = token;
-    return token;
-}
-
-- (void)setAuthToken:(NSString *)authToken
-{
-    self.cachedToken = nil;
-
-    if (authToken) {
-        NSError *error = nil;
-        [SFHFKeychainUtils storeUsername:self.username
-                             andPassword:authToken
-                          forServiceName:[WPAccount authKeychainServiceName]
-                             accessGroup:nil
-                          updateExisting:YES
-                                   error:&error];
-
-        if (error) {
-            DDLogError(@"Error while updating WordPressComOAuthKeychainServiceName token: %@", error);
-        }
-
-    } else {
-        NSError *error = nil;
-        [SFHFKeychainUtils deleteItemForUsername:self.username
-                                  andServiceName:[WPAccount authKeychainServiceName]
-                                     accessGroup:nil
-                                           error:&error];
-        if (error) {
-            DDLogError(@"Error while deleting WordPressComOAuthKeychainServiceName token: %@", error);
-        }
-    }
-
-    // Make sure to release any RestAPI alloc'ed, since it might have an invalid token
-    _private_wordPressComRestApi = nil;
-}
-
 - (BOOL)hasAtomicSite {
     for (Blog *blog in self.blogs) {
         if ([blog isAtomic]) {
@@ -125,40 +75,6 @@
         }
     }
     return NO;
-}
-
-#pragma mark - Static methods
-
-+ (NSString *)tokenForUsername:(NSString *)username isJetpack:(BOOL)isJetpack error:(NSError **)outError
-{
-    if (isJetpack) {
-        [WPAccount migrateAuthKeyForUsername:username];
-    }
-
-    NSError *error = nil;
-    NSString *authToken = [SFHFKeychainUtils getPasswordForUsername:username
-                                                     andServiceName:[WPAccount authKeychainServiceName]
-                                                        accessGroup:nil
-                                                              error:&error];
-    if (error) {
-        DDLogError(@"Error while retrieving WordPressComOAuthKeychainServiceName token: %@", error);
-
-        if (outError) {
-            *outError = error;
-        }
-        return nil;
-    }
-
-    return authToken;
-}
-
-+ (void)migrateAuthKeyForUsername:(NSString *)username
-{
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        SharedDataIssueSolver *sharedDataIssueSolver = [SharedDataIssueSolver instance];
-        [sharedDataIssueSolver migrateAuthKeyFor:username];
-    });
 }
 
 @end

--- a/Sources/WordPressData/Objective-C/include/WPAccount.h
+++ b/Sources/WordPressData/Objective-C/include/WPAccount.h
@@ -34,11 +34,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, strong, nullable)   Blog        *defaultBlog;
 @property (nonatomic, strong, nullable)   ManagedAccountSettings *settings;
 
-/**
- The OAuth2 auth token for WordPress.com accounts
- */
-@property (nonatomic, copy, nullable) NSString *authToken;
-
 ///------------------
 /// @name API Helpers
 ///------------------
@@ -50,6 +45,8 @@ NS_ASSUME_NONNULL_BEGIN
 /// It's reserved for Objective-C to Swift interoperability in the context of separating this model from the app target and will be removed at some point.
 @property (nonatomic, strong, nullable) WordPressComRestApi *_private_wordPressComRestApi;
 
+@property (nonatomic, copy, nullable) NSString *cachedToken;
+
 @end
 
 @interface WPAccount (CoreDataGeneratedAccessors)
@@ -58,7 +55,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)removeBlogsObject:(Blog *)value;
 - (void)addBlogs:(NSSet *)values;
 - (void)removeBlogs:(NSSet *)values;
-+ (NSString * _Nullable)tokenForUsername:(NSString *)username isJetpack:(BOOL)isJetpack error:(NSError ** _Nullable)error;
 - (BOOL)hasAtomicSite;
 
 @end

--- a/Sources/WordPressData/Swift/WPAccount+Keychain.swift
+++ b/Sources/WordPressData/Swift/WPAccount+Keychain.swift
@@ -1,8 +1,86 @@
 import BuildSettingsKit
+import SFHFKeychainUtils
+import WordPressShared
 
-public extension WPAccount {
+extension WPAccount {
 
-    @objc class var authKeychainServiceName: String {
+    private static var authKeychainServiceName: String {
         BuildSettings.current.authKeychainServiceName
+    }
+
+    /// The OAuth2 auth token for WordPress.com accounts
+    @objc public var authToken: String? {
+        get { _getAuthToken() }
+        set { _setAuthToken(newValue) }
+    }
+
+    private func _getAuthToken() -> String? {
+        if let cachedToken {
+            return cachedToken
+        }
+        let token = try? Self.token(forUsername: username)
+        cachedToken = token
+        return token
+    }
+
+    private func _setAuthToken(_ authToken: String?) {
+        cachedToken = nil
+
+        // Make sure to release any RestAPI alloc'ed, since it might have an invalid token
+        _private_wordPressComRestApi = nil
+
+        do {
+            if let authToken {
+                try SFHFKeychainUtils.storeUsername(
+                    username,
+                    andPassword: authToken,
+                    forServiceName: Self.authKeychainServiceName,
+                    accessGroup: nil,
+                    updateExisting: true
+                )
+            } else {
+                try SFHFKeychainUtils.deleteItem(
+                    forUsername: username,
+                    andServiceName: Self.authKeychainServiceName,
+                    accessGroup: nil
+                )
+            }
+        } catch {
+            WPLogError("Error while updating or deleting WordPressComOAuthKeychainServiceName token: %@", error.localizedDescription)
+        }
+    }
+
+    public static func token(
+        forUsername username: String,
+        isJetpack: Bool = BuildSettings.current.brand == .jetpack
+    ) throws -> String {
+        if isJetpack {
+            AuthKeyMigration.migrateIfNeeded(username: username)
+        }
+        do {
+            return try SFHFKeychainUtils.getPasswordForUsername(
+                username,
+                andServiceName: WPAccount.authKeychainServiceName,
+                accessGroup: nil
+            )
+        } catch {
+            WPLogError("Error while retrieving WordPressComOAuthKeychainServiceName token: %@", error.localizedDescription)
+            throw error
+        }
+    }
+}
+
+private enum AuthKeyMigration {
+    static let lock = NSLock()
+    static var didMigrate = false
+
+    static func migrateIfNeeded(username: String) {
+        let shouldMigrate = lock.withLock {
+            guard !didMigrate else { return false }
+            didMigrate = true
+            return true
+        }
+        guard shouldMigrate else { return }
+        SharedDataIssueSolver.instance().migrateAuthKey(for: username)
     }
 }

--- a/Sources/WordPressData/Swift/WPAccount+Lookup.swift
+++ b/Sources/WordPressData/Swift/WPAccount+Lookup.swift
@@ -16,17 +16,6 @@ public extension WPAccount {
         return self.uuid == uuid
     }
 
-    // This is here in an extension that belongs to the apps target so we can decouple WPAccount from AppConfiguration.
-    // Decoupling allows moving the type to WordPressData, see https://github.com/wordpress-mobile/WordPress-iOS/issues/24165.
-    @objc(tokenForUsername:)
-    static func objc_tokenForUsername(_ username: String) -> String? {
-        try? token(forUsername: username)
-    }
-
-    static func token(forUsername username: String) throws -> String {
-        try token(forUsername: username, isJetpack: BuildSettings.current.brand == .jetpack)
-    }
-
     /// Does this `WPAccount` object have any associated blogs?
     ///
     @objc


### PR DESCRIPTION
This is a first part of the rework of `WPAccount` auth token management to Swift. It is more of a mechanical change that doesn't introduce any refactoring.