### PR TITLE
Reader: Fix an issue with anchors not working

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,7 @@
 -----
 * [*] All self-hosted sites now sign in using application passwords [#25424]
 * [*] Reader: Fix button style [#25447]
+* [*] Reader: Fix a regression with anchors not working in posts [#25459]
 
 
 26.8

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailCoordinator.swift
@@ -502,11 +502,12 @@ class ReaderDetailCoordinator {
     ///
     /// - Parameter url: the URL to be handled
     func handle(_ url: URL) {
-        // If the URL has an anchor (#)
-        // and the URL is equal to the current post URL
-        if let hash = URLComponents(url: url, resolvingAgainstBaseURL: true)?.fragment,
-           let postURL = permaLinkURL,
-           postURL.isHostAndPathEqual(to: url) {
+        // If the URL has an anchor (#) and the URL matches either the current
+        // post URL or the webview's baseURL, scroll within the document.
+        // In-document anchors (e.g. footnotes) resolve against the baseURL,
+        // so we need to check both.
+        let isInDocumentAnchor = permaLinkURL?.isHostAndPathEqual(to: url) == true || ReaderWebView.baseURL.isHostAndPathEqual(to: url)
+        if let hash = URLComponents(url: url, resolvingAgainstBaseURL: true)?.fragment, isInDocumentAnchor {
             view?.scroll(to: hash)
         } else if let (gallery, index) = findGallery(containing: url) {
             presentGallery(gallery, startingAt: index)

--- a/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/ReaderDetailViewController.swift
@@ -459,7 +459,8 @@ class ReaderDetailViewController: UIViewController, ReaderDetailView {
                 return
             }
 
-            self.scrollView.setContentOffset(CGPoint(x: 0, y: height + self.webView.frame.origin.y), animated: true)
+            let y = height + self.webView.frame.origin.y - self.scrollView.adjustedContentInset.top
+            self.scrollView.setContentOffset(CGPoint(x: 0, y: y), animated: true)
         })
     }
 

--- a/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Detail/WebView/ReaderWebView.swift
@@ -21,7 +21,7 @@ class ReaderWebView: WKWebView {
     ///
     /// Documentation: https://developers.google.com/youtube/terms/required-minimum-functionality#set-the-referer
     /// See also: https://stackoverflow.com/q/79802987/496295
-    private let baseURL = URL(string: "https://wordpress.com/reader")!
+    static let baseURL = URL(string: "https://wordpress.com/reader")!
 
     let jsToRemoveSrcSet = "document.querySelectorAll('img, img-placeholder').forEach((el) => {el.removeAttribute('srcset')})"
 
@@ -53,7 +53,7 @@ class ReaderWebView: WKWebView {
 
         let content = formattedContent(addPlaceholder(string), additionalJavaScript: additionalJavaScript)
 
-        super.loadHTMLString(content, baseURL: baseURL)
+        super.loadHTMLString(content, baseURL: Self.baseURL)
     }
 
     /// Given a HTML content, returns it formatted.
@@ -79,31 +79,6 @@ class ReaderWebView: WKWebView {
                 \(additionalJavaScript)
                 // Remove autoplay to avoid media autoplaying
                 document.querySelectorAll('video-placeholder, audio-placeholder').forEach((el) => {el.removeAttribute('autoplay')})
-
-                // Replaces the bundle URL with the post URL for each "blank" anchor tag (<a href="#anchor"></a>).
-                // this fixes an issue where tapping on one would return a file url with the anchor attached to it
-                let baseURL = "\(Bundle.wordPressSharedBundle.bundleURL)"
-                let postURL = "\(postURL?.absoluteString ?? "")"
-
-                if(postURL.length > 0){
-                    let anchors = document.querySelectorAll('a')
-
-                    anchors.forEach(function(elem){
-                      // Ignore any regular links that don't have hashes
-                      if(!elem.hash || elem.hash.length < 0) {
-                        return
-                      }
-
-                      let href = elem.href;
-
-                      // Skip any links that aren't the base URL
-                      if(href.substr(0, baseURL.length) != baseURL){
-                        return
-                      }
-
-                      elem.href = postURL + elem.hash;
-                    });
-                }
             })
             function debounce(fn, timeout) {
                 let timer;


### PR DESCRIPTION
Fixes [CMM-1993: iOS: Footnote links in Reader mode redirect to Reader list instead of target location in post](https://linear.app/a8c/issue/CMM-1993/ios-footnote-links-in-reader-mode-redirect-to-reader-list-instead-of) and fixes an issue with `scroll(to:)` ignoring safe area insets, so that the content would end up under it.

https://github.com/user-attachments/assets/e00844a6-0f12-4951-8a4a-83f19941d8d3

## [Generated] Details and RCA

**Defect Summary**

Tapping in-document anchor links (e.g. footnotes) in a Reader post navigates the user to the Discover tab instead of scrolling within the article.

**Steps to Reproduce**

  1. Open any Reader post that contains footnote or anchor links (e.g. <a href="#fn-1">1</a>)
  2. Tap on a footnote superscript link
  3. Expected: The article scrolls to the footnote at the bottom of the post
  4. Actual: The app navigates away to the Reader Discover tab

**Root Cause**

The issue is caused by a mismatch between the web view's baseURL and the anchor link detection logic in `ReaderDetailCoordinator.handle(_:).`

**Step 1** — baseURL was changed for YouTube embeds.
  In a prior change, ReaderWebView.baseURL was set to https://wordpress.com/reader to satisfy Google/YouTube's HTTP referrer requirement. Previously it used the local bundle URL.

  **Step 2** — Anchor links resolve against baseURL.
  When the user taps <a href="#fn-1">, WKWebView resolves this relative URL against the baseURL, producing: https://wordpress.com/reader#fn-1

  **Step 3** — The coordinator fails to recognize it as an in-document anchor.
  ReaderDetailCoordinator.handle(_:) checked whether the tapped URL's host+path matched the post's permaLinkURL (e.g. https://example.com/my-post/). Since wordpress.com/reader !=
   example.com/my-post/, the check failed.

  **Step 4** — The URL falls through to the universal link router.
  The readerLinkRouter recognizes wordpress.com/reader as a valid Reader route and navigates the user to the Discover tab.

  Tap "#fn-1"
    → WKWebView resolves to https://wordpress.com/reader#fn-1
      → handle(_:) checks: does wordpress.com/reader == example.com/my-post? NO
        → Falls through to readerLinkRouter
          → Router matches wordpress.com/reader → navigates to Discover

  **Fix**

  Added ReaderWebView.baseURL as a second comparison in the anchor detection logic so that fragment-only links resolved against the web view's base URL are correctly identified as in-document anchors and handled with a scroll instead of navigation.

  **Secondary Note**

The JavaScript anchor fixup code in ReaderWebView.formattedContent(_:) (lines 83–106) is now dead code. It was written to rewrite anchors that started with the bundle URL, but since the baseURL is no longer the bundle URL, it never matches. It is harmless but could be cleaned up in a follow-up.