### PR TITLE
Fix a few issues in the Parent Page picker

### DIFF
--- a/Tests/KeystoneTests/Tests/Features/Posts/PostSettingsTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Posts/PostSettingsTests.swift
@@ -811,6 +811,33 @@ struct PostSettingsTests {
             PostSettings.Term(id: 20, name: ""),
         ])
     }
+
+    @Test("init(from: PostCreateParams) populates parentPageID")
+    func testInitFromCreateParamsReadsParent() {
+        // Given
+        var params = PostCreateParams(meta: nil)
+        params.parent = PostId(42)
+
+        // When
+        let settings = PostSettings(from: params)
+
+        // Then
+        #expect(settings.parentPageID == 42)
+    }
+
+    @Test("PostCreateParams parent survives round-trip through PostSettings")
+    func testParentRoundTripThroughPostSettings() {
+        // Given
+        var params = PostCreateParams(meta: nil)
+        params.parent = PostId(42)
+
+        // When
+        let settings = PostSettings(from: params)
+        let outputParams = settings.makeCreateParameters(from: .init(meta: nil), taxonomies: [])
+
+        // Then
+        #expect(outputParams.parent == PostId(42))
+    }
 }
 
 // MARK: - Test Helpers

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
@@ -17,6 +17,7 @@ final class CustomPostListViewModel: ObservableObject {
     private let details: PostTypeDetailsWithEditContext
     let blog: Blog
     private let isHierarchical: Bool
+    private let showsHierarchyIfApplicable: Bool
     private(set) var filter: CustomPostListFilter
     private let exclude: Predicate<CustomPostCollectionItem>?
     weak var presentingViewController: UIViewController?
@@ -61,6 +62,7 @@ final class CustomPostListViewModel: ObservableObject {
         filter: CustomPostListFilter,
         blog: Blog,
         exclude: Predicate<CustomPostCollectionItem>? = nil,
+        showsHierarchyIfApplicable: Bool = false,
         presentingViewController: UIViewController? = nil
     ) {
         self.client = client
@@ -71,6 +73,7 @@ final class CustomPostListViewModel: ObservableObject {
         self.isHierarchical = details.hierarchical
         self.filter = filter
         self.exclude = exclude
+        self.showsHierarchyIfApplicable = showsHierarchyIfApplicable
         self.presentingViewController = presentingViewController
 
         collection = service
@@ -242,7 +245,7 @@ final class CustomPostListViewModel: ObservableObject {
     }
 
     private var shouldAttemptDisplayHierarchy: Bool {
-        isHierarchical && (filter.statuses.contains(.publish) || filter.statuses.contains(.any))
+        isHierarchical && showsHierarchyIfApplicable
     }
 
     private func updateItems(from metadataItems: [PostMetadataCollectionItem]) {

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
@@ -18,6 +18,7 @@ final class CustomPostListViewModel: ObservableObject {
     let blog: Blog
     private let isHierarchical: Bool
     private(set) var filter: CustomPostListFilter
+    private let exclude: Predicate<CustomPostCollectionItem>?
     weak var presentingViewController: UIViewController?
 
     private var collection: PostMetadataCollectionWithEditContext
@@ -59,6 +60,7 @@ final class CustomPostListViewModel: ObservableObject {
         details: PostTypeDetailsWithEditContext,
         filter: CustomPostListFilter,
         blog: Blog,
+        exclude: Predicate<CustomPostCollectionItem>? = nil,
         presentingViewController: UIViewController? = nil
     ) {
         self.client = client
@@ -68,6 +70,7 @@ final class CustomPostListViewModel: ObservableObject {
         self.blog = blog
         self.isHierarchical = details.hierarchical
         self.filter = filter
+        self.exclude = exclude
         self.presentingViewController = presentingViewController
 
         collection = service
@@ -251,6 +254,10 @@ final class CustomPostListViewModel: ObservableObject {
            case .staticPage(let homepagePageID) = homepageSetting,
            filter.statuses.contains(.publish) || filter.statuses.contains(.custom("any")) {
             items.markHomepage(id: homepagePageID)
+        }
+
+        if let exclude {
+            items.removeAll { (try? exclude.evaluate($0)) == true }
         }
 
         guard shouldShowHierarchy else {

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostParentPagePicker.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostParentPagePicker.swift
@@ -16,6 +16,7 @@ struct CustomPostParentPagePicker: View {
 
     @Environment(\.dismiss) private var dismiss
     @State private var searchText = ""
+    @State private var finalSearchText = ""
 
     init(
         client: WordPressClient,
@@ -50,13 +51,21 @@ struct CustomPostParentPagePicker: View {
 
     var body: some View {
         ZStack {
-            if searchText.isEmpty {
+            if finalSearchText.isEmpty {
                 publishedList
             } else {
                 searchResultsList
             }
         }
         .searchable(text: $searchText)
+        .task(id: searchText) {
+            do {
+                try await Task.sleep(for: .milliseconds(100))
+                finalSearchText = searchText
+            } catch {
+                // Do nothing.
+            }
+        }
         .navigationTitle(Strings.title)
         .navigationBarTitleDisplayMode(.inline)
     }
@@ -92,7 +101,7 @@ struct CustomPostParentPagePicker: View {
                 client: client,
                 service: service,
                 details: details,
-                filter: .search(input: searchText),
+                filter: .search(input: finalSearchText),
                 blog: blog,
                 exclude: excludeCurrentPost
             ),

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostParentPagePicker.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostParentPagePicker.swift
@@ -34,12 +34,17 @@ struct CustomPostParentPagePicker: View {
         self.currentParentID = currentParentID
         self.onSelection = onSelection
 
+        let excludeCurrentPost = currentPostID.map { postID in
+            let id = Int64(postID)
+            return #Predicate<CustomPostCollectionItem> { $0.id == id }
+        }
         _listViewModel = StateObject(wrappedValue: CustomPostListViewModel(
             client: client,
             service: service,
             details: details,
             filter: CustomPostListFilter(statuses: [.publish]),
-            blog: blog
+            blog: blog,
+            exclude: excludeCurrentPost
         ))
     }
 
@@ -58,6 +63,13 @@ struct CustomPostParentPagePicker: View {
 
     private var selectedPostID: Int64? {
         currentParentID.map { Int64($0) }
+    }
+
+    private var excludeCurrentPost: Predicate<CustomPostCollectionItem>? {
+        currentPostID.map { postID in
+            let id = Int64(postID)
+            return #Predicate<CustomPostCollectionItem> { $0.id == id }
+        }
     }
 
     private var publishedList: some View {
@@ -81,7 +93,8 @@ struct CustomPostParentPagePicker: View {
                 service: service,
                 details: details,
                 filter: .search(input: searchText),
-                blog: blog
+                blog: blog,
+                exclude: excludeCurrentPost
             ),
             details: details,
             client: client,

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostTabView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostTabView.swift
@@ -61,6 +61,7 @@ struct CustomPostTabView: View {
             details: details,
             filter: CustomPostListFilter(tab: .all),
             blog: blog,
+            showsHierarchyIfApplicable: true,
             presentingViewController: presentingViewController
         ))
         _publishedViewModel = State(initialValue: CustomPostListViewModel(
@@ -69,6 +70,7 @@ struct CustomPostTabView: View {
             details: details,
             filter: CustomPostListFilter(tab: .published),
             blog: blog,
+            showsHierarchyIfApplicable: true,
             presentingViewController: presentingViewController
         ))
         _draftsViewModel = State(initialValue: CustomPostListViewModel(

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/CustomPostSettingsViewModel.swift
@@ -408,7 +408,7 @@ final class CustomPostSettingsViewModel: NSObject, ObservableObject, PostSetting
     }
 
     private func refreshParentPageText() {
-        guard let parentPageID = settings.parentPageID else {
+        guard let parentPageID = settings.parentPageID, parentPageID != 0 else {
             parentPageText = nil
             return
         }

--- a/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
+++ b/WordPress/Classes/ViewRelated/Post/PostSettings/PostSettings.swift
@@ -104,6 +104,9 @@ struct PostSettings: Hashable {
         if let sticky = params.sticky {
             isStickyPost = sticky
         }
+        if let parent = params.parent, parent > 0 {
+            parentPageID = Int(parent)
+        }
         if !params.categories.isEmpty {
             categoryIDs = Set(params.categories.map { Int($0) })
         }


### PR DESCRIPTION
## Description

Fixes a few issues in the parent page picker:
- The picker should not show the current page.
- The picker should not show a hierarchical view.
- Add deboucne to the search input field.
- The top-level page may incorrectly show a "Parent Page: (ID: 0)".
