### PR TITLE
Fix Claude analysis gating to handle co-failures correctly

### DIFF
--- a/.buildkite/claude-analysis.yml
+++ b/.buildkite/claude-analysis.yml
@@ -24,7 +24,7 @@ steps:
           build_log_mode: "failed"
           trigger: "on-failure"
           max_log_lines: 1500
-          custom_prompt: >
+          custom_prompt: |
             Ignore these jobs — they are not real failures:
             (1) The "Claude Build Analysis" job itself (uses `exit 1` to trigger this hook).
             (2) The "Danger - PR Check" job (external linter, not indicative of build health).

--- a/.buildkite/commands/upload-claude-analysis.sh
+++ b/.buildkite/commands/upload-claude-analysis.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -eu
+#!/usr/bin/env bash
+
+set -eu
 
 # Uploads the Claude analysis pipeline only when real build/test failures exist.
 # Skips when only non-essential jobs failed (e.g. Danger).
@@ -7,15 +9,44 @@ source .buildkite/shared-pipeline-vars
 
 # Non-essential steps whose failure alone should NOT trigger Claude analysis.
 # Add step keys here as needed.
-NON_ESSENTIAL_STEPS="danger"
+NON_ESSENTIAL_STEPS=("danger")
 
-for step_key in ${NON_ESSENTIAL_STEPS}; do
-  OUTCOME=$(buildkite-agent step get outcome --step "${step_key}" 2>/dev/null || echo "not_run")
-  if [ "${OUTCOME}" = "failed" ]; then
-    echo "Only non-essential job '${step_key}' failed, skipping Claude analysis"
-    exit 0
+# Count how many non-essential steps have a "failed" outcome.
+non_essential_failures=0
+for step_key in "${NON_ESSENTIAL_STEPS[@]}"; do
+  outcome=$(buildkite-agent step get outcome --step "${step_key}" 2>/dev/null || echo "not_run")
+  if [ "${outcome}" = "failed" ]; then
+    echo "Non-essential job '${step_key}' failed"
+    non_essential_failures=$((non_essential_failures + 1))
   fi
 done
 
-echo "Real failures detected, running Claude analysis"
+# No non-essential failures means something essential failed — run Claude.
+if [ "${non_essential_failures}" -eq 0 ]; then
+  echo "Real failures detected, running Claude analysis"
+  buildkite-agent pipeline upload .buildkite/claude-analysis.yml
+  exit 0
+fi
+
+# Non-essential jobs did fail. Only skip Claude if they account for ALL failures.
+# Query the Buildkite API to get the total count of failed jobs in this build.
+build_info=$(curl -sf \
+  -H "Authorization: Bearer ${BUILDKITE_TOKEN_FOR_CLAUDE:-}" \
+  "https://api.buildkite.com/v2/organizations/${BUILDKITE_ORGANIZATION_SLUG}/pipelines/${BUILDKITE_PIPELINE_SLUG}/builds/${BUILDKITE_BUILD_NUMBER}" \
+  2>/dev/null || echo "")
+
+if [ -z "${build_info}" ]; then
+  echo "Could not fetch build info; assuming real failures exist, running Claude analysis"
+  buildkite-agent pipeline upload .buildkite/claude-analysis.yml
+  exit 0
+fi
+
+total_failures=$(echo "${build_info}" | jq '[.jobs[] | select(.state == "failed" or .state == "timed_out")] | length' 2>/dev/null || echo "-1")
+
+if [ "${total_failures}" -eq "${non_essential_failures}" ]; then
+  echo "Only non-essential job(s) failed (${non_essential_failures}/${total_failures}), skipping Claude analysis"
+  exit 0
+fi
+
+echo "Real failures detected alongside non-essential failures, running Claude analysis"
 buildkite-agent pipeline upload .buildkite/claude-analysis.yml

--- a/.buildkite/commands/upload-claude-analysis.sh
+++ b/.buildkite/commands/upload-claude-analysis.sh
@@ -3,32 +3,10 @@
 set -eu
 
 # Uploads the Claude analysis pipeline only when real build/test failures exist.
-# Skips when only non-essential jobs failed (e.g. Danger).
+# Skips when only non-essential jobs failed (e.g. Danger) or nothing failed.
 
 source .buildkite/shared-pipeline-vars
 
-# Non-essential steps whose failure alone should NOT trigger Claude analysis.
-# Add step keys here as needed.
-NON_ESSENTIAL_STEPS=("danger")
-
-# Count how many non-essential steps have a "failed" outcome.
-non_essential_failures=0
-for step_key in "${NON_ESSENTIAL_STEPS[@]}"; do
-  outcome=$(buildkite-agent step get outcome --step "${step_key}" 2>/dev/null || echo "not_run")
-  if [ "${outcome}" = "failed" ]; then
-    echo "Non-essential job '${step_key}' failed"
-    non_essential_failures=$((non_essential_failures + 1))
-  fi
-done
-
-# No non-essential failures means something essential failed — run Claude.
-if [ "${non_essential_failures}" -eq 0 ]; then
-  echo "Real failures detected, running Claude analysis"
-  buildkite-agent pipeline upload .buildkite/claude-analysis.yml
-  exit 0
-fi
-
-# Non-essential jobs did fail. Only skip Claude if they account for ALL failures.
 # Query the Buildkite API to get the total count of failed jobs in this build.
 build_info=$(curl -sf \
   -H "Authorization: Bearer ${BUILDKITE_TOKEN_FOR_CLAUDE:-}" \
@@ -43,10 +21,30 @@ fi
 
 total_failures=$(echo "${build_info}" | jq '[.jobs[] | select(.state == "failed" or .state == "timed_out")] | length' 2>/dev/null || echo "-1")
 
+# Nothing failed — skip Claude analysis.
+if [ "${total_failures}" -eq 0 ]; then
+  echo "All steps passed, skipping Claude analysis"
+  exit 0
+fi
+
+# Non-essential steps whose failure alone should NOT trigger Claude analysis.
+# Add step keys here as needed.
+NON_ESSENTIAL_STEPS=("danger")
+
+# Count how many non-essential steps have a "hard_failed" outcome.
+non_essential_failures=0
+for step_key in "${NON_ESSENTIAL_STEPS[@]}"; do
+  outcome=$(buildkite-agent step get outcome --step "${step_key}" 2>/dev/null || echo "not_run")
+  if [ "${outcome}" = "hard_failed" ]; then
+    echo "Non-essential job '${step_key}' failed"
+    non_essential_failures=$((non_essential_failures + 1))
+  fi
+done
+
 if [ "${total_failures}" -eq "${non_essential_failures}" ]; then
   echo "Only non-essential job(s) failed (${non_essential_failures}/${total_failures}), skipping Claude analysis"
   exit 0
 fi
 
-echo "Real failures detected alongside non-essential failures, running Claude analysis"
+echo "Real failures detected, running Claude analysis"
 buildkite-agent pipeline upload .buildkite/claude-analysis.yml


### PR DESCRIPTION
## Description
Follow-up to #25477. Fixes a logic bug in `upload-claude-analysis.sh` where the script exited early on the first non-essential failure (e.g. Danger), causing Claude analysis to be silently skipped even when essential jobs also failed in the same build.

**Changes:**
- **Fix co-failure logic**: Count non-essential failures first, then query the Buildkite REST API for total failed job count. Only skip Claude when `non_essential_failures == total_failures`.
- **Fail-safe**: If the API call fails, Claude runs anyway (safe default).
- **Fix shebang**: `#!/bin/bash -eu` → `#!/usr/bin/env bash` + `set -eu` for portability.
- **Use Bash array**: `NON_ESSENTIAL_STEPS` is now a proper array to avoid word splitting/glob issues.
- **YAML literal scalar**: `custom_prompt: >` → `custom_prompt: |` to preserve numbered list and paragraph structure.
- **Include timed_out state**: The jq filter catches both `failed` and `timed_out` job states.

## Test Steps
1. Trigger a build where only Danger fails → Claude analysis should be skipped
2. Trigger a build where Danger and a real test both fail → Claude analysis should run
3. Trigger a build where only a real test fails → Claude analysis should run

---
- [x] I have considered if this change warrants user-facing release notes and have added them to `RELEASE-NOTES.txt` if necessary.