### PR TITLE
fix: resolve retain cycle in GutenbergCoverUploadProcessor

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergCoverUploadProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergCoverUploadProcessor.swift
@@ -22,9 +22,10 @@ class GutenbergCoverUploadProcessor: Processor {
         self.remoteURLString = remoteURLString
     }
 
-    lazy var coverBlockProcessor = GutenbergBlockProcessor(for: CoverBlockKeys.name, replacer: { coverBlock in
-        guard let mediaID = coverBlock.attributes[CoverBlockKeys.id] as? Int,
-            mediaID == self.mediaUploadID else {
+    lazy var coverBlockProcessor = GutenbergBlockProcessor(for: CoverBlockKeys.name, replacer: { [weak self] coverBlock in
+        guard let self,
+              let mediaID = coverBlock.attributes[CoverBlockKeys.id] as? Int,
+              mediaID == self.mediaUploadID else {
                 return nil
         }
         var block = "<!-- \(CoverBlockKeys.name) "


### PR DESCRIPTION
## Summary

<img width="1438" height="887" alt="Screenshot 2026-03-24 at 4 46 17 PM" src="https://github.com/user-attachments/assets/241ab93e-2ec1-4a17-9f37-081ea27d5c91" />

Report: 

[xctestleaks-artifacts.zip](https://github.com/user-attachments/files/26211626/xctestleaks-artifacts.zip)


Fixes #25441

The `lazy var coverBlockProcessor` in `GutenbergCoverUploadProcessor` created a `GutenbergBlockProcessor` with a `replacer` closure that strongly captured `self`, while `self` strongly held `coverBlockProcessor`, forming a retain cycle that prevented deallocation after every cover block upload.

**Cycle:**
```
GutenbergCoverUploadProcessor
  → lazy var coverBlockProcessor (strong)
    → GutenbergBlockProcessor.replacer closure (strong)
      → self (GutenbergCoverUploadProcessor) ← cycle back
```

**Fix:** add `[weak self]` to the `replacer` closure.

## Verification

Detected and verified using XCTestLeaks a tool I am working to get leaks from unit tests.

| Test | Before | After |
|---|---|---|
| testCoverBlockProcessor | leaks=1 | leaks=0 ✅ |
| testCoverBlockProcessorWithOtherAttributes | leaks=2 | leaks=0 ✅ |
| testDeepNestedCoverBlockProcessor | leaks=3 | leaks=0 ✅ |
| testImageCoverInVideoCoverBlockProcessor | leaks=4 | leaks=0 ✅ |
| testMultipleCoverBlocksProcessor | leaks=5 | leaks=0 ✅ |
| testNestedCoverBlockProcessor | leaks=5 | leaks=0 ✅ |
| testUpdateOuterCoverBlockProcessor | leaks=7 | leaks=0 ✅ |
| testVideoCoverBlockProcessor | leaks=7 | leaks=0 ✅ |
| testVideoCoverInImageCoverBlockProcessor | leaks=7 | leaks=0 ✅ |

## Test plan

- [x] All `GutenbergCoverUploadProcessorTests` pass with `leaks=0`
- [x] No functional behaviour changed — `[weak self]` with `guard let self` maintains the same logic

