### PR TITLE
Fix an issue with pan gesture failing to dismiss Lihghtbox

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 26.8
 -----
 * [*] Fix an issue Social Sharing placeholder card showing unsupported services [#25336]
+* [*] Fix an issue with pan gesture failing to dismiss Lightbox [#25372]
 * [*] Reader: Add support for viewing media galleries fullscreen with a way to swipe between images [#25365]
 * [*] [internal] Fix retain cycle in Reader Article screen [#25364]
 

--- a/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxImageScrollView.swift
+++ b/WordPress/Classes/ViewRelated/Media/Lightbox/LightboxImageScrollView.swift
@@ -39,6 +39,7 @@ final class LightboxImageScrollView: UIScrollView, UIScrollViewDelegate {
         maximumZoomScale = 3
         showsHorizontalScrollIndicator = false
         showsVerticalScrollIndicator = false
+        panGestureRecognizer.isEnabled = false
 
         let doubleTapRecognizer = UITapGestureRecognizer(target: self, action: #selector(didRecognizeDoubleTap))
         doubleTapRecognizer.numberOfTapsRequired = 2
@@ -76,6 +77,7 @@ final class LightboxImageScrollView: UIScrollView, UIScrollViewDelegate {
         contentSize = bounds.size
         imageView.frame = bounds
         zoomScale = minimumZoomScale
+        panGestureRecognizer.isEnabled = false
 
         configureImageView()
     }
@@ -124,6 +126,14 @@ final class LightboxImageScrollView: UIScrollView, UIScrollViewDelegate {
 
     func viewForZooming(in scrollView: UIScrollView) -> UIView? {
         imageView
+    }
+
+    func scrollViewWillBeginZooming(_ scrollView: UIScrollView, with view: UIView?) {
+        panGestureRecognizer.isEnabled = false
+    }
+
+    func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {
+        panGestureRecognizer.isEnabled = scale > minimumZoomScale
     }
 
     func scrollViewDidZoom(_ scrollView: UIScrollView) {


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-1950/lightbox-the-screens-sometimes-fails-to-dismiss-with-a-panswipe

## Recording

There is still a little bit of glitches sometimes likely related to the zoom transition. I think we might want to roll out a custom solution eventually. This fix largely eliminate the problem though.

https://github.com/user-attachments/assets/04d5e8f6-e4dd-48d0-9f24-6db085f41487


## (Generated) RCA

 The issue is a gesture conflict between the scroll view's built-in pan gesture and the iOS 18 zoom transition's interactive dismissal gesture.

 **What's happening**

`LightboxImageScrollView` is a `UIScrollView` with zoom support. It has its own `panGestureRecognizer` that's always active. When you use preferredTransition = .zoom(...) on iOS 18, the system provides a built-in interactive pan-to-dismiss. But the scroll view's pan gesture swallows the vertical pan before the system's dismissal gesture can handle it — especially when the touch starts on the imageView (which is the scroll view's content).

 **Why it's intermittent**

 When you start the pan from the image view area, the scroll view's pan gesture wins because the touch is directly on its content. When you start from the empty area (e.g., the black bars around the image), there's less contention and the system gesture is more likely to fire.

**The fix: NYTPhotoViewer's Strategy 4**

 The cleanest solution for this specific case — since an image at 1x zoom doesn't need scrolling — is to disable the scroll view's panGestureRecognizer when not zoomed:

```swift
  In LightboxImageScrollView.swift, in setupView():
  panGestureRecognizer.isEnabled = false  // disabled at 1x zoom

  Then toggle it in the scroll view delegate:
  func scrollViewWillBeginZooming(_ scrollView: UIScrollView, with view: UIView?) {
      panGestureRecognizer.isEnabled = true
  }

  func scrollViewDidEndZooming(_ scrollView: UIScrollView, with view: UIView?, atScale scale: CGFloat) {
      if scale == minimumZoomScale {
          panGestureRecognizer.isEnabled = false
      }
  }
```

  This way:
  - At 1x zoom: scroll view pan is disabled, system's zoom-transition dismissal gesture receives the vertical pan uncontested
  - When zoomed in: scroll view pan is enabled for panning around the image, and dismiss is naturally blocked (the system handles this)

This is the same approach used by NYTPhotoViewer (the New York Times photo viewer) and is the simplest fix because it completely eliminates the gesture conflict rather than trying to arbitrate between two competing recognizers.