### PR TITLE
Enable SwiftLint rule: joined_default_parameter

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -42,6 +42,10 @@ only_rules:
   # Prefer checking `isEmpty` over comparing to empty string literal `""`.
   - empty_string
 
+  # When calling the `joined` method on an array of strings, omit an
+  # explicit empty-string separator since that is the default.
+  - joined_default_parameter
+
   # MARK comment should be in valid format.
   - mark
 

--- a/WordPress/Classes/Extensions/NSAttributedString+StyledHTML.swift
+++ b/WordPress/Classes/Extensions/NSAttributedString+StyledHTML.swift
@@ -62,7 +62,7 @@ extension NSAttributedString {
             return style + " }"
         }
 
-        let joinedStyles = styles?.joined(separator: "") ?? ""
+        let joinedStyles = styles?.joined() ?? ""
         return "<style>" + joinedStyles + "</style>"
     }
 


### PR DESCRIPTION
## What

Enables the SwiftLint [`joined_default_parameter`](https://realm.github.io/SwiftLint/joined_default_parameter.html) rule, which flags calls to `joined(separator:)` that pass the default empty-string separator and should just use `joined()`.

## Details

- Auto-fixed violations: 1
- Manual (agentic) fixes: 0
- Violations left for human review: 0

Auto-fixed call site:

- `WordPress/Classes/Extensions/NSAttributedString+StyledHTML.swift`

Local build was deferred to CI per the `toggle_bool` precedent — the fix is mechanical and type-preserving so the risk of a local build regression is negligible and CI covers it.

## Context

Part of the [Orchard SwiftLint rollout campaign](https://github.com/Automattic/orchard-swiftlint), progressively enabling SwiftLint rules across Automattic's iOS repositories one rule at a time.