### PR TITLE
Fix retain cycle in ReaderDetailsViewController

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 26.8
 -----
 * [*] Fix an issue Social Sharing placeholder card showing unsupported services [#25336]
+* [*] [internal] Fix retain cycle in Reader Article screen [#25364]
 
 
 26.7

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -598,7 +598,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
             /// (except for a few times when it returns a very big weird number)
             /// We use that value so the content is not displayed with weird empty space at the bottom
             ///
-            self.webView.evaluateJavaScript("document.body.scrollHeight", completionHandler: { (webViewHeight, error) in
+            self.webView.evaluateJavaScript("document.body.scrollHeight", completionHandler: { [weak self] (webViewHeight, error) in
+                guard let self else { return }
                 guard let webViewHeight = webViewHeight as? CGFloat else {
                     self.webViewHeight.constant = height
                     return

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -31,10 +31,6 @@ class ReaderWebView: WKWebView {
 
     var displaySetting: ReaderDisplaySettings = .standard
 
-    deinit {
-        print("here")
-    }
-
     /// Make the webview transparent
     ///
     override func awakeFromNib() {


### PR DESCRIPTION
Now `ReaderDetailsViewController`, `ReaderWebView`, and everything else retains by the view controller deallocate as expected.