### PR TITLE
Update Lightbox to (pre)fetch previews

### DIFF
--- a/Modules/Sources/AsyncImageKit/ImageDownloader.swift
+++ b/Modules/Sources/AsyncImageKit/ImageDownloader.swift
@@ -121,7 +121,7 @@ public final class ImageDownloader {
     }
 
     /// The current disk usage of the URL cache, in bytes.
-    nonisolated public var diskCacheSize: Int {
+    public var diskCacheSize: Int {
         urlSessionWithCache.configuration.urlCache?.currentDiskUsage ?? 0
     }
 

--- a/Modules/Sources/AsyncImageKit/ImageDownloader.swift
+++ b/Modules/Sources/AsyncImageKit/ImageDownloader.swift
@@ -120,6 +120,11 @@ public final class ImageDownloader {
         return imageURL.absoluteString + (size.map { "?w=\($0.width),h=\($0.height)" } ?? "")
     }
 
+    /// The current disk usage of the URL cache, in bytes.
+    nonisolated public var diskCacheSize: Int {
+        urlSessionWithCache.configuration.urlCache?.currentDiskUsage ?? 0
+    }
+
     public func clearURLSessionCache() {
         urlSessionWithCache.configuration.urlCache?.removeAllCachedResponses()
         urlSession.configuration.urlCache?.removeAllCachedResponses()

--- a/Modules/Sources/WordPressReader/ReaderPostParser.swift
+++ b/Modules/Sources/WordPressReader/ReaderPostParser.swift
@@ -24,13 +24,27 @@ public enum ReaderPostParser {
         /// From `data-image-caption`.
         public let caption: String?
 
-        /// Returns the srcset URL whose width is closest to (but at least)
-        /// `maxWidth`. Falls back to the largest available entry.
-        /// Returns `nil` when srcset is empty.
-        public func bestURL(forMaxWidth maxWidth: Int) -> URL? {
+        /// Returns the srcset URL that best fills a square of `maxDimension` pixels.
+        ///
+        /// Uses `originalSize` to account for aspect ratio: for a landscape image
+        /// the width already matches the larger side, but for a portrait image the
+        /// required width is scaled up so the *height* fills `maxDimension`.
+        /// Falls back to the largest available entry if nothing is big enough.
+        ///
+        /// - Parameter maxDimension: The target size of the larger side, in **pixels**.
+        /// - Returns: The best matching URL, or `nil` when `srcset` is empty.
+        public func bestURL(maxDimension: Int) -> URL? {
             guard !srcset.isEmpty else { return nil }
+
+            // Compute the width needed so the larger side >= maxDimension.
+            var requiredWidth = maxDimension
+            if let originalSize, originalSize.height > originalSize.width {
+                // Portrait: we need a wider image so height fills maxDimension.
+                requiredWidth = Int(ceil(Double(maxDimension) * originalSize.width / originalSize.height))
+            }
+
             let sorted = srcset.sorted { $0.width < $1.width }
-            return (sorted.first { $0.width >= maxWidth } ?? sorted.last)?.url
+            return (sorted.first { $0.width >= requiredWidth } ?? sorted.last)?.url
         }
     }
 

--- a/Modules/Sources/WordPressReader/ReaderPostParser.swift
+++ b/Modules/Sources/WordPressReader/ReaderPostParser.swift
@@ -23,6 +23,15 @@ public enum ReaderPostParser {
         public let description: String?
         /// From `data-image-caption`.
         public let caption: String?
+
+        /// Returns the srcset URL whose width is closest to (but at least)
+        /// `maxWidth`. Falls back to the largest available entry.
+        /// Returns `nil` when srcset is empty.
+        public func bestURL(forMaxWidth maxWidth: Int) -> URL? {
+            guard !srcset.isEmpty else { return nil }
+            let sorted = srcset.sorted { $0.width < $1.width }
+            return (sorted.first { $0.width >= maxWidth } ?? sorted.last)?.url
+        }
     }
 
     public struct SrcsetEntry: Sendable {

--- a/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
@@ -151,7 +151,7 @@ struct DebugMenuView: View {
                 Task {
                     await ImageDownloader.shared.clearURLSessionCache()
                     await ImageDownloader.shared.clearMemoryCache()
-                    refreshImageCacheSize()
+                    await refreshImageCacheSize()
                     showSuccessNotice()
                 }
             } label: {
@@ -160,11 +160,11 @@ struct DebugMenuView: View {
             }
             .buttonStyle(.plain)
         }
-        .task { refreshImageCacheSize() }
+        .task { await refreshImageCacheSize() }
     }
 
-    private func refreshImageCacheSize() {
-        let bytes = ImageDownloader.shared.diskCacheSize
+    private func refreshImageCacheSize() async {
+        let bytes = await ImageDownloader.shared.diskCacheSize
         imageCacheSize = ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
     }
 

--- a/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/DebugMenuViewController.swift
@@ -1,4 +1,5 @@
 import UIKit
+import AsyncImageKit
 import AutomatticTracks
 import BuildSettingsKit
 import SwiftUI
@@ -13,6 +14,7 @@ struct DebugMenuView: View {
     @State private var isShowingWebViewURLDialog = false
     @State private var webViewURL = ""
     @State private var isAuthenticatedMode = true
+    @State private var imageCacheSize: String = ""
 
     fileprivate var navigation: NavigationContext
 
@@ -23,6 +25,7 @@ struct DebugMenuView: View {
             Section(Strings.sectionTipKit) { tipKit }
             Section(Strings.sectionWebView) { webView }
             Section(Strings.sectionLogging) { logging }
+            Section(Strings.sectionCaches) { caches }
         }
         .toolbar {
             ToolbarItem(placement: .principal) {
@@ -136,6 +139,33 @@ struct DebugMenuView: View {
             }.buttonStyle(.plain)
         }
         Toggle(Strings.alwaysSendLogs, isOn: $viewModel.isForcedCrashLoggingEnabled)
+    }
+
+    @ViewBuilder private var caches: some View {
+        HStack {
+            Text(Strings.imageCache)
+            Spacer()
+            Text(imageCacheSize)
+                .foregroundStyle(.secondary)
+            Button {
+                Task {
+                    await ImageDownloader.shared.clearURLSessionCache()
+                    await ImageDownloader.shared.clearMemoryCache()
+                    refreshImageCacheSize()
+                    showSuccessNotice()
+                }
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+                    .foregroundStyle(.secondary)
+            }
+            .buttonStyle(.plain)
+        }
+        .task { refreshImageCacheSize() }
+    }
+
+    private func refreshImageCacheSize() {
+        let bytes = ImageDownloader.shared.diskCacheSize
+        imageCacheSize = ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
     }
 
     private func presentAuthenticatedWebView() {
@@ -292,4 +322,7 @@ private enum Strings {
     static let showAllTips = NSLocalizedString("debugMenu.showAllTips", value: "Show All Tips", comment: "Debug Menu action for TipKit")
     static let hideAllTips = NSLocalizedString("debugMenu.hideAllTips", value: "Hide All Tips", comment: "Debug Menu action for TipKit")
     static let resetTipKitData = NSLocalizedString("debugMenu.resetTipKitData", value: "Reset Data", comment: "Debug Menu action for TipKit")
+
+    static let sectionCaches = NSLocalizedString("debugMenu.section.caches", value: "Caches", comment: "Debug Menu section title")
+    static let imageCache = NSLocalizedString("debugMenu.caches.imageCache", value: "Image Cache", comment: "Debug Menu label for image cache size")
 }

--- a/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxImagePageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxImagePageViewController.swift
@@ -130,16 +130,17 @@ final class LightboxImagePageViewController: UIViewController {
     private func showImage(_ image: UIImage) {
         activityIndicator.stopAnimating()
         scrollView.configure(with: image)
+        errorView?.isHidden = true
     }
 
     private func showError() {
         activityIndicator.stopAnimating()
         if errorView == nil {
-            let view = UIImageView(image: UIImage(systemName: "exclamationmark.triangle"))
-            view.tintColor = .separator
-            self.view.addSubview(view)
-            view.pinCenter()
-            errorView = view
+            let errorView = UIImageView(image: UIImage(systemName: "exclamationmark.triangle"))
+            errorView.tintColor = .separator
+            self.view.addSubview(errorView)
+            errorView.pinCenter()
+            self.errorView = errorView
         }
         errorView?.isHidden = false
     }

--- a/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxImagePageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxImagePageViewController.swift
@@ -4,11 +4,10 @@ import AsyncImageKit
 
 final class LightboxImagePageViewController: UIViewController {
     private(set) var scrollView = LightboxImageScrollView()
-    private let controller = ImageLoadingController()
-    private let siteMediaImageLoadingController = SiteMediaImageLoadingController()
     private let item: LightboxItem
     private let activityIndicator = UIActivityIndicatorView()
     private var errorView: UIImageView?
+    private var task: Task<Void, Never>?
 
     /// Used by UIPageViewController to track position.
     var pageIndex: Int = 0
@@ -20,6 +19,10 @@ final class LightboxImagePageViewController: UIViewController {
 
     required init?(coder aDecoder: NSCoder) {
         fatalError("init(coder:) has not been implemented")
+    }
+
+    deinit {
+        task?.cancel()
     }
 
     override func viewDidLoad() {
@@ -35,15 +38,9 @@ final class LightboxImagePageViewController: UIViewController {
             self?.parent?.presentingViewController?.dismiss(animated: true)
         }
 
-        controller.onStateChanged = { [weak self] in
-            self?.setState($0)
+        task = Task { @MainActor [weak self] in
+            await self?.loadImage()
         }
-
-        siteMediaImageLoadingController.onStateChanged = { [weak self] in
-            self?.setState($0)
-        }
-
-        startFetching()
     }
 
     override func viewDidLayoutSubviews() {
@@ -55,41 +52,91 @@ final class LightboxImagePageViewController: UIViewController {
         }
     }
 
-    private func startFetching() {
+    // MARK: - Loading
+
+    @MainActor
+    private func loadImage() async {
         switch item {
         case .image(let image):
-            setState(.success(image))
+            showImage(image)
         case .asset(let asset):
-            controller.setImage(with: ImageRequest(url: asset.sourceURL, host: asset.host))
+            await loadAsset(asset)
         case .media(let media):
-            siteMediaImageLoadingController.setImage(with: media, size: .original)
+            await loadMedia(media)
         }
     }
 
-    private func setState(_ state: ImageLoadingController.State) {
-        switch state {
-        case .loading:
-            if scrollView.imageView.image == nil {
-                activityIndicator.startAnimating()
+    @MainActor
+    private func loadAsset(_ asset: LightboxAsset) async {
+        let downloader = ImageDownloader.shared
+        let request = ImageRequest(url: asset.sourceURL, host: asset.host)
+
+        if let cached = downloader.cachedImage(for: request) {
+            showImage(cached)
+            return
+        }
+
+        activityIndicator.startAnimating()
+
+        // Load preview first if available.
+        if let previewURL = asset.previewURL {
+            let previewRequest = ImageRequest(url: previewURL, host: asset.host)
+            if let preview = try? await downloader.image(for: previewRequest) {
+                guard !Task.isCancelled else { return }
+                showImage(preview)
             }
-        case .success(let image):
-            activityIndicator.stopAnimating()
-            scrollView.configure(with: image)
-        case .failure:
-            activityIndicator.stopAnimating()
-            makeErrorView().isHidden = false
+        }
+
+        // Load full-resolution image.
+        do {
+            let image = try await downloader.image(for: request)
+            guard !Task.isCancelled else { return }
+            showImage(image)
+        } catch {
+            guard !Task.isCancelled else { return }
+            if scrollView.imageView.image == nil {
+                showError()
+            }
         }
     }
 
-    private func makeErrorView() -> UIImageView {
-        if let errorView {
-            return errorView
+    @MainActor
+    private func loadMedia(_ media: Media) async {
+        let service = MediaImageService.shared
+
+        if let cached = service.getCachedThumbnail(for: .init(media), size: .original) {
+            showImage(cached)
+            return
         }
-        let errorView = UIImageView(image: UIImage(systemName: "exclamationmark.triangle"))
-        errorView.tintColor = .separator
-        view.addSubview(errorView)
-        errorView.pinCenter()
-        self.errorView = errorView
-        return errorView
+
+        activityIndicator.startAnimating()
+
+        do {
+            let image = try await service.image(for: media, size: .original)
+            guard !Task.isCancelled else { return }
+            showImage(image)
+        } catch {
+            guard !Task.isCancelled else { return }
+            showError()
+        }
+    }
+
+    // MARK: - State
+
+    private func showImage(_ image: UIImage) {
+        activityIndicator.stopAnimating()
+        scrollView.configure(with: image)
+    }
+
+    private func showError() {
+        activityIndicator.stopAnimating()
+        if errorView == nil {
+            let view = UIImageView(image: UIImage(systemName: "exclamationmark.triangle"))
+            view.tintColor = .separator
+            self.view.addSubview(view)
+            view.pinCenter()
+            errorView = view
+        }
+        errorView?.isHidden = false
     }
 }

--- a/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxImagePageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxImagePageViewController.swift
@@ -78,12 +78,15 @@ final class LightboxImagePageViewController: UIViewController {
 
         activityIndicator.startAnimating()
 
-        // Load preview first if available.
+        // Load preview in parallel with the full image.
+        var previewTask: Task<Void, Never>?
         if let previewURL = asset.previewURL {
-            let previewRequest = ImageRequest(url: previewURL, host: asset.host)
-            if let preview = try? await downloader.image(for: previewRequest) {
-                guard !Task.isCancelled else { return }
-                showImage(preview)
+            previewTask = Task { @MainActor [weak self] in
+                let previewRequest = ImageRequest(url: previewURL, host: asset.host)
+                if let preview = try? await downloader.image(for: previewRequest) {
+                    guard !Task.isCancelled else { return }
+                    self?.showImage(preview)
+                }
             }
         }
 
@@ -91,6 +94,7 @@ final class LightboxImagePageViewController: UIViewController {
         do {
             let image = try await downloader.image(for: request)
             guard !Task.isCancelled else { return }
+            previewTask?.cancel()
             showImage(image)
         } catch {
             guard !Task.isCancelled else { return }

--- a/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxImagePageViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxImagePageViewController.swift
@@ -8,6 +8,7 @@ final class LightboxImagePageViewController: UIViewController {
     private let activityIndicator = UIActivityIndicatorView()
     private var errorView: UIImageView?
     private var task: Task<Void, Never>?
+    private var previewTask: Task<Void, Never>?
 
     /// Used by UIPageViewController to track position.
     var pageIndex: Int = 0
@@ -23,6 +24,7 @@ final class LightboxImagePageViewController: UIViewController {
 
     deinit {
         task?.cancel()
+        previewTask?.cancel()
     }
 
     override func viewDidLoad() {
@@ -88,6 +90,7 @@ final class LightboxImagePageViewController: UIViewController {
                     self?.showImage(preview)
                 }
             }
+            self.previewTask = previewTask
         }
 
         // Load full-resolution image.

--- a/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxItem.swift
+++ b/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxItem.swift
@@ -10,5 +10,7 @@ enum LightboxItem {
 
 struct LightboxAsset {
     let sourceURL: URL
+    /// An optional smaller preview to display while the full-resolution image loads.
+    var previewURL: URL?
     var host: MediaHost?
 }

--- a/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxViewController.swift
@@ -31,7 +31,7 @@ final class LightboxViewController: UIViewController {
     }
 
     convenience init(_ item: LightboxItem, configuration: Configuration = .init()) {
-        self.init(items: [item])
+        self.init(items: [item], configuration: configuration)
     }
 
     convenience init(assets: [LightboxAsset], selectedIndex: Int = 0) {

--- a/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxViewController.swift
+++ b/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxViewController.swift
@@ -10,6 +10,7 @@ final class LightboxViewController: UIViewController {
     private var items: [LightboxItem]
     private var selectedIndex: Int
     private var pageCounter: UILabel?
+    private var prefetchTask: Task<Void, Never>?
 
     /// A thumbnail to display during transition and for the initial image download.
     var thumbnail: UIImage?
@@ -62,6 +63,14 @@ final class LightboxViewController: UIViewController {
         if configuration.showsCloseButton {
             addCloseButton()
         }
+        prefetchPreviews()
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+
+        prefetchTask?.cancel()
+        prefetchTask = nil
     }
 
     // MARK: - Single item
@@ -121,6 +130,23 @@ final class LightboxViewController: UIViewController {
 
     private func updatePageCounter() {
         pageCounter?.text = "\(selectedIndex + 1) / \(items.count)"
+    }
+
+    // MARK: - Prefetching
+
+    private func prefetchPreviews() {
+        let urls = items.prefix(10).compactMap { item -> URL? in
+            guard case .asset(let asset) = item else { return nil }
+            return asset.previewURL
+        }
+        guard !urls.isEmpty else { return }
+        prefetchTask = Task {
+            let downloader = ImageDownloader.shared
+            for url in urls {
+                guard !Task.isCancelled else { return }
+                _ = try? await downloader.image(from: url)
+            }
+        }
     }
 
     // MARK: - Helpers

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -315,9 +315,9 @@ class ReaderDetailCoordinator {
     private func presentGallery(_ gallery: ReaderPostParser.Gallery, startingAt index: Int) {
         WPAnalytics.trackReader(.readerArticleImageTapped)
         let host = post.map(MediaHost.init)
-        let screenWidth = Int(UIScreen.main.bounds.width * min(UIScreen.main.scale, 2))
+        let maxDimension = Int(max(UIScreen.main.bounds.width, UIScreen.main.bounds.height) * min(UIScreen.main.scale, 2))
         let assets = gallery.images.map { image in
-            let sourceURL = image.bestURL(forMaxWidth: screenWidth) ?? image.originalFileURL ?? image.src
+            let sourceURL = image.bestURL(maxDimension: maxDimension) ?? image.originalFileURL ?? image.src
             let previewURL = image.srcset.min(by: { $0.width < $1.width })?.url
             return LightboxAsset(sourceURL: sourceURL, previewURL: previewURL, host: host)
         }

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -315,8 +315,11 @@ class ReaderDetailCoordinator {
     private func presentGallery(_ gallery: ReaderPostParser.Gallery, startingAt index: Int) {
         WPAnalytics.trackReader(.readerArticleImageTapped)
         let host = post.map(MediaHost.init)
-        let assets = gallery.images.map {
-            LightboxAsset(sourceURL: $0.originalFileURL ?? $0.src, host: host)
+        let screenWidth = Int(UIScreen.main.bounds.width * min(UIScreen.main.scale, 2))
+        let assets = gallery.images.map { image in
+            let sourceURL = image.bestURL(forMaxWidth: screenWidth) ?? image.originalFileURL ?? image.src
+            let previewURL = image.srcset.min(by: { $0.width < $1.width })?.url
+            return LightboxAsset(sourceURL: sourceURL, previewURL: previewURL, host: host)
         }
         let lightboxVC = LightboxViewController(assets: assets, selectedIndex: index)
         lightboxVC.configureZoomTransition()


### PR DESCRIPTION
A follow-up to https://github.com/wordpress-mobile/WordPress-iOS/pull/25365. In problem with the previous implementation was that it would try to load an original full-size image for every item in a gallery, which is slow.

## Changes

- Update `LightboxViewController` to support fetching previews before fetching original images
- Add prefetching for _all_ previews needed for the gallery
- Update Reader to use high-resolution (but not full-resolution) images when opening the gallery
- Add a way to clear the image cache from the debug menu (easily accessible with a swipe from the right edge)

An example of the images it picks based on the screen dimensions:

```
 ▿ 2 : LightboxAsset
    ▿ sourceURL : https://i0.wp.com/test841027.wpcomstaging.com/wp-content/uploads/2025/11/IMG_0005-1.jpeg?resize=2048%2C1367&ssl=1
    ▿ previewURL : https://i0.wp.com/test841027.wpcomstaging.com/wp-content/uploads/2025/11/IMG_0005-1.jpeg?resize=300%2C200&ssl=1
```

In addition, I refactored  `LightboxViewController`  to make it easier to change. In the previous version, it was using these two separate classes:

```swift
private let controller = ImageLoadingController()
private let siteMediaImageLoadingController = SiteMediaImageLoadingController()
```

In practice, they weren't adding enough or any value as they only contains very primitive code. They were, however, making it hard to change `LightboxViewController` and its fetching logic.

## Recording

with cleared cache:

https://github.com/user-attachments/assets/329d6272-977b-4782-b478-c9a82b90230f

