### PR TITLE
Fix a regerssion with univeral links

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.swift
@@ -52,6 +52,9 @@ public class BlogDetailsViewController: UIViewController {
 
         tableViewModel = BlogDetailsTableViewModel(blog: blog, viewController: self)
         tableViewModel?.configure(tableView: tableView)
+        // - warning: This needs to be populated early because tableViewModel.sections
+        // are what drive programmatical navigation with universal links
+        tableViewModel?.configureTableViewData()
 
         tableView.translatesAutoresizingMaskIntoConstraints = false
 


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-1286/jetpack-ios-tapping-stats-widget-opens-my-website-instead-of

## RCA

When the universal link handling reaches the following code to invoke the deep link, the `sections` are empty. It appears to be a regression introduced during the Swift rewrite. The `sections` configuration must be populated in `viewDidLoad` and not it does it only on `viewWillAppear`.

<img width="1694" height="565" alt="Screenshot 2026-02-25 at 11 23 10 AM" src="https://github.com/user-attachments/assets/45693230-0ff6-4f98-81c8-effe985316da" />

The fix is more of a workaround. It's not ideal that universal links depend on `sections` or rely on `BlogDetailsViewController` in the first place. The app needs to adopt something more like the Reader navigation system with a root coordinator handling every single possible route.

## Recording




https://github.com/user-attachments/assets/3977ea0c-9cc8-4fe6-a819-9649535b4a35

