### PR TITLE
Fix an issue where the Publish sheet is not dismissed after published

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
@@ -273,6 +273,7 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
             do {
                 try await editorService.save(settings: settings, publish: true)
                 onPostPublished?()
+                onDismiss?()
             } catch {
                 isSaving = false
                 Notice(error: error, title: PostSettingsStrings.saveFailedMessage).post()


### PR DESCRIPTION
## Description

To reproduce the issue: On the custom post list, go to the Drafts tab, tap the More button -> Publish, tap the "Publish" button or "Schedule" button, and wait.