### PR TITLE
Fix CPT not immediately displayed in the "Publish" section

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsTableViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsTableViewModel.swift
@@ -677,12 +677,14 @@ private extension BlogDetailsTableViewModel {
 
         rows.append(Row.comments(viewController: viewController))
 
-        if FeatureFlag.customPostTypes.enabled && blog.supportsCoreRESTAPI && hasCustomPostTypes {
+        if FeatureFlag.customPostTypes.enabled && blog.supportsCoreRESTAPI {
             let pinned = SiteStorageAccess.pinnedPostTypes(for: TaggedManagedObjectID(blog))
             for type in pinned {
                 rows.append(Row.pinnedPostType(type, viewController: viewController))
             }
-            rows.append(Row.customPostTypes(viewController: viewController))
+            if !pinned.isEmpty || hasCustomPostTypes {
+                rows.append(Row.customPostTypes(viewController: viewController))
+            }
         }
 
         let title = Strings.publishSection


### PR DESCRIPTION
## Description

There are two sections that almost look exactly the same: Content and Publish. This PR brings in the same code in the Content section over to the Publish section.

The changes were included in https://github.com/wordpress-mobile/WordPress-iOS/pull/25300. This PR cherry-picks it to the releas branch.