### PR TITLE
Extract CustomPostSettingsViewModel out of PostSettingsViewModel

### DIFF
--- a/WordPress/Classes/ViewRelated/NewGutenberg/CustomPostEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/CustomPostEditorViewController.swift
@@ -193,7 +193,7 @@ private extension CustomPostEditorViewController {
     }
 
     func showPostSettings() {
-        let viewModel = PostSettingsViewModel(editorService: editorService, blog: blog)
+        let viewModel = CustomPostSettingsViewModel(editorService: editorService, blog: blog)
         viewModel.onEditorPostSaved = { /* No-op: shared editorService is already up-to-date */ }
         let settingsVC = PostSettingsViewController(viewModel: viewModel)
         let navigation = UINavigationController(rootViewController: settingsVC)

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
@@ -1,0 +1,456 @@
+import Foundation
+import SwiftUI
+import WordPressAPI
+import WordPressData
+import WordPressKit
+import WordPressCore
+import WordPressShared
+import WordPressAPIInternal
+import Combine
+
+/// Post settings view model for REST API–backed custom post types (`CustomPostEditorService`).
+@MainActor
+final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSettingsViewModelProtocol {
+    private let editorService: CustomPostEditorService
+
+    let blog: Blog
+    let capabilities: PostSettingsCapabilities
+    let isStandalone: Bool
+    let context: PostSettingsContext
+    let featuredImageViewModel: PostSettingsFeaturedImageViewModel?
+    let client: WordPressClient?
+
+    @Published var settings: PostSettings {
+        didSet {
+            refresh(from: oldValue, to: settings)
+        }
+    }
+
+    @Published var isSaving = false
+    @Published var hasChanges = false
+    @Published var displayedCategories: [String] = []
+    @Published var displayedTags: [String] = []
+    @Published var isResolvingTags = false
+    @Published var isResolvingCustomTerms = false
+    @Published var suggestedTags: [String] = []
+    @Published var customTaxonomies: [SiteTaxonomy] = []
+    @Published var parentPageText: String?
+    @Published var socialSharingState: PostSettingsSocialSharingSectionState?
+    @Published var isShowingDeletedAlert = false
+
+    private let originalSettings: PostSettings
+    private let preferences: UserPersistentRepository
+    private var cancellables = Set<AnyCancellable>()
+
+    var onDismiss: (() -> Void)?
+    var onEditorPostSaved: (() -> Void)?
+    var onPostPublished: (() -> Void)?
+    weak var viewController: UIViewController?
+
+    // MARK: - Computed Properties
+
+    /// The content of the post, used for AI excerpt generation.
+    var postContent: String {
+        editorService.post?.content.raw ?? ""
+    }
+
+    var navigationTitle: String {
+        String.localizedStringWithFormat(
+            PostSettingsStrings.customPostSettingsTitle,
+            editorService.details.name
+        )
+    }
+
+    var deletedAlertTitle: String {
+        isPost ? PostSettingsStrings.postDeletedTitle : PostSettingsStrings.pageDeletedTitle
+    }
+
+    var deletedAlertMessage: String {
+        isPost ? PostSettingsStrings.postDeletedMessage : PostSettingsStrings.pageDeletedMessage
+    }
+
+    var isScheduled: Bool {
+        editorService.post?.status == .future
+    }
+
+    var authorDisplayName: String {
+        settings.author?.displayName ?? ""
+    }
+
+    var authorAvatarURL: URL? {
+        settings.author?.avatarURL
+    }
+
+    var emailToSubscribers: Bool {
+        get { !settings.metadata.isJetpackNewsletterEmailDisabled }
+        set { settings.metadata.isJetpackNewsletterEmailDisabled = !newValue }
+    }
+
+    var accessLevel: JetpackPostAccessLevel {
+        get { settings.metadata.accessLevel ?? .everybody }
+        set { settings.metadata.accessLevel = newValue }
+    }
+
+    var publishDateText: String? {
+        guard let date = settings.publishDate else {
+            return nil
+        }
+        return PostSettingsDateFormatter.formattedDate(date, in: timeZone)
+    }
+
+    var visibilityText: String {
+        PostVisibility(status: settings.status, password: settings.password)
+            .localizedTitle
+    }
+
+    var slugText: String {
+        settings.slug.isEmpty ? (suggestedSlug ?? "") : settings.slug
+    }
+
+    var suggestedSlug: String? {
+        editorService.post?.generatedSlug
+    }
+
+    var permalinkTemplate: String? {
+        editorService.post?.permalinkTemplate
+    }
+
+    var postFormatText: String {
+        guard capabilities.supportsPostFormats else { return "" }
+        return blog.postFormatText(fromSlug: settings.postFormat) ?? NSLocalizedString("Standard", comment: "Default post format")
+    }
+
+    var timeZone: TimeZone {
+        blog.timeZone ?? TimeZone.current
+    }
+
+    var isDraftOrPending: Bool {
+        if let post = editorService.post {
+            return post.status == .draft || post.status == .pending
+        }
+        return true
+    }
+
+    var isPost: Bool {
+        editorService.details.slug == "post"
+    }
+
+    var shouldShowStickyOption: Bool {
+        // Sticky is exclusively a WordPress "post" type feature
+        guard isPost else { return false }
+        // Show sticky option if blog supports WPComRESTAPI OR user is admin
+        return blog.supports(.wpComRESTAPI) || blog.isAdmin
+    }
+
+    var lastEditedText: String? {
+        editorService.post?.modifiedGmt.toMediumString()
+    }
+
+    var postID: Int? {
+        guard let id = editorService.post?.id else { return nil }
+        return id > 0 ? Int(id) : nil
+    }
+
+    /// The underlying Page, if this is a Core Data-backed page.
+    var page: Page? {
+        nil
+    }
+
+    /// Whether the post has a remote representation (used for permalink preview).
+    var hasRemote: Bool {
+        editorService.post != nil
+    }
+
+    var publishButtonTitle: String {
+        let isScheduled = settings.publishDate.map { $0 > .now } ?? false
+        return isScheduled ? PrepublishingSheetStrings.schedule : PrepublishingSheetStrings.publish
+    }
+
+    // MARK: - Initializer
+
+    init(
+        editorService: CustomPostEditorService,
+        blog: Blog,
+        context: PostSettingsContext = .settings,
+        preferences: UserPersistentRepository = UserDefaults.standard
+    ) {
+        self.editorService = editorService
+        self.blog = blog
+        self.isStandalone = false
+        self.context = context
+        self.preferences = preferences
+        self.client = editorService.client
+        self.capabilities = PostSettingsCapabilities(from: editorService.details)
+
+        var initialSettings = editorService.settings
+        // Resolve author display name from Blog's cached authors
+        if let authorId = initialSettings.author?.id,
+           let authors = blog.authors,
+           let author = authors.first(where: { $0.userID.intValue == authorId }) {
+            initialSettings.author = PostSettings.Author(
+                id: authorId,
+                displayName: author.displayName ?? "–",
+                avatarURL: author.avatarURL.flatMap(URL.init)
+            )
+        }
+
+        self.settings = initialSettings
+        self.originalSettings = initialSettings
+
+        let featuredImageViewModel: PostSettingsFeaturedImageViewModel?
+        if capabilities.supportsFeaturedImage {
+            let featuredImage = initialSettings.featuredImageID.flatMap {
+                Media.existingOrStubMediaWith(
+                    mediaID: NSNumber(value: $0),
+                    inBlog: blog
+                )
+            }
+            featuredImageViewModel = PostSettingsFeaturedImageViewModel(
+                blog: blog,
+                featuredImage: featuredImage
+            )
+        } else {
+            featuredImageViewModel = nil
+        }
+        self.featuredImageViewModel = featuredImageViewModel
+
+        super.init()
+
+        featuredImageViewModel?.$selection.dropFirst().sink { [weak self] media in
+            self?.settings.featuredImageID = media?.mediaID?.intValue
+        }.store(in: &cancellables)
+
+        WPAnalytics.track(.postSettingsShown)
+
+        refreshDisplayedCategories()
+        refreshDisplayedTags()
+        refreshCustomTaxonomies()
+        resolveTermNames()
+    }
+
+    // MARK: - Actions
+
+    func onAppear() {}
+
+    func shouldShow(_ row: PostSettingsRow) -> Bool {
+        // FIXME: meta support missing in AnyPostWithEditContext
+        false
+    }
+
+    func buttonCancelTapped() {
+        onDismiss?()
+    }
+
+    func buttonSaveTapped() {
+        guard isStandalone else {
+            let settingsToSave = getSettingsToSave(for: settings)
+            editorService.applyLocally(settings: settingsToSave)
+            didSaveChanges()
+            onEditorPostSaved?()
+            onDismiss?()
+            return
+        }
+
+        isSaving = true
+        Task {
+            do {
+                let settingsToSave = getSettingsToSave(for: settings)
+                try await editorService.save(settings: settingsToSave, publish: false)
+                didSaveChanges()
+                onEditorPostSaved?()
+                onDismiss?()
+            } catch {
+                isSaving = false
+                Notice(error: error, title: PostSettingsStrings.saveFailedMessage).post()
+            }
+        }
+    }
+
+    func buttonPublishTapped() {
+        isSaving = true
+        Task {
+            do {
+                try await editorService.save(settings: settings, publish: true)
+                onPostPublished?()
+            } catch {
+                isSaving = false
+                Notice(error: error, title: PostSettingsStrings.saveFailedMessage).post()
+            }
+        }
+    }
+
+    func getSettingsToSave(for settings: PostSettings) -> PostSettings {
+        var settings = settings
+        if context == .publishing {
+            // We don't support saving these changes on the "Publishing" sheet
+            // as it would trigger the change in status and publishing. We'll
+            // only save what we can without publishing: tags, categories, etc.
+            settings.status = originalSettings.status
+            settings.password = originalSettings.password
+            settings.publishDate = originalSettings.publishDate
+        }
+        return settings
+    }
+
+    func updateVisibility(_ selection: PostVisibilityPicker.Selection) {
+        track(.editorPostVisibilityChanged)
+
+        switch selection.type {
+        case .public, .protected:
+            if isScheduled {
+                break
+            }
+            settings.status = .publish
+        case .private:
+            settings.status = .publishPrivate
+        }
+        settings.password = selection.password.isEmpty ? nil : selection.password
+    }
+
+    func didSelectSuggestedTag(_ tag: String) {
+        suggestedTags.removeAll(where: { $0 == tag })
+        settings.tags.append(PostSettings.Term(id: 0, name: tag))
+        track(.intelligenceSuggestedTagSelected)
+    }
+
+    func didSelectTags(_ tags: [TagsViewModel.SelectedTerm]) {
+        settings.tags = tags.map { PostSettings.Term(id: $0.id, name: $0.name) }
+    }
+
+    func didSelectTerms(_ terms: [TagsViewModel.SelectedTerm], forTaxonomySlug taxonomySlug: String) {
+        settings.otherTerms[taxonomySlug] = terms.map { PostSettings.Term(id: $0.id, name: $0.name) }
+    }
+
+    func showCategoriesPicker() {
+        let categoriesVC = PostSettingsCategoriesPickerViewController(
+            blog: blog,
+            selectedCategoryIDs: settings.categoryIDs
+        ) { [weak self] newSelectedIDs in
+            self?.settings.categoryIDs = newSelectedIDs
+        }
+        viewController?.navigationController?.pushViewController(categoriesVC, animated: true)
+    }
+
+    func showSocialSharingOptions() {}
+
+    // MARK: - Term Resolution
+
+    private func resolveTermNames() {
+        isResolvingTags = true
+        isResolvingCustomTerms = !settings.otherTerms.isEmpty
+
+        Task { [weak self] in
+            guard let self else { return }
+
+            do {
+                let tagsService = AnyTermService(client: editorService.client, endpoint: .tags)
+                let resolvedTags = try await TermResolutionService(taxonomyService: tagsService)
+                    .resolveNames(for: settings.tags)
+                self.settings.tags = resolvedTags
+                self.refreshDisplayedTags()
+                self.isResolvingTags = false
+
+                for taxonomy in editorService.taxonomies {
+                    guard let slugTerms = self.settings.otherTerms[taxonomy.slug] else { continue }
+                    let termService = AnyTermService(client: editorService.client, endpoint: taxonomy.endpoint)
+                    let resolved = try await TermResolutionService(taxonomyService: termService)
+                        .resolveNames(for: slugTerms)
+                    self.settings.otherTerms[taxonomy.slug] = resolved
+                }
+                self.isResolvingCustomTerms = false
+            } catch {
+                // TODO: We need better error handling
+                Loggers.app.log(level: .error, "Failed to resolve taxonomy terms: \(error)")
+            }
+        }
+    }
+
+    // MARK: - Refresh
+
+    private func refresh(from old: PostSettings, to new: PostSettings) {
+        hasChanges = getSettingsToSave(for: new) != originalSettings
+
+        if old.categoryIDs != new.categoryIDs {
+            refreshDisplayedCategories()
+        }
+        if old.tags != new.tags {
+            refreshDisplayedTags()
+        }
+    }
+
+    private func refreshDisplayedCategories() {
+        displayedCategories = settings.getCategoryNames(for: blog)
+    }
+
+    private func refreshDisplayedTags() {
+        displayedTags = settings.tags.map(\.name)
+    }
+
+    private func refreshCustomTaxonomies() {
+        customTaxonomies = editorService.taxonomies
+    }
+
+    // MARK: - Analytics
+
+    private func didSaveChanges() {
+        trackChanges(from: originalSettings, to: settings)
+    }
+
+    private func trackChanges(from old: PostSettings, to new: PostSettings) {
+        if old.author?.id != new.author?.id {
+            track(.editorPostAuthorChanged)
+        }
+        if old.publishDate != new.publishDate {
+            track(.editorPostScheduledChanged)
+        }
+        if old.tags != new.tags {
+            track(.editorPostTagsChanged)
+        }
+        if old.postFormat != new.postFormat {
+            track(.editorPostFormatChanged)
+        }
+        if old.categoryIDs != new.categoryIDs {
+            track(.editorPostCategoryChanged)
+        }
+        if old.featuredImageID != new.featuredImageID {
+            let action = new.featuredImageID == nil ? "removed" : "changed"
+            track(.editorPostFeaturedImageChanged, properties: ["action": action])
+        }
+        if old.excerpt != new.excerpt {
+            track(.editorPostExcerptChanged)
+        }
+        if old.slug != new.slug {
+            track(.editorPostSlugChanged)
+        }
+        if old.status != new.status {
+            if (old.status == .pending) != (new.status == .pending) {
+                track(.editorPostPendingReviewChanged)
+            }
+        }
+        if old.isStickyPost != new.isStickyPost {
+            track(.editorPostStickyChanged)
+        }
+        if old.parentPageID != new.parentPageID {
+            track(.editorPostParentPageChanged)
+        }
+        if old.otherTerms != new.otherTerms {
+            track(.editorPostCustomTaxonomyChanged)
+        }
+        if old.metadata.isJetpackNewsletterEmailDisabled != new.metadata.isJetpackNewsletterEmailDisabled {
+            track(.editorPostNewsletterEmailToggled)
+        }
+    }
+
+    private func track(_ event: WPAnalyticsEvent, properties: [AnyHashable: Any] = [:]) {
+        var properties = properties
+        properties["via"] = source
+        WPAnalytics.track(event, properties: properties)
+    }
+
+    private var source: String {
+        switch context {
+        case .settings: "post_settings"
+        case .publishing: "pre_publishing"
+        }
+    }
+}

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
@@ -517,6 +517,22 @@ extension PostSettings {
 // MARK: - PostFormat Slug
 
 extension PostFormat {
+    static func from(slug: String) -> PostFormat {
+        switch slug {
+        case "standard": return .standard
+        case "aside": return .aside
+        case "chat": return .chat
+        case "gallery": return .gallery
+        case "link": return .link
+        case "image": return .image
+        case "quote": return .quote
+        case "status": return .status
+        case "video": return .video
+        case "audio": return .audio
+        default: return .custom(slug)
+        }
+    }
+
     // TODO: Export from wordpress-rs
     var id: String {
         switch self {

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -7,10 +7,10 @@ import WordPressShared
 import WordPressUI
 import SwiftUI
 
-final class PostSettingsViewController: UIHostingController<AnyView> {
-    private let viewModel: PostSettingsViewModel
+final class PostSettingsViewController<ViewModel: PostSettingsViewModelProtocol>: UIHostingController<AnyView> {
+    private let viewModel: ViewModel
 
-    init(viewModel: PostSettingsViewModel) {
+    init(viewModel: ViewModel) {
         self.viewModel = viewModel
         let postSettingsView = PostSettingsView(viewModel: viewModel)
         super.init(rootView: AnyView(postSettingsView))
@@ -34,6 +34,9 @@ final class PostSettingsViewController: UIHostingController<AnyView> {
         fatalError("init(coder:) has not been implemented")
     }
 
+}
+
+extension PostSettingsViewController where ViewModel == PostSettingsViewModel {
     static func showStandaloneEditor(for post: AbstractPost, from presentingVC: UIViewController) {
         let viewModel = PostSettingsViewModel(post: post, isStandalone: true)
         let postSettingsVC = PostSettingsViewController(viewModel: viewModel)
@@ -43,8 +46,8 @@ final class PostSettingsViewController: UIHostingController<AnyView> {
 }
 
 @MainActor
-private struct PostSettingsView: View {
-    @ObservedObject var viewModel: PostSettingsViewModel
+private struct PostSettingsView<ViewModel: PostSettingsViewModelProtocol>: View {
+    @ObservedObject var viewModel: ViewModel
 
     @State private var isShowingDiscardChangesAlert = false
 
@@ -130,8 +133,8 @@ private struct PostSettingsView: View {
     }
 }
 
-struct PostSettingsFormContentView: View {
-    @ObservedObject var viewModel: PostSettingsViewModel
+struct PostSettingsFormContentView<ViewModel: PostSettingsViewModelProtocol>: View {
+    @ObservedObject var viewModel: ViewModel
 
     var body: some View {
         if viewModel.context == .publishing {

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModel.swift
@@ -6,25 +6,19 @@ import WordPressData
 import WordPressKit
 import WordPressCore
 import WordPressShared
-import WordPressAPIInternal
 import Combine
 
+/// Post settings view model for Core Data–backed posts and pages (`AbstractPost`).
 @MainActor
-final class PostSettingsViewModel: NSObject, ObservableObject {
+final class PostSettingsViewModel: NSObject, ObservableObject, PostSettingsViewModelProtocol {
+    private let post: AbstractPost
+
     let blog: Blog
     let capabilities: PostSettingsCapabilities
     let isStandalone: Bool
-    let context: Context
+    let context: PostSettingsContext
     let featuredImageViewModel: PostSettingsFeaturedImageViewModel?
     let client: WordPressClient?
-
-    private let details: PostDetails
-    private let editorService: CustomPostEditorService?
-
-    private var abstractPost: AbstractPost? {
-        if case .abstractPost(let post) = details { return post }
-        return nil
-    }
 
     @Published var settings: PostSettings {
         didSet {
@@ -41,54 +35,33 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
     @Published private(set) var suggestedTags: [String] = []
     @Published private(set) var customTaxonomies: [SiteTaxonomy] = []
     @Published private(set) var parentPageText: String?
-    @Published private(set) var socialSharingState: SocialSharingSectionState?
+    @Published private(set) var socialSharingState: PostSettingsSocialSharingSectionState?
 
     @Published var isShowingDeletedAlert = false
 
     /// The content of the post, used for AI excerpt generation.
     var postContent: String {
-        switch details {
-        case .abstractPost(let post):
-            return post.content ?? ""
-        case .customPost(let service):
-            return service.post?.content.raw ?? ""
-        }
+        post.content ?? ""
     }
 
     var navigationTitle: String {
-        switch details {
-        case .abstractPost:
-            return isPost ? Strings.postSettingsTitle : Strings.pageSettingsTitle
-        case .customPost(let service):
-            return String.localizedStringWithFormat(
-                Strings.customPostSettingsTitle,
-                service.details.name
-            )
-        }
+        isPost ? PostSettingsStrings.postSettingsTitle : PostSettingsStrings.pageSettingsTitle
     }
 
     var deletedAlertTitle: String {
-        isPost ? Strings.postDeletedTitle : Strings.pageDeletedTitle
+        isPost ? PostSettingsStrings.postDeletedTitle : PostSettingsStrings.pageDeletedTitle
     }
 
     var deletedAlertMessage: String {
-        isPost ? Strings.postDeletedMessage : Strings.pageDeletedMessage
+        isPost ? PostSettingsStrings.postDeletedMessage : PostSettingsStrings.pageDeletedMessage
     }
 
     var isScheduled: Bool {
-        switch details {
-        case .abstractPost(let post): return post.getOriginal().status == .scheduled
-        case .customPost(let service): return service.post?.status == .future
-        }
+        post.getOriginal().status == .scheduled
     }
 
     var authorDisplayName: String {
-        switch details {
-        case .abstractPost(let post):
-            return settings.author?.displayName ?? post.author?.makePlainText() ?? ""
-        case .customPost:
-            return settings.author?.displayName ?? ""
-        }
+        settings.author?.displayName ?? post.author?.makePlainText() ?? ""
     }
 
     var authorAvatarURL: URL? {
@@ -109,15 +82,7 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
         guard let date = settings.publishDate else {
             return nil
         }
-        return Self.formattedDate(date, in: timeZone)
-    }
-
-    static func formattedDate(_ date: Date, in timeZone: TimeZone) -> String {
-        let formatter = DateFormatter()
-        formatter.dateStyle = .medium
-        formatter.timeStyle = .short
-        formatter.timeZone = timeZone
-        return formatter.string(from: date)
+        return PostSettingsDateFormatter.formattedDate(date, in: timeZone)
     }
 
     var visibilityText: String {
@@ -130,21 +95,11 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
     }
 
     var suggestedSlug: String? {
-        switch details {
-        case .abstractPost(let post):
-            return post.suggested_slug
-        case .customPost(let service):
-            return service.post?.generatedSlug
-        }
+        post.suggested_slug
     }
 
     var permalinkTemplate: String? {
-        switch details {
-        case .abstractPost(let post):
-            return post.permalinkTemplateURL
-        case .customPost(let service):
-            return service.post?.permalinkTemplate
-        }
+        post.permalinkTemplateURL
     }
 
     var postFormatText: String {
@@ -157,24 +112,11 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
     }
 
     var isDraftOrPending: Bool {
-        switch details {
-        case .abstractPost(let post):
-            return post.getOriginal().isStatus(in: [.draft, .pending])
-        case .customPost(let service):
-            if let post = service.post {
-                return post.status == .draft || post.status == .pending
-            }
-            return true
-        }
+        post.getOriginal().isStatus(in: [.draft, .pending])
     }
 
     var isPost: Bool {
-        switch details {
-        case .abstractPost(let post):
-            return post is Post
-        case .customPost(let service):
-            return service.details.slug == "post"
-        }
+        post is Post
     }
 
     var shouldShowStickyOption: Bool {
@@ -185,55 +127,32 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
     }
 
     var lastEditedText: String? {
-        switch details {
-        case .abstractPost(let post):
-            guard let date = post.dateModified ?? post.dateCreated else {
-                return nil
-            }
-            return date.toMediumString()
-        case .customPost(let service):
-            return service.post?.modifiedGmt.toMediumString()
+        guard let date = post.dateModified ?? post.dateCreated else {
+            return nil
         }
+        return date.toMediumString()
     }
 
     var postID: Int? {
-        switch details {
-        case .abstractPost(let post):
-            guard let postID = post.postID?.intValue, postID > 0 else {
-                return nil
-            }
-            return postID
-        case .customPost(let service):
-            guard let id = service.post?.id else { return nil }
-            return id > 0 ? Int(id) : nil
+        guard let postID = post.postID?.intValue, postID > 0 else {
+            return nil
         }
+        return postID
     }
 
     /// The underlying Page, if this is a Core Data-backed page.
     var page: Page? {
-        abstractPost as? Page
+        post as? Page
     }
 
     /// Whether the post has a remote representation (used for permalink preview).
     var hasRemote: Bool {
-        switch details {
-        case .abstractPost(let post):
-            return post.hasRemote()
-        case .customPost(let service):
-            return service.post != nil
-        }
+        post.hasRemote()
     }
 
-    enum SocialSharingSectionState {
-        /// The initial prompt to set up connections.
-        case setup(JetpackSocialNoConnectionViewModel)
-        /// The site has existing connections.
-        case connected
-    }
-
-    enum Row {
-        case jetpackAccessLevel
-        case jetpackNewsletterEmailOptions
+    var publishButtonTitle: String {
+        let isScheduled = settings.publishDate.map { $0 > .now } ?? false
+        return isScheduled ? PrepublishingSheetStrings.schedule : PrepublishingSheetStrings.publish
     }
 
     private let originalSettings: PostSettings
@@ -249,27 +168,21 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
     /// This is temporary until we can fully migrate to SwiftUI navigation.
     weak var viewController: UIViewController?
 
-    enum Context {
-        case settings
-        case publishing
-    }
-
-    // MARK: - AbstractPost Initializer
+    // MARK: - Initializer
 
     init(
         post: AbstractPost,
         isStandalone: Bool = false,
-        context: Context = .settings,
+        context: PostSettingsContext = .settings,
         preferences: UserPersistentRepository = UserDefaults.standard
     ) {
-        self.details = .abstractPost(post)
+        self.post = post
         self.blog = post.blog
         self.capabilities = post is Post ? .post() : .page()
         self.isStandalone = isStandalone
         self.context = context
         self.preferences = preferences
         self.client = try? WordPressClientFactory.shared.instance(for: .init(blog: post.blog))
-        self.editorService = nil
 
         // Initialize settings from the post
         let initialSettings = PostSettings(from: post)
@@ -297,73 +210,12 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
         WPAnalytics.track(.postSettingsShown)
     }
 
-    // MARK: - CustomPostEditorService Initializer
-
-    init(
-        editorService: CustomPostEditorService,
-        blog: Blog,
-        context: Context = .settings,
-        preferences: UserPersistentRepository = UserDefaults.standard
-    ) {
-        self.details = .customPost(editorService)
-        self.blog = blog
-        self.capabilities = PostSettingsCapabilities(from: editorService.details)
-        self.isStandalone = false
-        self.context = context
-        self.preferences = preferences
-        self.client = editorService.client
-        self.editorService = editorService
-
-        var initialSettings = editorService.settings
-        // Resolve author display name from Blog's cached authors
-        if let authorId = initialSettings.author?.id,
-           let authors = blog.authors,
-           let author = authors.first(where: { $0.userID.intValue == authorId }) {
-            initialSettings.author = PostSettings.Author(
-                id: authorId,
-                displayName: author.displayName ?? "–",
-                avatarURL: author.avatarURL.flatMap(URL.init)
-            )
-        }
-        self.settings = initialSettings
-        self.originalSettings = initialSettings
-
-        if capabilities.supportsFeaturedImage {
-            let featuredImage = initialSettings.featuredImageID.flatMap {
-                Media.existingOrStubMediaWith(
-                    mediaID: NSNumber(value: $0),
-                    inBlog: blog
-                )
-            }
-            self.featuredImageViewModel = PostSettingsFeaturedImageViewModel(
-                blog: blog,
-                featuredImage: featuredImage
-            )
-        } else {
-            self.featuredImageViewModel = nil
-        }
-
-        super.init()
-
-        featuredImageViewModel?.$selection.dropFirst().sink { [weak self] media in
-            self?.settings.featuredImageID = media?.mediaID?.intValue
-        }.store(in: &cancellables)
-
-        refreshDisplayedCategories()
-        refreshDisplayedTags()
-        refreshCustomTaxonomies()
-        resolveTermNames()
-
-        WPAnalytics.track(.postSettingsShown)
-    }
-
     func onAppear() {
         refreshSuggestedTags()
     }
 
-    func shouldShow(_ row: Row) -> Bool {
+    func shouldShow(_ row: PostSettingsRow) -> Bool {
         // FIXME: meta support missing in AnyPostWithEditContext
-        guard case .abstractPost = details else { return false }
         switch row {
         case .jetpackAccessLevel:
             return blog.supports(.wpComRESTAPI)
@@ -375,14 +227,15 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
     // MARK: - Suggested Tags
 
     private func refreshSuggestedTags() {
-        guard let abstractPost, isSuggestedTagsRefreshNeeded else {
+        guard isSuggestedTagsRefreshNeeded else {
             return
         }
         isSuggestedTagsRefreshNeeded = false
 
+        let post = self.post
         let task = Task { @MainActor [weak self] in
             do {
-                let tags = try await TagSuggestionsService().getSuggestedTags(for: abstractPost)
+                let tags = try await TagSuggestionsService().getSuggestedTags(for: post)
                 guard let self else { return }
                 if !tags.isEmpty {
                     withAnimation {
@@ -401,27 +254,21 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
     }
 
     private func refreshCustomTaxonomies() {
-        switch details {
-        case .abstractPost(let post):
-            let postType: String? = switch post {
-            case is Post: "post"
-            case is Page: "page"
-            default: nil
-            }
-            guard let postType else {
-                customTaxonomies = []
-                return
-            }
-            let taxonomies = try? blog.taxonomies
-                .filter {
-                    $0.slug != "post_tag" && $0.slug != "category" && $0.supportedPostTypes.contains(postType)
-                }
-                .sorted(using: KeyPathComparator(\.name))
-            customTaxonomies = taxonomies ?? []
-
-        case .customPost(let service):
-            customTaxonomies = service.taxonomies
+        let postType: String? = switch post {
+        case is Post: "post"
+        case is Page: "page"
+        default: nil
         }
+        guard let postType else {
+            customTaxonomies = []
+            return
+        }
+        let taxonomies = try? blog.taxonomies
+            .filter {
+                $0.slug != "post_tag" && $0.slug != "category" && $0.supportedPostTypes.contains(postType)
+            }
+            .sorted(using: KeyPathComparator(\.name))
+        customTaxonomies = taxonomies ?? []
     }
 
     // MARK: - Term Resolution
@@ -449,38 +296,6 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
         }
     }
 
-    private func resolveTermNames() {
-        guard let editorService else { return }
-
-        isResolvingTags = true
-        isResolvingCustomTerms = !settings.otherTerms.isEmpty
-
-        Task { [weak self] in
-            guard let self else { return }
-
-            do {
-                let tagsService = AnyTermService(client: editorService.client, endpoint: .tags)
-                let resolvedTags = try await TermResolutionService(taxonomyService: tagsService)
-                    .resolveNames(for: settings.tags)
-                self.settings.tags = resolvedTags
-                self.refreshDisplayedTags()
-                self.isResolvingTags = false
-
-                for taxonomy in editorService.taxonomies {
-                    guard let slugTerms = self.settings.otherTerms[taxonomy.slug] else { continue }
-                    let termService = AnyTermService(client: editorService.client, endpoint: taxonomy.endpoint)
-                    let resolved = try await TermResolutionService(taxonomyService: termService)
-                        .resolveNames(for: slugTerms)
-                    self.settings.otherTerms[taxonomy.slug] = resolved
-                }
-                self.isResolvingCustomTerms = false
-            } catch {
-                // TODO: We need better error handling
-                Loggers.app.log(level: .error, "Failed to resolve taxonomy terms: \(error)")
-            }
-        }
-    }
-
     // MARK: - Refresh
 
     private func refresh(from old: PostSettings, to new: PostSettings) {
@@ -498,12 +313,7 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
     }
 
     private func refreshDisplayedCategories() {
-        switch details {
-        case .abstractPost(let post):
-            displayedCategories = settings.getCategoryNames(for: post)
-        case .customPost:
-            displayedCategories = settings.getCategoryNames(for: blog)
-        }
+        displayedCategories = settings.getCategoryNames(for: post)
     }
 
     private func refreshDisplayedTags() {
@@ -527,15 +337,6 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
     }
 
     func buttonSaveTapped() {
-        switch details {
-        case .abstractPost(let post):
-            buttonSaveTappedForAbstractPost(post)
-        case .customPost:
-            buttonSaveTappedForCustomPost()
-        }
-    }
-
-    private func buttonSaveTappedForAbstractPost(_ post: AbstractPost) {
         // Check if the post still exists
         guard let context = post.managedObjectContext,
               let _ = try? context.existingObject(with: post.objectID) else {
@@ -574,36 +375,6 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
         }
     }
 
-    private func buttonSaveTappedForCustomPost() {
-        guard let editorService else {
-            wpAssertionFailure("missing editor service")
-            return
-        }
-
-        guard isStandalone else {
-            let settingsToSave = getSettingsToSave(for: settings)
-            editorService.applyLocally(settings: settingsToSave)
-            didSaveChanges()
-            onEditorPostSaved?()
-            onDismiss?()
-            return
-        }
-
-        isSaving = true
-        Task {
-            do {
-                let settingsToSave = getSettingsToSave(for: settings)
-                try await editorService.save(settings: settingsToSave, publish: false)
-                didSaveChanges()
-                onEditorPostSaved?()
-                onDismiss?()
-            } catch {
-                isSaving = false
-                Notice(error: error, title: Strings.saveFailedMessage).post()
-            }
-        }
-    }
-
     func getSettingsToSave(for settings: PostSettings) -> PostSettings {
         var settings = settings
         if context == .publishing {
@@ -618,15 +389,6 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
     }
 
     func buttonPublishTapped() {
-        switch details {
-        case .abstractPost(let post):
-            publishAbstractPost(post)
-        case .customPost:
-            publishCustomPost()
-        }
-    }
-
-    private func publishAbstractPost(_ post: AbstractPost) {
         // Check if the post still exists
         guard let context = post.managedObjectContext,
               let _ = try? context.existingObject(with: post.objectID) else {
@@ -644,24 +406,6 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
             } catch {
                 isSaving = false
                 // `PostCoordinator` handles errors by showing an alert when needed
-            }
-        }
-    }
-
-    private func publishCustomPost() {
-        guard let editorService else {
-            wpAssertionFailure("missing editor service")
-            return
-        }
-
-        isSaving = true
-        Task {
-            do {
-                try await editorService.save(settings: settings, publish: true)
-                onPostPublished?()
-            } catch {
-                isSaving = false
-                Notice(error: error, title: Strings.saveFailedMessage).post()
             }
         }
     }
@@ -704,7 +448,7 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
     // MARK: - Social Sharing
 
     private func refreshSocialSharingState() {
-        guard let post = abstractPost as? Post, isPostEligibleForSocialSharing(post) else {
+        guard let post = post as? Post, isPostEligibleForSocialSharing(post) else {
             socialSharingState = nil
             return
         }
@@ -781,12 +525,12 @@ final class PostSettingsViewModel: NSObject, ObservableObject {
 
     func showSocialSharingOptions() {
         guard let blogID = blog.dotComID?.intValue,
-              let settigns = settings.sharing else {
+              let settings = settings.sharing else {
             return wpAssertionFailure("invalid context")
         }
         let optionsVC = PrepublishingSocialAccountsViewController(
             blogID: blogID,
-            model: settigns,
+            model: settings,
             delegate: self,
             coreDataStack: ContextManager.shared
         )
@@ -895,83 +639,6 @@ extension PostSettingsViewModel: @MainActor PrepublishingSocialAccountsDelegate 
         settings.message = message ?? ""
         self.settings.sharing = settings
     }
-}
-
-// MARK: - PostFormat Helpers
-
-extension PostFormat {
-    static func from(slug: String) -> PostFormat {
-        switch slug {
-        case "standard": return .standard
-        case "aside": return .aside
-        case "chat": return .chat
-        case "gallery": return .gallery
-        case "link": return .link
-        case "image": return .image
-        case "quote": return .quote
-        case "status": return .status
-        case "video": return .video
-        case "audio": return .audio
-        default: return .custom(slug)
-        }
-    }
-}
-
-private enum PostDetails {
-    case abstractPost(AbstractPost)
-    case customPost(CustomPostEditorService)
-}
-
-// MARK: - Localized Strings
-
-private enum Strings {
-    static let postSettingsTitle = NSLocalizedString(
-        "postSettings.navigationTitle.post",
-        value: "Post Settings",
-        comment: "The title of the Post Settings screen."
-    )
-
-    static let pageSettingsTitle = NSLocalizedString(
-        "postSettings.navigationTitle.page",
-        value: "Page Settings",
-        comment: "The title of the Page Settings screen."
-    )
-
-    static let customPostSettingsTitle = NSLocalizedString(
-        "postSettings.navigationTitle.customPostType",
-        value: "%1$@ Settings",
-        comment: "The title of the Post Settings screen for custom post types. %1$@ is the post type name."
-    )
-
-    static let saveFailedMessage = NSLocalizedString(
-        "postSettings.saveFailed.message",
-        value: "Failed to save changes",
-        comment: "Error message shown when saving post settings via REST API fails"
-    )
-
-    static let postDeletedTitle = NSLocalizedString(
-        "postSettings.postDeleted.title",
-        value: "Post Deleted",
-        comment: "Title of alert when trying to save a deleted post"
-    )
-
-    static let pageDeletedTitle = NSLocalizedString(
-        "postSettings.pageDeleted.title",
-        value: "Page Deleted",
-        comment: "Title of alert when trying to save a deleted page"
-    )
-
-    static let postDeletedMessage = NSLocalizedString(
-        "postSettings.postDeleted.message",
-        value: "This post has been deleted and can no longer be saved.",
-        comment: "Message when trying to save a deleted post"
-    )
-
-    static let pageDeletedMessage = NSLocalizedString(
-        "postSettings.pageDeleted.message",
-        value: "This page has been deleted and can no longer be saved.",
-        comment: "Message when trying to save a deleted page"
-    )
 }
 
 private enum Constants {

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModelProtocol.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModelProtocol.swift
@@ -1,0 +1,165 @@
+import Foundation
+import UIKit
+import WordPressAPI
+import WordPressCore
+import WordPressData
+import WordPressKit
+import WordPressShared
+
+// MARK: - Types
+
+/// The context in which the post settings are displayed.
+enum PostSettingsContext {
+    case settings
+    case publishing
+}
+
+/// Rows that can be conditionally shown in the post settings form.
+enum PostSettingsRow {
+    case jetpackAccessLevel
+    case jetpackNewsletterEmailOptions
+}
+
+/// The state of the social sharing section.
+enum PostSettingsSocialSharingSectionState {
+    /// The initial prompt to set up connections.
+    case setup(JetpackSocialNoConnectionViewModel)
+    /// The site has existing connections.
+    case connected
+}
+
+// MARK: - Protocol
+
+/// Defines the contract for a post settings view model consumed by `PostSettingsView`
+/// and related views. Two concrete implementations exist:
+/// - `AbstractPostSettingsViewModel` for Core Data–backed posts/pages
+/// - `CustomPostSettingsViewModel` for REST API–backed custom post types
+@MainActor
+protocol PostSettingsViewModelProtocol: ObservableObject {
+    var blog: Blog { get }
+    var capabilities: PostSettingsCapabilities { get }
+    var isStandalone: Bool { get }
+    var context: PostSettingsContext { get }
+    var featuredImageViewModel: PostSettingsFeaturedImageViewModel? { get }
+    var client: WordPressClient? { get }
+
+    var settings: PostSettings { get set }
+    var isSaving: Bool { get }
+    var hasChanges: Bool { get }
+    var displayedCategories: [String] { get }
+    var displayedTags: [String] { get }
+    var isResolvingTags: Bool { get }
+    var isResolvingCustomTerms: Bool { get }
+    var suggestedTags: [String] { get }
+    var customTaxonomies: [SiteTaxonomy] { get }
+    var parentPageText: String? { get }
+    var socialSharingState: PostSettingsSocialSharingSectionState? { get }
+    var isShowingDeletedAlert: Bool { get set }
+
+    var postContent: String { get }
+    var navigationTitle: String { get }
+    var deletedAlertTitle: String { get }
+    var deletedAlertMessage: String { get }
+    var isScheduled: Bool { get }
+    var authorDisplayName: String { get }
+    var authorAvatarURL: URL? { get }
+    var emailToSubscribers: Bool { get set }
+    var accessLevel: JetpackPostAccessLevel { get set }
+    var publishDateText: String? { get }
+    var visibilityText: String { get }
+    var slugText: String { get }
+    var suggestedSlug: String? { get }
+    var permalinkTemplate: String? { get }
+    var postFormatText: String { get }
+    var timeZone: TimeZone { get }
+    var isDraftOrPending: Bool { get }
+    var isPost: Bool { get }
+    var shouldShowStickyOption: Bool { get }
+    var lastEditedText: String? { get }
+    var postID: Int? { get }
+    var page: Page? { get }
+    var hasRemote: Bool { get }
+    var publishButtonTitle: String { get }
+
+    var onDismiss: (() -> Void)? { get set }
+    var onEditorPostSaved: (() -> Void)? { get set }
+    var onPostPublished: (() -> Void)? { get set }
+    var viewController: UIViewController? { get set }
+
+    func onAppear()
+    func shouldShow(_ row: PostSettingsRow) -> Bool
+    func buttonCancelTapped()
+    func buttonSaveTapped()
+    func buttonPublishTapped()
+    func getSettingsToSave(for settings: PostSettings) -> PostSettings
+    func updateVisibility(_ selection: PostVisibilityPicker.Selection)
+    func didSelectSuggestedTag(_ tag: String)
+    func didSelectTags(_ tags: [TagsViewModel.SelectedTerm])
+    func didSelectTerms(_ terms: [TagsViewModel.SelectedTerm], forTaxonomySlug: String)
+    func showSocialSharingOptions()
+    func showCategoriesPicker()
+}
+
+// MARK: - Date Formatting
+
+enum PostSettingsDateFormatter {
+    static func formattedDate(_ date: Date, in timeZone: TimeZone) -> String {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        formatter.timeZone = timeZone
+        return formatter.string(from: date)
+    }
+}
+
+// MARK: - Localized Strings
+
+enum PostSettingsStrings {
+    static let postSettingsTitle = NSLocalizedString(
+        "postSettings.navigationTitle.post",
+        value: "Post Settings",
+        comment: "The title of the Post Settings screen."
+    )
+
+    static let pageSettingsTitle = NSLocalizedString(
+        "postSettings.navigationTitle.page",
+        value: "Page Settings",
+        comment: "The title of the Page Settings screen."
+    )
+
+    static let customPostSettingsTitle = NSLocalizedString(
+        "postSettings.navigationTitle.customPostType",
+        value: "%1$@ Settings",
+        comment: "The title of the Post Settings screen for custom post types. %1$@ is the post type name."
+    )
+
+    static let saveFailedMessage = NSLocalizedString(
+        "postSettings.saveFailed.message",
+        value: "Failed to save changes",
+        comment: "Error message shown when saving post settings via REST API fails"
+    )
+
+    static let postDeletedTitle = NSLocalizedString(
+        "postSettings.postDeleted.title",
+        value: "Post Deleted",
+        comment: "Title of alert when trying to save a deleted post"
+    )
+
+    static let pageDeletedTitle = NSLocalizedString(
+        "postSettings.pageDeleted.title",
+        value: "Page Deleted",
+        comment: "Title of alert when trying to save a deleted page"
+    )
+
+    static let postDeletedMessage = NSLocalizedString(
+        "postSettings.postDeleted.message",
+        value: "This post has been deleted and can no longer be saved.",
+        comment: "Message when trying to save a deleted post"
+    )
+
+    static let pageDeletedMessage = NSLocalizedString(
+        "postSettings.pageDeleted.message",
+        value: "This page has been deleted and can no longer be saved.",
+        comment: "Message when trying to save a deleted page"
+    )
+}

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostSettingsPublishDatePicker.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostSettingsPublishDatePicker.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 import WordPressUI
 
-struct PostSettingsPublishDatePicker: View {
-    @ObservedObject var viewModel: PostSettingsViewModel
+struct PostSettingsPublishDatePicker<ViewModel: PostSettingsViewModelProtocol>: View {
+    @ObservedObject var viewModel: ViewModel
 
     var body: some View {
         PublishDatePickerView(configuration: PublishDatePickerConfiguration(

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostStatusView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/Views/PostStatusView.swift
@@ -61,7 +61,7 @@ struct PostStatusView: View {
                         PostStatusRow(status: status, isSelected: settings.status == status)
                         if status == .scheduled && settings.status == .scheduled, let date = settings.publishDate {
                             HStack {
-                                SettingsRow(Strings.scheduleDate, value: PostSettingsViewModel.formattedDate(date, in: timeZone))
+                                SettingsRow(Strings.scheduleDate, value: PostSettingsDateFormatter.formattedDate(date, in: timeZone))
                                 Image(systemName: "chevron.forward")
                                     .font(.footnote.weight(.semibold))
                                     .foregroundColor(Color(.tertiaryLabel))

--- a/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
+++ b/WordPress/Classes/ViewRelated/Post/Publishing/PublishPostViewController.swift
@@ -19,8 +19,8 @@ enum PublishingSheetResult {
 
 /// A screen shown just before publishing the post and allows you to change
 /// the post settings along with some publishing options like the publish date.
-final class PublishPostViewController: UIHostingController<PublishPostView> {
-    private let viewModel: PostSettingsViewModel
+final class PublishPostViewController: UIHostingController<AnyView> {
+    private let viewModel: any PostSettingsViewModelProtocol
     private let uploadsViewModel: PostMediaUploadsViewModel?
 
     var onCompletion: ((PublishingSheetResult) -> Void)?
@@ -33,7 +33,7 @@ final class PublishPostViewController: UIHostingController<PublishPostView> {
         self.uploadsViewModel = uploadsViewModel
 
         let view = PublishPostView(viewModel: viewModel, uploadsViewModel: uploadsViewModel)
-        super.init(rootView: view)
+        super.init(rootView: AnyView(view))
     }
 
     static func show(for revision: AbstractPost, isStandalone: Bool = false, from presentingViewController: UIViewController, completion: @escaping (PublishingSheetResult) -> Void) {
@@ -57,12 +57,12 @@ final class PublishPostViewController: UIHostingController<PublishPostView> {
         editorService: CustomPostEditorService,
         blog: Blog
     ) {
-        let viewModel = PostSettingsViewModel(editorService: editorService, blog: blog, context: .publishing)
+        let viewModel = CustomPostSettingsViewModel(editorService: editorService, blog: blog, context: .publishing)
         self.viewModel = viewModel
         self.uploadsViewModel = nil
 
         let view = PublishPostView(viewModel: viewModel, uploadsViewModel: nil)
-        super.init(rootView: view)
+        super.init(rootView: AnyView(view))
     }
 
     static func show(
@@ -110,8 +110,8 @@ final class PublishPostViewController: UIHostingController<PublishPostView> {
     }
 }
 
-struct PublishPostView: View {
-    @ObservedObject var viewModel: PostSettingsViewModel
+struct PublishPostView<ViewModel: PostSettingsViewModelProtocol>: View {
+    @ObservedObject var viewModel: ViewModel
     var uploadsViewModel: PostMediaUploadsViewModel?
 
     @State private var isShowingDiscardChangesAlert = false
@@ -210,13 +210,6 @@ private struct PublishPostMediaSection: View {
                 PostMediaUploadsSnackbarView(state: state)
             }
         }
-    }
-}
-
-private extension PostSettingsViewModel {
-    var publishButtonTitle: String {
-        let isScheduled = settings.publishDate.map { $0 > .now } ?? false
-        return isScheduled ? Strings.schedule : Strings.publish
     }
 }
 


### PR DESCRIPTION
## Description

This is an alternative to https://github.com/wordpress-mobile/WordPress-iOS/pull/25363.

The new CustomPostSettingsViewModel duplicates lots of existing code in PostSettingsViewModel. I guess the good thing is the line between them is super clear.
