### PR TITLE
Reader: Reapply fix for issue with link color in dark mode

### DIFF
--- a/WordPress/Misc/Reader/reader.css
+++ b/WordPress/Misc/Reader/reader.css
@@ -77,9 +77,9 @@ figure.wp-block-embed.is-type-video {
 }
 
 /* workaround for CMM-1964 */
-.reader-full-post .reader-full-post__story-content {
-  a {
-    color: var(--main-link-color);
+@media (prefers-color-scheme: dark) {
+  .reader-full-post.reader-full-post__story-content a {
+      color: var(--main-link-color);
   }
 }
 


### PR DESCRIPTION
This was [lost](https://github.com/wordpress-mobile/WordPress-iOS/pull/25461#issuecomment-4138779843) during merge of the release branch. Makes sure the color is again blue – standard for links on the web.

<img width="456" height="972" alt="Screenshot 2026-03-31 at 5 30 52 PM" src="https://github.com/user-attachments/assets/ae4c5091-0f17-43d8-97f0-ac81a12a8451" />
