### PR TITLE
Stats: Add a confirmation dialog when marking referrers as spam

### DIFF
--- a/Modules/Sources/JetpackStats/Screens/ReferrerStatsView.swift
+++ b/Modules/Sources/JetpackStats/Screens/ReferrerStatsView.swift
@@ -15,6 +15,7 @@ struct ReferrerStatsView: View {
     @State private var showErrorAlert = false
     @State private var errorMessage = ""
     @State private var isMarkedAsSpam = false
+    @State private var showConfirmationDialog = false
 
     var body: some View {
         ScrollView {
@@ -56,6 +57,19 @@ struct ReferrerStatsView: View {
             referrerInfoRow
             Divider()
             markAsSpamButton
+                .confirmationDialog(
+                    Strings.ReferrerDetails.markAsSpam,
+                    isPresented: $showConfirmationDialog
+                ) {
+                    Button(Strings.ReferrerDetails.markAsSpam, role: .destructive) {
+                        Task {
+                            await markAsSpam()
+                        }
+                    }
+                    Button(Strings.Buttons.cancel, role: .cancel) { }
+                } message: {
+                    Text(Strings.ReferrerDetails.confirmAsSpamMessage(domain: referrer.domain ?? ""))
+                }
         }
         .padding(Constants.step2)
         .cardStyle()
@@ -128,11 +142,9 @@ struct ReferrerStatsView: View {
                 .frame(maxWidth: .infinity)
         } else {
             Button(role: .destructive) {
-                Task {
-                    await markAsSpam()
-                }
+                showConfirmationDialog = true
             } label: {
-                Label(Strings.ReferrerDetails.markAsSpam, systemImage: "exclamationmark.triangle")
+                Label(Strings.ReferrerDetails.markAsSpam, systemImage: "nosign")
                     .foregroundColor(.red)
                     .frame(maxWidth: .infinity)
             }

--- a/Modules/Sources/JetpackStats/Strings.swift
+++ b/Modules/Sources/JetpackStats/Strings.swift
@@ -247,6 +247,14 @@ enum Strings {
         static let referralSources = AppLocalizedString("jetpackStats.referrerDetails.referralSources", value: "Referral Sources", comment: "Section title for the list of referral sources")
         static let markAsSpamError = AppLocalizedString("jetpackStats.referrerDetails.markAsSpamError", value: "Failed to mark as spam", comment: "Error message when marking a referrer as spam fails")
         static let errorAlertTitle = AppLocalizedString("jetpackStats.referrerDetails.errorAlertTitle", value: "Error", comment: "Title for error alert when marking referrer as spam fails")
+        static func confirmAsSpamMessage(domain: String) -> String {
+            let message = AppLocalizedString(
+                "jetpackStats.referrerDetails.confirmAsSpam.message",
+                value: "Marking \"%1$@\" as spam will hide it from your future stats. You can undo this anytime using the web interface.",
+                comment: "Confirmation message when marking a referrer as spam. %1$@ is the domain name."
+            )
+            return String.localizedStringWithFormat(message, domain)
+        }
     }
 
     enum ExternalLinkDetails {

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -1,6 +1,7 @@
 26.9
 -----
 * [*] All self-hosted sites now sign in using application passwords [#25424]
+* [*] Stats: Add a confirmation dialog when marking referrers as spam [#25475]
 * [*] Reader: Fix button style [#25447]
 * [*] Reader: Fix a regression with anchors not working in posts [#25459]
 


### PR DESCRIPTION
Fixes [CMM-2011: Stats: Improve "Mark as Spam" workflow](https://linear.app/a8c/issue/CMM-2011/stats-improve-mark-as-spam-workflow). You can no longer accidentally mark something as spam.

**Note**: I considered also adding a way to manage referrers marked as spam, but it doesn't seem worth doing as it seems like an extremely rare use-case. You [will be able](https://github.com/Automattic/wp-calypso/pull/109208) to do that on the web if you really need to.

<img width="360" alt="Screenshot 2026-04-02 at 11 48 41 AM" src="https://github.com/user-attachments/assets/12c4bb97-2ad2-4276-be2c-f622eb283f99" />
