### PR TITLE
Fix: Separator not visible in Dark Mode for comments (#24430)

### DIFF
--- a/WordPress/Classes/ViewRelated/Comments/Controllers/Create/CommentCreateViewController.swift
+++ b/WordPress/Classes/ViewRelated/Comments/Controllers/Create/CommentCreateViewController.swift
@@ -36,7 +36,11 @@ final class CommentCreateViewController: UIViewController {
             let preview = CommentComposerReplyCommentView(comment: comment)
             contentView.addArrangedSubview(preview)
 
-            let separator = SeparatorView.horizontal()
+            let separator = SeparatorView.horizontal(height: 0.5)
+            separator.backgroundColor = UIColor(
+                light: .separator,
+                dark: UIColor(white: 1.0, alpha: 0.38)
+            )
             contentView.addArrangedSubview(separator)
         }
 


### PR DESCRIPTION
## Summary
Fixes the issue where the separator between a comment and reply is not visible in Dark Mode.

## Changes
- Added explicit separator height to improve visibility
- Applied Dark Mode-specific color using appropriate alpha

## Testing
- Verified in Light Mode → no visual regression
- Verified in Dark Mode → separator now clearly visible

## Issue
Closes #24430

Before

<img width="443" height="430" alt="Screenshot 2026-03-29 at 1 19 30 PM" src="https://github.com/user-attachments/assets/e449f5c1-e74a-43dc-abf5-98530a3f7198" />

After

<img width="443" height="275" alt="Screenshot 2026-03-29 at 1 23 24 PM" src="https://github.com/user-attachments/assets/78cee168-2fb5-4dc9-9df0-aeb431509c78" />
