### PR TITLE
fix: leak fixing retain cycle of GutenbergCoverUploadProcessor

### DIFF
--- a/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergCoverUploadProcessor.swift
+++ b/WordPress/Classes/ViewRelated/Gutenberg/Processors/GutenbergCoverUploadProcessor.swift
@@ -22,9 +22,10 @@ class GutenbergCoverUploadProcessor: Processor {
         self.remoteURLString = remoteURLString
     }
 
-    lazy var coverBlockProcessor = GutenbergBlockProcessor(for: CoverBlockKeys.name, replacer: { coverBlock in
-        guard let mediaID = coverBlock.attributes[CoverBlockKeys.id] as? Int,
-            mediaID == self.mediaUploadID else {
+    lazy var coverBlockProcessor = GutenbergBlockProcessor(for: CoverBlockKeys.name, replacer: { [weak self] coverBlock in
+        guard let self,
+              let mediaID = coverBlock.attributes[CoverBlockKeys.id] as? Int,
+              mediaID == self.mediaUploadID else {
                 return nil
         }
         var block = "<!-- \(CoverBlockKeys.name) "


### PR DESCRIPTION
This PR is to merge https://github.com/wordpress-mobile/WordPress-iOS/pull/25442. I followed the steps to run an external contributor PR build, but nothing worked. Merging it separately. 