### PR TITLE
Stats: Replace grayscale with simple spinners

### DIFF
--- a/Modules/Sources/JetpackStats/Cards/ChartCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/ChartCard.swift
@@ -41,13 +41,19 @@ struct ChartCard: View {
             viewModel.onAppear()
         }
         .overlay(alignment: .topTrailing) {
-            moreMenu
+            HStack(spacing: 0) {
+                if viewModel.isStale {
+                    ProgressView()
+                        .controlSize(.small)
+                        .transition(.scale.combined(with: .opacity))
+                }
+                moreMenu
+            }
+            .animation(.easeInOut(duration: 0.5), value: viewModel.isStale)
         }
         .cardStyle()
-        .grayscale(viewModel.isStale ? 1 : 0)
         .opacity(viewModel.isEditing ? 0.6 : 1)
         .scaleEffect(viewModel.isEditing ? 0.95 : 1)
-        .animation(.smooth, value: viewModel.isStale)
         .animation(.spring, value: viewModel.isEditing)
         .accessibilityElement(children: .contain)
         .accessibilityLabel(Strings.Accessibility.chartContainer)

--- a/Modules/Sources/JetpackStats/Cards/ChartCardViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/ChartCardViewModel.swift
@@ -127,7 +127,7 @@ final class ChartCardViewModel: ObservableObject, TrafficCardViewModel {
         // no response in more than T seconds.
         if !chartData.isEmpty {
             staleTimer = Task { [weak self] in
-                try? await Task.sleep(for: .seconds(2))
+                try? await Task.sleep(for: .seconds(0.8))
                 guard !Task.isCancelled else { return }
                 self?.isStale = true
             }

--- a/Modules/Sources/JetpackStats/Cards/TopListCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListCard.swift
@@ -56,7 +56,15 @@ struct TopListCard: View {
         }
         .padding(.vertical, Constants.step2)
         .overlay(alignment: .topTrailing) {
-            moreMenu
+            HStack(spacing: 0) {
+                if viewModel.isStale {
+                    ProgressView()
+                        .controlSize(.small)
+                        .transition(.scale.combined(with: .opacity))
+                }
+                moreMenu
+            }
+            .animation(.easeInOut(duration: 0.5), value: viewModel.isStale)
         }
         .cardStyle()
         .onTapGesture {
@@ -64,10 +72,8 @@ struct TopListCard: View {
                 navigateToTopListScreen()
             }
         }
-        .grayscale(viewModel.isStale ? 1 : 0)
         .opacity(viewModel.isEditing ? 0.6 : 1)
         .scaleEffect(viewModel.isEditing ? 0.95 : 1)
-        .animation(.smooth, value: viewModel.isStale)
         .animation(.spring, value: viewModel.isEditing)
         .accessibilityElement(children: .contain)
         .animation(.spring, value: viewModel.data.map(ObjectIdentifier.init)) // placing is important

--- a/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListViewModel.swift
@@ -133,7 +133,7 @@ final class TopListViewModel: ObservableObject, TrafficCardViewModel {
         // no response in more than T seconds.
         if data != nil {
             staleTimer = Task { [weak self] in
-                try? await Task.sleep(for: .seconds(2))
+                try? await Task.sleep(for: .seconds(0.8))
                 guard !Task.isCancelled else { return }
                 self?.isStale = true
             }


### PR DESCRIPTION
Replace the weird `grayscale` logic I originally added with simple delays loading indicators.

https://github.com/user-attachments/assets/0ed32ab4-08c3-48e4-ae43-a0f0491c4d16

