### PR TITLE
Add "Homepage" indicator to the custom post list

### DIFF
--- a/Modules/Sources/WordPressCore/WordPressClient.swift
+++ b/Modules/Sources/WordPressCore/WordPressClient.swift
@@ -114,6 +114,9 @@ public actor WordPressClient {
     /// The cached task for fetching the site's active theme.
     private var loadActiveThemeTask: Task<ThemeWithEditContext, Error>
 
+    /// The cached task for fetching the site settings.
+    private var loadSiteSettingsTask: Task<SiteSettingsWithEditContext, Error>
+
     /// Creates a new WordPress client for the specified site.
     ///
     /// Upon initialization, the client automatically begins fetching and caching site info,
@@ -139,6 +142,9 @@ public actor WordPressClient {
 
             return activeTheme
         }
+        self.loadSiteSettingsTask = Task {
+            try await api.siteSettings.retrieveWithEditContext().data
+        }
     }
 
     /// Invalidates all cached data and triggers a fresh fetch from the server.
@@ -151,6 +157,7 @@ public actor WordPressClient {
         loadSiteInfoTask = self.newSiteInfoTask()
         loadCurrentUserTask = self.newCurrentUserTask()
         loadActiveThemeTask = self.newActiveThemeTask()
+        loadSiteSettingsTask = self.newSiteSettingsTask()
     }
 
     /// Checks whether the WordPress site supports a given feature.
@@ -260,6 +267,25 @@ public actor WordPressClient {
             }
 
             return theme
+        }
+    }
+
+    /// Fetches the site settings, using the cached value if available.
+    ///
+    /// If the cached task has failed, creates a new task and retries the fetch.
+    public func fetchSiteSettings() async throws -> SiteSettingsWithEditContext {
+        switch await self.loadSiteSettingsTask.result {
+        case .success(let settings): return settings
+        case .failure:
+            self.loadSiteSettingsTask = newSiteSettingsTask()
+            return try await self.loadSiteSettingsTask.value
+        }
+    }
+
+    /// Creates a new task to fetch the site settings from the server.
+    private func newSiteSettingsTask() -> Task<SiteSettingsWithEditContext, Error> {
+        Task {
+            try await api.siteSettings.retrieveWithEditContext().data
         }
     }
 }

--- a/Modules/Tests/WordPressCoreTests/MockWordPressClientAPI.swift
+++ b/Modules/Tests/WordPressCoreTests/MockWordPressClientAPI.swift
@@ -11,6 +11,7 @@ final class MockWordPressClientAPI: WordPressClientAPI, @unchecked Sendable {
     private var _apiRootCallCount = 0
     private var _usersCallCount = 0
     private var _themesCallCount = 0
+    private var _siteSettingsCallCount = 0
 
     var apiRootCallCount: Int {
         lock.lock()
@@ -28,6 +29,12 @@ final class MockWordPressClientAPI: WordPressClientAPI, @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return _themesCallCount
+    }
+
+    var siteSettingsCallCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return _siteSettingsCallCount
     }
 
     var mockRoutes: Set<String> = []
@@ -54,6 +61,13 @@ final class MockWordPressClientAPI: WordPressClientAPI, @unchecked Sendable {
         return MockThemesRequestExecutor(isBlockTheme: mockIsBlockTheme)
     }
 
+    var siteSettings: SiteSettingsRequestExecutor {
+        lock.lock()
+        _siteSettingsCallCount += 1
+        lock.unlock()
+        return MockSiteSettingsRequestExecutor()
+    }
+
     // Unused in WordPressClient.supports() - provide minimal implementations
     var plugins: PluginsRequestExecutor { fatalError("Not implemented") }
     var comments: CommentsRequestExecutor { fatalError("Not implemented") }
@@ -63,7 +77,6 @@ final class MockWordPressClientAPI: WordPressClientAPI, @unchecked Sendable {
     var applicationPasswords: ApplicationPasswordsRequestExecutor { fatalError("Not implemented") }
     var posts: PostsRequestExecutor { fatalError("Not implemented") }
     var postTypes: PostTypesRequestExecutor { fatalError("Not implemented") }
-    var siteSettings: SiteSettingsRequestExecutor { fatalError("Not implemented") }
 
     func createSelfHostedService(cache: WordPressApiCache) throws -> WpService {
         fatalError("Not implemented")
@@ -167,6 +180,47 @@ final class MockThemesRequestExecutor: ThemesRequestExecutor {
         )
         let mockHeaderMap = WpNetworkHeaderMap(noHandle: WpNetworkHeaderMap.NoHandle())
         return ThemesRequestListWithEditContextResponse(data: [mockTheme], headerMap: mockHeaderMap)
+    }
+}
+
+final class MockSiteSettingsRequestExecutor: SiteSettingsRequestExecutor {
+    override init(noHandle: SiteSettingsRequestExecutor.NoHandle) {
+        super.init(noHandle: noHandle)
+    }
+
+    init() {
+        super.init(noHandle: SiteSettingsRequestExecutor.NoHandle())
+    }
+
+    required init(unsafeFromHandle handle: UInt64) {
+        super.init(unsafeFromHandle: handle)
+    }
+
+    override func retrieveWithEditContextCancellation(context: RequestContext?) async throws -> SiteSettingsRequestRetrieveWithEditContextResponse {
+        let mockSettings = SiteSettingsWithEditContext(
+            title: "Test Site",
+            description: "A test site",
+            url: "https://example.com",
+            email: "test@example.com",
+            timezone: "",
+            dateFormat: "Y-m-d",
+            timeFormat: "H:i",
+            startOfWeek: 0,
+            language: "en_US",
+            useSmilies: true,
+            defaultCategory: 1,
+            defaultPostFormat: "",
+            postsPerPage: 10,
+            showOnFront: "posts",
+            pageOnFront: 0,
+            pageForPosts: 0,
+            defaultPingStatus: .open,
+            defaultCommentStatus: .open,
+            siteLogo: nil,
+            siteIcon: 0
+        )
+        let mockHeaderMap = WpNetworkHeaderMap(noHandle: WpNetworkHeaderMap.NoHandle())
+        return SiteSettingsRequestRetrieveWithEditContextResponse(data: mockSettings, headerMap: mockHeaderMap)
     }
 }
 

--- a/WordPress/Classes/Services/BlogServiceRemoteCoreREST.swift
+++ b/WordPress/Classes/Services/BlogServiceRemoteCoreREST.swift
@@ -169,9 +169,8 @@ import WordPressAPIInternal
     ) {
         Task { @MainActor in
             do {
-                let response = try await client.api.siteSettings
-                    .retrieveWithEditContext()
-                let settings = Self.mapSiteSettings(response.data)
+                let response = try await client.fetchSiteSettings()
+                let settings = Self.mapSiteSettings(response)
                 success?(settings)
             } catch {
                 failure?(error)

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListView.swift
@@ -73,11 +73,10 @@ struct CustomPostListView<Header: View>: View {
             }
         }
         .refreshable {
-            await viewModel.refresh()
+            await viewModel.pullToRefresh()
         }
         .progressHUD(state: $viewModel.progressHUDState)
         .task(id: viewModel.filter) {
-            await viewModel.loadCachedItems()
             await viewModel.refresh()
         }
         .task(id: viewModel.filter) {
@@ -458,6 +457,7 @@ private struct PostContent: View {
             header
             content
             footer
+            homepageBadge
         }
         .frame(maxWidth: .infinity, alignment: .leading)
         .contentShape(Rectangle())
@@ -503,6 +503,18 @@ private struct PostContent: View {
                 .foregroundStyle(post.statusColor)
         }
     }
+
+    @ViewBuilder
+    private var homepageBadge: some View {
+        if post.isHomepage {
+            HStack(spacing: 2) {
+                Image(systemName: "house.fill")
+                Text(verbatim: Strings.homepageBadge)
+            }
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+        }
+    }
 }
 
 private struct ErrorRow: View {
@@ -526,6 +538,11 @@ private enum Strings {
         "customPostList.emptyState.message",
         value: "No %1$@",
         comment: "Empty state message when no custom posts exist. %1$@ is the post type name (e.g., 'Podcasts', 'Products')."
+    )
+    static let homepageBadge = NSLocalizedString(
+        "customPostList.badge.homepage",
+        value: "Homepage",
+        comment: "Badge label shown on the homepage row in the custom post list for pages"
     )
     static let publish = NSLocalizedString(
         "customPostList.action.publish",

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListView.swift
@@ -284,45 +284,43 @@ private struct ForEachContent: View {
     let viewModel: CustomPostListViewModel
 
     var body: some View {
-        switch item {
-        case .error(_, let message):
-            ErrorRow(message: message)
-
-        case .errorWithData(_, let message, let post):
-            VStack(spacing: 4) {
-                PostContent(post: post, client: client, mediaHost: mediaHost)
-                ErrorRow(message: message)
+        switch item.state {
+        // TODO: When isUpToDate is false, fetch fresh data before opening
+        // the editor to prevent overwriting newer content.
+        case .loaded(let fullPost, _):
+            if let post = item.post {
+                Button {
+                    onSelectPost(fullPost)
+                } label: {
+                    PostContent(post: post, client: client, mediaHost: mediaHost)
+                }
+                .buttonStyle(.plain)
+                .contextMenu {
+                    PostActionMenuContent(post: fullPost, viewModel: viewModel)
+                }
+                .overlay(alignment: .topTrailing) {
+                    PostActionMenu(post: fullPost, viewModel: viewModel)
+                        .offset(y: -6)
+                }
             }
 
-        case .fetching, .missing, .refreshing:
+        case .loading:
             PostContent(
-                post: CustomPostCollectionDisplayPost(
-                    date: Date(),
-                    title: "Lorem ipsum dolor sit amet",
-                    content: "Lorem ipsum dolor sit amet consectetur adipiscing elit"
-                ),
+                post: .placeholder,
                 client: client,
                 mediaHost: mediaHost
             )
             .redacted(reason: .placeholder)
 
-        case .ready(_, let displayPost, let post):
-            Button {
-                onSelectPost(post)
-            } label: {
-                PostContent(post: displayPost, client: client, mediaHost: mediaHost)
+        case .error(let message):
+            if let post = item.post {
+                VStack(spacing: 4) {
+                    PostContent(post: post, client: client, mediaHost: mediaHost)
+                    ErrorRow(message: message)
+                }
+            } else {
+                ErrorRow(message: message)
             }
-            .buttonStyle(.plain)
-            .contextMenu {
-                PostActionMenuContent(post: post, viewModel: viewModel)
-            }
-            .overlay(alignment: .topTrailing) {
-                PostActionMenu(post: post, viewModel: viewModel)
-                    .offset(y: -6)
-            }
-
-        case .stale(_, let post):
-            PostContent(post: post, client: client, mediaHost: mediaHost)
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
@@ -514,14 +514,11 @@ struct CustomPostCollectionDisplayPost: Equatable {
         self.isHomepage = isHomepage
     }
 
-    init(_ entity: AnyPostWithEditContext, blog: Blog, contentLimit: Int = 100, primaryStatus: PostStatus = .publish) {
+    init(_ entity: AnyPostWithEditContext, blog: Blog, primaryStatus: PostStatus = .publish) {
         self.date = entity.dateGmt
         self.title = entity.title?.raw
         let contentPreview = GutenbergExcerptGenerator
-            .firstParagraph(
-                from: entity.content.rendered,
-                maxLength: contentLimit
-            )
+            .firstParagraph(from: entity.content.rendered)
             .replacingOccurrences(
                 of: "[\n]{2,}",
                 with: "\n",

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
@@ -21,6 +21,7 @@ final class CustomPostListViewModel: ObservableObject {
     weak var presentingViewController: UIViewController?
 
     private var collection: PostMetadataCollectionWithEditContext
+    private var homepageSetting: HomepageSetting?
     private var isBatchSyncing = false
     // Whether we should show the content in a hierarchy view.
     // true if the number of cached items or the total items return by the API
@@ -77,7 +78,21 @@ final class CustomPostListViewModel: ObservableObject {
             )
     }
 
+    func pullToRefresh() async {
+        await refresh(pullToRefresh: true)
+    }
+
     func refresh() async {
+        await refresh(pullToRefresh: false)
+    }
+
+    private func refresh(pullToRefresh: Bool) async {
+        await fetchHomepageSettingsIfNeeded()
+
+        if !pullToRefresh {
+            await loadCachedItems()
+        }
+
         if shouldAttemptDisplayHierarchy {
             await fetchAllPagesIfBelowThreshold()
         } else {
@@ -100,7 +115,7 @@ final class CustomPostListViewModel: ObservableObject {
         }
     }
 
-    func loadCachedItems() async {
+    private func loadCachedItems() async {
         let listInfo = collection.listInfo()
 
         if let totalItems = listInfo?.totalItems, totalItems <= Constants.hierarchyPageCountThreshold {
@@ -210,8 +225,14 @@ final class CustomPostListViewModel: ObservableObject {
     }
 
     private func updateItems(from metadataItems: [PostMetadataCollectionItem]) {
-        let items = metadataItems.map {
+        var items = metadataItems.map {
             CustomPostCollectionItem(item: $0, blog: blog, primaryStatus: filter.primaryStatus)
+        }
+
+        if endpoint == .pages,
+           case .staticPage(let homepagePageID) = homepageSetting,
+           filter.statuses.contains(.publish) || filter.statuses.contains(.custom("any")) {
+            items.markHomepage(id: homepagePageID)
         }
 
         guard shouldShowHierarchy else {
@@ -398,6 +419,24 @@ final class CustomPostListViewModel: ObservableObject {
         }
     }
 
+    /// Fetches homepage settings using the cached site settings from
+    /// `WordPressClient` when the endpoint is `.pages` and the setting
+    /// has not been resolved yet.
+    private func fetchHomepageSettingsIfNeeded() async {
+        guard endpoint == .pages, homepageSetting == nil else { return }
+
+        do {
+            let settings = try await client.fetchSiteSettings()
+            if settings.showOnFront == "page", settings.pageOnFront > 0 {
+                homepageSetting = .staticPage(id: Int64(settings.pageOnFront))
+            } else {
+                homepageSetting = .latestPosts
+            }
+        } catch {
+            Loggers.app.error("Failed to fetch site settings for homepage detection: \(error)")
+        }
+    }
+
     private func show(error: Error) {
         // TODO: Ignore error https://github.com/Automattic/wordpress-rs/pull/1227
         self.error = error
@@ -451,6 +490,7 @@ struct CustomPostCollectionDisplayPost: Equatable {
     let sticky: Bool
     let featuredMedia: MediaId?
     let primaryStatus: PostStatus
+    var isHomepage: Bool
 
     init(
         date: Date,
@@ -460,7 +500,8 @@ struct CustomPostCollectionDisplayPost: Equatable {
         status: PostStatus = .publish,
         sticky: Bool = false,
         featuredMedia: MediaId? = nil,
-        primaryStatus: PostStatus = .publish
+        primaryStatus: PostStatus = .publish,
+        isHomepage: Bool = false
     ) {
         self.date = date
         self.title = title
@@ -470,6 +511,7 @@ struct CustomPostCollectionDisplayPost: Equatable {
         self.sticky = sticky
         self.featuredMedia = featuredMedia
         self.primaryStatus = primaryStatus
+        self.isHomepage = isHomepage
     }
 
     init(_ entity: AnyPostWithEditContext, blog: Blog, contentLimit: Int = 100, primaryStatus: PostStatus = .publish) {
@@ -495,6 +537,7 @@ struct CustomPostCollectionDisplayPost: Equatable {
         self.sticky = entity.sticky ?? false
         self.featuredMedia = entity.featuredMedia
         self.primaryStatus = primaryStatus
+        self.isHomepage = false
     }
 
     /// The title to display, with a placeholder for untitled posts.
@@ -591,6 +634,15 @@ struct CustomPostCollectionItem: Identifiable, Equatable {
         case error(message: String)
     }
 
+    var isHomepage: Bool {
+        get {
+            post?.isHomepage ?? false
+        }
+        set {
+            post?.isHomepage = newValue
+        }
+    }
+
     init(item: PostMetadataCollectionItem, blog: Blog, primaryStatus: PostStatus = .publish) {
         self.id = item.id
 
@@ -615,6 +667,16 @@ struct CustomPostCollectionItem: Identifiable, Equatable {
             self.post = CustomPostCollectionDisplayPost(entity.data, blog: blog, primaryStatus: primaryStatus)
             self.state = .error(message: error)
         }
+    }
+}
+
+extension Array where Element == CustomPostCollectionItem {
+    /// Marks the homepage item with the `isHomepage` flag.
+    mutating func markHomepage(id: Int64) {
+        guard let homepageIndex = firstIndex(where: { $0.id == id }) else {
+            return
+        }
+        self[homepageIndex].isHomepage = true
     }
 }
 
@@ -679,6 +741,12 @@ private enum Strings {
         value: "Settings",
         comment: "Menu action to open post settings"
     )
+}
+
+/// Represents the WordPress "Your homepage displays" setting.
+private enum HomepageSetting {
+    case latestPosts
+    case staticPage(id: Int64)
 }
 
 private enum Constants {

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
@@ -210,7 +210,9 @@ final class CustomPostListViewModel: ObservableObject {
     }
 
     private func updateItems(from metadataItems: [PostMetadataCollectionItem]) {
-        let items = metadataItems.map { CustomPostCollectionItem(item: $0, blog: blog, primaryStatus: filter.primaryStatus) }
+        let items = metadataItems.map {
+            CustomPostCollectionItem(item: $0, blog: blog, primaryStatus: filter.primaryStatus)
+        }
 
         guard shouldShowHierarchy else {
             indentationMap = [:]
@@ -578,53 +580,40 @@ extension PostStatus {
     }
 }
 
-// TODO: Decouple the "display item" from the internall states of the `PostMetadataCollectionItem`
-enum CustomPostCollectionItem: Identifiable, Equatable {
-    case ready(id: Int64, post: CustomPostCollectionDisplayPost, fullPost: AnyPostWithEditContext)
-    case stale(id: Int64, post: CustomPostCollectionDisplayPost)
-    case refreshing(id: Int64, post: CustomPostCollectionDisplayPost)
-    case fetching(id: Int64)
-    case missing(id: Int64)
-    case error(id: Int64, message: String)
-    case errorWithData(id: Int64, message: String, post: CustomPostCollectionDisplayPost)
+struct CustomPostCollectionItem: Identifiable, Equatable {
+    let id: Int64
+    var post: CustomPostCollectionDisplayPost?
+    var state: State
 
-    var id: Int64 {
-        switch self {
-        case .ready(let id, _, _),
-             .stale(let id, _),
-             .refreshing(let id, _),
-             .fetching(let id),
-             .missing(let id),
-             .error(let id, _),
-             .errorWithData(let id, _, _):
-            return id
-        }
+    enum State: Equatable {
+        case loaded(fullPost: AnyPostWithEditContext, isUpToDate: Bool)
+        case loading
+        case error(message: String)
     }
 
     init(item: PostMetadataCollectionItem, blog: Blog, primaryStatus: PostStatus = .publish) {
-        let id = item.id
+        self.id = item.id
 
         switch item.state {
         case .fresh(let entity):
-            self = .ready(id: id, post: CustomPostCollectionDisplayPost(entity.data, blog: blog, primaryStatus: primaryStatus), fullPost: entity.data)
+            self.post = CustomPostCollectionDisplayPost(entity.data, blog: blog, primaryStatus: primaryStatus)
+            self.state = .loaded(fullPost: entity.data, isUpToDate: true)
 
         case .stale(let entity):
-            self = .stale(id: id, post: CustomPostCollectionDisplayPost(entity.data, blog: blog, primaryStatus: primaryStatus))
+            self.post = CustomPostCollectionDisplayPost(entity.data, blog: blog, primaryStatus: primaryStatus)
+            self.state = .loaded(fullPost: entity.data, isUpToDate: false)
 
-        case .fetchingWithData(let entity):
-            self = .refreshing(id: id, post: CustomPostCollectionDisplayPost(entity.data, blog: blog, primaryStatus: primaryStatus))
-
-        case .fetching:
-            self = .fetching(id: id)
-
-        case .missing:
-            self = .missing(id: id)
+        case .fetchingWithData, .fetching, .missing:
+            self.post = nil
+            self.state = .loading
 
         case .failed(let error):
-            self = .error(id: id, message: error)
+            self.post = nil
+            self.state = .error(message: error)
 
         case .failedWithData(let error, let entity):
-            self = .errorWithData(id: id, message: error, post: CustomPostCollectionDisplayPost(entity.data, blog: blog, contentLimit: 50, primaryStatus: primaryStatus))
+            self.post = CustomPostCollectionDisplayPost(entity.data, blog: blog, primaryStatus: primaryStatus)
+            self.state = .error(message: error)
         }
     }
 }


### PR DESCRIPTION
## Description

Fixes https://linear.app/a8c/issue/CMM-1943

The test page title "This is the Homepage" in the screenshot might be a bit confusing. It's the actual page title, not a hard-coded text.

<img width="400" src="https://github.com/user-attachments/assets/c11f5642-52c6-488b-be2a-13565aeb3427" />

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->

<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
