### PR TITLE
Show CPT-based Posts and Pages if XMLRPC is disabled

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [*] Reader: Add support for viewing media galleries fullscreen with a way to swipe between images [#25365]
 * [*] [internal] Fix retain cycle in Reader Article screen [#25364]
 * [*] Fix incorrect default Post Format in new posts [#25369]
+* [*] Posts and Pages are available to XMLRPC-disable sites [#25382]
 
 
 26.7

--- a/WordPress/Classes/Services/BlogService.m
+++ b/WordPress/Classes/Services/BlogService.m
@@ -104,22 +104,6 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
             DDLogError(@"Failed syncing settings for blog %@: %@", blog.url, error);
             dispatch_group_leave(syncGroup);
         }];
-    } else if ([remote isKindOfClass:[BlogServiceRemoteCoreREST class]]) {
-        BlogServiceRemoteCoreREST *coreRestRemote = (BlogServiceRemoteCoreREST *)remote;
-        dispatch_group_enter(syncGroup);
-        [coreRestRemote syncBlogSettingsWithSuccess:^(RemoteBlogSettings *settings) {
-            [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
-                Blog *blogInContext = (Blog *)[context existingObjectWithID:blogObjectID error:nil];
-                if (blogInContext) {
-                    [self updateSettings:blogInContext.settings withRemoteSettings:settings];
-                }
-            } completion:^{
-                dispatch_group_leave(syncGroup);
-            } onQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)];
-        } failure:^(NSError *error) {
-            DDLogError(@"Failed syncing settings for blog %@: %@", blog.url, error);
-            dispatch_group_leave(syncGroup);
-        }];
     } else {
         dispatch_group_enter(syncGroup);
         OptionsHandler handler = [self optionsHandlerWithBlogObjectID:blogObjectID
@@ -127,6 +111,24 @@ NSString *const WPBlogSettingsUpdatedNotification = @"WPBlogSettingsUpdatedNotif
         [self syncXMLRPCOptionsIfApplicableFor:blog
                                 optionsHandler:handler
                                         failure:^{ dispatch_group_leave(syncGroup); }];
+
+        if ([remote isKindOfClass:[BlogServiceRemoteCoreREST class]]) {
+            BlogServiceRemoteCoreREST *coreRestRemote = (BlogServiceRemoteCoreREST *)remote;
+            dispatch_group_enter(syncGroup);
+            [coreRestRemote syncBlogSettingsWithSuccess:^(RemoteBlogSettings *settings) {
+                [self.coreDataStack performAndSaveUsingBlock:^(NSManagedObjectContext *context) {
+                    Blog *blogInContext = (Blog *)[context existingObjectWithID:blogObjectID error:nil];
+                    if (blogInContext) {
+                        [self updateSettings:blogInContext.settings withRemoteSettings:settings];
+                    }
+                } completion:^{
+                    dispatch_group_leave(syncGroup);
+                } onQueue:dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)];
+            } failure:^(NSError *error) {
+                DDLogError(@"Failed syncing settings for blog %@: %@", blog.url, error);
+                dispatch_group_leave(syncGroup);
+            }];
+        }
     }
 
     dispatch_group_enter(syncGroup);

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
@@ -74,6 +74,12 @@ extension BlogDetailsViewController {
 
     public func showPostList(from source: BlogDetailsNavigationSource) {
         trackEvent(.openedPosts, from: source)
+
+        if blog.isSelfHosted, blog.isXMLRPCDisabled {
+            showPinnedPostType(.posts)
+            return
+        }
+
         let controller = PostListViewController.controllerWithBlog(blog)
         controller.navigationItem.largeTitleDisplayMode = .never
         presentationDelegate?.presentBlogDetailsViewController(controller)
@@ -81,6 +87,12 @@ extension BlogDetailsViewController {
 
     public func showPageList(from source: BlogDetailsNavigationSource) {
         trackEvent(.openedPages, from: source)
+
+        if blog.isSelfHosted, blog.isXMLRPCDisabled {
+            showPinnedPostType(.pages)
+            return
+        }
+
         let controller = PageListViewController.controllerWithBlog(blog)
         controller.navigationItem.largeTitleDisplayMode = .never
         presentationDelegate?.presentBlogDetailsViewController(controller)
@@ -439,4 +451,11 @@ public class ApplicationPasswordAuthenticationInfo: NSObject {
         self.siteDetails = siteDetails
         self.siteUsername = siteUsername
     }
+}
+
+private extension PinnedPostType {
+    // TODO: Ideally use the post type details directly instead of PinnedPostType,
+    // once the CPT infrastructure is more mature.
+    static let posts = PinnedPostType(slug: "post", name: "Posts", icon: nil)
+    static let pages = PinnedPostType(slug: "page", name: "Pages", icon: nil)
 }


### PR DESCRIPTION
## Description

Fixes https://linear.app/a8c/issue/CMM-1955.

To test:
1. Sign in to an XMLRPC disabled site.
2. The Posts and Pages are usable.