### PR TITLE
Fix WordPressDataTests

### DIFF
--- a/Tests/WordPressDataTests/ContextManagerTests.swift
+++ b/Tests/WordPressDataTests/ContextManagerTests.swift
@@ -252,8 +252,7 @@ class ContextManagerTests: XCTestCase {
 
         let request = WPAccount.fetchRequest()
         request.predicate = NSPredicate(format: "username = %@", username)
-        XCTExpectFailure("See the comment in `ContextManager.writerQueue` for details")
-        try XCTAssertEqual(contextManager.mainContext.count(for: request), 1)
+        try XCTAssertNotEqual(contextManager.mainContext.count(for: request), 1, "See the comment in `ContextManager.writerQueue` for details")
     }
 
     /// This test case documents a pitfall in `ContextManager.performAndSave(_:)`, where the
@@ -285,8 +284,7 @@ class ContextManagerTests: XCTestCase {
 
         XCTAssertEqual(theBackgroundContext?.hasChanges, false, "The background context should be saved when `performAndSave` returns")
 
-        XCTExpectFailure("The account object in the main context doesn't get the updated value immediately")
-        XCTAssertEqual(account?.username, "Updated")
+        XCTAssertNotEqual(account?.username, "Updated", "The account object in the main context doesn't get the updated value immediately")
 
         // But eventually (probably in next run loop), it will get the updated value.
         let updated = expectation(for: NSPredicate { _, _ in

--- a/Tests/WordPressDataTests/CoreDataMigrationTests.swift
+++ b/Tests/WordPressDataTests/CoreDataMigrationTests.swift
@@ -179,8 +179,7 @@ struct CoreDataMigrationTests {
     }
 
     private func storeURL(named fileName: String) -> URL {
-        let documentsDirectory = NSSearchPathForDirectoriesInDomains(.documentDirectory, .userDomainMask, true).last!
-        let url = URL(fileURLWithPath: documentsDirectory).appendingPathComponent(fileName)
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
         try? FileManager.default.removeItem(at: url)
         return url
     }


### PR DESCRIPTION
Claude:

```
Problem: Two tests in CoreDataMigrationTests were failing on CI:
  - migrationFrom103To104Transformables()
  - migrationFrom103To104CustomTransformers()

  Both failed with NSCocoaErrorDomain Code=512 "The file couldn't be saved." because the storeURL(named:) helper used
  NSSearchPathForDirectoriesInDomains(.documentDirectory, ...) which points to a simulator Documents directory that doesn't exist on the CI machine.

  Fix: Changed storeURL(named:) to use FileManager.default.temporaryDirectory instead, which is always writable in both local and CI environments.
```

It did fix the issue. Not sure wha't the problem with `.documents` though.

The tests did move from `WordPressTests` with a host app to `WordPressDataTests` without it, so it might be one reason. The other reason might be a security model on CI – dunno.
