### PR TITLE
Improve build-test loop for AI agents

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,16 @@ WordPress-iOS uses a modular architecture with the main app and separate Swift p
 - **Accessibility**: Use proper accessibility labels and traits
 - **Localization**: follow best practices from @docs/localization.md
 
+## Build & Test
+
+If the Xcode MCP server is connected, use it to build and test.
+Otherwise, use the `test` Fastlane lane:
+
+```bash
+bundle exec fastlane test
+bundle exec fastlane test only_testing:TargetName/Class/method
+```
+
 ## Coding Standards
 - Follow Swift API Design Guidelines
 - Use strict access control modifiers where possible

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,12 +42,27 @@ WordPress-iOS uses a modular architecture with the main app and separate Swift p
 
 **Always check for the Xcode MCP server first.**
 If it is connected, use it to build and test — no exceptions.
-Only fall back to the `test` Fastlane lane when the Xcode MCP is unavailable:
+
+If the Xcode MCP fails (e.g. build errors from unrelated targets), fall back to the Fastlane `test` lane:
 
 ```bash
 bundle exec fastlane test
 bundle exec fastlane test only_testing:TargetName/Class/method
 ```
+
+If Fastlane also fails, fall back to `xcodebuild` directly:
+
+```bash
+xcodebuild \
+  -workspace WordPress.xcworkspace \
+  -scheme "${SCHEME}" \
+  -destination "platform=iOS Simulator,name=${DEVICE}" \
+  test \
+  | xcbeautify
+```
+
+Some test targets (e.g. `WordPressDataTests`) have their own scheme and are not part of the main `WordPress` scheme's test plan.
+When the `WordPress` scheme build fails due to an unrelated target, try using the target's dedicated scheme instead.
 
 ## Coding Standards
 - Follow Swift API Design Guidelines

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -40,8 +40,9 @@ WordPress-iOS uses a modular architecture with the main app and separate Swift p
 
 ## Build & Test
 
-If the Xcode MCP server is connected, use it to build and test.
-Otherwise, use the `test` Fastlane lane:
+**Always check for the Xcode MCP server first.**
+If it is connected, use it to build and test — no exceptions.
+Only fall back to the `test` Fastlane lane when the Xcode MCP is unavailable:
 
 ```bash
 bundle exec fastlane test

--- a/Modules/Sources/DesignSystem/Foundation/Bundle+DesignSystem.swift
+++ b/Modules/Sources/DesignSystem/Foundation/Bundle+DesignSystem.swift
@@ -1,0 +1,14 @@
+import Foundation
+
+extension Bundle {
+    public class var designSystemBundle: Bundle {
+#if DEBUG
+        // Workaround for https://forums.swift.org/t/swift-5-3-swiftpm-resources-in-tests-uses-wrong-bundle-path/37051
+        if let testBundlePath = ProcessInfo.processInfo.environment["XCTestBundlePath"],
+           let bundle = Bundle(path: "\(testBundlePath)/Modules_DesignSystem.bundle") {
+            return bundle
+        }
+#endif
+        return Bundle.module
+    }
+}

--- a/Modules/Sources/DesignSystem/Foundation/Bundle+DesignSystem.swift
+++ b/Modules/Sources/DesignSystem/Foundation/Bundle+DesignSystem.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 extension Bundle {
-    public class var designSystemBundle: Bundle {
+    class var designSystemBundle: Bundle {
 #if DEBUG
         // Workaround for https://forums.swift.org/t/swift-5-3-swiftpm-resources-in-tests-uses-wrong-bundle-path/37051
         if let testBundlePath = ProcessInfo.processInfo.environment["XCTestBundlePath"],

--- a/Modules/Sources/DesignSystem/Foundation/IconName.swift
+++ b/Modules/Sources/DesignSystem/Foundation/IconName.swift
@@ -22,7 +22,7 @@ public enum IconName: String, CaseIterable {
 public extension UIImage {
     enum DS {
         public static func icon(named name: IconName, with configuration: UIImage.Configuration? = nil) -> UIImage? {
-            return UIImage(named: name.rawValue, in: .module, with: configuration)
+            return UIImage(named: name.rawValue, in: .designSystemBundle, with: configuration)
         }
     }
 }
@@ -30,7 +30,7 @@ public extension UIImage {
 public extension Image {
     enum DS {
         public static func icon(named name: IconName) -> Image {
-            return Image(name.rawValue, bundle: .module)
+            return Image(name.rawValue, bundle: .designSystemBundle)
         }
     }
 }

--- a/Modules/Sources/DesignSystem/Typography/FontManager.swift
+++ b/Modules/Sources/DesignSystem/Typography/FontManager.swift
@@ -9,7 +9,7 @@ public enum FontManager {
 
     // Makes sure it's performed only once.
     private static let register: Void = {
-        let fontURLs = Bundle.module
+        let fontURLs = Bundle.designSystemBundle
             .urls(forResourcesWithExtension: "otf", subdirectory: nil)
         for fontURL in (fontURLs ?? []) {
             if !CTFontManagerRegisterFontsForURL(fontURL as CFURL, .process, nil) {

--- a/Modules/Sources/WordPressUI/Deprecated/NoResultsViewController.swift
+++ b/Modules/Sources/WordPressUI/Deprecated/NoResultsViewController.swift
@@ -132,7 +132,7 @@ import Reachability
     /// to set the view values before presenting the No Results View.
     ///
     @objc public class func controller() -> NoResultsViewController {
-        let storyBoard = UIStoryboard(name: "NoResults", bundle: Bundle.module)
+        let storyBoard = UIStoryboard(name: "NoResults", bundle: Bundle.wordPressUIBundle)
         let controller = storyBoard.instantiateViewController(withIdentifier: "NoResults") as! NoResultsViewController
         return controller
     }

--- a/Modules/Tests/DesignSystemTests/IconTests.swift
+++ b/Modules/Tests/DesignSystemTests/IconTests.swift
@@ -4,11 +4,6 @@ import SwiftUI
 
 final class IconTests: XCTestCase {
 
-    // This test will fail if DesignSystem is built as a dynamic library. For some reason, Xcode can't locate
-    // the library's resource bundle.
-    //
-    // DesignSystem will be built as a dynamic library if it's a dependency of a dynamic library, such as
-    // the WordPressAuthenticator target.
     func testCanLoadAllIconsAsUIImage() throws {
         for icon in IconName.allCases {
             let _ = try XCTUnwrap(UIImage.DS.icon(named: icon))

--- a/Modules/Tests/JetpackStatsTests/MockStatsServiceTests.swift
+++ b/Modules/Tests/JetpackStatsTests/MockStatsServiceTests.swift
@@ -9,7 +9,7 @@ struct MockStatsServiceTests {
     @Test("getTopListData returns valid data for posts")
     func testGetTopListDataPosts() async throws {
         // GIVEN
-        let service = MockStatsService(timeZone: .current)
+        let service = MockStatsService(timeZone: .eastern)
         let dateInterval = calendar.makeDateInterval(for: .today)
 
         // WHEN
@@ -43,7 +43,7 @@ struct MockStatsServiceTests {
     @Test("Verify getChartData returns valid data for views metric with today range")
     func testGetChartDataViewsToday() async throws {
         // GIVEN
-        let service = MockStatsService(timeZone: .current)
+        let service = MockStatsService(timeZone: .eastern)
         let dateInterval = calendar.makeDateInterval(for: .today)
         let granularity = dateInterval.preferredGranularity
 

--- a/Modules/Tests/WordPressUIUnitTests/NoResultsViewControllerTests.swift
+++ b/Modules/Tests/WordPressUIUnitTests/NoResultsViewControllerTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-@testable import WordPress
+@testable import WordPressUI
 
 class NoResultsViewControllerTests: XCTestCase {
 

--- a/Rakefile
+++ b/Rakefile
@@ -12,15 +12,11 @@ require 'zlib'
 
 RUBY_REPO_VERSION = File.read('./.ruby-version').rstrip
 XCODE_WORKSPACE = 'WordPress.xcworkspace'
-XCODE_SCHEME = 'WordPress'
-XCODE_CONFIGURATION = 'Debug'
 EXPECTED_XCODE_VERSION = File.read('.xcode-version').rstrip
 GUTENBERG_VERSION = 'v1.121.0'
 
 PROJECT_DIR = __dir__
 abort('Project directory contains one or more spaces – unable to continue.') if PROJECT_DIR.include?(' ')
-
-task default: %w[test]
 
 desc 'Install required dependencies'
 task dependencies: %w[dependencies:check assets:check dependencies:gutenberg_xcframeworks]
@@ -173,36 +169,6 @@ CLOBBER << 'vendor'
 desc 'Mocks'
 task :mocks do
   sh "#{File.join(PROJECT_DIR, 'API-Mocks', 'scripts', 'start.sh')} 8282"
-end
-
-desc "Build #{XCODE_SCHEME}"
-task build: [:dependencies] do
-  xcodebuild(:build)
-end
-
-desc "Profile build #{XCODE_SCHEME}"
-task buildprofile: [:dependencies] do
-  ENV['verbose'] = '1'
-  xcodebuild(:build, "OTHER_SWIFT_FLAGS='-Xfrontend -debug-time-compilation -Xfrontend -debug-time-expression-type-checking'")
-end
-
-task timed_build: [:clean] do
-  require 'benchmark'
-  time = Benchmark.measure do
-    Rake::Task['build'].invoke
-  end
-  puts "CPU Time: #{time.total}"
-  puts "Wall Time: #{time.real}"
-end
-
-desc 'Run test suite'
-task test: [:dependencies] do
-  xcodebuild(:build, :test)
-end
-
-desc 'Remove any temporary products'
-task :clean do
-  xcodebuild(:clean)
 end
 
 desc 'Checks the source for style errors'
@@ -632,23 +598,6 @@ def display_prompt_response?
   end
 
   response == 'Y'
-end
-
-def xcodebuild(*build_cmds)
-  cmd = 'xcodebuild'
-  cmd += " -destination 'platform=iOS Simulator,name=iPhone 16'"
-  cmd += ' -sdk iphonesimulator'
-  cmd += " -workspace #{XCODE_WORKSPACE}"
-  cmd += " -scheme #{XCODE_SCHEME}"
-  cmd += " -configuration #{xcode_configuration}"
-  cmd += ' '
-  cmd += build_cmds.map(&:to_s).join(' ')
-  cmd += ' | bundle exec xcpretty && exit ${PIPESTATUS[0]}' unless ENV['verbose']
-  sh(cmd)
-end
-
-def xcode_configuration
-  ENV.fetch('XCODE_CONFIGURATION') { XCODE_CONFIGURATION }
 end
 
 def command?(command)

--- a/Tests/KeystoneTests/WordPressUnitTests.xctestplan
+++ b/Tests/KeystoneTests/WordPressUnitTests.xctestplan
@@ -33,16 +33,30 @@
   "testTargets" : [
     {
       "target" : {
-        "containerPath" : "container:..\/Modules",
-        "identifier" : "WordPressFluxTests",
-        "name" : "WordPressFluxTests"
+        "containerPath" : "container:WordPress.xcodeproj",
+        "identifier" : "4AD953BA2C21451700D0EEFA",
+        "name" : "WordPressAuthenticatorTests"
       }
     },
     {
       "target" : {
-        "containerPath" : "container:WordPress.xcodeproj",
-        "identifier" : "E16AB92914D978240047A2E5",
-        "name" : "WordPressTest"
+        "containerPath" : "container:..\/Modules",
+        "identifier" : "DesignSystemTests",
+        "name" : "DesignSystemTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..\/Modules",
+        "identifier" : "WordPressSharedTests",
+        "name" : "WordPressSharedTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..\/Modules",
+        "identifier" : "JetpackStatsWidgetsCoreTests",
+        "name" : "JetpackStatsWidgetsCoreTests"
       }
     },
     {
@@ -55,36 +69,29 @@
     {
       "target" : {
         "containerPath" : "container:..\/Modules",
-        "identifier" : "WordPressSharedTests",
-        "name" : "WordPressSharedTests"
-      }
-    },
-    {
-      "target" : {
-        "containerPath" : "container:WordPress.xcodeproj",
-        "identifier" : "4A8280FC2E5FE9B60037E180",
-        "name" : "WordPressKitTests"
-      }
-    },
-    {
-      "target" : {
-        "containerPath" : "container:..\/Modules",
-        "identifier" : "JetpackStatsWidgetsCoreTests",
-        "name" : "JetpackStatsWidgetsCoreTests"
-      }
-    },
-    {
-      "target" : {
-        "containerPath" : "container:WordPress.xcodeproj",
-        "identifier" : "4AD953BA2C21451700D0EEFA",
-        "name" : "WordPressAuthenticatorTests"
-      }
-    },
-    {
-      "target" : {
-        "containerPath" : "container:..\/Modules",
         "identifier" : "WordPressUIUnitTests",
         "name" : "WordPressUIUnitTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:WordPress.xcodeproj",
+        "identifier" : "E16AB92914D978240047A2E5",
+        "name" : "WordPressTest"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..\/Modules",
+        "identifier" : "JetpackStatsTests",
+        "name" : "JetpackStatsTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..\/Modules",
+        "identifier" : "AsyncImageKitTests",
+        "name" : "AsyncImageKitTests"
       }
     },
     {
@@ -97,8 +104,22 @@
     {
       "target" : {
         "containerPath" : "container:..\/Modules",
-        "identifier" : "AsyncImageKitTests",
-        "name" : "AsyncImageKitTests"
+        "identifier" : "WordPressFluxTests",
+        "name" : "WordPressFluxTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:WordPress.xcodeproj",
+        "identifier" : "4A8280FC2E5FE9B60037E180",
+        "name" : "WordPressKitTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..\/Modules",
+        "identifier" : "WordPressIntelligenceTests",
+        "name" : "WordPressIntelligenceTests"
       }
     }
   ],

--- a/Tests/KeystoneTests/WordPressUnitTests.xctestplan
+++ b/Tests/KeystoneTests/WordPressUnitTests.xctestplan
@@ -41,6 +41,13 @@
     {
       "target" : {
         "containerPath" : "container:..\/Modules",
+        "identifier" : "DesignSystemTests",
+        "name" : "DesignSystemTests"
+      }
+    },
+    {
+      "target" : {
+        "containerPath" : "container:..\/Modules",
         "identifier" : "WordPressSharedTests",
         "name" : "WordPressSharedTests"
       }

--- a/Tests/KeystoneTests/WordPressUnitTests.xctestplan
+++ b/Tests/KeystoneTests/WordPressUnitTests.xctestplan
@@ -114,13 +114,6 @@
         "identifier" : "4A8280FC2E5FE9B60037E180",
         "name" : "WordPressKitTests"
       }
-    },
-    {
-      "target" : {
-        "containerPath" : "container:..\/Modules",
-        "identifier" : "WordPressIntelligenceTests",
-        "name" : "WordPressIntelligenceTests"
-      }
     }
   ],
   "version" : 1

--- a/Tests/KeystoneTests/WordPressUnitTests.xctestplan
+++ b/Tests/KeystoneTests/WordPressUnitTests.xctestplan
@@ -41,13 +41,6 @@
     {
       "target" : {
         "containerPath" : "container:..\/Modules",
-        "identifier" : "DesignSystemTests",
-        "name" : "DesignSystemTests"
-      }
-    },
-    {
-      "target" : {
-        "containerPath" : "container:..\/Modules",
         "identifier" : "WordPressSharedTests",
         "name" : "WordPressSharedTests"
       }

--- a/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressShared.xcscheme
+++ b/WordPress/WordPress.xcodeproj/xcshareddata/xcschemes/WordPressShared.xcscheme
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "2630"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "WordPressShared"
+               BuildableName = "WordPressShared"
+               BlueprintName = "WordPressShared"
+               ReferencedContainer = "container:../Modules">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <TestPlans>
+         <TestPlanReference
+            reference = "container:../Modules/Tests/WordPressSharedTests/WordPressShared.xctestplan"
+            default = "YES">
+         </TestPlanReference>
+      </TestPlans>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "WordPressShared"
+            BuildableName = "WordPressShared"
+            BlueprintName = "WordPressShared"
+            ReferencedContainer = "container:../Modules">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -183,7 +183,7 @@ before_all do |lane|
   ENV['FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT'] = '120'
 
   # Skip these checks/steps for test lane (not needed for testing)
-  next if lane == :test_without_building
+  next if %i[test test_without_building].include?(lane)
 
   # Ensure we use the latest version of the toolkit
   check_for_toolkit_updates unless is_ci || ENV['FASTLANE_SKIP_TOOLKIT_UPDATE_CHECK']

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -63,7 +63,8 @@ platform :ios do
       derived_data_path: DERIVED_DATA_PATH,
       deployment_target_version: ios_version,
       only_testing: only_testing,
-      clean: clean
+      clean: clean,
+      skip_package_dependencies_resolution: !clean
     )
   end
 

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -40,7 +40,7 @@ platform :ios do
   # Runs tests locally without CI prerequisites (env files, signing, etc.)
   #
   # @option [String] scheme The scheme to test (default: WordPress)
-  # @option [String] device The Simulator device name (default: iPhone 16)
+  # @option [String] device The Simulator device name
   # @option [String] ios_version The deployment target version
   # @option [String] only_testing Specific test target/class/method (e.g. WordPressUnitTests/MyClass/testFoo)
   # @option [Boolean] clean Whether to clean before building (default: false for incremental builds)
@@ -55,7 +55,7 @@ platform :ios do
   #   bundle exec fastlane test clean:true
   #
   desc 'Run tests locally'
-  lane :test do |scheme: 'WordPress', device: 'iPhone 16', ios_version: nil, only_testing: nil, clean: false|
+  lane :test do |scheme: 'WordPress', device: 'iPhone 17', ios_version: nil, only_testing: nil, clean: false|
     run_tests(
       workspace: WORKSPACE_PATH,
       scheme: scheme,

--- a/fastlane/lanes/build.rb
+++ b/fastlane/lanes/build.rb
@@ -37,6 +37,36 @@ COMMON_EXPORT_OPTIONS = { manageAppVersionAndBuildNumber: false }.freeze
 # Lanes related to Building and Testing the code
 #
 platform :ios do
+  # Runs tests locally without CI prerequisites (env files, signing, etc.)
+  #
+  # @option [String] scheme The scheme to test (default: WordPress)
+  # @option [String] device The Simulator device name (default: iPhone 16)
+  # @option [String] ios_version The deployment target version
+  # @option [String] only_testing Specific test target/class/method (e.g. WordPressUnitTests/MyClass/testFoo)
+  # @option [Boolean] clean Whether to clean before building (default: false for incremental builds)
+  #
+  # @example Run all WordPress tests:
+  #   bundle exec fastlane test
+  # @example Run a single test class:
+  #   bundle exec fastlane test only_testing:WordPressUnitTests/MyClass
+  # @example Test the Jetpack scheme:
+  #   bundle exec fastlane test scheme:Jetpack
+  # @example Clean build before testing:
+  #   bundle exec fastlane test clean:true
+  #
+  desc 'Run tests locally'
+  lane :test do |scheme: 'WordPress', device: 'iPhone 16', ios_version: nil, only_testing: nil, clean: false|
+    run_tests(
+      workspace: WORKSPACE_PATH,
+      scheme: scheme,
+      device: device,
+      derived_data_path: DERIVED_DATA_PATH,
+      deployment_target_version: ios_version,
+      only_testing: only_testing,
+      clean: clean
+    )
+  end
+
   # Builds the WordPress app for Testing
   #
   # @option [String] device the name of the Simulator device to run the tests on


### PR DESCRIPTION
## Description
Supersedes https://github.com/wordpress-mobile/WordPress-iOS/pull/25242 to address @kean 's experience trying to run tests.

The core difference is that `AGENTS.md` instructs to prioritize Xcode's MCP.

<img width="1256" height="404" alt="image" src="https://github.com/user-attachments/assets/3db24644-75c7-4722-8290-ffa48325d435" />

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

I retried all of Alex's experiments.

### Test WordPressData

Run into an issue. The MCP couldn't find the target/scheme to run

<img width="1272" height="552" alt="Screenshot 2026-02-27 at 9 29 42 AM" src="https://github.com/user-attachments/assets/b926eb67-ef7d-4060-ab99-18472d5b1190" />

Successfully fell back to Fastlane, but no luck there either. Claude then discovered the scheme and used `xcodebuild`:

<img width="2524" height="1608" alt="image" src="https://github.com/user-attachments/assets/7eeff912-b878-4ab3-95a8-c6009aa13b44" />

**Action Item**:

- [ ] Set up straightforward target-scheme-`xctestplan` for WordPressData

### Test WordPressShared

Again, the first MCP call failed

<img width="1261" height="611" alt="image" src="https://github.com/user-attachments/assets/5a9a7760-846a-4ddc-9079-d270544255fe" />

Claude then opted for `xcodebuild` given it worked before. It deprioritized the instruction in `AGENTS.md`. I let it run to see how it worked. Unfortunately, it kept running into linker issues.

<img width="1261" height="402" alt="image" src="https://github.com/user-attachments/assets/ecf9be6f-976b-4a06-b163-05da53e13254" />

Retried with explicit instruction to exhaust all MCP options first. Got stuck on this:

<img width="1263" height="390" alt="image" src="https://github.com/user-attachments/assets/6a19871b-8894-4416-8c24-5aeb3ee1a0f4" />

Cancelled and looked at Xcode on my own. Test run fine. I did a few more iterations of this test and figured out the issue is with how SwiftPM autogenerates the schemes Xcode uses for packages.

I worked around this by creating a new scheme for WordPressShared _in the project container_ so that it won't be accidentally modified:

<img width="1504" height="294" alt="image" src="https://github.com/user-attachments/assets/7b13c877-178c-47be-b248-50274c7f43be" />

However, despited having the scheme in place Claude did something funky here running the tests one at a time, but at least it worked and it was relatively fast.

<img width="1258" height="685" alt="Screenshot 2026-02-27 at 10 54 12 AM" src="https://github.com/user-attachments/assets/9b1efb3b-926b-4724-9699-700cf5010921" />

<img width="2512" height="444" alt="image" src="https://github.com/user-attachments/assets/59bd2417-17f5-400f-b615-ee8eaf8e8b77" />

### Make a small change to WordPressShared that would result in an error

I changed a test so that it would fail. MCP test failed to detect it

<img width="1275" height="187" alt="image" src="https://github.com/user-attachments/assets/fb372ed1-6db3-4139-8d9e-ea7568792540" />

Only picked up the failure when instructed 

<img width="2476" height="754" alt="image" src="https://github.com/user-attachments/assets/9cea54ca-ea4b-467f-bd6b-2683787e3440" />

### Run all tests (without reverting the failing test)

<img width="1638" height="234" alt="image" src="https://github.com/user-attachments/assets/75ce6d06-3aec-40b4-beca-db7b4322d3e0" />

<img width="1265" height="360" alt="image" src="https://github.com/user-attachments/assets/fdac53b6-207b-4bca-881d-45bc884d05eb" />

_I haven't investigated the expected failure or not run tests._

### Run all tests (after reverting the intentional failure)

<img width="1279" height="599" alt="image" src="https://github.com/user-attachments/assets/c18ea8fe-e5ac-4047-8989-3c17d88352e1" />
