### PR TITLE
Remove Twitter row from About screen

### DIFF
--- a/Modules/Sources/BuildSettingsKit/BuildSettings+Live.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings+Live.swift
@@ -16,8 +16,6 @@ extension BuildSettings {
         appURLScheme = bundle.infoValue(forKey: "WPAppURLScheme")
         jetpackAppURLScheme = bundle.infoValue(forKey: "WPJetpackAppURLScheme")
         about = ProductAboutDetails(
-            twitterHandle: bundle.infoValue(forKey: "WPProductTwitterHandle"),
-            twitterURL: bundle.urlValue(forKey: "WPProductTwitterURL"),
             blogURL: bundle.urlValue(forKey: "WPProductBlogURL")
         )
         zendeskSourcePlatform = bundle.infoValue(forKey: "WPZendeskSourcePlatform")

--- a/Modules/Sources/BuildSettingsKit/BuildSettings+Preview.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings+Preview.swift
@@ -15,8 +15,6 @@ extension BuildSettings {
         appURLScheme: "xcpreview",
         jetpackAppURLScheme: "jetpack",
         about: ProductAboutDetails(
-            twitterHandle: "@wordpress",
-            twitterURL: URL(string: "www.example.com")!,
             blogURL: URL(string: "www.example.com")!
         ),
         zendeskSourcePlatform: "zen",

--- a/Modules/Sources/BuildSettingsKit/BuildSettings.swift
+++ b/Modules/Sources/BuildSettingsKit/BuildSettings.swift
@@ -36,8 +36,6 @@ public struct BuildSettings: Sendable {
     public var authKeychainServiceName: String
 
     public struct ProductAboutDetails: Sendable {
-        public var twitterHandle: String
-        public var twitterURL: URL
         public var blogURL: URL
     }
 

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,6 +16,7 @@
 * [*] Reader: Fix an issues with Reader failing to clear cached comments if all the comments are deleted [#25482]
 * [*] Reader: Fix an issue with the article view removing autoplay without showing controls [#25468]
 * [*] Menus: Fix an issue with footer view in Menu Editing not resizing [#25481]
+* [*] About screen: Remove the non-functional Twitter/X link [#25496]
 
 26.8
 -----

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -16,7 +16,7 @@
 * [*] Reader: Fix an issues with Reader failing to clear cached comments if all the comments are deleted [#25482]
 * [*] Reader: Fix an issue with the article view removing autoplay without showing controls [#25468]
 * [*] Menus: Fix an issue with footer view in Menu Editing not resizing [#25481]
-* [*] About screen: Remove the non-functional Twitter/X link [#25496]
+* [*] About screen: Remove the non-functional Twitter/X link - thanks @zynp-KC for reporting! [#25496]
 
 26.8
 -----

--- a/Sources/Jetpack/Info.plist
+++ b/Sources/Jetpack/Info.plist
@@ -671,10 +671,6 @@
 	<string>6</string>
 	<key>WPProductBlogURL</key>
 	<string>jetpack.com/blog</string>
-	<key>WPProductTwitterHandle</key>
-	<string>@jetpack</string>
-	<key>WPProductTwitterURL</key>
-	<string>twitter.com/jetpack</string>
 	<key>WPPushNotificationAppID</key>
 	<string>${WP_PUSH_NOTIFICATION_APP_ID}</string>
 	<key>WPZendeskSourcePlatform</key>

--- a/Sources/Reader/Info.plist
+++ b/Sources/Reader/Info.plist
@@ -26,10 +26,6 @@
 	<string>6</string>
 	<key>WPProductBlogURL</key>
 	<string>jetpack.com/blog</string>
-	<key>WPProductTwitterHandle</key>
-	<string>@jetpack</string>
-	<key>WPProductTwitterURL</key>
-	<string>twitter.com/jetpack</string>
 	<key>WPPushNotificationAppID</key>
 	<string>${WP_PUSH_NOTIFICATION_APP_ID}</string>
 	<key>WPZendeskSourcePlatform</key>

--- a/Sources/WordPress/Info.plist
+++ b/Sources/WordPress/Info.plist
@@ -596,10 +596,6 @@
 	<string>2</string>
 	<key>WPProductBlogURL</key>
 	<string>wordpress.org/news/</string>
-	<key>WPProductTwitterHandle</key>
-	<string>@WordPressiOS</string>
-	<key>WPProductTwitterURL</key>
-	<string>twitter.com/WordPressiOS</string>
 	<key>WPPushNotificationAppID</key>
 	<string>${WP_PUSH_NOTIFICATION_APP_ID}</string>
 	<key>WPZendeskSourcePlatform</key>

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutScreenTracker.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AboutScreenTracker.swift
@@ -16,7 +16,6 @@ class AboutScreenTracker {
             case dismiss
             case rateUs = "rate_us"
             case share
-            case twitter
             case blog
             case legal
             case automatticFamily = "automattic_family"

--- a/WordPress/Classes/ViewRelated/Me/App Settings/About/AppAboutScreenConfiguration.swift
+++ b/WordPress/Classes/ViewRelated/Me/App Settings/About/AppAboutScreenConfiguration.swift
@@ -20,13 +20,17 @@ struct WebViewPresenter {
 
 class AppAboutScreenConfiguration: AboutScreenConfiguration {
     static var appInfo: AboutScreenAppInfo {
-        AboutScreenAppInfo(name: (Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String) ?? "",
-                           version: Bundle.main.detailedVersionNumber() ?? "",
-                           icon: UIImage(named: AppIcon.currentOrDefaultIconName) ?? UIImage())
+        AboutScreenAppInfo(
+            name: (Bundle.main.object(forInfoDictionaryKey: "CFBundleDisplayName") as? String) ?? "",
+            version: Bundle.main.detailedVersionNumber() ?? "",
+            icon: UIImage(named: AppIcon.currentOrDefaultIconName) ?? UIImage()
+        )
     }
 
-    static let fonts = AboutScreenFonts(appName: WPStyleGuide.serifFontForTextStyle(.largeTitle, fontWeight: .semibold),
-                                        appVersion: WPStyleGuide.tableviewTextFont())
+    static let fonts = AboutScreenFonts(
+        appName: WPStyleGuide.serifFontForTextStyle(.largeTitle, fontWeight: .semibold),
+        appVersion: WPStyleGuide.tableviewTextFont()
+    )
 
     let sharePresenter: ShareAppContentPresenter
     let webViewPresenter = WebViewPresenter()
@@ -35,46 +39,79 @@ class AppAboutScreenConfiguration: AboutScreenConfiguration {
     lazy var sections: [[AboutItem]] = {
         [
             [
-                AboutItem(title: TextContent.rateUs, action: { [weak self] context in
-                    WPAnalytics.track(.appReviewsRatedApp)
-                    self?.tracker.buttonPressed(.rateUs)
-                    AppRatingUtility.shared.ratedCurrentVersion()
-                    UIApplication.shared.open(AppRatingUtility.shared.appReviewUrl)
-                }),
-                AboutItem(title: TextContent.share, action: { [weak self] context in
-                    self?.tracker.buttonPressed(.share)
-                    self?.sharePresenter.present(for: BuildSettings.current.shareAppName, in: context.viewController, source: .about, sourceView: context.sourceView)
-                }),
-                AboutItem(title: TextContent.twitter, subtitle: BuildSettings.current.about.twitterHandle, cellStyle: .value1, action: { [weak self] context in
-                    self?.tracker.buttonPressed(.twitter)
-                    self?.webViewPresenter.presentInNavigationControlller(url: Links.twitter, context: context)
-                }),
-                AboutItem(title: Strings.current.blogName, subtitle: productBlogDisplayURL, cellStyle: .value1, action: { [weak self] context in
-                    self?.tracker.buttonPressed(.blog)
-                    self?.webViewPresenter.presentInNavigationControlller(url: Links.blog, context: context)
-                })
+                AboutItem(
+                    title: TextContent.rateUs,
+                    action: { [weak self] context in
+                        WPAnalytics.track(.appReviewsRatedApp)
+                        self?.tracker.buttonPressed(.rateUs)
+                        AppRatingUtility.shared.ratedCurrentVersion()
+                        UIApplication.shared.open(AppRatingUtility.shared.appReviewUrl)
+                    }
+                ),
+                AboutItem(
+                    title: TextContent.share,
+                    action: { [weak self] context in
+                        self?.tracker.buttonPressed(.share)
+                        self?.sharePresenter
+                            .present(
+                                for: BuildSettings.current.shareAppName,
+                                in: context.viewController,
+                                source: .about,
+                                sourceView: context.sourceView
+                            )
+                    }
+                ),
+                AboutItem(
+                    title: Strings.current.blogName,
+                    subtitle: productBlogDisplayURL,
+                    cellStyle: .value1,
+                    action: { [weak self] context in
+                        self?.tracker.buttonPressed(.blog)
+                        self?.webViewPresenter.presentInNavigationControlller(url: Links.blog, context: context)
+                    }
+                )
             ],
             [
-                AboutItem(title: TextContent.legalAndMore, accessoryType: .disclosureIndicator, action: { [weak self] context in
-                    self?.tracker.buttonPressed(.legal)
-                    context.showSubmenu(title: TextContent.legalAndMore, configuration: LegalAndMoreSubmenuConfiguration())
-                }),
+                AboutItem(
+                    title: TextContent.legalAndMore,
+                    accessoryType: .disclosureIndicator,
+                    action: { [weak self] context in
+                        self?.tracker.buttonPressed(.legal)
+                        context.showSubmenu(
+                            title: TextContent.legalAndMore,
+                            configuration: LegalAndMoreSubmenuConfiguration()
+                        )
+                    }
+                )
             ],
-            [.jetpack, .reader].contains(BuildSettings.current.brand) ?
+            [.jetpack, .reader].contains(BuildSettings.current.brand)
+                ? [
+                    AboutItem(
+                        title: TextContent.automatticFamily,
+                        accessoryType: .disclosureIndicator,
+                        hidesSeparator: true,
+                        action: { [weak self] context in
+                            self?.tracker.buttonPressed(.automatticFamily)
+                            self?.webViewPresenter
+                                .presentInNavigationControlller(url: Links.automattic, context: context)
+                        }
+                    ),
+                    AboutItem(title: "", cellStyle: .appLogos, accessoryType: .none)
+                ] : nil,
             [
-                AboutItem(title: TextContent.automatticFamily, accessoryType: .disclosureIndicator, hidesSeparator: true, action: { [weak self] context in
-                    self?.tracker.buttonPressed(.automatticFamily)
-                    self?.webViewPresenter.presentInNavigationControlller(url: Links.automattic, context: context)
-                }),
-                AboutItem(title: "", cellStyle: .appLogos, accessoryType: .none)
-            ] : nil,
-            [
-                AboutItem(title: Strings.current.workWithUs, subtitle: TextContent.workWithUsSubtitle, cellStyle: .subtitle, accessoryType: .disclosureIndicator, action: { [weak self] context in
-                    self?.tracker.buttonPressed(.workWithUs)
-                    self?.webViewPresenter.presentInNavigationControlller(url: Links.workWithUs, context: context)
-                }),
+                AboutItem(
+                    title: Strings.current.workWithUs,
+                    subtitle: TextContent.workWithUsSubtitle,
+                    cellStyle: .subtitle,
+                    accessoryType: .disclosureIndicator,
+                    action: { [weak self] context in
+                        self?.tracker.buttonPressed(.workWithUs)
+                        self?.webViewPresenter.presentInNavigationControlller(url: Links.workWithUs, context: context)
+                    }
+                )
             ]
-        ].compactMap { $0 }
+        ]
+        .compactMap { $0 }
     }()
 
     func dismissScreen(_ actionContext: AboutItemActionContext) {
@@ -99,16 +136,35 @@ class AppAboutScreenConfiguration: AboutScreenConfiguration {
     }
 
     private enum TextContent {
-        static let rateUs = NSLocalizedString("Rate Us", comment: "Title for button allowing users to rate the app in the App Store")
-        static let share = NSLocalizedString("Share with Friends", comment: "Title for button allowing users to share information about the app with friends, such as via Messages")
-        static let twitter = NSLocalizedString("Twitter", comment: "Title of button that displays the app's Twitter profile")
-        static let legalAndMore = NSLocalizedString("Legal and More", comment: "Title of button which shows a list of legal documentation such as privacy policy and acknowledgements")
-        static let automatticFamily = NSLocalizedString("Automattic Family", comment: "Title of button that displays information about the other apps available from Automattic")
-        static var workWithUsSubtitle = AppConfiguration.isWordPress ? nil : NSLocalizedString("Join From Anywhere", comment: "Subtitle for button displaying the Automattic Work With Us web page, indicating that Automattic employees can work from anywhere in the world")
+        static let rateUs = NSLocalizedString(
+            "Rate Us",
+            comment: "Title for button allowing users to rate the app in the App Store"
+        )
+        static let share = NSLocalizedString(
+            "Share with Friends",
+            comment:
+                "Title for button allowing users to share information about the app with friends, such as via Messages"
+        )
+        static let legalAndMore = NSLocalizedString(
+            "Legal and More",
+            comment:
+                "Title of button which shows a list of legal documentation such as privacy policy and acknowledgements"
+        )
+        static let automatticFamily = NSLocalizedString(
+            "Automattic Family",
+            comment: "Title of button that displays information about the other apps available from Automattic"
+        )
+        static var workWithUsSubtitle =
+            AppConfiguration.isWordPress
+            ? nil
+            : NSLocalizedString(
+                "Join From Anywhere",
+                comment:
+                    "Subtitle for button displaying the Automattic Work With Us web page, indicating that Automattic employees can work from anywhere in the world"
+            )
     }
 
     private enum Links {
-        static let twitter = BuildSettings.current.about.twitterURL
         static let blog = BuildSettings.current.about.blogURL
         static let workWithUs = URL(string: Strings.current.workWithUsURL)!
         static let automattic = URL(string: "https://automattic.com")!
@@ -125,21 +181,32 @@ class LegalAndMoreSubmenuConfiguration: AboutScreenConfiguration {
                 linkItem(title: Titles.termsOfService, link: Links.termsOfService, button: .termsOfService),
                 linkItem(title: Titles.privacyPolicy, link: Links.privacyPolicy, button: .privacyPolicy),
                 linkItem(title: Titles.sourceCode, link: Links.sourceCode, button: .sourceCode),
-                AboutItem(title: Titles.acknowledgements, accessoryType: .disclosureIndicator, action: { context in
-                    let rootView = AcknowledgementsListView(viewModel: AcknowledgementsListViewModel(dataProvider: AcknowledgementsService()))
-                    context.viewController.navigationController?.pushViewController(
-                        UIHostingController(rootView: rootView),
-                        animated: true
-                    )
-                })
+                AboutItem(
+                    title: Titles.acknowledgements,
+                    accessoryType: .disclosureIndicator,
+                    action: { context in
+                        let rootView = AcknowledgementsListView(
+                            viewModel: AcknowledgementsListViewModel(dataProvider: AcknowledgementsService())
+                        )
+                        context.viewController.navigationController?
+                            .pushViewController(
+                                UIHostingController(rootView: rootView),
+                                animated: true
+                            )
+                    }
+                )
             ]
         ]
     }()
 
     private func linkItem(title: String, link: URL, button: AboutScreenTracker.Event.Button) -> AboutItem {
-        AboutItem(title: title, accessoryType: .disclosureIndicator, action: { [weak self] context in
-            self?.buttonPressed(link: link, context: context, button: button)
-        })
+        AboutItem(
+            title: title,
+            accessoryType: .disclosureIndicator,
+            action: { [weak self] context in
+                self?.buttonPressed(link: link, context: context, button: button)
+            }
+        )
     }
 
     private func buttonPressed(link: URL, context: AboutItemActionContext, button: AboutScreenTracker.Event.Button) {
@@ -160,10 +227,22 @@ class LegalAndMoreSubmenuConfiguration: AboutScreenConfiguration {
     }
 
     private enum Titles {
-        static let termsOfService = NSLocalizedString("Terms of Service", comment: "Title of button that displays the App's terms of service")
-        static let privacyPolicy = NSLocalizedString("Privacy Policy", comment: "Title of button that displays the App's privacy policy")
-        static let sourceCode = NSLocalizedString("Source Code", comment: "Title of button that displays the App's source code information")
-        static let acknowledgements = NSLocalizedString("Acknowledgements", comment: "Title of button that displays the App's acknowledgements")
+        static let termsOfService = NSLocalizedString(
+            "Terms of Service",
+            comment: "Title of button that displays the App's terms of service"
+        )
+        static let privacyPolicy = NSLocalizedString(
+            "Privacy Policy",
+            comment: "Title of button that displays the App's privacy policy"
+        )
+        static let sourceCode = NSLocalizedString(
+            "Source Code",
+            comment: "Title of button that displays the App's source code information"
+        )
+        static let acknowledgements = NSLocalizedString(
+            "Acknowledgements",
+            comment: "Title of button that displays the App's acknowledgements"
+        )
     }
 
     private enum Links {
@@ -200,13 +279,19 @@ private struct Strings {
 
     static let wordpress = Strings(
         blogName: NSLocalizedString("News", comment: "Title of a button that displays the WordPress.org blog"),
-        workWithUs: NSLocalizedString("Contribute", comment: "Title of button that displays the WordPress.org contributor page"),
+        workWithUs: NSLocalizedString(
+            "Contribute",
+            comment: "Title of button that displays the WordPress.org contributor page"
+        ),
         workWithUsURL: "https://make.wordpress.org/mobile/handbook"
     )
 
     static let a8c = Strings(
         blogName: NSLocalizedString("Blog", comment: "Title of a button that displays the WordPress.com blog"),
-        workWithUs: NSLocalizedString("Work With Us", comment: "Title of button that displays the Automattic Work With Us web page"),
+        workWithUs: NSLocalizedString(
+            "Work With Us",
+            comment: "Title of button that displays the Automattic Work With Us web page"
+        ),
         workWithUsURL: "https://automattic.com/work-with-us"
     )
 }


### PR DESCRIPTION
## Summary

- Removes the Twitter/X row from the About screen — tapping it opened a blank webview because X.com doesn't render in an embedded `WKWebView`

Also cleans up the now-unused `TextContent.twitter` and `Links.twitter` constants

Fixes #25493 — reported by @zynp-KC

## Test plan

- [ ] Open Me → App Settings → About
- [ ] Verify the Twitter row is no longer present
- [ ] Verify remaining rows (Rate Us, Share, Blog, Legal and More, Work With Us) still function correctly