### PR TITLE
Menus: Fix an issue with footer view in Menu Editing not resizing

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,7 +3,7 @@
 * [*] All self-hosted sites now sign in using application passwords [#25424]
 * [*] Reader: Fix button style [#25447]
 * [*] Reader: Fix a regression with anchors not working in posts [#25459]
-
+* [*] Menus: Fix an issue with footer view in Menu Editing not resizing [#25481]
 
 26.8
 -----

--- a/WordPress/Classes/ViewRelated/Menus/MenuItemEditing.storyboard
+++ b/WordPress/Classes/ViewRelated/Menus/MenuItemEditing.storyboard
@@ -63,9 +63,6 @@
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="nri-tg-kjD">
                                                 <rect key="frame" x="164.5" y="10" width="46" height="40"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="46" id="ODJ-tH-Q74"/>
-                                                </constraints>
                                                 <state key="normal" title="Trash">
                                                     <color key="titleColor" red="1" green="0.092125669189999995" blue="0.0" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </state>
@@ -73,9 +70,6 @@
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="gAa-vi-ki4">
                                                 <rect key="frame" x="310" y="10" width="55" height="40"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="55" id="e8m-8I-UJH"/>
-                                                </constraints>
                                                 <state key="normal" title="Save">
                                                     <color key="titleColor" red="0.1076004438" green="0.55510221439999996" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                 </state>
@@ -83,9 +77,6 @@
                                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Cud-Sg-wSi">
                                                 <rect key="frame" x="10" y="10" width="63" height="40"/>
                                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                                                <constraints>
-                                                    <constraint firstAttribute="width" constant="63" id="oN6-Bi-mOt"/>
-                                                </constraints>
                                                 <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                                 <state key="normal" title="Cancel">
                                                     <color key="titleColor" red="0.1076004438" green="0.55510221439999996" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>


### PR DESCRIPTION
Fixes [CMM-1187: Menu item: Text of action buttons are not legible in non-English language](https://linear.app/a8c/issue/CMM-1187/menu-item-text-of-action-buttons-are-not-legible-in-non-english)

Before / After

<img width="360" alt="Screenshot 2026-04-06 at 10 26 23 AM" src="https://github.com/user-attachments/assets/b9198ec2-093e-4b0a-908a-017f9401a777" /> <img width="360" alt="Screenshot 2026-04-06 at 10 49 46 AM" src="https://github.com/user-attachments/assets/48217b38-dbb4-4bf1-89b6-28021be24ca0" />
