### PR TITLE
Enable SwiftLint rule: prefer_zero_over_explicit_init

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -53,6 +53,8 @@ only_rules:
 
   - overridden_super_call
 
+  - prefer_zero_over_explicit_init
+
   - shorthand_optional_binding
 
   # Files should have a single trailing newline.

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -53,6 +53,7 @@ only_rules:
 
   - overridden_super_call
 
+  # Example: CGPoint.zero instead of CGPoint(x: 0, y: 0)
   - prefer_zero_over_explicit_init
 
   - shorthand_optional_binding

--- a/Modules/Sources/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
+++ b/Modules/Sources/UITestsFoundation/Screens/Editor/BlockEditorScreen.swift
@@ -446,7 +446,7 @@ public class BlockEditorScreen: ScreenObject {
 
     @discardableResult
     public func closeBlockPicker() throws -> BlockEditorScreen {
-        editorCloseButton.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0)).tap()
+        editorCloseButton.coordinate(withNormalizedOffset: CGVector.zero).tap()
         return try BlockEditorScreen()
     }
 

--- a/Modules/Sources/UITestsFoundation/XCUIElement+Utils.swift
+++ b/Modules/Sources/UITestsFoundation/XCUIElement+Utils.swift
@@ -4,7 +4,7 @@ import XCTest
 public extension XCUIElement {
 
     func scroll(byDeltaX deltaX: CGFloat, deltaY: CGFloat) {
-        let startCoordinate = self.coordinate(withNormalizedOffset: CGVector(dx: 0, dy: 0))
+        let startCoordinate = self.coordinate(withNormalizedOffset: CGVector.zero)
         let destination = startCoordinate.withOffset(CGVector(dx: deltaX, dy: deltaY * -1))
 
         startCoordinate.press(forDuration: 0.01, thenDragTo: destination)

--- a/Modules/Tests/WordPressUIUnitTests/Extensions/UIImage+ScaleTests.swift
+++ b/Modules/Tests/WordPressUIUnitTests/Extensions/UIImage+ScaleTests.swift
@@ -42,9 +42,9 @@ struct UIImageScaleTests {
     }
 
     @Test func zeroTargetSize() {
-        let targetSize = CGSize(width: 0, height: 0)
+        let targetSize = CGSize.zero
         let originalImage = UIImage(color: .blue, size: CGSize(width: 1024, height: 680))
         let size = originalImage.dimensions(forSuggestedSize: targetSize, format: .scaleAspectFill)
-        #expect(size == CGSize(width: 0, height: 0))
+        #expect(size == CGSize.zero)
     }
 }

--- a/WordPress/Classes/Utility/WebViewController/WebKitViewController.swift
+++ b/WordPress/Classes/Utility/WebViewController/WebKitViewController.swift
@@ -94,7 +94,7 @@ class WebKitViewController: UIViewController, WebKitAuthenticatable {
     let linkBehavior: LinkBehavior
 
     private var reachabilityObserver: Any?
-    private var tapLocation = CGPoint(x: 0.0, y: 0.0)
+    private var tapLocation = CGPoint.zero
     private var widthConstraint: NSLayoutConstraint?
     private var stackViewBottomAnchor: NSLayoutConstraint?
     private var onClose: (() -> Void)?
@@ -613,7 +613,7 @@ extension WebKitViewController: UIPopoverPresentationControllerDelegate {
 
     private func handleDocumentMenuPresentation(presented: UIPopoverPresentationController) {
           presented.sourceView = webView
-          presented.sourceRect = CGRect(origin: tapLocation, size: CGSize(width: 0, height: 0))
+          presented.sourceRect = CGRect(origin: tapLocation, size: CGSize.zero)
       }
 }
 

--- a/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
+++ b/WordPress/Classes/ViewRelated/Cells/BorderedButtonTableViewCell.swift
@@ -143,7 +143,7 @@ private extension BorderedButtonTableViewCell {
     }
 
     struct Defaults {
-        static let buttonInsets = UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)
+        static let buttonInsets = UIEdgeInsets.zero
         static let titleFont = WPStyleGuide.fontForTextStyle(.body, fontWeight: .semibold)
         static let normalColor: UIColor = .label
         static let highlightedColor: UIColor = .label.variantInverted

--- a/WordPress/Classes/ViewRelated/Stats/Charts/SparklineView.swift
+++ b/WordPress/Classes/ViewRelated/Stats/Charts/SparklineView.swift
@@ -136,7 +136,7 @@ class SparklineView: UIView {
         // ... then the bottom gradient
         if let maskLayerPath = lineLayerPath.mutableCopy() {
             maskLayerPath.addLine(to: CGPoint(x: bounds.width, y: 0))
-            maskLayerPath.addLine(to: CGPoint(x: 0, y: 0))
+            maskLayerPath.addLine(to: CGPoint.zero)
             maskLayer.path = maskLayerPath
         }
 


### PR DESCRIPTION
## Summary

Enables the `prefer_zero_over_explicit_init` SwiftLint rule, which prefers `.zero` over explicit zero-valued initializers such as `CGPoint(x: 0, y: 0)`, `CGSize(width: 0, height: 0)`, `CGRect(x: 0, y: 0, width: 0, height: 0)`, and `UIEdgeInsets(top: 0, left: 0, bottom: 0, right: 0)`.

- Auto-fixed violations: 8 (across 6 files)
- Manual fixes: 0
- Violations left for human review: none

Part of the Orchard SwiftLint rollout campaign.

@jkmassel @crazytonyli  I admit this is a bit pedantic and I don't know if there is a runtime benefit (unlike say using `isEmpty` vs `count > 0`). [The docs](https://realm.github.io/SwiftLint/prefer_zero_over_explicit_init.html) don't have any extra information.

If it was up to me, I'd enable it, but I'll leave it up to you to decide.

---

*Posted by Claude (Opus 4.7) on behalf of @mokagio with approval.*