### PR TITLE
Remove xcpretty-travis-formatter dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,8 +18,6 @@ gem 'fastlane-plugin-wpmreleasetoolkit', '~> 14.0'
 gem 'rake'
 gem 'rubocop', '~> 1.84'
 gem 'rubocop-rake', '~> 0.7'
-gem 'xcpretty-travis-formatter'
-
 group :screenshots, optional: true do
   gem 'rmagick', '~> 6.2.0'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -408,7 +408,6 @@ DEPENDENCIES
   rmagick (~> 6.2.0)
   rubocop (~> 1.84)
   rubocop-rake (~> 0.7)
-  xcpretty-travis-formatter
 
 BUNDLED WITH
    2.4.22

--- a/Rakefile
+++ b/Rakefile
@@ -650,7 +650,7 @@ def xcodebuild(*build_cmds)
   cmd += " -configuration #{xcode_configuration}"
   cmd += ' '
   cmd += build_cmds.map(&:to_s).join(' ')
-  cmd += ' | bundle exec xcpretty -f `bundle exec xcpretty-travis-formatter` && exit ${PIPESTATUS[0]}' unless ENV['verbose']
+  cmd += ' | bundle exec xcpretty && exit ${PIPESTATUS[0]}' unless ENV['verbose']
   sh(cmd)
 end
 


### PR DESCRIPTION
## Summary

- Remove unused `xcpretty-travis-formatter` gem from `Gemfile`
- Update `Rakefile` to use plain `xcpretty` instead of the Travis CI formatter

The Travis CI formatter is unnecessary — CI runs on Buildkite, not Travis.

See https://github.com/woocommerce/woocommerce-ios/pull/16707#discussion_r2845925808

_Gio here_: We'll followup removing the `Rakefile` logic that was using the Travis formatter and now uses only `xcpretty`. It's unused legacy logic that we already removed from the WooCommerce implementation and can remove from here, too. I didn't realize the logic was there when I prompted for this work. But that's okay, let's move in small incremental steps.

## Test plan

- [ ] CI passes with the updated Rakefile
- [ ] `bundle install` succeeds without the explicit gem dependency

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*

🤖 Generated with [Claude Code](https://claude.ai/code)