### PR TITLE
Reader: Fix colors in post inline comment section

### DIFF
--- a/Modules/Sources/WordPressReader/Comments/Views/CommentContentRenderer.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/CommentContentRenderer.swift
@@ -5,6 +5,8 @@ import UIKit
 public protocol CommentContentRenderer: AnyObject {
     var delegate: CommentContentRendererDelegate? { get set }
 
+    var displaySettings: ReaderDisplaySettings { get set }
+
     /// A view for rendering the comments.
     var view: UIView { get }
 

--- a/Modules/Sources/WordPressReader/Comments/Views/CommentWebView.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/CommentWebView.swift
@@ -6,7 +6,7 @@ final class CommentWebView: UIView, CommentContentRendererDelegate {
     let renderer = WebCommentContentRenderer()
     lazy var heightConstraint = renderer.view.heightAnchor.constraint(equalToConstant: 20)
 
-    init(comment: String) {
+    init(comment: String, displaySettings: ReaderDisplaySettings = .standard) {
         super.init(frame: .zero)
 
         addSubview(renderer.view)
@@ -14,6 +14,7 @@ final class CommentWebView: UIView, CommentContentRendererDelegate {
 
         heightConstraint.isActive = true
 
+        renderer.displaySettings = displaySettings
         renderer.delegate = self
         renderer.render(comment: comment)
     }
@@ -43,6 +44,13 @@ final class CommentWebView: UIView, CommentContentRendererDelegate {
     """)
 }
 
+#Preview("Sepia") {
+    makeView(
+        comment: "<p>Thank you so much! You should <a href=\"https:://wordpress.com/\">see it now</a> &#8211; people are losing their minds!</p>\n",
+        displaySettings: ReaderDisplaySettings(color: .sepia, font: .sans, size: .normal)
+    )
+}
+
 #Preview("Media") {
     makeView(comment: """
     <p>Test image in the middle.</p>\n<figure class=\"wp-block-image size-medium\"><img src=\"https://fastly.picsum.photos/id/31/3264/4912.jpg?hmac=lfmmWE3h_aXmRwDDZ7pZb6p0Foq6u86k_PpaFMnq0r8\" alt=\"\" /></figure>\n<p>Text below.</p>\n
@@ -50,12 +58,13 @@ final class CommentWebView: UIView, CommentContentRendererDelegate {
 }
 
 @MainActor
-private func makeView(comment: String) -> UIView {
-    let webView = CommentWebView(comment: comment)
+private func makeView(comment: String, displaySettings: ReaderDisplaySettings = .standard) -> UIView {
+    let webView = CommentWebView(comment: comment, displaySettings: displaySettings)
     webView.layer.borderColor = UIColor.opaqueSeparator.withAlphaComponent(0.66).cgColor
     webView.layer.borderWidth = 0.5
 
     let container = UIView()
+    container.backgroundColor = displaySettings.color.background
     container.addSubview(webView)
     webView.pinEdges(insets: UIEdgeInsets(.all, 16))
 

--- a/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
+++ b/Modules/Sources/WordPressReader/Comments/Views/WebCommentContentRenderer.swift
@@ -20,7 +20,7 @@ public final class WebCommentContentRenderer: NSObject, CommentContentRenderer {
 
     /// It can't be changed at the moment, but this capability was included from the
     /// start, and this implementation continues supporting it.
-    private var displaySetting = ReaderDisplaySettings.standard
+    public var displaySettings = ReaderDisplaySettings.standard
 
     /// - warning: This has to be configured _before_ you render.
     public var tintColor: UIColor {
@@ -109,7 +109,7 @@ extension WebCommentContentRenderer: WKNavigationDelegate {
                 /// The display setting's custom size is applied through the HTML's initial-scale property
                 /// in the meta tag. The `scrollHeight` value seems to return the height as if it's at 1.0 scale,
                 /// so we'll need to add the custom scale into account.
-                let actualHeight = round(height * self.displaySetting.size.scale)
+                let actualHeight = round(height * self.displaySettings.size.scale)
                 self.delegate?.renderer(self, asyncRenderCompletedWithHeight: actualHeight, comment: comment)
             }
         }
@@ -175,8 +175,8 @@ private extension WebCommentContentRenderer {
     }
 
     private func actuallyMakeHead() -> String {
-        let meta = "width=device-width,initial-scale=\(displaySetting.size.scale),maximum-scale=\(displaySetting.size.scale),user-scalable=no,shrink-to-fit=no"
-        let styles = displaySetting.makeStyles(tintColor: webView.tintColor)
+        let meta = "width=device-width,initial-scale=\(displaySettings.size.scale),maximum-scale=\(displaySettings.size.scale),user-scalable=no,shrink-to-fit=no"
+        let styles = displaySettings.makeStyles(tintColor: webView.tintColor)
         return String(format: Self.headTemplate, meta, styles)
     }
 

--- a/Modules/Sources/WordPressReader/Settings/ReaderDisplaySettings+WebKit.swift
+++ b/Modules/Sources/WordPressReader/Settings/ReaderDisplaySettings+WebKit.swift
@@ -26,7 +26,7 @@ extension ReaderDisplaySettings {
         :root {
             --text-font: \(font.cssString);
             --link-font-weight: \(color == .system ? "inherit" : "600");
-            --link-text-decoration: \(color == .system ? "inherit" : "underline");
+            --link-text-decoration: underline;
         }
 
         @media(prefers-color-scheme: light) {
@@ -44,6 +44,7 @@ extension ReaderDisplaySettings {
     /// - parameter interfaceStyle: The current `UIUserInterfaceStyle` value.
     private func makeColors(interfaceStyle: UIUserInterfaceStyle, tintColor: UIColor) -> String {
         let trait = UITraitCollection(userInterfaceStyle: interfaceStyle)
+        let tintColor = color == .system ? tintColor : color.foreground
         return """
         :root {
             --text-color: \(color.foreground.color(for: trait).cssHex);

--- a/Modules/Sources/WordPressReader/Settings/ReaderDisplaySettings.swift
+++ b/Modules/Sources/WordPressReader/Settings/ReaderDisplaySettings.swift
@@ -166,9 +166,9 @@ public struct ReaderDisplaySettings: Codable, Equatable, Hashable, Sendable {
             case .system:
                 return .tertiaryLabel
             case .evening, .oled, .hacker:
-                return foreground.withAlphaComponent(0.8) // slightly higher contrast for dark themes.
+                return foreground.withAlphaComponent(0.45) // slightly higher contrast for dark themes.
             default:
-                return foreground.withAlphaComponent(0.6)
+                return foreground.withAlphaComponent(0.33)
             }
         }
 

--- a/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Views/Detail/CommentContentTableViewCell.swift
@@ -113,7 +113,7 @@ final class CommentContentTableViewCell: UITableViewCell, NibReusable {
     /// can be scoped by using the "legacy" style when the passed parameter is nil.
     private var style: CellStyle = .init(displaySetting: nil)
 
-    var displaySetting: ReaderDisplaySettings? = nil {
+    var displaySetting: ReaderDisplaySettings = .standard {
         didSet {
             style = CellStyle(displaySetting: displaySetting)
             applyStyles()
@@ -377,20 +377,17 @@ private extension CommentContentTableViewCell {
         dateLabel?.font = style.dateFont
         dateLabel?.textColor = style.dateTextColor
 
-        accessoryButton?.tintColor = .secondaryLabel
         accessoryButton?.setImage(accessoryButtonImage, for: .normal)
         accessoryButton?.addTarget(self, action: #selector(accessoryButtonTapped), for: .touchUpInside)
 
         replyButton.configuration = makeReactionButtonConfiguration(image: UIImage(named: "icon-reader-comment-reply"))
         replyButton.configuration?.contentInsets.leading = 0
-        replyButton.tintColor = .secondaryLabel
         replyButton.setTitle(.reply, for: .normal)
         replyButton.addTarget(self, action: #selector(replyButtonTapped), for: .touchUpInside)
         replyButton.maximumContentSizeCategory = .accessibilityMedium
         replyButton.accessibilityIdentifier = .replyButtonAccessibilityId
 
         likeButton.configuration = makeReactionButtonConfiguration(image: WPStyleGuide.ReaderDetail.likeToolbarIcon)
-        likeButton.tintColor = .secondaryLabel
 
         likeButton.addTarget(self, action: #selector(likeButtonTapped), for: .touchUpInside)
         likeButton.maximumContentSizeCategory = .accessibilityMedium
@@ -422,6 +419,11 @@ private extension CommentContentTableViewCell {
 
         dateLabel?.font = style.dateFont
         dateLabel?.textColor = style.dateTextColor
+
+        replyButton?.tintColor = displaySetting.color.secondaryForeground
+        likeButton?.tintColor = displaySetting.color.secondaryForeground
+
+        accessoryButton?.tintColor = displaySetting.color.secondaryForeground
     }
 
     private func getShowMoreOverlay() -> UIView {
@@ -461,7 +463,7 @@ private extension CommentContentTableViewCell {
     }
 
     func updateLikeButton(isLiked: Bool, likeCount: Int) {
-        likeButton.tintColor = isLiked ? UIAppColor.primary : .secondaryLabel
+        likeButton.tintColor = isLiked ? UIAppColor.primary : displaySetting.color.secondaryForeground
         if var configuration = likeButton.configuration {
             configuration.image = isLiked ? WPStyleGuide.ReaderDetail.likeSelectedToolbarIcon : WPStyleGuide.ReaderDetail.likeToolbarIcon
             configuration.title = likeCount > 0 ? "\(likeCount)" : String.noLikes
@@ -488,6 +490,8 @@ private extension CommentContentTableViewCell {
             self.renderer = renderer
             return renderer
         }()
+
+        renderer.displaySettings = displaySetting
 
         configureContentView(contentHeight: helper.getCachedContentHeight(for: content))
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/Views/ReaderDetailCommentsTableViewDelegate.swift
@@ -167,6 +167,7 @@ private extension ReaderDetailCommentsTableViewDelegate {
         }
 
         cell.displaySetting = displaySetting
+
         cell.configureForPostDetails(with: comment, helper: helper) { _ in
             do {
                 try WPException.objcTry {
@@ -215,12 +216,13 @@ private extension ReaderDetailCommentsTableViewDelegate {
         configuration.title = Constants.viewAllButtonTitle.localizedCapitalized + "   \(totalComments)"
         configuration.image = UIImage(systemName: "chevron.right")
         configuration.imagePlacement = .trailing
-        configuration.titleTextAttributesTransformer = .init {
+        configuration.titleTextAttributesTransformer = .init { [displaySetting] in
             var container = $0
+            container.foregroundColor = displaySetting.color.foreground
             container.font = UIFont.preferredFont(forTextStyle: .headline).withWeight(.medium)
             return container
         }
-        configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(paletteColors: [.tertiaryLabel])
+        configuration.preferredSymbolConfigurationForImage = UIImage.SymbolConfiguration(paletteColors: [displaySetting.color.tertiatyForeground])
             .applying(UIImage.SymbolConfiguration(font: UIFont.preferredFont(forTextStyle: .caption2).withWeight(.bold)))
         configuration.imagePadding = 4
         configuration.contentInsets = .init(top: 9, leading: 12, bottom: 9, trailing: 12)

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -234,13 +234,6 @@ class ReaderWebView: WKWebView {
                 font-weight: \(displaySetting.color == .system ? "inherit" : "600");
                 text-decoration: underline;
             }
-
-            /* workaround for CMM-1964 */
-            .reader-full-post.reader-full-post__story-content {
-                a {
-                    color: var(--main-link-color);
-                }
-            }
         """
     }
 

--- a/WordPress/Misc/Reader/reader.css
+++ b/WordPress/Misc/Reader/reader.css
@@ -76,6 +76,24 @@ figure.wp-block-embed.is-type-video {
     max-width: 99vw;
 }
 
+/* workaround for CMM-1964 */
+@media (prefers-color-scheme: dark) {
+  .reader-full-post.reader-full-post__story-content a {
+      color: var(--main-link-color);
+  }
+}
+
+.reader-full-post__story-content .wp-block-button {
+  a {
+    color: var(--color-text);
+    font-weight: 500;
+    font-size: 1rem;
+    text-decoration: none;
+  }
+
+  border-radius: 8px;
+}
+
 /* Temporary override for Reader Customization */
 .reader-full-post__story-content blockquote {
     color: var(--color-text);


### PR DESCRIPTION
Fixes [CMM-1987: Reader: Incorrect inline comments colors on dark mode with non-dynamic theme](https://linear.app/a8c/issue/CMM-1987/reader-incorrect-inline-comments-colors-on-dark-mode-with-non-dynamic)

I identified and fixed a couple of more issues when testing Reader Preferences. 

**Changes**

- Update inline comments to respect `ReaderDisplaySettings`
- Fix some previous workarounds (needed more specific qualifiers)
- Update links in comments to show underlines so it matches the article

**Known issue**: comment style doesn't refresh when you change a theme (minor)

<img width="340"  alt="Screenshot 2026-03-26 at 11 05 27 AM" src="https://github.com/user-attachments/assets/7a6a7882-abd9-47e3-b0c4-2d28d6ac42e7" /> <img width="340" alt="Screenshot 2026-03-26 at 12 16 52 PM" src="https://github.com/user-attachments/assets/2a0d8da8-124c-4134-bba2-8b77267f21b2" />
