### PR TITLE
Use global class names for Core Data entities

### DIFF
--- a/Sources/WordPressData/Resources/WordPress.xcdatamodeld/WordPress 158.xcdatamodel/contents
+++ b/Sources/WordPressData/Resources/WordPress.xcdatamodeld/WordPress 158.xcdatamodel/contents
@@ -54,7 +54,7 @@
             <fetchIndexElement property="blogs" type="Binary" order="ascending"/>
         </fetchIndex>
     </entity>
-    <entity name="AccountSettings" representedClassName=".ManagedAccountSettings" syncable="YES">
+    <entity name="AccountSettings" representedClassName="ManagedAccountSettings" syncable="YES">
         <attribute name="aboutMe" attributeType="String" syncable="YES"/>
         <attribute name="blockEmailNotifications" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="displayName" attributeType="String" syncable="YES"/>
@@ -198,7 +198,7 @@
         </fetchIndex>
         <userInfo/>
     </entity>
-    <entity name="BlogAuthor" representedClassName=".BlogAuthor" syncable="YES">
+    <entity name="BlogAuthor" representedClassName="BlogAuthor" syncable="YES">
         <attribute name="avatarURL" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="deletedFromBlog" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="displayName" optional="YES" attributeType="String" syncable="YES"/>
@@ -209,7 +209,7 @@
         <attribute name="username" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="authors" inverseEntity="Blog" syncable="YES"/>
     </entity>
-    <entity name="BloggingPrompt" representedClassName=".BloggingPrompt" syncable="YES">
+    <entity name="BloggingPrompt" representedClassName="BloggingPrompt" syncable="YES">
         <attribute name="additionalPostTags" optional="YES" attributeType="Transformable" valueTransformerName="NSSecureUnarchiveFromData" customClassName="[String]" syncable="YES"/>
         <attribute name="answerCount" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="answered" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
@@ -220,7 +220,7 @@
         <attribute name="siteID" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="text" attributeType="String" defaultValueString="" syncable="YES"/>
     </entity>
-    <entity name="BloggingPromptSettings" representedClassName=".BloggingPromptSettings" syncable="YES">
+    <entity name="BloggingPromptSettings" representedClassName="BloggingPromptSettings" syncable="YES">
         <attribute name="isPotentialBloggingSite" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="promptCardEnabled" attributeType="Boolean" defaultValueString="YES" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="promptRemindersEnabled" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
@@ -228,7 +228,7 @@
         <attribute name="siteID" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <relationship name="reminderDays" maxCount="1" deletionRule="Cascade" destinationEntity="BloggingPromptSettingsReminderDays" inverseName="settings" inverseEntity="BloggingPromptSettingsReminderDays" syncable="YES"/>
     </entity>
-    <entity name="BloggingPromptSettingsReminderDays" representedClassName=".BloggingPromptSettingsReminderDays" syncable="YES">
+    <entity name="BloggingPromptSettingsReminderDays" representedClassName="BloggingPromptSettingsReminderDays" syncable="YES">
         <attribute name="friday" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="monday" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="saturday" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
@@ -238,7 +238,7 @@
         <attribute name="wednesday" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES" syncable="YES"/>
         <relationship name="settings" maxCount="1" deletionRule="Cascade" destinationEntity="BloggingPromptSettings" inverseName="reminderDays" inverseEntity="BloggingPromptSettings" syncable="YES"/>
     </entity>
-    <entity name="BlogSettings" representedClassName=".BlogSettings" syncable="YES">
+    <entity name="BlogSettings" representedClassName="BlogSettings" syncable="YES">
         <attribute name="ampEnabled" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="ampSupported" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="commentsAllowed" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
@@ -337,19 +337,19 @@
         </fetchIndex>
         <userInfo/>
     </entity>
-    <entity name="DiffAbstractValue" representedClassName=".DiffAbstractValue" isAbstract="YES" syncable="YES">
+    <entity name="DiffAbstractValue" representedClassName="DiffAbstractValue" isAbstract="YES" syncable="YES">
         <attribute name="diffOperation" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="diffType" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="index" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="value" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
-    <entity name="DiffContentValue" representedClassName=".DiffContentValue" parentEntity="DiffAbstractValue" syncable="YES">
+    <entity name="DiffContentValue" representedClassName="DiffContentValue" parentEntity="DiffAbstractValue" syncable="YES">
         <relationship name="revisionDiff" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="RevisionDiff" inverseName="contentDiffs" inverseEntity="RevisionDiff" syncable="YES"/>
     </entity>
-    <entity name="DiffTitleValue" representedClassName=".DiffTitleValue" parentEntity="DiffAbstractValue" syncable="YES">
+    <entity name="DiffTitleValue" representedClassName="DiffTitleValue" parentEntity="DiffAbstractValue" syncable="YES">
         <relationship name="revisionDiff" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="RevisionDiff" inverseName="titleDiffs" inverseEntity="RevisionDiff" syncable="YES"/>
     </entity>
-    <entity name="Domain" representedClassName=".ManagedDomain" syncable="YES">
+    <entity name="Domain" representedClassName="ManagedDomain" syncable="YES">
         <attribute name="autoRenewalDate" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="autoRenewing" optional="YES" attributeType="Boolean" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="domainName" optional="YES" attributeType="String" syncable="YES"/>
@@ -497,7 +497,7 @@
         <attribute name="title" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="categories" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PageTemplateCategory" inverseName="layouts" inverseEntity="PageTemplateCategory" syncable="YES"/>
     </entity>
-    <entity name="Person" representedClassName=".ManagedPerson" syncable="YES">
+    <entity name="Person" representedClassName="ManagedPerson" syncable="YES">
         <attribute name="avatarURL" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="creationDate" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="displayName" attributeType="String" syncable="YES"/>
@@ -511,7 +511,7 @@
         <attribute name="userID" attributeType="Integer 64" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="username" attributeType="String" syncable="YES"/>
     </entity>
-    <entity name="Plan" representedClassName=".Plan" syncable="YES">
+    <entity name="Plan" representedClassName="Plan" syncable="YES">
         <attribute name="features" attributeType="String" syncable="YES"/>
         <attribute name="groups" attributeType="String" syncable="YES"/>
         <attribute name="icon" attributeType="String" syncable="YES"/>
@@ -525,12 +525,12 @@
         <attribute name="supportPriority" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="tagline" attributeType="String" syncable="YES"/>
     </entity>
-    <entity name="PlanFeature" representedClassName=".PlanFeature" syncable="YES">
+    <entity name="PlanFeature" representedClassName="PlanFeature" syncable="YES">
         <attribute name="slug" attributeType="String" syncable="YES"/>
         <attribute name="summary" attributeType="String" syncable="YES"/>
         <attribute name="title" attributeType="String" syncable="YES"/>
     </entity>
-    <entity name="PlanGroup" representedClassName=".PlanGroup" syncable="YES">
+    <entity name="PlanGroup" representedClassName="PlanGroup" syncable="YES">
         <attribute name="name" attributeType="String" syncable="YES"/>
         <attribute name="order" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="slug" attributeType="String" syncable="YES"/>
@@ -570,7 +570,7 @@
         <attribute name="name" optional="YES" attributeType="String" syncable="YES"/>
         <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="postTypes" inverseEntity="Blog" syncable="YES"/>
     </entity>
-    <entity name="PublicizeConnection" representedClassName=".PublicizeConnection" syncable="YES">
+    <entity name="PublicizeConnection" representedClassName="PublicizeConnection" syncable="YES">
         <attribute name="connectionID" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="dateExpires" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="dateIssued" optional="YES" attributeType="Date" usesScalarValueType="NO" syncable="YES"/>
@@ -598,7 +598,7 @@
         <attribute name="toBePublicizedCount" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <relationship name="blog" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Blog" inverseName="publicizeInfo" inverseEntity="Blog"/>
     </entity>
-    <entity name="PublicizeService" representedClassName=".PublicizeService" syncable="YES">
+    <entity name="PublicizeService" representedClassName="PublicizeService" syncable="YES">
         <attribute name="connectURL" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="detail" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="externalUsersOnly" optional="YES" attributeType="Boolean" usesScalarValueType="NO" syncable="YES"/>
@@ -629,7 +629,7 @@
             <fetchIndexElement property="path" type="Binary" order="ascending"/>
         </fetchIndex>
     </entity>
-    <entity name="ReaderCard" representedClassName=".ReaderCard" syncable="YES">
+    <entity name="ReaderCard" representedClassName="ReaderCard" syncable="YES">
         <attribute name="sortRank" attributeType="Double" defaultValueString="0.0" usesScalarValueType="NO" syncable="YES"/>
         <relationship name="post" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="ReaderPost" inverseName="card" inverseEntity="ReaderPost" syncable="YES"/>
         <relationship name="sites" optional="YES" toMany="YES" deletionRule="Nullify" ordered="YES" destinationEntity="ReaderSiteTopic" inverseName="cards" inverseEntity="ReaderSiteTopic" syncable="YES"/>
@@ -766,7 +766,7 @@
         <attribute name="organizationID" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES" syncable="YES"/>
         <attribute name="slug" optional="YES" attributeType="String" syncable="YES"/>
     </entity>
-    <entity name="Revision" representedClassName=".Revision" syncable="YES">
+    <entity name="Revision" representedClassName="Revision" syncable="YES">
         <attribute name="postAuthorId" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="postContent" optional="YES" attributeType="String" syncable="YES"/>
         <attribute name="postDateGmt" optional="YES" attributeType="String" syncable="YES"/>
@@ -778,7 +778,7 @@
         <attribute name="siteId" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <relationship name="diff" optional="YES" maxCount="1" deletionRule="Cascade" destinationEntity="RevisionDiff" inverseName="revision" inverseEntity="RevisionDiff" syncable="YES"/>
     </entity>
-    <entity name="RevisionDiff" representedClassName=".RevisionDiff" syncable="YES">
+    <entity name="RevisionDiff" representedClassName="RevisionDiff" syncable="YES">
         <attribute name="fromRevisionId" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="toRevisionId" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="totalAdditions" attributeType="Integer 32" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
@@ -787,7 +787,7 @@
         <relationship name="revision" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="Revision" inverseName="diff" inverseEntity="Revision" syncable="YES"/>
         <relationship name="titleDiffs" optional="YES" toMany="YES" deletionRule="Cascade" destinationEntity="DiffTitleValue" inverseName="revisionDiff" inverseEntity="DiffTitleValue" syncable="YES"/>
     </entity>
-    <entity name="Role" representedClassName=".Role" syncable="YES">
+    <entity name="Role" representedClassName="Role" syncable="YES">
         <attribute name="name" attributeType="String" syncable="YES"/>
         <attribute name="order" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="NO" syncable="YES"/>
         <attribute name="slug" attributeType="String" syncable="YES"/>

--- a/Sources/WordPressData/Swift/BlogAuthor.swift
+++ b/Sources/WordPressData/Swift/BlogAuthor.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreData
 
+@objc(BlogAuthor)
 public class BlogAuthor: NSManagedObject {
     @NSManaged public var userID: NSNumber
     @NSManaged public var username: String?

--- a/Sources/WordPressData/Swift/BlogSettings.swift
+++ b/Sources/WordPressData/Swift/BlogSettings.swift
@@ -3,6 +3,7 @@ import Foundation
 
 /// This class encapsulates all of the settings available for a Blog entity
 ///
+@objc(BlogSettings)
 open class BlogSettings: NSManagedObject {
     // MARK: - Relationships
 

--- a/Sources/WordPressData/Swift/BloggingPrompt+CoreDataClass.swift
+++ b/Sources/WordPressData/Swift/BloggingPrompt+CoreDataClass.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreData
 
+@objc(BloggingPrompt)
 public class BloggingPrompt: NSManagedObject {
 
     @nonobjc public class func fetchRequest() -> NSFetchRequest<BloggingPrompt> {

--- a/Sources/WordPressData/Swift/BloggingPromptSettings+CoreDataClass.swift
+++ b/Sources/WordPressData/Swift/BloggingPromptSettings+CoreDataClass.swift
@@ -2,6 +2,7 @@ import Foundation
 import CoreData
 import WordPressKit
 
+@objc(BloggingPromptSettings)
 public class BloggingPromptSettings: NSManagedObject {
 
     public static func of(_ blog: Blog) throws -> BloggingPromptSettings? {

--- a/Sources/WordPressData/Swift/BloggingPromptSettingsReminderDays+CoreDataClass.swift
+++ b/Sources/WordPressData/Swift/BloggingPromptSettingsReminderDays+CoreDataClass.swift
@@ -2,6 +2,7 @@ import Foundation
 import CoreData
 import WordPressKit
 
+@objc(BloggingPromptSettingsReminderDays)
 public class BloggingPromptSettingsReminderDays: NSManagedObject {
 
     public func configure(with remoteReminderDays: RemoteBloggingPromptsSettings.ReminderDays) {

--- a/Sources/WordPressData/Swift/DiffAbstractValue.swift
+++ b/Sources/WordPressData/Swift/DiffAbstractValue.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreData
 
+@objc(DiffAbstractValue)
 public class DiffAbstractValue: NSManagedObject {
     public enum Operation: String {
         case add

--- a/Sources/WordPressData/Swift/DiffContentValue.swift
+++ b/Sources/WordPressData/Swift/DiffContentValue.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreData
 
+@objc(DiffContentValue)
 public class DiffContentValue: DiffAbstractValue {
     @NSManaged var revisionDiff: RevisionDiff?
 }

--- a/Sources/WordPressData/Swift/DiffTitleValue.swift
+++ b/Sources/WordPressData/Swift/DiffTitleValue.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreData
 
+@objc(DiffTitleValue)
 public class DiffTitleValue: DiffAbstractValue {
     @NSManaged var revisionDiff: RevisionDiff?
 }

--- a/Sources/WordPressData/Swift/Domain.swift
+++ b/Sources/WordPressData/Swift/Domain.swift
@@ -17,6 +17,7 @@ public extension Domain {
     }
 }
 
+@objc(ManagedDomain)
 public class ManagedDomain: NSManagedObject {
 
     // MARK: - NSManagedObject

--- a/Sources/WordPressData/Swift/ManagedAccountSettings.swift
+++ b/Sources/WordPressData/Swift/ManagedAccountSettings.swift
@@ -4,6 +4,7 @@ import WordPressKit
 
 // MARK: - Reflects the user's Account Settings, as stored in Core Data.
 //
+@objc(ManagedAccountSettings)
 public class ManagedAccountSettings: NSManagedObject {
 
     // MARK: - NSManagedObject

--- a/Sources/WordPressData/Swift/ManagedPerson.swift
+++ b/Sources/WordPressData/Swift/ManagedPerson.swift
@@ -8,6 +8,7 @@ public typealias Person = RemotePerson
 
 // MARK: - Reflects a Person, stored in Core Data
 //
+@objc(ManagedPerson)
 public class ManagedPerson: NSManagedObject {
 
     public func updateWith<T: Person>(_ person: T) {

--- a/Sources/WordPressData/Swift/Plan.swift
+++ b/Sources/WordPressData/Swift/Plan.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreData
 
+@objc(Plan)
 public class Plan: NSManagedObject {
     @NSManaged public var order: Int16
     @NSManaged public var tagline: String

--- a/Sources/WordPressData/Swift/PlanFeature.swift
+++ b/Sources/WordPressData/Swift/PlanFeature.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreData
 
+@objc(PlanFeature)
 public class PlanFeature: NSManagedObject {
     @NSManaged public var summary: String
     @NSManaged public var title: String

--- a/Sources/WordPressData/Swift/PlanGroup.swift
+++ b/Sources/WordPressData/Swift/PlanGroup.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreData
 
+@objc(PlanGroup)
 public class PlanGroup: NSManagedObject {
     @NSManaged public var order: Int16
     @NSManaged public var name: String

--- a/Sources/WordPressData/Swift/PublicizeConnection.swift
+++ b/Sources/WordPressData/Swift/PublicizeConnection.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreData
 
+@objc(PublicizeConnection)
 open class PublicizeConnection: NSManagedObject {
     // Relations
     @NSManaged open var blog: Blog

--- a/Sources/WordPressData/Swift/PublicizeService.swift
+++ b/Sources/WordPressData/Swift/PublicizeService.swift
@@ -2,6 +2,7 @@ import Foundation
 import CoreData
 import WordPressShared
 
+@objc(PublicizeService)
 open class PublicizeService: NSManagedObject {
     @objc public static let googlePlusServiceID = "google_plus"
     @objc public static let facebookServiceID = "facebook"

--- a/Sources/WordPressData/Swift/ReaderCard+CoreDataClass.swift
+++ b/Sources/WordPressData/Swift/ReaderCard+CoreDataClass.swift
@@ -2,6 +2,7 @@ import Foundation
 import CoreData
 import WordPressKit
 
+@objc(ReaderCard)
 public class ReaderCard: NSManagedObject {
     public enum CardType {
         case post

--- a/Sources/WordPressData/Swift/Revision.swift
+++ b/Sources/WordPressData/Swift/Revision.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreData
 
+@objc(Revision)
 public class Revision: NSManagedObject {
     @NSManaged public var siteId: NSNumber
     @NSManaged public var revisionId: NSNumber

--- a/Sources/WordPressData/Swift/RevisionDiff.swift
+++ b/Sources/WordPressData/Swift/RevisionDiff.swift
@@ -1,6 +1,7 @@
 import Foundation
 import CoreData
 
+@objc(RevisionDiff)
 public class RevisionDiff: NSManagedObject {
     @NSManaged public var fromRevisionId: NSNumber
     @NSManaged public var toRevisionId: NSNumber

--- a/Sources/WordPressData/Swift/Role.swift
+++ b/Sources/WordPressData/Swift/Role.swift
@@ -2,6 +2,7 @@ import Foundation
 import CoreData
 import WordPressKit
 
+@objc(Role)
 public class Role: NSManagedObject {
     @NSManaged public var name: String!
     @NSManaged public var slug: String!


### PR DESCRIPTION
This is a prerequisite for https://github.com/wordpress-mobile/WordPress-iOS/pull/25377. For most classes that represent Core Entities, we simply use `@objc` class names to put them into the global namespace, which is a recommended practice. This PR updates the remaining classes, so they all follow the same practice.

**Potential issues**: collisions at runtime; unlikely since most of the code is now in Swift.
**Note on migration**: `WordPress 158` is shipping in 26.8, so I added the change to it.
