### PR TITLE
Fix Style/FileOpen rubocop offense

### DIFF
--- a/API-Mocks/Rakefile
+++ b/API-Mocks/Rakefile
@@ -51,7 +51,7 @@ task :lint do
     ## Ensure there are no references to the actual API location – we should use the mocks
     # base URL – this ensures that any requests made based on the contents of other
     # requests won't fail.
-    if File.open(file).each_line.any? { |line| line.include?('public-api.wordpress.com') }
+    if File.foreach(file).any? { |line| line.include?('public-api.wordpress.com') }
       append_error(file, file_errors, 'Contains references to `https://public-api.wordpress.com`. Replace them with `{{request.requestLine.baseUrl}}`.')
     end
   end


### PR DESCRIPTION
## Summary
- Fix `Style/FileOpen` rubocop offense introduced by the rubocop 1.85.0 bump
- Replace `File.open(file).each_line` with `File.foreach(file)` in `API-Mocks/Rakefile` to avoid leaking a file descriptor

## Test plan
- [x] `bundle exec rubocop` passes with no offenses

🤖 Generated with [Claude Code](https://claude.com/claude-code)