### PR TITLE
Add ui-test-wpcom-token option to auto sign-in WP.com sites

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -64,11 +64,15 @@ xcodebuild \
 Some test targets (e.g. `WordPressDataTests`) have their own scheme and are not part of the main `WordPress` scheme's test plan.
 When the `WordPress` scheme build fails due to an unrelated target, try using the target's dedicated scheme instead.
 
+### Simulator Sign-In
+
+To automatically sign in to the app on an iOS simulator, see @docs/simulator-sign-in.md.
+
 ## Coding Standards
 - Follow Swift API Design Guidelines
 - Use strict access control modifiers where possible
 - Use four spaces (not tabs)
-- Lines should not have trailing whitespace 
+- Lines should not have trailing whitespace
 - Follow the standard formatting practices enforced by SwiftLint
 - Don't create `body` for `View` that are too long
 - Use semantics text sizes like `.headline`

--- a/WordPress/Classes/Login/WordPressDotComAuthenticator.swift
+++ b/WordPress/Classes/Login/WordPressDotComAuthenticator.swift
@@ -122,7 +122,11 @@ struct WordPressDotComAuthenticator {
 
         let token: String
         do {
-            token = try await authenticate(from: viewController, prefersEphemeralWebBrowserSession: hasAlreadySignedIn, accountEmail: context.accountEmail(in: coreDataStack.mainContext))
+            if let tokenLaunchArgument = UserDefaults.standard.string(forKey: "ui-test-wpcom-token") {
+                token = tokenLaunchArgument
+            } else {
+                token = try await authenticate(from: viewController, prefersEphemeralWebBrowserSession: hasAlreadySignedIn, accountEmail: context.accountEmail(in: coreDataStack.mainContext))
+            }
         } catch {
             throw .authentication(error)
         }

--- a/docs/simulator-sign-in.md
+++ b/docs/simulator-sign-in.md
@@ -1,0 +1,39 @@
+# Simulator Sign-In
+
+Launch the app with credentials to enable automatic sign-in on the simulator.
+
+## Step 1: Providing Credentials
+
+### Self-hosted site
+
+```bash
+xcrun simctl launch --terminate-running-process booted org.wordpress \
+  -ui-test-reset-everything \
+  -ui-test-site-url https://example.com \
+  -ui-test-site-user <username> \
+  -ui-test-site-pass <application-password>
+```
+
+### WordPress.com account
+
+```bash
+xcrun simctl launch --terminate-running-process booted org.wordpress \
+  -ui-test-reset-everything \
+  -ui-test-wpcom-token <bearer-token>
+```
+
+## Step 2: Signing In
+
+After launching with credentials, the app displays a sign-in page with two buttons: **"Continue with WordPress.com"** and **"Enter your existing site address"**.
+
+### WordPress.com account
+
+Tap **"Continue with WordPress.com"**. You will be automatically signed in.
+
+### Self-hosted site
+
+1. Tap **"Enter your existing site address"**
+2. Enter the site address in the text field
+3. Tap **"Continue"**
+
+You will be automatically signed in.


### PR DESCRIPTION
## Description

Similar to https://github.com/wordpress-mobile/WordPress-iOS/pull/25325, this PR implements auto-sign-in WP.com sites using launch arguments.

This PR adds documentation about the auto-sign-in capability to AGENTS.md, so that your coding agents can know how to sign in to test sites and [perform end-to-end tests](https://github.com/wordpress-mobile/WordPress-iOS/pull/25354).