### PR TITLE
Enable SwiftLint rule: toggle_bool

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -55,6 +55,9 @@ only_rules:
 
   - shorthand_optional_binding
 
+  # Prefer `someBool.toggle()` over `someBool = !someBool`.
+  - toggle_bool
+
   # Files should have a single trailing newline.
   - trailing_newline
 

--- a/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
+++ b/Sources/WordPressAuthenticator/Helpers/UnifiedAuth/ViewRelated/ReusableViews/TextFieldTableViewCell.swift
@@ -173,7 +173,7 @@ private extension TextFieldTableViewCell {
     }
 
     @objc func secureTextEntryToggleAction(_ sender: Any) {
-        textField.isSecureTextEntry = !textField.isSecureTextEntry
+        textField.isSecureTextEntry.toggle()
 
         // Save and re-apply the current selection range to save the cursor position
         let currentTextRange = textField.selectedTextRange

--- a/WordPress/Classes/ViewRelated/Blog/Sharing/SharingButtonsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Blog/Sharing/SharingButtonsViewController.swift
@@ -406,7 +406,7 @@ class SharingButtonsViewController: UITableViewController {
                 switchCell.onChange = { [weak self] newValue in
                     guard let self else { return }
                     WPAnalytics.track(.sharingButtonsEditSharingButtonsToggled, properties: ["checked": newValue as Any], blog: self.blog)
-                    self.buttonsSection.editing = !self.buttonsSection.editing
+                    self.buttonsSection.editing.toggle()
                     self.updateButtonOrderAfterEditing()
                     self.reloadButtons()
                 }
@@ -452,7 +452,7 @@ class SharingButtonsViewController: UITableViewController {
                     guard let self else { return }
                     WPAnalytics.track(.sharingButtonsEditMoreButtonToggled, properties: ["checked": newValue as Any], blog: self.blog)
                     self.updateButtonOrderAfterEditing()
-                    self.moreSection.editing = !self.moreSection.editing
+                    self.moreSection.editing.toggle()
                     self.reloadButtons()
                 }
             }

--- a/WordPress/Classes/ViewRelated/Cells/ExpandableCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/ExpandableCell.swift
@@ -53,7 +53,7 @@ class ExpandableCell: WPReusableTableViewCell, NibLoadable {
     }
 
     public func toggle() {
-        expanded = !expanded
+        expanded.toggle()
     }
 
     private func setupSubviews() {

--- a/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Controllers/NotificationSettingsViewController.swift
@@ -582,10 +582,10 @@ extension NotificationSettingsViewController {
         let section = self.section(at: index.section)
         switch section {
         case .blog:
-            displayBlogMoreWasAccepted = !displayBlogMoreWasAccepted
+            displayBlogMoreWasAccepted.toggle()
 
         case .followedSites:
-            displayFollowedMoreWasAccepted = !displayFollowedMoreWasAccepted
+            displayFollowedMoreWasAccepted.toggle()
 
         default:
             return

--- a/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockUserTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Notifications/Views/NoteBlockUserTableViewCell.swift
@@ -96,7 +96,7 @@ class NoteBlockUserTableViewCell: NoteBlockTableViewCell {
             if let listener = isFollowOn ? onUnfollowClick : onFollowClick {
                 listener()
             }
-            isFollowOn = !isFollowOn
+            isFollowOn.toggle()
         }
     }
 

--- a/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginViewModel.swift
+++ b/WordPress/Classes/ViewRelated/Plugins/ViewModels/PluginViewModel.swift
@@ -383,7 +383,7 @@ class PluginViewModel: Observable {
             expandedText: setHTMLTextAttributes(text),
             expanded: descriptionExpandedStatus,
             action: { [unowned self] row in
-                self.descriptionExpandedStatus = !self.descriptionExpandedStatus
+                self.descriptionExpandedStatus.toggle()
                 (row as? ExpandableRow)?.expanded = self.descriptionExpandedStatus
             },
             onLinkTap: { [unowned self] url in
@@ -399,7 +399,7 @@ class PluginViewModel: Observable {
             expandedText: setHTMLTextAttributes(text),
             expanded: installationExpandedStatus,
             action: { [unowned self] row in
-                self.installationExpandedStatus = !self.installationExpandedStatus
+                self.installationExpandedStatus.toggle()
                 (row as? ExpandableRow)?.expanded = self.installationExpandedStatus
             },
             onLinkTap: { [unowned self] url in
@@ -415,7 +415,7 @@ class PluginViewModel: Observable {
             expandedText: setHTMLTextAttributes(text),
             expanded: changeLogExpandedStatus,
             action: { [unowned self] row in
-                self.changeLogExpandedStatus = !self.changeLogExpandedStatus
+                self.changeLogExpandedStatus.toggle()
                 (row as? ExpandableRow)?.expanded = self.changeLogExpandedStatus
             },
             onLinkTap: { [unowned self] url in
@@ -431,7 +431,7 @@ class PluginViewModel: Observable {
             expandedText: setHTMLTextAttributes(text),
             expanded: faqExpandedStatus,
             action: { [unowned self] row in
-                self.faqExpandedStatus = !self.faqExpandedStatus
+                self.faqExpandedStatus.toggle()
                 (row as? ExpandableRow)?.expanded = self.faqExpandedStatus
             },
             onLinkTap: { [unowned self] url in

--- a/WordPress/Classes/ViewRelated/Reader/Cards/Tags View/ReaderTopicCollectionViewCoordinator.swift
+++ b/WordPress/Classes/ViewRelated/Reader/Cards/Tags View/ReaderTopicCollectionViewCoordinator.swift
@@ -206,7 +206,7 @@ extension ReaderTopicCollectionViewCoordinator: UICollectionViewDelegateFlowLayo
             return
         }
 
-        layout.isExpanded = !layout.isExpanded
+        layout.isExpanded.toggle()
         layout.invalidateLayout()
 
         WPAnalytics.trackReader(.readerChipsMoreToggled)


### PR DESCRIPTION
## Summary

Enables the `toggle_bool` SwiftLint rule, which prefers `someBool.toggle()` over `someBool = !someBool`.

- Auto-fixed violations: 12 (across 7 files)
- Manual fixes: 0
- Violations left for human review: none

Part of the Orchard SwiftLint rollout campaign.

---

*Posted by Claude (Opus 4.7) on behalf of @mokagio with approval.*