### PR TITLE
Add gallery viewer support to Reader Article screen

### DIFF
--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -235,7 +235,12 @@ let package = Package(
         ),
         .target(
             name: "WordPressReader",
-            dependencies: ["AsyncImageKit", "WordPressUI", "WordPressShared"],
+            dependencies: [
+                "AsyncImageKit",
+                "WordPressUI",
+                "WordPressShared",
+                .product(name: "SwiftSoup", package: "SwiftSoup"),
+            ],
             resources: [.process("Resources")]
         ),
         .testTarget(name: "JetpackStatsTests", dependencies: ["JetpackStats"]),
@@ -256,7 +261,8 @@ let package = Package(
         .testTarget(name: "WordPressSharedObjCTests", dependencies: [.target(name: "WordPressShared"), .target(name: "WordPressTesting")], swiftSettings: [.swiftLanguageMode(.v5)]),
         .testTarget(name: "WordPressUIUnitTests", dependencies: [.target(name: "WordPressUI")], swiftSettings: [.swiftLanguageMode(.v5)]),
         .testTarget(name: "WordPressCoreTests", dependencies: [.target(name: "WordPressCore")]),
-        .testTarget(name: "WordPressIntelligenceTests", dependencies: [.target(name: "WordPressIntelligence")])
+        .testTarget(name: "WordPressIntelligenceTests", dependencies: [.target(name: "WordPressIntelligence")]),
+        .testTarget(name: "WordPressReaderTests", dependencies: [.target(name: "WordPressReader")])
     ]
 )
 

--- a/Modules/Sources/WordPressReader/ReaderPostParser.swift
+++ b/Modules/Sources/WordPressReader/ReaderPostParser.swift
@@ -1,0 +1,145 @@
+import Foundation
+import SwiftSoup
+
+public enum ReaderPostParser {
+    public enum InteractiveElement: Sendable {
+        case gallery(Gallery)
+    }
+
+    public struct Gallery: Sendable {
+        public let images: [GalleryImage]
+    }
+
+    public struct GalleryImage: Sendable {
+        /// URL from the `src` attribute (displayed, possibly resized).
+        public let src: URL
+        /// Full-resolution URL from `data-orig-file`.
+        public let originalFileURL: URL?
+        /// Original dimensions from `data-orig-size` (e.g. "4032,3024").
+        public let originalSize: CGSize?
+        /// All srcset variants with their width descriptors.
+        public let srcset: [SrcsetEntry]
+        /// From `data-image-description`.
+        public let description: String?
+        /// From `data-image-caption`.
+        public let caption: String?
+    }
+
+    public struct SrcsetEntry: Sendable {
+        public let url: URL
+        public let width: Int
+    }
+
+    /// Parses post HTML and returns interactive elements (galleries).
+    public static func parse(_ html: String) -> [InteractiveElement] {
+        guard let document = try? SwiftSoup.parse(html) else {
+            return []
+        }
+
+        var elements: [InteractiveElement] = []
+
+        // Supported gallery selectors (order matters for specificity)
+        let selectors = [
+            "figure.wp-block-gallery",
+            "figure.wp-block-jetpack-tiled-gallery",
+            "div.tiled-gallery",
+            "div.gallery"
+        ]
+
+        for selector in selectors {
+            guard let containers = try? document.select(selector) else { continue }
+            for container in containers {
+                let images = parseImages(from: container)
+                if !images.isEmpty {
+                    elements.append(.gallery(Gallery(images: images)))
+                }
+                // Remove the container so nested galleries aren't matched again
+                try? container.remove()
+            }
+        }
+
+        return elements
+    }
+
+    private static func parseImages(from container: Element) -> [GalleryImage] {
+        guard let imgElements = try? container.select("img") else {
+            return []
+        }
+        return imgElements.compactMap { parseImage(from: $0) }
+    }
+
+    private static func parseImage(from img: Element) -> GalleryImage? {
+        guard let srcString = try? img.attr("src"),
+              !srcString.isEmpty,
+              let src = URL(string: srcString) else {
+            return nil
+        }
+
+        let originalFileURL: URL? = {
+            guard let value = try? img.attr("data-orig-file"), !value.isEmpty else { return nil }
+            return URL(string: value)
+        }()
+
+        let originalSize: CGSize? = {
+            guard let value = try? img.attr("data-orig-size"), !value.isEmpty else { return nil }
+            return parseSize(value)
+        }()
+
+        let srcset: [SrcsetEntry] = {
+            guard let value = try? img.attr("srcset"), !value.isEmpty else { return [] }
+            return parseSrcset(value)
+        }()
+
+        let description: String? = {
+            guard let value = try? img.attr("data-image-description"), !value.isEmpty else { return nil }
+            // Strip HTML tags from description
+            return try? SwiftSoup.clean(value, Whitelist.none())
+        }()
+
+        let caption: String? = {
+            guard let value = try? img.attr("data-image-caption"), !value.isEmpty else { return nil }
+            // Strip HTML tags from caption
+            return try? SwiftSoup.clean(value, Whitelist.none())
+        }()
+
+        return GalleryImage(
+            src: src,
+            originalFileURL: originalFileURL,
+            originalSize: originalSize,
+            srcset: srcset,
+            description: description,
+            caption: caption
+        )
+    }
+
+    /// Parses "W,H" format (e.g. "4032,3024") into CGSize.
+    private static func parseSize(_ value: String) -> CGSize? {
+        let parts = value.split(separator: ",")
+        guard parts.count == 2,
+              let width = Double(parts[0].trimmingCharacters(in: .whitespaces)),
+              let height = Double(parts[1].trimmingCharacters(in: .whitespaces)) else {
+            return nil
+        }
+        return CGSize(width: width, height: height)
+    }
+
+    /// Parses srcset string (e.g. "url1 300w, url2 600w") into entries.
+    private static func parseSrcset(_ value: String) -> [SrcsetEntry] {
+        value.split(separator: ",").compactMap { entry in
+            let parts = entry.trimmingCharacters(in: .whitespaces).split(separator: " ")
+            guard parts.count == 2,
+                  let url = URL(string: String(parts[0])),
+                  let widthStr = parts[1].dropLast().description.nilIfEmpty,
+                  let width = Int(widthStr) else {
+                return nil
+            }
+            return SrcsetEntry(url: url, width: width)
+        }
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/Modules/Sources/WordPressReader/ReaderPostParser.swift
+++ b/Modules/Sources/WordPressReader/ReaderPostParser.swift
@@ -41,7 +41,9 @@ public enum ReaderPostParser {
         // Supported gallery selectors (order matters for specificity)
         let selectors = [
             "figure.wp-block-gallery",
+            "div.wp-block-gallery",
             "figure.wp-block-jetpack-tiled-gallery",
+            "div.wp-block-jetpack-tiled-gallery",
             "div.tiled-gallery",
             "div.gallery"
         ]

--- a/Modules/Tests/WordPressReaderTests/ReaderPostParserTests.swift
+++ b/Modules/Tests/WordPressReaderTests/ReaderPostParserTests.swift
@@ -188,7 +188,7 @@ struct ReaderPostParserTests {
 
     // MARK: - Multiple galleries
 
-    @Test func parseMultipleGalleries() {
+    @Test func parseMultipleGalleries() throws {
         let html = """
         <p>Some text</p>
         <figure class="wp-block-gallery">
@@ -208,7 +208,7 @@ struct ReaderPostParserTests {
         """
 
         let elements = ReaderPostParser.parse(html)
-        #expect(elements.count == 2)
+        try #require(elements.count == 2)
 
         guard case .gallery(let gallery1) = elements[0],
               case .gallery(let gallery2) = elements[1] else {

--- a/Modules/Tests/WordPressReaderTests/ReaderPostParserTests.swift
+++ b/Modules/Tests/WordPressReaderTests/ReaderPostParserTests.swift
@@ -1,0 +1,279 @@
+import Testing
+import Foundation
+@testable import WordPressReader
+
+@Suite
+struct ReaderPostParserTests {
+
+    // MARK: - Gutenberg Gallery (wp-block-gallery)
+
+    @Test func parseWPBlockGalleryWithThreeImages() {
+        let html = """
+        <figure class="wp-block-gallery has-nested-images columns-3 is-cropped wp-block-gallery-1 is-layout-flex wp-block-gallery-is-layout-flex">
+            <figure class="wp-block-image size-large">
+                <img decoding="async" width="1024" height="768"
+                     data-id="2001"
+                     src="https://example.com/wp-content/uploads/photo1.jpg?w=1024"
+                     alt="Sunset over mountains"
+                     class="wp-image-2001"
+                     data-orig-file="https://example.com/wp-content/uploads/photo1.jpg"
+                     data-orig-size="4032,3024"
+                     srcset="https://example.com/wp-content/uploads/photo1.jpg?w=1024 1024w, https://example.com/wp-content/uploads/photo1.jpg?w=150 150w, https://example.com/wp-content/uploads/photo1.jpg?w=300 300w, https://example.com/wp-content/uploads/photo1.jpg?w=768 768w"
+                     data-image-description="<p>A beautiful sunset</p>"
+                     data-image-caption="<p>Sunset caption</p>" />
+            </figure>
+            <figure class="wp-block-image size-large">
+                <img decoding="async" width="1024" height="768"
+                     data-id="2002"
+                     src="https://example.com/wp-content/uploads/photo2.jpg?w=1024"
+                     alt="Forest trail"
+                     class="wp-image-2002"
+                     data-orig-file="https://example.com/wp-content/uploads/photo2.jpg"
+                     data-orig-size="3000,2000"
+                     srcset="https://example.com/wp-content/uploads/photo2.jpg?w=1024 1024w, https://example.com/wp-content/uploads/photo2.jpg?w=300 300w"
+                     data-image-description=""
+                     data-image-caption="" />
+            </figure>
+            <figure class="wp-block-image size-large">
+                <img decoding="async" width="768" height="1024"
+                     data-id="2003"
+                     src="https://example.com/wp-content/uploads/photo3.jpg?w=768"
+                     alt=""
+                     class="wp-image-2003"
+                     data-orig-file="https://example.com/wp-content/uploads/photo3.jpg"
+                     data-orig-size="3024,4032" />
+            </figure>
+        </figure>
+        """
+
+        let elements = ReaderPostParser.parse(html)
+        #expect(elements.count == 1)
+
+        guard case .gallery(let gallery) = elements.first else {
+            Issue.record("Expected gallery element")
+            return
+        }
+
+        #expect(gallery.images.count == 3)
+
+        // First image
+        let first = gallery.images[0]
+        #expect(first.src.absoluteString == "https://example.com/wp-content/uploads/photo1.jpg?w=1024")
+        #expect(first.originalFileURL?.absoluteString == "https://example.com/wp-content/uploads/photo1.jpg")
+        #expect(first.originalSize == CGSize(width: 4032, height: 3024))
+        #expect(first.srcset.count == 4)
+        #expect(first.srcset[0].width == 1024)
+        #expect(first.srcset[1].width == 150)
+        #expect(first.description == "A beautiful sunset")
+        #expect(first.caption == "Sunset caption")
+
+        // Second image
+        let second = gallery.images[1]
+        #expect(second.src.absoluteString == "https://example.com/wp-content/uploads/photo2.jpg?w=1024")
+        #expect(second.originalSize == CGSize(width: 3000, height: 2000))
+        #expect(second.srcset.count == 2)
+        #expect(second.description == nil)
+        #expect(second.caption == nil)
+
+        // Third image - no srcset, no description/caption
+        let third = gallery.images[2]
+        #expect(third.src.absoluteString == "https://example.com/wp-content/uploads/photo3.jpg?w=768")
+        #expect(third.originalSize == CGSize(width: 3024, height: 4032))
+        #expect(third.srcset.isEmpty)
+        #expect(third.description == nil)
+        #expect(third.caption == nil)
+    }
+
+    // MARK: - Jetpack Tiled Gallery (block)
+
+    @Test func parseJetpackTiledGalleryBlock() {
+        let html = """
+        <figure class="wp-block-jetpack-tiled-gallery">
+            <div class="tiled-gallery__gallery">
+                <div class="tiled-gallery__row">
+                    <img src="https://example.com/photo-a.jpg"
+                         data-orig-file="https://example.com/photo-a-full.jpg"
+                         data-orig-size="2000,1500" />
+                    <img src="https://example.com/photo-b.jpg"
+                         data-orig-file="https://example.com/photo-b-full.jpg"
+                         data-orig-size="1800,1200" />
+                </div>
+            </div>
+        </figure>
+        """
+
+        let elements = ReaderPostParser.parse(html)
+        #expect(elements.count == 1)
+
+        guard case .gallery(let gallery) = elements.first else {
+            Issue.record("Expected gallery element")
+            return
+        }
+        #expect(gallery.images.count == 2)
+        #expect(gallery.images[0].src.absoluteString == "https://example.com/photo-a.jpg")
+        #expect(gallery.images[1].src.absoluteString == "https://example.com/photo-b.jpg")
+    }
+
+    // MARK: - Jetpack Tiled Gallery (classic)
+
+    @Test func parseJetpackTiledGalleryClassic() {
+        let html = """
+        <div class="tiled-gallery type-rectangular">
+            <div class="gallery-row">
+                <div class="gallery-group">
+                    <img src="https://example.com/classic1.jpg"
+                         data-orig-file="https://example.com/classic1-full.jpg" />
+                </div>
+                <div class="gallery-group">
+                    <img src="https://example.com/classic2.jpg" />
+                </div>
+            </div>
+        </div>
+        """
+
+        let elements = ReaderPostParser.parse(html)
+        #expect(elements.count == 1)
+
+        guard case .gallery(let gallery) = elements.first else {
+            Issue.record("Expected gallery element")
+            return
+        }
+        #expect(gallery.images.count == 2)
+        #expect(gallery.images[0].originalFileURL?.absoluteString == "https://example.com/classic1-full.jpg")
+        #expect(gallery.images[1].originalFileURL == nil)
+    }
+
+    // MARK: - Classic Gallery Shortcode
+
+    @Test func parseClassicGalleryShortcode() {
+        let html = """
+        <div class="gallery gallery-columns-3">
+            <figure class="gallery-item">
+                <div class="gallery-icon landscape">
+                    <img src="https://example.com/shortcode1.jpg"
+                         data-orig-size="800,600" />
+                </div>
+            </figure>
+            <figure class="gallery-item">
+                <div class="gallery-icon portrait">
+                    <img src="https://example.com/shortcode2.jpg"
+                         data-orig-size="600,800" />
+                </div>
+            </figure>
+        </div>
+        """
+
+        let elements = ReaderPostParser.parse(html)
+        #expect(elements.count == 1)
+
+        guard case .gallery(let gallery) = elements.first else {
+            Issue.record("Expected gallery element")
+            return
+        }
+        #expect(gallery.images.count == 2)
+        #expect(gallery.images[0].originalSize == CGSize(width: 800, height: 600))
+        #expect(gallery.images[1].originalSize == CGSize(width: 600, height: 800))
+    }
+
+    // MARK: - No galleries
+
+    @Test func parseHTMLWithNoGalleries() {
+        let html = """
+        <p>Just a regular paragraph with an <img src="https://example.com/single.jpg" /> image.</p>
+        """
+
+        let elements = ReaderPostParser.parse(html)
+        #expect(elements.isEmpty)
+    }
+
+    // MARK: - Multiple galleries
+
+    @Test func parseMultipleGalleries() {
+        let html = """
+        <p>Some text</p>
+        <figure class="wp-block-gallery">
+            <figure class="wp-block-image">
+                <img src="https://example.com/gallery1-img1.jpg" />
+            </figure>
+        </figure>
+        <p>More text</p>
+        <figure class="wp-block-gallery">
+            <figure class="wp-block-image">
+                <img src="https://example.com/gallery2-img1.jpg" />
+            </figure>
+            <figure class="wp-block-image">
+                <img src="https://example.com/gallery2-img2.jpg" />
+            </figure>
+        </figure>
+        """
+
+        let elements = ReaderPostParser.parse(html)
+        #expect(elements.count == 2)
+
+        guard case .gallery(let gallery1) = elements[0],
+              case .gallery(let gallery2) = elements[1] else {
+            Issue.record("Expected gallery elements")
+            return
+        }
+        #expect(gallery1.images.count == 1)
+        #expect(gallery2.images.count == 2)
+    }
+
+    // MARK: - Srcset edge cases
+
+    @Test func parseSrcsetWithSingleEntry() {
+        let html = """
+        <figure class="wp-block-gallery">
+            <figure class="wp-block-image">
+                <img src="https://example.com/photo.jpg"
+                     srcset="https://example.com/photo.jpg?w=800 800w" />
+            </figure>
+        </figure>
+        """
+
+        let elements = ReaderPostParser.parse(html)
+        guard case .gallery(let gallery) = elements.first else {
+            Issue.record("Expected gallery")
+            return
+        }
+        #expect(gallery.images[0].srcset.count == 1)
+        #expect(gallery.images[0].srcset[0].width == 800)
+    }
+
+    // MARK: - Malformed HTML
+
+    @Test func parseMalformedHTML() {
+        let html = "<div class=\"gallery\"><img src=\"https://example.com/a.jpg\"><p>unclosed tags"
+
+        let elements = ReaderPostParser.parse(html)
+        #expect(elements.count == 1)
+        guard case .gallery(let gallery) = elements.first else {
+            Issue.record("Expected gallery")
+            return
+        }
+        #expect(gallery.images.count == 1)
+    }
+
+    @Test func parseEmptyHTML() {
+        let elements = ReaderPostParser.parse("")
+        #expect(elements.isEmpty)
+    }
+
+    @Test func parseGalleryWithNoImages() {
+        let html = "<figure class=\"wp-block-gallery\"><p>No images here</p></figure>"
+        let elements = ReaderPostParser.parse(html)
+        #expect(elements.isEmpty)
+    }
+
+    @Test func parseImageWithMissingSrc() {
+        let html = """
+        <figure class="wp-block-gallery">
+            <figure class="wp-block-image">
+                <img data-orig-file="https://example.com/photo.jpg" />
+            </figure>
+        </figure>
+        """
+        let elements = ReaderPostParser.parse(html)
+        #expect(elements.isEmpty)
+    }
+}

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,7 +1,7 @@
 26.8
 -----
 * [*] Fix an issue Social Sharing placeholder card showing unsupported services [#25336]
-
+* [*] Reader: Add support for viewing media galleries fullscreen with a way to swipe between images [#25365]
 
 26.7
 -----

--- a/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxImagePageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxImagePageViewController.swift
@@ -10,6 +10,9 @@ final class LightboxImagePageViewController: UIViewController {
     private let activityIndicator = UIActivityIndicatorView()
     private var errorView: UIImageView?
 
+    /// Used by UIPageViewController to track position.
+    var pageIndex: Int = 0
+
     init(item: LightboxItem) {
         self.item = item
         super.init(nibName: nil, bundle: nil)

--- a/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxViewController.swift
@@ -8,6 +8,8 @@ import UniformTypeIdentifiers
 final class LightboxViewController: UIViewController {
     private var pageVC: LightboxImagePageViewController?
     private var items: [LightboxItem]
+    private var selectedIndex: Int
+    private var pageCounter: UILabel?
 
     /// A thumbnail to display during transition and for the initial image download.
     var thumbnail: UIImage?
@@ -32,9 +34,13 @@ final class LightboxViewController: UIViewController {
         self.init(items: [item])
     }
 
-    private init(items: [LightboxItem], configuration: Configuration = .init()) {
-        assert(items.count == 1, "Current API supports only one item at a time")
+    convenience init(assets: [LightboxAsset], selectedIndex: Int = 0) {
+        self.init(items: assets.map { .asset($0) }, selectedIndex: selectedIndex)
+    }
+
+    private init(items: [LightboxItem], selectedIndex: Int = 0, configuration: Configuration = .init()) {
         self.items = items
+        self.selectedIndex = min(selectedIndex, max(items.count - 1, 0))
         self.configuration = configuration
         super.init(nibName: nil, bundle: nil)
     }
@@ -48,26 +54,83 @@ final class LightboxViewController: UIViewController {
 
         view.backgroundColor = configuration.backgroundColor
 
-        if let item = items.first {
-            show(item)
+        if items.count > 1 {
+            showPageViewController()
+        } else if let item = items.first {
+            showSingle(item)
         }
         if configuration.showsCloseButton {
             addCloseButton()
         }
     }
 
-    private func show(_ item: LightboxItem) {
+    // MARK: - Single item
+
+    private func showSingle(_ item: LightboxItem) {
         let pageVC = LightboxImagePageViewController(item: item)
-        pageVC.willMove(toParent: self)
-        addChild(pageVC)
-        view.addSubview(pageVC.view)
-        pageVC.view.pinEdges()
-        pageVC.didMove(toParent: self)
+        addFullscreenChild(pageVC)
         if let thumbnail {
             pageVC.scrollView.configure(with: thumbnail)
             self.thumbnail = nil
         }
         self.pageVC = pageVC
+    }
+
+    // MARK: - Multi-item (UIPageViewController)
+
+    private var uiPageVC: UIPageViewController?
+
+    private func showPageViewController() {
+        let pageVC = UIPageViewController(transitionStyle: .scroll, navigationOrientation: .horizontal)
+        pageVC.dataSource = self
+        pageVC.delegate = self
+        let initialVC = makeImagePageVC(at: selectedIndex)
+        pageVC.setViewControllers([initialVC], direction: .forward, animated: false)
+        addFullscreenChild(pageVC)
+        self.uiPageVC = pageVC
+
+        addPageCounter()
+        updatePageCounter()
+    }
+
+    private func makeImagePageVC(at index: Int) -> LightboxImagePageViewController {
+        let vc = LightboxImagePageViewController(item: items[index])
+        vc.pageIndex = index
+        return vc
+    }
+
+    // MARK: - Page Counter
+
+    private func addPageCounter() {
+        let label = UILabel()
+        label.font = .preferredFont(forTextStyle: .footnote)
+        label.textColor = .white
+        label.textAlignment = .center
+        label.layer.shadowColor = UIColor.black.cgColor
+        label.layer.shadowOffset = .zero
+        label.layer.shadowRadius = 3
+        label.layer.shadowOpacity = 0.5
+        view.addSubview(label)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            label.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+            label.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor, constant: -12)
+        ])
+        self.pageCounter = label
+    }
+
+    private func updatePageCounter() {
+        pageCounter?.text = "\(selectedIndex + 1) / \(items.count)"
+    }
+
+    // MARK: - Helpers
+
+    private func addFullscreenChild(_ child: UIViewController) {
+        child.willMove(toParent: self)
+        addChild(child)
+        view.addSubview(child.view)
+        child.view.pinEdges()
+        child.didMove(toParent: self)
     }
 
     private func addCloseButton() {
@@ -94,7 +157,7 @@ final class LightboxViewController: UIViewController {
             options.alignmentRectProvider = { context in
                 // For more info, see https://douglashill.co/zoom-transitions/#Zooming-to-only-part-of-the-destination-view
                 let detailViewController = context.zoomedViewController as! LightboxViewController
-                let detailsView: UIView = detailViewController.pageVC?.scrollView.imageView ?? detailViewController.view
+                let detailsView: UIView = detailViewController.currentPageVC?.scrollView.imageView ?? detailViewController.view
                 return detailsView.convert(detailsView.bounds, to: detailViewController.view)
             }
             preferredTransition = .zoom(options: options) { context in
@@ -112,6 +175,39 @@ final class LightboxViewController: UIViewController {
                 thumbnail = getThumbnail(fromSourceView: sourceView)
             }
         }
+    }
+
+    /// Returns the currently visible `LightboxImagePageViewController`.
+    private var currentPageVC: LightboxImagePageViewController? {
+        if let pageVC { return pageVC }
+        return uiPageVC?.viewControllers?.first as? LightboxImagePageViewController
+    }
+}
+
+// MARK: - UIPageViewControllerDataSource
+
+extension LightboxViewController: UIPageViewControllerDataSource {
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerBefore viewController: UIViewController) -> UIViewController? {
+        guard let vc = viewController as? LightboxImagePageViewController,
+              vc.pageIndex > 0 else { return nil }
+        return makeImagePageVC(at: vc.pageIndex - 1)
+    }
+
+    func pageViewController(_ pageViewController: UIPageViewController, viewControllerAfter viewController: UIViewController) -> UIViewController? {
+        guard let vc = viewController as? LightboxImagePageViewController,
+              vc.pageIndex < items.count - 1 else { return nil }
+        return makeImagePageVC(at: vc.pageIndex + 1)
+    }
+}
+
+// MARK: - UIPageViewControllerDelegate
+
+extension LightboxViewController: UIPageViewControllerDelegate {
+    func pageViewController(_ pageViewController: UIPageViewController, didFinishAnimating finished: Bool, previousViewControllers: [UIViewController], transitionCompleted completed: Bool) {
+        guard completed,
+              let vc = pageViewController.viewControllers?.first as? LightboxImagePageViewController else { return }
+        selectedIndex = vc.pageIndex
+        updatePageCounter()
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -49,6 +49,11 @@ class ReaderDetailCoordinator {
     /// Called if the view controller's post fails to load
     var postLoadFailureBlock: (() -> Void)? = nil
 
+    private lazy var interactiveElements: [ReaderPostParser.InteractiveElement] = {
+        guard let content = post?.content else { return [] }
+        return ReaderPostParser.parse(content)
+    }()
+
     private var likesAvatarURLs: [String]?
 
     /// An authenticator to ensure any request made to WP sites is properly authenticated
@@ -296,6 +301,28 @@ class ReaderDetailCoordinator {
         viewController?.present(lightboxVC, animated: true)
     }
 
+    private func findGallery(containing url: URL) -> (ReaderPostParser.Gallery, Int)? {
+        let urlString = url.absoluteString
+        for element in interactiveElements {
+            if case .gallery(let gallery) = element,
+               let index = gallery.images.firstIndex(where: { $0.src.absoluteString == urlString }) {
+                return (gallery, index)
+            }
+        }
+        return nil
+    }
+
+    private func presentGallery(_ gallery: ReaderPostParser.Gallery, startingAt index: Int) {
+        WPAnalytics.trackReader(.readerArticleImageTapped)
+        let host = post.map(MediaHost.init)
+        let assets = gallery.images.map {
+            LightboxAsset(sourceURL: $0.originalFileURL ?? $0.src, host: host)
+        }
+        let lightboxVC = LightboxViewController(assets: assets, selectedIndex: index)
+        lightboxVC.configureZoomTransition()
+        viewController?.present(lightboxVC, animated: true)
+    }
+
     /// Open the postURL in a separated view controller
     ///
     func openInBrowser() {
@@ -478,6 +505,8 @@ class ReaderDetailCoordinator {
            let postURL = permaLinkURL,
            postURL.isHostAndPathEqual(to: url) {
             view?.scroll(to: hash)
+        } else if let (gallery, index) = findGallery(containing: url) {
+            presentGallery(gallery, startingAt: index)
         } else if url.pathExtension.contains("gif") ||
                     url.pathExtension.contains("jpg") ||
                     url.pathExtension.contains("jpeg") ||


### PR DESCRIPTION
Fixes [CMM-944: Image gallery blocks are not displayed as gallery](https://linear.app/a8c/issue/CMM-944/image-gallery-blocks-are-not-displayed-as-gallery).

In future PRs, I plan to slightly improve `LightboxViewController`: add captions and add `thumbnailURL` to be displayed ahead of loading the original images.


https://github.com/user-attachments/assets/34dac787-6cb8-40d5-b077-cd39ec33fd7a

