### PR TITLE
Remove application password availablity check

### DIFF
--- a/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Details/BlogDetailsViewController+Swift.swift
@@ -121,8 +121,6 @@ extension BlogDetailsViewController {
     }
 
     func showPinnedPostType(_ postType: PinnedPostType) {
-        guard let site = try? WordPressSite(blog: blog), case .selfHosted = site else { return }
-
         let feature = NSLocalizedString(
             "applicationPasswordRequired.feature.customPosts",
             value: "Custom Post Types",


### PR DESCRIPTION
## Description

The removed guard ensures only self-hosted site with an application password goes through. But that check is not necessary because the `ApplicationPasswordRequiredView` below will ensure an application password is created for viewing the post list.

This change fixes an issue that is reproducible as follows:
1. Sign in a self-hosted site using account username and password.
2. After signing in, disable XML-RPC.
3. Tap the Posts or Pages.

The app should present the cpt-based post list. But tapping the Posts and Pages row does nothing.
