### PR TITLE
Fix an issue Social Sharing placeholder card showing unsupported services

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,5 +1,6 @@
 26.8
 -----
+* [*] Fix an issue Social Sharing placeholder card showing unsupported services [#25336]
 
 
 26.7

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -713,7 +713,7 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
 
     private func getPublicizeServices() -> [PublicizeService] {
         let context = ContextManager.shared.mainContext
-        return (try? PublicizeService.allPublicizeServices(in: context)) ?? []
+        return (try? PublicizeService.allSupportedServices(in: context)) ?? []
     }
 
     /// Convenience variable representing whether the No Connection view has been dismissed.


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-1293/jetpack-app-remove-old-twitter-icon-from-the-list-of-social-accounts.

<img width="502" height="1063" alt="Screenshot 2026-03-03 at 8 03 02 AM" src="https://github.com/user-attachments/assets/5374826e-489e-4ffb-80ae-8ebd9b144be9" />
