### PR TITLE
[Tooling] Enable Danger as a required check compatible with merge queue

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -150,7 +150,7 @@ steps:
       - label: ":danger: Danger - PR Check"
         command: danger
         key: danger
-        # No "build.pull_request.id" condition as we want this check to run also on merge queues (no-op)
+        # No "build.pull_request.id" condition as we want this check to run also on merge queues where it is a no-op
         retry:
           manual:
             permit_on_passed: true

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -150,7 +150,7 @@ steps:
       - label: ":danger: Danger - PR Check"
         command: danger
         key: danger
-        if: "build.pull_request.id != null"
+        # No "build.pull_request.id" condition as we want this check to run also on merge queues (no-op)
         retry:
           manual:
             permit_on_passed: true


### PR DESCRIPTION
Fixes AINFRA-1985

## Summary
The Danger step was removed from required checks because it blocked the merge queue: on merge queue builds, `build.pull_request.id` is null, so the step was skipped entirely and no commit status was posted.

With the PR https://github.com/Automattic/buildkite-ci/pull/824 targeting the Linter agent, we'll gracefully skip on non-PR builds. This lets us remove the `if` condition and rely on Buildkite's `notify` to always post a status.

## Test plan
- [ ] Verify Danger runs normally on PR builds
- [ ] Verify merge queue builds pass with a green status on Danger