### PR TITLE
Replace the Reachability Swift package with NWPathMonitor

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3c17ad47fa74d088d3a4cdf98c8e1b35e19c735a0d996e782588e5b295c34aca",
+  "originHash" : "5cc06955f402a22a393b23b48582f917f06a1a799e1a9f9ceab0d2274a0d2247",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -212,15 +212,6 @@
       "state" : {
         "revision" : "6125ce7fb51b114ba71b761d18cfd5557923bd4d",
         "version" : "5.1.4"
-      }
-    },
-    {
-      "identity" : "reachability",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/Automattic/Reachability",
-      "state" : {
-        "branch" : "framework-support-via-spm",
-        "revision" : "5552d6a2ceeb40ad6aa1a288ea7bbd544fb68d6f"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -47,7 +47,7 @@ let package = Package(
         .package(url: "https://github.com/squarefrog/UIDeviceIdentifier", from: "2.3.0"),
         // We can remove the SVProgressHUD fork once this PR is merged: https://github.com/SVProgressHUD/SVProgressHUD/pull/1131
         .package(url: "https://github.com/automattic/SVProgressHUD", branch: "master"),
-        .package(url: "https://github.com/Automattic/Reachability", branch: "framework-support-via-spm"),
+
         .package(url: "https://github.com/weichsel/ZIPFoundation", from: "0.9.19"),
         .package(url: "https://github.com/wordpress-mobile/FSInteractiveMap", from: "0.3.0"),
         .package(url: "https://github.com/wordpress-mobile/MediaEditor-iOS", branch: "task/spm-support"),
@@ -174,7 +174,6 @@ let package = Package(
         .target(
             name: "WordPressShared",
             dependencies: [
-                .product(name: "Reachability", package: "Reachability"),
                 .product(name: "SwiftSoup", package: "SwiftSoup"),
                 .target(name: "SFHFKeychainUtils"),
                 .target(name: "WordPressSharedObjC"),
@@ -191,7 +190,6 @@ let package = Package(
                 "WordPressShared",
                 "WordPressLegacy",
                 .product(name: "ColorStudio", package: "color-studio"),
-                .product(name: "Reachability", package: "Reachability"),
             ],
             resources: [.process("Resources")],
             swiftSettings: [.swiftLanguageMode(.v5)]
@@ -330,7 +328,6 @@ enum XcodeSupport {
             .product(name: "CocoaLumberjackSwift", package: "CocoaLumberjack"),
             .product(name: "Down", package: "Down"),
             .product(name: "Gridicons", package: "Gridicons-iOS"),
-            .product(name: "Reachability", package: "Reachability"),
             .product(name: "SVProgressHUD", package: "SVProgressHUD"),
             .product(name: "ZIPFoundation", package: "ZIPFoundation"),
             .product(name: "Aztec", package: "AztecEditor-iOS"),
@@ -382,7 +379,6 @@ enum XcodeSupport {
             .product(name: "NSURL-IDN", package: "NSURL-IDN"),
             .product(name: "Pulse", package: "Pulse"),
             .product(name: "PulseUI", package: "Pulse"),
-            .product(name: "Reachability", package: "Reachability"),
             .product(name: "Starscream", package: "Starscream"),
             .product(name: "SVProgressHUD", package: "SVProgressHUD"),
             .product(name: "SwiftSoup", package: "SwiftSoup"),

--- a/Modules/Sources/WordPressShared/Reachability/ReachabilityUtils.swift
+++ b/Modules/Sources/WordPressShared/Reachability/ReachabilityUtils.swift
@@ -1,11 +1,10 @@
 import Foundation
-import Reachability
+import Network
 
 @objc
 public class ReachabilityUtils: NSObject {
 
-    @objc
-    public private(set) static var internetReachability: Reachability?
+    private static var pathMonitor: NWPathMonitor?
 
     public static var connectionAvailable = false
 
@@ -16,7 +15,7 @@ public class ReachabilityUtils: NSObject {
 
     @objc
     public static func isReachableViaWiFi() -> Bool {
-        internetReachability?.isReachableViaWiFi() ?? false
+        pathMonitor?.currentPath.usesInterfaceType(.wifi) ?? false
     }
 
     @objc
@@ -43,39 +42,20 @@ public class ReachabilityUtils: NSObject {
         currentReachabilityAlert != nil
     }
 
-    public static func configure(
-        notificationCenter: NotificationCenter = .default,
-        reachability: Reachability? = .forInternetConnection()
-    ) {
-        // The fact that the reachability instance is nullable is only an Objective-C bridging byproduct.
-        guard let internetReachability = reachability else {
-            fatalError("Failed to acquire internet reachability. This should never happen.")
+    public static func configure() {
+        let monitor = NWPathMonitor()
+        monitor.pathUpdateHandler = { path in
+            let newValue = path.status == .satisfied
+            connectionAvailable = newValue
+
+            NotificationCenter.default.post(
+                name: .reachabilityUpdated,
+                object: self,
+                userInfo: [Notification.reachabilityKey: newValue]
+            )
         }
-
-        let reachableStateChangedHandler: NetworkReachable = { reachability in
-            guard let reachability else { return }
-
-            DispatchQueue.main.async {
-                print(
-                    "Reachability state changed. WiFi: \(reachability.isReachableViaWiFi()) WWAN: \(reachability.isReachableViaWWAN())"
-                )
-                let newValue = reachability.isReachable()
-                connectionAvailable = newValue
-
-                notificationCenter.post(
-                    name: .reachabilityUpdated,
-                    object: self,
-                    userInfo: [Notification.reachabilityKey: newValue]
-                )
-            }
-        }
-
-        internetReachability.reachableBlock = reachableStateChangedHandler
-        internetReachability.unreachableBlock = reachableStateChangedHandler
-
-        internetReachability.startNotifier()
-
-        self.internetReachability = internetReachability
-        connectionAvailable = internetReachability.isReachable()
+        monitor.start(queue: .main)
+        pathMonitor = monitor
+        connectionAvailable = monitor.currentPath.status == .satisfied
     }
 }

--- a/Modules/Sources/WordPressShared/Reachability/ReachabilityUtils.swift
+++ b/Modules/Sources/WordPressShared/Reachability/ReachabilityUtils.swift
@@ -15,6 +15,11 @@ public class ReachabilityUtils: NSObject {
     }
 
     @objc
+    public static func isReachableViaWiFi() -> Bool {
+        internetReachability?.isReachableViaWiFi() ?? false
+    }
+
+    @objc
     public static func showAlertNoInternetConnection() {
         ReachabilityAlert(retryBlock: nil).show()
     }

--- a/Modules/Sources/WordPressShared/Reachability/ReachabilityUtils.swift
+++ b/Modules/Sources/WordPressShared/Reachability/ReachabilityUtils.swift
@@ -6,7 +6,12 @@ public class ReachabilityUtils: NSObject {
 
     private static var pathMonitor: NWPathMonitor?
 
-    public static var connectionAvailable = false
+    /// Whether the device currently has internet connectivity.
+    ///
+    /// The initial value is `false`. After `configure()` is called, `NWPathMonitor`
+    /// updates it to the correct value on the next main run loop cycle. Subsequent
+    /// changes are pushed automatically as the network state changes.
+    public internal(set) static var connectionAvailable = false
 
     @objc
     public static func isInternetReachable() -> Bool {
@@ -43,6 +48,8 @@ public class ReachabilityUtils: NSObject {
     }
 
     public static func configure() {
+        guard pathMonitor == nil else { return }
+
         let monitor = NWPathMonitor()
         monitor.pathUpdateHandler = { path in
             let newValue = path.status == .satisfied

--- a/Modules/Sources/WordPressUI/Deprecated/NoResultsViewController.swift
+++ b/Modules/Sources/WordPressUI/Deprecated/NoResultsViewController.swift
@@ -1,6 +1,5 @@
 import UIKit
 import WordPressShared
-import Reachability
 
 @objc public protocol NoResultsViewControllerDelegate {
     @objc optional func actionButtonPressed()
@@ -54,8 +53,6 @@ import Reachability
     private var titleLabelMaxWidthConstraint: NSLayoutConstraint?
     private var titleLabelTopConstraint: NSLayoutConstraint?
 
-    //For No results on connection issue
-    private let reachability = Reachability.forInternetConnection()
     /// sets an additional/alternate handler for the action button that can be directly injected
     public var actionButtonHandler: (() -> Void)?
     /// sets an additional/alternate handler for the dismiss button that can be directly injected
@@ -72,13 +69,7 @@ import Reachability
 
     public override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
-        reachability?.startNotifier()
         configureView()
-    }
-
-    public override func viewDidDisappear(_ animated: Bool) {
-        super.viewDidDisappear(animated)
-        reachability?.stopNotifier()
     }
 
     public override func didMove(toParent parent: UIViewController?) {
@@ -160,7 +151,7 @@ import Reachability
                          image: String? = nil,
                          subtitleImage: String? = nil,
                          accessoryView: UIView? = nil) {
-        isReachable = reachability?.isReachable() ?? false
+        isReachable = ReachabilityUtils.isInternetReachable()
         if !isReachable {
             titleText = noConnectionTitle != nil ? noConnectionTitle : NoConnection.title
             let subtitle = noConnectionSubtitle != nil ? noConnectionSubtitle : NoConnection.subTitle

--- a/Modules/Tests/WordPressUIUnitTests/NoResultsViewControllerTests.swift
+++ b/Modules/Tests/WordPressUIUnitTests/NoResultsViewControllerTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+@testable import WordPressShared
 @testable import WordPressUI
 
 class NoResultsViewControllerTests: XCTestCase {
@@ -21,6 +22,7 @@ class NoResultsViewControllerTests: XCTestCase {
     private var parentViewController: UIViewController!
 
     override func setUpWithError() throws {
+        ReachabilityUtils.connectionAvailable = true
         resultViewController = NoResultsViewController.controller()
         parentViewController = UIViewController()
     }

--- a/Tests/KeystoneTests/Helpers/NetworkStatus.swift
+++ b/Tests/KeystoneTests/Helpers/NetworkStatus.swift
@@ -1,4 +1,4 @@
-import WordPressShared
+@testable import WordPressShared
 
 func makeNetworkAvailable() {
     ReachabilityUtils.connectionAvailable = true

--- a/WordPress/Classes/Services/AccountSettingsService.swift
+++ b/WordPress/Classes/Services/AccountSettingsService.swift
@@ -1,5 +1,4 @@
 import Foundation
-import Reachability
 import WordPressData
 import WordPressKit
 

--- a/WordPress/Classes/System/WordPressAppDelegate.swift
+++ b/WordPress/Classes/System/WordPressAppDelegate.swift
@@ -8,7 +8,6 @@ import CocoaLumberjackSwiftLogBackend
 import DesignSystem
 import Logging
 import Pulse
-import Reachability
 import SFHFKeychainUtils
 import SVProgressHUD
 import ShareExtensionCore

--- a/WordPress/Classes/Utility/PingHubManager.swift
+++ b/WordPress/Classes/Utility/PingHubManager.swift
@@ -1,6 +1,6 @@
 import UIKit
-import Reachability
 import WordPressData
+import WordPressShared
 
 // This is added as a top level function to avoid cluttering PingHubManager.init
 private func defaultAccountToken() -> String? {
@@ -22,7 +22,7 @@ private func defaultAccountToken() -> String? {
 /// app is in the foreground.
 ///
 /// When a connection fails for some reason, it will try to reconnect whenever
-/// there is an internet connection, as detected by Reachability. If the app
+/// there is an internet connection, as detected by ReachabilityUtils. If the app
 /// thinks it's online but connections are still failing, the manager adds an
 /// increasing delay to the reconnection to avoid too many attempts.
 ///
@@ -77,7 +77,6 @@ class PingHubManager: NSObject {
         }
     }
 
-    fileprivate let reachability: Reachability = Reachability.forInternetConnection()
     fileprivate var state: State {
         didSet {
             stateChanged(old: oldValue, new: state)
@@ -85,11 +84,12 @@ class PingHubManager: NSObject {
     }
     fileprivate var delay = IncrementalDelay(Configuration.delaySequence)
     fileprivate var delayedRetry: DispatchDelayedAction?
+    private var reachabilityObserver: NSObjectProtocol?
 
     override init() {
         let foreground = (UIApplication.shared.applicationState != .background)
         let authToken = defaultAccountToken()
-        state = State(connected: false, reachable: reachability.isReachable(), foreground: foreground, authToken: authToken)
+        state = State(connected: false, reachable: ReachabilityUtils.connectionAvailable, foreground: foreground, authToken: authToken)
         super.init()
 
         guard enabled else {
@@ -107,12 +107,18 @@ class PingHubManager: NSObject {
             stateChanged(old: state, new: state)
         }
 
-        setupReachability()
+        reachabilityObserver = NotificationCenter.default.addObserver(forName: .reachabilityUpdated, object: nil, queue: .main) { [weak self] notification in
+            if let reachable = notification.userInfo?[Notification.reachabilityKey] as? Bool {
+                self?.state.reachable = reachable
+            }
+        }
     }
 
     deinit {
         delayedRetry?.cancel()
-        reachability.stopNotifier()
+        if let reachabilityObserver {
+            NotificationCenter.default.removeObserver(reachabilityObserver)
+        }
     }
 
     fileprivate func stateChanged(old: State, new: State) {
@@ -191,20 +197,6 @@ fileprivate extension PingHubManager {
         state.foreground = true
     }
 
-    // MARK: reachability
-    func setupReachability() {
-        let reachabilityChanged: (Reachability?) -> Void = { [weak self] reachability in
-            guard let manager = self, let reachability else {
-                return
-            }
-            DispatchQueue.main.async {
-                manager.state.reachable = reachability.isReachable()
-            }
-        }
-        reachability.reachableBlock = reachabilityChanged
-        reachability.unreachableBlock = reachabilityChanged
-        reachability.startNotifier()
-    }
 }
 
 // MARK: - Actions

--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController.swift
@@ -2,7 +2,6 @@ import UIKit
 import WordPressData
 import WordPressShared
 import WordPressUI
-import Reachability
 import Gridicons
 
 public protocol BlogDetailsPresentationDelegate: AnyObject {
@@ -189,7 +188,7 @@ public class BlogDetailsViewController: UIViewController {
 
     private func preloadBlogData() {
         // only preload on wifi
-        guard ReachabilityUtils.internetReachability?.isReachableViaWiFi() == true else {
+        guard ReachabilityUtils.isReachableViaWiFi() else {
             return
         }
 

--- a/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/View Model/ChangeUsernameViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Me/My Profile/Change Username/View Model/ChangeUsernameViewModel.swift
@@ -1,4 +1,3 @@
-import Reachability
 import WordPressFlux
 import WordPressKit
 import WordPressShared
@@ -18,7 +17,7 @@ class ChangeUsernameViewModel {
     }
 
     var isReachable: Bool {
-        return reachability?.isReachable() ?? false
+        return ReachabilityUtils.isInternetReachable()
     }
 
     var usernameIsValidToBeChanged: Bool {
@@ -39,7 +38,6 @@ class ChangeUsernameViewModel {
 
     private let settings: AccountSettings?
     private let store: AccountSettingsStore
-    private let reachability = Reachability.forInternetConnection()
     private var receipt: Receipt?
     private var saveUsernameBlock: StateBlock?
     private var reloadAllSections: Bool = true
@@ -106,20 +104,15 @@ private extension ChangeUsernameViewModel {
         let notificationCenter = NotificationCenter.default
         notificationCenter.addObserver(self, selector: #selector(adjustForKeyboard), name: UIResponder.keyboardWillHideNotification, object: nil)
         notificationCenter.addObserver(self, selector: #selector(adjustForKeyboard), name: UIResponder.keyboardWillChangeFrameNotification, object: nil)
-
-        let reachabilityBlock: NetworkReachable = { [weak self] reachability in
-            DispatchQueue.main.async {
-                self?.reachabilityListener?()
-            }
-        }
-        reachability?.reachableBlock = reachabilityBlock
-        reachability?.unreachableBlock = reachabilityBlock
-        reachability?.startNotifier()
+        notificationCenter.addObserver(self, selector: #selector(reachabilityChanged), name: .reachabilityUpdated, object: nil)
     }
 
     func removeObserver() {
         NotificationCenter.default.removeObserver(self)
-        reachability?.stopNotifier()
+    }
+
+    @objc func reachabilityChanged() {
+        reachabilityListener?()
     }
 
     @objc func adjustForKeyboard(notification: Foundation.Notification) {

--- a/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
+++ b/WordPress/Classes/ViewRelated/Stats/StatsViewController.m
@@ -5,7 +5,6 @@
 
 @import WordPressData;
 @import WordPressShared;
-@import Reachability;
 
 @interface StatsViewController () <NoResultsViewControllerDelegate>
 
@@ -52,7 +51,7 @@
         self.title = self.blog.settings.name;
     }
 
-    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(reachabilityChanged:) name:kTMReachabilityChangedNotification object:ReachabilityUtils.internetReachability];
+    [[NSNotificationCenter defaultCenter] addObserver:self selector:@selector(reachabilityChanged:) name:NSNotification.ReachabilityUpdatedNotification object:nil];
 
     [self registerForTraitChanges:@[UITraitHorizontalSizeClass.class] withAction:@selector(updateNavigationTitle)];
 
@@ -181,8 +180,7 @@
 
 - (void)reachabilityChanged:(NSNotification *)notification
 {
-    Reachability *reachability = notification.object;
-    if (reachability.isReachable) {
+    if ([ReachabilityUtils isInternetReachable]) {
         [self initStats];
     }
 }


### PR DESCRIPTION
## Description

The Reachability package does not compile on Xcode 26.4

```
TMReachability.m:32:9: error: Use of private header from outside its module: 'netinet6/in6.h'
```

> [!Note]
> I recommend reviewing this PR commit by commit.