### PR TITLE
Weekly Roundup: Fix notification body parameters

### DIFF
--- a/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
+++ b/WordPress/Classes/Utility/BackgroundTasks/WeeklyRoundupBackgroundTask.swift
@@ -636,7 +636,7 @@ class WeeklyRoundupNotificationScheduler {
         completion: @escaping (Result<Void, Error>) -> Void
     ) {
         let title = notificationTitle(siteTitle)
-        let body = notificationBodyWith(views: views, comments: likes, likes: comments)
+        let body = notificationBodyWith(views: views, comments: comments, likes: likes)
 
         // The dynamic notification date is defined by when the background task is run.
         // Since these lines of code execute when the BG Task is run, we can just schedule


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->

Fixes a bug where the Weekly Roundup notification was showing number of likes as comments and vice versa.

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
