### PR TITLE
Automatically create an application password when viewing site

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,7 @@ To automatically sign in to the app on an iOS simulator, see @docs/simulator-sig
 - Follow the standard formatting practices enforced by SwiftLint
 - Don't create `body` for `View` that are too long
 - Use semantics text sizes like `.headline`
+- Use swift-log (see the `WordPress/Classes/System/Logging.swift` file) instead of CocoaLumberjack (`DDLogError`, etc)
 
 ## Development Workflow
 - Branch from `trunk` (main branch)

--- a/WordPress/Classes/Services/ApplicationPasswordRepository.swift
+++ b/WordPress/Classes/Services/ApplicationPasswordRepository.swift
@@ -206,7 +206,7 @@ private extension ApplicationPasswordRepository {
         return validPasswords.first
     }
 
-    func createPassword(for blogId: TaggedManagedObjectID<Blog>) async throws -> ApplicationPassword {
+    private func createPassword(for blogId: TaggedManagedObjectID<Blog>) async throws -> ApplicationPassword {
         // Update `Blog.username` so that we can associate the created password with the site itself, in addition to the Jetpack site ID.
         let siteUsername = try await updateSiteUsernameIfNeeded(blogId)
         let apiRootURL = try await updateRestAPIURLIfNeeded(blogId)

--- a/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/My Site/MySiteViewController.swift
@@ -385,6 +385,14 @@ final class MySiteViewController: UIViewController, UIScrollViewDelegate, NoSite
             // Also refresh editor capabilities
             EditorDependencyManager.shared.fetchEditorCapabilities(for: blog)
         }
+
+        Task { [blogID = TaggedManagedObjectID(blog)] in
+            do {
+                try await ApplicationPasswordRepository.shared.createPasswordIfNeeded(for: blogID)
+            } catch {
+                Loggers.app.error("Failed to create an application password: \(error)")
+            }
+        }
     }
 
     @objc


### PR DESCRIPTION
## Description

Relates to https://github.com/wordpress-mobile/WordPress-iOS/pull/25424.

Automatically create an application password for the user, so that one is ready when needed. The function call is a no-op if a valid application password already exists.
