### PR TITLE
Remove Content Guidelines from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,9 +51,3 @@ WordPress-iOS uses a modular architecture with the main app and separate Swift p
 - Branch from `trunk` (main branch)
 - PR target should be `trunk`
 - When writing commit messages, never include references to Claude
-
-### Content Guidelines
-- **Include**: New features, UI improvements, performance enhancements, user experience changes
-- **Exclude**: CI changes, code refactoring, dependency updates, internal technical changes
-- **Language**: Positive sentiment, avoid "fix" terminology, focus on improvements and enhancements
-- **Priority Order**: New features → Improvements → Performance → Other user-facing changes


### PR DESCRIPTION
This is a left-over from https://github.com/wordpress-mobile/WordPress-iOS/commit/0d6051122976e073effbea3d16ce3b2b31382286 and release notes generation.