### PR TITLE
Enable SwiftLint rule: empty_string

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -36,7 +36,7 @@ only_rules:
   # Prefer `() -> ` over `Void -> `.
   - empty_parameters
 
-  # Prefer checking `isEmpty` over comparing `string` to an empty string literal.
+  # Prefer checking `isEmpty` over comparing to empty string literal `""`.
   - empty_string
 
   # MARK comment should be in valid format.

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -36,6 +36,9 @@ only_rules:
   # Prefer `() -> ` over `Void -> `.
   - empty_parameters
 
+  # Prefer checking `isEmpty` over comparing `string` to an empty string literal.
+  - empty_string
+
   # MARK comment should be in valid format.
   - mark
 

--- a/Modules/Sources/WordPressKitModels/ObjectValidation.swift
+++ b/Modules/Sources/WordPressKitModels/ObjectValidation.swift
@@ -16,6 +16,6 @@ import Foundation
     ///
     /// - Returns: Bool value
     func wp_isValidString() -> Bool {
-        return wp_isValidObject() && self != ""
+        return wp_isValidObject() && length > 0
     }
 }

--- a/Sources/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
+++ b/Sources/WordPressAuthenticator/Extensions/WPStyleGuide+Login.swift
@@ -273,7 +273,7 @@ extension WPStyleGuide {
 
         let labelString = NSMutableAttributedString(string: firstPart, attributes: [.foregroundColor: WPStyleGuide.greyDarken30()])
 
-        if lastPart != "" {
+        if !lastPart.isEmpty {
             labelString.append(formattedGoogleString(forHyperlink: true))
         }
 

--- a/Tests/KeystoneTests/Helpers/JSONObject.swift
+++ b/Tests/KeystoneTests/Helpers/JSONObject.swift
@@ -10,7 +10,7 @@ extension JSONObject {
     /// - Parameter fileName: The name of the json file to load. The "json" file extension can be omitted.
     init(fromFileNamed fileName: String) throws {
         let type = (fileName as NSString).pathExtension
-        if type != "" && type != "json" {
+        if !type.isEmpty && type != "json" {
             throw NSError(
                 domain: "JSONObject",
                 code: 1,

--- a/Tests/KeystoneTests/Tests/Utility/RemoteFeatureFlagTests.swift
+++ b/Tests/KeystoneTests/Tests/Utility/RemoteFeatureFlagTests.swift
@@ -18,7 +18,7 @@ class RemoteFeatureFlagTests: XCTestCase {
         exp.expectedFulfillmentCount = 2
 
         mock.deviceIdCallback = {
-            deviceId == "" ? deviceId = $0 : XCTAssertEqual(deviceId, $0)
+            deviceId.isEmpty ? deviceId = $0 : XCTAssertEqual(deviceId, $0)
             exp.fulfill()
         }
 

--- a/Tests/WordPressDataTests/BlogTests.swift
+++ b/Tests/WordPressDataTests/BlogTests.swift
@@ -202,7 +202,7 @@ struct BlogTests {
             .build()
 
         #expect((blog.version as Any) is String)
-        #expect(blog.version == "")
+        #expect(blog.version?.isEmpty == true)
     }
 
     @Test func removeDuplicates() async throws {

--- a/Tests/WordPressDataTests/BlogTests.swift
+++ b/Tests/WordPressDataTests/BlogTests.swift
@@ -202,7 +202,7 @@ struct BlogTests {
             .build()
 
         #expect((blog.version as Any) is String)
-        #expect(blog.version?.isEmpty == true)
+        #expect(blog.version.isEmpty)
     }
 
     @Test func removeDuplicates() async throws {

--- a/Tests/WordPressDataTests/PostMetadataTests.swift
+++ b/Tests/WordPressDataTests/PostMetadataTests.swift
@@ -79,7 +79,7 @@ struct PostMetadataTests {
         metadata.encode(in: &container)
 
         // THEN
-        #expect(container.getString(for: .jetpackNewsletterEmailDisabled) == "")
+        #expect(container.getString(for: .jetpackNewsletterEmailDisabled)?.isEmpty == true)
     }
 }
 

--- a/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
+++ b/WordPress/Classes/ViewRelated/Aztec/ViewControllers/AztecAttachmentViewController.swift
@@ -222,7 +222,7 @@ class AztecAttachmentViewController: UITableViewController {
     }
 
     @objc func handleDoneButtonTapped(sender: UIBarButtonItem) {
-        let checkedAlt = alt == "" ? nil : alt
+        let checkedAlt = alt?.isEmpty == true ? nil : alt
         onUpdate?(alignment, size, linkURL, checkedAlt, caption)
         dismiss(animated: true)
     }

--- a/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
+++ b/WordPress/Classes/ViewRelated/CustomPostTypes/CustomPostListViewModel.swift
@@ -406,7 +406,7 @@ final class CustomPostListViewModel: ObservableObject {
     func menuNavigation(forBlaze post: AnyPostWithEditContext) -> PostMenuNavigation? {
         guard endpoint == .posts
                 && BlazeHelper.isBlazeFlagEnabled() && blog.canBlaze
-                && post.status == .publish && (post.password ?? "") == "" else { return nil }
+                && post.status == .publish && (post.password ?? "").isEmpty else { return nil }
         return .blaze(post: post)
     }
 

--- a/WordPress/Classes/ViewRelated/NUX/Controllers/Social Signup/SignupEpilogueViewController.swift
+++ b/WordPress/Classes/ViewRelated/NUX/Controllers/Social Signup/SignupEpilogueViewController.swift
@@ -194,7 +194,7 @@ private extension SignupEpilogueViewController {
     }
 
     func changeUsername(to newUsername: String, finished: @escaping (() -> Void)) {
-        guard newUsername != "" else {
+        guard !newUsername.isEmpty else {
             finished()
             return
         }

--- a/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Shared Views/StatsCellHeader.swift
@@ -68,7 +68,7 @@ private extension StatsCellHeader {
 
     func updateStackView() {
         // Only show the top padding if there is actually a label.
-        stackViewTopConstraint.constant = headerLabel.text == "" ? 0 : defaultStackViewTopConstraint
+        stackViewTopConstraint.constant = (headerLabel.text ?? "").isEmpty ? 0 : defaultStackViewTopConstraint
 
         // Adjust the height if displaying on Post Stats with no title.
         stackViewHeightConstraint.constant = adjustHeightForPostStats ? emptyPostStatsHeight : defaultStackViewHeightConstraint

--- a/WordPress/WordPressShareExtension/Sources/UI/ShareTagsPickerViewController.swift
+++ b/WordPress/WordPressShareExtension/Sources/UI/ShareTagsPickerViewController.swift
@@ -264,7 +264,7 @@ extension ShareTagsPickerViewController: UITextViewDelegate {
             // Don't allow a second comma if the last tag is blank
             return false
         } else if
-            range.length == 1 && text == "", // Deleting last character
+            range.length == 1 && text.isEmpty, // Deleting last character
             range.location > 0, // Not at the beginning
             range.location + range.length == original.length, // At the end
             original.substring(with: NSRange(location: range.location - 1, length: 1)) == "," { // Previous is a comma


### PR DESCRIPTION
## Summary

The `empty_string` rule prefers checking `.isEmpty` over comparing a string to an empty string literal (`""`).

- 0 auto-fixed violations (rule has no autocorrect)
- 11 manually fixed violations across 11 files
- `NSString.wp_isValidString()` uses `length > 0` instead of `!isEmpty` because `isEmpty` is not directly callable on `NSString` in this Swift 6 module context
- 0 violations remaining

This is part of the [Orchard SwiftLint rollout campaign](https://github.com/nickvth/orchard).

*Posted by Claude (Opus 4.6) on behalf of @mokagio with approval.*