### PR TITLE
Remove CocoaLumberJackConfiguration.m

### DIFF
--- a/Sources/WordPressData/Objective-C/CocoaLumberJackConfiguration.m
+++ b/Sources/WordPressData/Objective-C/CocoaLumberJackConfiguration.m
@@ -1,8 +1,0 @@
-@import CocoaLumberjack;
-
-DDLogLevel ddLogLevel = DDLogLevelInfo;
-
-void SetCocoaLumberjackObjCLogLevel(NSUInteger ddLogLevelRawValue)
-{
-    ddLogLevel = (DDLogLevel)ddLogLevelRawValue;
-}

--- a/Sources/WordPressData/WordPressData.h
+++ b/Sources/WordPressData/WordPressData.h
@@ -9,5 +9,3 @@ FOUNDATION_EXPORT const unsigned char WordPressDataVersionString[];
 // Note: Some of these might not need to be public, but it was simpler to extract to WordPressData by making everything public.
 // As we'll hopefully soon rewrite these in Swift, we can implement proper access level then.
 #import <WordPressData/Blog.h>
-
-FOUNDATION_EXTERN void SetCocoaLumberjackObjCLogLevel(NSUInteger ddLogLevelRawValue);


### PR DESCRIPTION
It is now unused. This was the last ObjC file in the framework, yay.