### PR TITLE
Remove the Post Settings feature flag

### DIFF
--- a/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
+++ b/WordPress/Classes/Utility/BuildInformation/FeatureFlag.swift
@@ -29,7 +29,6 @@ public enum FeatureFlag: Int, CaseIterable {
     case nativeBlockInserter
     case statsAds
     case customPostTypes
-    case cptPostSettings
     case cptPostsAndPages
 
     /// Returns a boolean indicating if the feature is enabled.
@@ -94,8 +93,6 @@ public enum FeatureFlag: Int, CaseIterable {
             return BuildConfiguration.current == .debug
         case .customPostTypes:
             return BuildConfiguration.current == .debug
-        case .cptPostSettings:
-            return BuildConfiguration.current == .debug
         case .cptPostsAndPages:
             return BuildConfiguration.current == .debug
         }
@@ -143,7 +140,6 @@ extension FeatureFlag {
         case .nativeBlockInserter: "Native Block Inserter"
         case .statsAds: "Stats Ads Tab"
         case .customPostTypes: "Custom Post Types"
-        case .cptPostSettings: "Custom Post Types: Post Settings"
         case .cptPostsAndPages: "Custom Post Types: Posts and Pages"
         }
     }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/CustomPostEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/CustomPostEditorViewController.swift
@@ -131,11 +131,7 @@ private extension CustomPostEditorViewController {
     }
 
     func rightBarButtonItems() -> [UIBarButtonItem] {
-        var children: [UIMenuElement] = [editorModeToggle()]
-        if FeatureFlag.cptPostSettings.enabled {
-            children.append(settingsAction())
-        }
-        children.append(contentsOf: [helpAction(), feedbackAction()])
+        var children: [UIMenuElement] = [editorModeToggle(), settingsAction(), helpAction(), feedbackAction()]
 
         if post?.status ?? .draft == .draft {
             let menu = UIDeferredMenuElement.uncached { [weak self] resolve in
@@ -167,11 +163,7 @@ private extension CustomPostEditorViewController {
         if post?.status ?? .draft == .draft {
             return UIAction(title: PostEditorStrings.publish) { [weak self] _ in
                 Task {
-                    if FeatureFlag.cptPostSettings.enabled {
-                        await self?.showPublishingSheet()
-                    } else {
-                        await self?.save(publish: true)
-                    }
+                    await self?.showPublishingSheet()
                 }
             }
         } else {


### PR DESCRIPTION
## Description

Post Settings are now mostly implemented. Removing this feature flag on the release branch because XMLRPC-disabled sites will need to access the Post Settings.
