### PR TITLE
Enable SwiftLint rule: contains_over_filter_is_empty

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -16,6 +16,9 @@ only_rules:
   # There should be no space before and one after any comma.
   - comma
 
+  # Prefer `contains` over using `filter(where:).isEmpty`.
+  - contains_over_filter_is_empty
+
   # if,for,while,do statements shouldn't wrap their conditionals in parentheses.
   - control_statement
 

--- a/Modules/Sources/WordPressKit/JetpackThreatFixStatus.swift
+++ b/Modules/Sources/WordPressKit/JetpackThreatFixStatus.swift
@@ -23,7 +23,7 @@ public struct JetpackThreatFixResponse: Decodable {
             statusArray.append(fixStatus)
         }
 
-        isFixingThreats = !statusArray.filter { $0.status == .inProgress }.isEmpty
+        isFixingThreats = statusArray.contains { $0.status == .inProgress }
         threats = statusArray
     }
 

--- a/Sources/WordPressData/Swift/Blog+Lookup.swift
+++ b/Sources/WordPressData/Swift/Blog+Lookup.swift
@@ -113,9 +113,8 @@ public extension Blog {
             return true
         }
 
-        return !Blog.selfHosted(in: context)
-            .filter { $0.jetpack?.isConnected == true }
-            .isEmpty
+        return Blog.selfHosted(in: context)
+            .contains { $0.jetpack?.isConnected == true }
     }
 
     @objc(selfHostedInContext:)

--- a/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackSocialCardCell.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Blog Dashboard/Cards/DashboardJetpackSocialCardCell.swift
@@ -278,7 +278,7 @@ private extension DashboardJetpackSocialCardCell {
         let isNoSharesViewHidden = hiddenSites[dotComID] ?? false
 
         return blog.supports(.publicize)
-        && !connections.filter { !$0.requiresUserAction() }.isEmpty
+        && connections.contains { !$0.requiresUserAction() }
         && !isNoSharesViewHidden
         && sharingLimit.remaining == 0
     }


### PR DESCRIPTION
## Summary

- Enable the `contains_over_filter_is_empty` SwiftLint rule, which prefers `.contains` over `.filter { ... }.isEmpty`
- 0 auto-correctable violations; 3 manual fixes applied
- Part of the Orchard SwiftLint rollout campaign

## Test plan

- [x] SwiftLint passes clean
- [ ] CI build passes

*Posted by Claude Code (Opus 4.6) on behalf of @mokagio with approval.*