### PR TITLE
fix: update Blogging Reminders "Not Now" button text

### DIFF
--- a/WordPress/Classes/Utility/SharedStrings.swift
+++ b/WordPress/Classes/Utility/SharedStrings.swift
@@ -21,7 +21,7 @@ enum SharedStrings {
         static let `continue` = NSLocalizedString("shared.button.continue", value: "Continue", comment: "A shared button title used in different contexts")
         static let undo = NSLocalizedString("shared.button.undo", value: "Undo", comment: "A shared button title used in different contexts")
         static let clear = NSLocalizedString("shared.button.clear", value: "Clear", comment: "A shared button title used in different contexts")
-        static let notNow = NSLocalizedString("shared.button.notNow", value: "Now Now", comment: "A shared button title used in different contexts")
+        static let notNow = NSLocalizedString("shared.button.notNow", value: "Not Now", comment: "A shared button title used in different contexts")
     }
 
     enum Misc {


### PR DESCRIPTION
## Description
<!-- Describe the changes, why they are needed, and how they address the issue -->
Fix button text typo where "Now Now" was erroneously displayed. Introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/25337. Recently [raised](https://wordpress.slack.com/archives/C02RQC4LY/p1774040849707209) in WordPress #mobile Slack channel. 

## Testing instructions
<!-- Consider listing specific testing steps for helping reviewers evaluate the efficacy of the changes -->
Likely unnecessary for this simple string change.

Before | After 
-- | --
![before](https://github.com/user-attachments/assets/ac5cfc81-ea9a-4eb5-955a-9c6668ffb1b8) | ![after](https://github.com/user-attachments/assets/5e0f5cba-2545-49f9-a6d1-1c49dac3806e) 


<!--

Consider testing the following *yourself* before requesting a review:

- Compatibility with WordPress.com sites and self-hosted Jetpack sites
- Both portrait and landscape orientations
- Light and dark modes
- Dynamic font sizes: larger, smaller and bold text
- High contrast mode
- Screen reader experience (e.g., VoiceOver)
- Languages with large words or with letters/accents not frequently used in English
- Right-to-left languages layout
- Multi-tasking: split view and slide over

-->
