### PR TITLE
Stats: Fix timezone label showing Standard Time during DST

### DIFF
--- a/Modules/Sources/JetpackStats/Views/TimezoneInfoView.swift
+++ b/Modules/Sources/JetpackStats/Views/TimezoneInfoView.swift
@@ -27,7 +27,7 @@ struct TimezoneInfoView: View {
     }
 
     private var formattedTimeZone: String {
-        let name = context.timeZone.localizedName(for: .standard, locale: .current)
+        let name = context.timeZone.localizedName(for: .generic, locale: .current)
         return name ?? context.timeZone.identifier
     }
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -3,6 +3,7 @@
 * [*] All self-hosted sites now sign in using application passwords [#25424]
 * [*] Comments: Fix "Trash" trailing action not updating the status of the comments cached on the device [#25485]
 * [*] Stats: Add a confirmation dialog when marking referrers as spam [#25475]
+* [*] Stats: Fix timezone label showing "Standard Time" during daylight saving time - thanks @btraviswright for the report! [#25495]
 * [*] Reader: Fix an issue with Article screen not updating comments if comment is posted from inline section [#25483]
 * [*] Reader: Fix button style [#25447]
 * [*] Reader: Add smart cropping for featured images in the feed so it never cut the heads off [#25451]


### PR DESCRIPTION
## Summary

- Fixes the Stats timezone label always displaying "Standard Time" (e.g. "Pacific Standard Time") even during daylight saving time
- Switches from `.standard` to `.generic` name style, which displays a name that's correct year-round (e.g. "Pacific Time")

## Root Cause

`TimezoneInfoView.formattedTimeZone` used `TimeZone.localizedName(for: .standard, ...)` which unconditionally returns the standard-time name regardless of whether DST is active.

## Fix

Use `.generic` name style, which is already used elsewhere in the codebase (`SiteSettingsViewController`, `PublishDatePickerViewController`) for the same reason.

## Test plan

- [ ] Open Stats on a site whose timezone observes DST (e.g. US Pacific, US Central)
- [ ] Verify the timezone label shows a generic name like "Central Time" rather than "Central Standard Time"