### PR TITLE
Add test and release note for post list preview newline fix

### DIFF
--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -30,6 +30,7 @@
 * [*] Fix incorrect default Post Format in new posts [#25369]
 * [*] Posts and Pages are available to XMLRPC-disable sites [#25382]
 * [*] Activity Log: Show when actions were performed by an MCP agent [#25397]
+* [*] Fix post list preview showing an extra blank line when content contains paragraph separators [#25349]
 
 26.7
 -----

--- a/Sources/WordPressData/Swift/Post.swift
+++ b/Sources/WordPressData/Swift/Post.swift
@@ -219,14 +219,14 @@ public class Post: AbstractPost {
             if let preview = PostPreviewCache.shared.excerpt[excerpt] {
                 return preview
             }
-            let preview = excerpt.makePlainText().withCollapsedNewlines()
+            let preview = excerpt.makePlainText().withCollapsedNewlines().trimmedForPreview()
             PostPreviewCache.shared.excerpt[excerpt] = preview
             return preview
         } else if let content {
             if let preview = PostPreviewCache.shared.content[content] {
                 return preview
             }
-            let preview = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 200).withCollapsedNewlines()
+            let preview = GutenbergExcerptGenerator.firstParagraph(from: content, maxLength: 200).withCollapsedNewlines().trimmedForPreview()
             PostPreviewCache.shared.content[content] = preview
             return preview
         } else {
@@ -252,6 +252,11 @@ private extension String {
     // Normalize newlines by collapsing multiple occurrences of newlines to a single newline
     func withCollapsedNewlines() -> String {
         replacingOccurrences(of: "[\n]{2,}", with: "\n", options: .regularExpression)
+    }
+
+    // Remove leading/trailing line breaks to avoid rendering blank trailing lines in preview labels.
+    func trimmedForPreview() -> String {
+        trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 

--- a/Tests/KeystoneTests/Tests/Models/PostTests.swift
+++ b/Tests/KeystoneTests/Tests/Models/PostTests.swift
@@ -259,6 +259,15 @@ class PostTests: CoreDataTestCase {
         XCTAssertEqual(post.contentPreviewForDisplay(), "some contents\u{A0}go here")
     }
 
+    func testThatContentPreviewForDisplayTrimsLeadingAndTrailingNewlines() {
+        let post = newTestPost()
+
+        post.content = "<p>Paragraph 1</p><p>Paragraph 2</p>"
+        let preview = post.contentPreviewForDisplay()
+
+        XCTAssertEqual("Paragraph 1", preview)
+    }
+
     func testThatEnablingDisablingPublicizeConnectionsWorks() {
         let post = newTestPost()
 


### PR DESCRIPTION
## Summary
- Fix the test assertion in `testThatContentPreviewForDisplayTrimsLeadingAndTrailingNewlines` to match actual `firstParagraph()` behavior
- Add release note for #25349

## Test plan
- CI should pass on this branch
- PR #25349 is retargeted on top of this branch