### PR TITLE
Convert Blog to Swift (P4)

### DIFF
--- a/Sources/WordPressData/Objective-C/Blog.m
+++ b/Sources/WordPressData/Objective-C/Blog.m
@@ -7,10 +7,8 @@
 
 @class Comment;
 
-
 @interface Blog ()
 
-@property (nonatomic, strong, readwrite) WordPressOrgXMLRPCApi *xmlrpcApi;
 @property (nonatomic, strong, readwrite) WordPressOrgRestApi *selfHostedSiteRestApi;
 
 @end
@@ -20,7 +18,6 @@
 @dynamic accountForDefaultBlog;
 @dynamic blogID;
 @dynamic url;
-@dynamic xmlrpc;
 @dynamic restApiRootURL;
 @dynamic apiKey;
 @dynamic organizationID;
@@ -120,53 +117,6 @@
     [[NSNotificationCenter defaultCenter] removeObserver:self];
 }
 
-- (NSNumber *)organizationID {
-    NSNumber *organizationID = [self primitiveValueForKey:@"organizationID"];
-
-    if (organizationID == nil) {
-        return @0;
-    } else {
-        return organizationID;
-    }
-}
-
-- (void)setXmlrpc:(NSString *)xmlrpc
-{
-    [self willChangeValueForKey:@"xmlrpc"];
-    [self setPrimitiveValue:xmlrpc forKey:@"xmlrpc"];
-    [self didChangeValueForKey:@"xmlrpc"];
-
-    // Reset the api client so next time we use the new XML-RPC URL
-    self.xmlrpcApi = nil;
-}
-
-- (NSNumber *)dotComID
-{
-    [self willAccessValueForKey:@"blogID"];
-    NSNumber *dotComID = [self primitiveValueForKey:@"blogID"];
-    if (dotComID.integerValue == 0) {
-        dotComID = self.jetpack.siteID;
-        if (dotComID.integerValue > 0) {
-            self.dotComID = dotComID;
-        }
-    }
-    [self didAccessValueForKey:@"blogID"];
-    return dotComID;
-}
-
-- (void)setDotComID:(NSNumber *)dotComID
-{
-    [self willChangeValueForKey:@"blogID"];
-    [self setPrimitiveValue:dotComID forKey:@"blogID"];
-    [self didChangeValueForKey:@"blogID"];
-}
-
-+ (NSSet *)keyPathsForValuesAffectingJetpack
-{
-    return [NSSet setWithObject:@"options"];
-}
-
-
 #pragma mark - api accessor
 
 - (WordPressOrgXMLRPCApi *)xmlrpcApi
@@ -187,12 +137,6 @@
         _selfHostedSiteRestApi = self.account == nil ? [[WordPressOrgRestApi alloc] initWithBlog:self] : nil;
     }
     return _selfHostedSiteRestApi;
-}
-
-- (BOOL)supportsRestApi {
-    // We don't want to check for `restApi` as it can be `nil` when the token
-    // is missing from the keychain.
-    return self.account != nil;
 }
 
 @end

--- a/Sources/WordPressData/Objective-C/include/Blog.h
+++ b/Sources/WordPressData/Objective-C/include/Blog.h
@@ -39,12 +39,9 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 @interface Blog : NSManagedObject
 
 @property (nonatomic, strong, readwrite, nullable) NSNumber *blogID __deprecated_msg("Use dotComID instead");
-/// WordPress.com site ID stored as signed 32-bit integer.
-@property (nonatomic, strong, readwrite, nullable) NSNumber *dotComID;
-@property (nonatomic, strong, readwrite, nullable) NSString *xmlrpc;
 @property (nonatomic, strong, readwrite, nullable) NSString *restApiRootURL;
 @property (nonatomic, strong, readwrite, nullable) NSString *apiKey;
-@property (nonatomic, strong, readwrite, nonnull) NSNumber *organizationID;
+@property (nonatomic, strong, readwrite, nullable) NSNumber *organizationID;
 @property (nonatomic, strong, readwrite, nullable) NSSet<AbstractPost *> *posts;
 @property (nonatomic, strong, readwrite, nullable) NSSet<PostCategory *> *categories;
 @property (nonatomic, strong, readwrite, nullable) NSSet<PostTag *> *tags;
@@ -112,7 +109,7 @@ typedef NS_ENUM(NSInteger, SiteVisibility) {
 
 
 // Readonly Properties
-@property (nonatomic, strong, readonly, nullable) WordPressOrgXMLRPCApi *xmlrpcApi;
+@property (nonatomic, strong, readwrite, nullable) WordPressOrgXMLRPCApi *xmlrpcApi;
 @property (nonatomic, strong, readonly, nullable) WordPressOrgRestApi *selfHostedSiteRestApi;
 
 // http://wp.koke.me/sub

--- a/Sources/WordPressData/Swift/Blog+Swift.swift
+++ b/Sources/WordPressData/Swift/Blog+Swift.swift
@@ -8,6 +8,49 @@ private nonisolated(unsafe) var blogKeychainKey: UInt8 = 0
 
 extension Blog {
 
+    // MARK: - Core Data Accessors
+
+    @objc public var xmlrpc: String? {
+        get {
+            willAccessValue(forKey: "xmlrpc")
+            let value = primitiveValue(forKey: "xmlrpc") as? String
+            didAccessValue(forKey: "xmlrpc")
+            return value
+        }
+        set {
+            willChangeValue(forKey: "xmlrpc")
+            setPrimitiveValue(newValue, forKey: "xmlrpc")
+            didChangeValue(forKey: "xmlrpc")
+            // Reset the API client so next time we use the new XML-RPC URL
+            xmlrpcApi = nil
+        }
+    }
+
+    /// WordPress.com site ID. Backed by the `blogID` Core Data attribute.
+    @objc public var dotComID: NSNumber? {
+        get {
+            willAccessValue(forKey: "blogID")
+            var value = primitiveValue(forKey: "blogID") as? NSNumber
+            if (value?.intValue ?? 0) == 0 {
+                value = jetpack?.siteID
+                if let value, value.intValue > 0 {
+                    self.dotComID = value
+                }
+            }
+            didAccessValue(forKey: "blogID")
+            return value
+        }
+        set {
+            willChangeValue(forKey: "blogID")
+            setPrimitiveValue(newValue, forKey: "blogID")
+            didChangeValue(forKey: "blogID")
+        }
+    }
+
+    @objc class var keyPathsForValuesAffectingJetpack: Set<String> {
+        ["options"]
+    }
+
     // MARK: - Keychain
 
     /// Injectable keychain for testability.
@@ -174,7 +217,7 @@ extension Blog {
     @objc public var logDescription: String {
         let extra: String
         if let account {
-            extra = " wp.com account: \(account.username ?? "") blogId: \(dotComID?.intValue ?? 0) plan: \(planTitle ?? "") (\(planID?.intValue ?? 0))"
+            extra = " wp.com account: \(account.username) blogId: \(dotComID?.intValue ?? 0) plan: \(planTitle ?? "") (\(planID?.intValue ?? 0))"
         } else if let jetpack {
             extra = " jetpack: \(jetpack)"
         } else {

--- a/WordPress/Classes/Models/Blog/Blog+Organization.swift
+++ b/WordPress/Classes/Models/Blog/Blog+Organization.swift
@@ -3,6 +3,9 @@ import WordPressData
 
 extension Blog {
     var isAutomatticP2: Bool {
-        SiteOrganizationType(rawValue: organizationID.intValue) == .automattic
+        guard let organizationID = organizationID?.intValue else {
+            return nil
+        }
+        return SiteOrganizationType(rawValue: organizationID) == .automattic
     }
 }

--- a/WordPress/Classes/Models/Blog/Blog+Organization.swift
+++ b/WordPress/Classes/Models/Blog/Blog+Organization.swift
@@ -4,7 +4,7 @@ import WordPressData
 extension Blog {
     var isAutomatticP2: Bool {
         guard let organizationID = organizationID?.intValue else {
-            return nil
+            return false
         }
         return SiteOrganizationType(rawValue: organizationID) == .automattic
     }


### PR DESCRIPTION
One more part that converts the computed properties. The next PR will only need to remove the lifecycle methods and the properties.