### PR TITLE
Custom Posts: Show published pages with hierarchy

### DIFF
--- a/Tests/KeystoneTests/Tests/Utility/PageTreeTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/PageTreeTests.swift
@@ -1,0 +1,89 @@
+import Testing
+
+@testable import WordPress
+
+struct PageTreeTests {
+
+    private struct MockPost: HierarchicalPost {
+        var id: Int64 { postId }
+        var postId: Int64
+        var parentPostId: Int64 = 0
+        var order: Int64 = 0
+    }
+
+    @Test func flatList() {
+        let posts = [
+            MockPost(postId: 1),
+            MockPost(postId: 2),
+            MockPost(postId: 3),
+        ]
+        let result = PageTree.buildHierarchy(from: posts)
+        #expect(result.count == 3)
+        #expect(result.map(\.id) == [1, 2, 3])
+        #expect(result.allSatisfy { $0.indentationLevel == 0 })
+        #expect(result.allSatisfy { !$0.hasVisibleParent })
+    }
+
+    @Test func parentWithChildren() {
+        let posts = [
+            MockPost(postId: 1),
+            MockPost(postId: 2, parentPostId: 1),
+            MockPost(postId: 3, parentPostId: 1),
+            MockPost(postId: 4),
+        ]
+        let result = PageTree.buildHierarchy(from: posts)
+        #expect(result.map(\.id) == [1, 2, 3, 4])
+        #expect(result.map(\.indentationLevel) == [0, 1, 1, 0])
+        #expect(!result[0].hasVisibleParent)
+        #expect(result[1].hasVisibleParent)
+        #expect(result[2].hasVisibleParent)
+        #expect(!result[3].hasVisibleParent)
+    }
+
+    @Test func nestedHierarchy() {
+        let posts = [
+            MockPost(postId: 1),
+            MockPost(postId: 2, parentPostId: 1),
+            MockPost(postId: 3, parentPostId: 2),
+        ]
+        let result = PageTree.buildHierarchy(from: posts)
+        #expect(result.map(\.id) == [1, 2, 3])
+        #expect(result.map(\.indentationLevel) == [0, 1, 2])
+    }
+
+    @Test func orphanedPostsBecomeTopLevel() {
+        let posts = [
+            MockPost(postId: 1),
+            MockPost(postId: 2, parentPostId: 999),
+        ]
+        let result = PageTree.buildHierarchy(from: posts)
+        #expect(result.count == 2)
+        #expect(result.allSatisfy { $0.indentationLevel == 0 })
+    }
+
+    @Test func childBeforeParent() {
+        let posts = [
+            MockPost(postId: 2, parentPostId: 1),
+            MockPost(postId: 1),
+        ]
+        let result = PageTree.buildHierarchy(from: posts)
+        #expect(result.map(\.id) == [1, 2])
+        #expect(result.map(\.indentationLevel) == [0, 1])
+    }
+
+    @Test func childrenSortedByOrder() {
+        let posts = [
+            MockPost(postId: 1),
+            MockPost(postId: 2, parentPostId: 1, order: 3),
+            MockPost(postId: 3, parentPostId: 1, order: 1),
+            MockPost(postId: 4, parentPostId: 1, order: 2),
+        ]
+        let result = PageTree.buildHierarchy(from: posts)
+        #expect(result.map(\.id) == [1, 3, 4, 2])
+    }
+
+    @Test func emptyInput() {
+        let result = PageTree.buildHierarchy(from: [MockPost]())
+        #expect(result.isEmpty)
+    }
+}

--- a/WordPress/Classes/Utility/PageTree.swift
+++ b/WordPress/Classes/Utility/PageTree.swift
@@ -1,81 +1,84 @@
 import WordPressData
 
+protocol HierarchicalPost: Identifiable {
+    var postId: Int64 { get }
+    var parentPostId: Int64 { get }
+    var order: Int64 { get }
+}
+
 final class PageTree {
 
+    struct Entry<ID: Hashable>: Equatable {
+        let id: ID
+        let indentationLevel: Int
+        let hasVisibleParent: Bool
+    }
+
     // A node in a tree, which of course is also a tree itself.
-    private class TreeNode {
-        let page: Page
+    private class TreeNode<ID: Hashable> {
+        let id: ID
+        let postId: Int64
+        let parentPostId: Int64
+        let order: Int64
+
         var children = [TreeNode]()
         var parentNode: TreeNode?
 
-        init(page: Page) {
-            self.page = page
+        init<P: HierarchicalPost>(post: P) where P.ID == ID {
+            self.id = post.id
+            self.postId = post.postId
+            self.parentPostId = post.parentPostId
+            self.order = post.order
         }
 
-        func dfsList() -> [Page] {
-            var pages = [Page]()
-            _ = depthFirstSearch(sortByPageOrder: true) { level, node in
-                let page = node.page
-                page.hierarchyIndex = level
-                page.hasVisibleParent = node.parentNode != nil
-                pages.append(page)
-                return false
+        func dfsList() -> [Entry<ID>] {
+            var entries = [Entry<ID>]()
+            depthFirstSearch(level: 0) { level, node in
+                entries.append(Entry(
+                    id: node.id,
+                    indentationLevel: level,
+                    hasVisibleParent: node.parentNode != nil
+                ))
             }
-            return pages
+            return entries
         }
 
         /// Perform depth-first search starting with the current (`self`) node.
-        ///
-        /// - Parameter closure: A closure that takes a node and its level in the page tree as arguments and returns
-        ///     a boolean value indicate whether the search should be stopped.
-        /// - Returns: `true` if search has been stopped by the closure.
-        @discardableResult
-        func depthFirstSearch(sortByPageOrder: Bool, using closure: (Int, TreeNode) -> Bool) -> Bool {
-            depthFirstSearch(level: 0, sortByPageOrder: sortByPageOrder, using: closure)
-        }
-
-        private func depthFirstSearch(level: Int, sortByPageOrder: Bool, using closure: (Int, TreeNode) -> Bool) -> Bool {
-            let shouldStop = closure(level, self)
-            if shouldStop {
-                return true
+        private func depthFirstSearch(level: Int, using closure: (Int, TreeNode) -> Void) {
+            closure(level, self)
+            let sorted = children.sorted { $0.order < $1.order }
+            for child in sorted {
+                child.depthFirstSearch(level: level + 1, using: closure)
             }
-
-            let pages = sortByPageOrder ? children.sorted(using: KeyPathComparator(\TreeNode.page.order)) : children
-            for child in pages {
-                let shouldStop = child.depthFirstSearch(level: level + 1, sortByPageOrder: sortByPageOrder, using: closure)
-                if shouldStop {
-                    return true
-                }
-            }
-
-            return false
         }
     }
 
-    static func hierarchyList(of pages: [Page]) -> [Page] {
-        // An array of `TreeNode` instances that are one-to-one map of the `pages` list.
-        var nodes: [TreeNode] = []
-        // A map of parent page (the dictionary key) to its children (the dictionary value).
-        var children: [NSNumber: [TreeNode]] = [:]
-        var allPostIDs: Set<NSNumber> = []
+    static func buildHierarchy<P: HierarchicalPost>(from posts: [P]) -> [Entry<P.ID>] {
+        // An array of `TreeNode` instances that are one-to-one map of the `posts` list.
+        var nodes: [TreeNode<P.ID>] = []
+        // A map of parent post (the dictionary key) to its children (the dictionary value).
+        var children: [Int64: [TreeNode<P.ID>]] = [:]
+        var allPostIDs: Set<Int64> = []
 
-        for page in pages {
-            let node = TreeNode(page: page)
+        for post in posts {
+            let node = TreeNode(post: post)
             nodes.append(node)
-            allPostIDs.insert(page.postID ?? 0)
-            children[page.parentID ?? 0, default: []].append(node)
+            allPostIDs.insert(post.postId)
+            children[post.parentPostId, default: []].append(node)
         }
 
-        // Move children nodes to through the given node and its descendants.
-        func addChildren(to node: TreeNode) {
-            node.children = children[node.page.postID ?? 0] ?? []
+        // Move children nodes to the given node and its descendants.
+        func addChildren(to node: TreeNode<P.ID>) {
+            node.children = children[node.postId] ?? []
+            for child in node.children {
+                child.parentNode = node
+            }
             node.children.forEach(addChildren(to:))
         }
 
-        // The top level nodes are pages whose parent id is 0 and pages whose parent page are not in the `pages` list.
+        // The top level nodes are posts whose parent id is 0 and posts whose parent are not in the `posts` list.
         let topLevelNodes = nodes.filter {
-            let parentID = $0.page.parentID ?? 0
-            return ($0.page.parentID ?? 0) == 0 || !allPostIDs.contains(parentID)
+            $0.parentPostId == 0 || !allPostIDs.contains($0.parentPostId)
         }
 
         topLevelNodes.forEach(addChildren(to:))
@@ -83,5 +86,37 @@ final class PageTree {
         return topLevelNodes.reduce(into: []) {
             $0.append(contentsOf: $1.dfsList())
         }
+    }
+
+    static func hierarchyList(of pages: [Page]) -> [Page] {
+        let entries = buildHierarchy(from: pages.map { HierarchicalPage(page: $0) })
+        let pageMap = Dictionary(pages.map { ($0.objectID, $0) }, uniquingKeysWith: { first, _ in first })
+
+        return entries.compactMap { entry -> Page? in
+            guard let page = pageMap[entry.id] else { return nil }
+            page.hierarchyIndex = entry.indentationLevel
+            page.hasVisibleParent = entry.hasVisibleParent
+            return page
+        }
+    }
+}
+
+private struct HierarchicalPage: HierarchicalPost {
+    let page: Page
+
+    var id: NSManagedObjectID {
+        page.objectID
+    }
+
+    var postId: Int64 {
+        page.postID?.int64Value ?? 0
+    }
+
+    var parentPostId: Int64 {
+        page.parentID?.int64Value ?? 0
+    }
+
+    var order: Int64 {
+        page.order
     }
 }

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListView.swift
@@ -139,38 +139,9 @@ private struct PaginatedList<Header: View>: View {
             .listSectionSeparator(.hidden)
 
             if indentationMap.isEmpty {
-                ForEach(items) { item in
-                    ForEachContent(
-                        item: item,
-                        client: client,
-                        onSelectPost: onSelectPost,
-                        mediaHost: mediaHost
-                    )
-                    .task {
-                        await onRowAppear(item: item)
-                    }
-                }
+                flatList
             } else {
-                ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
-                    let showSubdirectoryIcon: Bool = {
-                        guard let entry = indentationMap[item.id], entry.indentationLevel > 0, index > 0 else {
-                            return false
-                        }
-                        let previousLevel = indentationMap[items[index - 1].id]?.indentationLevel ?? 0
-                        return entry.indentationLevel == previousLevel + 1
-                    }()
-                    ForEachContentWithIndentation(
-                        item: item,
-                        client: client,
-                        onSelectPost: onSelectPost,
-                        mediaHost: mediaHost,
-                        indentationLevel: indentationMap[item.id]?.indentationLevel ?? 0,
-                        showSubdirectoryIcon: showSubdirectoryIcon
-                    )
-                    .task {
-                        await onRowAppear(item: item)
-                    }
-                }
+                hierarchicalList
             }
 
             Section {
@@ -179,6 +150,45 @@ private struct PaginatedList<Header: View>: View {
             .listSectionSeparator(.hidden)
         }
         .listStyle(.plain)
+    }
+
+    private var flatList: some View {
+        ForEach(items) { item in
+            ForEachContent(
+                item: item,
+                client: client,
+                onSelectPost: onSelectPost,
+                mediaHost: mediaHost
+            )
+            .task {
+                await onRowAppear(item: item)
+            }
+        }
+    }
+
+    private var hierarchicalList: some View {
+        ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+            ForEachContentWithIndentation(
+                item: item,
+                client: client,
+                onSelectPost: onSelectPost,
+                mediaHost: mediaHost,
+                indentationLevel: indentationMap[item.id]?.indentationLevel ?? 0,
+                showSubdirectoryIcon: showSubdirectoryIcon(at: index)
+            )
+            .task {
+                await onRowAppear(item: item)
+            }
+        }
+    }
+
+    private func showSubdirectoryIcon(at index: Int) -> Bool {
+        let item = items[index]
+        guard let entry = indentationMap[item.id], entry.indentationLevel > 0, index > 0 else {
+            return false
+        }
+        let previousLevel = indentationMap[items[index - 1].id]?.indentationLevel ?? 0
+        return entry.indentationLevel == previousLevel + 1
     }
 
     private func onRowAppear(item: CustomPostCollectionItem) async {

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListView.swift
@@ -54,6 +54,7 @@ struct CustomPostListView<Header: View>: View {
             client: client,
             onSelectPost: onSelectPost,
             mediaHost: mediaHost,
+            indentationMap: viewModel.indentationMap,
             header: header
         )
         .overlay {
@@ -87,6 +88,7 @@ private struct PaginatedList<Header: View>: View {
     let client: WordPressClient?
     let onSelectPost: (AnyPostWithEditContext) -> Void
     let mediaHost: MediaHost?
+    let indentationMap: CustomPostListViewModel.IndentationMap
     @ViewBuilder let header: () -> Header
 
     @State var isLoadingMore = false
@@ -97,13 +99,15 @@ private struct PaginatedList<Header: View>: View {
         onLoadNextPage: @escaping () async throws -> Void,
         client: WordPressClient? = nil,
         onSelectPost: @escaping (AnyPostWithEditContext) -> Void,
-        mediaHost: MediaHost? = nil
+        mediaHost: MediaHost? = nil,
+        indentationMap: CustomPostListViewModel.IndentationMap = [:]
     ) where Header == EmptyView {
         self.items = items
         self.onLoadNextPage = onLoadNextPage
         self.client = client
         self.onSelectPost = onSelectPost
         self.mediaHost = mediaHost
+        self.indentationMap = indentationMap
         self.header = { EmptyView() }
     }
 
@@ -113,6 +117,7 @@ private struct PaginatedList<Header: View>: View {
         client: WordPressClient? = nil,
         onSelectPost: @escaping (AnyPostWithEditContext) -> Void,
         mediaHost: MediaHost? = nil,
+        indentationMap: CustomPostListViewModel.IndentationMap = [:],
         @ViewBuilder header: @escaping () -> Header
     ) {
         self.items = items
@@ -120,6 +125,7 @@ private struct PaginatedList<Header: View>: View {
         self.client = client
         self.onSelectPost = onSelectPost
         self.mediaHost = mediaHost
+        self.indentationMap = indentationMap
         self.header = header
     }
 
@@ -132,11 +138,39 @@ private struct PaginatedList<Header: View>: View {
             .listSectionSpacing(0)
             .listSectionSeparator(.hidden)
 
-            ForEach(items) { item in
-                ForEachContent(item: item, client: client, onSelectPost: onSelectPost, mediaHost: mediaHost)
+            if indentationMap.isEmpty {
+                ForEach(items) { item in
+                    ForEachContent(
+                        item: item,
+                        client: client,
+                        onSelectPost: onSelectPost,
+                        mediaHost: mediaHost
+                    )
                     .task {
                         await onRowAppear(item: item)
                     }
+                }
+            } else {
+                ForEach(Array(items.enumerated()), id: \.element.id) { index, item in
+                    let showSubdirectoryIcon: Bool = {
+                        guard let entry = indentationMap[item.id], entry.indentationLevel > 0, index > 0 else {
+                            return false
+                        }
+                        let previousLevel = indentationMap[items[index - 1].id]?.indentationLevel ?? 0
+                        return entry.indentationLevel == previousLevel + 1
+                    }()
+                    ForEachContentWithIndentation(
+                        item: item,
+                        client: client,
+                        onSelectPost: onSelectPost,
+                        mediaHost: mediaHost,
+                        indentationLevel: indentationMap[item.id]?.indentationLevel ?? 0,
+                        showSubdirectoryIcon: showSubdirectoryIcon
+                    )
+                    .task {
+                        await onRowAppear(item: item)
+                    }
+                }
             }
 
             Section {
@@ -230,6 +264,34 @@ private struct ForEachContent: View {
         case .stale(_, let post):
             PostContent(post: post, client: client, mediaHost: mediaHost)
         }
+    }
+}
+
+private struct ForEachContentWithIndentation: View {
+    let item: CustomPostCollectionItem
+    let client: WordPressClient?
+    let onSelectPost: (AnyPostWithEditContext) -> Void
+    let mediaHost: MediaHost?
+    let indentationLevel: Int
+    let showSubdirectoryIcon: Bool
+
+    var body: some View {
+        HStack(spacing: 0) {
+            if indentationLevel > 0 {
+                Image("subdirectory")
+                    .foregroundStyle(.secondary)
+                    .opacity(showSubdirectoryIcon ? 1 : 0)
+                    .padding(.trailing, 8)
+            }
+
+            ForEachContent(
+                item: item,
+                client: client,
+                onSelectPost: onSelectPost,
+                mediaHost: mediaHost
+            )
+        }
+        .padding(.leading, CGFloat(max(0, indentationLevel - 1)) * 32)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
@@ -8,15 +8,19 @@ import WordPressShared
 
 @MainActor
 final class CustomPostListViewModel: ObservableObject {
+    typealias IndentationMap = [Int64: PageTree.Entry<Int64>]
+
     private let client: WordPressClient
-    private let endpoint: PostEndpointType
     private let blog: Blog
+    private let isHierarchical: Bool
     let filter: CustomPostListFilter
 
     private var collection: PostMetadataCollectionWithEditContext
+    private var isBatchSyncing = false
 
     @Published private(set) var items: [CustomPostCollectionItem] = []
     @Published private(set) var listInfo: ListInfo?
+    @Published private(set) var indentationMap: IndentationMap = [:]
     @Published private var error: Error?
 
     var shouldDisplayEmptyView: Bool {
@@ -34,34 +38,36 @@ final class CustomPostListViewModel: ObservableObject {
     init(
         client: WordPressClient,
         service: WpService,
-        endpoint: PostEndpointType,
+        details: PostTypeDetailsWithEditContext,
         filter: CustomPostListFilter,
         blog: Blog
     ) {
         self.client = client
-        self.endpoint = endpoint
         self.blog = blog
+        self.isHierarchical = details.hierarchical
         self.filter = filter
 
         collection = service
             .posts()
             .createPostMetadataCollectionWithEditContext(
-                endpointType: endpoint,
+                endpointType: details.toPostEndpointType(),
                 filter: filter.asPostListFilter(),
                 perPage: 20
             )
     }
 
     func refresh() async {
-        do {
-            _ = try await collection.refresh()
-        } catch {
-            DDLogError("Failed to refresh posts: \(error)")
-            self.show(error: error)
+        if shouldDisplayHierarchy {
+            await fetchAllPages()
+        } else {
+            await fetchWithPagination()
         }
     }
 
     func loadNextPage() async throws {
+        // All pages are already loaded by refresh() for hierarchical posts.
+        guard !shouldDisplayHierarchy else { return }
+
         if let listInfo, listInfo.isSyncing || !listInfo.hasMorePages {
             return
         }
@@ -77,13 +83,11 @@ final class CustomPostListViewModel: ObservableObject {
         let listInfo = collection.listInfo()
 
         do {
-            let items = try await collection.loadItems().map { CustomPostCollectionItem(item: $0, blog: blog, filterStatus: filter.status) }
+            let metadataItems = try await collection.loadItems()
             if self.listInfo != listInfo {
                 self.listInfo = listInfo
             }
-            if self.items != items {
-                self.items = items
-            }
+            updateItems(from: metadataItems)
         } catch {
             DDLogError("Failed to load cached items: \(error)")
         }
@@ -95,6 +99,8 @@ final class CustomPostListViewModel: ObservableObject {
             .collect(.byTime(DispatchQueue.main, .milliseconds(50)))
             .values
         for await batch in batches {
+            guard !isBatchSyncing else { continue }
+
             DDLogInfo("\(batch.count) updates received from WpApiCache")
 
             #if DEBUG
@@ -108,19 +114,81 @@ final class CustomPostListViewModel: ObservableObject {
             DDLogInfo("List info: \(String(describing: listInfo))")
 
             do {
-                let items = try await collection.loadItems().map { CustomPostCollectionItem(item: $0, blog: blog, filterStatus: filter.status) }
+                let metadataItems = try await collection.loadItems()
                 withAnimation {
                     if self.listInfo != listInfo {
                         self.listInfo = listInfo
                     }
-                    if self.items != items {
-                        self.items = items
-                    }
+                    updateItems(from: metadataItems)
                 }
             } catch {
                 DDLogError("Failed to get collection items: \(error)")
             }
         }
+    }
+
+    // MARK: - Loading Strategies
+
+    /// Fetches the first page and lets `handleDataChanges` update the UI
+    /// incrementally as each page loads.
+    private func fetchWithPagination() async {
+        do {
+            _ = try await collection.refresh()
+        } catch {
+            DDLogError("Failed to refresh posts: \(error)")
+            self.show(error: error)
+        }
+    }
+
+    /// Fetches all pages before updating the UI, so the hierarchy tree is
+    /// built once from the complete dataset.
+    private func fetchAllPages() async {
+        isBatchSyncing = true
+        defer { isBatchSyncing = false }
+
+        do {
+            _ = try await collection.refresh()
+
+            while true {
+                guard let listInfo = collection.listInfo(), listInfo.hasMorePages, !listInfo.isSyncing else {
+                    break
+                }
+                _ = try await collection.loadNextPage()
+            }
+
+            await loadCachedItems()
+        } catch {
+            DDLogError("Failed to refresh all pages: \(error)")
+            self.show(error: error)
+        }
+    }
+
+    private var shouldDisplayHierarchy: Bool {
+        isHierarchical && filter.status == .publish
+    }
+
+    private func updateItems(from metadataItems: [PostMetadataCollectionItem]) {
+        let items = metadataItems.map { CustomPostCollectionItem(item: $0, blog: blog, filterStatus: filter.status) }
+
+        guard shouldDisplayHierarchy else {
+            indentationMap = [:]
+            self.items = items
+            return
+        }
+
+        // Use metadata items for hierarchy data, since parent/menuOrder are
+        // available from list metadata regardless of the item's fetch state.
+        let posts = metadataItems.map { item in
+            HierarchyInput(postId: item.id, parentPostId: item.parent ?? 0, order: Int64(item.menuOrder ?? 0))
+        }
+
+        let entries = PageTree.buildHierarchy(from: posts)
+        let itemMap = Dictionary(uniqueKeysWithValues: items.compactMap { item -> (Int64, CustomPostCollectionItem)? in
+            return (item.id, item)
+        })
+
+        indentationMap = Dictionary(uniqueKeysWithValues: entries.map { ($0.id, $0) })
+        self.items = entries.compactMap { itemMap[$0.id] }
     }
 
     private func show(error: Error) {
@@ -340,5 +408,29 @@ private extension ListInfo {
     var hasMorePages: Bool {
         guard let currentPage, let totalPages else { return true }
         return currentPage < totalPages
+    }
+}
+
+private struct HierarchyInput: HierarchicalPost {
+    var id: Int64 {
+        postId
+    }
+
+    var postId: Int64
+    var parentPostId: Int64
+    var order: Int64
+}
+
+extension AnyPostWithEditContext: HierarchicalPost {
+    var postId: Int64 {
+        id
+    }
+
+    var parentPostId: Int64 {
+        parent ?? 0
+    }
+
+    var order: Int64 {
+        Int64(menuOrder ?? 0)
     }
 }

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
@@ -149,7 +149,7 @@ final class CustomPostListViewModel: ObservableObject {
         do {
             _ = try await collection.refresh()
 
-            while true {
+            while !Task.isCancelled {
                 guard let listInfo = collection.listInfo(), listInfo.hasMorePages, !listInfo.isSyncing else {
                     break
                 }
@@ -192,6 +192,7 @@ final class CustomPostListViewModel: ObservableObject {
     }
 
     private func show(error: Error) {
+        // TODO: Ignore error https://github.com/Automattic/wordpress-rs/pull/1227
         self.error = error
 
         if !items.isEmpty {

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
@@ -164,7 +164,7 @@ final class CustomPostListViewModel: ObservableObject {
     }
 
     private var shouldDisplayHierarchy: Bool {
-        isHierarchical && filter.status == .publish
+        isHierarchical && (filter.status == .publish || filter.status == .custom("any"))
     }
 
     private func updateItems(from metadataItems: [PostMetadataCollectionItem]) {

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostSearchResultView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostSearchResultView.swift
@@ -9,7 +9,6 @@ struct CustomPostSearchResultView: View {
     let blog: Blog
     let client: WordPressClient
     let service: WpService
-    let endpoint: PostEndpointType
     let details: PostTypeDetailsWithEditContext
     @Binding var searchText: String
     let onSelectPost: (AnyPostWithEditContext) -> Void
@@ -21,7 +20,7 @@ struct CustomPostSearchResultView: View {
             viewModel: CustomPostListViewModel(
                 client: client,
                 service: service,
-                endpoint: endpoint,
+                details: details,
                 filter: CustomPostListFilter.default.with(search: finalSearchText),
                 blog: blog
             ),

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostTabView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostTabView.swift
@@ -11,7 +11,6 @@ import DesignSystem
 struct CustomPostTabView: View {
     let client: WordPressClient
     let service: WpService
-    let endpoint: PostEndpointType
     let details: PostTypeDetailsWithEditContext
     let blog: Blog
 
@@ -43,48 +42,46 @@ struct CustomPostTabView: View {
     init(
         client: WordPressClient,
         service: WpService,
-        endpoint: PostEndpointType,
         details: PostTypeDetailsWithEditContext,
         blog: Blog
     ) {
         self.client = client
         self.service = service
-        self.endpoint = endpoint
         self.details = details
         self.blog = blog
 
         _allViewModel = State(initialValue: CustomPostListViewModel(
             client: client,
             service: service,
-            endpoint: endpoint,
+            details: details,
             filter: CustomPostListFilter(status: .custom("any")),
             blog: blog
         ))
         _publishedViewModel = State(initialValue: CustomPostListViewModel(
             client: client,
             service: service,
-            endpoint: endpoint,
+            details: details,
             filter: CustomPostListFilter(status: .publish),
             blog: blog
         ))
         _draftsViewModel = State(initialValue: CustomPostListViewModel(
             client: client,
             service: service,
-            endpoint: endpoint,
+            details: details,
             filter: CustomPostListFilter(status: .draft),
             blog: blog
         ))
         _scheduledViewModel = State(initialValue: CustomPostListViewModel(
             client: client,
             service: service,
-            endpoint: endpoint,
+            details: details,
             filter: CustomPostListFilter(status: .future),
             blog: blog
         ))
         _trashViewModel = State(initialValue: CustomPostListViewModel(
             client: client,
             service: service,
-            endpoint: endpoint,
+            details: details,
             filter: CustomPostListFilter(status: .trash),
             blog: blog
         ))
@@ -106,7 +103,6 @@ struct CustomPostTabView: View {
                     blog: blog,
                     client: client,
                     service: service,
-                    endpoint: endpoint,
                     details: details,
                     searchText: $searchText,
                     onSelectPost: { editorPresentation = .editPost($0) }

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostTypesView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostTypesView.swift
@@ -106,7 +106,7 @@ struct CustomPostTypesView: View {
         let isPinned = pinnedTypes.contains { $0.slug == details.slug }
         return NavigationLink {
             if let wpService = service.wpService {
-                CustomPostTabView(client: service.client, service: wpService, endpoint: details.toPostEndpointType(), details: details, blog: blog)
+                CustomPostTabView(client: service.client, service: wpService, details: details, blog: blog)
             } else {
                 let _ = wpAssertionFailure("Expected wpService to be available")
             }

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/PinnedPostTypeView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/PinnedPostTypeView.swift
@@ -28,7 +28,7 @@ struct PinnedPostTypeView: View {
     var body: some View {
         Group {
             if let details, let wpService = customPostTypeService.wpService {
-                CustomPostTabView(client: customPostTypeService.client, service: wpService, endpoint: details.toPostEndpointType(), details: details, blog: blog)
+                CustomPostTabView(client: customPostTypeService.client, service: wpService, details: details, blog: blog)
             } else if isLoading {
                 ProgressView()
                     .progressViewStyle(.circular)


### PR DESCRIPTION
## Description

In the existing Pages screen, all pages are fetched and reorganized into a tree. This PR implements the same on the custom post list.

## Testing instructions

Compare the existing Pages screen with the one backed by the wordpress-rs library. They should show the same list of pages.
