### PR TITLE
Notifications: Fix navigational buttons spacing

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -9,6 +9,7 @@
 * [*] Stats: Improve bar selection. When you tap on a bar, it will now select this subrange without fully navigating it, which makes it much easier to go through multiple subranges. [#25374]
 * [*] Reader: Fix an issue with pan gesture failing to dismiss Lightbox [#25372]
 * [*] Reader: Add support for viewing media galleries fullscreen with a way to swipe between images [#25365]
+* [*] Notifications: Fix navigational buttons spacing [#25401]
 * [*] [internal] Fix retain cycle in Reader Article screen [#25364]
 * [*] Fix incorrect default Post Format in new posts [#25369]
 * [*] Posts and Pages are available to XMLRPC-disable sites [#25382]

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
@@ -43,18 +43,14 @@ class NotificationCommentDetailViewController: UIViewController, NoResultsViewHo
 
     // MARK: - Notification Navigation Buttons
 
-    private lazy var nextButton: UIButton = {
-        let button = UIButton(type: .custom)
-        button.setImage(.gridicon(.arrowUp), for: .normal)
-        button.addTarget(self, action: #selector(nextButtonTapped), for: .touchUpInside)
+    private lazy var nextButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(image: .gridicon(.arrowUp), style: .plain, target: self, action: #selector(nextButtonTapped))
         button.accessibilityLabel = NSLocalizedString("Next notification", comment: "Accessibility label for the next notification button")
         return button
     }()
 
-    private lazy var previousButton: UIButton = {
-        let button = UIButton(type: .custom)
-        button.setImage(.gridicon(.arrowDown), for: .normal)
-        button.addTarget(self, action: #selector(previousButtonTapped), for: .touchUpInside)
+    private lazy var previousButton: UIBarButtonItem = {
+        let button = UIBarButtonItem(image: .gridicon(.arrowDown), style: .plain, target: self, action: #selector(previousButtonTapped))
         button.accessibilityLabel = NSLocalizedString("Previous notification", comment: "Accessibility label for the previous notification button")
         return button
     }()
@@ -120,7 +116,7 @@ private extension NotificationCommentDetailViewController {
         var barButtonItems: [UIBarButtonItem] = []
 
         if splitViewControllerIsHorizontallyCompact {
-            barButtonItems.append(makeNavigationButtons())
+            barButtonItems.append(contentsOf: [nextButton, previousButton])
         }
 
         if let comment, comment.allowsModeration(), let detailsVC {
@@ -128,18 +124,6 @@ private extension NotificationCommentDetailViewController {
         }
 
         navigationItem.setRightBarButtonItems(barButtonItems, animated: false)
-    }
-
-    func makeNavigationButtons() -> UIBarButtonItem {
-        // Create custom view to match that in NotificationDetailsViewController.
-        let buttonStackView = UIStackView(arrangedSubviews: [nextButton, previousButton])
-        buttonStackView.axis = .horizontal
-        buttonStackView.spacing = Constants.arrowButtonSpacing
-
-        let width = (Constants.arrowButtonSize * 2) + Constants.arrowButtonSpacing
-        buttonStackView.frame = CGRect(x: 0, y: 0, width: width, height: Constants.arrowButtonSize)
-
-        return UIBarButtonItem(customView: buttonStackView)
     }
 
     @objc func previousButtonTapped() {
@@ -294,11 +278,6 @@ private extension NotificationCommentDetailViewController {
               }
 
         fetchComment(parentID, completion: { _ in completion() }, failure: { failure($0) })
-    }
-
-    struct Constants {
-        static let arrowButtonSize: CGFloat = 24
-        static let arrowButtonSpacing: CGFloat = 12
     }
 
     // MARK: - No Results Views

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
@@ -116,7 +116,7 @@ private extension NotificationCommentDetailViewController {
         var barButtonItems: [UIBarButtonItem] = []
 
         if splitViewControllerIsHorizontallyCompact {
-            barButtonItems.append(contentsOf: [nextButton, previousButton])
+            barButtonItems.append(contentsOf: [previousButton, nextButton])
         }
 
         if let comment, comment.allowsModeration(), let detailsVC {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationCommentDetailViewController.swift
@@ -44,13 +44,13 @@ class NotificationCommentDetailViewController: UIViewController, NoResultsViewHo
     // MARK: - Notification Navigation Buttons
 
     private lazy var nextButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(image: .gridicon(.arrowUp), style: .plain, target: self, action: #selector(nextButtonTapped))
+        let button = UIBarButtonItem(image: UIImage(systemName: "chevron.up"), style: .plain, target: self, action: #selector(nextButtonTapped))
         button.accessibilityLabel = NSLocalizedString("Next notification", comment: "Accessibility label for the next notification button")
         return button
     }()
 
     private lazy var previousButton: UIBarButtonItem = {
-        let button = UIBarButtonItem(image: .gridicon(.arrowDown), style: .plain, target: self, action: #selector(previousButtonTapped))
+        let button = UIBarButtonItem(image: UIImage(systemName: "chevron.down"), style: .plain, target: self, action: #selector(previousButtonTapped))
         button.accessibilityLabel = NSLocalizedString("Previous notification", comment: "Accessibility label for the previous notification button")
         return button
     }()

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -312,8 +312,8 @@ extension NotificationDetailsViewController {
 
         navigationItem.backBarButtonItem = backButton
 
-        nextNavigationButton = UIBarButtonItem(image: .gridicon(.arrowUp), style: .plain, target: self, action: #selector(nextNotificationWasPressed))
-        previousNavigationButton = UIBarButtonItem(image: .gridicon(.arrowDown), style: .plain, target: self, action: #selector(previousNotificationWasPressed))
+        nextNavigationButton = UIBarButtonItem(image: UIImage(systemName: "chevron.up"), style: .plain, target: self, action: #selector(nextNotificationWasPressed))
+        previousNavigationButton = UIBarButtonItem(image: UIImage(systemName: "chevron.down"), style: .plain, target: self, action: #selector(previousNotificationWasPressed))
 
         enableNavigationRightBarButtonItems()
     }

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -214,7 +214,7 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
 
     fileprivate func enableNavigationRightBarButtonItems() {
         UIView.performWithoutAnimation {
-            navigationItem.rightBarButtonItems = [nextNavigationButton, previousNavigationButton]
+            navigationItem.rightBarButtonItems = [previousNavigationButton, nextNavigationButton]
         }
 
         previousNavigationButton.isEnabled = shouldEnablePreviousButton

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationDetailsViewController.swift
@@ -60,11 +60,11 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
 
     /// Previous NavBar Navigation Button
     ///
-    var previousNavigationButton: UIButton!
+    var previousNavigationButton: UIBarButtonItem!
 
     /// Next NavBar Navigation Button
     ///
-    var nextNavigationButton: UIButton!
+    var nextNavigationButton: UIBarButtonItem!
 
     /// Arrows Navigation Datasource
     ///
@@ -213,20 +213,8 @@ class NotificationDetailsViewController: UIViewController, NoResultsViewHost {
     }
 
     fileprivate func enableNavigationRightBarButtonItems() {
-
-        // https://github.com/wordpress-mobile/WordPress-iOS/issues/6662#issue-207316186
-        let buttonSize = CGFloat(24)
-        let buttonSpacing = CGFloat(12)
-
-        let width = buttonSize + buttonSpacing + buttonSize
-        let height = buttonSize
-        let buttons = UIStackView(arrangedSubviews: [nextNavigationButton, previousNavigationButton])
-        buttons.axis = .horizontal
-        buttons.spacing = buttonSpacing
-        buttons.frame = CGRect(x: 0, y: 0, width: width, height: height)
-
         UIView.performWithoutAnimation {
-            navigationItem.rightBarButtonItem = UIBarButtonItem(customView: buttons)
+            navigationItem.rightBarButtonItems = [nextNavigationButton, previousNavigationButton]
         }
 
         previousNavigationButton.isEnabled = shouldEnablePreviousButton
@@ -324,16 +312,8 @@ extension NotificationDetailsViewController {
 
         navigationItem.backBarButtonItem = backButton
 
-        let next = UIButton(type: .custom)
-        next.setImage(.gridicon(.arrowUp), for: .normal)
-        next.addTarget(self, action: #selector(nextNotificationWasPressed), for: .touchUpInside)
-
-        let previous = UIButton(type: .custom)
-        previous.setImage(.gridicon(.arrowDown), for: .normal)
-        previous.addTarget(self, action: #selector(previousNotificationWasPressed), for: .touchUpInside)
-
-        previousNavigationButton = previous
-        nextNavigationButton = next
+        nextNavigationButton = UIBarButtonItem(image: .gridicon(.arrowUp), style: .plain, target: self, action: #selector(nextNotificationWasPressed))
+        previousNavigationButton = UIBarButtonItem(image: .gridicon(.arrowDown), style: .plain, target: self, action: #selector(previousNotificationWasPressed))
 
         enableNavigationRightBarButtonItems()
     }


### PR DESCRIPTION
- Fix spacing by using individual bar button items
- Remove the deprecated gridirons. Use the same icons Apple Mail uses for navigation in the same context.

Before / After

<img width="340"  alt="Screenshot 2026-03-18 at 12 20 40 PM" src="https://github.com/user-attachments/assets/8f2bddf3-04ad-4ca2-978c-a3407b849186" /> <img width="340" alt="Screenshot 2026-03-18 at 12 35 27 PM" src="https://github.com/user-attachments/assets/6778227e-2ec8-443a-a9c7-161775a94968" />
