### PR TITLE
Stats: Final Touches

### DIFF
--- a/Modules/Sources/JetpackStats/Cards/ChartCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/ChartCard.swift
@@ -81,7 +81,8 @@ struct ChartCard: View {
         return ChartCardHeaderView.ViewModel(
             trend: viewModel.selectedBarTrend ?? .make(data, context: .regular),
             metricTitle: metric.localizedTitle,
-            period: context.formatters.dateRange.string(from: viewModel.dateRange.subrange ?? viewModel.dateRange.range)
+            period: context.formatters.dateRange.string(from: viewModel.dateRange.subrange ?? viewModel.dateRange.range),
+            showDisclosureIndicator: viewModel.dateRange.subrange != nil
         )
     }
 
@@ -92,6 +93,9 @@ struct ChartCard: View {
             .padding(.trailing, Constants.step3 + Constants.step0_5)
             .accessibilityElement(children: .combine)
             .accessibilityLabel(Strings.Accessibility.cardTitle(metric.localizedTitle))
+            .simultaneousGesture(TapGesture().onEnded {
+                viewModel.promoteSubrangeToMainRange()
+            })
     }
 
     @ViewBuilder
@@ -314,6 +318,7 @@ struct ChartCardHeaderView: View {
         let metricTitle: String
         let period: String
         var showComparison: Bool = true
+        var showDisclosureIndicator: Bool = false
     }
 
     let viewModel: ViewModel
@@ -331,9 +336,17 @@ struct ChartCardHeaderView: View {
                         .font(.caption.weight(.medium))
                         .foregroundColor(.secondary)
                 }
-                Text(viewModel.period)
-                    .font(.system(.caption, design: .rounded, weight: .medium))
-                    .foregroundStyle(Color.secondary)
+                HStack(spacing: 2) {
+                    Text(viewModel.period)
+                        .font(.system(.caption, design: .rounded, weight: .medium))
+                        .foregroundStyle(Color.secondary)
+                    if viewModel.showDisclosureIndicator {
+                        Image(systemName: "chevron.forward")
+                            .font(.system(.caption2, weight: .semibold))
+                            .scaleEffect(0.8)
+                            .foregroundStyle(Color.secondary)
+                    }
+                }
                 if viewModel.showComparison {
                     Text("\(viewModel.trend.formattedChange)  \(viewModel.trend.iconSign) \(viewModel.trend.formattedPercentage)")
                         .font(.caption.weight(.semibold))

--- a/Modules/Sources/JetpackStats/Cards/ChartCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/ChartCard.swift
@@ -81,8 +81,7 @@ struct ChartCard: View {
         return ChartCardHeaderView.ViewModel(
             trend: viewModel.selectedBarTrend ?? .make(data, context: .regular),
             metricTitle: metric.localizedTitle,
-            period: context.formatters.dateRange.string(from: viewModel.dateRange.subrange ?? viewModel.dateRange.range),
-            showComparison: dateRange.comparison != .off
+            period: context.formatters.dateRange.string(from: viewModel.dateRange.subrange ?? viewModel.dateRange.range)
         )
     }
 
@@ -314,7 +313,7 @@ struct ChartCardHeaderView: View {
         let trend: TrendViewModel
         let metricTitle: String
         let period: String
-        let showComparison: Bool
+        var showComparison: Bool = true
     }
 
     let viewModel: ViewModel

--- a/Modules/Sources/JetpackStats/Cards/ChartCardViewModel.swift
+++ b/Modules/Sources/JetpackStats/Cards/ChartCardViewModel.swift
@@ -32,6 +32,7 @@ final class ChartCardViewModel: ObservableObject, TrafficCardViewModel {
     }
 
     weak var configurationDelegate: CardConfigurationDelegate?
+    var onDateRangeChanged: ((StatsDateRangeSelection) -> Void)?
 
     var dateRange: StatsDateRangeSelection {
         didSet {
@@ -219,6 +220,11 @@ final class ChartCardViewModel: ObservableObject, TrafficCardViewModel {
         }
 
         return output
+    }
+
+    func promoteSubrangeToMainRange() {
+        guard let subrange = dateRange.subrange else { return }
+        onDateRangeChanged?(StatsDateRangeSelection(range: subrange))
     }
 
     var selectedBarTrend: TrendViewModel? {

--- a/Modules/Sources/JetpackStats/Cards/TodayCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TodayCard.swift
@@ -92,7 +92,7 @@ struct TodayCard: View {
     }
 
     private func makeMetricsView(with metrics: SiteMetricsSet) -> some View {
-        HStack(alignment: .bottom, spacing: 16) {
+        HStack(alignment: .bottom, spacing: 20) {
             ForEach(viewModel.configuration.metrics) { metric in
                 if metric == .views {
                     TodayCardProminentMetricView(value: metrics[metric], metric: metric)
@@ -130,7 +130,7 @@ struct TodayCard: View {
         .frame(maxWidth: .infinity)
         .padding(.trailing, 32)
         .padding(.vertical, 2)
-        .offset(y: -9)
+        .offset(y: -3)
         .transition(.opacity.combined(with: .scale(scale: 0.97)))
     }
 

--- a/Modules/Sources/JetpackStats/Cards/TopListCard.swift
+++ b/Modules/Sources/JetpackStats/Cards/TopListCard.swift
@@ -108,7 +108,7 @@ struct TopListCard: View {
     private var mapView: some View {
         CountriesMapView(
             data: viewModel.countriesMapData ?? .init(metric: viewModel.selection.metric, locations: []),
-            primaryColor: Constants.Colors.uiColorBlue
+            primaryColor: Constants.Colors.uiColorOrange
         )
     }
 

--- a/Modules/Sources/JetpackStats/Charts/BarChartView.swift
+++ b/Modules/Sources/JetpackStats/Charts/BarChartView.swift
@@ -324,12 +324,9 @@ struct BarChartView: View {
             return nil
         }
 
-        let origin = geometry[frame].origin
-        let location = CGPoint(
-            x: location.x - origin.x,
-            y: location.y - origin.y
-        )
-        guard let date: Date = proxy.value(atX: location.x) else {
+        let plotFrame = geometry[frame]
+        let adjustedX = max(0, min(location.x - plotFrame.origin.x, plotFrame.width))
+        guard let date: Date = proxy.value(atX: adjustedX) else {
             return nil
         }
         // `proxy.value(atX:)` returns a precise date at the tap location.

--- a/Modules/Sources/JetpackStats/Charts/Helpers/ChartHelper.swift
+++ b/Modules/Sources/JetpackStats/Charts/Helpers/ChartHelper.swift
@@ -67,7 +67,7 @@ struct ChartHelper {
         } else {
             AxisMarks(values: .stride(by: granularity.component, count: 1, calendar: calendar)) { value in
                 if let date = value.as(Date.self) {
-                    AxisValueLabel(centered: true, collisionResolution: .greedy(minimumSpacing: 6)) {
+                    AxisValueLabel(centered: true, collisionResolution: .greedy(minimumSpacing: 5)) {
                         ChartAxisDateLabel(date: date, granularity: granularity)
                     }
                 }

--- a/Modules/Sources/JetpackStats/Constants.swift
+++ b/Modules/Sources/JetpackStats/Constants.swift
@@ -43,6 +43,7 @@ public enum Constants {
         static let celadon = Color(palette: CSColor.Celadon.self)
 
         static let uiColorBlue = UIColor(palette: CSColor.Blue.self)
+        static let uiColorOrange = UIColor(palette: CSColor.Orange.self)
 
         static let jetpack = Color(palette: CSColor.JetpackGreen.self)
 

--- a/Modules/Sources/JetpackStats/StatsViewModel.swift
+++ b/Modules/Sources/JetpackStats/StatsViewModel.swift
@@ -183,12 +183,16 @@ final class StatsViewModel: ObservableObject, CardConfigurationDelegate {
                 context: context
             )
         case .chart(let configuration):
-            viewModel = ChartCardViewModel(
+            let chartVM = ChartCardViewModel(
                 configuration: configuration,
                 dateRange: effectiveDateRange,
                 service: context.service,
                 tracker: context.tracker
             )
+            chartVM.onDateRangeChanged = { [weak self] newRange in
+                self?.dateRange = newRange
+            }
+            viewModel = chartVM
         case .topList(let configuration):
             viewModel = TopListViewModel(
                 configuration: configuration,

--- a/Modules/Sources/JetpackStats/Utilities/SelectedDataPoints.swift
+++ b/Modules/Sources/JetpackStats/Utilities/SelectedDataPoints.swift
@@ -13,31 +13,21 @@ struct SelectedDataPoints {
         mappedPreviousSeries: [DataPoint]
     ) -> SelectedDataPoints? {
         guard let date else { return nil }
-
-        // Since mappedPreviousData has the same dates as currentData,
-        // we only need to find the closest date in the current series
         guard !currentSeries.isEmpty else { return nil }
 
-        // Find the closest data point in the current series
-        guard let closestPoint = findClosestDataPoint(to: date, in: currentSeries + mappedPreviousSeries) else {
-            return nil
-        }
+        // Find the index of the closest point in currentSeries.
+        // Using index-based lookup so that the corresponding previous point is
+        // retrieved by position, not by exact Date equality — the mapped dates
+        // may differ slightly (e.g. across DST boundaries).
+        guard let closestIndex = currentSeries.indices.min(by: {
+            abs(currentSeries[$0].date.timeIntervalSince(date)) <
+            abs(currentSeries[$1].date.timeIntervalSince(date))
+        }) else { return nil }
 
-        // Find the closest date value
-        let closestDate = closestPoint.date
+        let currentPoint = currentSeries[closestIndex]
+        let previousPoint = mappedPreviousSeries.indices.contains(closestIndex) ? mappedPreviousSeries[closestIndex] : nil
+        let unmappedPrevious = previousSeries.indices.contains(closestIndex) ? previousSeries[closestIndex] : nil
 
-        // Find points with this exact date in both series
-        let currentPoint = currentSeries.first { $0.date == closestDate }
-        let previousPointIndex = mappedPreviousSeries.firstIndex { $0.date == closestDate }
-        var previousPoint: DataPoint? {
-            guard let previousPointIndex, mappedPreviousSeries.indices.contains(previousPointIndex) else { return nil }
-            return mappedPreviousSeries[previousPointIndex]
-        }
-        // We need this just to display the data in the tooltip.
-        var unmappedPrevious: DataPoint? {
-            guard let previousPointIndex, previousSeries.indices.contains(previousPointIndex) else { return nil }
-            return previousSeries[previousPointIndex]
-        }
         return SelectedDataPoints(current: currentPoint, previous: previousPoint, unmappedPrevious: unmappedPrevious)
     }
 
@@ -50,13 +40,4 @@ struct SelectedDataPoints {
         )
     }
 
-    // Helper method to find the closest data point to a given date
-    private static func findClosestDataPoint(to date: Date, in points: [DataPoint]) -> DataPoint? {
-        guard !points.isEmpty else { return nil }
-
-        // Find the point with minimum time difference
-        return points.min { point1, point2 in
-            abs(point1.date.timeIntervalSince(date)) < abs(point2.date.timeIntervalSince(date))
-        }
-    }
 }

--- a/Modules/Sources/JetpackStats/Views/ChartValueTooltipView.swift
+++ b/Modules/Sources/JetpackStats/Views/ChartValueTooltipView.swift
@@ -75,8 +75,8 @@ struct ChartValueTooltipView: View {
             // Summary view
             if let trend {
                 ChartValuesSummaryView(trend: trend, style: .compact)
-            } else if let previousValue = previousPoint?.value {
-                Text(StatsValueFormatter(metric: metric).format(value: previousValue, context: .regular))
+            } else if let value = currentPoint?.value ?? previousPoint?.value {
+                Text(StatsValueFormatter(metric: metric).format(value: value, context: .regular))
                     .font(.subheadline.weight(.medium))
             }
 


### PR DESCRIPTION
**1. Revert some of the changes to “Today” card**

Just minor visual fixes.

**2. Use orange color for “Country” map**

It now matches the web, and the blue we use already matches the new direction for Core and Jetpack Stats.

<img width="340" alt="Screenshot 2026-03-20 at 1 07 13 PM" src="https://github.com/user-attachments/assets/8eda7f57-c6ab-4103-ade1-db380843618e" />

**3. Add a way to promote subrange to range**

This is a follow-up to https://github.com/wordpress-mobile/WordPress-iOS/pull/25374 so the users could still drill-down to the subrange if they want to.


https://github.com/user-attachments/assets/213c6fd8-e0e4-4499-a55a-a234b015c528

**4. Fix long-press or pan on a bar chart sometimes failing to find the related data points**

I think it need to refactor this further, but it seems to work OK now.

https://github.com/user-attachments/assets/f0be1d9d-0ccb-4804-9a07-fa5dd98810ca

**5. Mark the chart stale a bit faster**
**6 Slightly reduce minimum spacing for collision detection for x axis marks.** 

It ensures when y axis is wide (large numbers), the expected labels still fit. Previously, it sometimes wouldn't fit for sites iwht larger numbers (500K+).

<img width="486" height="361" alt="Screenshot 2026-03-20 at 1 53 50 PM" src="https://github.com/user-attachments/assets/e7fccde1-02a7-4076-8dc8-4727112d8b1a" />
