### PR TITLE
Fix UITestsFoundation build

### DIFF
--- a/Modules/Sources/UITestsFoundation/Screens/CommentsScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/CommentsScreen.swift
@@ -68,7 +68,8 @@ public class CommentsScreen: ScreenObject {
     public func verifyCommentsListEmpty() -> CommentsScreen {
         XCTAssertTrue(emptyImage.waitForExistence(timeout: 3))
         XCTAssertTrue(app.staticTexts["Be the first to leave a comment."].isHittable)
-        XCTAssertTrue(app.cells.containing(.button, identifier: "reply-comment-button").isEmpty)
+        // swiftlint:disable:next empty_count
+        XCTAssertTrue(app.cells.containing(.button, identifier: "reply-comment-button").count == 0)
         return self
     }
 


### PR DESCRIPTION
Fixes the following issues introduced in https://github.com/wordpress-mobile/WordPress-iOS/pull/25434:

<img width="723" height="184" alt="Screenshot 2026-04-01 at 10 33 01 AM" src="https://github.com/user-attachments/assets/089d07cc-df8f-4b98-9879-6324e956dac0" />

It looks like it's not captured by the existing test plans, but when you try and run auto-generated `Modules-Package` from Xcode, it attempts to compile the `UITestsFoundation` module.