### PR TITLE
Add experimental feature tracking

### DIFF
--- a/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
+++ b/WordPress/Classes/Utility/Analytics/WPAnalyticsEvent.swift
@@ -348,6 +348,7 @@ import WordPressShared
     case appSettingsClearSpotlightIndexTapped
     case appSettingsClearSiriSuggestionsTapped
     case appSettingsOpenDeviceSettingsTapped
+    case experimentalFeatureToggled
 
     // Notifications
     case notificationsPreviousTapped
@@ -1313,6 +1314,8 @@ import WordPressShared
             return "app_settings_max_image_size_changed"
         case .appSettingsImageQualityChanged:
             return "app_settings_image_quality_changed"
+        case .experimentalFeatureToggled:
+            return "experimental_feature_toggled"
 
         // Account Close
         case .accountCloseTapped:

--- a/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/ExperimentalFeaturesDataProvider.swift
@@ -36,6 +36,11 @@ class ExperimentalFeaturesDataProvider: ExperimentalFeaturesViewModel.DataProvid
     func didChangeValue(for feature: WordPressUI.Feature, to newValue: Bool) {
         flagStore.override(flag(for: feature), withValue: newValue)
 
+        WPAnalytics.track(.experimentalFeatureToggled, properties: [
+            "feature": feature.name,
+            "enabled": newValue
+        ])
+
         if feature.key == RemoteFeatureFlag.newGutenberg.key && !newValue {
             let alert = UIAlertController(title: Strings.editorFeedbackTitle, message: Strings.editorFeedbackMessage, preferredStyle: .alert)
             alert.addAction(UIAlertAction(title: Strings.editorFeedbackDecline, style: .cancel, handler: nil))


### PR DESCRIPTION
Copy of https://github.com/wordpress-mobile/WordPress-Android/pull/22720.

Example:

```
🔵 Tracked: experimental_feature_toggled <enabled: true, feature: Experimental Block Editor>
```