### PR TITLE
Implement the Duplicate post action

### DIFF
--- a/Tests/KeystoneTests/Tests/Features/Posts/CustomPostEditorServiceTests.swift
+++ b/Tests/KeystoneTests/Tests/Features/Posts/CustomPostEditorServiceTests.swift
@@ -150,13 +150,39 @@ struct CustomPostEditorServiceTests {
 
         #expect(service.hasSettingsChanges == true)
     }
+
+    // MARK: - initialParams Tests
+
+    @Test("init with initialParams uses provided params instead of defaults")
+    func initWithInitialParamsUsesProvidedParams() throws {
+        let context = ContextManager.forTesting().mainContext
+        let blog = BlogBuilder(context).build()
+
+        var params = PostCreateParams(meta: nil)
+        params.status = .draft
+        params.title = "Copied Title"
+        params.content = "Copied Content"
+        params.categories = [TermId(5)]
+
+        let service = try makeService(blog: blog, post: nil, initialParams: params)
+
+        // PostSettings does not store title/content (those are managed by the
+        // Gutenberg editor), so verify via categoryIDs which PostSettings does map.
+        #expect(service.settings.categoryIDs == [5])
+        // Also verify via the test-only inspection method that the full params
+        // are stored, including title and content.
+        let storedParams = service.inspectCreateParams()
+        #expect(storedParams?.title == "Copied Title")
+        #expect(storedParams?.content == "Copied Content")
+    }
 }
 
 // MARK: - Test Helpers
 
 private func makeService(
     blog: Blog,
-    post: AnyPostWithEditContext?
+    post: AnyPostWithEditContext?,
+    initialParams: PostCreateParams? = nil
 ) throws -> CustomPostEditorService {
     let api = try WordPressAPI(
         urlSession: .shared,
@@ -174,7 +200,8 @@ private func makeService(
         post: post,
         details: makePostTypeDetails(),
         client: client,
-        wpService: wpService
+        wpService: wpService,
+        initialParams: initialParams
     )
 }
 

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostEditor.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostEditor.swift
@@ -11,10 +11,18 @@ struct CustomPostEditor: View {
     let post: AnyPostWithEditContext?
     let details: PostTypeDetailsWithEditContext
     let blog: Blog
+    let initialParams: PostCreateParams?
 
     var body: some View {
-        ViewControllerWrapper(wpService: wpService, client: client, post: post, details: details, blog: blog)
-            .ignoresSafeArea()
+        ViewControllerWrapper(
+            wpService: wpService,
+            client: client,
+            post: post,
+            details: details,
+            blog: blog,
+            initialParams: initialParams
+        )
+        .ignoresSafeArea()
     }
 }
 
@@ -24,12 +32,20 @@ private struct ViewControllerWrapper: UIViewControllerRepresentable {
     let post: AnyPostWithEditContext?
     let details: PostTypeDetailsWithEditContext
     let blog: Blog
+    let initialParams: PostCreateParams?
 
     @Environment(\.dismiss)
     var dismiss: DismissAction
 
     func makeUIViewController(context: Context) -> UIViewController {
-        let viewController = CustomPostEditorViewController(blog: blog, wpService: wpService, client: client, post: post, details: details) {
+        let viewController = CustomPostEditorViewController(
+            blog: blog,
+            wpService: wpService,
+            client: client,
+            post: post,
+            details: details,
+            initialParams: initialParams
+        ) {
             dismiss()
         }
         return UINavigationController(rootViewController: viewController)

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostEditorService.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostEditorService.swift
@@ -68,10 +68,13 @@ class CustomPostEditorService {
         post: AnyPostWithEditContext?,
         details: PostTypeDetailsWithEditContext,
         client: WordPressClient,
-        wpService: WpService
+        wpService: WpService,
+        initialParams: PostCreateParams? = nil
     ) {
         if let post {
             self.state = .existingPost(post)
+        } else if let initialParams {
+            self.state = .newPost(initialParams)
         } else {
             self.state = .newPost(PostCreateParams.defaultParams(from: blog))
         }
@@ -230,6 +233,14 @@ extension CustomPostEditorService {
     func inspectPendingSettings() -> PostSettings? {
         if case .existingPost(_, let pending) = state {
             return pending
+        }
+        return nil
+    }
+
+    // Used in unit tests.
+    func inspectCreateParams() -> PostCreateParams? {
+        if case .newPost(let params) = state {
+            return params
         }
         return nil
     }

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListView.swift
@@ -18,6 +18,7 @@ struct CustomPostListView<Header: View>: View {
     let showsPostActions: Bool
     let selectedPostID: Int64?
     let onSelectPost: (AnyPostWithEditContext) -> Void
+    let onDuplicate: (AnyPostWithEditContext) -> Void
     @ViewBuilder let header: () -> Header
 
     init(
@@ -27,7 +28,8 @@ struct CustomPostListView<Header: View>: View {
         mediaHost: MediaHost? = nil,
         showsPostActions: Bool = true,
         selectedPostID: Int64? = nil,
-        onSelectPost: @escaping (AnyPostWithEditContext) -> Void
+        onSelectPost: @escaping (AnyPostWithEditContext) -> Void,
+        onDuplicate: @escaping (AnyPostWithEditContext) -> Void = { _ in }
     ) where Header == EmptyView {
         self.viewModel = viewModel
         self.details = details
@@ -36,6 +38,7 @@ struct CustomPostListView<Header: View>: View {
         self.showsPostActions = showsPostActions
         self.selectedPostID = selectedPostID
         self.onSelectPost = onSelectPost
+        self.onDuplicate = onDuplicate
         self.header = { EmptyView() }
     }
 
@@ -47,6 +50,7 @@ struct CustomPostListView<Header: View>: View {
         showsPostActions: Bool = true,
         selectedPostID: Int64? = nil,
         onSelectPost: @escaping (AnyPostWithEditContext) -> Void,
+        onDuplicate: @escaping (AnyPostWithEditContext) -> Void = { _ in },
         @ViewBuilder header: @escaping () -> Header
     ) {
         self.viewModel = viewModel
@@ -56,6 +60,7 @@ struct CustomPostListView<Header: View>: View {
         self.showsPostActions = showsPostActions
         self.selectedPostID = selectedPostID
         self.onSelectPost = onSelectPost
+        self.onDuplicate = onDuplicate
         self.header = header
     }
 
@@ -66,6 +71,7 @@ struct CustomPostListView<Header: View>: View {
             onLoadNextPage: { try await viewModel.loadNextPage() },
             client: client,
             onSelectPost: onSelectPost,
+            onDuplicate: onDuplicate,
             mediaHost: mediaHost,
             showsPostActions: showsPostActions,
             selectedPostID: selectedPostID,
@@ -133,6 +139,7 @@ private struct PaginatedList<Header: View>: View {
     let onLoadNextPage: () async throws -> Void
     let client: WordPressClient?
     let onSelectPost: (AnyPostWithEditContext) -> Void
+    let onDuplicate: (AnyPostWithEditContext) -> Void
     let mediaHost: MediaHost?
     let showsPostActions: Bool
     let selectedPostID: Int64?
@@ -148,6 +155,7 @@ private struct PaginatedList<Header: View>: View {
         onLoadNextPage: @escaping () async throws -> Void,
         client: WordPressClient? = nil,
         onSelectPost: @escaping (AnyPostWithEditContext) -> Void,
+        onDuplicate: @escaping (AnyPostWithEditContext) -> Void = { _ in },
         mediaHost: MediaHost? = nil,
         showsPostActions: Bool = true,
         selectedPostID: Int64? = nil,
@@ -158,6 +166,7 @@ private struct PaginatedList<Header: View>: View {
         self.onLoadNextPage = onLoadNextPage
         self.client = client
         self.onSelectPost = onSelectPost
+        self.onDuplicate = onDuplicate
         self.mediaHost = mediaHost
         self.showsPostActions = showsPostActions
         self.selectedPostID = selectedPostID
@@ -171,6 +180,7 @@ private struct PaginatedList<Header: View>: View {
         onLoadNextPage: @escaping () async throws -> Void,
         client: WordPressClient? = nil,
         onSelectPost: @escaping (AnyPostWithEditContext) -> Void,
+        onDuplicate: @escaping (AnyPostWithEditContext) -> Void = { _ in },
         mediaHost: MediaHost? = nil,
         showsPostActions: Bool = true,
         selectedPostID: Int64? = nil,
@@ -182,6 +192,7 @@ private struct PaginatedList<Header: View>: View {
         self.onLoadNextPage = onLoadNextPage
         self.client = client
         self.onSelectPost = onSelectPost
+        self.onDuplicate = onDuplicate
         self.mediaHost = mediaHost
         self.showsPostActions = showsPostActions
         self.selectedPostID = selectedPostID
@@ -218,6 +229,7 @@ private struct PaginatedList<Header: View>: View {
                 item: item,
                 client: client,
                 onSelectPost: onSelectPost,
+                onDuplicate: onDuplicate,
                 mediaHost: mediaHost,
                 viewModel: viewModel,
                 showsPostActions: showsPostActions,
@@ -235,6 +247,7 @@ private struct PaginatedList<Header: View>: View {
                 item: item,
                 client: client,
                 onSelectPost: onSelectPost,
+                onDuplicate: onDuplicate,
                 mediaHost: mediaHost,
                 viewModel: viewModel,
                 showsPostActions: showsPostActions,
@@ -304,6 +317,7 @@ private struct ForEachContent: View {
     let item: CustomPostCollectionItem
     let client: WordPressClient?
     let onSelectPost: (AnyPostWithEditContext) -> Void
+    let onDuplicate: (AnyPostWithEditContext) -> Void
     let mediaHost: MediaHost?
     @ObservedObject var viewModel: CustomPostListViewModel
     var showsPostActions: Bool = true
@@ -341,10 +355,10 @@ private struct ForEachContent: View {
                 } else if showsPostActions {
                     button
                         .contextMenu {
-                            PostActionMenuContent(post: fullPost, viewModel: viewModel)
+                            PostActionMenuContent(post: fullPost, viewModel: viewModel, onDuplicate: onDuplicate)
                         }
                         .overlay(alignment: .topTrailing) {
-                            PostActionMenu(post: fullPost, viewModel: viewModel)
+                            PostActionMenu(post: fullPost, viewModel: viewModel, onDuplicate: onDuplicate)
                                 .offset(y: -6)
                         }
                 } else {
@@ -377,6 +391,7 @@ private struct ForEachContentWithIndentation: View {
     let item: CustomPostCollectionItem
     let client: WordPressClient?
     let onSelectPost: (AnyPostWithEditContext) -> Void
+    let onDuplicate: (AnyPostWithEditContext) -> Void
     let mediaHost: MediaHost?
     let viewModel: CustomPostListViewModel
     var showsPostActions: Bool = true
@@ -397,6 +412,7 @@ private struct ForEachContentWithIndentation: View {
                 item: item,
                 client: client,
                 onSelectPost: onSelectPost,
+                onDuplicate: onDuplicate,
                 mediaHost: mediaHost,
                 viewModel: viewModel,
                 showsPostActions: showsPostActions,
@@ -410,10 +426,11 @@ private struct ForEachContentWithIndentation: View {
 private struct PostActionMenu: View {
     let post: AnyPostWithEditContext
     let viewModel: CustomPostListViewModel
+    let onDuplicate: (AnyPostWithEditContext) -> Void
 
     var body: some View {
         Menu {
-            PostActionMenuContent(post: post, viewModel: viewModel)
+            PostActionMenuContent(post: post, viewModel: viewModel, onDuplicate: onDuplicate)
         } label: {
             Image(systemName: "ellipsis")
                 .font(.body)
@@ -427,6 +444,7 @@ private struct PostActionMenu: View {
 private struct PostActionMenuContent: View {
     let post: AnyPostWithEditContext
     let viewModel: CustomPostListViewModel
+    let onDuplicate: (AnyPostWithEditContext) -> Void
 
     var body: some View {
         primarySection
@@ -457,7 +475,11 @@ private struct PostActionMenuContent: View {
                 }
             }
 
-            // FIXME: Duplicate requires Core Data editor (Post.blog.createDraftPost, PostListEditorPresenter)
+            if post.status == .publish || post.status == .draft || post.status == .pending {
+                Button(action: { onDuplicate(post) }) {
+                    Label(Strings.duplicate, systemImage: "doc.on.doc")
+                }
+            }
 
             if post.status == .publish, let url = URL(string: post.link) {
                 ShareLink(item: url, subject: Text(post.title?.raw ?? "")) {
@@ -601,6 +623,11 @@ private enum Strings {
         "customPostList.action.publish",
         value: "Publish",
         comment: "Menu action to publish a draft or pending post"
+    )
+    static let duplicate = NSLocalizedString(
+        "customPostList.action.duplicate",
+        value: "Duplicate",
+        comment: "Menu action to create a draft copy of a post"
     )
     static let moveToDraft = NSLocalizedString(
         "customPostList.action.moveToDraft",

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostSearchResultView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostSearchResultView.swift
@@ -14,6 +14,7 @@ struct CustomPostSearchResultView: View {
     @Binding var searchText: String
     weak var presentingViewController: UIViewController?
     let onSelectPost: (AnyPostWithEditContext) -> Void
+    var onDuplicate: (AnyPostWithEditContext) -> Void = { _ in }
 
     @State private var finalSearchText = ""
 
@@ -30,7 +31,8 @@ struct CustomPostSearchResultView: View {
             details: details,
             client: client,
             mediaHost: MediaHost(blog),
-            onSelectPost: onSelectPost
+            onSelectPost: onSelectPost,
+            onDuplicate: onDuplicate
         )
         .task(id: searchText) {
             do {

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostTabView.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostTabView.swift
@@ -111,6 +111,7 @@ struct CustomPostTabView: View {
                     client: client,
                     mediaHost: MediaHost(blog),
                     onSelectPost: { editorPresentation = .editPost($0) },
+                    onDuplicate: { duplicatePost($0) },
                     header: { tabBar }
                 )
             } else {
@@ -121,7 +122,8 @@ struct CustomPostTabView: View {
                     details: details,
                     searchText: $searchText,
                     presentingViewController: presentingViewController,
-                    onSelectPost: { editorPresentation = .editPost($0) }
+                    onSelectPost: { editorPresentation = .editPost($0) },
+                    onDuplicate: { duplicatePost($0) }
                 )
             }
         }
@@ -150,7 +152,14 @@ struct CustomPostTabView: View {
             SubmitFeedbackViewRepresentable()
         }
         .fullScreenCover(item: $editorPresentation) { presentation in
-            CustomPostEditor(wpService: service, client: client, post: presentation.post, details: details, blog: blog)
+            CustomPostEditor(
+                wpService: service,
+                client: client,
+                post: presentation.post,
+                details: details,
+                blog: blog,
+                initialParams: presentation.initialParams
+            )
         }
         .onChange(of: authorFilter, applyAuthorFilter)
         .task {
@@ -202,6 +211,22 @@ struct CustomPostTabView: View {
         draftsViewModel.updateAuthorFilter(authorIds)
         scheduledViewModel.updateAuthorFilter(authorIds)
         trashViewModel.updateAuthorFilter(authorIds)
+    }
+
+    private func duplicatePost(_ post: AnyPostWithEditContext) {
+        let capabilities = PostSettingsCapabilities(from: details)
+        var params = PostCreateParams.defaultParams(from: blog)
+        params.title = post.title?.raw
+        params.content = post.content.raw
+        if capabilities.supportsCategories, let categories = post.categories {
+            params.categories = categories
+        }
+        if capabilities.supportsPostFormats {
+            params.format = post.format
+        }
+        editorPresentation = .duplicatePost(params)
+
+        WPAnalytics.track(.postListDuplicateAction, withProperties: ["post_type": details.slug])
     }
 
     private var tabBar: some View {
@@ -317,18 +342,27 @@ private struct SubmitFeedbackViewRepresentable: UIViewControllerRepresentable {
 private enum EditorPresentation: Identifiable {
     case newPost
     case editPost(AnyPostWithEditContext)
+    case duplicatePost(PostCreateParams)
 
     var id: String {
         switch self {
         case .newPost: return "new"
         case .editPost(let post): return "post-\(post.id)"
+        case .duplicatePost: return "duplicate"
         }
     }
 
     var post: AnyPostWithEditContext? {
         switch self {
-        case .newPost: return nil
+        case .newPost, .duplicatePost: return nil
         case .editPost(let post): return post
+        }
+    }
+
+    var initialParams: PostCreateParams? {
+        switch self {
+        case .duplicatePost(let params): return params
+        default: return nil
         }
     }
 }

--- a/WordPress/Classes/ViewRelated/NewGutenberg/CustomPostEditorViewController.swift
+++ b/WordPress/Classes/ViewRelated/NewGutenberg/CustomPostEditorViewController.swift
@@ -31,6 +31,7 @@ class CustomPostEditorViewController: PostGBKEditorViewController {
         client: WordPressClient,
         post: AnyPostWithEditContext?,
         details: PostTypeDetailsWithEditContext,
+        initialParams: PostCreateParams? = nil,
         completion: @escaping () -> Void
     ) {
         self.client = client
@@ -38,7 +39,8 @@ class CustomPostEditorViewController: PostGBKEditorViewController {
         self.completion = completion
 
         self.editorService = CustomPostEditorService(
-            blog: blog, post: post, details: details, client: client, wpService: wpService
+            blog: blog, post: post, details: details, client: client, wpService: wpService,
+            initialParams: initialParams
         )
 
         let postTypeDetails = PostTypeDetails(
@@ -49,8 +51,8 @@ class CustomPostEditorViewController: PostGBKEditorViewController {
         super.init(
             postId: post.map { Int($0.id) },
             postType: postTypeDetails,
-            title: post?.title?.raw,
-            content: post?.content.raw,
+            title: post?.title?.raw ?? initialParams?.title,
+            content: post?.content.raw ?? initialParams?.content,
             status: (post?.status ?? .draft).description,
             blog: blog
         )


### PR DESCRIPTION
## Description

Fixes https://linear.app/a8c/issue/CMM-1975

The "Duplicate" action is implemented as opening a post editor with another post's content and some basic settings (categories and post format, which follows the existing duplicating AbstractPost behaviour). Nothing is saved, neither locally nor remotely.