### PR TITLE
Update the custom post list UI to look like the Posts screen

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -30,6 +30,7 @@ public enum FeatureFlag: Int, CaseIterable {
     case statsAds
     case customPostTypes
     case cptPostSettings
+    case cptPostsAndPages
 
     /// Returns a boolean indicating if the feature is enabled.
     ///
@@ -95,6 +96,8 @@ public enum FeatureFlag: Int, CaseIterable {
             return BuildConfiguration.current == .debug
         case .cptPostSettings:
             return BuildConfiguration.current == .debug
+        case .cptPostsAndPages:
+            return BuildConfiguration.current == .debug
         }
     }
 
@@ -141,6 +144,7 @@ extension FeatureFlag {
         case .statsAds: "Stats Ads Tab"
         case .customPostTypes: "Custom Post Types"
         case .cptPostSettings: "Custom Post Types: Post Settings"
+        case .cptPostsAndPages: "Custom Post Types: Posts and Pages"
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsTableViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsTableViewModel.swift
@@ -677,12 +677,14 @@ private extension BlogDetailsTableViewModel {
 
         rows.append(Row.comments(viewController: viewController))
 
-        if FeatureFlag.customPostTypes.enabled && blog.supportsCoreRESTAPI && hasCustomPostTypes {
+        if FeatureFlag.customPostTypes.enabled && blog.supportsCoreRESTAPI {
             let pinned = SiteStorageAccess.pinnedPostTypes(for: TaggedManagedObjectID(blog))
             for type in pinned {
                 rows.append(Row.pinnedPostType(type, viewController: viewController))
             }
-            rows.append(Row.customPostTypes(viewController: viewController))
+            if !pinned.isEmpty || hasCustomPostTypes {
+                rows.append(Row.customPostTypes(viewController: viewController))
+            }
         }
 
         let title = Strings.publishSection

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListView.swift
@@ -11,29 +11,39 @@ import WordPressUI
 struct CustomPostListView<Header: View>: View {
     @ObservedObject var viewModel: CustomPostListViewModel
     let details: PostTypeDetailsWithEditContext
+    let client: WordPressClient
     let onSelectPost: (AnyPostWithEditContext) -> Void
+    let mediaHost: MediaHost?
     @ViewBuilder let header: () -> Header
 
     init(
         viewModel: CustomPostListViewModel,
         details: PostTypeDetailsWithEditContext,
-        onSelectPost: @escaping (AnyPostWithEditContext) -> Void
+        client: WordPressClient,
+        onSelectPost: @escaping (AnyPostWithEditContext) -> Void,
+        mediaHost: MediaHost? = nil
     ) where Header == EmptyView {
         self.viewModel = viewModel
         self.details = details
+        self.client = client
         self.onSelectPost = onSelectPost
+        self.mediaHost = mediaHost
         self.header = { EmptyView() }
     }
 
     init(
         viewModel: CustomPostListViewModel,
         details: PostTypeDetailsWithEditContext,
+        client: WordPressClient,
         onSelectPost: @escaping (AnyPostWithEditContext) -> Void,
+        mediaHost: MediaHost? = nil,
         @ViewBuilder header: @escaping () -> Header
     ) {
         self.viewModel = viewModel
         self.details = details
+        self.client = client
         self.onSelectPost = onSelectPost
+        self.mediaHost = mediaHost
         self.header = header
     }
 
@@ -41,7 +51,9 @@ struct CustomPostListView<Header: View>: View {
         PaginatedList(
             items: viewModel.items,
             onLoadNextPage: { try await viewModel.loadNextPage() },
+            client: client,
             onSelectPost: onSelectPost,
+            mediaHost: mediaHost,
             header: header
         )
         .overlay {
@@ -72,7 +84,9 @@ struct CustomPostListView<Header: View>: View {
 private struct PaginatedList<Header: View>: View {
     let items: [CustomPostCollectionItem]
     let onLoadNextPage: () async throws -> Void
+    let client: WordPressClient?
     let onSelectPost: (AnyPostWithEditContext) -> Void
+    let mediaHost: MediaHost?
     @ViewBuilder let header: () -> Header
 
     @State var isLoadingMore = false
@@ -81,23 +95,31 @@ private struct PaginatedList<Header: View>: View {
     init(
         items: [CustomPostCollectionItem],
         onLoadNextPage: @escaping () async throws -> Void,
-        onSelectPost: @escaping (AnyPostWithEditContext) -> Void
+        client: WordPressClient? = nil,
+        onSelectPost: @escaping (AnyPostWithEditContext) -> Void,
+        mediaHost: MediaHost? = nil
     ) where Header == EmptyView {
         self.items = items
         self.onLoadNextPage = onLoadNextPage
+        self.client = client
         self.onSelectPost = onSelectPost
+        self.mediaHost = mediaHost
         self.header = { EmptyView() }
     }
 
     init(
         items: [CustomPostCollectionItem],
         onLoadNextPage: @escaping () async throws -> Void,
+        client: WordPressClient? = nil,
         onSelectPost: @escaping (AnyPostWithEditContext) -> Void,
+        mediaHost: MediaHost? = nil,
         @ViewBuilder header: @escaping () -> Header
     ) {
         self.items = items
         self.onLoadNextPage = onLoadNextPage
+        self.client = client
         self.onSelectPost = onSelectPost
+        self.mediaHost = mediaHost
         self.header = header
     }
 
@@ -111,7 +133,7 @@ private struct PaginatedList<Header: View>: View {
             .listSectionSeparator(.hidden)
 
             ForEach(items) { item in
-                ForEachContent(item: item, onSelectPost: onSelectPost)
+                ForEachContent(item: item, client: client, onSelectPost: onSelectPost, mediaHost: mediaHost)
                     .task {
                         await onRowAppear(item: item)
                     }
@@ -170,7 +192,9 @@ private struct PaginatedList<Header: View>: View {
 
 private struct ForEachContent: View {
     let item: CustomPostCollectionItem
+    let client: WordPressClient?
     let onSelectPost: (AnyPostWithEditContext) -> Void
+    let mediaHost: MediaHost?
 
     var body: some View {
         switch item {
@@ -179,7 +203,7 @@ private struct ForEachContent: View {
 
         case .errorWithData(_, let message, let post):
             VStack(spacing: 4) {
-                PostContent(post: post)
+                PostContent(post: post, client: client, mediaHost: mediaHost)
                 ErrorRow(message: message)
             }
 
@@ -188,8 +212,10 @@ private struct ForEachContent: View {
                 post: CustomPostCollectionDisplayPost(
                     date: Date(),
                     title: "Lorem ipsum dolor sit amet",
-                    excerpt: "Lorem ipsum dolor sit amet consectetur adipiscing elit"
-                )
+                    content: "Lorem ipsum dolor sit amet consectetur adipiscing elit"
+                ),
+                client: client,
+                mediaHost: mediaHost
             )
             .redacted(reason: .placeholder)
 
@@ -197,44 +223,92 @@ private struct ForEachContent: View {
             Button {
                 onSelectPost(post)
             } label: {
-                PostContent(post: displayPost)
+                PostContent(post: displayPost, client: client, mediaHost: mediaHost)
             }
             .buttonStyle(.plain)
 
         case .stale(_, let post):
-            PostContent(post: post)
+            PostContent(post: post, client: client, mediaHost: mediaHost)
         }
     }
 }
 
 private struct PostContent: View {
     let post: CustomPostCollectionDisplayPost
-
-    init(post: CustomPostCollectionDisplayPost) {
-        self.post = post
-    }
+    let client: WordPressClient?
+    let mediaHost: MediaHost?
+    var showsEllipsisMenu: Bool = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(post.date, format: .dateTime.day().month().year())
-                .font(.caption)
-                .foregroundStyle(.secondary)
-
-            if let title = post.title {
-                Text(verbatim: title)
-                    .font(.headline)
-                    .foregroundStyle(.primary)
-            }
-
-            if let excerpt = post.excerpt {
-                Text(verbatim: excerpt)
-                    .font(.subheadline)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
-            }
+        VStack(alignment: .leading, spacing: 6) {
+            header
+            content
+            footer
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
+    }
+
+    private var header: some View {
+        HStack {
+            Text(verbatim: post.headerBadges)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            if showsEllipsisMenu {
+                ellipsisMenu
+            }
+        }
+    }
+
+    private var content: some View {
+        HStack(alignment: .top, spacing: 8) {
+            VStack(alignment: .leading, spacing: 3) {
+                Text(verbatim: post.titleForDisplay)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+
+                if let content = post.content, !content.isEmpty {
+                    Text(verbatim: content)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                }
+            }
+
+            Spacer(minLength: 0)
+
+            if let featuredMedia = post.featuredMedia, let client {
+                FeaturedMediaImage(mediaId: featuredMedia, client: client, mediaHost: mediaHost)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var footer: some View {
+        if let badges = post.statusBadges {
+            Text(verbatim: badges)
+                .font(.footnote)
+                .foregroundStyle(post.statusColor)
+        }
+    }
+
+    private var ellipsisMenu: some View {
+        // TODO: To be implemented
+        Menu {
+            Button(action: { Loggers.app.info("View tapped") }) {
+                Label(SharedStrings.Button.view, systemImage: "safari")
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .font(.body)
+                .foregroundStyle(.secondary)
+                .frame(width: 28, height: 28)
+                .contentShape(Rectangle())
+        }
     }
 }
 
@@ -259,6 +333,11 @@ private enum Strings {
         "customPostList.emptyState.message",
         value: "No %1$@",
         comment: "Empty state message when no custom posts exist. %1$@ is the post type name (e.g., 'Podcasts', 'Products')."
+    )
+    static let trashButton = NSLocalizedString(
+        "customPostList.action.trash",
+        value: "Trash",
+        comment: "Button title to move a post to trash"
     )
 }
 
@@ -295,7 +374,7 @@ private enum Strings {
                 post: CustomPostCollectionDisplayPost(
                     date: .now,
                     title: "First Draft Post",
-                    excerpt: "This is a preview of the first post that might be outdated."
+                    content: "This is a preview of the first post that might be outdated."
                 )
             ),
             .stale(
@@ -303,7 +382,7 @@ private enum Strings {
                 post: CustomPostCollectionDisplayPost(
                     date: .now.addingTimeInterval(-86400),
                     title: "Second Post",
-                    excerpt: "Another post with stale data showing in the list."
+                    content: "Another post with stale data showing in the list."
                 )
             ),
             .stale(
@@ -311,7 +390,7 @@ private enum Strings {
                 post: CustomPostCollectionDisplayPost(
                     date: .now.addingTimeInterval(-86400 * 7),
                     title: nil,
-                    excerpt: "Post without a title"
+                    content: "Post without a title"
                 )
             )
         ],
@@ -328,7 +407,7 @@ private enum Strings {
                 post: CustomPostCollectionDisplayPost(
                     date: .now,
                     title: "Published Post",
-                    excerpt: "This post has stale data and is being refreshed."
+                    content: "This post has stale data and is being refreshed."
                 )
             ),
             .refreshing(
@@ -336,7 +415,7 @@ private enum Strings {
                 post: CustomPostCollectionDisplayPost(
                     date: .now.addingTimeInterval(-86400),
                     title: "Refreshing Post",
-                    excerpt: "Currently being refreshed in the background."
+                    content: "Currently being refreshed in the background."
                 )
             ),
             .fetching(id: 3),
@@ -347,7 +426,7 @@ private enum Strings {
                 post: CustomPostCollectionDisplayPost(
                     date: .now.addingTimeInterval(-86400 * 3),
                     title: "Cached Post",
-                    excerpt: "This post failed to sync but we have old data."
+                    content: "This post failed to sync but we have old data."
                 )
             ),
         ],
@@ -364,11 +443,63 @@ private enum Strings {
                 post: CustomPostCollectionDisplayPost(
                     date: .now,
                     title: "Published Post",
-                    excerpt: "This post has stale data and is being refreshed."
+                    content: "This post has stale data and is being refreshed."
                 )
             ),
         ],
         onLoadNextPage: { throw CollectionError.DatabaseError(errMessage: "SQL error") },
         onSelectPost: { _ in },
     )
+}
+
+#Preview("Status Variants") {
+    List {
+        PostContent(
+            post: CustomPostCollectionDisplayPost(
+                date: .now,
+                title: "My Draft Post",
+                content: "This post is still being worked on.",
+                status: .draft
+            ),
+            client: nil,
+            mediaHost: nil
+        )
+        PostContent(
+            post: CustomPostCollectionDisplayPost(
+                date: .now.addingTimeInterval(-86400),
+                title: "Scheduled for Tomorrow",
+                content: "This post will be published automatically.",
+                status: .future
+            ),
+            client: nil,
+            mediaHost: nil
+        )
+        PostContent(
+            post: CustomPostCollectionDisplayPost(
+                date: .now.addingTimeInterval(-86400 * 7),
+                title: "Trashed Post",
+                content: "This post was moved to trash.",
+                status: .trash
+            ),
+            client: nil,
+            mediaHost: nil
+        )
+    }
+    .listStyle(.plain)
+}
+
+#Preview("Flags: No Menu") {
+    List {
+        PostContent(
+            post: CustomPostCollectionDisplayPost(
+                date: .now,
+                title: "Minimal Row",
+                content: "No ellipsis menu."
+            ),
+            client: nil,
+            mediaHost: nil,
+            showsEllipsisMenu: false
+        )
+    }
+    .listStyle(.plain)
 }

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
@@ -3,12 +3,14 @@ import SwiftUI
 import WordPressAPI
 import WordPressAPIInternal
 import WordPressCore
+import WordPressData
 import WordPressShared
 
 @MainActor
 final class CustomPostListViewModel: ObservableObject {
     private let client: WordPressClient
     private let endpoint: PostEndpointType
+    private let blog: Blog
     let filter: CustomPostListFilter
 
     private var collection: PostMetadataCollectionWithEditContext?
@@ -33,10 +35,12 @@ final class CustomPostListViewModel: ObservableObject {
         client: WordPressClient,
         service: WpSelfHostedService,
         endpoint: PostEndpointType,
-        filter: CustomPostListFilter
+        filter: CustomPostListFilter,
+        blog: Blog
     ) {
         self.client = client
         self.endpoint = endpoint
+        self.blog = blog
         self.filter = filter
 
         collection = service
@@ -75,7 +79,7 @@ final class CustomPostListViewModel: ObservableObject {
         let listInfo = collection.listInfo()
 
         do {
-            let items = try await collection.loadItems().map(CustomPostCollectionItem.init)
+            let items = try await collection.loadItems().map { CustomPostCollectionItem(item: $0, blog: blog) }
             if self.listInfo != listInfo {
                 self.listInfo = listInfo
             }
@@ -101,7 +105,7 @@ final class CustomPostListViewModel: ObservableObject {
             DDLogInfo("List info: \(String(describing: listInfo))")
 
             do {
-                let items = try await collection.loadItems().map(CustomPostCollectionItem.init)
+                let items = try await collection.loadItems().map { CustomPostCollectionItem(item: $0, blog: blog) }
                 withAnimation {
                     if self.listInfo != listInfo {
                         self.listInfo = listInfo
@@ -129,34 +133,131 @@ final class CustomPostListViewModel: ObservableObject {
 struct CustomPostCollectionDisplayPost: Equatable {
     let date: Date
     let title: String?
-    let excerpt: String?
+    let content: String?
+    let authorName: String?
+    let status: PostStatus
+    let sticky: Bool
+    let featuredMedia: MediaId?
 
-    init(date: Date, title: String?, excerpt: String?) {
+    init(
+        date: Date,
+        title: String?,
+        content: String?,
+        authorName: String? = nil,
+        status: PostStatus = .publish,
+        sticky: Bool = false,
+        featuredMedia: MediaId? = nil
+    ) {
         self.date = date
         self.title = title
-        self.excerpt = excerpt
+        self.content = content
+        self.authorName = authorName
+        self.status = status
+        self.sticky = sticky
+        self.featuredMedia = featuredMedia
     }
 
-    init(_ entity: AnyPostWithEditContext, excerptLimit: Int = 100) {
+    init(_ entity: AnyPostWithEditContext, blog: Blog, contentLimit: Int = 100) {
         self.date = entity.dateGmt
         self.title = entity.title?.raw
-        self.excerpt = entity.excerpt?.raw
-            ?? GutenbergExcerptGenerator
-                .firstParagraph(
-                    from: entity.content.rendered,
-                    maxLength: excerptLimit
-                )
-                .replacingOccurrences(
-                    of: "[\n]{2,}",
-                    with: "\n",
-                    options: .regularExpression
-                )
+        let contentPreview = GutenbergExcerptGenerator
+            .firstParagraph(
+                from: entity.content.rendered,
+                maxLength: contentLimit
+            )
+            .replacingOccurrences(
+                of: "[\n]{2,}",
+                with: "\n",
+                options: .regularExpression
+            )
+        self.content = contentPreview.isEmpty ? entity.excerpt?.raw : contentPreview
+        if let authorId = entity.author {
+            self.authorName = blog.getAuthorWith(id: NSNumber(value: authorId))?.displayName
+        } else {
+            self.authorName = nil
+        }
+        self.status = entity.status
+        self.sticky = entity.sticky ?? false
+        self.featuredMedia = entity.featuredMedia
+    }
+
+    /// The title to display, with a placeholder for untitled posts.
+    var titleForDisplay: String {
+        let trimmed = title?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if trimmed.isEmpty {
+            return NSLocalizedString(
+                "customPostList.untitled",
+                value: "(no title)",
+                comment: "Placeholder title for posts without a title"
+            )
+        }
+        return trimmed
+    }
+
+    /// The header badges string (e.g. "Jan 15, 2026 · Author Name") matching
+    /// the regular posts list. Combines the formatted date and author name.
+    var headerBadges: String {
+        var badges = [dateForDisplay]
+        if let authorName, !authorName.isEmpty {
+            badges.append(authorName)
+        }
+        return badges.joined(separator: " · ")
+    }
+
+    private var dateForDisplay: String {
+        if status == .future {
+            return date.formatted(date: .abbreviated, time: .shortened)
+        }
+        return date.formatted(date: .abbreviated, time: .omitted)
+    }
+
+    /// Combined status badges (e.g. "Private · Sticky") matching the regular
+    /// posts list. Returns nil when there is nothing to display.
+    var statusBadges: String? {
+        var badges: [String] = []
+
+        if status == .pending {
+            badges.append(Strings.pendingReview)
+        }
+        if status == .private {
+            badges.append(Strings.privatePost)
+        }
+        if sticky {
+            badges.append(Strings.sticky)
+        }
+
+        return badges.isEmpty ? nil : badges.joined(separator: " · ")
+    }
+
+    var statusColor: Color {
+        if status == .trash {
+            return .red
+        }
+        return .secondary
     }
 
     static let placeholder = CustomPostCollectionDisplayPost(
         date: .now,
         title: "Lorem ipsum dolor sit amet",
-        excerpt: "Lorem ipsum dolor sit amet consectetur adipiscing elit"
+        content: "Lorem ipsum dolor sit amet consectetur adipiscing elit"
+    )
+}
+
+private enum Strings {
+    static let pendingReview = NSLocalizedString(
+        "customPostList.badge.pendingReview",
+        value: "Pending review",
+        comment: "Badge shown in the post list for posts pending review"
+    )
+    static let privatePost = NSLocalizedString(
+        "customPostList.badge.private",
+        value: "Private",
+        comment: "Badge shown in the post list for private posts"
+    )
+    static let sticky = NSLocalizedString(
+        "customPostList.badge.sticky",
+        value: "Sticky",
+        comment: "Badge shown in the post list for sticky posts"
     )
 }
 
@@ -183,18 +284,18 @@ enum CustomPostCollectionItem: Identifiable, Equatable {
         }
     }
 
-    init(item: PostMetadataCollectionItem) {
+    init(item: PostMetadataCollectionItem, blog: Blog) {
         let id = item.id
 
         switch item.state {
         case .fresh(let entity):
-            self = .ready(id: id, post: CustomPostCollectionDisplayPost(entity.data), fullPost: entity.data)
+            self = .ready(id: id, post: CustomPostCollectionDisplayPost(entity.data, blog: blog), fullPost: entity.data)
 
         case .stale(let entity):
-            self = .stale(id: id, post: CustomPostCollectionDisplayPost(entity.data))
+            self = .stale(id: id, post: CustomPostCollectionDisplayPost(entity.data, blog: blog))
 
         case .fetchingWithData(let entity):
-            self = .refreshing(id: id, post: CustomPostCollectionDisplayPost(entity.data))
+            self = .refreshing(id: id, post: CustomPostCollectionDisplayPost(entity.data, blog: blog))
 
         case .fetching:
             self = .fetching(id: id)
@@ -206,7 +307,7 @@ enum CustomPostCollectionItem: Identifiable, Equatable {
             self = .error(id: id, message: error)
 
         case .failedWithData(let error, let entity):
-            self = .errorWithData(id: id, message: error, post: CustomPostCollectionDisplayPost(entity.data, excerptLimit: 50))
+            self = .errorWithData(id: id, message: error, post: CustomPostCollectionDisplayPost(entity.data, blog: blog, contentLimit: 50))
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostSearchResultView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostSearchResultView.swift
@@ -3,6 +3,7 @@ import SwiftUI
 import WordPressAPI
 import WordPressAPIInternal
 import WordPressCore
+import WordPressData
 
 struct CustomPostSearchResultView: View {
     let client: WordPressClient
@@ -11,6 +12,7 @@ struct CustomPostSearchResultView: View {
     let details: PostTypeDetailsWithEditContext
     @Binding var searchText: String
     let onSelectPost: (AnyPostWithEditContext) -> Void
+    let blog: Blog
 
     @State private var finalSearchText = ""
 
@@ -20,10 +22,13 @@ struct CustomPostSearchResultView: View {
                 client: client,
                 service: service,
                 endpoint: endpoint,
-                filter: CustomPostListFilter.default.with(search: finalSearchText)
+                filter: CustomPostListFilter.default.with(search: finalSearchText),
+                blog: blog
             ),
             details: details,
-            onSelectPost: onSelectPost
+            client: client,
+            onSelectPost: onSelectPost,
+            mediaHost: MediaHost(blog)
         )
         .task(id: searchText) {
             do {

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostTabView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostTabView.swift
@@ -56,31 +56,36 @@ struct CustomPostTabView: View {
             client: client,
             service: service,
             endpoint: endpoint,
-            filter: CustomPostListFilter(status: .custom("any"))
+            filter: CustomPostListFilter(status: .custom("any")),
+            blog: blog
         ))
         _publishedViewModel = State(initialValue: CustomPostListViewModel(
             client: client,
             service: service,
             endpoint: endpoint,
-            filter: CustomPostListFilter(status: .publish)
+            filter: CustomPostListFilter(status: .publish),
+            blog: blog
         ))
         _draftsViewModel = State(initialValue: CustomPostListViewModel(
             client: client,
             service: service,
             endpoint: endpoint,
-            filter: CustomPostListFilter(status: .draft)
+            filter: CustomPostListFilter(status: .draft),
+            blog: blog
         ))
         _scheduledViewModel = State(initialValue: CustomPostListViewModel(
             client: client,
             service: service,
             endpoint: endpoint,
-            filter: CustomPostListFilter(status: .future)
+            filter: CustomPostListFilter(status: .future),
+            blog: blog
         ))
         _trashViewModel = State(initialValue: CustomPostListViewModel(
             client: client,
             service: service,
             endpoint: endpoint,
-            filter: CustomPostListFilter(status: .trash)
+            filter: CustomPostListFilter(status: .trash),
+            blog: blog
         ))
     }
 
@@ -90,7 +95,9 @@ struct CustomPostTabView: View {
                 CustomPostListView(
                     viewModel: activeViewModel,
                     details: details,
+                    client: client,
                     onSelectPost: { selectedPost = $0 },
+                    mediaHost: MediaHost(blog),
                     header: { tabBar }
                 )
             } else {
@@ -100,7 +107,8 @@ struct CustomPostTabView: View {
                     endpoint: endpoint,
                     details: details,
                     searchText: $searchText,
-                    onSelectPost: { selectedPost = $0 }
+                    onSelectPost: { selectedPost = $0 },
+                    blog: blog
                 )
             }
         }
@@ -181,6 +189,7 @@ private struct AdaptiveTabBarRepresentable: UIViewRepresentable {
 
     func makeUIView(context: Context) -> AdaptiveTabBar {
         let tabBar = AdaptiveTabBar()
+        tabBar.preferredFont = UIFont.preferredFont(forTextStyle: .subheadline)
         tabBar.items = items
         tabBar.addTarget(context.coordinator, action: #selector(Coordinator.tabChanged(_:)), for: .valueChanged)
         return tabBar

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostTabView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostTabView.swift
@@ -14,8 +14,9 @@ struct CustomPostTabView: View {
     let details: PostTypeDetailsWithEditContext
     let blog: Blog
 
-    @State private var selectedTab: CustomPostTab = .published
+    @State private var selectedTab: CustomPostTab = .all
     @State private var searchText = ""
+    @State private var allViewModel: CustomPostListViewModel
     @State private var publishedViewModel: CustomPostListViewModel
     @State private var draftsViewModel: CustomPostListViewModel
     @State private var scheduledViewModel: CustomPostListViewModel
@@ -25,6 +26,8 @@ struct CustomPostTabView: View {
 
     private var activeViewModel: CustomPostListViewModel {
         switch selectedTab {
+        case .all:
+            allViewModel
         case .published:
             publishedViewModel
         case .drafts:
@@ -49,6 +52,12 @@ struct CustomPostTabView: View {
         self.details = details
         self.blog = blog
 
+        _allViewModel = State(initialValue: CustomPostListViewModel(
+            client: client,
+            service: service,
+            endpoint: endpoint,
+            filter: CustomPostListFilter(status: .custom("any"))
+        ))
         _publishedViewModel = State(initialValue: CustomPostListViewModel(
             client: client,
             service: service,
@@ -137,7 +146,8 @@ struct CustomPostTabView: View {
 }
 
 enum CustomPostTab: Int, CaseIterable, AdaptiveTabBarItem {
-    case published = 0
+    case all = 0
+    case published
     case drafts
     case scheduled
     case trash
@@ -146,6 +156,7 @@ enum CustomPostTab: Int, CaseIterable, AdaptiveTabBarItem {
 
     var localizedTitle: String {
         switch self {
+        case .all: return Strings.all
         case .published: return Strings.published
         case .drafts: return Strings.drafts
         case .scheduled: return Strings.scheduled
@@ -155,6 +166,7 @@ enum CustomPostTab: Int, CaseIterable, AdaptiveTabBarItem {
 
     var status: PostStatus {
         switch self {
+        case .all: return .custom("any")
         case .published: return .publish
         case .drafts: return .draft
         case .scheduled: return .future
@@ -210,6 +222,11 @@ private struct SubmitFeedbackViewRepresentable: UIViewControllerRepresentable {
 }
 
 private enum Strings {
+    static let all = NSLocalizedString(
+        "customPostTab.all",
+        value: "All",
+        comment: "Tab title for showing all posts regardless of status"
+    )
     static let published = NSLocalizedString(
         "customPostTab.published",
         value: "Published",

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostTypeService.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostTypeService.swift
@@ -46,9 +46,12 @@ class CustomPostTypeService {
                 if case .custom = details.toPostEndpointType(), details.slug != "attachment" {
                     return details
                 }
+                if FeatureFlag.cptPostsAndPages.enabled, [.posts, .pages].contains(details.toPostEndpointType()) {
+                    return details
+                }
                 return nil
             }
-            .sorted { $0.slug < $1.slug }
+            .sorted(using: KeyPathComparator(\.name))
     }
 
     func resolvePostType(slug: String) async throws -> PostTypeDetailsWithEditContext? {

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/FeaturedMediaImage.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/FeaturedMediaImage.swift
@@ -1,0 +1,41 @@
+import SwiftUI
+import AsyncImageKit
+import WordPressAPI
+import WordPressAPIInternal
+import WordPressCore
+
+/// Resolves a featured media ID to an image URL via the WordPress media REST
+/// API, then displays it with `CachedAsyncImage`.
+struct FeaturedMediaImage: View {
+    let mediaId: MediaId
+    let client: WordPressClient
+    let mediaHost: MediaHost?
+
+    @State private var imageURL: URL?
+
+    var body: some View {
+        if mediaId > 0 {
+            CachedAsyncImage(url: imageURL, host: mediaHost) { image in
+                image
+                    .resizable()
+                    .scaledToFill()
+            } placeholder: {
+                Color(.tertiarySystemFill)
+            }
+            .frame(width: 54, height: 54)
+            .clipShape(RoundedRectangle(cornerRadius: 8))
+            .task(id: mediaId) {
+                await resolveImageURL()
+            }
+        }
+    }
+
+    private func resolveImageURL() async {
+        do {
+            let response = try await client.api.media.retrieveWithViewContext(mediaId: mediaId)
+            imageURL = URL(string: response.data.sourceUrl)
+        } catch {
+            DDLogError("Failed to resolve featured media \(mediaId): \(error)")
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/Icons.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/Icons.swift
@@ -8,7 +8,14 @@ extension Image {
 
 extension UIImage {
     convenience init?(dashicon: String?) {
-        self.init(systemName: systemName(forDashicon: dashicon))
+        switch dashicon {
+        case "dashicons-admin-post":
+            self.init(named: "site-menu-posts")
+        case "dashicons-admin-page":
+            self.init(named: "site-menu-pages")
+        default:
+            self.init(systemName: systemName(forDashicon: dashicon))
+        }
     }
 }
 


### PR DESCRIPTION
## Description

This PR also adds a feature flag to show Posts and Pages that's backed by wordpress-rs. I plan to show them on XMLRPC disabled sites, which will be done separately.

Unlike the regular posts, the custom posts list now shows an "All" tab, which is similar to the wp-admin.
