### PR TITLE
Fix an issue with the like button being disabled on the Article screen

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailToolbar.swift
@@ -143,7 +143,7 @@ class ReaderDetailToolbar {
     }
 
     private func makeLikeButton() -> UIBarButtonItem? {
-        guard let post else { return nil }
+        guard let post, post.isLikesEnabled else { return nil }
 
         let isLiked = post.isLiked
 
@@ -153,9 +153,6 @@ class ReaderDetailToolbar {
             isSelected: isLiked,
             action: #selector(didTapLike)
         )
-
-        customButton.isEnabled = (ReaderHelpers.isLoggedIn() || likeCount > 0) && !post.isExternal
-        customButton.alpha = customButton.isEnabled ? 1.0 : 0.5
 
         let button = UIBarButtonItem(customView: customButton)
         button.accessibilityHint = isLiked ? Constants.likedButtonHint : Constants.likeButtonHint


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-836/jetpack-ios-reader-cannot-like-a-post-yet-single-post-view-shows-like.

The feed and the article views are now consistent. They don't show the "Like" button if like is not available, e.g. RSS feeds.

<img width="517" height="1093" alt="Screenshot 2026-02-25 at 2 17 46 PM" src="https://github.com/user-attachments/assets/6c30dc45-69b2-4d18-9861-de178921c362" />
