### PR TITLE
Update Claude build analysis prompt and model to Sonnet 4.6

### DIFF
--- a/.buildkite/claude-analysis.yml
+++ b/.buildkite/claude-analysis.yml
@@ -27,7 +27,8 @@ steps:
           custom_prompt: >
             Ignore these jobs — they are not real failures:
             (1) The "Claude Build Analysis" job itself (uses `exit 1` to trigger this hook).
-            (2) Jobs in "broken" state due to unmet branch conditions — expected skips, not failures.
+            (2) The "Danger - PR Check" job (external linter, not indicative of build health).
+            (3) Jobs in "broken" state due to unmet branch conditions — expected skips, not failures.
 
             Focus on real failures and recovery. Keep the analysis succinct. Do not mention successful jobs.
             Only add a `Root Cause` section when you are confident about the cause.

--- a/.buildkite/claude-analysis.yml
+++ b/.buildkite/claude-analysis.yml
@@ -25,14 +25,12 @@ steps:
           trigger: "on-failure"
           max_log_lines: 1500
           custom_prompt: >
-            Ignore these jobs entirely — they are not real failures:
-            (1) The "Claude Build Analysis" job itself (it uses `exit 1` intentionally to trigger this analysis hook).
-            (2) The "Danger - PR Check" job (external linter, not indicative of build health).
-            (3) Jobs in "broken" state due to unmet `if:` branch conditions — these are expected skips, not failures.
+            Ignore these jobs — they are not real failures:
+            (1) The "Claude Build Analysis" job itself (uses `exit 1` to trigger this hook).
+            (2) Jobs in "broken" state due to unmet branch conditions — expected skips, not failures.
 
-            If, after excluding the above, there are no real failures, respond with a single short sentence confirming the build is healthy. Do not produce a full analysis.
-
-            When there are real failures: focus on failures and recovery to keep the analysis succinct. Do not mention successful jobs. Only add a `Best Practices` section if the PR changes are directly relevant. Only add a `Root Cause` section when you are confident about the cause.
+            Focus on real failures and recovery. Keep the analysis succinct. Do not mention successful jobs.
+            Only add a `Root Cause` section when you are confident about the cause.
           model: "claude-sonnet-4-6"
 
   - label: ":claude: 💬 Comment Claude Analysis"

--- a/.buildkite/claude-analysis.yml
+++ b/.buildkite/claude-analysis.yml
@@ -24,8 +24,16 @@ steps:
           build_log_mode: "failed"
           trigger: "on-failure"
           max_log_lines: 1500
-          custom_prompt: "Do not mention successful points, focus on failures and recovery to keep the analysis succinct. Only add the `Best Practices` section if the changes in this PR are directly relevant to it. Only add a `Root Cause` section when you're sure about the issues' causes."
-          model: "claude-sonnet-4-5"
+          custom_prompt: >
+            Ignore these jobs entirely — they are not real failures:
+            (1) The "Claude Build Analysis" job itself (it uses `exit 1` intentionally to trigger this analysis hook).
+            (2) The "Danger - PR Check" job (external linter, not indicative of build health).
+            (3) Jobs in "broken" state due to unmet `if:` branch conditions — these are expected skips, not failures.
+
+            If, after excluding the above, there are no real failures, respond with a single short sentence confirming the build is healthy. Do not produce a full analysis.
+
+            When there are real failures: focus on failures and recovery to keep the analysis succinct. Do not mention successful jobs. Only add a `Best Practices` section if the PR changes are directly relevant. Only add a `Root Cause` section when you are confident about the cause.
+          model: "claude-sonnet-4-6"
 
   - label: ":claude: 💬 Comment Claude Analysis"
     command: .buildkite/commands/comment-claude-analysis.sh

--- a/.buildkite/commands/upload-claude-analysis.sh
+++ b/.buildkite/commands/upload-claude-analysis.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -eu
+
+# Uploads the Claude analysis pipeline only when real build/test failures exist.
+# Skips when only non-essential jobs failed (e.g. Danger).
+
+source .buildkite/shared-pipeline-vars
+
+# Non-essential steps whose failure alone should NOT trigger Claude analysis.
+# Add step keys here as needed.
+NON_ESSENTIAL_STEPS="danger"
+
+for step_key in ${NON_ESSENTIAL_STEPS}; do
+  OUTCOME=$(buildkite-agent step get outcome --step "${step_key}" 2>/dev/null || echo "not_run")
+  if [ "${OUTCOME}" = "failed" ]; then
+    echo "Only non-essential job '${step_key}' failed, skipping Claude analysis"
+    exit 0
+  fi
+done
+
+echo "Real failures detected, running Claude analysis"
+buildkite-agent pipeline upload .buildkite/claude-analysis.yml

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -142,9 +142,7 @@ steps:
   # Claude Build Analysis - dynamically uploaded so Build result conditions evaluate at runtime after the wait
   #################
   - label: ":claude: 🕵️ Check for Build Failures and Run Claude Analysis"
-    command: |
-      source .buildkite/shared-pipeline-vars
-      buildkite-agent pipeline upload .buildkite/claude-analysis.yml
+    command: .buildkite/commands/upload-claude-analysis.sh
     # Add specific group dependencies. Using a `wait` step wouldn't work as it would never start given the prompt block
     depends_on:
       - linters_group


### PR DESCRIPTION
## Description
- Migrate Claude build analysis model from Sonnet 4.5 to Sonnet 4.6
- Gate Claude analysis on real failures: `upload-claude-analysis.sh` checks non-essential step outcomes (currently Danger) via `buildkite-agent` before uploading the pipeline. When only Danger failed, Claude is skipped entirely — no annotation, no PR comment
- Simplify the custom prompt now that non-essential jobs are filtered upstream

(This repo already used the `iangmaia/claude-summarize` fork with `build_log_mode` support.)

## Test Steps
- Verify the Claude analysis step passes (green) and does not post a PR comment when only Danger fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)