### PR TITLE
Stats: Fix font in Insights / Most Popular Time

### DIFF
--- a/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Extensions/WPStyleGuide+Stats.swift
@@ -219,7 +219,7 @@ extension WPStyleGuide {
 
         static let subTitleFont = WPStyleGuide.fontForTextStyle(.footnote, fontWeight: .medium)
         static let summaryFont = WPStyleGuide.fontForTextStyle(.subheadline, fontWeight: .regular)
-        static let insightsCountFont = UIFont.preferredFont(forTextStyle: .title1).bold()
+        static let insightsCountFont = UIFont.preferredFont(forTextStyle: .title2).bold()
 
         static let tableBackgroundColor = UIColor.systemGroupedBackground
         static let cellBackgroundColor = UIColor.secondarySystemGroupedBackground


### PR DESCRIPTION
Reduce the font a notch as `.title1` just would't fit in many cases. Originally reported buy Rob on P2.

<img width="456" height="972" alt="Screenshot 2026-03-26 at 1 04 06 PM" src="https://github.com/user-attachments/assets/ec6341c6-688e-41ea-a6dd-2de267f09dc8" />


