### PR TITLE
Reader: Add support for <br> tags in excerpt generator

### DIFF
--- a/Modules/Sources/WordPressData/Swift/Post.swift
+++ b/Modules/Sources/WordPressData/Swift/Post.swift
@@ -240,7 +240,7 @@ public class Post: AbstractPost {
                 return preview
             }
             let preview = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 200)
-                .withCollapsedNewlines().trimmedForPreview()
+                .trimmedForPreview()
             PostPreviewCache.shared.content[content] = preview
             return preview
         } else {

--- a/Modules/Sources/WordPressKitModels/NSString+Summary.swift
+++ b/Modules/Sources/WordPressKitModels/NSString+Summary.swift
@@ -17,6 +17,7 @@ extension NSString {
         let characterSet = CharacterSet(charactersIn: "\n")
 
         return (self as String).strippingGutenbergContentForExcerpt()
+            .replacingOccurrences(of: "<br\\s*/?>", with: " ", options: .regularExpression)
             .strippingShortcodes()
             .makePlainText()
             .trimmingCharacters(in: characterSet)

--- a/Modules/Sources/WordPressKitModels/NSString+Summary.swift
+++ b/Modules/Sources/WordPressKitModels/NSString+Summary.swift
@@ -16,8 +16,6 @@ extension NSString {
 
     @objc
     public func wpkit_makePlainText() -> String {
-        self.strippingHTML()
-            .stringByDecodingXMLCharacters()
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+        makePlainText()
     }
 }

--- a/Modules/Sources/WordPressKitModels/NSString+Summary.swift
+++ b/Modules/Sources/WordPressKitModels/NSString+Summary.swift
@@ -5,77 +5,19 @@ import WordPressShared
 /// and convert HTML into plain text.
 ///
 extension NSString {
-
-    static let PostDerivedSummaryLength = 150
-
     /// Create a summary for the post based on the post's content.
     ///
     /// - Returns: A summary for the post.
     ///
     @objc
     public func wpkit_summarized() -> String {
-        let characterSet = CharacterSet(charactersIn: "\n")
-
-        return (self as String).strippingGutenbergContentForExcerpt()
-            .replacingOccurrences(of: "<br\\s*/?>", with: " ", options: .regularExpression)
-            .strippingShortcodes()
-            .makePlainText()
-            .trimmingCharacters(in: characterSet)
-            .wp_stringByEllipsizing(withMaxLength: NSString.PostDerivedSummaryLength, preserveWords: true)
+        GutenbergExcerptGenerator.firstParagraph(from: (self as String))
     }
-}
 
-private extension String {
-    func makePlainText() -> String {
-        let characterSet = NSCharacterSet.whitespacesAndNewlines
-
-        return self.strippingHTML()
+    @objc
+    public func wpkit_makePlainText() -> String {
+        self.strippingHTML()
             .stringByDecodingXMLCharacters()
-            .trimmingCharacters(in: characterSet)
-    }
-
-    /// Creates a new string by stripping all shortcodes from this string.
-    ///
-    func strippingShortcodes() -> String {
-        let pattern = "\\[[^\\]]+\\]"
-
-        return removingMatches(pattern: pattern, options: .caseInsensitive)
-    }
-
-    /// This method is the main entry point to generate excerpts for Gutenberg content.
-    ///
-    func strippingGutenbergContentForExcerpt() -> String {
-        return strippingGutenbergGalleries().strippingGutenbergVideoPress()
-    }
-
-    /// Strips Gutenberg galleries from strings.
-    ///
-    func strippingGutenbergGalleries() -> String {
-        let pattern = "(?s)<!--\\swp:gallery?(.*?)wp:gallery\\s-->"
-
-        return removingMatches(pattern: pattern, options: .caseInsensitive)
-    }
-
-    /// Strips VideoPress references from Gutenberg VideoPress and Video blocks.
-    ///
-    func strippingGutenbergVideoPress() -> String {
-        let pattern = "(?s)\n?<!--\\swp:video.*?(.*?)wp:video.*?\\s-->"
-
-        return removingMatches(pattern: pattern, options: .caseInsensitive)
-    }
-
-    /// Creates a new string by removing all matches of the specified regex.
-    ///
-    func removingMatches(pattern: String, options: NSRegularExpression.Options = []) -> String {
-        let range = NSRange(location: 0, length: self.utf16.count)
-        let regex: NSRegularExpression
-
-        do {
-            regex = try NSRegularExpression(pattern: pattern, options: options)
-        } catch {
-            return self
-        }
-
-        return regex.stringByReplacingMatches(in: self, options: .reportCompletion, range: range, withTemplate: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }

--- a/Modules/Sources/WordPressKitObjC/RemoteReaderPost.m
+++ b/Modules/Sources/WordPressKitObjC/RemoteReaderPost.m
@@ -707,7 +707,7 @@ static const NSUInteger ReaderPostTitleLength = 30;
  */
 - (NSString *)makePlainText:(NSString *)string
 {
-    return [string wpkit_summarized];
+    return [string wpkit_makePlainText];
 }
 
 /**

--- a/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
+++ b/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
@@ -15,7 +15,7 @@ public struct GutenbergExcerptGenerator {
 
         // Extract content while convering  <br>, <br/>, <br /> to newlines first
         let rawText = String(content[pOpen.upperBound..<pEnd.lowerBound])
-            .replacingOccurrences(of: "(<br\\s*/?>)+", with: " ", options: [.regularExpression, .caseInsensitive])
+            .replacingOccurrences(of: "(<br\\b[^>]*>)+", with: " ", options: [.regularExpression, .caseInsensitive])
 
         let range = NSRange(rawText.startIndex..., in: rawText)
         let text = (regex?.stringByReplacingMatches(in: rawText, options: [], range: range, withTemplate: "") ?? rawText)

--- a/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
+++ b/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
@@ -3,28 +3,40 @@ import Foundation
 /// A fast excerpt generator that returns the first paragraph of plain text for
 /// a Gutenberg post.
 public struct GutenbergExcerptGenerator {
-    // Matches HTML tags OR shortcodes
-    private static let regex = try? NSRegularExpression(pattern: "<[^>]+>|\\[[^\\]]+\\]", options: [])
+    /// Matches an opening `<p>` tag (optionally with attributes), but not other
+    /// elements that merely begin with `<p`, such as `<pre>` or `<param>`.
+    private static let openingParagraphRegex = try? NSRegularExpression(pattern: "<p(\\s[^>]*)?>", options: [.caseInsensitive])
+
+    /// Matches a run of one or more `<br>` tags, including self-closing and
+    /// attributed variants: `<br>`, `<br/>`, `<br />`, `<br class="…">`.
+    private static let lineBreakRegex = try? NSRegularExpression(pattern: "(<br\\b[^>]*>)+", options: [.caseInsensitive])
+
+    /// Matches any remaining HTML tag or shortcode.
+    private static let tagOrShortcodeRegex = try? NSRegularExpression(pattern: "<[^>]+>|\\[[^\\]]+\\]", options: [])
 
     public static func firstParagraph(from content: String, maxLength: Int = 150) -> String {
-        // Find the first real <p> tag (not <pre>, <param>, etc.) and its </p>.
-        guard let pOpen = content.range(of: "<p(\\s[^>]*)?>", options: [.regularExpression, .caseInsensitive]),
-              let pEnd = content.range(of: "</p>", options: .caseInsensitive, range: pOpen.upperBound..<content.endIndex) else {
+        // Find the first real `<p>` element and its matching `</p>`.
+        guard let paragraphTag = firstMatch(of: openingParagraphRegex, in: content),
+              let pEnd = content.range(of: "</p>", options: .caseInsensitive, range: paragraphTag.upperBound..<content.endIndex) else {
             return ""
         }
 
-        // Convert <br> runs to spaces so words don't run together.
-        let rawText = String(content[pOpen.upperBound..<pEnd.lowerBound])
-            .replacingOccurrences(of: "(<br\\b[^>]*>)+", with: " ", options: [.regularExpression, .caseInsensitive])
+        let paragraph = String(content[paragraphTag.upperBound..<pEnd.lowerBound])
 
-        let range = NSRange(rawText.startIndex..., in: rawText)
-        let text = (regex?.stringByReplacingMatches(in: rawText, options: [], range: range, withTemplate: "") ?? rawText)
+        // Convert `<br>` runs to spaces so words don't run together, then remove
+        // any remaining tags and shortcodes.
+        let withoutBreaks = replacingMatches(of: lineBreakRegex, in: paragraph, withTemplate: " ")
+        let stripped = replacingMatches(of: tagOrShortcodeRegex, in: withoutBreaks, withTemplate: "")
+
+        // Decode entities and collapse every whitespace run into a single space,
+        // yielding single-line plain text.
+        let text = stripped
             .stringByDecodingXMLCharacters()
             .components(separatedBy: CharacterSet.whitespacesAndNewlines)
             .filter { !$0.isEmpty }
             .joined(separator: " ")
 
-        // Truncate if needed
+        // Truncate if needed.
         if text.count <= maxLength {
             return text
         }
@@ -34,5 +46,21 @@ public struct GutenbergExcerptGenerator {
             return String(truncated[..<lastSpace]) + "…"
         }
         return truncated + "…"
+    }
+
+    /// Returns the range of the first match of `regex` in `string`, or `nil`.
+    private static func firstMatch(of regex: NSRegularExpression?, in string: String) -> Range<String.Index>? {
+        guard let regex else { return nil }
+        let range = NSRange(string.startIndex..., in: string)
+        guard let match = regex.firstMatch(in: string, options: [], range: range) else { return nil }
+        return Range(match.range, in: string)
+    }
+
+    /// Replaces every match of `regex` in `string` with `template`, returning the
+    /// original string unchanged when the regex is unavailable.
+    private static func replacingMatches(of regex: NSRegularExpression?, in string: String, withTemplate template: String) -> String {
+        guard let regex else { return string }
+        let range = NSRange(string.startIndex..., in: string)
+        return regex.stringByReplacingMatches(in: string, options: [], range: range, withTemplate: template)
     }
 }

--- a/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
+++ b/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
@@ -7,15 +7,14 @@ public struct GutenbergExcerptGenerator {
     private static let regex = try? NSRegularExpression(pattern: "<[^>]+>|\\[[^\\]]+\\]", options: [])
 
     public static func firstParagraph(from content: String, maxLength: Int = 150) -> String {
-        // Find first <p> tag content
-        guard let pStart = content.range(of: "<p", options: .caseInsensitive),
-              let pEnd = content.range(of: "</p>", options: .caseInsensitive, range: pStart.upperBound..<content.endIndex),
-              let tagEnd = content.range(of: ">", range: pStart.upperBound..<pEnd.lowerBound) else {
+        // Find the first real <p> tag (not <pre>, <param>, etc.) and its </p>.
+        guard let pOpen = content.range(of: "<p(\\s[^>]*)?>", options: [.regularExpression, .caseInsensitive]),
+              let pEnd = content.range(of: "</p>", options: .caseInsensitive, range: pOpen.upperBound..<content.endIndex) else {
             return ""
         }
 
         // Extract content while convering  <br>, <br/>, <br /> to newlines first
-        let rawText = String(content[tagEnd.upperBound..<pEnd.lowerBound])
+        let rawText = String(content[pOpen.upperBound..<pEnd.lowerBound])
             .replacingOccurrences(of: "(<br\\s*/?>)+", with: " ", options: [.regularExpression, .caseInsensitive])
 
         let range = NSRange(rawText.startIndex..., in: rawText)

--- a/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
+++ b/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
@@ -20,7 +20,9 @@ public struct GutenbergExcerptGenerator {
         let range = NSRange(rawText.startIndex..., in: rawText)
         let text = (regex?.stringByReplacingMatches(in: rawText, options: [], range: range, withTemplate: "") ?? rawText)
             .stringByDecodingXMLCharacters()
-            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .components(separatedBy: CharacterSet.whitespacesAndNewlines)
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
 
         // Truncate if needed
         if text.count <= maxLength {

--- a/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
+++ b/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
@@ -14,6 +14,11 @@ public struct GutenbergExcerptGenerator {
     /// Matches any remaining HTML tag or shortcode.
     private static let tagOrShortcodeRegex = try? NSRegularExpression(pattern: "<[^>]+>|\\[[^\\]]+\\]", options: [])
 
+    /// Whitespace collapsed into single spaces. Excludes U+00A0 (non-breaking
+    /// space) so an intentional `&nbsp;` survives into the excerpt.
+    private static let collapsibleWhitespace = CharacterSet.whitespacesAndNewlines
+        .subtracting(CharacterSet(charactersIn: "\u{00A0}"))
+
     public static func firstParagraph(from content: String, maxLength: Int = 150) -> String {
         // Find the first real `<p>` element and its matching `</p>`.
         guard let paragraphTag = firstMatch(of: openingParagraphRegex, in: content),
@@ -32,7 +37,7 @@ public struct GutenbergExcerptGenerator {
         // yielding single-line plain text.
         let text = stripped
             .stringByDecodingXMLCharacters()
-            .components(separatedBy: CharacterSet.whitespacesAndNewlines)
+            .components(separatedBy: collapsibleWhitespace)
             .filter { !$0.isEmpty }
             .joined(separator: " ")
 

--- a/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
+++ b/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
@@ -19,18 +19,19 @@ public struct GutenbergExcerptGenerator {
             .replacingOccurrences(of: "<br\\s*/?>", with: " ", options: .regularExpression)
 
         let range = NSRange(rawText.startIndex..., in: rawText)
-        var text = (regex?.stringByReplacingMatches(in: rawText, options: [], range: range, withTemplate: "") ?? rawText)
+        let text = (regex?.stringByReplacingMatches(in: rawText, options: [], range: range, withTemplate: "") ?? rawText)
             .stringByDecodingXMLCharacters()
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
-        if text.count > maxLength {
-            let truncated = String(text.prefix(maxLength))
-            text = truncated.lastIndex(of: " ").map { String(truncated[..<$0]) } ?? truncated
+        // Truncate if needed
+        if text.count <= maxLength {
+            return text
         }
 
-        if text.hasSuffix(".") {
-            text = String(text.dropLast())
+        let truncated = String(text.prefix(maxLength))
+        if let lastSpace = truncated.lastIndex(of: " ") {
+            return String(truncated[..<lastSpace]) + "…"
         }
-        return text + "…"
+        return truncated + "…"
     }
 }

--- a/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
+++ b/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
@@ -14,8 +14,9 @@ public struct GutenbergExcerptGenerator {
             return ""
         }
 
-        // Extract content
+        // Extract content while convering  <br>, <br/>, <br /> to newlines first
         let rawText = String(content[tagEnd.upperBound..<pEnd.lowerBound])
+            .replacingOccurrences(of: "<br\\s*/?>", with: "\n", options: .regularExpression)
 
         // Remove HTML tags AND shortcodes in one pass
         let range = NSRange(rawText.startIndex..., in: rawText)

--- a/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
+++ b/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
@@ -16,7 +16,7 @@ public struct GutenbergExcerptGenerator {
 
         // Extract content while convering  <br>, <br/>, <br /> to newlines first
         let rawText = String(content[tagEnd.upperBound..<pEnd.lowerBound])
-            .replacingOccurrences(of: "<br\\s*/?>", with: "\n", options: .regularExpression)
+            .replacingOccurrences(of: "<br\\s*/?>", with: " ", options: .regularExpression)
 
         // Remove HTML tags AND shortcodes in one pass
         let range = NSRange(rawText.startIndex..., in: rawText)

--- a/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
+++ b/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
@@ -13,7 +13,7 @@ public struct GutenbergExcerptGenerator {
             return ""
         }
 
-        // Extract content while convering  <br>, <br/>, <br /> to newlines first
+        // Convert <br> runs to spaces so words don't run together.
         let rawText = String(content[pOpen.upperBound..<pEnd.lowerBound])
             .replacingOccurrences(of: "(<br\\b[^>]*>)+", with: " ", options: [.regularExpression, .caseInsensitive])
 

--- a/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
+++ b/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
@@ -18,21 +18,19 @@ public struct GutenbergExcerptGenerator {
         let rawText = String(content[tagEnd.upperBound..<pEnd.lowerBound])
             .replacingOccurrences(of: "<br\\s*/?>", with: " ", options: .regularExpression)
 
-        // Remove HTML tags AND shortcodes in one pass
         let range = NSRange(rawText.startIndex..., in: rawText)
-        let text = (regex?.stringByReplacingMatches(in: rawText, options: [], range: range, withTemplate: "") ?? rawText)
+        var text = (regex?.stringByReplacingMatches(in: rawText, options: [], range: range, withTemplate: "") ?? rawText)
             .stringByDecodingXMLCharacters()
             .trimmingCharacters(in: .whitespacesAndNewlines)
 
-        // Truncate if needed
-        if text.count <= maxLength {
-            return text
+        if text.count > maxLength {
+            let truncated = String(text.prefix(maxLength))
+            text = truncated.lastIndex(of: " ").map { String(truncated[..<$0]) } ?? truncated
         }
 
-        let truncated = String(text.prefix(maxLength))
-        if let lastSpace = truncated.lastIndex(of: " ") {
-            return String(truncated[..<lastSpace]) + "…"
+        if text.hasSuffix(".") {
+            text = String(text.dropLast())
         }
-        return truncated + "…"
+        return text + "…"
     }
 }

--- a/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
+++ b/Modules/Sources/WordPressShared/Utility/GutenbergExcerptGenerator.swift
@@ -16,7 +16,7 @@ public struct GutenbergExcerptGenerator {
 
         // Extract content while convering  <br>, <br/>, <br /> to newlines first
         let rawText = String(content[tagEnd.upperBound..<pEnd.lowerBound])
-            .replacingOccurrences(of: "<br\\s*/?>", with: " ", options: .regularExpression)
+            .replacingOccurrences(of: "(<br\\s*/?>)+", with: " ", options: [.regularExpression, .caseInsensitive])
 
         let range = NSRange(rawText.startIndex..., in: rawText)
         let text = (regex?.stringByReplacingMatches(in: rawText, options: [], range: range, withTemplate: "") ?? rawText)

--- a/Modules/Tests/WordPressSharedTests/GutenbergExcerptGeneratorTests.swift
+++ b/Modules/Tests/WordPressSharedTests/GutenbergExcerptGeneratorTests.swift
@@ -66,4 +66,11 @@ struct GutenbergPostExcerptGeneratorTests {
         let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
         #expect(summary == "Hello world again")
     }
+
+    @Test func preservesNonBreakingSpace() {
+        let content = "<p>some contents&nbsp;go here</p>"
+
+        let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
+        #expect(summary == "some contents\u{00A0}go here")
+    }
 }

--- a/Modules/Tests/WordPressSharedTests/GutenbergExcerptGeneratorTests.swift
+++ b/Modules/Tests/WordPressSharedTests/GutenbergExcerptGeneratorTests.swift
@@ -14,14 +14,14 @@ struct GutenbergPostExcerptGeneratorTests {
         let content = "<!-- wp:gallery {\"ids\":[2315,2309,2308]} --><figure class=\"wp-block-gallery columns-3 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0005-1-1.jpg\" data-id=\"2315\" class=\"wp-image-2315\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0111-1-1.jpg\" data-id=\"2309\" class=\"wp-image-2309\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0004-1.jpg\" data-id=\"2308\" class=\"wp-image-2308\"/><figcaption class=\"blocks-gallery-item__caption\">Adsasdasdasd</figcaption></figure></li></ul></figure><!-- /wp:gallery --><p>Some Content</p>"
 
         let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
-        #expect(summary == "Some Content…")
+        #expect(summary == "Some Content")
     }
 
     @Test func summaryForContentWithGallery2() {
         let content = "<p>Before</p>\n<!-- wp:gallery {\"ids\":[2315,2309,2308]} --><figure class=\"wp-block-gallery columns-3 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0005-1-1.jpg\" data-id=\"2315\" class=\"wp-image-2315\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0111-1-1.jpg\" data-id=\"2309\" class=\"wp-image-2309\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0004-1.jpg\" data-id=\"2308\" class=\"wp-image-2308\"/><figcaption class=\"blocks-gallery-item__caption\">Adsasdasdasd</figcaption></figure></li></ul></figure><!-- /wp:gallery --><p>After</p>"
 
         let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
-        #expect(summary == "Before…")
+        #expect(summary == "Before")
     }
 
     @Test
@@ -29,14 +29,13 @@ struct GutenbergPostExcerptGeneratorTests {
         let content = "<p>Before</p>\n<!-- wp:videopress/video {\"title\":\"demo\",\"description\":\"\",\"id\":5297,\"guid\":\"AbCDe\",\"videoRatio\":56.333333333333336,\"privacySetting\":2,\"allowDownload\":false,\"rating\":\"G\",\"isPrivate\":true,\"duration\":1673} -->\n<figure class=\"wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player\"><div class=\"jetpack-videopress-player__wrapper\">\nhttps://videopress.com/v/AbCDe?resizeToParent=true&amp;cover=true&amp;preloadContent=metadata&amp;useAverageColor=true\n</div></figure>\n<!-- /wp:videopress/video -->\n<p>After</p>"
 
         let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
-        #expect(summary == "Before…")
+        #expect(summary == "Before")
     }
 
     @Test func testPostWithBRTags() {
-        let content = #"<p class="wp-block-paragraph">Yes,<br>look behind<br>in remembrance and with gratitude.</p><p class="wp-block-paragraph">Then,<br>stay present,<br>or miss memories in the making.</p>"#
+        let content = #"<p class="wp-block-paragraph">Yes,<br>look behind<br><br>in remembrance and with gratitude.</p><p class="wp-block-paragraph">Then,<br>stay present,<BR />or miss memories in the making.</p>"#
 
         let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
-        print(summary)
         #expect(summary == "Yes, look behind in remembrance and with gratitude.")
     }
 }

--- a/Modules/Tests/WordPressSharedTests/GutenbergExcerptGeneratorTests.swift
+++ b/Modules/Tests/WordPressSharedTests/GutenbergExcerptGeneratorTests.swift
@@ -38,4 +38,18 @@ struct GutenbergPostExcerptGeneratorTests {
         let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
         #expect(summary == "Yes, look behind in remembrance and with gratitude.")
     }
+
+    @Test func ignoresLeadingCodeBlock() {
+        let content = #"<pre class="wp-block-code"><code>let x = 1</code></pre><p>Actual paragraph.</p>"#
+
+        let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
+        #expect(summary == "Actual paragraph.")
+    }
+
+    @Test func ignoresLeadingVerseBlock() {
+        let content = #"<pre class="wp-block-verse">Roses are red</pre><p>Real paragraph.</p>"#
+
+        let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
+        #expect(summary == "Real paragraph.")
+    }
 }

--- a/Modules/Tests/WordPressSharedTests/GutenbergExcerptGeneratorTests.swift
+++ b/Modules/Tests/WordPressSharedTests/GutenbergExcerptGeneratorTests.swift
@@ -14,14 +14,14 @@ struct GutenbergPostExcerptGeneratorTests {
         let content = "<!-- wp:gallery {\"ids\":[2315,2309,2308]} --><figure class=\"wp-block-gallery columns-3 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0005-1-1.jpg\" data-id=\"2315\" class=\"wp-image-2315\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0111-1-1.jpg\" data-id=\"2309\" class=\"wp-image-2309\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0004-1.jpg\" data-id=\"2308\" class=\"wp-image-2308\"/><figcaption class=\"blocks-gallery-item__caption\">Adsasdasdasd</figcaption></figure></li></ul></figure><!-- /wp:gallery --><p>Some Content</p>"
 
         let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
-        #expect(summary == "Some Content")
+        #expect(summary == "Some Content…")
     }
 
     @Test func summaryForContentWithGallery2() {
         let content = "<p>Before</p>\n<!-- wp:gallery {\"ids\":[2315,2309,2308]} --><figure class=\"wp-block-gallery columns-3 is-cropped\"><ul class=\"blocks-gallery-grid\"><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0005-1-1.jpg\" data-id=\"2315\" class=\"wp-image-2315\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0111-1-1.jpg\" data-id=\"2309\" class=\"wp-image-2309\"/><figcaption class=\"blocks-gallery-item__caption\">Asdasdasd</figcaption></figure></li><li class=\"blocks-gallery-item\"><figure><img src=\"https://diegotest4.files.wordpress.com/2020/01/img_0004-1.jpg\" data-id=\"2308\" class=\"wp-image-2308\"/><figcaption class=\"blocks-gallery-item__caption\">Adsasdasdasd</figcaption></figure></li></ul></figure><!-- /wp:gallery --><p>After</p>"
 
         let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
-        #expect(summary == "Before")
+        #expect(summary == "Before…")
     }
 
     @Test
@@ -29,7 +29,7 @@ struct GutenbergPostExcerptGeneratorTests {
         let content = "<p>Before</p>\n<!-- wp:videopress/video {\"title\":\"demo\",\"description\":\"\",\"id\":5297,\"guid\":\"AbCDe\",\"videoRatio\":56.333333333333336,\"privacySetting\":2,\"allowDownload\":false,\"rating\":\"G\",\"isPrivate\":true,\"duration\":1673} -->\n<figure class=\"wp-block-videopress-video wp-block-jetpack-videopress jetpack-videopress-player\"><div class=\"jetpack-videopress-player__wrapper\">\nhttps://videopress.com/v/AbCDe?resizeToParent=true&amp;cover=true&amp;preloadContent=metadata&amp;useAverageColor=true\n</div></figure>\n<!-- /wp:videopress/video -->\n<p>After</p>"
 
         let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
-        #expect(summary == "Before")
+        #expect(summary == "Before…")
     }
 
     @Test func testPostWithBRTags() {
@@ -37,6 +37,6 @@ struct GutenbergPostExcerptGeneratorTests {
 
         let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
         print(summary)
-        #expect(summary == "Yes, look behind in remembrance and with gratitude.")
+        #expect(summary == "Yes, look behind in remembrance and with gratitude…")
     }
 }

--- a/Modules/Tests/WordPressSharedTests/GutenbergExcerptGeneratorTests.swift
+++ b/Modules/Tests/WordPressSharedTests/GutenbergExcerptGeneratorTests.swift
@@ -52,4 +52,11 @@ struct GutenbergPostExcerptGeneratorTests {
         let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
         #expect(summary == "Real paragraph.")
     }
+
+    @Test func convertsAttributedBreakTagsToSpaces() {
+        let content = #"<p>foo<br class="clear">bar<br clear="all">baz<br />qux</p>"#
+
+        let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
+        #expect(summary == "foo bar baz qux")
+    }
 }

--- a/Modules/Tests/WordPressSharedTests/GutenbergExcerptGeneratorTests.swift
+++ b/Modules/Tests/WordPressSharedTests/GutenbergExcerptGeneratorTests.swift
@@ -37,6 +37,6 @@ struct GutenbergPostExcerptGeneratorTests {
 
         let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
         print(summary)
-        #expect(summary == "Yes, look behind in remembrance and with gratitude…")
+        #expect(summary == "Yes, look behind in remembrance and with gratitude.")
     }
 }

--- a/Modules/Tests/WordPressSharedTests/GutenbergExcerptGeneratorTests.swift
+++ b/Modules/Tests/WordPressSharedTests/GutenbergExcerptGeneratorTests.swift
@@ -59,4 +59,11 @@ struct GutenbergPostExcerptGeneratorTests {
         let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
         #expect(summary == "foo bar baz qux")
     }
+
+    @Test func collapsesWhitespaceAroundBreakTags() {
+        let content = "<p>Hello <br> world<br>  <br>again</p>"
+
+        let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
+        #expect(summary == "Hello world again")
+    }
 }

--- a/Modules/Tests/WordPressSharedTests/GutenbergExcerptGeneratorTests.swift
+++ b/Modules/Tests/WordPressSharedTests/GutenbergExcerptGeneratorTests.swift
@@ -31,4 +31,12 @@ struct GutenbergPostExcerptGeneratorTests {
         let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
         #expect(summary == "Before")
     }
+
+    @Test func testPostWithBRTags() {
+        let content = #"<p class="wp-block-paragraph">Yes,<br>look behind<br>in remembrance and with gratitude.</p><p class="wp-block-paragraph">Then,<br>stay present,<br>or miss memories in the making.</p>"#
+
+        let summary = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 150)
+        print(summary)
+        #expect(summary == "Yes, look behind in remembrance and with gratitude.")
+    }
 }

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
@@ -692,14 +692,7 @@ struct CustomPostCollectionDisplayPost: Equatable {
         self.date = entity.dateGmt
         self.modifiedDate = entity.modifiedGmt
         self.title = entity.title?.raw
-        let contentPreview =
-            GutenbergExcerptGenerator
-            .firstParagraph(from: entity.content.rendered)
-            .replacingOccurrences(
-                of: "[\n]{2,}",
-                with: "\n",
-                options: .regularExpression
-            )
+        let contentPreview = GutenbergExcerptGenerator.firstParagraph(from: entity.content.rendered)
         self.content = contentPreview.isEmpty ? entity.excerpt?.raw : contentPreview
         if let authorId = entity.author {
             self.authorName = blog.getAuthorWith(id: NSNumber(value: authorId))?.displayName


### PR DESCRIPTION
Fixes [CMM-82: Reader incorrectly renders newlines in excerpts](https://linear.app/a8c/issue/CMM-82/reader-incorrectly-renders-newlines-in-excerpts).

Prerequisite: https://github.com/wordpress-mobile/WordPress-iOS/pull/25400.

This PR is for excerpts generated on the client. In the case of the post from the issue, the lack of whitespaces is backed in on the server. I opened a separate issue for the Loop team. The client-side one should be considered fixed, which you can see in the unit tests.

