### PR TITLE
Do not update image on UI if the downloading task is cancelled

### DIFF
--- a/Modules/Sources/AsyncImageKit/Views/CachedAsyncImage.swift
+++ b/Modules/Sources/AsyncImageKit/Views/CachedAsyncImage.swift
@@ -139,9 +139,12 @@ public struct CachedAsyncImage<Content>: View where Content: View {
             } else {
                 phase = .empty
                 let image = try await imageDownloader.image(for: request)
+
+                try Task.checkCancellation()
                 phase = .success(Image(uiImage: image))
             }
         } catch {
+            guard !Task.isCancelled else { return }
             phase = .failure(error)
         }
     }

--- a/Modules/Sources/AsyncImageKit/Views/CachedAsyncImage.swift
+++ b/Modules/Sources/AsyncImageKit/Views/CachedAsyncImage.swift
@@ -38,9 +38,13 @@ public struct CachedAsyncImage<Content>: View where Content: View {
         @ViewBuilder content: @escaping (AsyncImagePhase) -> Content
     ) {
         if let url {
-            let request = ImageRequest(url: url, host: host, options: ImageRequestOptions(
-                mutability: mutability
-            ))
+            let request = ImageRequest(
+                url: url,
+                host: host,
+                options: ImageRequestOptions(
+                    mutability: mutability
+                )
+            )
 
             self.init(
                 request: request,
@@ -63,9 +67,13 @@ public struct CachedAsyncImage<Content>: View where Content: View {
         @ViewBuilder placeholder: @escaping () -> P
     ) where Content == _ConditionalContent<I, P>, I: View, P: View {
         if let url {
-            let request = ImageRequest(url: url, host: host, options: ImageRequestOptions(
-                mutability: mutability
-            ))
+            let request = ImageRequest(
+                url: url,
+                host: host,
+                options: ImageRequestOptions(
+                    mutability: mutability
+                )
+            )
 
             self.init(
                 request: request,
@@ -89,9 +97,13 @@ public struct CachedAsyncImage<Content>: View where Content: View {
         @ViewBuilder placeholder: @escaping () -> P
     ) where Content == _ConditionalContent<I, P>, I: View, P: View {
         self.init(
-            request: ImageRequest(videoUrl: videoUrl, host: host, options: ImageRequestOptions(
-                mutability: mutability
-            )),
+            request: ImageRequest(
+                videoUrl: videoUrl,
+                host: host,
+                options: ImageRequestOptions(
+                    mutability: mutability
+                )
+            ),
             imageDownloader: imageDownloader,
             content: content,
             placeholder: placeholder
@@ -153,7 +165,9 @@ public struct CachedAsyncImage<Content>: View where Content: View {
 fileprivate let testURL = URL(string: "https://i0.wp.com/themes.svn.wordpress.org/twentytwentyfive/1.3/screenshot.png")!
 
 // This video is the preview because it's not just black for the first frame, and right now video previews only fetch the first frame
-fileprivate let videoURL = URL(string: "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4")!
+fileprivate let videoURL = URL(
+    string: "https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/ForBiggerJoyrides.mp4"
+)!
 
 #Preview("Basic Image") {
     CachedAsyncImage(url: testURL)

--- a/RELEASE-NOTES.txt
+++ b/RELEASE-NOTES.txt
@@ -17,6 +17,7 @@
 * [*] Reader: Fix an issue with the article view removing autoplay without showing controls [#25468]
 * [*] Menus: Fix an issue with footer view in Menu Editing not resizing [#25481]
 * [*] About screen: Remove the non-functional Twitter/X link - thanks @zynp-KC for reporting! [#25496]
+* [*] Notifications: Attempt to fix incorrect avatars in the notifications [#25501]
 
 26.8
 -----


### PR DESCRIPTION
## Description

The first commit contains the core change, which skips updating the UI if the fetching image task was canceled.
