### PR TITLE
 Rewrite some Blog optons to Swift

### DIFF
--- a/Sources/WordPressData/Objective-C/Blog.m
+++ b/Sources/WordPressData/Objective-C/Blog.m
@@ -27,9 +27,6 @@ NSString * const ActiveModulesKeyPublicize = @"publicize";
 NSString * const ActiveModulesKeySharingButtons = @"sharedaddy";
 NSString * const OptionsKeyActiveModules = @"active_modules";
 NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled";
-NSString * const OptionsKeyIsAutomatedTransfer = @"is_automated_transfer";
-NSString * const OptionsKeyIsAtomic = @"is_wpcom_atomic";
-NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 
 @interface Blog ()
 
@@ -159,24 +156,6 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
     } else {
         return organizationID;
     }
-}
-
-- (BOOL)isAtomic
-{
-    NSNumber *value = (NSNumber *)[self getOptionValue:OptionsKeyIsAtomic];
-    return [value boolValue];
-}
-
-- (BOOL)isWPForTeams
-{
-    NSNumber *value = (NSNumber *)[self getOptionValue:OptionsKeyIsWPForTeams];
-    return [value boolValue];
-}
-
-- (BOOL)isAutomatedTransfer
-{
-    NSNumber *value = (NSNumber *)[self getOptionValue:OptionsKeyIsAutomatedTransfer];
-    return [value boolValue];
 }
 
 // Used as a key to store passwords, if you change the algorithm, logins will break
@@ -475,33 +454,6 @@ NSString * const OptionsKeyIsWPForTeams = @"is_wpforteams_site";
 - (NSString *)authToken
 {
     return self.account.authToken;
-}
-
-- (NSString *)usernameForSite
-{
-    if (self.username) {
-        return self.username;
-    } else if (self.account && self.isAccessibleThroughWPCom) {
-        return self.account.username;
-    } else {
-        // FIXME: Figure out how to get the self hosted username when using Jetpack REST (@koke 2015-06-15)
-        return nil;
-    }
-}
-
-- (BOOL)canBlaze
-{
-    return [[self getOptionValue:@"can_blaze"] boolValue] && self.isAdmin;
-}
-
-- (BOOL)supportsFeaturedImages
-{
-    id hasSupport = [self getOptionValue:@"post_thumbnail"];
-    if (hasSupport) {
-        return [hasSupport boolValue];
-    }
-
-    return NO;
 }
 
 - (BOOL)supports:(BlogFeature)feature

--- a/Sources/WordPressData/Objective-C/include/Blog.h
+++ b/Sources/WordPressData/Objective-C/include/Blog.h
@@ -200,7 +200,7 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 /**
  *  @details    Stores the username for self hosted sites
  *
- *  @warn       For WordPress.com or Jetpack Managed sites this will be nil. Use usernameForSite instead
+ *  @warn       For WordPress.com or Jetpack Managed sites this will be nil. Use effectiveUsername instead
  */
 @property (nonatomic, strong, readwrite, nullable) NSString *username;
 @property (nonatomic, strong, readwrite, nullable) NSString *password;
@@ -212,8 +212,6 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 @property (nonatomic, weak, readonly, nullable) NSString *version;
 @property (nonatomic, strong, readonly, nullable) NSString *authToken;
 @property (nonatomic, strong, readonly, nullable) NSSet *allowedFileTypes;
-@property (nonatomic, copy, readonly, nullable) NSString *usernameForSite;
-@property (nonatomic, assign, readonly) BOOL canBlaze;
 
 /**
  *  @details    URL properties (example: http://wp.koke.me/sub/xmlrpc.php)
@@ -240,9 +238,6 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 
 #pragma mark - Blog information
 
-- (BOOL)isAtomic;
-- (BOOL)isWPForTeams;
-- (BOOL)isAutomatedTransfer;
 - (BOOL)isPrivate;
 - (BOOL)isPrivateAtWPCom;
 - (nullable NSArray *)sortedCategories;
@@ -252,7 +247,6 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 - (nullable NSString *)urlWithPath:(NSString *)path;
 - (NSString *)adminUrlWithPath:(NSString *)path;
 - (NSDictionary *) getImageResizeDimensions;
-- (BOOL)supportsFeaturedImages;
 - (BOOL)supports:(BlogFeature)feature;
 - (BOOL)supportsPublicize;
 - (BOOL)supportsShareButtons;

--- a/Sources/WordPressData/Swift/Blog+Jetpack.swift
+++ b/Sources/WordPressData/Swift/Blog+Jetpack.swift
@@ -1,23 +1,4 @@
 public extension Blog {
-    func getOption<T>(name: String) -> T? {
-        return getOptionValue(name) as? T
-    }
-
-    func getOptionString(name: String) -> String? {
-        return (getOption(name: name) as NSString?).map(String.init)
-    }
-
-    func getOptionNumeric(name: String) -> NSNumber? {
-        switch getOptionValue(name) {
-        case let numericValue as NSNumber:
-            return numericValue
-        case let stringValue as NSString:
-            return stringValue.numericValue()
-        default:
-            return nil
-        }
-    }
-
     @objc var jetpack: JetpackState? {
         guard let options,
             !options.isEmpty else {

--- a/Sources/WordPressData/Swift/Blog+Options.swift
+++ b/Sources/WordPressData/Swift/Blog+Options.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+extension Blog {
+    @objc public var isAtomic: Bool {
+        getOptionBoolean(name: "is_wpcom_atomic")
+    }
+
+    @objc public var isWPForTeams: Bool {
+        getOptionBoolean(name: "is_wpforteams_site")
+    }
+
+    public var isAutomatedTransfer: Bool {
+        getOptionBoolean(name: "is_automated_transfer")
+    }
+
+    @objc public var canBlaze: Bool {
+        getOptionBoolean(name: "can_blaze") && isAdmin
+    }
+
+    @objc public var supportsFeaturedImages: Bool {
+        getOptionBoolean(name: "post_thumbnail")
+    }
+
+    public var isWPComStagingSite: Bool {
+        getOptionBoolean(name: "is_wpcom_staging_site")
+    }
+
+    // MARK: - Internal
+
+    func getOptionBoolean(name: String) -> Bool {
+        (getOptionValue(name) as? NSNumber)?.boolValue ?? false
+    }
+
+    func getOption<T>(name: String) -> T? {
+        getOptionValue(name) as? T
+    }
+
+    public func getOptionString(name: String) -> String? {
+        (getOption(name: name) as NSString?).map(String.init)
+    }
+
+    func getOptionNumeric(name: String) -> NSNumber? {
+        switch getOptionValue(name) {
+        case let numericValue as NSNumber:
+            return numericValue
+        case let stringValue as NSString:
+            return stringValue.numericValue()
+        default:
+            return nil
+        }
+    }
+}

--- a/Sources/WordPressData/Swift/Blog+Plans.swift
+++ b/Sources/WordPressData/Swift/Blog+Plans.swift
@@ -20,7 +20,7 @@
 
     public var supportsCoreRESTAPI: Bool {
         if isHostedAtWPcom {
-            return isAtomic()
+            return isAtomic
         }
         return true
     }

--- a/Sources/WordPressData/Swift/Blog+Swift.swift
+++ b/Sources/WordPressData/Swift/Blog+Swift.swift
@@ -12,4 +12,18 @@ extension Blog {
     public func supportsBlockEditorSettings() -> Bool {
         return hasRequiredWordPressVersion("5.8")
     }
+
+    /// Returns the username to use for this site.
+    ///
+    /// For self-hosted sites, returns the stored `username`. For WordPress.com
+    /// or Jetpack-connected sites, returns the account's username.
+    @objc public var effectiveUsername: String? {
+        if let username {
+            return username
+        } else if let account, isAccessibleThroughWPCom() {
+            return account.username
+        } else {
+            return nil
+        }
+    }
 }

--- a/Sources/WordPressData/Swift/Comment+CoreDataClass.swift
+++ b/Sources/WordPressData/Swift/Comment+CoreDataClass.swift
@@ -26,7 +26,7 @@ public class Comment: NSManagedObject {
         }
 
         // If the current user cannot moderate the comment, they can only Like and Reply if the comment is Approved.
-        return (blog.isHostedAtWPcom || blog.isAtomic()) && !canModerate && !isApproved()
+        return (blog.isHostedAtWPcom || blog.isAtomic) && !canModerate && !isApproved()
     }
 
     // This can be removed when `unifiedCommentsAndNotificationsList` is permanently enabled
@@ -70,7 +70,7 @@ public class Comment: NSManagedObject {
             return canModerate
         }
 
-        guard let blog, blog.isHostedAtWPcom || blog.isAtomic() else {
+        guard let blog, blog.isHostedAtWPcom || blog.isAtomic else {
             return true
         }
         return canModerate

--- a/Tests/KeystoneTests/Tests/Models/BlogTests.swift
+++ b/Tests/KeystoneTests/Tests/Models/BlogTests.swift
@@ -11,7 +11,7 @@ final class BlogTests: CoreDataTestCase {
             .with(atomic: true)
             .build()
 
-        XCTAssertTrue(blog.isAtomic())
+        XCTAssertTrue(blog.isAtomic)
     }
 
     func testIsNotAtomic() {
@@ -19,7 +19,7 @@ final class BlogTests: CoreDataTestCase {
             .with(atomic: false)
             .build()
 
-        XCTAssertFalse(blog.isAtomic())
+        XCTAssertFalse(blog.isAtomic)
     }
 
     // MARK: - Blog Lookup

--- a/Tests/WordPressDataTests/BlogTests.swift
+++ b/Tests/WordPressDataTests/BlogTests.swift
@@ -14,7 +14,7 @@ struct BlogTests {
             .with(atomic: true)
             .build()
 
-        #expect(blog.isAtomic())
+        #expect(blog.isAtomic)
     }
 
     @Test func isNotAtomic() {
@@ -22,7 +22,7 @@ struct BlogTests {
             .with(atomic: false)
             .build()
 
-        #expect(!blog.isAtomic())
+        #expect(!blog.isAtomic)
     }
 
     // MARK: - Blog Lookup
@@ -311,4 +311,29 @@ struct BlogTests {
             #expect((try? Blog.lookup(withID: 123, in: context)) != nil)
         }
     }
+
+    // MARK: - Username For Site
+
+    @Test func effectiveUsernameReturnsBlogUsername() {
+        let blog = BlogBuilder(mainContext)
+            .with(username: "self_hosted_user")
+            .build()
+
+        #expect(blog.effectiveUsername == "self_hosted_user")
+    }
+
+    @Test func effectiveUsernameReturnsNilWithoutUsernameOrAccount() {
+        let blog = BlogBuilder(mainContext).build()
+
+        #expect(blog.effectiveUsername == nil)
+    }
+
+    // FIXME: Crashes because WPAccount fixture sets username and triggers BuildSettings access
+//    @Test func effectiveUsernameReturnsAccountUsername() {
+//        let blog = BlogBuilder(mainContext)
+//            .withAnAccount(username: "wpcom_user")
+//            .build()
+//
+//        #expect(blog.effectiveUsername == "wpcom_user")
+//    }
 }

--- a/WordPress/Classes/Login/ApplicationPasswordRequiredView.swift
+++ b/WordPress/Classes/Login/ApplicationPasswordRequiredView.swift
@@ -24,7 +24,7 @@ struct ApplicationPasswordRequiredView<Content: View>: View {
 
     var body: some View {
         VStack {
-            if blog.isHostedAtWPcom && !blog.isAtomic() {
+            if blog.isHostedAtWPcom && !blog.isAtomic {
                 EmptyStateView(Strings.unsupported, systemImage: "exclamationmark.triangle.fill")
             } else if showLoading {
                 ProgressView()

--- a/WordPress/Classes/Models/Blog/Blog+JetpackSocial.swift
+++ b/WordPress/Classes/Models/Blog/Blog+JetpackSocial.swift
@@ -8,7 +8,7 @@ extension Blog {
     /// Note that sites hosted at WP.com has no Social sharing limitations.
     var isSocialSharingLimited: Bool {
         let hasUnlimitedSharing = (planActiveFeatures ?? []).contains(Constants.unlimitedSharingFeatureKey)
-        return !(isHostedAtWPcom || isAtomic() || hasUnlimitedSharing)
+        return !(isHostedAtWPcom || isAtomic || hasUnlimitedSharing)
     }
 
     /// The auto-sharing limit information for the blog.

--- a/WordPress/Classes/Networking/MediaHost+Extensions.swift
+++ b/WordPress/Classes/Networking/MediaHost+Extensions.swift
@@ -15,9 +15,9 @@ extension MediaHost {
         self.init(
             isAccessibleThroughWPCom: blog.isAccessibleThroughWPCom(),
             isPrivate: blog.isPrivate(),
-            isAtomic: blog.isAtomic(),
+            isAtomic: blog.isAtomic,
             siteID: blog.dotComID?.intValue,
-            username: blog.usernameForSite,
+            username: blog.effectiveUsername,
             authToken: blog.authToken,
             failure: { error in
                 WordPressAppDelegate.crashLogging?.logError(error)

--- a/WordPress/Classes/Stores/PluginStore.swift
+++ b/WordPress/Classes/Stores/PluginStore.swift
@@ -659,7 +659,7 @@ private extension PluginStore {
                 return plugin
             })
         }
-        if BlogService.blog(with: site)?.isAutomatedTransfer() == true {
+        if BlogService.blog(with: site)?.isAutomatedTransfer == true {
             plugins.plugins = plugins.plugins.map({ (plugin) in
                 var plugin = plugin
                 if ["akismet", "jetpack", "vaultpress"].contains(plugin.slug) {

--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -1989,7 +1989,7 @@ extension WPAnalytics {
     static func track(_ event: WPAnalyticsEvent, properties: [AnyHashable: Any], blog: Blog) {
         var props = properties
         props[WPAppAnalyticsKeyBlogID] = blog.dotComID
-        props[WPAppAnalyticsKeySiteType] = blog.isWPForTeams() ? WPAppAnalyticsValueSiteTypeP2 : WPAppAnalyticsValueSiteTypeBlog
+        props[WPAppAnalyticsKeySiteType] = blog.isWPForTeams ? WPAppAnalyticsValueSiteTypeP2 : WPAppAnalyticsValueSiteTypeBlog
         WPAnalytics.track(event, properties: props)
     }
 

--- a/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Extensions.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAppAnalytics+Extensions.swift
@@ -64,7 +64,7 @@ extension WPAppAnalytics {
     }
 
     private static func siteType(for blog: Blog) -> String {
-        blog.isWPForTeams() ? WPAppAnalyticsValueSiteTypeP2 : WPAppAnalyticsValueSiteTypeBlog
+        blog.isWPForTeams ? WPAppAnalyticsValueSiteTypeP2 : WPAppAnalyticsValueSiteTypeBlog
     }
 
     // MARK: WPAppAnalytics (AbstractPost)

--- a/WordPress/Classes/Utility/Editor/EditorFactory.swift
+++ b/WordPress/Classes/Utility/Editor/EditorFactory.swift
@@ -62,7 +62,7 @@ class EditorFactory {
         }
 
         // Application passwords do not support private Atomic sites currently
-        if blog.isAtomic() && blog.isPrivate() {
+        if blog.isAtomic && blog.isPrivate() {
             return false
         }
 

--- a/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
+++ b/WordPress/Classes/Utility/Editor/GutenbergSettings.swift
@@ -196,7 +196,7 @@ class GutenbergSettings {
     // MARK: - Gutenberg Choice Logic
 
     func isSimpleWPComSite(_ blog: Blog) -> Bool {
-        return !blog.isAtomic() && blog.isHostedAtWPcom
+        return !blog.isAtomic && blog.isHostedAtWPcom
     }
 
     /// Call this method to know if Gutenberg must be used for the specified post.

--- a/WordPress/Classes/Utility/Networking/RequestAuthenticator.swift
+++ b/WordPress/Classes/Utility/Networking/RequestAuthenticator.swift
@@ -50,7 +50,7 @@ class RequestAuthenticator: NSObject {
 
         if let blog, let dotComID = blog.dotComID as? Int {
 
-            if blog.isAtomic() {
+            if blog.isAtomic {
                 authenticationType = blog.isPrivate() ? .privateAtomic(blogID: dotComID) : .atomic(loginURL: blog.loginUrl())
             } else if blog.hasMappedDomain() {
                 authenticationType = .regularMapped(siteID: dotComID)
@@ -63,7 +63,7 @@ class RequestAuthenticator: NSObject {
     @objc convenience init?(blog: Blog) {
         if let account = blog.account {
             self.init(account: account, blog: blog)
-        } else if let username = blog.usernameForSite,
+        } else if let username = blog.effectiveUsername,
             let password = blog.password,
             let loginURL = URL(string: blog.loginUrl()) {
             self.init(credentials: .siteLogin(loginURL: loginURL, username: username, password: password))

--- a/WordPress/Classes/Utility/ZendeskUtils.swift
+++ b/WordPress/Classes/Utility/ZendeskUtils.swift
@@ -817,7 +817,7 @@ private extension ZendeskUtils {
             }
         }
 
-        if let currentSite = Blog.lastUsedOrFirst(in: context), !currentSite.isHostedAtWPcom, !currentSite.isAtomic() {
+        if let currentSite = Blog.lastUsedOrFirst(in: context), !currentSite.isHostedAtWPcom, !currentSite.isAtomic {
             tags.append(Constants.mobileSelfHosted)
         }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/Activity Log/DashboardActivityLogCardCell.swift
@@ -158,7 +158,7 @@ extension DashboardActivityLogCardCell {
     static func shouldShowCard(for blog: Blog) -> Bool {
         guard RemoteFeatureFlag.activityLogDashboardCard.enabled(),
               blog.supports(.activity),
-              !blog.isWPForTeams() else {
+              !blog.isWPForTeams else {
             return false
         }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsTableViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsTableViewModel.swift
@@ -618,7 +618,7 @@ private extension BlogDetailsTableViewModel {
             rows.append(Row.stats(viewController: viewController))
         }
 
-        if blog.supports(.activity) && !blog.isWPForTeams() {
+        if blog.supports(.activity) && !blog.isWPForTeams {
             rows.append(Row.activityLog(viewController: viewController))
         }
 
@@ -654,7 +654,7 @@ private extension BlogDetailsTableViewModel {
             rows.append(Row.stats(viewController: viewController))
         }
 
-        if blog.supports(.activity) && !blog.isWPForTeams() {
+        if blog.supports(.activity) && !blog.isWPForTeams {
             rows.append(Row.activity(viewController: viewController))
         }
 
@@ -692,7 +692,7 @@ private extension BlogDetailsTableViewModel {
     func buildPersonalizeSection() -> Section {
         var rows: [Row] = []
 
-        if blog.supports(.themeBrowsing) && !blog.isWPForTeams() {
+        if blog.supports(.themeBrowsing) && !blog.isWPForTeams {
             rows.append(Row.themes(viewController: viewController))
         }
 
@@ -804,7 +804,7 @@ private extension BlogDetailsTableViewModel {
         var thirdSectionRows: [Row] = []
 
         // First section: Activity, Backup, Scan, Site Monitoring
-        if blog.supports(.activity) && !blog.isWPForTeams() {
+        if blog.supports(.activity) && !blog.isWPForTeams {
             firstSectionRows.append(Row.activityLog(viewController: viewController))
         }
 
@@ -833,7 +833,7 @@ private extension BlogDetailsTableViewModel {
             secondSectionRows.append(Row.plugins(viewController: viewController))
         }
 
-        if blog.supports(.themeBrowsing) && !blog.isWPForTeams() {
+        if blog.supports(.themeBrowsing) && !blog.isWPForTeams {
             secondSectionRows.append(Row.themes(viewController: viewController))
         }
 

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+SectionHelpers.swift
@@ -101,7 +101,7 @@ extension BlogDetailsViewController {
 private extension Blog {
     /// If the blog should show the "Jetpack" or the "General" section
     var shouldShowJetpackSection: Bool {
-        if supports(.activity) && !isWPForTeams() {
+        if supports(.activity) && !isWPForTeams {
             return true
         }
         if supports(.jetpackSettings) && JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() {

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListSiteView.swift
@@ -79,7 +79,7 @@ final class BlogListSiteViewModel: Identifiable {
         // By adding displayURL _after_ the title, it loweres its weight in search
         self.searchTags = "\(title) \(domain)"
 
-        if (blog.getOption(name: "is_wpcom_staging_site") as Bool?) == true {
+        if blog.isWPComStagingSite {
             badge = Badge(title: Strings.staging, color: Color.yellow.opacity(0.33))
         }
     }

--- a/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
+++ b/WordPress/Classes/ViewRelated/Blog/Site Settings/SiteSettingsViewController.m
@@ -98,7 +98,7 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
     self = [super initWithStyle:UITableViewStyleInsetGrouped];
     if (self) {
         _blog = blog;
-        _username = blog.usernameForSite;
+        _username = blog.effectiveUsername;
         _password = blog.password;
         [WPStyleGuide configureAutomaticHeightRowsFor:self.tableView];
     }
@@ -318,8 +318,8 @@ NS_ENUM(NSInteger, SiteSettingsJetpack) {
 {
     switch (row) {
         case SiteSettingsAccountUsername:
-            if (self.blog.usernameForSite) {
-                [self.usernameTextCell setTextValue:self.blog.usernameForSite];
+            if (self.blog.effectiveUsername) {
+                [self.usernameTextCell setTextValue:self.blog.effectiveUsername];
             } else {
                 [self.usernameTextCell setTextValue:NSLocalizedString(@"Enter username", @"(placeholder) Help enter WordPress username")];
             }

--- a/WordPress/Classes/ViewRelated/Domains/Utility/Blog+DomainsDashboardView.swift
+++ b/WordPress/Classes/ViewRelated/Domains/Utility/Blog+DomainsDashboardView.swift
@@ -25,7 +25,7 @@ extension Blog {
     }
 
     var canRegisterDomainWithPaidPlan: Bool {
-        (isHostedAtWPcom || isAtomic()) && hasDomainCredit
+        (isHostedAtWPcom || isAtomic) && hasDomainCredit
     }
 
     var freeDomain: Domain? {

--- a/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/GutenbergViewController.swift
@@ -1123,7 +1123,7 @@ extension GutenbergViewController: GutenbergBridgeDataSource {
 
     func gutenbergCapabilities() -> [Capabilities: Bool] {
         let isFreeWPCom = post.blog.isHostedAtWPcom && !post.blog.hasPaidPlan
-        let isWPComSite = post.blog.isHostedAtWPcom || post.blog.isAtomic()
+        let isWPComSite = post.blog.isHostedAtWPcom || post.blog.isAtomic
 
         // Disable Jetpack-powered editor features in WordPress app based on Features Removal coordination
         if !JetpackFeaturesRemovalCoordinator.jetpackFeaturesEnabled() {

--- a/WordPress/Classes/ViewRelated/People/Controllers/InvitePersonViewController.swift
+++ b/WordPress/Classes/ViewRelated/People/Controllers/InvitePersonViewController.swift
@@ -182,7 +182,7 @@ class InvitePersonViewController: UITableViewController {
         // Use the system separator color rather than the one defined by WPStyleGuide
         // so cell separators stand out in darkmode.
         tableView.separatorColor = .separator
-        if blog.isWPForTeams() {
+        if blog.isWPForTeams {
             syncInviteLinks()
         }
     }
@@ -197,12 +197,12 @@ class InvitePersonViewController: UITableViewController {
     override func numberOfSections(in tableView: UITableView) -> Int {
         // Hide the last section if the site is not a p2.
         let count = super.numberOfSections(in: tableView)
-        return blog.isWPForTeams() ? count : count - 1
+        return blog.isWPForTeams ? count : count - 1
     }
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
         guard
-            blog.isWPForTeams(),
+            blog.isWPForTeams,
             section == numberOfSections(in: tableView) - 1
         else {
             // If not a P2 or not the last section, just call super.

--- a/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginViewModel.swift
@@ -312,7 +312,7 @@ class PluginViewModel: Observable {
 
         guard let autoUpdatePlugin = plugin,
             let siteCapabilities = capabilities,
-            BlogService.blog(with: site)?.isAutomatedTransfer() == false,
+            BlogService.blog(with: site)?.isAutomatedTransfer == false,
             siteCapabilities.autoupdate,
             !autoUpdatePlugin.state.automanaged else { return nil }
 


### PR DESCRIPTION
I'm starting a bit slow. I didn't want to introduce any new abstractions for now, so it's mostly a mechanical rewrite from the existing Objective-C method into Swift properties. It already creates a pretty large diff.