### PR TITLE
Fix runtime warnings in tests with duplicated entity definitions

### DIFF
--- a/Tests/WordPressDataTests/CoreDataHelperTests.swift
+++ b/Tests/WordPressDataTests/CoreDataHelperTests.swift
@@ -175,7 +175,8 @@ class DummyEntity: NSManagedObject {
 // MARK: - InMemory Stack with Dynamic Model
 
 class DummyStack {
-    lazy var model: NSManagedObjectModel = {
+    // Only one had to exist at a time
+    static var model: NSManagedObjectModel = {
         let keyAttribute = NSAttributeDescription()
         keyAttribute.name = "key"
         keyAttribute.attributeType = .stringAttributeType
@@ -202,7 +203,7 @@ class DummyStack {
     }()
 
     lazy var coordinator: NSPersistentStoreCoordinator = {
-        let coordinator = NSPersistentStoreCoordinator(managedObjectModel: self.model)
+        let coordinator = NSPersistentStoreCoordinator(managedObjectModel: Self.model)
         _ = try? coordinator.addPersistentStore(ofType: NSInMemoryStoreType, configurationName: nil, at: nil, options: nil)
         return coordinator
     }()

--- a/Tests/WordPressDataTests/CoreDataHelperTests.swift
+++ b/Tests/WordPressDataTests/CoreDataHelperTests.swift
@@ -176,7 +176,7 @@ class DummyEntity: NSManagedObject {
 
 class DummyStack {
     // Only one had to exist at a time
-    static var model: NSManagedObjectModel = {
+    static let model: NSManagedObjectModel = {
         let keyAttribute = NSAttributeDescription()
         keyAttribute.name = "key"
         keyAttribute.attributeType = .stringAttributeType


### PR DESCRIPTION
Fixes this error:

```
❌ CoreData: +[WordPressDataTests.DummyEntity entity] Failed to find a unique match for an NSEntityDescription to a managed object subclass
```

Loading the same entity more than once in memory is illegal.
