### PR TITLE
Fix an issue where page update is not showing up in the page list

### DIFF
--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
@@ -126,7 +126,7 @@ final class CustomPostListViewModel: ObservableObject {
         for await batch in batches {
             // When fetching all page to display hierarchical view, the post list is updated on one go after the
             // fetching is completed. In that scenario, we should skip the paginationed UI update.
-            guard !isBatchSyncing && !shouldShowHierarchy else { continue }
+            guard !isBatchSyncing else { continue }
 
             Loggers.app.info("\(batch.count) updates received from WpApiCache")
 


### PR DESCRIPTION
## Description

To reproduce the issue:
1. Go to a self-hosted site with a few pages.
2. Go to the Published tab.
3. Edit a page's title. Save the changes.

The page list should show the updated title.
