### PR TITLE
Remove metric icons from stats overview tab bar

### DIFF
--- a/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
+++ b/Modules/Sources/JetpackStats/Views/MetricsOverviewTabView.swift
@@ -97,18 +97,11 @@ private struct MetricItemView<Metric: MetricType>: View {
     }
 
     private var headerView: some View {
-        HStack(spacing: 2) {
-            if showTrend {
-                Image(systemName: data.metric.systemImage)
-                    .font(.caption2.weight(.medium))
-                    .scaleEffect(x: 0.9, y: 0.9)
-            }
-            Text(data.metric.localizedTitle.uppercased())
-                .font(.caption.weight(.medium))
-        }
-        .foregroundColor(isSelected ? .primary : .secondary)
-        .animation(.easeInOut(duration: 0.25), value: isSelected)
-        .padding(.trailing, 4) // Visually spacing matters less than for metricsView
+        Text(data.metric.localizedTitle.uppercased())
+            .font(.caption.weight(.medium))
+            .foregroundColor(isSelected ? .primary : .secondary)
+            .animation(.easeInOut(duration: 0.25), value: isSelected)
+            .padding(.trailing, 4) // Visually spacing matters less than for metricsView
     }
 
     private var metricsView: some View {


### PR DESCRIPTION
## Summary

- Drop the SF Symbol leading each metric tab (`Views`, `Visitors`, `Likes`, `Comments`, `Posts`) in `MetricsOverviewTabView`.
- Flatten the `HStack` wrapper in `headerView` now that only the label remains.

The icon added visual noise without carrying information beyond the uppercase label. `showTrend` still gates the trend badge below; only the header icon is removed.

## Test plan

- [ ] Stats → Traffic tab: metric tab bar shows only the uppercase labels, no icons
- [ ] Selected metric underline + animation still works
- [ ] `MetricsOverviewTabView` preview renders correctly in Xcode