### PR TITLE
Fix an issue where the "More Options" section content is empty

### DIFF
--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -406,30 +406,70 @@ struct PostSettingsFormContentView<ViewModel: PostSettingsViewModelProtocol>: Vi
     /// The least-used options.
     @ViewBuilder
     private var moreOptionsSection: some View {
-        Section {
-            if viewModel.shouldShow(.jetpackNewsletterEmailOptions) {
-                Toggle(isOn: $viewModel.emailToSubscribers) {
-                    Text(Strings.emailToSubscribers)
+        let options = visibleMoreOptions
+        if !options.isEmpty {
+            Section {
+                ForEach(options) { option in
+                    moreOptionRow(for: option)
                 }
+            } header: {
+                SectionHeader(Strings.moreOptionsHeader)
             }
-            if viewModel.shouldShowStickyOption {
-                stickyPostRow
-            }
-            if viewModel.isDraftOrPending {
-                pendingReviewRow
-            }
-            if viewModel.capabilities.supportsComments {
-                discussionRow
-            }
-            if viewModel.capabilities.supportsPostFormats {
-                postFormatRow
-            }
-            if viewModel.capabilities.supportsPageAttributes {
-                parentPageRow
-            }
-        } header: {
-            SectionHeader(Strings.moreOptionsHeader)
         }
+    }
+
+    @ViewBuilder
+    private func moreOptionRow(for option: MoreOption) -> some View {
+        switch option {
+        case .emailToSubscribers:
+            Toggle(isOn: $viewModel.emailToSubscribers) {
+                Text(Strings.emailToSubscribers)
+            }
+        case .stickyPost:
+            stickyPostRow
+        case .pendingReview:
+            pendingReviewRow
+        case .discussion:
+            discussionRow
+        case .postFormat:
+            postFormatRow
+        case .parentPage:
+            parentPageRow
+        }
+    }
+
+    private enum MoreOption: Identifiable {
+        case emailToSubscribers
+        case stickyPost
+        case pendingReview
+        case discussion
+        case postFormat
+        case parentPage
+
+        var id: Self { self }
+    }
+
+    private var visibleMoreOptions: [MoreOption] {
+        var options: [MoreOption] = []
+        if viewModel.shouldShow(.jetpackNewsletterEmailOptions) {
+            options.append(.emailToSubscribers)
+        }
+        if viewModel.shouldShowStickyOption {
+            options.append(.stickyPost)
+        }
+        if viewModel.isDraftOrPending {
+            options.append(.pendingReview)
+        }
+        if viewModel.capabilities.supportsComments {
+            options.append(.discussion)
+        }
+        if viewModel.capabilities.supportsPostFormats {
+            options.append(.postFormat)
+        }
+        if viewModel.capabilities.supportsPageAttributes {
+            options.append(.parentPage)
+        }
+        return options
     }
 
     private var postFormatRow: some View {

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsView.swift
@@ -406,7 +406,7 @@ struct PostSettingsFormContentView<ViewModel: PostSettingsViewModelProtocol>: Vi
     /// The least-used options.
     @ViewBuilder
     private var moreOptionsSection: some View {
-        let options = visibleMoreOptions
+        let options = viewModel.visibleMoreOptions
         if !options.isEmpty {
             Section {
                 ForEach(options) { option in
@@ -419,7 +419,7 @@ struct PostSettingsFormContentView<ViewModel: PostSettingsViewModelProtocol>: Vi
     }
 
     @ViewBuilder
-    private func moreOptionRow(for option: MoreOption) -> some View {
+    private func moreOptionRow(for option: PostSettingsMoreOption) -> some View {
         switch option {
         case .emailToSubscribers:
             Toggle(isOn: $viewModel.emailToSubscribers) {
@@ -436,40 +436,6 @@ struct PostSettingsFormContentView<ViewModel: PostSettingsViewModelProtocol>: Vi
         case .parentPage:
             parentPageRow
         }
-    }
-
-    private enum MoreOption: Identifiable {
-        case emailToSubscribers
-        case stickyPost
-        case pendingReview
-        case discussion
-        case postFormat
-        case parentPage
-
-        var id: Self { self }
-    }
-
-    private var visibleMoreOptions: [MoreOption] {
-        var options: [MoreOption] = []
-        if viewModel.shouldShow(.jetpackNewsletterEmailOptions) {
-            options.append(.emailToSubscribers)
-        }
-        if viewModel.shouldShowStickyOption {
-            options.append(.stickyPost)
-        }
-        if viewModel.isDraftOrPending {
-            options.append(.pendingReview)
-        }
-        if viewModel.capabilities.supportsComments {
-            options.append(.discussion)
-        }
-        if viewModel.capabilities.supportsPostFormats {
-            options.append(.postFormat)
-        }
-        if viewModel.capabilities.supportsPageAttributes {
-            options.append(.parentPage)
-        }
-        return options
     }
 
     private var postFormatRow: some View {

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModelProtocol.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettingsViewModelProtocol.swift
@@ -20,6 +20,18 @@ enum PostSettingsRow {
     case jetpackNewsletterEmailOptions
 }
 
+/// Options that can appear in the "More Options" section of the post settings form.
+enum PostSettingsMoreOption: Identifiable {
+    case emailToSubscribers
+    case stickyPost
+    case pendingReview
+    case discussion
+    case postFormat
+    case parentPage
+
+    var id: Self { self }
+}
+
 /// The state of the social sharing section.
 enum PostSettingsSocialSharingSectionState {
     /// The initial prompt to set up connections.
@@ -98,6 +110,33 @@ protocol PostSettingsViewModelProtocol: ObservableObject {
     func didSelectTerms(_ terms: [TagsViewModel.SelectedTerm], forTaxonomySlug: String)
     func showSocialSharingOptions()
     func showCategoriesPicker()
+}
+
+// MARK: - Default Implementations
+
+extension PostSettingsViewModelProtocol {
+    var visibleMoreOptions: [PostSettingsMoreOption] {
+        var options: [PostSettingsMoreOption] = []
+        if shouldShow(.jetpackNewsletterEmailOptions) {
+            options.append(.emailToSubscribers)
+        }
+        if shouldShowStickyOption {
+            options.append(.stickyPost)
+        }
+        if isDraftOrPending {
+            options.append(.pendingReview)
+        }
+        if capabilities.supportsComments {
+            options.append(.discussion)
+        }
+        if capabilities.supportsPostFormats {
+            options.append(.postFormat)
+        }
+        if capabilities.supportsPageAttributes {
+            options.append(.parentPage)
+        }
+        return options
+    }
 }
 
 // MARK: - Date Formatting


### PR DESCRIPTION
## Description

It's possible that the custom post type is configured in a way that none of the "More Options" are applicable. In that case, we should not show the section at all. At the moment, the header shows, but the content is empty.