### PR TITLE
Convert URL-related parts of Blog.m to Swift

### DIFF
--- a/Sources/WordPressData/Blog+Extensions.swift
+++ b/Sources/WordPressData/Blog+Extensions.swift
@@ -8,7 +8,7 @@ extension Blog {
     /// The title of the blog
     public var title: String? {
         guard let blogName = settings?.name, !blogName.isEmpty else {
-            return displayURL as String?
+            return displayURL
         }
         return blogName
     }

--- a/Sources/WordPressData/Objective-C/Blog.m
+++ b/Sources/WordPressData/Objective-C/Blog.m
@@ -6,7 +6,6 @@
 @import SFHFKeychainUtils;
 @import WordPressShared;
 @import NSObject_SafeExpectations;
-@import NSURL_IDN;
 @import WordPressKit;
 
 @class Comment;
@@ -156,99 +155,6 @@ NSString * const OptionsKeyPublicizeDisabled = @"publicize_permanently_disabled"
     } else {
         return organizationID;
     }
-}
-
-// Used as a key to store passwords, if you change the algorithm, logins will break
-- (NSString *)displayURL
-{
-    if (self.url == nil) {
-        DDLogInfo(@"Blog display URL is nil");
-        return nil;
-    }
-
-    NSError *error = nil;
-    NSRegularExpression *protocol = [NSRegularExpression regularExpressionWithPattern:@"http(s?)://" options:NSRegularExpressionCaseInsensitive error:&error];
-    NSString *result = [NSString stringWithFormat:@"%@", [protocol stringByReplacingMatchesInString:self.url options:0 range:NSMakeRange(0, [self.url length]) withTemplate:@""]];
-
-    if ([result hasSuffix:@"/"]) {
-        result = [result substringToIndex:[result length] - 1];
-    }
-
-    NSString *decodedResult = [NSURL IDNDecodedHostname:result];
-    NSAssert(decodedResult != nil, @"Decoded url shouldn't be nil");
-    if (decodedResult == nil) {
-        DDLogInfo(@"displayURL: decoded url is nil: %@", self.url);
-        return result;
-    }
-
-    return decodedResult;
-}
-
-- (NSString *)hostURL
-{
-    return [self displayURL];
-}
-
-- (NSString *)homeURL
-{
-    NSString *homeURL = [self getOptionValue:@"home_url"];
-    if (!homeURL) {
-        homeURL = self.url;
-    }
-    return homeURL;
-}
-
-- (NSString *)hostname
-{
-    NSString *hostname = [[NSURL URLWithString:self.xmlrpc] host];
-    if (hostname == nil) {
-        NSError *error = nil;
-        NSRegularExpression *protocol = [NSRegularExpression regularExpressionWithPattern:@"^.*://" options:NSRegularExpressionCaseInsensitive error:&error];
-        hostname = [protocol stringByReplacingMatchesInString:self.url options:0 range:NSMakeRange(0, [self.url length]) withTemplate:@""];
-    }
-
-    // NSURL seems to not recongnize some TLDs like .me and .it, which results in hostname returning a full path.
-    // This can break reachibility (among other things) for the blog.
-    // As a saftey net, make sure we drop any path component before returning the hostname.
-    NSArray *parts = [hostname componentsSeparatedByString:@"/"];
-    if (parts.count) {
-        hostname = [parts firstObject];
-    }
-
-    return hostname;
-}
-
-- (NSString *)loginUrl
-{
-    NSString *loginUrl = [self getOptionValue:@"login_url"];
-    if (!loginUrl) {
-        loginUrl = [self urlWithPath:@"wp-login.php"];
-    }
-    return loginUrl;
-}
-
-- (NSString *)urlWithPath:(NSString *)path
-{
-    if (!path || !self.xmlrpc) {
-        DDLogError(@"Blog: Error creating urlWithPath.");
-        return nil;
-    }
-
-    NSError *error = nil;
-    NSRegularExpression *xmlrpc = [NSRegularExpression regularExpressionWithPattern:@"xmlrpc.php$" options:NSRegularExpressionCaseInsensitive error:&error];
-    return [xmlrpc stringByReplacingMatchesInString:self.xmlrpc options:0 range:NSMakeRange(0, [self.xmlrpc length]) withTemplate:path];
-}
-
-- (NSString *)adminUrlWithPath:(NSString *)path
-{
-    NSString *adminBaseUrl = [self getOptionValue:@"admin_url"];
-    if (!adminBaseUrl) {
-        adminBaseUrl = [self urlWithPath:@"wp-admin/"];
-    }
-    if (![adminBaseUrl hasSuffix:@"/"]) {
-        adminBaseUrl = [adminBaseUrl stringByAppendingString:@"/"];
-    }
-    return [NSString stringWithFormat:@"%@%@", adminBaseUrl, path];
 }
 
 - (NSArray *)sortedCategories

--- a/Sources/WordPressData/Objective-C/include/Blog.h
+++ b/Sources/WordPressData/Objective-C/include/Blog.h
@@ -213,22 +213,8 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 @property (nonatomic, strong, readonly, nullable) NSString *authToken;
 @property (nonatomic, strong, readonly, nullable) NSSet *allowedFileTypes;
 
-/**
- *  @details    URL properties (example: http://wp.koke.me/sub/xmlrpc.php)
- */
-
-// User to display the blog url to the user (IDN decoded, no http:)
-// wp.koke.me/sub
-@property (weak, readonly, nullable) NSString *displayURL;
-// alias of displayURL
-// kept for compatibilty, used as a key to store passwords
-@property (weak, readonly, nullable) NSString *hostURL;
-@property (weak, readonly, nullable) NSString *homeURL;
 // http://wp.koke.me/sub
 @property (nonatomic, strong, nullable) NSString *url;
-// Used for reachability checks (IDN encoded)
-// wp.koke.me
-@property (weak, readonly, nullable) NSString *hostname;
 
 // Used to check if the blog has an icon set up
 @property (readonly) BOOL hasIcon;
@@ -243,9 +229,6 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 - (nullable NSArray *)sortedCategories;
 - (nullable id)getOptionValue:(NSString *) name;
 - (void)setValue:(id)value forOption:(NSString *)name;
-- (NSString *)loginUrl;
-- (nullable NSString *)urlWithPath:(NSString *)path;
-- (NSString *)adminUrlWithPath:(NSString *)path;
 - (NSDictionary *) getImageResizeDimensions;
 - (BOOL)supports:(BlogFeature)feature;
 - (BOOL)supportsPublicize;

--- a/Sources/WordPressData/Swift/AbstractPost+Searchable.swift
+++ b/Sources/WordPressData/Swift/AbstractPost+Searchable.swift
@@ -35,7 +35,7 @@ extension AbstractPost: SearchableItemConvertable {
 
     public var searchDescription: String? {
         guard let postPreview = contentPreviewForDisplay(), !postPreview.isEmpty else {
-            return blog.displayURL as String? ?? contentForDisplay()
+            return blog.displayURL ?? contentForDisplay()
         }
         return postPreview
     }

--- a/Sources/WordPressData/Swift/Blog+Swift.swift
+++ b/Sources/WordPressData/Swift/Blog+Swift.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreData
+import NSURL_IDN
 
 extension Blog {
 
@@ -25,5 +26,69 @@ extension Blog {
         } else {
             return nil
         }
+    }
+
+    // MARK: - URLs
+
+    /// User-facing display URL with protocol and trailing slash stripped, IDN decoded.
+    @objc public var displayURL: String? {
+        guard let url else { return nil }
+        var result = url.replacingOccurrences(
+            of: "^https?://",
+            with: "",
+            options: [.regularExpression, .caseInsensitive]
+        )
+        if result.hasSuffix("/") {
+            result = String(result.dropLast())
+        }
+        return NSURL.idnDecodedHostname(result) ?? result
+    }
+
+    /// The home URL for the blog. Falls back to ``url``.
+    @objc public var homeURL: String? {
+        getOptionString(name: "home_url") ?? url
+    }
+
+    /// The hostname extracted from the XML-RPC endpoint, used for reachability checks.
+    @objc public var hostname: String? {
+        var result: String?
+        if let xmlrpc {
+            result = URL(string: xmlrpc)?.host
+        }
+        if result == nil, let url {
+            result = url.replacingOccurrences(
+                of: "^.*://",
+                with: "",
+                options: [.regularExpression, .caseInsensitive]
+            )
+        }
+        // NSURL doesn't recognize some TLDs like .me and .it, returning
+        // a full path. Strip path components to avoid breaking reachability.
+        return result?.components(separatedBy: "/").first
+    }
+
+    /// The login URL for the blog.
+    public var loginURL: URL? {
+        let string = getOptionString(name: "login_url") ?? url(withPath: "wp-login.php")
+        return string.flatMap(URL.init)
+    }
+
+    /// Builds a URL by replacing `xmlrpc.php` in the XML-RPC endpoint with the given path.
+    public func url(withPath path: String) -> String? {
+        guard let xmlrpc else { return nil }
+        return xmlrpc.replacingOccurrences(
+            of: "xmlrpc\\.php$",
+            with: path,
+            options: [.regularExpression, .caseInsensitive]
+        )
+    }
+
+    /// Builds an admin URL by appending the given path to the admin base URL.
+    public func makeAdminURL(path: String? = nil) -> URL? {
+        var base = getOptionString(name: "admin_url") ?? url(withPath: "wp-admin/") ?? ""
+        if !base.hasSuffix("/") {
+            base += "/"
+        }
+        return URL(string: base + (path ?? ""))
     }
 }

--- a/Sources/WordPressData/Swift/Theme+Swift.swift
+++ b/Sources/WordPressData/Swift/Theme+Swift.swift
@@ -4,7 +4,7 @@ extension Theme {
         guard let themePathForCustomization else { return nil }
 
         let path = "customize.php?theme=\(themePathForCustomization)&hide_close=true"
-        return blog?.adminUrl(withPath: path)
+        return blog?.makeAdminURL(path: path)?.absoluteString
     }
 
     private var themePathForCustomization: String? {

--- a/Sources/WordPressData/Swift/WordPressOrgRestApi+WordPress.swift
+++ b/Sources/WordPressData/Swift/WordPressOrgRestApi+WordPress.swift
@@ -44,8 +44,8 @@ extension WordPressOrgRestApi {
             let credential: WordPressOrgRestApi.SelfHostedSiteCredential
             if let appPassword = try? blog.getApplicationToken() {
                 credential = .applicationPassword(username: username, password: .init(appPassword))
-            } else if let loginURL = URL(string: blog.loginUrl()),
-                      let adminURL = URL(string: blog.adminUrl(withPath: "")),
+            } else if let loginURL = blog.loginURL,
+                      let adminURL = blog.makeAdminURL(),
                       let password = blog.password {
                 credential = .accountPassword(loginURL: loginURL, username: username, password: .init(password), adminURL: adminURL)
             } else {

--- a/Tests/WordPressDataTests/BlogTests.swift
+++ b/Tests/WordPressDataTests/BlogTests.swift
@@ -276,6 +276,180 @@ struct BlogTests {
         #expect(!blog.supports(.domains), "Domains should not be supported when the site is P2 site")
     }
 
+    // MARK: - displayURL
+
+    @Test func displayURLStripsHTTP() {
+        let blog = BlogBuilder(mainContext)
+            .with(url: "http://example.com")
+            .build()
+
+        #expect(blog.displayURL == "example.com")
+    }
+
+    @Test func displayURLStripsHTTPS() {
+        let blog = BlogBuilder(mainContext)
+            .with(url: "https://example.com")
+            .build()
+
+        #expect(blog.displayURL == "example.com")
+    }
+
+    @Test func displayURLStripsTrailingSlash() {
+        let blog = BlogBuilder(mainContext)
+            .with(url: "http://example.com/")
+            .build()
+
+        #expect(blog.displayURL == "example.com")
+    }
+
+    @Test func displayURLPreservesPath() {
+        let blog = BlogBuilder(mainContext)
+            .with(url: "http://example.com/sub")
+            .build()
+
+        #expect(blog.displayURL == "example.com/sub")
+    }
+
+    @Test func displayURLReturnsNilForNilURL() {
+        let blog = BlogBuilder(mainContext).build()
+        blog.url = nil
+
+        #expect(blog.displayURL == nil)
+    }
+
+    @Test func displayURLIsCaseInsensitiveForProtocol() {
+        let blog = BlogBuilder(mainContext)
+            .with(url: "HTTP://example.com")
+            .build()
+
+        #expect(blog.displayURL == "example.com")
+    }
+
+    @Test func displayURLDecodesIDNPunycode() {
+        let blog = BlogBuilder(mainContext)
+            .with(url: "http://test.xn--soymao-0wa.com")
+            .build()
+
+        #expect(blog.displayURL == "test.soymaño.com")
+    }
+
+    // MARK: - homeURL
+
+    @Test func homeURLReturnsOptionWhenSet() {
+        let blog = BlogBuilder(mainContext)
+            .with(url: "http://example.com")
+            .set(blogOption: "home_url", value: "http://home.example.com")
+            .build()
+
+        #expect(blog.homeURL == "http://home.example.com")
+    }
+
+    @Test func homeURLFallsBackToURL() {
+        let blog = BlogBuilder(mainContext)
+            .with(url: "http://example.com")
+            .build()
+
+        #expect(blog.homeURL == "http://example.com")
+    }
+
+    // MARK: - hostname
+
+    @Test func hostnameExtractsFromXmlrpc() {
+        let blog = BlogBuilder(mainContext)
+            .with(url: "http://example.com")
+            .build()
+        blog.xmlrpc = "http://example.com/xmlrpc.php"
+
+        #expect(blog.hostname == "example.com")
+    }
+
+    @Test func hostnameStripsPath() {
+        let blog = BlogBuilder(mainContext)
+            .with(url: "http://example.com/blog")
+            .build()
+        blog.xmlrpc = nil
+
+        #expect(blog.hostname == "example.com")
+    }
+
+    // MARK: - loginURL
+
+    @Test func loginURLReturnsOptionWhenSet() {
+        let blog = BlogBuilder(mainContext)
+            .with(url: "http://example.com")
+            .set(blogOption: "login_url", value: "http://example.com/custom-login")
+            .build()
+
+        #expect(blog.loginURL == URL(string: "http://example.com/custom-login"))
+    }
+
+    @Test func loginURLFallsBackToWpLogin() {
+        let blog = BlogBuilder(mainContext)
+            .with(url: "http://example.com")
+            .build()
+        blog.xmlrpc = "http://example.com/xmlrpc.php"
+
+        #expect(blog.loginURL == URL(string: "http://example.com/wp-login.php"))
+    }
+
+    // MARK: - urlWithPath
+
+    @Test func urlWithPathReplacesXmlrpc() {
+        let blog = BlogBuilder(mainContext)
+            .with(url: "http://example.com")
+            .build()
+        blog.xmlrpc = "http://example.com/xmlrpc.php"
+
+        #expect(blog.url(withPath: "wp-admin/") == "http://example.com/wp-admin/")
+    }
+
+    @Test func urlWithPathReturnsNilForNilXmlrpc() {
+        let blog = BlogBuilder(mainContext)
+            .with(url: "http://example.com")
+            .build()
+        blog.xmlrpc = nil
+
+        #expect(blog.url(withPath: "wp-login.php") == nil)
+    }
+
+    @Test func urlWithPathWorksWithSubdirectory() {
+        let blog = BlogBuilder(mainContext)
+            .with(url: "http://example.com/blog")
+            .build()
+        blog.xmlrpc = "http://example.com/blog/xmlrpc.php"
+
+        #expect(blog.url(withPath: "wp-login.php") == "http://example.com/blog/wp-login.php")
+    }
+
+    // MARK: - makeAdminURL
+
+    @Test func makeAdminURLUsesOptionWhenSet() {
+        let blog = BlogBuilder(mainContext)
+            .with(url: "http://example.com")
+            .set(blogOption: "admin_url", value: "http://example.com/wp-admin/")
+            .build()
+
+        #expect(blog.makeAdminURL(path: "options.php") == URL(string: "http://example.com/wp-admin/options.php"))
+    }
+
+    @Test func makeAdminURLFallsBackToXmlrpcBased() {
+        let blog = BlogBuilder(mainContext)
+            .with(url: "http://example.com")
+            .build()
+        blog.xmlrpc = "http://example.com/xmlrpc.php"
+
+        #expect(blog.makeAdminURL(path: "options.php") == URL(string: "http://example.com/wp-admin/options.php"))
+    }
+
+    @Test func makeAdminURLAddsTrailingSlash() {
+        let blog = BlogBuilder(mainContext)
+            .with(url: "http://example.com")
+            .set(blogOption: "admin_url", value: "http://example.com/wp-admin")
+            .build()
+
+        #expect(blog.makeAdminURL(path: "options.php") == URL(string: "http://example.com/wp-admin/options.php"))
+    }
+
     // MARK: - Blog URL Parsing
 
     @Test func blogUrlParseableForSimpleUrl() throws {

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -388,7 +388,7 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
 
 - (void)removeBlog:(Blog *)blog
 {
-    DDLogInfo(@"<Blog:%@> remove", blog.hostURL);
+    DDLogInfo(@"<Blog:%@> remove", blog.displayURL);
     [blog.xmlrpcApi invalidateAndCancelTasks];
     [self unscheduleBloggingRemindersFor:blog];
 
@@ -576,7 +576,7 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
     }] firstObject];
 
     if (jetpackBlog) {
-        DDLogInfo(@"Migrating %@ to wp.com account %@", [jetpackBlog hostURL], account.username);
+        DDLogInfo(@"Migrating %@ to wp.com account %@", [jetpackBlog displayURL], account.username);
         jetpackBlog.account = account;
     }
 

--- a/WordPress/Classes/Services/PostCoordinator+Notices.swift
+++ b/WordPress/Classes/Services/PostCoordinator+Notices.swift
@@ -9,7 +9,7 @@ extension PostCoordinator {
             if !title.isEmpty {
                 return title
             }
-            return post.blog.displayURL as String? ?? ""
+            return post.blog.displayURL ?? ""
         }
         let isPublished = post.status == .publish
         let isUpdated = post.status == previousStatus
@@ -33,7 +33,7 @@ extension PostCoordinator {
             return "“\(title)” \(status)"
         }
         var body: String {
-            post.blog.displayURL as String? ?? ""
+            post.blog.displayURL ?? ""
         }
         return NoticeNotificationInfo(
             identifier: UUID().uuidString,

--- a/WordPress/Classes/Utility/Networking/RequestAuthenticator.swift
+++ b/WordPress/Classes/Utility/Networking/RequestAuthenticator.swift
@@ -49,9 +49,8 @@ class RequestAuthenticator: NSObject {
         var authenticationType: DotComAuthenticationType = .regular
 
         if let blog, let dotComID = blog.dotComID as? Int {
-
             if blog.isAtomic {
-                authenticationType = blog.isPrivate() ? .privateAtomic(blogID: dotComID) : .atomic(loginURL: blog.loginUrl())
+                authenticationType = blog.isPrivate() ? .privateAtomic(blogID: dotComID) : .atomic(loginURL: blog.loginURL?.absoluteString ?? "")
             } else if blog.hasMappedDomain() {
                 authenticationType = .regularMapped(siteID: dotComID)
             }
@@ -65,7 +64,7 @@ class RequestAuthenticator: NSObject {
             self.init(account: account, blog: blog)
         } else if let username = blog.effectiveUsername,
             let password = blog.password,
-            let loginURL = URL(string: blog.loginUrl()) {
+            let loginURL = blog.loginURL {
             self.init(credentials: .siteLogin(loginURL: loginURL, username: username, password: password))
         } else {
             DDLogError("Can't authenticate blog \(String(describing: blog.displayURL)) yet")

--- a/WordPress/Classes/Utility/Universal Links/Migration/WPAdminConvertibleRouter.swift
+++ b/WordPress/Classes/Utility/Universal Links/Migration/WPAdminConvertibleRouter.swift
@@ -82,7 +82,7 @@ private extension WPAdminConvertibleNavigationAction {
         // If it is, then try to look up existing blogs and return the URL instead.
         if let siteID = Int(domain) {
             let blog = try? Blog.lookup(withID: siteID, in: ContextManager.shared.mainContext)
-            return blog?.hostURL as? String
+            return blog?.displayURL
         }
 
         if let _ = URL(string: domain) {

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Activity.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Activity.swift
@@ -65,7 +65,7 @@ extension BlogDetailsViewController: SearchableActivityConvertable {
     }
 
     fileprivate var displayURL: String? {
-        guard let displayURL = blog.displayURL as String?, displayURL.isEmpty == false else {
+        guard let displayURL = blog.displayURL, displayURL.isEmpty == false else {
             return nil
         }
         return displayURL

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
@@ -349,7 +349,7 @@ extension BlogDetailsViewController {
         if blog.isHostedAtWPcom, let hostname = blog.hostname {
             dashboardPath = "\(Constants.calypsoDashboardPath)\(hostname)"
         } else {
-            dashboardPath = blog.adminUrl(withPath: "")
+            dashboardPath = blog.makeAdminURL()?.absoluteString ?? ""
         }
 
         guard let url = URL(string: dashboardPath) else { return }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/Detail Header/BlogDetailHeaderView.swift
@@ -46,7 +46,7 @@ class BlogDetailHeaderView: UIView {
             refreshIconImage()
             refreshSiteTitle()
 
-            if let displayURL = blog?.displayURL as String? {
+            if let displayURL = blog?.displayURL {
                 titleView.set(url: displayURL)
             }
 
@@ -68,7 +68,7 @@ class BlogDetailHeaderView: UIView {
 
     func refreshSiteTitle() {
         let blogName = blog?.settings?.name
-        let title = blogName != nil && blogName?.isEmpty == false ? blogName : blog?.displayURL as String?
+        let title = blogName != nil && blogName?.isEmpty == false ? blogName : blog?.displayURL
         titleView.titleButton.setTitle(title, for: .normal)
     }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Management/DeleteSiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Management/DeleteSiteViewController.swift
@@ -76,7 +76,7 @@ open class DeleteSiteViewController: UITableViewController {
         warningImage.tintColor = UIAppColor.warning
         siteTitleLabel.textColor = UIAppColor.neutral(.shade70)
         siteTitleLabel.font = WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .semibold)
-        siteTitleLabel.text = blog.displayURL as String?
+        siteTitleLabel.text = blog.displayURL
         siteTitleSubText.textColor = UIAppColor.neutral(.shade70)
         siteTitleSubText.text = NSLocalizedString("will be unavailable in the future.",
                                                   comment: "Second part of delete screen title stating [the site] will be unavailable in the future.")
@@ -191,7 +191,7 @@ open class DeleteSiteViewController: UITableViewController {
     /// - Returns: UIAlertController
     ///
     fileprivate func confirmDeleteController() -> UIAlertController? {
-        guard let value = blog.displayURL as String? else {
+        guard let value = blog.displayURL else {
             return nil
         }
 

--- a/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Site Picker/BlogList/BlogListSiteView.swift
@@ -73,7 +73,7 @@ final class BlogListSiteViewModel: Identifiable {
     init(blog: Blog) {
         self.blog = blog
         self.title = blog.title ?? "–"
-        self.domain = blog.displayURL as String? ?? ""
+        self.domain = blog.displayURL ?? ""
         self.icon = SiteIconViewModel(blog: blog)
 
         // By adding displayURL _after_ the title, it loweres its weight in search

--- a/WordPress/Classes/ViewRelated/Jetpack/Install/Webview/JetpackConnectionWebViewController.swift
+++ b/WordPress/Classes/ViewRelated/Jetpack/Install/Webview/JetpackConnectionWebViewController.swift
@@ -205,17 +205,16 @@ private extension JetpackConnectionWebViewController {
     }
 
     func isSiteLogin(url: URL) -> Bool {
-        guard let loginURL = URL(string: blog.loginUrl()) else {
+        guard let loginURL = blog.loginURL else {
             return false
         }
-
         return url.matchesPath(in: loginURL)
     }
 
     /// Returns a function that matches a wp-admin URL with the given path
     ///
     func isSiteAdmin(path: String) -> (URL) -> Bool {
-        guard let adminURL = URL(string: blog.adminUrl(withPath: path)) else {
+        guard let adminURL = blog.makeAdminURL(path: path) else {
             return { _ in return false }
         }
         return { url in

--- a/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/Account Settings/AccountSettingsViewController.swift
@@ -113,7 +113,7 @@ private class AccountSettingsController: SettingsController {
         // If the primary site has no Site Title, then show the displayURL.
         if primarySiteName.isEmpty {
             let account = try? WPAccount.lookupDefaultWordPressComAccount(in: ContextManager.shared.mainContext)
-            primarySiteName = account?.defaultBlog?.displayURL as String? ?? ""
+            primarySiteName = account?.defaultBlog?.displayURL ?? ""
         }
 
         let primarySite = EditableTextRow(

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NotificationSettingsSiteView.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NotificationSettingsSiteView.swift
@@ -32,7 +32,7 @@ struct NotificationSettingsSiteViewModel {
 
     init(blog: Blog) {
         self.title = blog.title ?? "–"
-        self.details = blog.displayURL as String? ?? ""
+        self.details = blog.displayURL ?? ""
         self.icon = SiteIconViewModel(blog: blog)
     }
 

--- a/WordPress/Classes/ViewRelated/Pages/Controllers/PageListViewController.swift
+++ b/WordPress/Classes/ViewRelated/Pages/Controllers/PageListViewController.swift
@@ -294,7 +294,7 @@ final class PageListViewController: AbstractPostListViewController {
         switch Section(rawValue: indexPath.section)! {
         case .templates:
             WPAnalytics.track(.pageListEditHomepageTapped)
-            guard let editorUrl = URL(string: blog.adminUrl(withPath: Constant.editorUrl)) else {
+            guard let editorUrl = blog.makeAdminURL(path: Constant.editorUrl) else {
                 return
             }
 

--- a/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
+++ b/WordPress/Classes/ViewRelated/Site Creation/Final Assembly/SiteAssemblyWizardContent.swift
@@ -119,7 +119,7 @@ final class SiteAssemblyWizardContent: UIViewController {
                 }
 
                 self.contentView.siteURLString = blog?.url as String?
-                self.contentView.siteName = blog?.displayURL as String?
+                self.contentView.siteName = blog?.displayURL
                 self.createdBlog = blog
 
                 // This stat is part of a funnel that provides critical information.  Before

--- a/WordPress/Classes/ViewRelated/System/Sidebar/SiteMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/System/Sidebar/SiteMenuViewController.swift
@@ -42,7 +42,7 @@ final class SiteMenuViewController: UIViewController {
 
         blogDetailsVC.showInitialDetailsForBlog()
 
-        navigationItem.title = blog.settings?.name ?? (blog.displayURL as String?) ?? ""
+        navigationItem.title = blog.settings?.name ?? (blog.displayURL) ?? ""
 
     }
 


### PR DESCRIPTION
This PR affects `displayURL`, `loginURL`, etc. In addition to a mechanical rewrite I changed some of these to be more idiomatic Swift: naming, `URL?`, etc.