### PR TITLE
Custom Posts: Load cached items upfront before refreshing from network

### DIFF
--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListView.swift
@@ -61,8 +61,6 @@ struct CustomPostListView<Header: View>: View {
         }
         .task(id: viewModel.filter) {
             await viewModel.loadCachedItems()
-        }
-        .task(id: viewModel.filter) {
             await viewModel.refresh()
         }
         .task(id: viewModel.filter) {

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListView.swift
@@ -60,6 +60,9 @@ struct CustomPostListView<Header: View>: View {
             await viewModel.refresh()
         }
         .task(id: viewModel.filter) {
+            await viewModel.loadCachedItems()
+        }
+        .task(id: viewModel.filter) {
             await viewModel.refresh()
         }
         .task(id: viewModel.filter) {

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
@@ -69,6 +69,24 @@ final class CustomPostListViewModel: ObservableObject {
         }
     }
 
+    func loadCachedItems() async {
+        guard let collection else { return }
+
+        let listInfo = collection.listInfo()
+
+        do {
+            let items = try await collection.loadItems().map(CustomPostCollectionItem.init)
+            if self.listInfo != listInfo {
+                self.listInfo = listInfo
+            }
+            if self.items != items {
+                self.items = items
+            }
+        } catch {
+            DDLogError("Failed to load cached items: \(error)")
+        }
+    }
+
     func handleDataChanges() async {
         let updates = await client.cache.databaseUpdatesPublisher()
             .debounce(for: .milliseconds(50), scheduler: DispatchQueue.main)


### PR DESCRIPTION
## Description

What says in the title.

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
