### PR TITLE
Reader: Fix color of links in comments

### DIFF
--- a/Modules/Sources/DesignSystem/Foundation/AppColor.swift
+++ b/Modules/Sources/DesignSystem/Foundation/AppColor.swift
@@ -20,6 +20,11 @@ public enum UIAppColor {
         }
     }
 
+    /// Color used for links.
+    public static var link: UIColor {
+        UIColor(light: CSColor.Blue.base, dark: CSColor.Blue.shade(.shade30))
+    }
+
     public static func primary(_ shade: ColorStudioShade) -> UIColor {
         switch AppBrand.current {
         case .wordpress: CSColor.Blue.shade(shade)

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -6,6 +6,7 @@
 * [*] Stats: Add new "Last 14 days" period [#25361]
 * [*] Stats: The incomplete dates (include today) are displayed using dotted line on a line chart and are more visible on a bar chart too [#25361]
 * [*] Reader: Fix an issue with pan gesture failing to dismiss Lightbox [#25372]
+* [*] Reader: Fix color of links in comments [#25390]
 * [*] Reader: Add support for viewing media galleries fullscreen with a way to swipe between images [#25365]
 * [*] [internal] Fix retain cycle in Reader Article screen [#25364]
 * [*] Fix incorrect default Post Format in new posts [#25369]

--- a/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsHelper.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Comments/ReaderCommentsHelper.swift
@@ -1,5 +1,6 @@
 import Foundation
 import CoreData
+import DesignSystem
 import WordPressReader
 import WordPressUI
 
@@ -13,7 +14,7 @@ import WordPressUI
 
     func makeWebRenderer() -> WebCommentContentRenderer {
         let renderer = WebCommentContentRenderer()
-        renderer.tintColor = UIAppColor.primary
+        renderer.tintColor = UIAppColor.link
         return renderer
     }
 


### PR DESCRIPTION
Fix an issue with the color of links in comments. The color now matches the color used for the articles. It's common and expected for links and other similar highlighted elements to be blue.

<img width="360" alt="Screenshot 2026-03-17 at 12 23 48 PM" src="https://github.com/user-attachments/assets/b0071bf8-3528-4b18-ae35-cc75f520bc2d" /> <img width="360" alt="Screenshot 2026-03-17 at 12 26 43 PM" src="https://github.com/user-attachments/assets/5569a3b9-4dbb-4141-b190-631fbf6cbb89" />
