### PR TITLE
Reader: Fix incorrect Notification Settings state when subscribing to a post

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -2,6 +2,8 @@
 -----
 * [*] All self-hosted sites now sign in using application passwords [#25424]
 * [*] Reader: Fix button style [#25447]
+* [*] Reader: Fix an issue with "Notificaton Settings" showing incorrect state right after subscribing [#25459]
+* [*] Reader: Fix an issue with "Notificaton Settings" button shown when you are not subscribed [#25459]
 * [*] Reader: Fix a regression with anchors not working in posts [#25459]
 
 

--- a/WordPress/Classes/ViewRelated/Reader/Headers/ReaderSiteHeaderView.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Headers/ReaderSiteHeaderView.swift
@@ -90,12 +90,19 @@ private struct ReaderSiteHeader: View {
                 countsDisplay
             }
             HStack {
-                ReaderFollowButton(isFollowing: viewModel.isFollowingSite,
-                                   isEnabled: viewModel.isFollowEnabled,
-                                   size: .regular) {
-                    viewModel.updateFollowStatus()
+                HStack(spacing: 12) {
+                    ReaderFollowButton(isFollowing: viewModel.isFollowingSite,
+                                       isEnabled: viewModel.isFollowEnabled && !viewModel.isFollowLoading,
+                                       size: .regular) {
+                        viewModel.updateFollowStatus()
+                    }
+                    if viewModel.isFollowLoading {
+                        ProgressView()
+                            .scaleEffect(0.9, anchor: .center)
+                    }
                 }
-                if let site = viewModel.site, site.canManageNotifications {
+
+                if viewModel.isFollowingSite, let site = viewModel.site, site.canManageNotifications, !viewModel.isFollowLoading {
                     ReaderSubscriptionNotificationSettingsButton(site: site)
                         .padding(.horizontal, 2)
                         .padding(.vertical, 8)
@@ -146,6 +153,7 @@ private final class ReaderSiteHeaderViewModel: ObservableObject {
     @Published var followerCount: String
     @Published var isFollowingSite: Bool
     @Published var isFollowEnabled: Bool
+    @Published var isFollowLoading: Bool = false
 
     private let onFollowTap: (_ completion: @escaping () -> Void) -> Void
 
@@ -168,9 +176,11 @@ private final class ReaderSiteHeaderViewModel: ObservableObject {
     }
 
     func updateFollowStatus() {
-        isFollowEnabled = false
+        isFollowLoading = true
         onFollowTap { [weak self] in
-            self?.isFollowEnabled = true
+            withAnimation {
+                self?.isFollowLoading = false
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes [CMM-1190: Subscribing to a site shows no notifications, while I'm actually getting emails](https://linear.app/a8c/issue/CMM-1190/subscribing-to-a-site-shows-no-notifications-while-im-actually-getting). In addition, it no longer shows the "Notifications Settings" if you are not subscribed.

It still does optimistic-ish UI, but at least no longer shows notifications in incorrect state and clearly communicates loading state.




https://github.com/user-attachments/assets/de0c9c57-b29e-48c3-8b54-eeee009967bd




