### PR TITLE
Update activesupport to fix security vulnerabilities

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.8)
     abbrev (0.1.2)
-    activesupport (7.2.3)
+    activesupport (7.2.3.1)
       base64
       benchmark (>= 0.3)
       bigdecimal
@@ -12,7 +12,7 @@ GEM
       drb
       i18n (>= 1.6, < 2)
       logger (>= 1.4.2)
-      minitest (>= 5.1)
+      minitest (>= 5.1, < 6)
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
     addressable (2.8.9)
@@ -279,9 +279,7 @@ GEM
     mini_magick (4.13.2)
     mini_mime (1.1.5)
     mini_portile2 (2.8.9)
-    minitest (6.0.2)
-      drb (~> 2.0)
-      prism (~> 1.5)
+    minitest (5.27.0)
     multi_json (1.19.1)
     multipart-post (2.4.1)
     mutex_m (0.3.0)


### PR DESCRIPTION
## Summary
- Updates `activesupport` gem to fix three security vulnerabilities published on 2026-03-23
- **GHSA-cg4j-q9v8-6v38**: ReDoS vulnerability in `number_to_delimited` (`NumberToDelimitedConverter` used a regex with `gsub!` causing quadratic time complexity)
- **GHSA-89vf-4333-qx8v**: XSS vulnerability in `SafeBuffer#%`
- **GHSA-2j26-frm8-cmj9**: DoS vulnerability in number helpers

## Test plan
- [ ] Verify CI passes
- [ ] Confirm `activesupport` version in `Gemfile.lock` is patched (>= 8.1.2.1 for 8.1.x, >= 8.0.4.1 for 8.0.x, >= 7.2.3.1 for 7.x)

🤖 Generated with [Claude Code](https://claude.com/claude-code)