### PR TITLE
Reader: Fix color or links in dark mode on custom themes

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * [*] Stats: Improve bar selection. When you tap on a bar, it will now select this subrange without fully navigating it, which makes it much easier to go through multiple subranges. [#25374]
 * [*] Reader: Fix an issue with pan gesture failing to dismiss Lightbox [#25372]
 * [*] Reader: Fix color of links in comments [#25390]
+* [*] Reader: Fix color or links in dark mode on custom themes [#25391]
 * [*] Reader: Add support for viewing media galleries fullscreen with a way to swipe between images [#25365]
 * [*] Notifications: Fix navigational buttons spacing [#25401]
 * [*] [internal] Fix retain cycle in Reader Article screen [#25364]

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -216,6 +216,7 @@ class ReaderWebView: WKWebView {
         """
     }
 
+    // TODO: remove `reader-full-post.reader-full-post__story-content` from-mobile-reader.css on Calypso when this fixed is shipped on the app level
     private func overrideStyles() -> String {
         /// Some context: We are fetching the CSS file from a remote endpoint, but we store a local `reader.css` file
         /// to override some styles for mobile-specific purposes.
@@ -232,6 +233,13 @@ class ReaderWebView: WKWebView {
             a {
                 font-weight: \(displaySetting.color == .system ? "inherit" : "600");
                 text-decoration: underline;
+            }
+
+            /* workaround for CMM-1964 */
+            .reader-full-post.reader-full-post__story-content {
+                a {
+                    color: var(--main-link-color);
+                }
             }
         """
     }
@@ -314,12 +322,12 @@ class ReaderWebView: WKWebView {
     }
 
     func linkColor(for trait: UITraitCollection) -> UIColor {
-        let color = displaySetting.color == .system ? UIAppColor.blue : displaySetting.color.foreground
+        let color = displaySetting.color == .system ? UIAppColor.link : displaySetting.color.foreground
         return color.color(for: trait)
     }
 
     func activeLinkColor(for trait: UITraitCollection) -> UIColor {
-        let color = displaySetting.color == .system ? UIAppColor.blue(.shade30) : displaySetting.color.secondaryForeground
+        let color = displaySetting.color == .system ? UIAppColor.link : displaySetting.color.secondaryForeground
         return color.color(for: trait)
     }
 }


### PR DESCRIPTION
Fixes [CMM-1964: Reader has green tint in dark mode](https://linear.app/a8c/issue/CMM-1964/reader-has-green-tint-in-dark-mode). RCA on Linear.

Before / After

<img width="310" alt="image" src="https://github.com/user-attachments/assets/30ff2889-b2cf-460e-806a-debe74fc8a09" /> <img width="360" height="1205" alt="Screenshot 2026-03-17 at 4 28 05 PM" src="https://github.com/user-attachments/assets/908d3ce8-0151-42d8-a1fb-d674cf7268cc" />

This also fixes the standard theme. Currently, 

<img width="629" height="1205" alt="Screenshot 2026-03-17 at 4 28 12 PM" src="https://github.com/user-attachments/assets/fb328e51-5cb9-46bf-b010-1effb8c2fa79" />
