### PR TITLE
Test GutenbergKit XCFramework integration

### DIFF
--- a/Modules/Package.resolved
+++ b/Modules/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "5ffd94f84f898d44742c91287b3318dac8ebb97055078775d91834e7c3565cd4",
+  "originHash" : "5b4c3756245cbdaed38a367c1bfaf0a5a6f7e56f0bf6ee2dec541c8f75fdec79",
   "pins" : [
     {
       "identity" : "alamofire",
@@ -131,8 +131,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/wordpress-mobile/GutenbergKit",
       "state" : {
-        "revision" : "652fcc6ed2bcf8785cc00bbcddc484a871e8e9be",
-        "version" : "0.14.0"
+        "branch" : "one-off-xcframework-infra-test",
+        "revision" : "997c4813a3a4fc24d36018a46e1c54a6f4159419"
       }
     },
     {

--- a/Modules/Package.swift
+++ b/Modules/Package.swift
@@ -55,7 +55,7 @@ let package = Package(
         .package(url: "https://github.com/wordpress-mobile/wpxmlrpc", from: "0.9.0"),
         .package(url: "https://github.com/wordpress-mobile/NSURL-IDN", revision: "b34794c9a3f32312e1593d4a3d120572afa0d010"),
         .package(url: "https://github.com/zendesk/support_sdk_ios", from: "8.0.3"),
-        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", from: "0.14.0"),
+        .package(url: "https://github.com/wordpress-mobile/GutenbergKit", branch: "one-off-xcframework-infra-test"),
         // We can't use wordpress-rs branches nor commits here. Only tags work.
         .package(url: "https://github.com/Automattic/wordpress-rs", revision: "alpha-20260313.1"),
         .package(


### PR DESCRIPTION
<!-- blue -->
> [!NOTE]  
> PR closed because the test was successful and I want to keep the PRs list tidy. The Prototype Builds will remain available.


 ## Summary

Verifies changes from https://github.com/wordpress-mobile/gutenbergkit/pull/401 

- Points GutenbergKit at the `one-off-xcframework-infra-test` branch to verify end-to-end XCFramework binary distribution via CDN.
- The XCFramework was built, signed, and published to S3 by [GutenbergKit build 1758](https://buildkite.com/automattic/gutenbergkit/builds/1758).

## Test plan

- [ ] CI builds and tests pass with the binary XCFramework dependency
- [ ] Editor loads correctly at runtime

> **Do not merge** — this is a throwaway verification PR.

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*

🤖 Generated with [Claude Code](https://claude.ai/code)