### PR TITLE
Reader: Fix "Leave Comment" button wrong background color with a custom reading theme

### DIFF
--- a/Modules/Sources/WordPressReader/Settings/ReaderDisplaySettings.swift
+++ b/Modules/Sources/WordPressReader/Settings/ReaderDisplaySettings.swift
@@ -161,6 +161,17 @@ public struct ReaderDisplaySettings: Codable, Equatable, Hashable, Sendable {
             }
         }
 
+        public var tertiatyForeground: UIColor {
+            switch self {
+            case .system:
+                return .tertiaryLabel
+            case .evening, .oled, .hacker:
+                return foreground.withAlphaComponent(0.8) // slightly higher contrast for dark themes.
+            default:
+                return foreground.withAlphaComponent(0.6)
+            }
+        }
+
         public var background: UIColor {
             switch self {
             case .system:

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -15,6 +15,7 @@
 * [*] Reader: Fix an issue with pan gesture failing to dismiss Lightbox [#25372]
 * [*] Reader: Fix color of links in comments [#25390]
 * [*] Reader: Fix color or links in dark mode on custom themes [#25391]
+* [*] Reader: Fix "Leave Comment" button wrong background color with a custom reading theme [#25412]
 * [*] Reader: Add support for viewing media galleries fullscreen with a way to swipe between images [#25365]
 * [*] Notifications: Fix navigational buttons spacing [#25401]
 * [*] [internal] Fix retain cycle in Reader Article screen [#25364]

--- a/WordPress/Classes/ViewRelated/Notifications/Views/CommentLargeButton.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/CommentLargeButton.swift
@@ -1,6 +1,7 @@
 import UIKit
 import WordPressUI
 import WordPressShared
+import WordPressReader
 
 final class CommentLargeButton: UIView {
     private let leaveCommentView = LeaveCommentView()
@@ -69,6 +70,13 @@ final class LeaveCommentView: UIView {
         get { placeholderLabel.text }
     }
 
+    var displaySettings: ReaderDisplaySettings = .standard {
+        didSet {
+            placeholderLabel.textColor = displaySettings.color.tertiatyForeground
+            containerView.backgroundColor = displaySettings.color.secondaryBackground
+        }
+    }
+
     override init(frame: CGRect) {
         super.init(frame: frame)
         setupView()
@@ -96,8 +104,6 @@ private final class CommentLargeButtonContainerView: UIView {
     override func layoutSubviews() {
         super.layoutSubviews()
 
-        backgroundColor = .secondarySystemBackground
-
         layer.cornerRadius = bounds.height / 2
         layer.masksToBounds = true
     }
@@ -116,6 +122,7 @@ private func makeCommentsClosedView() -> UIView {
     let stackView = UIStackView(spacing: 8, [imageView, titleLabel])
 
     let containerView = CommentLargeButtonContainerView()
+    containerView.backgroundColor = .secondarySystemBackground
     containerView.addSubview(stackView)
     stackView.pinEdges(insets: UIEdgeInsets(horizontal: 14, vertical: 10))
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -153,6 +153,7 @@ private extension ReaderDetailCommentsTableViewDelegate {
 
         let leaveCommentView = LeaveCommentView()
         leaveCommentView.addGestureRecognizer(UITapGestureRecognizer(target: self, action: #selector(leaveCommentCellTapped)))
+        leaveCommentView.displaySettings = displaySetting
 
         cell.contentView.addSubview(leaveCommentView)
         leaveCommentView.pinEdges(insets: UIEdgeInsets(top: 16, left: 0, bottom: 8, right: 0))


### PR DESCRIPTION
Fixes https://linear.app/a8c/issue/CMM-1970/reader-leave-comment-button-wrong-background-color-with-a-custom.

I've tested all custom themes and the work well on both light and dark mode.

<img width="340" alt="Screenshot 2026-03-19 at 4 51 39 PM" src="https://github.com/user-attachments/assets/3d8f22c1-f202-43df-978e-e1cbdf21ee7f" /> <img width="340" alt="Screenshot 2026-03-19 at 4 51 44 PM" src="https://github.com/user-attachments/assets/98e8e164-b712-41fb-97b7-7c29dc84172d" />
