### PR TITLE
Cache Gutenberg XCFramework downloads on disk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+GUTENBERG_VERSION := v1.121.0
+FRAMEWORKS_DIR := WordPress/Frameworks
+
+.PHONY: dependencies
+
+dependencies:
+	./Scripts/download-gutenberg-xcframeworks.sh $(GUTENBERG_VERSION) $(FRAMEWORKS_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,4 @@
-GUTENBERG_VERSION := v1.121.0
-FRAMEWORKS_DIR := WordPress/Frameworks
-
 .PHONY: dependencies
 
 dependencies:
-	./Scripts/download-gutenberg-xcframeworks.sh $(GUTENBERG_VERSION) $(FRAMEWORKS_DIR)
+	./Scripts/download-gutenberg-xcframeworks.sh

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-.PHONY: dependencies
+.PHONY: help dependencies
 
-dependencies:
+help: ## Show available targets
+	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | awk -F ':.*## ' '{printf "  %-20s %s\n", $$1, $$2}'
+
+dependencies: ## Download and cache Gutenberg XCFrameworks
 	./Scripts/download-gutenberg-xcframeworks.sh

--- a/Rakefile
+++ b/Rakefile
@@ -10,8 +10,6 @@ require 'digest'
 RUBY_REPO_VERSION = File.read('./.ruby-version').rstrip
 XCODE_WORKSPACE = 'WordPress.xcworkspace'
 EXPECTED_XCODE_VERSION = File.read('.xcode-version').rstrip
-GUTENBERG_VERSION = 'v1.121.0'
-
 PROJECT_DIR = __dir__
 abort('Project directory contains one or more spaces – unable to continue.') if PROJECT_DIR.include?(' ')
 
@@ -98,7 +96,7 @@ bundle exec fastlane run configure_apply force:true
 
   desc 'Download and extract Gutenberg xcframeworks'
   task :gutenberg_xcframeworks do
-    sh("#{PROJECT_DIR}/Scripts/download-gutenberg-xcframeworks.sh", GUTENBERG_VERSION, 'WordPress/Frameworks')
+    sh("#{PROJECT_DIR}/Scripts/download-gutenberg-xcframeworks.sh")
   end
 end
 

--- a/Rakefile
+++ b/Rakefile
@@ -6,9 +6,6 @@ require 'tmpdir'
 require 'rake/clean'
 require 'yaml'
 require 'digest'
-require 'open-uri'
-require 'rubygems/package'
-require 'zlib'
 
 RUBY_REPO_VERSION = File.read('./.ruby-version').rstrip
 XCODE_WORKSPACE = 'WordPress.xcworkspace'
@@ -101,53 +98,7 @@ bundle exec fastlane run configure_apply force:true
 
   desc 'Download and extract Gutenberg xcframeworks'
   task :gutenberg_xcframeworks do
-    puts 'Setting up Gutenberg xcframeworks...'
-
-    frameworks_dir = 'WordPress/Frameworks'
-
-    # Clean the slate
-    FileUtils.rm_rf(frameworks_dir)
-    FileUtils.mkdir_p(frameworks_dir)
-
-    gutenberg_tar_gz_download_path = "#{frameworks_dir}/Gutenberg.tar.gz"
-
-    URI.open("https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-#{GUTENBERG_VERSION}.tar.gz") do |remote_file|
-      File.binwrite(gutenberg_tar_gz_download_path, remote_file.read)
-    end
-
-    # Extract the archive
-    Zlib::GzipReader.open(gutenberg_tar_gz_download_path) do |gz|
-      Gem::Package::TarReader.new(gz) do |tar|
-        tar.each do |entry|
-          next unless entry.file?
-
-          dest_path = File.join(frameworks_dir, entry.full_name)
-          FileUtils.mkdir_p(File.dirname(dest_path))
-
-          File.binwrite(dest_path, entry.read)
-        end
-      end
-    end
-
-    # Move xcframeworks to the correct location
-    Dir.glob("#{frameworks_dir}/Frameworks/*.xcframework").each do |framework|
-      FileUtils.mv(framework, frameworks_dir, force: false)
-    end
-
-    # Create dSYMs directories
-    FileUtils.mkdir_p [
-      "#{frameworks_dir}/hermes.xcframework/ios-arm64/dSYMs",
-      "#{frameworks_dir}/hermes.xcframework/ios-arm64_x86_64-simulator/dSYMs"
-    ]
-
-    # Cleanup
-    FileUtils.rm_rf [
-      gutenberg_tar_gz_download_path,
-      "#{frameworks_dir}/Frameworks",
-      "#{frameworks_dir}/dummy.txt"
-    ]
-
-    puts 'Gutenberg xcframeworks setup complete'
+    sh("#{PROJECT_DIR}/Scripts/download-gutenberg-xcframeworks.sh", GUTENBERG_VERSION, 'WordPress/Frameworks')
   end
 end
 

--- a/Scripts/download-gutenberg-xcframeworks.sh
+++ b/Scripts/download-gutenberg-xcframeworks.sh
@@ -20,6 +20,7 @@ else
 
     # Extract into a temp directory first so a partial download doesn't
     # leave a corrupt cache that persists across runs.
+    mkdir -p "$(dirname "${CACHE_DIR}")"
     TEMP_DIR="$(mktemp -d "${CACHE_DIR}.XXXXXX")"
     trap 'rm -rf "${TEMP_DIR}"' EXIT
 
@@ -41,7 +42,6 @@ else
     rm -f "${TEMP_DIR}/dummy.txt"
 
     # Atomically promote the temp directory to the final cache path.
-    mkdir -p "$(dirname "${CACHE_DIR}")"
     mv "${TEMP_DIR}" "${CACHE_DIR}"
     trap - EXIT
 fi

--- a/Scripts/download-gutenberg-xcframeworks.sh
+++ b/Scripts/download-gutenberg-xcframeworks.sh
@@ -1,4 +1,5 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
 set -euo pipefail
 
 # Downloads and installs Gutenberg XCFrameworks with progress and on-disk caching.

--- a/Scripts/download-gutenberg-xcframeworks.sh
+++ b/Scripts/download-gutenberg-xcframeworks.sh
@@ -48,7 +48,10 @@ else
 fi
 
 # Copy cached contents into the project.
-rm -rf "${FRAMEWORKS_DIR}"
+if [[ -z "${FRAMEWORKS_DIR}" || "${FRAMEWORKS_DIR}" == "/" ]]; then
+    echo "Error: invalid frameworks directory: '${FRAMEWORKS_DIR}'" >&2
+    exit 1
+fi
 cp -a "${CACHE_DIR}" "${FRAMEWORKS_DIR}"
 
 echo "Gutenberg ${VERSION} setup complete."

--- a/Scripts/download-gutenberg-xcframeworks.sh
+++ b/Scripts/download-gutenberg-xcframeworks.sh
@@ -17,24 +17,33 @@ if [[ -d "${CACHE_DIR}" ]]; then
     echo "Using cached Gutenberg ${VERSION}"
 else
     echo "Downloading Gutenberg ${VERSION}..."
-    mkdir -p "${CACHE_DIR}"
+
+    # Extract into a temp directory first so a partial download doesn't
+    # leave a corrupt cache that persists across runs.
+    TEMP_DIR="$(mktemp -d "${CACHE_DIR}.XXXXXX")"
+    trap 'rm -rf "${TEMP_DIR}"' EXIT
 
     curl --fail --location --progress-bar "${DOWNLOAD_URL}" \
-        | tar xzf - -C "${CACHE_DIR}"
+        | tar xzf - -C "${TEMP_DIR}"
 
     # Move xcframeworks up from the nested Frameworks/ directory.
-    if [[ -d "${CACHE_DIR}/Frameworks" ]]; then
-        mv "${CACHE_DIR}"/Frameworks/*.xcframework "${CACHE_DIR}/"
-        rm -rf "${CACHE_DIR}/Frameworks"
+    if [[ -d "${TEMP_DIR}/Frameworks" ]]; then
+        mv "${TEMP_DIR}"/Frameworks/*.xcframework "${TEMP_DIR}/"
+        rm -rf "${TEMP_DIR}/Frameworks"
     fi
 
     # Create dSYMs directories that Xcode expects for hermes.
     mkdir -p \
-        "${CACHE_DIR}/hermes.xcframework/ios-arm64/dSYMs" \
-        "${CACHE_DIR}/hermes.xcframework/ios-arm64_x86_64-simulator/dSYMs"
+        "${TEMP_DIR}/hermes.xcframework/ios-arm64/dSYMs" \
+        "${TEMP_DIR}/hermes.xcframework/ios-arm64_x86_64-simulator/dSYMs"
 
     # Clean up leftover files from the archive.
-    rm -f "${CACHE_DIR}/dummy.txt"
+    rm -f "${TEMP_DIR}/dummy.txt"
+
+    # Atomically promote the temp directory to the final cache path.
+    mkdir -p "$(dirname "${CACHE_DIR}")"
+    mv "${TEMP_DIR}" "${CACHE_DIR}"
+    trap - EXIT
 fi
 
 # Copy cached frameworks into the project.

--- a/Scripts/download-gutenberg-xcframeworks.sh
+++ b/Scripts/download-gutenberg-xcframeworks.sh
@@ -3,11 +3,11 @@ set -euo pipefail
 
 # Downloads and installs Gutenberg XCFrameworks with progress and on-disk caching.
 #
-# Usage: download-gutenberg-xcframeworks.sh <version> <frameworks_dir>
-# Example: download-gutenberg-xcframeworks.sh v1.121.0 WordPress/Frameworks
+# Usage: download-gutenberg-xcframeworks.sh [frameworks_dir]
+#   frameworks_dir defaults to WordPress/Frameworks
 
-VERSION="${1:?Usage: $0 <version> <frameworks_dir>}"
-FRAMEWORKS_DIR="${2:?Usage: $0 <version> <frameworks_dir>}"
+VERSION="v1.121.0"
+FRAMEWORKS_DIR="${1:-WordPress/Frameworks}"
 
 CACHE_DIR="${HOME}/Library/Caches/WordPress-iOS/Gutenberg/${VERSION}"
 DOWNLOAD_URL="https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-${VERSION}.tar.gz"

--- a/Scripts/download-gutenberg-xcframeworks.sh
+++ b/Scripts/download-gutenberg-xcframeworks.sh
@@ -27,9 +27,9 @@ else
     curl --fail --location --progress-bar "${DOWNLOAD_URL}" \
         | tar xzf - -C "${TEMP_DIR}"
 
-    # Move xcframeworks up from the nested Frameworks/ directory.
+    # Move contents up from the nested Frameworks/ directory.
     if [[ -d "${TEMP_DIR}/Frameworks" ]]; then
-        mv "${TEMP_DIR}"/Frameworks/*.xcframework "${TEMP_DIR}/"
+        mv "${TEMP_DIR}"/Frameworks/* "${TEMP_DIR}/"
         rm -rf "${TEMP_DIR}/Frameworks"
     fi
 
@@ -46,9 +46,8 @@ else
     trap - EXIT
 fi
 
-# Copy cached frameworks into the project.
+# Copy cached contents into the project.
 rm -rf "${FRAMEWORKS_DIR}"
-mkdir -p "${FRAMEWORKS_DIR}"
-cp -a "${CACHE_DIR}/"*.xcframework "${FRAMEWORKS_DIR}/"
+cp -a "${CACHE_DIR}" "${FRAMEWORKS_DIR}"
 
 echo "Gutenberg ${VERSION} setup complete."

--- a/Scripts/download-gutenberg-xcframeworks.sh
+++ b/Scripts/download-gutenberg-xcframeworks.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+set -euo pipefail
+
+# Downloads and installs Gutenberg XCFrameworks with progress and on-disk caching.
+#
+# Usage: download-gutenberg-xcframeworks.sh <version> <frameworks_dir>
+# Example: download-gutenberg-xcframeworks.sh v1.121.0 WordPress/Frameworks
+
+VERSION="${1:?Usage: $0 <version> <frameworks_dir>}"
+FRAMEWORKS_DIR="${2:?Usage: $0 <version> <frameworks_dir>}"
+
+CACHE_DIR="${HOME}/Library/Caches/WordPress-iOS/Gutenberg/${VERSION}"
+DOWNLOAD_URL="https://cdn.a8c-ci.services/gutenberg-mobile/Gutenberg-${VERSION}.tar.gz"
+
+# Download and extract into the cache if this version isn't cached yet.
+if [[ -d "${CACHE_DIR}" ]]; then
+    echo "Using cached Gutenberg ${VERSION}"
+else
+    echo "Downloading Gutenberg ${VERSION}..."
+    mkdir -p "${CACHE_DIR}"
+
+    curl --fail --location --progress-bar "${DOWNLOAD_URL}" \
+        | tar xzf - -C "${CACHE_DIR}"
+
+    # Move xcframeworks up from the nested Frameworks/ directory.
+    if [[ -d "${CACHE_DIR}/Frameworks" ]]; then
+        mv "${CACHE_DIR}"/Frameworks/*.xcframework "${CACHE_DIR}/"
+        rm -rf "${CACHE_DIR}/Frameworks"
+    fi
+
+    # Create dSYMs directories that Xcode expects for hermes.
+    mkdir -p \
+        "${CACHE_DIR}/hermes.xcframework/ios-arm64/dSYMs" \
+        "${CACHE_DIR}/hermes.xcframework/ios-arm64_x86_64-simulator/dSYMs"
+
+    # Clean up leftover files from the archive.
+    rm -f "${CACHE_DIR}/dummy.txt"
+fi
+
+# Copy cached frameworks into the project.
+rm -rf "${FRAMEWORKS_DIR}"
+mkdir -p "${FRAMEWORKS_DIR}"
+cp -a "${CACHE_DIR}/"*.xcframework "${FRAMEWORKS_DIR}/"
+
+echo "Gutenberg ${VERSION} setup complete."


### PR DESCRIPTION
## Summary

We're not quite done with Gutenberg Mobile yet, and we'll still have Aztec around for the foreseeable future. Using worktrees, it's annoying having to redownload 160MB every time, so I wanted to improve the situation.

This PR moves the logic to Bash to make it pretty much dependency-free, but for folks with `rake` muscle memory everything still works properly.

- Replace Ruby download/extract logic in Rakefile with a bash script (`Scripts/download-gutenberg-xcframeworks.sh`) that uses `curl --progress-bar` for visible download feedback
- Cache extracted XCFrameworks in `~/Library/Caches/WordPress-iOS/Gutenberg/<version>/` so subsequent runs just `cp -a` from cache instead of re-downloading
- Add a `Makefile` with a `dependencies` target as a lightweight alternative to `rake dependencies:gutenberg_xcframeworks`
- Remove now-unused `open-uri`, `rubygems/package`, and `zlib` requires from Rakefile

## Test plan
- [ ] `rm -rf WordPress/Frameworks ~/Library/Caches/WordPress-iOS/Gutenberg` then `bundle exec rake dependencies:gutenberg_xcframeworks` — should download with progress and complete successfully
- [ ] Run the same rake task again — should print "Using cached" and skip the download
- [ ] `rm -rf WordPress/Frameworks` then `make dependencies` — should restore frameworks from cache without downloading
- [ ] Verify the app builds after running the script

🤖 Generated with [Claude Code](https://claude.com/claude-code)