### PR TITLE
Reader: Add separator to site header

### DIFF
--- a/WordPress/Classes/ViewRelated/Reader/Headers/ReaderSiteHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Headers/ReaderSiteHeaderView.swift
@@ -15,6 +15,12 @@ class ReaderSiteHeaderView: ReaderBaseHeaderView, ReaderStreamHeader {
         })
     }()
 
+    private let separatorView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .separator
+        return view
+    }()
+
     override init(frame: CGRect) {
         super.init(frame: frame)
 
@@ -22,6 +28,15 @@ class ReaderSiteHeaderView: ReaderBaseHeaderView, ReaderStreamHeader {
         let view = UIView.embedSwiftUIView(header)
         contentView.addSubview(view)
         view.pinEdges()
+
+        addSubview(separatorView)
+        separatorView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            separatorView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            separatorView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            separatorView.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -8),
+            separatorView.heightAnchor.constraint(equalToConstant: 1)
+        ])
     }
 
     required init?(coder: NSCoder) {


### PR DESCRIPTION
There is clearly a need for a separator between the site header and the list of posts.

Before / After

<img width="340" height="1093" alt="Screenshot 2026-03-18 at 1 20 28 PM" src="https://github.com/user-attachments/assets/9e11198e-4fb7-4c1d-bf28-3ea05c3ce564" />
<img width="340" height="1093" alt="Screenshot 2026-03-18 at 1 18 17 PM" src="https://github.com/user-attachments/assets/c487822b-1963-47eb-ab12-1baae3c8f05e" />

iPad

<img width="1316" height="1011" alt="Screenshot 2026-03-18 at 1 15 52 PM" src="https://github.com/user-attachments/assets/3cec3a25-4784-4483-8332-d6bc8ea10e5c" />